### PR TITLE
bug fix: Access egress walk backward compatibility

### DIFF
--- a/matsim/src/main/java/org/matsim/core/controler/PrepareForSimImpl.java
+++ b/matsim/src/main/java/org/matsim/core/controler/PrepareForSimImpl.java
@@ -321,6 +321,9 @@ public final class PrepareForSimImpl implements PrepareForSim, PrepareForMobsim 
 								}
 							} else {
 								if (plansConfigGroup.getHandlingOfPlansWithoutRoutingMode().equals(HandlingOfPlansWithoutRoutingMode.useMainModeIdentifier)) {
+									for (Leg leg: legs) {
+										replaceOutdatedAccessEgressWalkModes(leg, routingMode);
+									}
 									routingMode = getAndAddRoutingModeFromBackwardCompatibilityMainModeIdentifier(
 											person, trip);
 								} else {
@@ -348,7 +351,8 @@ public final class PrepareForSimImpl implements PrepareForSim, PrepareForMobsim 
 						}
 
 						for (Leg leg : legs) {
-							replaceOutdatedAccessEgressHelperModes(leg, routingMode);
+							replaceOutdatedAccessEgressWalkModes(leg, routingMode);
+							replaceOutdatedNonNetworkWalk(leg, routingMode);
 							replaceOutdatedFallbackModesAndReturnOldMainMode(leg, routingMode);
 						}
 					}
@@ -385,15 +389,17 @@ public final class PrepareForSimImpl implements PrepareForSim, PrepareForMobsim 
 		return routingMode;
 	}
 
-	private void replaceOutdatedAccessEgressHelperModes(Leg leg, String routingMode) {
+	private void replaceOutdatedAccessEgressWalkModes(Leg leg, String routingMode) {
 		// access_walk and egress_walk were replaced by non_network_walk
 		if (leg.getMode().equals("access_walk") || leg.getMode().equals("egress_walk")) {
 			leg.setMode(TransportMode.non_network_walk);
 			TripStructureUtils.setRoutingMode(leg, routingMode);
 		}
+	}
 
-		// non_network_walk as access/egress to modes other than walk on the network was replaced by walk. -
-		// kn/gl-nov'19
+	// non_network_walk as access/egress to modes other than walk on the network was replaced by walk. -
+	// kn/gl-nov'19
+	private void replaceOutdatedNonNetworkWalk(Leg leg, String routingMode) {
 		if (leg.getMode().equals(TransportMode.non_network_walk)) {
 			leg.setMode(TransportMode.walk);
 			TripStructureUtils.setRoutingMode(leg, routingMode);

--- a/matsim/src/test/java/org/matsim/core/controler/PrepareForSimImplTest.java
+++ b/matsim/src/test/java/org/matsim/core/controler/PrepareForSimImplTest.java
@@ -439,7 +439,7 @@ public class PrepareForSimImplTest {
 			Plan plan = pf.createPlan();
 			Activity activity1 = pf.createActivityFromCoord("h", new Coord((double) 10, -10));
 			plan.addActivity(activity1);
-			Leg leg1 = pf.createLeg(TransportMode.access_walk);
+			Leg leg1 = pf.createLeg("access_walk");
 			TripStructureUtils.setRoutingMode(leg1, null);
 			plan.addLeg(leg1);
 			Activity activity2 = pf.createActivityFromCoord("car interaction", new Coord((double) 0, -10));
@@ -449,7 +449,7 @@ public class PrepareForSimImplTest {
 			plan.addLeg(leg2);
 			Activity activity3 = pf.createActivityFromCoord("car interaction", new Coord((double) -10, -10));
 			plan.addActivity(activity3);
-			Leg leg3 = pf.createLeg(TransportMode.egress_walk);
+			Leg leg3 = pf.createLeg("egress_walk");
 			TripStructureUtils.setRoutingMode(leg3, null);
 			plan.addLeg(leg3);
 			Activity activity4 = pf.createActivityFromCoord("w", new Coord((double) 1900, -10));
@@ -548,7 +548,7 @@ public class PrepareForSimImplTest {
 			Plan plan = pf.createPlan();
 			Activity activity1 = pf.createActivityFromCoord("h", new Coord((double) 10, -10));
 			plan.addActivity(activity1);
-			Leg leg1 = pf.createLeg(TransportMode.access_walk);
+			Leg leg1 = pf.createLeg("access_walk");
 			TripStructureUtils.setRoutingMode(leg1, null);
 			plan.addLeg(leg1);
 			Activity activity2 = pf.createActivityFromCoord("drt interaction", new Coord((double) 0, -10));
@@ -578,7 +578,7 @@ public class PrepareForSimImplTest {
 			plan.addLeg(leg6);
 			Activity activity7 = pf.createActivityFromCoord("walk interaction", new Coord((double) 1900, -10));
 			plan.addActivity(activity7);
-			Leg leg7 = pf.createLeg(TransportMode.egress_walk);
+			Leg leg7 = pf.createLeg("egress_walk");
 			TripStructureUtils.setRoutingMode(leg7, null);
 			plan.addLeg(leg7);
 			Activity activity8 = pf.createActivityFromCoord("w", new Coord((double) 1900, -10));
@@ -649,7 +649,7 @@ public class PrepareForSimImplTest {
 			Plan plan = pf.createPlan();
 			Activity activity1 = pf.createActivityFromCoord("h", new Coord((double) 10, -10));
 			plan.addActivity(activity1);
-			Leg leg1 = pf.createLeg(TransportMode.access_walk);
+			Leg leg1 = pf.createLeg("access_walk");
 			TripStructureUtils.setRoutingMode(leg1, null);
 			plan.addLeg(leg1);
 			Activity activity2 = pf.createActivityFromCoord("drt interaction", new Coord((double) 0, -10));

--- a/matsim/src/test/java/org/matsim/core/controler/PrepareForSimImplTest.java
+++ b/matsim/src/test/java/org/matsim/core/controler/PrepareForSimImplTest.java
@@ -232,9 +232,9 @@ public class PrepareForSimImplTest {
 			prepareForSimImpl.run();
 			
 			// Check leg modes remain unchanged
-			Assert.assertEquals("wrong routing mode!", TransportMode.walk, leg1.getMode());
+			Assert.assertEquals("wrong leg mode!", TransportMode.walk, leg1.getMode());
 			Assert.assertEquals("wrong routing mode!", TransportMode.car, leg2.getMode());
-			Assert.assertEquals("wrong routing mode!", TransportMode.walk, leg3.getMode());
+			Assert.assertEquals("wrong leg mode!", TransportMode.walk, leg3.getMode());
 			
 			// Check routing mode:
 			Assert.assertEquals("wrong routing mode!", TransportMode.car, TripStructureUtils.getRoutingMode(leg1));
@@ -318,15 +318,15 @@ public class PrepareForSimImplTest {
 			// TODO: Currently all TransportMode.non_network_walk legs are replaced by TransportMode.walk, so we cannot check
 			// the correct handling of them right now.
 //			Assert.assertEquals("wrong routing mode!", TransportMode.non_network_walk, leg1.getMode());
-			Assert.assertEquals("wrong routing mode!", TransportMode.walk, leg2.getMode());
+			Assert.assertEquals("wrong leg mode!", TransportMode.walk, leg2.getMode());
 //			Assert.assertEquals("wrong routing mode!", TransportMode.non_network_walk, leg3.getMode());
-			Assert.assertEquals("wrong routing mode!", TransportMode.drt, leg4.getMode());
+			Assert.assertEquals("wrong leg mode!", TransportMode.drt, leg4.getMode());
 //			Assert.assertEquals("wrong routing mode!", TransportMode.non_network_walk, leg5.getMode());
-			Assert.assertEquals("wrong routing mode!", TransportMode.walk, leg6.getMode());
+			Assert.assertEquals("wrong leg mode!", TransportMode.walk, leg6.getMode());
 //			Assert.assertEquals("wrong routing mode!", TransportMode.non_network_walk, leg7.getMode());
-			Assert.assertEquals("wrong routing mode!", TransportMode.pt, leg8.getMode());
+			Assert.assertEquals("wrong leg mode!", TransportMode.pt, leg8.getMode());
 //			Assert.assertEquals("wrong routing mode!", TransportMode.non_network_walk, leg9.getMode());
-			Assert.assertEquals("wrong routing mode!", TransportMode.walk, leg10.getMode());
+			Assert.assertEquals("wrong leg mode!", TransportMode.walk, leg10.getMode());
 //			Assert.assertEquals("wrong routing mode!", TransportMode.non_network_walk, leg11.getMode());
 			
 			// Check routing mode remains unchanged
@@ -476,9 +476,9 @@ public class PrepareForSimImplTest {
 			prepareForSimImpl.run();
 			
 			// Check replacement of outdated helper modes.
-			Assert.assertEquals("wrong routing mode!", TransportMode.walk, leg1.getMode());
-			Assert.assertEquals("wrong routing mode!", TransportMode.car, leg2.getMode());
-			Assert.assertEquals("wrong routing mode!", TransportMode.walk, leg3.getMode());
+			Assert.assertEquals("wrong leg mode!", TransportMode.walk, leg1.getMode());
+			Assert.assertEquals("wrong leg mode!", TransportMode.car, leg2.getMode());
+			Assert.assertEquals("wrong leg mode!", TransportMode.walk, leg3.getMode());
 			
 			// Check routing mode:
 			Assert.assertEquals("wrong routing mode!", TransportMode.car, TripStructureUtils.getRoutingMode(leg1));
@@ -531,9 +531,9 @@ public class PrepareForSimImplTest {
 			prepareForSimImpl.run();
 			
 			// Check replacement of outdated helper modes.
-			Assert.assertEquals("wrong routing mode!", TransportMode.walk, leg1.getMode());
-			Assert.assertEquals("wrong routing mode!", TransportMode.car, leg2.getMode());
-			Assert.assertEquals("wrong routing mode!", TransportMode.walk, leg3.getMode());
+			Assert.assertEquals("wrong leg mode replacement!", TransportMode.walk, leg1.getMode());
+			Assert.assertEquals("wrong leg mode!", TransportMode.car, leg2.getMode());
+			Assert.assertEquals("wrong leg mode replacement!", TransportMode.walk, leg3.getMode());
 			
 			// Check routing mode:
 			Assert.assertEquals("wrong routing mode!", TransportMode.car, TripStructureUtils.getRoutingMode(leg1));
@@ -606,13 +606,13 @@ public class PrepareForSimImplTest {
 			prepareForSimImpl.run();
 			
 			// Check replacement of outdated helper modes.
-			Assert.assertEquals("wrong routing mode!", TransportMode.walk, leg1.getMode());
-			Assert.assertEquals("wrong routing mode!", TransportMode.drt, leg2.getMode());
-			Assert.assertEquals("wrong routing mode!", TransportMode.walk, leg3.getMode());
-			Assert.assertEquals("wrong routing mode!", TransportMode.pt, leg4.getMode());
-			Assert.assertEquals("wrong routing mode!", TransportMode.walk, leg5.getMode());
-			Assert.assertEquals("wrong routing mode!", TransportMode.pt, leg6.getMode());
-			Assert.assertEquals("wrong routing mode!", TransportMode.walk, leg7.getMode());
+			Assert.assertEquals("wrong leg mode replacement!", TransportMode.walk, leg1.getMode());
+			Assert.assertEquals("wrong leg mode!", TransportMode.drt, leg2.getMode());
+			Assert.assertEquals("wrong leg mode replacement!", TransportMode.walk, leg3.getMode());
+			Assert.assertEquals("wrong leg mode!", TransportMode.pt, leg4.getMode());
+			Assert.assertEquals("wrong leg mode replacement!", TransportMode.walk, leg5.getMode());
+			Assert.assertEquals("wrong leg mode!", TransportMode.pt, leg6.getMode());
+			Assert.assertEquals("wrong leg mode replacement!", TransportMode.walk, leg7.getMode());
 			
 			/*
 			 * Check routing mode:
@@ -696,11 +696,11 @@ public class PrepareForSimImplTest {
 			prepareForSimImpl.run();
 			
 			// Check replacement of outdated helper modes.
-			Assert.assertEquals("wrong routing mode!", TransportMode.walk, leg1.getMode());
-			Assert.assertEquals("wrong routing mode!", TransportMode.drt, leg2.getMode());
-			Assert.assertEquals("wrong routing mode!", TransportMode.walk, leg3.getMode());
-			Assert.assertEquals("wrong routing mode!", TransportMode.walk, leg4.getMode());
-			Assert.assertEquals("wrong routing mode!", TransportMode.walk, leg5.getMode());
+			Assert.assertEquals("wrong leg mode replacement!", TransportMode.walk, leg1.getMode());
+			Assert.assertEquals("wrong leg mode!", TransportMode.drt, leg2.getMode());
+			Assert.assertEquals("wrong leg mode replacement!", TransportMode.walk, leg3.getMode());
+			Assert.assertEquals("wrong leg mode replacement!", TransportMode.walk, leg4.getMode());
+			Assert.assertEquals("wrong leg mode replacement!", TransportMode.walk, leg5.getMode());
 			
 			/*
 			 * Check routing mode:


### PR DESCRIPTION
old plan files without routing mode and using access_walk or egress_walk:
PrepareForSimImpl did not replace access_walk/egress_walk by non_network_walk before running the MainModeIdentifier. MainModeIdentifierImpl did not check for "access_walk" because TransportMode.access_walk = "non_network_walk" and later MainModeIdentifierImpl only checked for TransportMode.non_network_walk. The same reason made the test pass although input plan files with access_walk were not handled correctly.