### PR TITLE
fix weird compile errors in IntelliJ w/Eclipse compiler (after switch…

### DIFF
--- a/contribs/accessibility/pom.xml
+++ b/contribs/accessibility/pom.xml
@@ -58,6 +58,14 @@
 			<groupId>org.openstreetmap.osmosis</groupId>
 			<artifactId>osmosis-core</artifactId>
 			<version>0.47</version>
+			<exclusions>
+				<!-- needed to compile in IntelliJ with Eclipse compiler -->
+				<!-- see: https://bugs.eclipse.org/bugs/show_bug.cgi?id=536928 -->
+				<exclusion>
+					<artifactId>xml-apis</artifactId>
+					<groupId>xml-apis</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.openstreetmap.osmosis</groupId>

--- a/contribs/freight/pom.xml
+++ b/contribs/freight/pom.xml
@@ -82,6 +82,14 @@
 			<groupId>com.graphhopper</groupId>
 			<artifactId>jsprit-io</artifactId>
 			<version>1.7.2</version>
+			<exclusions>
+				<!-- needed to compile in IntelliJ with Eclipse compiler -->
+				<!-- see: https://bugs.eclipse.org/bugs/show_bug.cgi?id=536928 -->
+				<exclusion>
+					<artifactId>xml-apis</artifactId>
+					<groupId>xml-apis</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/contribs/pom.xml
+++ b/contribs/pom.xml
@@ -234,6 +234,12 @@
 			<version>12.0-SNAPSHOT</version>
 			<!--(This has possibly no effect here, don't know.)-->
 		</dependency>
+		<dependency>
+			<!-- needed to compile in IntelliJ with Eclipse compiler -->
+			<groupId>commons-logging</groupId>
+			<artifactId>commons-logging</artifactId>
+			<version>1.2</version>
+		</dependency>
 	</dependencies>
 
 	<profiles>

--- a/contribs/vsp/pom.xml
+++ b/contribs/vsp/pom.xml
@@ -102,6 +102,14 @@
 			<groupId>org.openstreetmap.osmosis</groupId>
 			<artifactId>osmosis-core</artifactId>
 			<version>0.47</version>
+			<exclusions>
+				<!-- needed to compile in IntelliJ with Eclipse compiler -->
+				<!-- see: https://bugs.eclipse.org/bugs/show_bug.cgi?id=536928 -->
+				<exclusion>
+					<artifactId>xml-apis</artifactId>
+					<groupId>xml-apis</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.openstreetmap.osmosis</groupId>
@@ -139,6 +147,18 @@
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
 			<version>3.12</version>
+			<exclusions>
+				<!-- needed to compile in IntelliJ with Eclipse compiler -->
+				<!-- see: https://bugs.eclipse.org/bugs/show_bug.cgi?id=536928 -->
+				<exclusion>
+					<groupId>xml-apis</groupId>
+					<artifactId>xml-apis</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>stax</groupId>
+					<artifactId>stax-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/com.jcraft/jsch -->
 		<dependency>


### PR DESCRIPTION
…ing to Java 11)

Latest IntelliJ 2019.3.3 (with ECJ 4.10)

https://bugs.eclipse.org/bugs/show_bug.cgi?id=536928