### PR TITLE
Id set and map contracts

### DIFF
--- a/matsim/src/main/java/org/matsim/api/core/v01/IdMap.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/IdMap.java
@@ -1,7 +1,5 @@
 package org.matsim.api.core.v01;
 
-import java.util.AbstractMap;
-import java.util.AbstractSet;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -15,7 +13,7 @@ import java.util.function.BiConsumer;
 /**
  * @author mrieser / Simunto GmbH
  */
-public class IdMap<T, V> extends AbstractMap<Id<T>, V> implements Iterable<V> {
+public class IdMap<T, V> implements Map<Id<T>, V>, Iterable<V> {
 
 	private Class<T> idClass;
 	private int size = 0;
@@ -208,6 +206,55 @@ public class IdMap<T, V> extends AbstractMap<Id<T>, V> implements Iterable<V> {
 	@Override
 	public Iterator<V> iterator() {
 		return new DataIterator<>(this);
+	}
+	
+	@Override
+	public boolean equals(Object o) {
+		if (o == this)
+            return true;
+        if (!(o instanceof Map))
+            return false;
+        if (o instanceof IdMap) {
+        	IdMap<?,?> m = (IdMap<?,?>) o;
+        	if (this.size != m.size)
+        		return false;
+        	for (int i=0; i<this.data.length && i<m.data.length; i++) { // one of the data arrays may have more capacity than the other despite having the same number of non-null entries. This is okay if and only if the additional entries are null. This gets checked implicitly by the loop because we already know they have the same number of nun-null elements.
+        		if (this.data[i] != m.data[i])
+        			return false;
+        	}
+        	return true;
+        } else {
+        	Map<Id<?>,?> m = (Map<Id<?>,?>) o;
+        	try {
+                Iterator<java.util.Map.Entry<Id<T>, V>> iter = entrySet().iterator();
+                while (iter.hasNext()) {
+                    java.util.Map.Entry<Id<T>, V> e = iter.next();
+                    Id<T> key = e.getKey();
+                    V value = e.getValue();
+                    if (value == null) {
+                        if (!(m.get(key)==null && m.containsKey(key)))
+                            return false;
+                    } else {
+                        if (!value.equals(m.get(key)))
+                            return false;
+                    }
+                }
+            } catch (ClassCastException noIdAsKey) {
+                return false;
+            } catch (NullPointerException unused) {
+                return false;
+            }
+            return true;
+        }
+	}
+	
+	@Override
+	public int hashCode() {
+		int h = 0;
+		for (int i=0; i<data.length; i++) {
+			h += data[i] == null ? 0 : i^data[i].hashCode();
+		}
+		return h;
 	}
 
 	private static class DataCollection<K, V> implements Collection<V> {
@@ -421,7 +468,7 @@ public class IdMap<T, V> extends AbstractMap<Id<T>, V> implements Iterable<V> {
 		}
 	}
 
-	private static class KeySet<T, V> extends AbstractSet<Id<T>> {
+	private static class KeySet<T, V> implements Set<Id<T>> {
 
 		private final IdMap<T, V> map;
 
@@ -547,9 +594,47 @@ public class IdMap<T, V> extends AbstractMap<Id<T>, V> implements Iterable<V> {
 		public void clear() {
 			this.map.clear();
 		}
+		
+		@Override
+		public boolean equals(Object o) {
+			if (o == this)
+	            return true;
+	        if (!(o instanceof Set))
+	            return false;
+	        if(o instanceof KeySet) {
+	        	KeySet<?,?> k = (KeySet<?,?>) o;
+	        	if(this.size()!=k.size())
+	        		return false;
+	        	for (int i=0; i<this.map.data.length && i<k.map.data.length; i++) { // one of the data arrays may have more capacity than the other despite having the same number of non-null entries. This is okay if and only if the additional entries are null. This gets checked implicitly by the loop because we already know they have the same number of nun-null elements.
+	        		if((this.map.data[i]==null && k.map.data[i]!=null) || (this.map.data[i]!=null && k.map.data[i]==null))
+	        			return false;
+	        	}
+	        	return true;
+	        } else {
+		        Collection<?> c = (Collection<?>) o;
+		        if (c.size() != size())
+		            return false;
+		        try {
+		            return containsAll(c);
+		        } catch (ClassCastException unused)   {
+		            return false;
+		        } catch (NullPointerException unused) {
+		            return false;
+		        }
+	        }
+		}
+		
+		@Override
+		public int hashCode() {
+			int h = 0;
+			for (int i = 0; i < this.map.data.length; i++) {
+				h += this.map.data[i] == null ? 0 : i;
+			}
+			return h;
+		}
 	}
 
-	private static class EntrySet<T, V> extends AbstractSet<Map.Entry<Id<T>, V>> {
+	private static class EntrySet<T, V> implements Set<Map.Entry<Id<T>, V>> {
 
 		private final IdMap<T, V> map;
 
@@ -570,7 +655,7 @@ public class IdMap<T, V> extends AbstractMap<Id<T>, V> implements Iterable<V> {
 		@Override
 		public boolean contains(Object o) {
 			if (o instanceof Map.Entry) {
-				Map.Entry e = (Entry) o;
+				Map.Entry<?,?> e = (Map.Entry<?,?>) o;
 				return e.getValue().equals(this.map.get(e.getKey()));
 			}
 			return false;
@@ -655,6 +740,34 @@ public class IdMap<T, V> extends AbstractMap<Id<T>, V> implements Iterable<V> {
 		public void clear() {
 			this.map.clear();
 		}
+		
+		@Override
+		public boolean equals(Object o) {
+			if (o == this)
+	            return true;
+	        if (!(o instanceof Set))
+	            return false;
+	        if(o instanceof EntrySet) {
+	        	EntrySet<?,?> e = (EntrySet<?,?>) o;
+	        	return this.map.equals(e.map);
+	        } else {
+	        	Collection<?> c = (Collection<?>) o;
+	            if (c.size() != size())
+	                return false;
+	            try {
+	                return containsAll(c);
+	            } catch (ClassCastException unused)   {
+	                return false;
+	            } catch (NullPointerException unused) {
+	                return false;
+	            }
+	        }
+		}
+		
+		@Override
+		public int hashCode() {
+			return this.map.hashCode();
+		}
 	}
 
 	public static class Entry<T, V> implements Map.Entry<Id<T>, V> {
@@ -693,7 +806,7 @@ public class IdMap<T, V> extends AbstractMap<Id<T>, V> implements Iterable<V> {
             	Entry<?, ?> e = (Entry<?, ?>) o;
             	return this.index == e.index && this.value.equals(e.value); // Since our values should never be null we can skip the null-check they do in AbstractMap#eq(Object, Object)
             } else {
-	            Map.Entry<?,?> e = (Map.Entry<?,?>)o;
+	            Map.Entry<?,?> e = (Map.Entry<?,?>) o;
 	            if (e.getKey() == null || e.getValue() == null)
 	            	return false; // our keys and values should never be null
 	            return this.getKey().equals(e.getKey()) && this.value.equals(e.getValue());

--- a/matsim/src/main/java/org/matsim/api/core/v01/IdSet.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/IdSet.java
@@ -1,6 +1,6 @@
 package org.matsim.api.core.v01;
 
-import java.util.AbstractSet;
+import java.util.Set;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
@@ -10,7 +10,7 @@ import java.util.NoSuchElementException;
 /**
  * @author mrieser / Simunto GmbH
  */
-public class IdSet<T> extends AbstractSet<Id<T>> {
+public class IdSet<T> implements Set<Id<T>> {
 
 	private Class<T> idClass;
 	private int size = 0;
@@ -217,6 +217,40 @@ public class IdSet<T> extends AbstractSet<Id<T>> {
 	public void clear() {
 		this.size = 0;
 		this.data.clear();
+	}
+	
+	@Override
+	public boolean equals(Object o) {
+		if (o == this)
+            return true;
+        if (!(o instanceof Set))
+            return false;
+        if (o instanceof IdSet) {
+        	IdSet<?> m = (IdSet<?>) o;
+        	return this.idClass.equals(m.idClass) && this.size == m.size && this.data.equals(m.data);
+        } else {
+        	Collection<?> c = (Collection<?>) o;
+            if (c.size() != size())
+                return false;
+            try {
+                return containsAll(c);
+            } catch (ClassCastException unused)   {
+                return false;
+            } catch (NullPointerException unused) {
+                return false;
+            }
+        }
+	}
+	
+	@Override
+	public int hashCode() {
+		if(isEmpty())
+			return -1;
+		int h = 0;
+		for (int i=0; i<this.data.length(); i++) {
+			h += this.data.get(i) ? i : 0;
+		}
+		return h;
 	}
 
 	private static class IdSetIterator<T> implements Iterator<Id<T>> {

--- a/matsim/src/main/java/org/matsim/api/core/v01/IdSet.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/IdSet.java
@@ -1,16 +1,16 @@
 package org.matsim.api.core.v01;
 
+import java.util.AbstractSet;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.Set;
 
 /**
  * @author mrieser / Simunto GmbH
  */
-public class IdSet<T> implements Set<Id<T>> {
+public class IdSet<T> extends AbstractSet<Id<T>> {
 
 	private Class<T> idClass;
 	private int size = 0;

--- a/matsim/src/test/java/org/matsim/api/core/v01/IdMapTest.java
+++ b/matsim/src/test/java/org/matsim/api/core/v01/IdMapTest.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
@@ -451,6 +452,106 @@ public class IdMapTest {
 		Assert.assertEquals(id4, array[2]);
 		Assert.assertEquals(id5, array[3]);
 
+	}
+	
+	@Test
+	public void testEqualsAndHashCode() {
+		Id<Person> id1 = Id.create(1, Person.class);
+		Id<Person> id2 = Id.create(2, Person.class);
+		Id<Person> id3 = Id.create(3, Person.class);
+		Id<Person> id4 = Id.create(4, Person.class);
+		Id<Person> id5 = Id.create(5, Person.class);
+		Id<Person> id6 = Id.create(6, Person.class);
+		
+		IdMap<Person, String> mapA = new IdMap<>(Person.class, 4);
+		IdMap<Person, String> mapB = new IdMap<>(Person.class, 4);
+		IdMap<Person, String> mapC = new IdMap<>(Person.class, 10);
+		
+		Assert.assertEquals(mapA, mapA);
+		Assert.assertEquals(mapA, mapB);
+		Assert.assertEquals(mapA, mapC);
+		Assert.assertEquals(mapA.hashCode(), mapB.hashCode());
+		Assert.assertEquals(mapA.hashCode(), mapC.hashCode());
+		
+		mapA.put(id1, "one");
+		mapB.put(id1, "one");
+		
+		Assert.assertEquals(mapA, mapA);
+		Assert.assertEquals(mapA, mapB);
+		Assert.assertNotEquals(mapA, mapC);
+		Assert.assertEquals(mapA.hashCode(), mapB.hashCode());
+		Assert.assertNotEquals(mapA.hashCode(), mapC.hashCode());
+		
+		mapC.put(id1, "one");
+		
+		Assert.assertEquals(mapA, mapC);
+		Assert.assertEquals(mapA.hashCode(), mapC.hashCode());
+		
+		mapA.put(id2, "two");
+		mapB.put(id3, "three");
+		
+		Assert.assertNotEquals(mapA, mapB);
+		Assert.assertNotEquals(mapA.hashCode(), mapB.hashCode());
+		
+		mapA.put(id3, "three");
+		mapB.put(id2, "two");
+		
+		Assert.assertEquals(mapA, mapB);
+		Assert.assertEquals(mapA.hashCode(), mapB.hashCode());
+		
+		mapA.put(id4, "four");
+		mapA.put(id5, "five");
+		mapA.put(id6, "six");
+		mapA.remove(id4, "four");
+		mapA.remove(id5, "five");
+		mapA.remove(id6, "six");
+		
+		Assert.assertEquals(mapA, mapB);
+		Assert.assertEquals(mapA.hashCode(), mapB.hashCode());
+		
+		Assert.assertEquals(mapA.entrySet(), mapB.entrySet());
+		Assert.assertEquals(mapA.entrySet().hashCode(), mapB.entrySet().hashCode());
+		Assert.assertEquals(mapA.keySet(), mapB.keySet());
+		Assert.assertEquals(mapA.keySet().hashCode(), mapB.keySet().hashCode());
+		
+		mapA.put(id4, "four");
+		mapB.put(id4, "DifferentFour");
+		
+		Assert.assertNotEquals(mapA, mapB);
+		Assert.assertNotEquals(mapA.hashCode(), mapB.hashCode());
+		
+		Assert.assertNotEquals(mapA.entrySet(), mapB.entrySet());
+		Assert.assertNotEquals(mapA.entrySet().hashCode(), mapB.entrySet().hashCode());
+		Assert.assertEquals(mapA.keySet(), mapB.keySet());
+		Assert.assertEquals(mapA.keySet().hashCode(), mapB.keySet().hashCode());
+		
+		HashMap<Id<Person>, String> hMapA = new HashMap<Id<Person>, String>(mapA);
+		
+		// The commented out tests will fail right now because the hashCode of IdImpl is based on the id, not the index
+		Assert.assertEquals(hMapA, mapA);
+//		Assert.assertEquals(hMapA.hashCode(), mapA.hashCode());
+		Assert.assertEquals(hMapA.entrySet(), mapA.entrySet());
+//		Assert.assertEquals(hMapA.entrySet().hashCode(), mapA.entrySet().hashCode());
+		Assert.assertEquals(hMapA.keySet(), mapA.keySet());
+//		Assert.assertEquals(hMapA.keySet().hashCode(), mapA.keySet().hashCode());
+		Assert.assertNotEquals(hMapA, mapB);
+		Assert.assertNotEquals(hMapA.hashCode(), mapB.hashCode());
+		Assert.assertNotEquals(hMapA.entrySet(), mapB.entrySet());
+		Assert.assertNotEquals(hMapA.entrySet().hashCode(), mapB.entrySet().hashCode());
+		Assert.assertEquals(hMapA.keySet(), mapB.keySet());
+//		Assert.assertEquals(hMapA.keySet().hashCode(), mapB.keySet().hashCode());
+		
+		// Best way I could think of to explicitly test the equals() of Entry (i.e. not inside the EntrySet)
+		Iterator<Entry<Id<Person>, String>> iter = mapA.entrySet().iterator();
+		while(iter.hasNext()) {
+			Entry<Id<Person>, String> e = iter.next();
+			if (e.getKey() != id4) {
+				Assert.assertTrue(mapB.entrySet().contains(e));
+			} else {
+				Assert.assertFalse(mapB.entrySet().contains(e));
+			}
+			Assert.assertTrue(hMapA.entrySet().contains(e));
+		}
 	}
 
 }

--- a/matsim/src/test/java/org/matsim/api/core/v01/IdSetTest.java
+++ b/matsim/src/test/java/org/matsim/api/core/v01/IdSetTest.java
@@ -2,8 +2,10 @@ package org.matsim.api.core.v01;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
 
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -271,6 +273,66 @@ public class IdSetTest {
 		Assert.assertEquals(id1, array4[0]);
 		Assert.assertEquals(id3, array4[1]);
 		Assert.assertEquals(id4, array4[2]);
+	}
+	
+	@Test
+	public void testEqualsAndHashCode() {
+		Id<Person> id1 = Id.create("1", Person.class);
+		Id<Person> id2 = Id.create("2", Person.class);
+		Id<Person> id3 = Id.create("3", Person.class);
+		Id<Person> id4 = Id.create("4", Person.class);
+		Id<Person> id5 = Id.create("5", Person.class);
+		Id<Person> id6 = Id.create("6", Person.class);
+
+		IdSet<Person> setA = new IdSet<>(Person.class, 4);
+		IdSet<Person> setB = new IdSet<>(Person.class, 4);
+		IdSet<Link> setWrongType = new IdSet<>(Link.class, 4);
+		
+		Assert.assertEquals(setA, setA);
+		Assert.assertEquals(setA, setB);
+		Assert.assertNotEquals(setA, setWrongType);
+		
+		setA.add(id1);
+		
+		Assert.assertEquals(setA, setA);
+		Assert.assertNotEquals(setA, setB);
+		Assert.assertEquals(setA.hashCode(), setA.hashCode());
+		Assert.assertNotEquals(setA.hashCode(), setB.hashCode());
+		
+		setB.add(id1);
+		
+		Assert.assertEquals(setA, setB);
+		Assert.assertEquals(setA.hashCode(), setB.hashCode());
+		
+		setA.add(id2);
+		setA.add(id3);
+		
+		Assert.assertNotEquals(setA, setB);
+		Assert.assertNotEquals(setA.hashCode(), setB.hashCode());
+		
+		setB.add(id3);
+		setB.add(id2);
+		
+		Assert.assertEquals(setA, setB);
+		Assert.assertEquals(setA.hashCode(), setB.hashCode());
+		
+		setA.add(id4);
+		setA.add(id5);
+		setA.add(id6);
+		setA.remove(id4);
+		setA.remove(id5);
+		setA.remove(id6);
+		
+		Assert.assertEquals(setA, setB);
+		Assert.assertEquals(setA.hashCode(), setB.hashCode());
+		
+		setA.add(id4);
+		HashSet<Id<Person>> hSetA = new HashSet<Id<Person>>(setA);
+
+		Assert.assertEquals(hSetA, setA);
+		Assert.assertNotEquals(hSetA, setB);
+//		Assert.assertEquals(hSetA.hashCode(), setA.hashCode()); // this does not work yet because the hashCode() of IdImpl still uses id instead of index
+		Assert.assertNotEquals(hSetA.hashCode(), setB.hashCode());
 	}
 
 }


### PR DESCRIPTION
The internal classes for handling Ids (IdMap, KeySet, Entry, ...) do not fulfill the contracts for the Map, Set, Entry, ... interface for comparison and equals().

This pull request tries to fix this.

There still is an inconsistency with comparing two ids directly, which is done by String, while the new functions mostly use the id. However, after a short discussion with @mrieser this should not be a problem.