### PR TITLE
make subpopulation attribute name no longer defineable

### DIFF
--- a/contribs/analysis/src/main/java/org/matsim/contrib/analysis/kai/KNAnalysisEventsHandler.java
+++ b/contribs/analysis/src/main/java/org/matsim/contrib/analysis/kai/KNAnalysisEventsHandler.java
@@ -29,6 +29,7 @@ import org.matsim.api.core.v01.events.handler.*;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.*;
 import org.matsim.contrib.roadpricing.*;
+import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.events.algorithms.Vehicle2DriverEventHandler;
 import org.matsim.core.gbl.Gbl;
@@ -319,11 +320,11 @@ public class KNAnalysisEventsHandler implements PersonDepartureEventHandler, Per
 	}
 
 	private String getSubpopName(Person person) {
-		return "yy_" + getSubpopName( person, this.scenario.getConfig().plans().getSubpopulationAttributeName() ) ;
+		return "yy_" + getSubpopName( person, this.scenario.getConfig() ) ;
 	}
-	private String getSubpopName( Person person, String subpopAttrName ) {
+	private String getSubpopName( Person person, Config config ) {
 //		String subpop = (String) personAttributes.getAttribute( personId.toString(), subpopAttrName ) ;
-		String subpop = (String) PopulationUtils.getPersonAttribute( person, subpopAttrName) ;
+		String subpop = PopulationUtils.getSubpopulation(person,  config );
 		return "subpop_" + subpop;
 	}
 

--- a/contribs/analysis/src/main/java/org/matsim/contrib/analysis/kai/KNAnalysisEventsHandler.java
+++ b/contribs/analysis/src/main/java/org/matsim/contrib/analysis/kai/KNAnalysisEventsHandler.java
@@ -324,7 +324,7 @@ public class KNAnalysisEventsHandler implements PersonDepartureEventHandler, Per
 	}
 	private String getSubpopName( Person person, Config config ) {
 //		String subpop = (String) personAttributes.getAttribute( personId.toString(), subpopAttrName ) ;
-		String subpop = PopulationUtils.getSubpopulation(person,  config );
+		String subpop = PopulationUtils.getSubpopulation(person );
 		return "subpop_" + subpop;
 	}
 

--- a/contribs/commercialTrafficApplications/src/test/resources/config.xml
+++ b/contribs/commercialTrafficApplications/src/test/resources/config.xml
@@ -344,7 +344,7 @@
         <!-- (not tested) will remove plan attributes that are presumably not used, such as activityStartTime. default=false. Use with Caution! -->
         <param name="removingUnnecessaryPlanAttributes" value="false"/>
         <!-- Name of the (Object)Attribute defining the subpopulation to which pertains a Person (as freight, through traffic, etc.). The attribute must be of String type.  Change away from default only in desperate situations. -->
-        <param name="subpopulationAttributeName" value="subpopulation"/>
+<!--        <param name="subpopulationAttributeName" value="subpopulation"/>-->
     </module>
     <module name="planscalcroute">
         <!-- All the modes for which the router is supposed to generate network routes (like car) -->

--- a/contribs/signals/examples/tutorial/example90TrafficLights/useSignalInput/withLanes/config.xml
+++ b/contribs/signals/examples/tutorial/example90TrafficLights/useSignalInput/withLanes/config.xml
@@ -419,7 +419,7 @@
 		<param name="removingUnnecessaryPlanAttributes" value="false" />
 
 		<!-- Name of the (Object)Attribute defining the subpopulation to which pertains a Person (as freight, through traffic, etc.). The attribute must be of String type.  Change away from default only in desperate situations. -->
-		<param name="subpopulationAttributeName" value="subpopulation" />
+<!--		<param name="subpopulationAttributeName" value="subpopulation" />-->
 	</module>
 
 <!-- ====================================================================== -->

--- a/contribs/signals/examples/tutorial/example90TrafficLights/useSignalInput/woLanes/config.xml
+++ b/contribs/signals/examples/tutorial/example90TrafficLights/useSignalInput/woLanes/config.xml
@@ -419,7 +419,7 @@
 		<param name="removingUnnecessaryPlanAttributes" value="false" />
 
 		<!-- Name of the (Object)Attribute defining the subpopulation to which pertains a Person (as freight, through traffic, etc.). The attribute must be of String type.  Change away from default only in desperate situations. -->
-		<param name="subpopulationAttributeName" value="subpopulation" />
+<!--		<param name="subpopulationAttributeName" value="subpopulation" />-->
 	</module>
 
 <!-- ====================================================================== -->

--- a/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/framework/replanning/GroupStrategyManager.java
+++ b/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/framework/replanning/GroupStrategyManager.java
@@ -34,7 +34,6 @@ import org.matsim.api.core.v01.population.Population;
 import org.matsim.core.gbl.MatsimRandom;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.replanning.ReplanningContext;
-import org.matsim.utils.objectattributes.ObjectAttributes;
 
 import org.matsim.core.utils.collections.MapUtils;
 import org.matsim.contrib.socnetsim.framework.population.JointPlans;
@@ -119,14 +118,11 @@ public class GroupStrategyManager {
 	private static String identifySubpopulation(
 			final ReplanningGroup g,
 			final Scenario sc) {
-		final String attName = sc.getConfig().plans().getSubpopulationAttributeName();
-//		final ObjectAttributes atts = sc.getPopulation().getPersonAttributes();
 
 		String name = null;
 
 		for ( Person p : g.getPersons() ) {
-//			final String persSubPop = (String) atts.getAttribute( p.getId().toString() , attName );
-			final String persSubPop = (String) PopulationUtils.getPersonAttribute( p, attName );
+			final String persSubPop = PopulationUtils.getSubpopulation( p, sc.getConfig() );
 			if ( persSubPop == null && name != null ) throw new RuntimeException( "inconsistent subpopulations in group "+g );
 			if ( name != null && !name.equals( persSubPop ) ) throw new RuntimeException( "inconsistent subpopulations in group "+g );
 			name = persSubPop;

--- a/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/framework/replanning/GroupStrategyManager.java
+++ b/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/framework/replanning/GroupStrategyManager.java
@@ -122,7 +122,7 @@ public class GroupStrategyManager {
 		String name = null;
 
 		for ( Person p : g.getPersons() ) {
-			final String persSubPop = PopulationUtils.getSubpopulation( p, sc.getConfig() );
+			final String persSubPop = PopulationUtils.getSubpopulation( p );
 			if ( persSubPop == null && name != null ) throw new RuntimeException( "inconsistent subpopulations in group "+g );
 			if ( name != null && !name.equals( persSubPop ) ) throw new RuntimeException( "inconsistent subpopulations in group "+g );
 			name = persSubPop;

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptor.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptor.java
@@ -11,6 +11,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.Person;
+import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.utils.geometry.CoordUtils;
 import org.matsim.facilities.Facility;
 import org.matsim.pt.router.TransitRouter;
@@ -38,26 +39,25 @@ public class SwissRailRaptor implements TransitRouter {
     private final RaptorParametersForPerson parametersForPerson;
     private final RaptorRouteSelector defaultRouteSelector;
     private final RaptorStopFinder stopFinder;
-    private final String subpopulationAttribute;
+//    private final String subpopulationAttribute;
 
     private boolean treeWarningShown = false;
 
-    public SwissRailRaptor(final SwissRailRaptorData data, RaptorParametersForPerson parametersForPerson,
-                           RaptorRouteSelector routeSelector, RaptorStopFinder stopFinder) {
-        this(data, parametersForPerson, routeSelector, stopFinder, null );
-        log.info("SwissRailRaptor was initialized without support for subpopulations or intermodal access/egress legs.");
-    }
+//    public SwissRailRaptor(final SwissRailRaptorData data, RaptorParametersForPerson parametersForPerson,
+//                           RaptorRouteSelector routeSelector, RaptorStopFinder stopFinder) {
+//        this(data, parametersForPerson, routeSelector, stopFinder );
+//        log.info("SwissRailRaptor was initialized without support for subpopulations or intermodal access/egress legs.");
+//    }
 
     public SwissRailRaptor( final SwissRailRaptorData data, RaptorParametersForPerson parametersForPerson,
-				    RaptorRouteSelector routeSelector,
-				    RaptorStopFinder stopFinder,
-				    String subpopulationAttribute ) {
+                            RaptorRouteSelector routeSelector,
+                            RaptorStopFinder stopFinder ) {
         this.data = data;
         this.raptor = new SwissRailRaptorCore(data);
         this.parametersForPerson = parametersForPerson;
         this.defaultRouteSelector = routeSelector;
         this.stopFinder = stopFinder;
-        this.subpopulationAttribute = subpopulationAttribute;
+//        this.subpopulationAttribute = subpopulationAttribute;
     }
 
     @Override
@@ -131,8 +131,9 @@ public class SwissRailRaptor implements TransitRouter {
         SwissRailRaptorConfigGroup srrConfig = parameters.getConfig();
 
 //        Object attr = this.personAttributes.getAttribute(person.getId().toString(), this.subpopulationAttribute);
-	    Object attr = person.getAttributes().getAttribute( this.subpopulationAttribute ) ;
-        String subpopulation = attr == null ? null : attr.toString();
+//	    Object attr = person.getAttributes().getAttribute( this.subpopulationAttribute ) ;
+//        String subpopulation = attr == null ? null : attr.toString();
+                String subpopulation = PopulationUtils.getSubpopulation( person );
         SwissRailRaptorConfigGroup.RangeQuerySettingsParameterSet rangeSettings = srrConfig.getRangeQuerySettings(subpopulation);
 
         double earliestDepartureTime = desiredDepartureTime - rangeSettings.getMaxEarlierDeparture();

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorFactory.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorFactory.java
@@ -28,20 +28,20 @@ public class SwissRailRaptorFactory implements Provider<SwissRailRaptor> {
     private final RaptorRouteSelector routeSelector;
     private final Provider<RaptorStopFinder> stopFinderProvider;
     private final Network network;
-    private final PlansConfigGroup plansConfigGroup;
+//    private final PlansConfigGroup plansConfigGroup;
 
     @Inject
-    public SwissRailRaptorFactory(final TransitSchedule schedule, final Config config, final Network network,
-                                  RaptorParametersForPerson raptorParametersForPerson, RaptorRouteSelector routeSelector,
-                                  Provider<RaptorStopFinder> stopFinderProvider, PlansConfigGroup plansConfigGroup,
-                                  final EventsManager events) {
+    public SwissRailRaptorFactory( final TransitSchedule schedule, final Config config, final Network network,
+                                   RaptorParametersForPerson raptorParametersForPerson, RaptorRouteSelector routeSelector,
+                                   Provider<RaptorStopFinder> stopFinderProvider,
+                                   final EventsManager events ) {
         this.schedule = schedule;
         this.raptorConfig = RaptorUtils.createStaticConfig(config);
         this.network = network;
         this.raptorParametersForPerson = raptorParametersForPerson;
         this.routeSelector = routeSelector;
         this.stopFinderProvider = stopFinderProvider;
-        this.plansConfigGroup = plansConfigGroup;
+//        this.plansConfigGroup = plansConfigGroup;
 
         if (events != null) {
             events.addHandler((TransitScheduleChangedEventHandler) event -> this.data = null);
@@ -51,8 +51,7 @@ public class SwissRailRaptorFactory implements Provider<SwissRailRaptor> {
     @Override
     public SwissRailRaptor get() {
         SwissRailRaptorData data = getData();
-        return new SwissRailRaptor(data, this.raptorParametersForPerson, this.routeSelector, this.stopFinderProvider.get(),
-                this.plansConfigGroup.getSubpopulationAttributeName());
+        return new SwissRailRaptor(data, this.raptorParametersForPerson, this.routeSelector, this.stopFinderProvider.get() );
     }
 
     private SwissRailRaptorData getData() {

--- a/matsim/src/main/java/org/matsim/api/core/v01/population/HasPlansAndId.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/population/HasPlansAndId.java
@@ -26,7 +26,7 @@ import java.util.List;
 import org.matsim.api.core.v01.Identifiable;
 import org.matsim.utils.objectattributes.attributable.Attributable;
 
-public interface HasPlansAndId<T extends BasicPlan, I> extends Identifiable<I> /*, Attributable*/ {
+public interface HasPlansAndId<T extends BasicPlan, I> extends Identifiable<I>, Attributable {
 
 	// I added "Attributable".  Does not feel like it keeps the interface minimal.  However, the subpopulation attribute comes from it, which is used
 	// rather centrally in the StrategyManager stuff, which is the place for which this interface exists.  Also so far wasn't totally systematic there

--- a/matsim/src/main/java/org/matsim/core/config/groups/PlansConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/PlansConfigGroup.java
@@ -42,13 +42,13 @@ public final class PlansConfigGroup extends ReflectiveConfigGroup {
 	private static final String INPUT_FILE = "inputPlansFile";
 	private static final String INPUT_PERSON_ATTRIBUTES_FILE = "inputPersonAttributesFile";
 	private static final String NETWORK_ROUTE_TYPE = "networkRouteType";
-	private static final String SUBPOPULATION_ATTRIBUTE = "subpopulationAttributeName";
+//	private static final String SUBPOPULATION_ATTRIBUTE = "subpopulationAttributeName";
 	private static final String INPUT_CRS = "inputCRS";
 
 	private String inputFile = null;
 	private String networkRouteType = NetworkRouteType.LinkNetworkRoute;
 	private String inputPersonAttributeFile = null;
-	private String subpopulationAttributeName = "subpopulation";
+//	private String subpopulationAttributeName = "subpopulation";
 	private String inputCRS = null;
 	
 	//--
@@ -73,10 +73,10 @@ public final class PlansConfigGroup extends ReflectiveConfigGroup {
 //		comments.put(
 //				INPUT_PERSON_ATTRIBUTES_FILE,
 //				"Path to a file containing person attributes (required file format: ObjectAttributes).");
-		comments.put(
-				SUBPOPULATION_ATTRIBUTE,
-				"Name of the (Object)Attribute defining the subpopulation to which pertains a Person"+
-				" (as freight, through traffic, etc.). The attribute must be of String type.  Change away from default only in desperate situations." );
+//		comments.put(
+//				SUBPOPULATION_ATTRIBUTE,
+//				"Name of the (Object)Attribute defining the subpopulation to which pertains a Person"+
+//				" (as freight, through traffic, etc.). The attribute must be of String type.  Change away from default only in desperate situations." );
 
 		StringBuilder str = new StringBuilder() ;
 		for ( PlansConfigGroup.ActivityDurationInterpretation itp : PlansConfigGroup.ActivityDurationInterpretation.values() ) {
@@ -134,7 +134,7 @@ public final class PlansConfigGroup extends ReflectiveConfigGroup {
 	}
 	
 	@StringGetter( INPUT_PERSON_ATTRIBUTES_FILE )
-	@Deprecated // I think that this should be phased out; use Attributes inside each facility.  kai, mar'19
+	@Deprecated // this should be phased out; use Attributes inside each person.  kai, mar'19
 	public String getInputPersonAttributeFile() {
 		return this.inputPersonAttributeFile;
 	}
@@ -143,12 +143,12 @@ public final class PlansConfigGroup extends ReflectiveConfigGroup {
 						 "insistingOnUsingDeprecatedPersonAttributeFile to true.  The file will then be read, but the values " +
 						 "will be entered into each person using Attributable, and written as such to output_plans.  kai, may'19";
 	@StringSetter( INPUT_PERSON_ATTRIBUTES_FILE )
-	@Deprecated // I think that this should be phased out; use Attributes inside each facility.  kai, mar'19
+	@Deprecated // this should be phased out; use Attributes inside each person.  kai, mar'19
 	public void setInputPersonAttributeFile(final String inputPersonAttributeFile) {
 		this.inputPersonAttributeFile = inputPersonAttributeFile;
 	}
 
-	@Deprecated // I think that this should be phased out; use Attributes inside each facility.  kai, mar'19
+	@Deprecated // this should be phased out; use Attributes inside each person.  kai, mar'19
 	public URL getInputPersonAttributeFileURL(URL context) {
 		return ConfigGroup.getInputFileURL(context, this.inputPersonAttributeFile);
 	}
@@ -163,22 +163,22 @@ public final class PlansConfigGroup extends ReflectiveConfigGroup {
 		this.networkRouteType = routeType;
 	}
 	// ---
-	/**
-	 * @deprecated -- use {@link org.matsim.core.population.PopulationUtils#getSubpopulation(Person, Config)}
-	 */
-	@Deprecated
-	@StringGetter( SUBPOPULATION_ATTRIBUTE )
-	public String getSubpopulationAttributeName() {
-		return subpopulationAttributeName;
-	}
-	/**
-	 * @deprecated -- do not set away from default
-	 */
-	@Deprecated
-	@StringSetter( SUBPOPULATION_ATTRIBUTE )
-	public void setSubpopulationAttributeName(String subpopulationAttributeName) {
-		this.subpopulationAttributeName = subpopulationAttributeName;
-	}
+//	/**
+//	 * @deprecated -- use {@link org.matsim.core.population.PopulationUtils#getSubpopulation(Person, Config)}
+//	 */
+//	@Deprecated
+//	@StringGetter( SUBPOPULATION_ATTRIBUTE )
+//	public String getSubpopulationAttributeName() {
+//		return subpopulationAttributeName;
+//	}
+//	/**
+//	 * @deprecated -- do not set away from default
+//	 */
+//	@Deprecated
+//	@StringSetter( SUBPOPULATION_ATTRIBUTE )
+//	public void setSubpopulationAttributeName(String subpopulationAttributeName) {
+//		this.subpopulationAttributeName = subpopulationAttributeName;
+//	}
 	// ---
 	@StringGetter(ACTIVITY_DURATION_INTERPRETATION)
 	public PlansConfigGroup.ActivityDurationInterpretation getActivityDurationInterpretation() {

--- a/matsim/src/main/java/org/matsim/core/config/groups/PlansConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/PlansConfigGroup.java
@@ -21,6 +21,8 @@
 package org.matsim.core.config.groups;
 
 import org.apache.log4j.Logger;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ReflectiveConfigGroup;
 
@@ -160,17 +162,24 @@ public final class PlansConfigGroup extends ReflectiveConfigGroup {
 	public void setNetworkRouteType(final String routeType) {
 		this.networkRouteType = routeType;
 	}
-
+	// ---
+	/**
+	 * @deprecated -- use {@link org.matsim.core.population.PopulationUtils#getSubpopulation(Person, Config)}
+	 */
+	@Deprecated
 	@StringGetter( SUBPOPULATION_ATTRIBUTE )
 	public String getSubpopulationAttributeName() {
 		return subpopulationAttributeName;
 	}
-
+	/**
+	 * @deprecated -- do not set away from default
+	 */
+	@Deprecated
 	@StringSetter( SUBPOPULATION_ATTRIBUTE )
 	public void setSubpopulationAttributeName(String subpopulationAttributeName) {
 		this.subpopulationAttributeName = subpopulationAttributeName;
 	}
-	
+	// ---
 	@StringGetter(ACTIVITY_DURATION_INTERPRETATION)
 	public PlansConfigGroup.ActivityDurationInterpretation getActivityDurationInterpretation() {
 		return this.activityDurationInterpretation ;

--- a/matsim/src/main/java/org/matsim/core/population/PopulationUtils.java
+++ b/matsim/src/main/java/org/matsim/core/population/PopulationUtils.java
@@ -1111,4 +1111,7 @@ public final class PopulationUtils {
 		person.getAttributes().clear();
 	}
 
+        public static String getSubpopulation( Person p, Config config ){
+		return (String) getPersonAttribute( p, config.plans().getSubpopulationAttributeName() );
+        }
 }

--- a/matsim/src/main/java/org/matsim/core/population/PopulationUtils.java
+++ b/matsim/src/main/java/org/matsim/core/population/PopulationUtils.java
@@ -72,6 +72,9 @@ public final class PopulationUtils {
 	private static final PopulationFactory populationFactory = createPopulation( new PlansConfigGroup(), null  ).getFactory() ;
 	// try to avoid misleading comment about config context.  kai, dec'18
 
+	private static final String SUBPOPULATION_ATTRIBUTE_NAME = "subpopulation";
+
+
 	/**
 	 * Is a namespace, so don't instantiate:
 	 */
@@ -1099,7 +1102,7 @@ public final class PopulationUtils {
 		}
 		return null;
 	}
-	public static void putPersonAttribute( Person person, String key, Object value ) {
+	public static void putPersonAttribute( HasPlansAndId<?,?> person, String key, Object value ) {
 		person.getAttributes().putAttribute( key, value ) ;
 	}
 	public static Object removePersonAttribute( Person person, String key ) {
@@ -1111,7 +1114,10 @@ public final class PopulationUtils {
 		person.getAttributes().clear();
 	}
 
-        public static String getSubpopulation( Person p, Config config ){
-		return (String) getPersonAttribute( p, config.plans().getSubpopulationAttributeName() );
+        public static String getSubpopulation( HasPlansAndId<?,?> person ){
+		return (String) getPersonAttribute( person, SUBPOPULATION_ATTRIBUTE_NAME );
         }
+        public static void putSubpopulation( HasPlansAndId<?,?> person, String subpopulation ) {
+		putPersonAttribute( person, SUBPOPULATION_ATTRIBUTE_NAME, subpopulation );
+	}
 }

--- a/matsim/src/main/java/org/matsim/core/population/algorithms/TripPlanMutateTimeAllocation.java
+++ b/matsim/src/main/java/org/matsim/core/population/algorithms/TripPlanMutateTimeAllocation.java
@@ -44,22 +44,22 @@ public final class TripPlanMutateTimeAllocation implements PlanAlgorithm {
 	private final Random random;
 	private boolean useActivityDurations = true;
 	private final boolean affectingDuration;
-	private final String subpopulationAttribute;
+//	private final String subpopulationAttribute;
 	private final Map<String, Double> subpopulationMutationRanges;
 	private final Map<String, Boolean> subpopulationAffectingDuration;
 
 	public TripPlanMutateTimeAllocation(final double mutationRange,
 			final boolean affectingDuration, final Random random) {
-		this(mutationRange, affectingDuration, random, null, null, null);
+		this(mutationRange, affectingDuration, random, null, null );
 	}
 
-	public TripPlanMutateTimeAllocation(final double mutationRange, 
-			final boolean affectingDuration, final Random random, final String subpopulationAttribute,
-			final Map<String, Double> subpopulationMutationRanges, final Map<String, Boolean> subpopulationAffectingDuration) {
+	public TripPlanMutateTimeAllocation( final double mutationRange,
+					     final boolean affectingDuration, final Random random,
+					     final Map<String, Double> subpopulationMutationRanges, final Map<String, Boolean> subpopulationAffectingDuration ) {
 		this.mutationRange = mutationRange;
 		this.affectingDuration = affectingDuration;
 		this.random = random;
-		this.subpopulationAttribute = subpopulationAttribute;
+//		this.subpopulationAttribute = subpopulationAttribute;
 		this.subpopulationMutationRanges = subpopulationMutationRanges;
 		this.subpopulationAffectingDuration = subpopulationAffectingDuration;
 	}
@@ -180,9 +180,10 @@ public final class TripPlanMutateTimeAllocation implements PlanAlgorithm {
 	}
 	
 	private final String getSubpopulation(final Plan plan) {
-		if (this.subpopulationAttribute == null) return null;
+//		if (this.subpopulationAttribute == null) return null;
 		if (plan.getPerson() == null) return null;
-		return (String) PopulationUtils.getPersonAttribute(plan.getPerson(), this.subpopulationAttribute);
+//		return (String) PopulationUtils.getPersonAttribute(plan.getPerson(), this.subpopulationAttribute);
+		return PopulationUtils.getSubpopulation( plan.getPerson() );
 	}
 	
 	private final boolean isAffectingDuration(final String subpopulation) {

--- a/matsim/src/main/java/org/matsim/core/replanning/GenericStrategyManager.java
+++ b/matsim/src/main/java/org/matsim/core/replanning/GenericStrategyManager.java
@@ -72,18 +72,18 @@ public class GenericStrategyManager<PL extends BasicPlan, AG extends HasPlansAnd
 
 	private PlanSelector<PL, AG> removalPlanSelector = new GenericWorstPlanForRemovalSelector<>();
 
-	private String subpopulationAttributeName = null;
+//	private String subpopulationAttributeName = null;
 	
 	public GenericStrategyManager() {
 	}
 
-	/**
-	 * @param name the name of the subpopulation attribute
-	 * in the person's object attributes.
-	 */
-	public final void setSubpopulationAttributeName(final String name) {
-		this.subpopulationAttributeName = name;
-	}
+//	/**
+//	 * @param name the name of the subpopulation attribute
+//	 * in the person's object attributes.
+//	 */
+//	public final void setSubpopulationAttributeName(final String name) {
+//		this.subpopulationAttributeName = name;
+//	}
 
 	/**
 	 * Adds a strategy to this manager with the specified weight. This weight
@@ -203,10 +203,11 @@ public class GenericStrategyManager<PL extends BasicPlan, AG extends HasPlansAnd
 			}
 
 			// ... choose the strategy to be used for this person (in evol comp lang this would be the choice of the mutation operator)
-			String subpopName = null;
-			if (this.subpopulationAttributeName != null) {
-				subpopName = (String) PopulationUtils.getPersonAttribute( person, this.subpopulationAttributeName) ;
-			}
+//			String subpopName = null;
+//			if (this.subpopulationAttributeName != null) {
+//				subpopName = (String) PopulationUtils.getPersonAttribute( person, this.subpopulationAttributeName) ;
+//			}
+			String subpopName = PopulationUtils.getSubpopulation( person );
 			GenericPlanStrategy<PL, AG> strategy = this.chooseStrategy(person, subpopName);
 
 			if (strategy==null) {

--- a/matsim/src/main/java/org/matsim/core/replanning/StrategyManager.java
+++ b/matsim/src/main/java/org/matsim/core/replanning/StrategyManager.java
@@ -61,7 +61,7 @@ public class StrategyManager implements MatsimManager {
 				* strategyConfigGroup.getFractionOfIterationsToDisableInnovation() + controlerConfigGroup.getFirstIteration());
 		log.info("global innovation switch off after iteration: " + globalInnovationDisableAfter);
 
-		setSubpopulationAttributeName(plansConfigGroup.getSubpopulationAttributeName());
+//		setSubpopulationAttributeName(plansConfigGroup.getSubpopulationAttributeName());
 		for (Map.Entry<StrategyConfigGroup.StrategySettings, PlanStrategy> entry : planStrategies.entrySet()) {
 			PlanStrategy strategy = entry.getValue();
 			StrategyConfigGroup.StrategySettings settings = entry.getKey();
@@ -91,13 +91,13 @@ public class StrategyManager implements MatsimManager {
 		this.delegate = new GenericStrategyManager<>();
 	}
 
-	/**
-	 * @param name the name of the subpopulation attribute
-	 * in the person's object attributes.
-	 */
-	public final void setSubpopulationAttributeName(final String name) {
-		delegate.setSubpopulationAttributeName(name);
-	}
+//	/**
+//	 * @param name the name of the subpopulation attribute
+//	 * in the person's object attributes.
+//	 */
+//	public final void setSubpopulationAttributeName(final String name) {
+//		delegate.setSubpopulationAttributeName(name);
+//	}
 
 	@Deprecated
 	public final void addStrategyForDefaultSubpopulation(

--- a/matsim/src/main/java/org/matsim/core/replanning/strategies/TimeAllocationMutatorModule.java
+++ b/matsim/src/main/java/org/matsim/core/replanning/strategies/TimeAllocationMutatorModule.java
@@ -57,7 +57,7 @@ class TimeAllocationMutatorModule extends AbstractMultithreadedModule{
 	
 	private final double mutationRange;
 	private final boolean affectingDuration;
-	private final String subpopulationAttribute;
+//	private final String subpopulationAttribute;
 	private final Map<String, Double> subpopulationMutationRanges;
 	private final Map<String, Boolean> subpopulationAffectingDuration;
 	private final PlansConfigGroup.ActivityDurationInterpretation activityDurationInterpretation;
@@ -72,7 +72,7 @@ class TimeAllocationMutatorModule extends AbstractMultithreadedModule{
 		this.affectingDuration = affectingDuration;
 		this.mutationRange = mutationRange;
 		this.activityDurationInterpretation = (config.plans().getActivityDurationInterpretation());
-		this.subpopulationAttribute = null;
+//		this.subpopulationAttribute = null;
 		this.subpopulationMutationRanges = null;
 		this.subpopulationAffectingDuration = null;
 		log.warn("deprecated constructor was used - individual time allocation mutator settings for subpopulations is not supported!");
@@ -90,8 +90,10 @@ class TimeAllocationMutatorModule extends AbstractMultithreadedModule{
 		this.affectingDuration = timeAllocationMutatorConfigGroup.isAffectingDuration();
 		
 		// in case we have subpopulations and individual settings for them
-		if (plansConfigGroup.getSubpopulationAttributeName() != null && timeAllocationMutatorConfigGroup.isUseIndividualSettingsForSubpopulations() && population != null) {
-			this.subpopulationAttribute = plansConfigGroup.getSubpopulationAttributeName();
+		if (
+//				plansConfigGroup.getSubpopulationAttributeName() != null &&
+				timeAllocationMutatorConfigGroup.isUseIndividualSettingsForSubpopulations() && population != null) {
+//			this.subpopulationAttribute = plansConfigGroup.getSubpopulationAttributeName();
 			this.subpopulationMutationRanges = new HashMap<>();
 			this.subpopulationAffectingDuration = new HashMap<>();
 
@@ -104,7 +106,7 @@ class TimeAllocationMutatorModule extends AbstractMultithreadedModule{
 				log.info("Found individual time mutator settings for subpopulation: " + subpopulation);
 			}
 		} else {
-			this.subpopulationAttribute = null;
+//			this.subpopulationAttribute = null;
 			this.subpopulationMutationRanges = null;
 			this.subpopulationAffectingDuration = null;
 		}
@@ -116,7 +118,7 @@ class TimeAllocationMutatorModule extends AbstractMultithreadedModule{
 		switch (this.activityDurationInterpretation) {
 		case minOfDurationAndEndTime:
 			pmta = new TripPlanMutateTimeAllocation(this.mutationRange, this.affectingDuration, MatsimRandom.getLocalInstance(),
-					this.subpopulationAttribute, this.subpopulationMutationRanges, this.subpopulationAffectingDuration);
+					this.subpopulationMutationRanges, this.subpopulationAffectingDuration);
 			break;
 		default:
 			if(this.affectingDuration) log.warn("Please be aware that durations of activities now can mutate freely and possibly become negative." +

--- a/matsim/src/main/java/org/matsim/core/scoring/functions/ScoringParameters.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/functions/ScoringParameters.java
@@ -101,7 +101,7 @@ public class ScoringParameters implements MatsimParameters {
 				final Person person ) {
 			this(
 					scenario.getConfig().planCalcScore(),
-					scenario.getConfig().planCalcScore().getScoringParameters( PopulationUtils.getSubpopulation( person, scenario.getConfig() ) ),
+					scenario.getConfig().planCalcScore().getScoringParameters( PopulationUtils.getSubpopulation( person ) ),
 					scenario.getConfig().scenario() );
 		}
 

--- a/matsim/src/main/java/org/matsim/core/scoring/functions/ScoringParameters.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/functions/ScoringParameters.java
@@ -101,11 +101,7 @@ public class ScoringParameters implements MatsimParameters {
 				final Person person ) {
 			this(
 					scenario.getConfig().planCalcScore(),
-					scenario.getConfig().planCalcScore().getScoringParameters(
-							(String)
-									PopulationUtils.getPersonAttribute(
-										  person, scenario.getConfig().plans().getSubpopulationAttributeName()
-														    ) ),
+					scenario.getConfig().planCalcScore().getScoringParameters( PopulationUtils.getSubpopulation( person, scenario.getConfig() ) ),
 					scenario.getConfig().scenario() );
 		}
 

--- a/matsim/src/main/java/org/matsim/core/scoring/functions/SubpopulationScoringParameters.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/functions/SubpopulationScoringParameters.java
@@ -39,7 +39,7 @@ public class SubpopulationScoringParameters implements ScoringParametersForPerso
 	private final PlanCalcScoreConfigGroup config;
 	private final ScenarioConfigGroup scConfig;
 	private final TransitConfigGroup transitConfigGroup;
-	private final String subpopulationAttributeName;
+//	private final String subpopulationAttributeName;
 	private final Map<String, ScoringParameters> params = new HashMap<>();
 	private final Population population;
 
@@ -48,7 +48,7 @@ public class SubpopulationScoringParameters implements ScoringParametersForPerso
 		this.config = planCalcScoreConfigGroup;
 		this.scConfig = scenarioConfigGroup;
 		this.transitConfigGroup = transitConfigGroup;
-		this.subpopulationAttributeName = plansConfigGroup.getSubpopulationAttributeName();
+//		this.subpopulationAttributeName = plansConfigGroup.getSubpopulationAttributeName();
 		this.population = population ;
 	}
 
@@ -58,7 +58,8 @@ public class SubpopulationScoringParameters implements ScoringParametersForPerso
 
 	@Override
 	public ScoringParameters getScoringParameters(Person person) {
-		final String subpopulation = (String) PopulationUtils.getPersonAttribute( person, subpopulationAttributeName) ;
+//		final String subpopulation = (String) PopulationUtils.getPersonAttribute( person, subpopulationAttributeName) ;
+		final String subpopulation = PopulationUtils.getSubpopulation( person );
 
 		if (!this.params.containsKey(subpopulation)) {
 			/* lazy initialization of params. not strictly thread safe, as different threads could

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/RaptorStopFinderTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/RaptorStopFinderTest.java
@@ -77,7 +77,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
 
@@ -106,7 +106,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
             for (Leg leg : legs) {
@@ -151,7 +151,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f1.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f1.config), f1.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f1.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f1.dummyPerson);
             for (Leg leg : legs) {
@@ -209,7 +209,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
             
@@ -244,7 +244,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
             for (Leg leg : legs) {
@@ -296,7 +296,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
             for (Leg leg : legs) {
@@ -352,7 +352,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
             for (Leg leg : legs) {
@@ -401,7 +401,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
 
@@ -431,7 +431,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
             for (Leg leg : legs) {
@@ -476,7 +476,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f1.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f1.config), f1.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f1.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f1.dummyPerson);
             for (Leg leg : legs) {
@@ -534,7 +534,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
 
@@ -570,7 +570,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
             for (Leg leg : legs) {
@@ -623,7 +623,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
             for (Leg leg : legs) {
@@ -680,7 +680,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
             for (Leg leg : legs) {
@@ -742,7 +742,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f1.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f1.config), f1.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f1.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f1.dummyPerson);
             for (Leg leg : legs) {
@@ -788,7 +788,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f1.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f1.config), f1.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f1.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f1.dummyPerson);
             for (Leg leg : legs) {
@@ -834,7 +834,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f1.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f1.config), f1.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f1.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f1.dummyPerson);
             for (Leg leg : legs) {
@@ -889,7 +889,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
             for (Leg leg : legs) {
@@ -942,7 +942,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
             for (Leg leg : legs) {
@@ -991,7 +991,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f1.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f1.config), f1.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f1.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f1.dummyPerson);
             for (Leg leg : legs) {
@@ -1038,7 +1038,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f1.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f1.config), f1.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f1.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f1.dummyPerson);
             for (Leg leg : legs) {
@@ -1085,7 +1085,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f1.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f1.config), f1.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f1.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f1.dummyPerson);
             for (Leg leg : legs) {
@@ -1141,7 +1141,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
             for (Leg leg : legs) {
@@ -1195,7 +1195,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
             for (Leg leg : legs) {
@@ -1259,7 +1259,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
             for (Leg leg : legs) {
@@ -1307,7 +1307,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f1.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f1.config), f1.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f1.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f1.dummyPerson);
             for (Leg leg : legs) {
@@ -1366,7 +1366,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
             for (Leg leg : legs) {
@@ -1422,7 +1422,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
             for (Leg leg : legs) {
@@ -1475,7 +1475,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
             for (Leg leg : legs) {
@@ -1524,7 +1524,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f1.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f1.config), f1.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f1.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f1.dummyPerson);
             for (Leg leg : legs) {
@@ -1584,7 +1584,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
             for (Leg leg : legs) {
@@ -1641,7 +1641,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
             for (Leg leg : legs) {
@@ -1715,7 +1715,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
             for (Leg leg : legs) {
@@ -1782,7 +1782,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
             for (Leg leg : legs) {
@@ -1845,7 +1845,7 @@ public class RaptorStopFinderTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f0.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f0.config), f0.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f0.scenario.getConfig()),
-                    new LeastCostRaptorRouteSelector(), stopFinder, null);
+                    new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f0.dummyPerson);
             for (Leg leg : legs) {

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorIntermodalTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorIntermodalTest.java
@@ -76,7 +76,7 @@ public class SwissRailRaptorIntermodalTest {
         SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f.config), f.scenario.getNetwork());
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
         SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-                new LeastCostRaptorRouteSelector(), stopFinder, null );
+                new LeastCostRaptorRouteSelector(), stopFinder );
 
         Facility fromFac = new FakeFacility(new Coord(10000, 10500), Id.create("from", Link.class));
         Facility toFac = new FakeFacility(new Coord(50000, 10500), Id.create("to", Link.class));
@@ -148,7 +148,7 @@ public class SwissRailRaptorIntermodalTest {
         SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f.config), f.scenario.getNetwork());
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
         SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-            new LeastCostRaptorRouteSelector(), stopFinder, null );
+            new LeastCostRaptorRouteSelector(), stopFinder );
 
         RoutingModule ptRoutingModule = new SwissRailRaptorRoutingModule(raptor, f.scenario.getTransitSchedule(), f.scenario.getNetwork(), walkRoutingModule);
         tripRouterBuilder.setRoutingModule(TransportMode.pt, ptRoutingModule);
@@ -215,7 +215,7 @@ public class SwissRailRaptorIntermodalTest {
         SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f.config), f.scenario.getNetwork());
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
         SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-            new LeastCostRaptorRouteSelector(), stopFinder, null );
+            new LeastCostRaptorRouteSelector(), stopFinder );
 
         Facility fromFac = new FakeFacility(new Coord(10000, 10500), Id.create("from", Link.class));
         Facility toFac = new FakeFacility(new Coord(50000, 10500), Id.create("to", Link.class));
@@ -271,7 +271,7 @@ public class SwissRailRaptorIntermodalTest {
         SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f.config), f.scenario.getNetwork());
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
         SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-            new LeastCostRaptorRouteSelector(), stopFinder, null );
+            new LeastCostRaptorRouteSelector(), stopFinder );
 
         Facility fromFac = new FakeFacility(new Coord(10000, 9000), Id.create("from", Link.class));
         Facility toFac = new FakeFacility(new Coord(11000, 11000), Id.create("to", Link.class));
@@ -326,7 +326,7 @@ public class SwissRailRaptorIntermodalTest {
         SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f.config), f.scenario.getNetwork());
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
         SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-                new LeastCostRaptorRouteSelector(), stopFinder, null );
+                new LeastCostRaptorRouteSelector(), stopFinder );
 
         List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson);
         for (Leg leg : legs) {
@@ -344,7 +344,7 @@ public class SwissRailRaptorIntermodalTest {
         data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f.config), f.scenario.getNetwork());
         stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
         raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-                new LeastCostRaptorRouteSelector(), stopFinder, null );
+                new LeastCostRaptorRouteSelector(), stopFinder );
 
         legs = raptor.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson);
         for (Leg leg1 : legs) {
@@ -412,7 +412,7 @@ public class SwissRailRaptorIntermodalTest {
         SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f.config), f.scenario.getNetwork());
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
         SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-                new LeastCostRaptorRouteSelector(), stopFinder, null );
+                new LeastCostRaptorRouteSelector(), stopFinder );
 
         Facility fromFac = new FakeFacility(new Coord(10000, 10500), Id.create("from", Link.class));
         Facility toFac = new FakeFacility(new Coord(10500, 10500), Id.create("to", Link.class));
@@ -469,7 +469,7 @@ public class SwissRailRaptorIntermodalTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f.config), f.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-                new LeastCostRaptorRouteSelector(), stopFinder, null );
+                new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f.dummyPerson);
             for (Leg leg : legs) {
@@ -500,7 +500,7 @@ public class SwissRailRaptorIntermodalTest {
             SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f.config), f.scenario.getNetwork());
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-                new LeastCostRaptorRouteSelector(), stopFinder, null );
+                new LeastCostRaptorRouteSelector(), stopFinder );
 
             List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f.dummyPerson);
             for (Leg leg : legs) {
@@ -577,7 +577,7 @@ public class SwissRailRaptorIntermodalTest {
 
             for (int i = 0; i < 1000; i++) {
                 SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-                        new LeastCostRaptorRouteSelector(), stopFinder, null );
+                        new LeastCostRaptorRouteSelector(), stopFinder );
 
                 List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f.dummyPerson);
 
@@ -641,7 +641,7 @@ public class SwissRailRaptorIntermodalTest {
         SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f.config), f.scenario.getNetwork());
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), f.routingModules);
         SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-                new LeastCostRaptorRouteSelector(), stopFinder, null );
+                new LeastCostRaptorRouteSelector(), stopFinder );
 
         List<Leg> legs = raptor.calcRoute(fromFac, toFac, 8 * 3600 - 900, f.dummyPerson);
         for (Leg leg : legs) {
@@ -697,7 +697,7 @@ public class SwissRailRaptorIntermodalTest {
         SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f.config), f.scenario.getNetwork());
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), f.routingModules);
         SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-            new LeastCostRaptorRouteSelector(), stopFinder, null);
+            new LeastCostRaptorRouteSelector(), stopFinder );
 
         List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7.5 * 3600 + 900, f.dummyPerson);
         for (Leg leg : legs) {
@@ -733,7 +733,7 @@ public class SwissRailRaptorIntermodalTest {
         SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f.config), f.scenario.getNetwork());
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), f.routingModules);
         SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-            new LeastCostRaptorRouteSelector(), stopFinder, null );
+            new LeastCostRaptorRouteSelector(), stopFinder );
 
         List<Leg> legs = raptor.calcRoute(fromFac, toFac, 8 * 3600 - 900, f.dummyPerson);
         for (Leg leg : legs) {
@@ -784,7 +784,7 @@ public class SwissRailRaptorIntermodalTest {
         SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f.config), f.scenario.getNetwork());
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), f.routingModules);
         SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-                new LeastCostRaptorRouteSelector(), stopFinder, null);
+                new LeastCostRaptorRouteSelector(), stopFinder );
 
         List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7.5 * 3600, f.dummyPerson);
 
@@ -818,7 +818,7 @@ public class SwissRailRaptorIntermodalTest {
         SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f.config), f.scenario.getNetwork());
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), f.routingModules);
         SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-                new LeastCostRaptorRouteSelector(), stopFinder, null );
+                new LeastCostRaptorRouteSelector(), stopFinder );
 
         List<Leg> legs = raptor.calcRoute(fromFac, toFac, 8 * 3600 - 900, f.dummyPerson);
         for (Leg leg : legs) {
@@ -864,7 +864,7 @@ public class SwissRailRaptorIntermodalTest {
         SwissRailRaptorData data2 = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f.config), f.scenario.getNetwork());
         DefaultRaptorStopFinder stopFinder2 = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), f.routingModules);
         SwissRailRaptor raptor2 = new SwissRailRaptor(data2, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-                new LeastCostRaptorRouteSelector(), stopFinder2, null );
+                new LeastCostRaptorRouteSelector(), stopFinder2 );
 
         List<Leg> legs2 = raptor2.calcRoute(fromFac, toFac, 8 * 3600 - 900, f.dummyPerson);
         

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorTreeTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorTreeTest.java
@@ -33,7 +33,7 @@ public class SwissRailRaptorTreeTest {
         SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), config, f.scenario.getNetwork());
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), null);
         SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-                new LeastCostRaptorRouteSelector(), stopFinder, null );
+                new LeastCostRaptorRouteSelector(), stopFinder );
 
         RaptorParameters raptorParams = RaptorUtils.createParameters(f.config);
 
@@ -78,7 +78,7 @@ public class SwissRailRaptorTreeTest {
         SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f.config), f.scenario.getNetwork());
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), null);
         SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-            new LeastCostRaptorRouteSelector(), stopFinder, null );
+            new LeastCostRaptorRouteSelector(), stopFinder );
 
         RaptorParameters raptorParams = RaptorUtils.createParameters(f.config);
 
@@ -125,7 +125,7 @@ public class SwissRailRaptorTreeTest {
         SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), config, f.scenario.getNetwork());
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), null);
         SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-            new LeastCostRaptorRouteSelector(), stopFinder, null );
+            new LeastCostRaptorRouteSelector(), stopFinder );
 
         RaptorParameters raptorParams = RaptorUtils.createParameters(f.config);
 
@@ -171,7 +171,7 @@ public class SwissRailRaptorTreeTest {
         SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f.config), f.scenario.getNetwork());
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), null);
         SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-            new LeastCostRaptorRouteSelector(), stopFinder, null );
+            new LeastCostRaptorRouteSelector(), stopFinder );
 
         RaptorParameters raptorParams = RaptorUtils.createParameters(f.config);
 
@@ -219,7 +219,7 @@ public class SwissRailRaptorTreeTest {
         SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), config, f.scenario.getNetwork());
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), null);
         SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-            new LeastCostRaptorRouteSelector(), stopFinder, null );
+            new LeastCostRaptorRouteSelector(), stopFinder );
 
         RaptorParameters raptorParams = RaptorUtils.createParameters(f.config);
 
@@ -268,7 +268,7 @@ public class SwissRailRaptorTreeTest {
         SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), RaptorUtils.createStaticConfig(f.config), f.scenario.getNetwork());
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), null);
         SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-            new LeastCostRaptorRouteSelector(), stopFinder, null );
+            new LeastCostRaptorRouteSelector(), stopFinder );
 
         RaptorParameters raptorParams = RaptorUtils.createParameters(f.config);
 
@@ -319,7 +319,7 @@ public class SwissRailRaptorTreeTest {
         SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), config, f.scenario.getNetwork());
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), null);
         SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-            new LeastCostRaptorRouteSelector(), stopFinder, null );
+            new LeastCostRaptorRouteSelector(), stopFinder );
 
         RaptorParameters raptorParams = RaptorUtils.createParameters(f.config);
 
@@ -354,7 +354,7 @@ public class SwissRailRaptorTreeTest {
         SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), config, f.scenario.getNetwork());
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(null, new DefaultRaptorIntermodalAccessEgress(), null);
         SwissRailRaptor raptor = new SwissRailRaptor(data, new DefaultRaptorParametersForPerson(f.scenario.getConfig()),
-            new LeastCostRaptorRouteSelector(), stopFinder, null );
+            new LeastCostRaptorRouteSelector(), stopFinder );
 
         RaptorParameters raptorParams = RaptorUtils.createParameters(f.config);
 

--- a/matsim/src/test/java/org/matsim/core/replanning/StrategyManagerSubpopulationsTest.java
+++ b/matsim/src/test/java/org/matsim/core/replanning/StrategyManagerSubpopulationsTest.java
@@ -36,7 +36,7 @@ import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.utils.misc.Counter;
 
 public class StrategyManagerSubpopulationsTest {
-	private static final String SUBPOP_ATT_NAME = "subpopulation";
+//	private static final String SUBPOP_ATT_NAME = "subpopulation";
 
 	private static final String POP_NAME_1 = "mangeurs_de_boudin";
 	private static final String POP_NAME_2 = "buveurs_de_vin";
@@ -58,12 +58,14 @@ public class StrategyManagerSubpopulationsTest {
 			case 1:
 //				population.getPersonAttributes().putAttribute(
 //						p.getId().toString(), SUBPOP_ATT_NAME, POP_NAME_1);
-				PopulationUtils.putPersonAttribute( p, SUBPOP_ATT_NAME, POP_NAME_1 );
+//				PopulationUtils.putPersonAttribute( p, SUBPOP_ATT_NAME, POP_NAME_1 );
+				PopulationUtils.putSubpopulation( p, POP_NAME_1 );
 				break;
 			case 2:
 //				population.getPersonAttributes().putAttribute(
 //						p.getId().toString(), SUBPOP_ATT_NAME, POP_NAME_2);
-				PopulationUtils.putPersonAttribute( p, SUBPOP_ATT_NAME, POP_NAME_2 );
+//				PopulationUtils.putPersonAttribute( p, SUBPOP_ATT_NAME, POP_NAME_2 );
+				PopulationUtils.putSubpopulation( p, POP_NAME_2 );
 				break;
 			default:
 				throw new RuntimeException(group + " ???");
@@ -71,7 +73,7 @@ public class StrategyManagerSubpopulationsTest {
 		}
 
 		final Counter counter = new Counter( "test person # " );
-		manager.setSubpopulationAttributeName(SUBPOP_ATT_NAME);
+//		manager.setSubpopulationAttributeName(SUBPOP_ATT_NAME);
 		manager.addStrategy(new PlanStrategy() {
 					@Override
 					public void run(HasPlansAndId<Plan, Person> person) {
@@ -80,7 +82,8 @@ public class StrategyManagerSubpopulationsTest {
 						Gbl.assertNotNull( person1 );
 						Assert.assertNull(
 							"unexpected subpopulation",
-							  PopulationUtils.getPersonAttribute( person1, SUBPOP_ATT_NAME) );
+//							  PopulationUtils.getPersonAttribute( person1, SUBPOP_ATT_NAME) );
+								PopulationUtils.getSubpopulation( person1 ) );
 
 					}
 
@@ -101,7 +104,8 @@ public class StrategyManagerSubpopulationsTest {
 						Assert.assertEquals(
 							"unexpected subpopulation",
 							POP_NAME_1,
-							  PopulationUtils.getPersonAttribute( person1, SUBPOP_ATT_NAME) );
+//							  PopulationUtils.getPersonAttribute( person1, SUBPOP_ATT_NAME) );
+								PopulationUtils.getSubpopulation( person1 ) );
 					}
 
 					@Override
@@ -121,7 +125,8 @@ public class StrategyManagerSubpopulationsTest {
 						Assert.assertEquals(
 							"unexpected subpopulation",
 							POP_NAME_2,
-							  PopulationUtils.getPersonAttribute( person1, SUBPOP_ATT_NAME) );
+//							  PopulationUtils.getPersonAttribute( person1, SUBPOP_ATT_NAME) );
+								PopulationUtils.getSubpopulation( person1 ) );
 					}
 
 					@Override

--- a/matsim/src/test/java/org/matsim/core/replanning/strategies/TimeAllocationMutatorModuleTest.java
+++ b/matsim/src/test/java/org/matsim/core/replanning/strategies/TimeAllocationMutatorModuleTest.java
@@ -82,7 +82,7 @@ public class TimeAllocationMutatorModuleTest extends MatsimTestCase {
 		String freightSubpopulation = "freight";
 		
 		Config config  = ConfigUtils.createConfig();
-		config.plans().setSubpopulationAttributeName("subpopulation");
+//		config.plans().setSubpopulationAttributeName("subpopulation");
 		config.timeAllocationMutator().setUseIndividualSettingsForSubpopulations(true);
 		config.timeAllocationMutator().setMutationRange(1800.0);
 		
@@ -123,7 +123,7 @@ public class TimeAllocationMutatorModuleTest extends MatsimTestCase {
 	 * @param tripPlanMutateTimeAllocation A preset TimeAllocationMutator to be used for the tests.
 	 * @param expectedMutationRange The expected range for mutation.
 	 */
-	private void runMutationRangeTest(final PlanAlgorithm tripPlanMutateTimeAllocation, final int expectedMutationRange) {
+	private static void runMutationRangeTest( final PlanAlgorithm tripPlanMutateTimeAllocation, final int expectedMutationRange ) {
 		// setup network
 		Network network = NetworkUtils.createNetwork();
 		network.setCapacityPeriod(Time.parseTime("01:00:00"));


### PR DESCRIPTION
now absorbed in `PopulationUtils.getSubpopulation(person)`.  Is this what you had in mind re https://matsim.atlassian.net/browse/MATSIM-206 ?