### PR TITLE
WIP Set typed event as "oneof" in protocol buffers

### DIFF
--- a/contribs/protobuf/src/main/java/org/matsim/contrib/protobuf/Event2ProtoEvent.java
+++ b/contribs/protobuf/src/main/java/org/matsim/contrib/protobuf/Event2ProtoEvent.java
@@ -42,7 +42,7 @@ public abstract class Event2ProtoEvent {
 					.setTime(event.getTime())
 					.setLinkId(ProtobufEvents.LinkId.newBuilder().setId(((LinkLeaveEvent) event).getLinkId().toString()))
 					.setVehId(ProtobufEvents.VehicleId.newBuilder().setId(((LinkLeaveEvent) event).getVehicleId().toString()));
-			eb.setType(ProtobufEvents.Event.Type.LinkLeave).setLinkLeave(ll);
+			eb.setLinkLeave(ll);
 		}
 		else {
 			if (event instanceof LinkEnterEvent) {
@@ -50,7 +50,7 @@ public abstract class Event2ProtoEvent {
 						.setTime(event.getTime())
 						.setLinkId(ProtobufEvents.LinkId.newBuilder().setId(((LinkEnterEvent) event).getLinkId().toString()))
 						.setVehId(ProtobufEvents.VehicleId.newBuilder().setId(((LinkEnterEvent) event).getVehicleId().toString()));
-				eb.setType(ProtobufEvents.Event.Type.LinkEnter).setLinkEnter(ll);
+				eb.setLinkEnter(ll);
 			}
 			else {
 				if (event instanceof ActivityEndEvent) {
@@ -60,7 +60,7 @@ public abstract class Event2ProtoEvent {
 							.setPersId(ProtobufEvents.PersonId.newBuilder().setId(((ActivityEndEvent) event).getPersonId().toString()))
 							.setActType(((ActivityEndEvent) event).getActType());
 					if (((ActivityEndEvent) event).getFacilityId() != null)  ae.setFacilityId(ProtobufEvents.ActivityFacilityId.newBuilder().setId(((ActivityEndEvent) event).getFacilityId().toString()));
-					eb.setType(ProtobufEvents.Event.Type.ActivityEnd).setActEnd(ae);
+					eb.setActEnd(ae);
 
 				}
 				else {
@@ -73,7 +73,7 @@ public abstract class Event2ProtoEvent {
 						if (((ActivityStartEvent) event).getFacilityId() != null ) {
 							as.setFacilityId(ProtobufEvents.ActivityFacilityId.newBuilder().setId(((ActivityStartEvent) event).getFacilityId().toString()));
 						}
-						eb.setType(ProtobufEvents.Event.Type.ActivityStart).setActStart(as);
+						eb.setActStart(as);
 					}
 					else {
 						if (event instanceof PersonArrivalEvent) {
@@ -82,7 +82,7 @@ public abstract class Event2ProtoEvent {
 									.setLinkId(ProtobufEvents.LinkId.newBuilder().setId(((PersonArrivalEvent) event).getLinkId().toString()))
 									.setLegMode(((PersonArrivalEvent) event).getLegMode())
 									.setPersId(ProtobufEvents.PersonId.newBuilder().setId(((PersonArrivalEvent) event).getPersonId().toString()));
-							eb.setType(ProtobufEvents.Event.Type.PersonArrival).setPersonArrival(pa);
+							eb.setPersonArrival(pa);
 						}
 						else {
 							if (event instanceof PersonDepartureEvent) {
@@ -91,7 +91,7 @@ public abstract class Event2ProtoEvent {
 										.setLinkId(ProtobufEvents.LinkId.newBuilder().setId(((PersonDepartureEvent) event).getLinkId().toString()))
 										.setLegMode(((PersonDepartureEvent) event).getLegMode())
 										.setPersId(ProtobufEvents.PersonId.newBuilder().setId(((PersonDepartureEvent) event).getPersonId().toString()));
-								eb.setType(ProtobufEvents.Event.Type.PersonDeparture).setPersonDeparture(pd);
+								eb.setPersonDeparture(pd);
 							}
 							else {
 								if (event instanceof PersonEntersVehicleEvent) {
@@ -99,7 +99,7 @@ public abstract class Event2ProtoEvent {
 											.setTime(event.getTime())
 											.setPersId(ProtobufEvents.PersonId.newBuilder().setId(((PersonEntersVehicleEvent) event).getPersonId().toString()))
 											.setVehId(ProtobufEvents.VehicleId.newBuilder().setId(((PersonEntersVehicleEvent) event).getVehicleId().toString()));
-									eb.setType(ProtobufEvents.Event.Type.PersonEntersVehicle).setPersonEntersVehicle(pe);
+									eb.setPersonEntersVehicle(pe);
 								}
 								else {
 									if (event instanceof PersonLeavesVehicleEvent) {
@@ -107,7 +107,7 @@ public abstract class Event2ProtoEvent {
 												.setTime(event.getTime())
 												.setPersId(ProtobufEvents.PersonId.newBuilder().setId(((PersonLeavesVehicleEvent) event).getPersonId().toString()))
 												.setVehId(ProtobufEvents.VehicleId.newBuilder().setId(((PersonLeavesVehicleEvent) event).getVehicleId().toString()));
-										eb.setType(ProtobufEvents.Event.Type.PersonLeavesVehicle).setPersonLeavesVehicle(pl);
+										eb.setPersonLeavesVehicle(pl);
 									}
 									else {
 										if (event instanceof PersonMoneyEvent) {
@@ -115,7 +115,7 @@ public abstract class Event2ProtoEvent {
 													.setTime(event.getTime())
 													.setPersId(ProtobufEvents.PersonId.newBuilder().setId(((PersonMoneyEvent) event).getPersonId().toString()))
 													.setAmount(((PersonMoneyEvent) event).getAmount());
-											eb.setType(ProtobufEvents.Event.Type.PersonMoney).setPersonMoney(pm);
+											eb.setPersonMoney(pm);
 										}
 										else {
 											if (event instanceof PersonStuckEvent) {
@@ -124,7 +124,7 @@ public abstract class Event2ProtoEvent {
 														.setPersId(ProtobufEvents.PersonId.newBuilder().setId(((PersonStuckEvent) event).getPersonId().toString()))
 														.setLinkId(ProtobufEvents.LinkId.newBuilder().setId(((PersonStuckEvent) event).getLinkId().toString()))
 														.setLegMode(((PersonStuckEvent) event).getLegMode());
-												eb.setType(ProtobufEvents.Event.Type.PersonStuck).setPersonStuck(ps);
+												eb.setPersonStuck(ps);
 											}
 											else {
 												if (event instanceof TransitDriverStartsEvent) {
@@ -135,7 +135,7 @@ public abstract class Event2ProtoEvent {
 															.setTransitRouteId(ProtobufEvents.TransitRouteId.newBuilder().setId(((TransitDriverStartsEvent) event).getTransitRouteId().toString()))
 															.setTransitLineId(ProtobufEvents.TransitLineId.newBuilder().setId(((TransitDriverStartsEvent) event).getTransitLineId().toString()))
 															.setDepartureId(ProtobufEvents.DepartureId.newBuilder().setId(((TransitDriverStartsEvent) event).getDepartureId().toString()));
-													eb.setType(ProtobufEvents.Event.Type.TransitDriverStarts).setTransitDriverStarts(td);
+													eb.setTransitDriverStarts(td);
 												}
 												else {
 													if (event instanceof VehicleAbortsEvent) {
@@ -143,7 +143,7 @@ public abstract class Event2ProtoEvent {
 																.setTime(event.getTime())
 																.setVehId(ProtobufEvents.VehicleId.newBuilder().setId(((VehicleAbortsEvent) event).getVehicleId().toString()))
 																.setLinkId(ProtobufEvents.LinkId.newBuilder().setId(((VehicleAbortsEvent) event).getLinkId().toString()));
-														eb.setType(ProtobufEvents.Event.Type.VehicleAborts).setVehicleAborts(va);
+														eb.setVehicleAborts(va);
 													}
 													else {
 														if (event instanceof VehicleEntersTrafficEvent) {
@@ -154,7 +154,7 @@ public abstract class Event2ProtoEvent {
 																	.setVehId(ProtobufEvents.VehicleId.newBuilder().setId(((VehicleEntersTrafficEvent) event).getVehicleId().toString()))
 																	.setNetworkMode(((VehicleEntersTrafficEvent) event).getNetworkMode())
 																	.setRelPosOnLink(((VehicleEntersTrafficEvent) event).getRelativePositionOnLink());
-															eb.setType(ProtobufEvents.Event.Type.VehicleEntersTraffic).setVehicleEntersTraffic(ve);
+															eb.setVehicleEntersTraffic(ve);
 														}
 														else {
 															if (event instanceof VehicleLeavesTrafficEvent) {
@@ -165,7 +165,7 @@ public abstract class Event2ProtoEvent {
 																		.setVehId(ProtobufEvents.VehicleId.newBuilder().setId(((VehicleLeavesTrafficEvent) event).getVehicleId().toString()))
 																		.setNetworkMode(((VehicleLeavesTrafficEvent) event).getNetworkMode())
 																		.setRelPosOnLink(((VehicleLeavesTrafficEvent) event).getRelativePositionOnLink());
-																eb.setType(ProtobufEvents.Event.Type.VehicleLeavesTraffic).setVehicleLeavesTraffic(vl);
+																eb.setVehicleLeavesTraffic(vl);
 															}
 															else {
 																if (Event2ProtoEvent.REPORT_GENERIC_EVENT) {
@@ -178,7 +178,7 @@ public abstract class Event2ProtoEvent {
 																for (Map.Entry<String,String> e : event.getAttributes().entrySet()) {
 																	ge.addAttrVal(ProtobufEvents.AttrVal.newBuilder().setValue(e.getValue()).setAttribut(e.getKey()));
 																}
-																eb.setType(ProtobufEvents.Event.Type.GenericEvent).setGenericEvent(ge);
+																eb.setGenericEvent(ge);
 															}
 														}
 													}

--- a/contribs/protobuf/src/main/java/org/matsim/contrib/protobuf/ProtoEvent2Event.java
+++ b/contribs/protobuf/src/main/java/org/matsim/contrib/protobuf/ProtoEvent2Event.java
@@ -34,108 +34,65 @@ import java.util.Map;
  */
 public abstract class ProtoEvent2Event {
 	static Event getEvent(ProtobufEvents.Event pe) {
-		if (pe.getType() == ProtobufEvents.Event.Type.LinkEnter) {
-			return new LinkEnterEvent(pe.getLinkEnter().getTime(), Id.createVehicleId(pe.getLinkEnter().getVehId().getId()),
-					Id.createLinkId(pe.getLinkEnter().getLinkId().getId()));
-		}
-		else {
-			if (pe.getType() == ProtobufEvents.Event.Type.LinkLeave) {
+		switch (pe.getEventTypeCase()) {
+			case ACTEND:
+				return new ActivityEndEvent(pe.getActEnd().getTime(), Id.createPersonId(pe.getActEnd().getPersId().getId()),
+						Id.createLinkId(pe.getActEnd().getLinkId().getId()), Id.create(pe.getActEnd().getFacilityId().getId(),
+						ActivityFacility.class), pe.getActEnd().getActType());
+			case ACTSTART:
+				return new ActivityStartEvent(pe.getActStart().getTime(), Id.createPersonId(pe.getActStart().getPersId().getId()),
+						Id.createLinkId(pe.getActStart().getLinkId().getId()), Id.create(pe.getActStart().getFacilityId().getId(),
+						ActivityFacility.class), pe.getActStart().getActType());
+			case LINKENTER:
+				return new LinkEnterEvent(pe.getLinkEnter().getTime(), Id.createVehicleId(pe.getLinkEnter().getVehId().getId()),
+						Id.createLinkId(pe.getLinkEnter().getLinkId().getId()));
+			case LINKLEAVE:
 				return new LinkLeaveEvent(pe.getLinkLeave().getTime(), Id.createVehicleId(pe.getLinkLeave().getVehId().getId()),
 						Id.createLinkId(pe.getLinkLeave().getLinkId().getId()));
-			}
-			else {
-				if (pe.getType() == ProtobufEvents.Event.Type.ActivityEnd) {
-					return new ActivityEndEvent(pe.getActEnd().getTime(), Id.createPersonId(pe.getActEnd().getPersId().getId()),
-							Id.createLinkId(pe.getActEnd().getLinkId().getId()), Id.create(pe.getActEnd().getFacilityId().getId(),
-							ActivityFacility.class), pe.getActEnd().getActType());
+			case PERSONARRIVAL:
+				return new PersonArrivalEvent(pe.getPersonArrival().getTime(), Id.createPersonId(pe.getPersonArrival().getPersId().getId()),
+						Id.createLinkId(pe.getPersonArrival().getLinkId().getId()), pe.getPersonArrival().getLegMode());
+			case PERSONDEPARTURE:
+				return new PersonDepartureEvent(pe.getPersonDeparture().getTime(), Id.createPersonId(pe.getPersonDeparture().getPersId().getId()),
+						Id.createLinkId(pe.getPersonDeparture().getLinkId().getId()), pe.getPersonDeparture().getLegMode());
+			case PERSONENTERSVEHICLE:
+				return new PersonEntersVehicleEvent(pe.getPersonEntersVehicle().getTime(), Id.createPersonId(pe.getPersonEntersVehicle().getPersId().getId()),
+						Id.createVehicleId(pe.getPersonEntersVehicle().getVehId().getId()));
+			case PERSONLEAVESVEHICLE:
+				return new PersonLeavesVehicleEvent(pe.getPersonLeavesVehicle().getTime(), Id.createPersonId(pe.getPersonLeavesVehicle().getPersId().getId()),
+						Id.createVehicleId(pe.getPersonLeavesVehicle().getVehId().getId()));
+			case PERSONMONEY:
+				return new PersonMoneyEvent(pe.getPersonMoney().getTime(), Id.createPersonId(pe.getPersonMoney().getPersId().getId()),
+						pe.getPersonMoney().getAmount());
+			case PERSONSTUCK:
+				return new PersonStuckEvent(pe.getPersonStuck().getTime(), Id.createPersonId(pe.getPersonStuck().getPersId().getId()),
+						Id.createLinkId(pe.getPersonStuck().getLinkId().getId()), pe.getPersonStuck().getLegMode());
+			case TRANSITDRIVERSTARTS:
+				return new TransitDriverStartsEvent(pe.getTransitDriverStarts().getTime(), Id.createPersonId(pe.getTransitDriverStarts().getDriverId().getId()),
+						Id.createVehicleId(pe.getTransitDriverStarts().getVehId().getId()), Id.create(pe.getTransitDriverStarts().getTransitLineId().getId(),
+						TransitLine.class), Id.create(pe.getTransitDriverStarts().getTransitRouteId().getId(), TransitRoute.class),
+						Id.create(pe.getTransitDriverStarts().getDepartureId().getId(), Departure.class));
+			case VEHICLEABORTS:
+				return new VehicleAbortsEvent(pe.getVehicleAborts().getTime(), Id.createVehicleId(pe.getVehicleAborts().getVehId().getId()),
+						Id.createLinkId(pe.getVehicleAborts().getLinkId().getId()));
+			case VEHICLEENTERSTRAFFIC:
+				return new VehicleEntersTrafficEvent(pe.getVehicleEntersTraffic().getTime(), Id.createPersonId(pe.getVehicleEntersTraffic().getDriverId().getId()),
+						Id.createLinkId(pe.getVehicleEntersTraffic().getLinkId().getId()), Id.createVehicleId(pe.getVehicleEntersTraffic().getVehId().getId()),
+						pe.getVehicleEntersTraffic().getNetworkMode(), pe.getVehicleEntersTraffic().getRelPosOnLink());
+			case VEHICLELEAVESTRAFFIC:
+				return new VehicleLeavesTrafficEvent(pe.getVehicleLeavesTraffic().getTime(), Id.createPersonId(pe.getVehicleLeavesTraffic().getDriverId().getId()),
+						Id.createLinkId(pe.getVehicleLeavesTraffic().getLinkId().getId()), Id.createVehicleId(pe.getVehicleLeavesTraffic().getVehId().getId()),
+						pe.getVehicleLeavesTraffic().getNetworkMode(), pe.getVehicleLeavesTraffic().getRelPosOnLink());
+			case GENERICEVENT:
+				GenericEvent ge = new GenericEvent(pe.getGenericEvent().getType(),pe.getGenericEvent().getTime());
+				Map<String, String> map = ge.getAttributes();
+				for (ProtobufEvents.AttrVal av : pe.getGenericEvent().getAttrValList()) {
+					map.put(av.getAttribut(),av.getValue());
 				}
-				else {
-					if (pe.getType() == ProtobufEvents.Event.Type.ActivityStart) {
-						return new ActivityStartEvent(pe.getActStart().getTime(), Id.createPersonId(pe.getActStart().getPersId().getId()),
-								Id.createLinkId(pe.getActStart().getLinkId().getId()), Id.create(pe.getActStart().getFacilityId().getId(),
-								ActivityFacility.class), pe.getActStart().getActType());
-
-					}
-					else {
-						if (pe.getType() == ProtobufEvents.Event.Type.PersonArrival) {
-							return new PersonArrivalEvent(pe.getPersonArrival().getTime(), Id.createPersonId(pe.getPersonArrival().getPersId().getId()),
-									Id.createLinkId(pe.getPersonArrival().getLinkId().getId()), pe.getPersonArrival().getLegMode());
-						}
-						else {
-							if (pe.getType() == ProtobufEvents.Event.Type.PersonDeparture) {
-								return new PersonDepartureEvent(pe.getPersonDeparture().getTime(), Id.createPersonId(pe.getPersonDeparture().getPersId().getId()),
-										Id.createLinkId(pe.getPersonDeparture().getLinkId().getId()), pe.getPersonDeparture().getLegMode());
-							}
-							else {
-								if (pe.getType() == ProtobufEvents.Event.Type.VehicleEntersTraffic) {
-									return new VehicleEntersTrafficEvent(pe.getVehicleEntersTraffic().getTime(), Id.createPersonId(pe.getVehicleEntersTraffic().getDriverId().getId()),
-											Id.createLinkId(pe.getVehicleEntersTraffic().getLinkId().getId()), Id.createVehicleId(pe.getVehicleEntersTraffic().getVehId().getId()),
-											pe.getVehicleEntersTraffic().getNetworkMode(), pe.getVehicleEntersTraffic().getRelPosOnLink());
-								}
-								else {
-									if (pe.getType() == ProtobufEvents.Event.Type.PersonLeavesVehicle) {
-										return new PersonLeavesVehicleEvent(pe.getPersonLeavesVehicle().getTime(), Id.createPersonId(pe.getPersonLeavesVehicle().getPersId().getId()),
-												Id.createVehicleId(pe.getPersonLeavesVehicle().getVehId().getId()));
-									}
-									else {
-										if (pe.getType() == ProtobufEvents.Event.Type.VehicleLeavesTraffic) {
-											return new VehicleLeavesTrafficEvent(pe.getVehicleLeavesTraffic().getTime(), Id.createPersonId(pe.getVehicleLeavesTraffic().getDriverId().getId()),
-													Id.createLinkId(pe.getVehicleLeavesTraffic().getLinkId().getId()), Id.createVehicleId(pe.getVehicleLeavesTraffic().getVehId().getId()),
-													pe.getVehicleLeavesTraffic().getNetworkMode(), pe.getVehicleLeavesTraffic().getRelPosOnLink());
-										}
-										else {
-											if (pe.getType() == ProtobufEvents.Event.Type.PersonEntersVehicle) {
-												return new PersonEntersVehicleEvent(pe.getPersonEntersVehicle().getTime(), Id.createPersonId(pe.getPersonEntersVehicle().getPersId().getId()),
-														Id.createVehicleId(pe.getPersonEntersVehicle().getVehId().getId()));
-											}
-											else {
-												if (pe.getType() == ProtobufEvents.Event.Type.PersonMoney) {
-													return new PersonMoneyEvent(pe.getPersonMoney().getTime(), Id.createPersonId(pe.getPersonMoney().getPersId().getId()),
-															pe.getPersonMoney().getAmount());
-												}
-												else {
-													if (pe.getType() == ProtobufEvents.Event.Type.PersonStuck) {
-														return new PersonStuckEvent(pe.getPersonStuck().getTime(), Id.createPersonId(pe.getPersonStuck().getPersId().getId()),
-																Id.createLinkId(pe.getPersonStuck().getLinkId().getId()), pe.getPersonStuck().getLegMode());
-													}
-													else {
-														if (pe.getType() == ProtobufEvents.Event.Type.TransitDriverStarts) {
-															return new TransitDriverStartsEvent(pe.getTransitDriverStarts().getTime(), Id.createPersonId(pe.getTransitDriverStarts().getDriverId().getId()),
-																	Id.createVehicleId(pe.getTransitDriverStarts().getVehId().getId()), Id.create(pe.getTransitDriverStarts().getTransitLineId().getId(),
-																	TransitLine.class), Id.create(pe.getTransitDriverStarts().getTransitRouteId().getId(), TransitRoute.class),
-																	Id.create(pe.getTransitDriverStarts().getDepartureId().getId(), Departure.class));
-														}
-														else {
-															if (pe.getType() == ProtobufEvents.Event.Type.VehicleAborts) {
-																return new VehicleAbortsEvent(pe.getVehicleAborts().getTime(), Id.createVehicleId(pe.getVehicleAborts().getVehId().getId()),
-																		Id.createLinkId(pe.getVehicleAborts().getLinkId().getId()));
-															}
-															else {
-																if (pe.getType() == ProtobufEvents.Event.Type.GenericEvent) {
-																	GenericEvent ge = new GenericEvent(pe.getGenericEvent().getType(),pe.getGenericEvent().getTime());
-																	Map<String, String> map = ge.getAttributes();
-																	for (ProtobufEvents.AttrVal av : pe.getGenericEvent().getAttrValList()) {
-																		map.put(av.getAttribut(),av.getValue());
-																	}
-																	return ge;
-																} else {
-																	throw new RuntimeException("Unsupported event type: " + pe.getType());
-																}
-
-															}
-														}
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
+				return ge;
 		}
+
+		throw new RuntimeException("Unsupported event type: " + pe.getEventTypeCase());
 	}
 
 }

--- a/contribs/protobuf/src/main/proto/events.proto
+++ b/contribs/protobuf/src/main/proto/events.proto
@@ -28,25 +28,27 @@ option java_outer_classname = "ProtobufEvents";
 
 
 message Event {
-	enum Type { ActivityEnd = 0; ActivityStart = 1; LinkEnter = 2; LinkLeave = 3; PersonArrival = 4; PersonDeparture = 5;
-		PersonEntersVehicle = 6; PersonLeavesVehicle = 7; PersonMoney = 8; PersonStuck = 9; TransitDriverStarts = 10;
-		VehicleAborts = 11; VehicleEntersTraffic = 12; VehicleLeavesTraffic = 13; GenericEvent = 14;}
-	Type type =  1;
-	ActivityEndEvent actEnd = 2;
-	ActivityStartEvent actStart = 3;
-	LinkEnterEvent linkEnter = 4;
-	LinkLeaveEvent linkLeave = 5;
-	PersonArrivalEvent personArrival = 6;
-	PersonDepartureEvent personDeparture = 7;
-	PersonEntersVehicleEvent personEntersVehicle = 8;
-	PersonLeavesVehicleEvent personLeavesVehicle = 9;
-	PersonMoneyEvent personMoney = 10;
-	PersonStuckEvent personStuck = 11;
-	TransitDriverStartsEvent transitDriverStarts = 12;
-	VehicleAbortsEvent vehicleAborts = 13;
-	VehicleEntersTrafficEvent vehicleEntersTraffic = 14;
-	VehicleLeavesTrafficEvent vehicleLeavesTraffic = 15;
-	GenericEvent genericEvent = 16;
+	//enum Type { ActivityEnd = 0; ActivityStart = 1; LinkEnter = 2; LinkLeave = 3; PersonArrival = 4; PersonDeparture = 5;
+	//	PersonEntersVehicle = 6; PersonLeavesVehicle = 7; PersonMoney = 8; PersonStuck = 9; TransitDriverStarts = 10;
+	//	VehicleAborts = 11; VehicleEntersTraffic = 12; VehicleLeavesTraffic = 13; GenericEvent = 14;}
+	//Type type =  1;
+	oneof event_type {
+		ActivityEndEvent actEnd = 2;
+		ActivityStartEvent actStart = 3;
+		LinkEnterEvent linkEnter = 4;
+		LinkLeaveEvent linkLeave = 5;
+		PersonArrivalEvent personArrival = 6;
+		PersonDepartureEvent personDeparture = 7;
+		PersonEntersVehicleEvent personEntersVehicle = 8;
+		PersonLeavesVehicleEvent personLeavesVehicle = 9;
+		PersonMoneyEvent personMoney = 10;
+		PersonStuckEvent personStuck = 11;
+		TransitDriverStartsEvent transitDriverStarts = 12;
+		VehicleAbortsEvent vehicleAborts = 13;
+		VehicleEntersTrafficEvent vehicleEntersTraffic = 14;
+		VehicleLeavesTrafficEvent vehicleLeavesTraffic = 15;
+		GenericEvent genericEvent = 16;
+	}
 }
 
 message GenericEvent {

--- a/contribs/protobuf/src/test/java/org/matsim/contrib/protobuf/Event2ProtoEventTest.java
+++ b/contribs/protobuf/src/test/java/org/matsim/contrib/protobuf/Event2ProtoEventTest.java
@@ -45,21 +45,7 @@ public class Event2ProtoEventTest {
 		ActivityEndEvent e = new ActivityEndEvent(42.0, Id.createPersonId("Alice"),
 				Id.createLinkId("link123"), Id.create(55, ActivityFacility.class), "sleep");
 		ProtobufEvents.Event pbe = Event2ProtoEvent.getProtoEvent(e);
-		Assert.assertTrue(pbe.getType() == ProtobufEvents.Event.Type.ActivityEnd);
-		Assert.assertTrue(pbe.hasActStart() == false);
-		Assert.assertTrue(pbe.hasActEnd() == true);
-		Assert.assertTrue(pbe.hasLinkEnter() == false);
-		Assert.assertTrue(pbe.hasLinkLeave() == false);
-		Assert.assertTrue(pbe.hasPersonArrival() == false);
-		Assert.assertTrue(pbe.hasPersonDeparture() == false);
-		Assert.assertTrue(pbe.hasPersonEntersVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonLeavesVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonMoney() == false);
-		Assert.assertTrue(pbe.hasPersonStuck() == false);
-		Assert.assertTrue(pbe.hasTransitDriverStarts() == false);
-		Assert.assertTrue(pbe.hasVehicleAborts() == false);
-		Assert.assertTrue(pbe.hasVehicleEntersTraffic() == false);
-		Assert.assertTrue(pbe.hasVehicleLeavesTraffic() == false);
+		Assert.assertEquals(ProtobufEvents.Event.EventTypeCase.ACTEND, pbe.getEventTypeCase());
 
 		Assert.assertEquals(42.0,pbe.getActEnd().getTime(),0.);
 		Assert.assertEquals("Alice",pbe.getActEnd().getPersId().getId());
@@ -74,21 +60,7 @@ public class Event2ProtoEventTest {
 		ActivityStartEvent e = new ActivityStartEvent(42.0, Id.createPersonId("Bob"),
 				Id.createLinkId("link123"), Id.create(55, ActivityFacility.class), "sleep");
 		ProtobufEvents.Event pbe = Event2ProtoEvent.getProtoEvent(e);
-		Assert.assertTrue(pbe.getType() == ProtobufEvents.Event.Type.ActivityStart);
-		Assert.assertTrue(pbe.hasActStart() == true);
-		Assert.assertTrue(pbe.hasActEnd() == false);
-		Assert.assertTrue(pbe.hasLinkEnter() == false);
-		Assert.assertTrue(pbe.hasLinkLeave() == false);
-		Assert.assertTrue(pbe.hasPersonArrival() == false);
-		Assert.assertTrue(pbe.hasPersonDeparture() == false);
-		Assert.assertTrue(pbe.hasPersonEntersVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonLeavesVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonMoney() == false);
-		Assert.assertTrue(pbe.hasPersonStuck() == false);
-		Assert.assertTrue(pbe.hasTransitDriverStarts() == false);
-		Assert.assertTrue(pbe.hasVehicleAborts() == false);
-		Assert.assertTrue(pbe.hasVehicleEntersTraffic() == false);
-		Assert.assertTrue(pbe.hasVehicleLeavesTraffic() == false);
+		Assert.assertEquals(ProtobufEvents.Event.EventTypeCase.ACTSTART, pbe.getEventTypeCase());
 
 		Assert.assertEquals(42.0,pbe.getActStart().getTime(),0.);
 		Assert.assertEquals("Bob",pbe.getActStart().getPersId().getId());
@@ -102,21 +74,7 @@ public class Event2ProtoEventTest {
 
 		LinkEnterEvent e = new LinkEnterEvent(42.0,Id.createVehicleId("K.I.T.T."),Id.createLinkId("link123"));
 		ProtobufEvents.Event pbe = Event2ProtoEvent.getProtoEvent(e);
-		Assert.assertTrue(pbe.getType() == ProtobufEvents.Event.Type.LinkEnter);
-		Assert.assertTrue(pbe.hasActStart() == false);
-		Assert.assertTrue(pbe.hasActEnd() == false);
-		Assert.assertTrue(pbe.hasLinkEnter() == true);
-		Assert.assertTrue(pbe.hasLinkLeave() == false);
-		Assert.assertTrue(pbe.hasPersonArrival() == false);
-		Assert.assertTrue(pbe.hasPersonDeparture() == false);
-		Assert.assertTrue(pbe.hasPersonEntersVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonLeavesVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonMoney() == false);
-		Assert.assertTrue(pbe.hasPersonStuck() == false);
-		Assert.assertTrue(pbe.hasTransitDriverStarts() == false);
-		Assert.assertTrue(pbe.hasVehicleAborts() == false);
-		Assert.assertTrue(pbe.hasVehicleEntersTraffic() == false);
-		Assert.assertTrue(pbe.hasVehicleLeavesTraffic() == false);
+		Assert.assertEquals(ProtobufEvents.Event.EventTypeCase.LINKENTER, pbe.getEventTypeCase());
 
 		Assert.assertEquals(42.0,pbe.getLinkEnter().getTime(),0.);
 		Assert.assertEquals("K.I.T.T.",pbe.getLinkEnter().getVehId().getId());
@@ -128,21 +86,7 @@ public class Event2ProtoEventTest {
 
 		LinkLeaveEvent e = new LinkLeaveEvent(42.0,Id.createVehicleId("K.I.T.T."),Id.createLinkId("link123"));
 		ProtobufEvents.Event pbe = Event2ProtoEvent.getProtoEvent(e);
-		Assert.assertTrue(pbe.getType() == ProtobufEvents.Event.Type.LinkLeave);
-		Assert.assertTrue(pbe.hasActStart() == false);
-		Assert.assertTrue(pbe.hasActEnd() == false);
-		Assert.assertTrue(pbe.hasLinkEnter() == false);
-		Assert.assertTrue(pbe.hasLinkLeave() == true);
-		Assert.assertTrue(pbe.hasPersonArrival() == false);
-		Assert.assertTrue(pbe.hasPersonDeparture() == false);
-		Assert.assertTrue(pbe.hasPersonEntersVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonLeavesVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonMoney() == false);
-		Assert.assertTrue(pbe.hasPersonStuck() == false);
-		Assert.assertTrue(pbe.hasTransitDriverStarts() == false);
-		Assert.assertTrue(pbe.hasVehicleAborts() == false);
-		Assert.assertTrue(pbe.hasVehicleEntersTraffic() == false);
-		Assert.assertTrue(pbe.hasVehicleLeavesTraffic() == false);
+		Assert.assertEquals(ProtobufEvents.Event.EventTypeCase.LINKLEAVE, pbe.getEventTypeCase());
 
 		Assert.assertEquals(42.0,pbe.getLinkLeave().getTime(),0.);
 		Assert.assertEquals("K.I.T.T.",pbe.getLinkLeave().getVehId().getId());
@@ -154,21 +98,7 @@ public class Event2ProtoEventTest {
 
 		PersonArrivalEvent e = new PersonArrivalEvent(42.0,Id.createPersonId("Alice"),Id.createLinkId("link123"),"swim");
 		ProtobufEvents.Event pbe = Event2ProtoEvent.getProtoEvent(e);
-		Assert.assertTrue(pbe.getType() == ProtobufEvents.Event.Type.PersonArrival);
-		Assert.assertTrue(pbe.hasActStart() == false);
-		Assert.assertTrue(pbe.hasActEnd() == false);
-		Assert.assertTrue(pbe.hasLinkEnter() == false);
-		Assert.assertTrue(pbe.hasLinkLeave() == false);
-		Assert.assertTrue(pbe.hasPersonArrival() == true);
-		Assert.assertTrue(pbe.hasPersonDeparture() == false);
-		Assert.assertTrue(pbe.hasPersonEntersVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonLeavesVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonMoney() == false);
-		Assert.assertTrue(pbe.hasPersonStuck() == false);
-		Assert.assertTrue(pbe.hasTransitDriverStarts() == false);
-		Assert.assertTrue(pbe.hasVehicleAborts() == false);
-		Assert.assertTrue(pbe.hasVehicleEntersTraffic() == false);
-		Assert.assertTrue(pbe.hasVehicleLeavesTraffic() == false);
+		Assert.assertEquals(ProtobufEvents.Event.EventTypeCase.PERSONARRIVAL, pbe.getEventTypeCase());
 
 		Assert.assertEquals(42.0,pbe.getPersonArrival().getTime(),0.);
 		Assert.assertEquals("Alice",pbe.getPersonArrival().getPersId().getId());
@@ -180,21 +110,7 @@ public class Event2ProtoEventTest {
 
 		PersonDepartureEvent e = new PersonDepartureEvent(42.0,Id.createPersonId("Bob"),Id.createLinkId("link123"),"swim");
 		ProtobufEvents.Event pbe = Event2ProtoEvent.getProtoEvent(e);
-		Assert.assertTrue(pbe.getType() == ProtobufEvents.Event.Type.PersonDeparture);
-		Assert.assertTrue(pbe.hasActStart() == false);
-		Assert.assertTrue(pbe.hasActEnd() == false);
-		Assert.assertTrue(pbe.hasLinkEnter() == false);
-		Assert.assertTrue(pbe.hasLinkLeave() == false);
-		Assert.assertTrue(pbe.hasPersonArrival() == false);
-		Assert.assertTrue(pbe.hasPersonDeparture() == true);
-		Assert.assertTrue(pbe.hasPersonEntersVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonLeavesVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonMoney() == false);
-		Assert.assertTrue(pbe.hasPersonStuck() == false);
-		Assert.assertTrue(pbe.hasTransitDriverStarts() == false);
-		Assert.assertTrue(pbe.hasVehicleAborts() == false);
-		Assert.assertTrue(pbe.hasVehicleEntersTraffic() == false);
-		Assert.assertTrue(pbe.hasVehicleLeavesTraffic() == false);
+		Assert.assertEquals(ProtobufEvents.Event.EventTypeCase.PERSONDEPARTURE, pbe.getEventTypeCase());
 
 		Assert.assertEquals(42.0,pbe.getPersonDeparture().getTime(),0.);
 		Assert.assertEquals("Bob",pbe.getPersonDeparture().getPersId().getId());
@@ -206,21 +122,7 @@ public class Event2ProtoEventTest {
 
 		PersonEntersVehicleEvent e = new PersonEntersVehicleEvent(42.,Id.createPersonId("Alice"),Id.createVehicleId("K.I.T.T."));
 		ProtobufEvents.Event pbe = Event2ProtoEvent.getProtoEvent(e);
-		Assert.assertTrue(pbe.getType() == ProtobufEvents.Event.Type.PersonEntersVehicle);
-		Assert.assertTrue(pbe.hasActStart() == false);
-		Assert.assertTrue(pbe.hasActEnd() == false);
-		Assert.assertTrue(pbe.hasLinkEnter() == false);
-		Assert.assertTrue(pbe.hasLinkLeave() == false);
-		Assert.assertTrue(pbe.hasPersonArrival() == false);
-		Assert.assertTrue(pbe.hasPersonDeparture() == false);
-		Assert.assertTrue(pbe.hasPersonEntersVehicle() == true);
-		Assert.assertTrue(pbe.hasPersonLeavesVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonMoney() == false);
-		Assert.assertTrue(pbe.hasPersonStuck() == false);
-		Assert.assertTrue(pbe.hasTransitDriverStarts() == false);
-		Assert.assertTrue(pbe.hasVehicleAborts() == false);
-		Assert.assertTrue(pbe.hasVehicleEntersTraffic() == false);
-		Assert.assertTrue(pbe.hasVehicleLeavesTraffic() == false);
+		Assert.assertEquals(ProtobufEvents.Event.EventTypeCase.PERSONENTERSVEHICLE, pbe.getEventTypeCase());
 
 		Assert.assertEquals(42.0,pbe.getPersonEntersVehicle().getTime(),0.);
 		Assert.assertEquals("Alice",pbe.getPersonEntersVehicle().getPersId().getId());
@@ -232,21 +134,7 @@ public class Event2ProtoEventTest {
 
 		PersonLeavesVehicleEvent e = new PersonLeavesVehicleEvent(42.,Id.createPersonId("Alice"),Id.createVehicleId("K.I.T.T."));
 		ProtobufEvents.Event pbe = Event2ProtoEvent.getProtoEvent(e);
-		Assert.assertTrue(pbe.getType() == ProtobufEvents.Event.Type.PersonLeavesVehicle);
-		Assert.assertTrue(pbe.hasActStart() == false);
-		Assert.assertTrue(pbe.hasActEnd() == false);
-		Assert.assertTrue(pbe.hasLinkEnter() == false);
-		Assert.assertTrue(pbe.hasLinkLeave() == false);
-		Assert.assertTrue(pbe.hasPersonArrival() == false);
-		Assert.assertTrue(pbe.hasPersonDeparture() == false);
-		Assert.assertTrue(pbe.hasPersonEntersVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonLeavesVehicle() == true);
-		Assert.assertTrue(pbe.hasPersonMoney() == false);
-		Assert.assertTrue(pbe.hasPersonStuck() == false);
-		Assert.assertTrue(pbe.hasTransitDriverStarts() == false);
-		Assert.assertTrue(pbe.hasVehicleAborts() == false);
-		Assert.assertTrue(pbe.hasVehicleEntersTraffic() == false);
-		Assert.assertTrue(pbe.hasVehicleLeavesTraffic() == false);
+		Assert.assertEquals(ProtobufEvents.Event.EventTypeCase.PERSONLEAVESVEHICLE, pbe.getEventTypeCase());
 
 		Assert.assertEquals(42.0,pbe.getPersonLeavesVehicle().getTime(),0.);
 		Assert.assertEquals("Alice",pbe.getPersonLeavesVehicle().getPersId().getId());
@@ -258,21 +146,7 @@ public class Event2ProtoEventTest {
 
 		PersonMoneyEvent e = new PersonMoneyEvent(42.0,Id.createPersonId("Bob"),-123.45);
 		ProtobufEvents.Event pbe = Event2ProtoEvent.getProtoEvent(e);
-		Assert.assertTrue(pbe.getType() == ProtobufEvents.Event.Type.PersonMoney);
-		Assert.assertTrue(pbe.hasActStart() == false);
-		Assert.assertTrue(pbe.hasActEnd() == false);
-		Assert.assertTrue(pbe.hasLinkEnter() == false);
-		Assert.assertTrue(pbe.hasLinkLeave() == false);
-		Assert.assertTrue(pbe.hasPersonArrival() == false);
-		Assert.assertTrue(pbe.hasPersonDeparture() == false);
-		Assert.assertTrue(pbe.hasPersonEntersVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonLeavesVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonMoney() == true);
-		Assert.assertTrue(pbe.hasPersonStuck() == false);
-		Assert.assertTrue(pbe.hasTransitDriverStarts() == false);
-		Assert.assertTrue(pbe.hasVehicleAborts() == false);
-		Assert.assertTrue(pbe.hasVehicleEntersTraffic() == false);
-		Assert.assertTrue(pbe.hasVehicleLeavesTraffic() == false);
+		Assert.assertEquals(ProtobufEvents.Event.EventTypeCase.PERSONMONEY, pbe.getEventTypeCase());
 
 		Assert.assertEquals(42.0,pbe.getPersonMoney().getTime(),0.);
 		Assert.assertEquals("Bob",pbe.getPersonMoney().getPersId().getId());
@@ -284,21 +158,7 @@ public class Event2ProtoEventTest {
 
 		PersonStuckEvent e = new PersonStuckEvent(42.0,Id.createPersonId("Alice"), Id.createLinkId("link123"),"fly");
 		ProtobufEvents.Event pbe = Event2ProtoEvent.getProtoEvent(e);
-		Assert.assertTrue(pbe.getType() == ProtobufEvents.Event.Type.PersonStuck);
-		Assert.assertTrue(pbe.hasActStart() == false);
-		Assert.assertTrue(pbe.hasActEnd() == false);
-		Assert.assertTrue(pbe.hasLinkEnter() == false);
-		Assert.assertTrue(pbe.hasLinkLeave() == false);
-		Assert.assertTrue(pbe.hasPersonArrival() == false);
-		Assert.assertTrue(pbe.hasPersonDeparture() == false);
-		Assert.assertTrue(pbe.hasPersonEntersVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonLeavesVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonMoney() == false);
-		Assert.assertTrue(pbe.hasPersonStuck() == true);
-		Assert.assertTrue(pbe.hasTransitDriverStarts() == false);
-		Assert.assertTrue(pbe.hasVehicleAborts() == false);
-		Assert.assertTrue(pbe.hasVehicleEntersTraffic() == false);
-		Assert.assertTrue(pbe.hasVehicleLeavesTraffic() == false);
+		Assert.assertEquals(ProtobufEvents.Event.EventTypeCase.PERSONSTUCK, pbe.getEventTypeCase());
 
 		Assert.assertEquals(42.0,pbe.getPersonStuck().getTime(),0.);
 		Assert.assertEquals("Alice",pbe.getPersonStuck().getPersId().getId());
@@ -312,21 +172,7 @@ public class Event2ProtoEventTest {
 		TransitDriverStartsEvent e = new TransitDriverStartsEvent(42.0,Id.createPersonId("Bob"),Id.createVehicleId("K.I.T.T."),
 				Id.create("l11", TransitLine.class),Id.create("r11", TransitRoute.class),Id.create("d11", Departure.class));
 		ProtobufEvents.Event pbe = Event2ProtoEvent.getProtoEvent(e);
-		Assert.assertTrue(pbe.getType() == ProtobufEvents.Event.Type.TransitDriverStarts);
-		Assert.assertTrue(pbe.hasActStart() == false);
-		Assert.assertTrue(pbe.hasActEnd() == false);
-		Assert.assertTrue(pbe.hasLinkEnter() == false);
-		Assert.assertTrue(pbe.hasLinkLeave() == false);
-		Assert.assertTrue(pbe.hasPersonArrival() == false);
-		Assert.assertTrue(pbe.hasPersonDeparture() == false);
-		Assert.assertTrue(pbe.hasPersonEntersVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonLeavesVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonMoney() == false);
-		Assert.assertTrue(pbe.hasPersonStuck() == false);
-		Assert.assertTrue(pbe.hasTransitDriverStarts() == true);
-		Assert.assertTrue(pbe.hasVehicleAborts() == false);
-		Assert.assertTrue(pbe.hasVehicleEntersTraffic() == false);
-		Assert.assertTrue(pbe.hasVehicleLeavesTraffic() == false);
+		Assert.assertEquals(ProtobufEvents.Event.EventTypeCase.TRANSITDRIVERSTARTS, pbe.getEventTypeCase());
 
 		Assert.assertEquals(42.0,pbe.getTransitDriverStarts().getTime(),0.);
 		Assert.assertEquals("Bob",pbe.getTransitDriverStarts().getDriverId().getId());
@@ -341,21 +187,7 @@ public class Event2ProtoEventTest {
 
 		VehicleAbortsEvent e = new VehicleAbortsEvent(42.0,Id.createVehicleId("K.I.T.T."),Id.createLinkId("link123"));
 		ProtobufEvents.Event pbe = Event2ProtoEvent.getProtoEvent(e);
-		Assert.assertTrue(pbe.getType() == ProtobufEvents.Event.Type.VehicleAborts);
-		Assert.assertTrue(pbe.hasActStart() == false);
-		Assert.assertTrue(pbe.hasActEnd() == false);
-		Assert.assertTrue(pbe.hasLinkEnter() == false);
-		Assert.assertTrue(pbe.hasLinkLeave() == false);
-		Assert.assertTrue(pbe.hasPersonArrival() == false);
-		Assert.assertTrue(pbe.hasPersonDeparture() == false);
-		Assert.assertTrue(pbe.hasPersonEntersVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonLeavesVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonMoney() == false);
-		Assert.assertTrue(pbe.hasPersonStuck() == false);
-		Assert.assertTrue(pbe.hasTransitDriverStarts() == false);
-		Assert.assertTrue(pbe.hasVehicleAborts() == true);
-		Assert.assertTrue(pbe.hasVehicleEntersTraffic() == false);
-		Assert.assertTrue(pbe.hasVehicleLeavesTraffic() == false);
+		Assert.assertEquals(ProtobufEvents.Event.EventTypeCase.VEHICLEABORTS, pbe.getEventTypeCase());
 
 		Assert.assertEquals(42.0,pbe.getVehicleAborts().getTime(),0.);
 		Assert.assertEquals("K.I.T.T.",pbe.getVehicleAborts().getVehId().getId());
@@ -369,21 +201,7 @@ public class Event2ProtoEventTest {
 		VehicleEntersTrafficEvent e = new VehicleEntersTrafficEvent(42.0,Id.createPersonId("Alice"),Id.createLinkId("link123"),
 				Id.createVehicleId("K.I.T.T."),"super pursuit",111.0);
 		ProtobufEvents.Event pbe = Event2ProtoEvent.getProtoEvent(e);
-		Assert.assertTrue(pbe.getType() == ProtobufEvents.Event.Type.VehicleEntersTraffic);
-		Assert.assertTrue(pbe.hasActStart() == false);
-		Assert.assertTrue(pbe.hasActEnd() == false);
-		Assert.assertTrue(pbe.hasLinkEnter() == false);
-		Assert.assertTrue(pbe.hasLinkLeave() == false);
-		Assert.assertTrue(pbe.hasPersonArrival() == false);
-		Assert.assertTrue(pbe.hasPersonDeparture() == false);
-		Assert.assertTrue(pbe.hasPersonEntersVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonLeavesVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonMoney() == false);
-		Assert.assertTrue(pbe.hasPersonStuck() == false);
-		Assert.assertTrue(pbe.hasTransitDriverStarts() == false);
-		Assert.assertTrue(pbe.hasVehicleAborts() == false);
-		Assert.assertTrue(pbe.hasVehicleEntersTraffic() == true);
-		Assert.assertTrue(pbe.hasVehicleLeavesTraffic() == false);
+		Assert.assertEquals(ProtobufEvents.Event.EventTypeCase.VEHICLEENTERSTRAFFIC, pbe.getEventTypeCase());
 
 		Assert.assertEquals(42.0,pbe.getVehicleEntersTraffic().getTime(),0.);
 		Assert.assertEquals("Alice",pbe.getVehicleEntersTraffic().getDriverId().getId());
@@ -400,21 +218,7 @@ public class Event2ProtoEventTest {
 		VehicleLeavesTrafficEvent e = new VehicleLeavesTrafficEvent(42.0,Id.createPersonId("Alice"),Id.createLinkId("link123"),
 				Id.createVehicleId("K.I.T.T."),"super pursuit",111.0);
 		ProtobufEvents.Event pbe = Event2ProtoEvent.getProtoEvent(e);
-		Assert.assertTrue(pbe.getType() == ProtobufEvents.Event.Type.VehicleLeavesTraffic);
-		Assert.assertTrue(pbe.hasActStart() == false);
-		Assert.assertTrue(pbe.hasActEnd() == false);
-		Assert.assertTrue(pbe.hasLinkEnter() == false);
-		Assert.assertTrue(pbe.hasLinkLeave() == false);
-		Assert.assertTrue(pbe.hasPersonArrival() == false);
-		Assert.assertTrue(pbe.hasPersonDeparture() == false);
-		Assert.assertTrue(pbe.hasPersonEntersVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonLeavesVehicle() == false);
-		Assert.assertTrue(pbe.hasPersonMoney() == false);
-		Assert.assertTrue(pbe.hasPersonStuck() == false);
-		Assert.assertTrue(pbe.hasTransitDriverStarts() == false);
-		Assert.assertTrue(pbe.hasVehicleAborts() == false);
-		Assert.assertTrue(pbe.hasVehicleEntersTraffic() == false);
-		Assert.assertTrue(pbe.hasVehicleLeavesTraffic() == true);
+		Assert.assertEquals(ProtobufEvents.Event.EventTypeCase.VEHICLELEAVESTRAFFIC, pbe.getEventTypeCase());
 
 		Assert.assertEquals(42.0,pbe.getVehicleLeavesTraffic().getTime(),0.);
 		Assert.assertEquals("Alice",pbe.getVehicleLeavesTraffic().getDriverId().getId());

--- a/contribs/protobuf/src/test/java/org/matsim/contrib/protobuf/ProtoEvent2EventTest.java
+++ b/contribs/protobuf/src/test/java/org/matsim/contrib/protobuf/ProtoEvent2EventTest.java
@@ -38,7 +38,7 @@ public class ProtoEvent2EventTest {
 		ProtobufEvents.LinkEnterEvent.Builder le = ProtobufEvents.LinkEnterEvent.newBuilder().setTime(42.0).
 				setLinkId(ProtobufEvents.LinkId.newBuilder().setId("link123")).setVehId(ProtobufEvents.VehicleId.newBuilder().setId("K.I.T.T."));
 
-		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().setType(ProtobufEvents.Event.Type.LinkEnter).
+		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().
 				setLinkEnter(le).build();
 
 		Event e = ProtoEvent2Event.getEvent(pe);
@@ -53,7 +53,7 @@ public class ProtoEvent2EventTest {
 		ProtobufEvents.LinkLeaveEvent.Builder le = ProtobufEvents.LinkLeaveEvent.newBuilder().setTime(42.0).
 				setLinkId(ProtobufEvents.LinkId.newBuilder().setId("link123")).setVehId(ProtobufEvents.VehicleId.newBuilder().setId("K.I.T.T."));
 
-		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().setType(ProtobufEvents.Event.Type.LinkLeave).
+		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().
 				setLinkLeave(le).build();
 
 		Event e = ProtoEvent2Event.getEvent(pe);
@@ -68,7 +68,7 @@ public class ProtoEvent2EventTest {
 		ProtobufEvents.ActivityEndEvent.Builder le = ProtobufEvents.ActivityEndEvent.newBuilder().setTime(42.0).
 				setLinkId(ProtobufEvents.LinkId.newBuilder().setId("link123")).setPersId(ProtobufEvents.PersonId.newBuilder().setId("Bob"));
 
-		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().setType(ProtobufEvents.Event.Type.ActivityEnd).
+		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().
 				setActEnd(le).build();
 
 		Event e = ProtoEvent2Event.getEvent(pe);
@@ -83,7 +83,7 @@ public class ProtoEvent2EventTest {
 		ProtobufEvents.ActivityStartEvent.Builder le = ProtobufEvents.ActivityStartEvent.newBuilder().setTime(42.0).
 				setLinkId(ProtobufEvents.LinkId.newBuilder().setId("link123")).setPersId(ProtobufEvents.PersonId.newBuilder().setId("Bob"));
 
-		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().setType(ProtobufEvents.Event.Type.ActivityStart).
+		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().
 				setActStart(le).build();
 
 		Event e = ProtoEvent2Event.getEvent(pe);
@@ -99,7 +99,7 @@ public class ProtoEvent2EventTest {
 				setLinkId(ProtobufEvents.LinkId.newBuilder().setId("link123")).setPersId(ProtobufEvents.PersonId.newBuilder().
 				setId("Bob")).setLegMode("crawling");
 
-		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().setType(ProtobufEvents.Event.Type.PersonArrival).
+		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().
 				setPersonArrival(le).build();
 
 		Event e = ProtoEvent2Event.getEvent(pe);
@@ -116,7 +116,7 @@ public class ProtoEvent2EventTest {
 				setLinkId(ProtobufEvents.LinkId.newBuilder().setId("link123")).setPersId(ProtobufEvents.PersonId.newBuilder().
 				setId("Alice")).setLegMode("crawling");
 
-		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().setType(ProtobufEvents.Event.Type.PersonDeparture).
+		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().
 				setPersonDeparture(le).build();
 
 		Event e = ProtoEvent2Event.getEvent(pe);
@@ -132,7 +132,7 @@ public class ProtoEvent2EventTest {
 		ProtobufEvents.PersonEntersVehicleEvent.Builder le = ProtobufEvents.PersonEntersVehicleEvent.newBuilder().setTime(42.0).
 				setPersId(ProtobufEvents.PersonId.newBuilder().setId("Alice")).setVehId(ProtobufEvents.VehicleId.newBuilder().setId("K.I.T.T."));
 
-		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().setType(ProtobufEvents.Event.Type.PersonEntersVehicle).
+		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().
 				setPersonEntersVehicle(le).build();
 
 		Event e = ProtoEvent2Event.getEvent(pe);
@@ -147,7 +147,7 @@ public class ProtoEvent2EventTest {
 		ProtobufEvents.PersonLeavesVehicleEvent.Builder le = ProtobufEvents.PersonLeavesVehicleEvent.newBuilder().setTime(42.0).
 				setPersId(ProtobufEvents.PersonId.newBuilder().setId("Alice")).setVehId(ProtobufEvents.VehicleId.newBuilder().setId("K.I.T.T."));
 
-		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().setType(ProtobufEvents.Event.Type.PersonLeavesVehicle).
+		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().
 				setPersonLeavesVehicle(le).build();
 
 		Event e = ProtoEvent2Event.getEvent(pe);
@@ -162,7 +162,7 @@ public class ProtoEvent2EventTest {
 		ProtobufEvents.PersonMoneyEvent.Builder le = ProtobufEvents.PersonMoneyEvent.newBuilder().setTime(42.0).
 				setPersId(ProtobufEvents.PersonId.newBuilder().setId("Alice")).setAmount(-123.45);
 
-		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().setType(ProtobufEvents.Event.Type.PersonMoney).
+		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().
 				setPersonMoney(le).build();
 
 		Event e = ProtoEvent2Event.getEvent(pe);
@@ -179,7 +179,7 @@ public class ProtoEvent2EventTest {
 				setLegMode("flying");
 
 
-		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().setType(ProtobufEvents.Event.Type.PersonStuck).
+		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().
 				setPersonStuck(le).build();
 
 		Event e = ProtoEvent2Event.getEvent(pe);
@@ -199,7 +199,7 @@ public class ProtoEvent2EventTest {
 				setDepartureId(ProtobufEvents.DepartureId.newBuilder().setId("d11"));
 
 
-		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().setType(ProtobufEvents.Event.Type.TransitDriverStarts).
+		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().
 				setTransitDriverStarts(le).build();
 
 		Event e = ProtoEvent2Event.getEvent(pe);
@@ -219,7 +219,7 @@ public class ProtoEvent2EventTest {
 				setLinkId(ProtobufEvents.LinkId.newBuilder().setId("link123"));
 
 
-		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().setType(ProtobufEvents.Event.Type.VehicleAborts).
+		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().
 				setVehicleAborts(le).build();
 
 		Event e = ProtoEvent2Event.getEvent(pe);
@@ -237,7 +237,7 @@ public class ProtoEvent2EventTest {
 				setNetworkMode("super pursuit").setRelPosOnLink(3.1415);
 
 
-		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().setType(ProtobufEvents.Event.Type.VehicleEntersTraffic).
+		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().
 				setVehicleEntersTraffic(le).build();
 
 		Event e = ProtoEvent2Event.getEvent(pe);
@@ -258,7 +258,7 @@ public class ProtoEvent2EventTest {
 				setNetworkMode("super pursuit").setRelPosOnLink(3.1415);
 
 
-		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().setType(ProtobufEvents.Event.Type.VehicleLeavesTraffic).
+		ProtobufEvents.Event pe = ProtobufEvents.Event.newBuilder().
 				setVehicleLeavesTraffic(le).build();
 
 		Event e = ProtoEvent2Event.getEvent(pe);


### PR DESCRIPTION
This is what was implemented by hand. The docs
(https://developers.google.com/protocol-buffers/docs/proto#updating)
say:

> Changing a single optional value into a member of a new oneof is safe
> and binary compatible. Moving multiple optional fields into a new oneof
> may be safe if you are sure that no code sets more than one at a time.
> Moving any fields into an existing oneof is not safe.

We are in the second case, so that should be safe.
What surprises me is that the code required adaptations, because
checking which field is set is done differently.

As it was now redundant, I also removed the "type" field. Again, the
docs say

> Non-required fields can be removed, as long as the field number is not
> used again in your updated message type. You may want to rename the
> field instead, perhaps adding the prefix "OBSOLETE_", or make the field
> number reserved, so that future users of your .proto can't accidentally
> reuse the number.

So that should be fine.

I am a bit unsure about what type of compatibility it relates to,
however. They speak of "not breaking existing code", but here the
concern would rather be "being able to ingest old format". I understand
compatibility goes in both directions, but I am not sure.