### PR TITLE
Finalise removal of undefined time

### DIFF
--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/events/EmissionEventsReader.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/events/EmissionEventsReader.java
@@ -19,18 +19,17 @@
  * *********************************************************************** */
 package org.matsim.contrib.emissions.events;
 
+import java.net.URL;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.emissions.Pollutant;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.api.internal.MatsimReader;
 import org.matsim.core.events.MatsimEventsReader;
-import org.matsim.core.utils.misc.Time;
 import org.matsim.vehicles.Vehicle;
-
-import java.net.URL;
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 
 /**
@@ -53,7 +52,7 @@ public final class EmissionEventsReader implements MatsimReader {
 			Map<String, String> attributes = event.getAttributes();
 			Map<Pollutant, Double> warmEmissions = new LinkedHashMap<>();
 
-			double time = Time.getUndefinedTime();
+			double time = Double.NaN;
 			Id<Link> linkId = null;
 			Id<Vehicle> vehicleId = null;
 
@@ -83,7 +82,7 @@ public final class EmissionEventsReader implements MatsimReader {
 			Map<String, String> attributes = event.getAttributes();
 			Map<Pollutant, Double> coldEmissions = new LinkedHashMap<>();
 
-			double time = Time.getUndefinedTime();
+			double time = Double.NaN;
 			Id<Link> linkId = null;
 			Id<Vehicle> vehicleId = null;
 

--- a/contribs/eventsBasedPTRouter/src/main/java/org/matsim/contrib/eventsBasedPTRouter/waitTimes/WaitTimeCalculatorImpl.java
+++ b/contribs/eventsBasedPTRouter/src/main/java/org/matsim/contrib/eventsBasedPTRouter/waitTimes/WaitTimeCalculatorImpl.java
@@ -37,7 +37,6 @@ import org.matsim.core.api.experimental.events.VehicleArrivesAtFacilityEvent;
 import org.matsim.core.api.experimental.events.handler.VehicleArrivesAtFacilityEventHandler;
 import org.matsim.core.config.Config;
 import org.matsim.core.utils.collections.Tuple;
-import org.matsim.core.utils.misc.Time;
 import org.matsim.pt.transitSchedule.api.Departure;
 import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
@@ -91,7 +90,7 @@ public class WaitTimeCalculatorImpl implements WaitTimeCalculator, PersonDepartu
 						double endTime = timeSlot*(i+1);
 						if(endTime>24*3600)
 							endTime-=24*3600;
-						cacheWaitTimes[i] = Time.getUndefinedTime();
+						cacheWaitTimes[i] = Double.NaN;
 						SORTED_DEPARTURES:
 						for(double departure:sortedDepartures) {
 							double arrivalTime = departure+stop.getArrivalOffset().or(stop::getDepartureOffset).seconds();
@@ -100,7 +99,7 @@ public class WaitTimeCalculatorImpl implements WaitTimeCalculator, PersonDepartu
 								break SORTED_DEPARTURES;
 							}
 						}
-						if(Time.isUndefinedTime(cacheWaitTimes[i]))
+						if(Double.isNaN(cacheWaitTimes[i]))
 							cacheWaitTimes[i] = sortedDepartures[0]+24*3600+stop.getArrivalOffset().or(stop::getDepartureOffset).seconds()-endTime;
 					}
 					stopsScheduledMap.put(stop.getStopFacility().getId(), cacheWaitTimes);

--- a/contribs/eventsBasedPTRouter/src/main/java/org/matsim/contrib/eventsBasedPTRouter/waitTimes/WaitTimeCalculatorSerializable.java
+++ b/contribs/eventsBasedPTRouter/src/main/java/org/matsim/contrib/eventsBasedPTRouter/waitTimes/WaitTimeCalculatorSerializable.java
@@ -37,7 +37,6 @@ import org.matsim.core.api.experimental.events.VehicleArrivesAtFacilityEvent;
 import org.matsim.core.api.experimental.events.handler.VehicleArrivesAtFacilityEventHandler;
 import org.matsim.core.config.Config;
 import org.matsim.core.utils.collections.Tuple;
-import org.matsim.core.utils.misc.Time;
 import org.matsim.pt.transitSchedule.api.Departure;
 import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
@@ -104,7 +103,7 @@ public class WaitTimeCalculatorSerializable implements
 						double endTime = timeSlot * (i + 1);
 						if (endTime > 24 * 3600)
 							endTime -= 24 * 3600;
-						cacheWaitTimes[i] = Time.getUndefinedTime();
+						cacheWaitTimes[i] = Double.NaN;
 						SORTED_DEPARTURES:
 						for (double departure : sortedDepartures) {
 							double arrivalTime = departure + stop.getArrivalOffset().or(stop::getDepartureOffset).seconds();
@@ -113,7 +112,7 @@ public class WaitTimeCalculatorSerializable implements
 								break SORTED_DEPARTURES;
 							}
 						}
-						if (Time.isUndefinedTime(cacheWaitTimes[i]))
+						if (Double.isNaN(cacheWaitTimes[i]))
 							cacheWaitTimes[i] = sortedDepartures[0] + 24 * 3600 + stop.getArrivalOffset().or(stop::getDepartureOffset).seconds() - endTime;
 					}
 					stopsScheduledMap.put(stop.getStopFacility().getId().toString(), cacheWaitTimes);

--- a/contribs/eventsBasedPTRouter/src/main/java/org/matsim/contrib/eventsBasedPTRouter/waitTimes/WaitTimeStuckCalculator.java
+++ b/contribs/eventsBasedPTRouter/src/main/java/org/matsim/contrib/eventsBasedPTRouter/waitTimes/WaitTimeStuckCalculator.java
@@ -39,7 +39,6 @@ import org.matsim.api.core.v01.population.Route;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.utils.collections.Tuple;
-import org.matsim.core.utils.misc.Time;
 import org.matsim.pt.routes.ExperimentalTransitRouteFactory;
 import org.matsim.pt.routes.TransitPassengerRoute;
 import org.matsim.pt.transitSchedule.api.Departure;
@@ -93,7 +92,7 @@ public class WaitTimeStuckCalculator implements PersonDepartureEventHandler, Per
 						double endTime = timeSlot*(i+1);
 						if(endTime>24*3600)
 							endTime-=24*3600;
-						cacheWaitTimes[i] = Time.getUndefinedTime();
+						cacheWaitTimes[i] = Double.NaN;
 						SORTED_DEPARTURES:
 						for(double departure:sortedDepartures) {
 							double arrivalTime = departure+stop.getArrivalOffset().or(stop::getDepartureOffset).seconds();
@@ -102,7 +101,7 @@ public class WaitTimeStuckCalculator implements PersonDepartureEventHandler, Per
 								break SORTED_DEPARTURES;
 							}
 						}
-						if(Time.isUndefinedTime(cacheWaitTimes[i]))
+						if(Double.isNaN(cacheWaitTimes[i]))
 							cacheWaitTimes[i] = sortedDepartures[0]+24*3600+stop.getArrivalOffset().or(stop::getDepartureOffset).seconds()-endTime;
 					}
 					stopsScheduledMap.put(stop.getStopFacility().getId(), cacheWaitTimes);

--- a/contribs/locationchoice/src/main/java/org/matsim/contrib/locationchoice/frozenepsilons/PlanTimesAdapter.java
+++ b/contribs/locationchoice/src/main/java/org/matsim/contrib/locationchoice/frozenepsilons/PlanTimesAdapter.java
@@ -36,7 +36,6 @@ import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.router.PlanRouter;
 import org.matsim.core.scoring.ScoringFunction;
 import org.matsim.core.scoring.ScoringFunctionFactory;
-import org.matsim.core.utils.misc.Time;
 
 class PlanTimesAdapter {
 	private static final Logger log = Logger.getLogger( PlanTimesAdapter.class ) ;
@@ -58,7 +57,7 @@ class PlanTimesAdapter {
 		// yy The honest way of doing the following would be using the psim. kai, mar'19
 		boolean firstAct = true ;
 		Activity rememberedActivity = null ;
-		double now = Time.getUndefinedTime() ;
+		double now = Double.NaN ;
 		for( PlanElement pe : planTmp.getPlanElements() ){
 			if ( pe instanceof Activity ) {
 				rememberedActivity = (Activity) pe;

--- a/contribs/roadpricing/src/main/java/org/matsim/contrib/roadpricing/RoadPricingSchemeWithTollAvoidance.java
+++ b/contribs/roadpricing/src/main/java/org/matsim/contrib/roadpricing/RoadPricingSchemeWithTollAvoidance.java
@@ -17,16 +17,15 @@
  * *********************************************************************** */
 package org.matsim.contrib.roadpricing;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
-import org.matsim.core.utils.misc.Time;
 import org.matsim.vehicles.Vehicle;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * A road pricing scheme that is subject to person-specific avoidance. Those
@@ -74,7 +73,7 @@ public class RoadPricingSchemeWithTollAvoidance implements RoadPricingScheme {
 		} else {
 			boolean tollEvader = (boolean) attr;
 			if (tollEvader) {
-				return new RoadPricingSchemeImpl.Cost(0.0, Time.getUndefinedTime(), 0.0);
+				return new RoadPricingSchemeImpl.Cost(0.0, Double.NEGATIVE_INFINITY, 0.0);
 			} else {
 				return delegate.getLinkCostInfo(linkId, time, personId, vehicleId);
 			}

--- a/contribs/vsp/src/main/java/playground/vsp/andreas/bvgAna/level1/StopId2RouteId2DelayAtStopMapData.java
+++ b/contribs/vsp/src/main/java/playground/vsp/andreas/bvgAna/level1/StopId2RouteId2DelayAtStopMapData.java
@@ -47,8 +47,8 @@ public class StopId2RouteId2DelayAtStopMapData {
 	}
 	
 	public void addDepartureEvent(VehicleDepartsAtFacilityEvent departureEvent){
-		this.plannedDepartures.add(new Double(departureEvent.getTime() - departureEvent.getDelay()));
-		this.realizedDepartures.add(new Double(departureEvent.getTime()));
+		this.plannedDepartures.add(departureEvent.getTime() - departureEvent.getDelay());
+		this.realizedDepartures.add(departureEvent.getTime());
 	}
 	
 	public ArrayList<Double> getPlannedDepartures() {

--- a/contribs/vsp/src/main/java/playground/vsp/andreas/bvgAna/level2/VehiclePlannedRealizedMissedDepartures.java
+++ b/contribs/vsp/src/main/java/playground/vsp/andreas/bvgAna/level2/VehiclePlannedRealizedMissedDepartures.java
@@ -26,7 +26,7 @@ import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.core.utils.collections.Tuple;
-import org.matsim.core.utils.misc.Time;
+import org.matsim.core.utils.misc.OptionalTime;
 
 import playground.vsp.andreas.bvgAna.level1.StopId2RouteId2DelayAtStopMap;
 import playground.vsp.andreas.bvgAna.level1.StopId2RouteId2DelayAtStopMapData;
@@ -69,10 +69,10 @@ public class VehiclePlannedRealizedMissedDepartures {
 	 * @return The number of missed vehicles, if positive. Negative number, if the agent could get some vehicles earlier. Zero, if the agent took the vehicle as scheduled.
 	 */
 	public int getNumberOfMissedVehicles(Id stopId, double plannedDepartureTime, double realizedDepartureTime, Id lineId, Id routeId){
-		Tuple<Double, Integer> plannedDeparture = this.getNextDepartureTime(stopId, plannedDepartureTime, lineId, routeId, this.planned);
-		Tuple<Double, Integer> realizedDeparture = this.getNextDepartureTime(stopId, realizedDepartureTime, lineId, routeId, this.realized);
+		Tuple<OptionalTime, Integer> plannedDeparture = this.getNextDepartureTime(stopId, plannedDepartureTime, lineId, routeId, this.planned);
+		Tuple<OptionalTime, Integer> realizedDeparture = this.getNextDepartureTime(stopId, realizedDepartureTime, lineId, routeId, this.realized);
 
-		int numberOfMissedVehicles = realizedDeparture.getSecond().intValue() - plannedDeparture.getSecond().intValue();
+		int numberOfMissedVehicles = realizedDeparture.getSecond() - plannedDeparture.getSecond();
 
 		if(log.getLevel() == Level.DEBUG){
 			double delay = realizedDepartureTime - plannedDepartureTime;
@@ -94,7 +94,7 @@ public class VehiclePlannedRealizedMissedDepartures {
 	 * @return Returns the next planned departure time in the future for a given stop and time.
 	 */
 	public double getNextPlannedDepartureTime(Id stopId, double time, Id lineId, Id routeId){
-		return this.getNextDepartureTime(stopId, time, lineId, routeId, this.planned).getFirst().doubleValue();
+		return this.getNextDepartureTime(stopId, time, lineId, routeId, this.planned).getFirst().seconds();
 	}
 
 	/**
@@ -105,22 +105,22 @@ public class VehiclePlannedRealizedMissedDepartures {
 	 * @return Returns the next realized departure time in the future for a given stop and time.
 	 */
 	public double getNextRealizedDepartureTime(Id stopId, double time, Id lineId, Id routeId){
-		return this.getNextDepartureTime(stopId, time, lineId, routeId, this.realized).getFirst().doubleValue();
+		return this.getNextDepartureTime(stopId, time, lineId, routeId, this.realized).getFirst().seconds();
 	}
 
-	private Tuple<Double, Integer> getNextDepartureTime(Id stopId, double time, Id lineId, Id routeId, String type){
+	private Tuple<OptionalTime, Integer> getNextDepartureTime(Id stopId, double time, Id lineId, Id routeId, String type){
 		this.log.debug("TransitAgent.getEnterTransitRoute only checks for line id and stops to come ignoring route id. Agent probably too fast in simulation compared to plan.");
 		TreeMap<Id, StopId2RouteId2DelayAtStopMapData> possibleRoutes = this.stopId2Route2DelayAtStopMap.get(stopId);
-		Tuple<Double, Integer> closestDepartureTimeAndSlot = new Tuple<Double, Integer>(new Double(Double.POSITIVE_INFINITY), new Integer(Integer.MIN_VALUE));
-
 		if (possibleRoutes == null) {
 			/* this could happen if a stop is served only by few lines (e.g. night-buses), but the simulation
 			 * stops before ever a single vehicle could reach that stop
 			 */
-			return new Tuple<>(Time.getUndefinedTime(), 1);
+			return new Tuple<>(OptionalTime.undefined(), 1);
 		}
-		for (StopId2RouteId2DelayAtStopMapData delayContainer : possibleRoutes.values()) {
 
+		Tuple<OptionalTime, Integer> closestDepartureTimeAndSlot = new Tuple<>(OptionalTime.defined(Double.POSITIVE_INFINITY), Integer.MIN_VALUE);
+
+		for (StopId2RouteId2DelayAtStopMapData delayContainer : possibleRoutes.values()) {
 			if(delayContainer.getLineId().toString().equalsIgnoreCase(lineId.toString()) && delayContainer.getRouteId().toString().equalsIgnoreCase(routeId.toString())){
 				ArrayList<Double> departures;
 				if(type.equalsIgnoreCase(this.planned)){
@@ -134,16 +134,16 @@ public class VehiclePlannedRealizedMissedDepartures {
 					return null;
 				}
 				for (int i = 0; i < departures.size(); i++) {
-					if(departures.get(i).doubleValue() > time){
-						if(departures.get(i).doubleValue() < closestDepartureTimeAndSlot.getFirst().doubleValue()){
-							closestDepartureTimeAndSlot = new Tuple<Double, Integer>(new Double(departures.get(i).doubleValue()), new Integer(i));
+					if(departures.get(i) > time){
+						if(departures.get(i) < closestDepartureTimeAndSlot.getFirst().seconds()){
+							closestDepartureTimeAndSlot = new Tuple<OptionalTime, Integer>(OptionalTime.defined(departures.get(i)), i);
 						}
 					}
 				}
 			}
 		}
 
-		if(closestDepartureTimeAndSlot.getFirst().doubleValue() == Double.POSITIVE_INFINITY){
+		if(closestDepartureTimeAndSlot.getFirst().seconds() == Double.POSITIVE_INFINITY){
 			this.log.warn("Could not find next " + type + " departure time for stop " + stopId + ", line " + lineId + " route " + routeId + " and time " + time + "s. Returning positive Inf");
 		}
 		return closestDepartureTimeAndSlot;

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/RaptorUtils.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/RaptorUtils.java
@@ -20,7 +20,6 @@ import org.matsim.core.config.groups.PlanCalcScoreConfigGroup;
 import org.matsim.core.config.groups.PlansCalcRouteConfigGroup;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.population.routes.RouteUtils;
-import org.matsim.core.utils.misc.Time;
 import org.matsim.pt.router.TransitRouterConfig;
 import org.matsim.pt.routes.DefaultTransitPassengerRoute;
 
@@ -96,7 +95,7 @@ public final class RaptorUtils {
 
     public static List<Leg> convertRouteToLegs(RaptorRoute route) {
         List<Leg> legs = new ArrayList<>(route.parts.size());
-        double lastArrivalTime = Time.getUndefinedTime();
+        double lastArrivalTime = Double.NaN;
         for (RaptorRoute.RoutePart part : route.parts) {
             if (part.planElements != null) {
                 for (PlanElement pe : part.planElements) {

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorCore.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorCore.java
@@ -4,18 +4,6 @@
 
 package ch.sbb.matsim.routing.pt.raptor;
 
-import ch.sbb.matsim.routing.pt.raptor.SwissRailRaptorData.RRoute;
-import ch.sbb.matsim.routing.pt.raptor.SwissRailRaptorData.RRouteStop;
-import ch.sbb.matsim.routing.pt.raptor.SwissRailRaptorData.RTransfer;
-import org.apache.log4j.Logger;
-import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.TransportMode;
-import org.matsim.core.utils.misc.Time;
-import org.matsim.facilities.Facility;
-import org.matsim.pt.transitSchedule.api.TransitLine;
-import org.matsim.pt.transitSchedule.api.TransitRoute;
-import org.matsim.pt.transitSchedule.api.TransitStopFacility;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
@@ -24,6 +12,18 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.log4j.Logger;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.facilities.Facility;
+import org.matsim.pt.transitSchedule.api.TransitLine;
+import org.matsim.pt.transitSchedule.api.TransitRoute;
+import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+
+import ch.sbb.matsim.routing.pt.raptor.SwissRailRaptorData.RRoute;
+import ch.sbb.matsim.routing.pt.raptor.SwissRailRaptorData.RRouteStop;
+import ch.sbb.matsim.routing.pt.raptor.SwissRailRaptorData.RTransfer;
 
 /**
  * The actual RAPTOR implementation, based on Delling et al, Round-Based Public Transit Routing.
@@ -175,7 +175,7 @@ public class SwissRailRaptorCore {
                 } else if (isIntermodalAccess) {
                     // there is no more departure, but we start here by intermodal access, so still register to allow transfers to other (non-)intermodal stops.
                     RRouteStop toRouteStop = this.data.routeStops[routeStopIndex];
-                    PathElement pe = new PathElement(null, toRouteStop, Double.NaN, Time.getUndefinedTime(), arrivalTime, arrivalCost, 0, stop.distance, 0, true, stop);
+                    PathElement pe = new PathElement(null, toRouteStop, Double.NaN, Double.NaN, arrivalTime, arrivalCost, 0, stop.distance, 0, true, stop);
 
                     /* okay, the following is not very nice...
                      * ... see long comment above, it's the same

--- a/matsim/src/main/java/org/matsim/analysis/PHbyModeCalculator.java
+++ b/matsim/src/main/java/org/matsim/analysis/PHbyModeCalculator.java
@@ -101,7 +101,6 @@ public class PHbyModeCalculator {
                 		Activity act = (Activity) pe;
                 		if (StageActivityTypeIdentifier.isStageActivity(act.getType())) {
                             double duration = act.getEndTime().orElse(0) - act.getStartTime().orElse(0);
-                            if (Double.isNaN(duration)) {duration = 0.0; }
                             return new AbstractMap.SimpleEntry<>(STAGE_ACTIVITY,new TravelTimeAndWaitTime(0.0, duration));
                 		}
                 	}

--- a/matsim/src/main/java/org/matsim/api/core/v01/network/Link.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/network/Link.java
@@ -23,7 +23,6 @@ import java.util.Set;
 
 import org.matsim.api.core.v01.BasicLocation;
 import org.matsim.api.core.v01.Identifiable;
-import org.matsim.core.utils.misc.Time;
 import org.matsim.utils.objectattributes.attributable.Attributable;
 
 /**
@@ -98,7 +97,7 @@ public interface Link extends BasicLocation, Attributable, Identifiable<Link> {
 	 * This method returns the capacity as set in the xml defining the network. Be aware
 	 * that this capacity is not normalized in time, it depends on the period set
 	 * in the network file (the capperiod attribute).
-	 * @param time the time at which the capacity is requested. Use {@link Time#getUndefinedTime()} to get the default value.
+	 * @param time the time at which the capacity is requested. Use {@link Double#NEGATIVE_INFINITY} to get the default value.
 	 * @return the capacity per network's capperiod timestep
 	 *
 	 * @see Network#getCapacityPeriod()

--- a/matsim/src/main/java/org/matsim/core/network/FixedIntervalTimeVariantAttribute.java
+++ b/matsim/src/main/java/org/matsim/core/network/FixedIntervalTimeVariantAttribute.java
@@ -114,6 +114,7 @@ final class FixedIntervalTimeVariantAttribute implements TimeVariantAttribute {
 
 	@Override
 	public double getValue(final double time) {
+		Preconditions.checkArgument(!Double.isNaN(time), "NaN time is not supported");
 		if (eventsCount == 0) {
 			return baseValue;
 		}

--- a/matsim/src/main/java/org/matsim/core/network/FixedIntervalTimeVariantAttribute.java
+++ b/matsim/src/main/java/org/matsim/core/network/FixedIntervalTimeVariantAttribute.java
@@ -19,20 +19,20 @@
 
 package org.matsim.core.network;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.TreeMap;
 
 import org.matsim.core.network.NetworkChangeEvent.ChangeValue;
-import org.matsim.core.trafficmonitoring.*;
-import org.matsim.core.utils.misc.Time;
+import org.matsim.core.trafficmonitoring.TimeBinUtils;
+import org.matsim.core.trafficmonitoring.TravelTimeCalculator;
 
+import com.google.common.base.Preconditions;
 
 /**
  * This class follows the rules assumed in {@link TravelTimeCalculator}: The constructor arguments
  * timeSlice and maxTime have the same meaning as there, and the last time bin is open ended.
  */
-final class FixedIntervalTimeVariantAttribute
-implements TimeVariantAttribute
-{
+final class FixedIntervalTimeVariantAttribute implements TimeVariantAttribute {
 	private final int timeSlice;
 	private final int numSlots;
 
@@ -42,26 +42,20 @@ implements TimeVariantAttribute
 	private int eventsCount = 0;
 	private int eventsCountWhenLastRecalc = -1;
 
-
-	public FixedIntervalTimeVariantAttribute(int timeSlice, int maxTime)
-	{
+	public FixedIntervalTimeVariantAttribute(int timeSlice, int maxTime) {
 		this.timeSlice = timeSlice;
 		this.numSlots = TimeBinUtils.getTimeBinCount(maxTime, timeSlice);
 	}
 
-
 	@Override
-	public boolean isRecalcRequired()
-	{
+	public boolean isRecalcRequired() {
 		return eventsCountWhenLastRecalc != eventsCount;
 	}
 
-
 	//TODO before calling this method we could convert changeEvents into a sequence of non-null changeValues
 	@Override
-	public void recalc(TreeMap<Double, NetworkChangeEvent> changeEvents,
-			ChangeValueGetter valueGetter, double baseValue1)
-	{
+	public void recalc(TreeMap<Double, NetworkChangeEvent> changeEvents, ChangeValueGetter valueGetter,
+			double baseValue1) {
 		this.baseValue = baseValue1;
 
 		if (eventsCount == 0) {
@@ -84,21 +78,23 @@ implements TimeVariantAttribute
 				if (value != null) {
 					numEvent++;
 
-					int toBin = (int) (event.getStartTime() / timeSlice);//exclusive
+					Preconditions.checkArgument(event.getStartTime() >= 0,
+							"The current implementation supports only non-negative change event times");
+					int toBin = (int)(event.getStartTime() / timeSlice);//exclusive
 					Arrays.fill(values, fromBin, toBin, currentValue);
 
-					switch ( value.getType() ) {
-					case ABSOLUTE_IN_SI_UNITS:
-						currentValue = value.getValue();
-						break;
-					case FACTOR:
-						currentValue *= value.getValue();
-						break;
-					case OFFSET_IN_SI_UNITS:
-						currentValue += value.getValue();
-						break;
-					default:
-						throw new RuntimeException( "unknown ChangeType" ) ;
+					switch (value.getType()) {
+						case ABSOLUTE_IN_SI_UNITS:
+							currentValue = value.getValue();
+							break;
+						case FACTOR:
+							currentValue *= value.getValue();
+							break;
+						case OFFSET_IN_SI_UNITS:
+							currentValue += value.getValue();
+							break;
+						default:
+							throw new RuntimeException("unknown ChangeType");
 					}
 					fromBin = toBin;
 				}
@@ -108,34 +104,31 @@ implements TimeVariantAttribute
 		eventsCountWhenLastRecalc = eventsCount;
 
 		if (numEvent != this.eventsCount) {
-			throw new RuntimeException("Expected number of change events (" + (this.eventsCount)
-					+ ") differs from the number of events found (" + numEvent + ")!");
+			throw new RuntimeException("Expected number of change events ("
+					+ (this.eventsCount)
+					+ ") differs from the number of events found ("
+					+ numEvent
+					+ ")!");
 		}
 	}
 
-
 	@Override
-	public double getValue(final double time)
-	{
-		if (Time.isUndefinedTime(time) || eventsCount == 0) {
+	public double getValue(final double time) {
+		if (eventsCount == 0) {
 			return baseValue;
 		}
 
 		int bin = TimeBinUtils.getTimeBinIndex(time, timeSlice, numSlots);
-		return values[bin];
+		return bin < 0 ? baseValue : values[bin];
 	}
 
-
 	@Override
-	public void incChangeEvents()
-	{
+	public void incChangeEvents() {
 		eventsCount++;
 	}
 
-
 	@Override
-	public void clearEvents()
-	{
+	public void clearEvents() {
 		eventsCount = 0;
 		eventsCountWhenLastRecalc = -1;
 		values = null;

--- a/matsim/src/main/java/org/matsim/core/network/FixedIntervalTimeVariantLinkFactory.java
+++ b/matsim/src/main/java/org/matsim/core/network/FixedIntervalTimeVariantLinkFactory.java
@@ -21,34 +21,28 @@
 package org.matsim.core.network;
 
 import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.network.*;
-
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
 
 /**
  * A link that is able to store time-dependent information, using a fixed interval (i.e. array) data structure underneath.
- * 
- * @author (of documentation) nagel
  *
+ * @author (of documentation) nagel
  */
-public final class FixedIntervalTimeVariantLinkFactory
-    implements LinkFactory
-{
-    private final int interval;
-    private final int maxTime;
+public final class FixedIntervalTimeVariantLinkFactory implements LinkFactory {
+	private final int interval;
+	private final int maxTime;
 
+	public FixedIntervalTimeVariantLinkFactory(int interval, int maxTime) {
+		this.interval = interval;
+		this.maxTime = maxTime;
+	}
 
-    public FixedIntervalTimeVariantLinkFactory(int interval, int maxTime)
-    {
-        this.interval = interval;
-        this.maxTime = maxTime;
-    }
-
-
-    @Override
-    public Link createLink(Id<Link> id, Node from, Node to, Network network, double length,
-            double freespeed, double capacity, double nOfLanes)
-    {
-        return TimeVariantLinkImpl.createLinkWithFixedIntervalAttributes(id, from, to, network,
-                length, freespeed, capacity, nOfLanes, interval, maxTime);
-    }
+	@Override
+	public Link createLink(Id<Link> id, Node from, Node to, Network network, double length, double freespeed,
+			double capacity, double nOfLanes) {
+		return TimeVariantLinkImpl.createLinkWithFixedIntervalAttributes(id, from, to, network, length, freespeed,
+				capacity, nOfLanes, interval, maxTime);
+	}
 }

--- a/matsim/src/main/java/org/matsim/core/network/TimeVariantAttribute.java
+++ b/matsim/src/main/java/org/matsim/core/network/TimeVariantAttribute.java
@@ -49,6 +49,11 @@ public interface TimeVariantAttribute
 		}
 	};
 
+	/**
+	 * For base value, use {@link Double#NEGATIVE_INFINITY}. {@link Double#NaN} is not supported
+	 * @param time
+	 * @return
+	 */
 	double getValue(final double time);
 
 	boolean isRecalcRequired();

--- a/matsim/src/main/java/org/matsim/core/network/VariableIntervalTimeVariantAttribute.java
+++ b/matsim/src/main/java/org/matsim/core/network/VariableIntervalTimeVariantAttribute.java
@@ -19,10 +19,12 @@
 
 package org.matsim.core.network;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.TreeMap;
 
 import org.matsim.core.network.NetworkChangeEvent.ChangeValue;
 
+import com.google.common.base.Preconditions;
 
 final class VariableIntervalTimeVariantAttribute
 implements TimeVariantAttribute
@@ -97,6 +99,7 @@ implements TimeVariantAttribute
 	@Override
 	public double getValue(final double time)
 	{
+		Preconditions.checkArgument(!Double.isNaN(time), "NaN time is not supported");
 		// after we have put everything into an array by recalc, we just need a binary search:
 		int key = Arrays.binarySearch(this.aTimes, time);
 		key = key >= 0 ? key : -key - 2;

--- a/matsim/src/main/java/org/matsim/core/network/VariableIntervalTimeVariantLinkFactory.java
+++ b/matsim/src/main/java/org/matsim/core/network/VariableIntervalTimeVariantLinkFactory.java
@@ -25,17 +25,12 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
 
+public final class VariableIntervalTimeVariantLinkFactory implements LinkFactory {
 
-public final class VariableIntervalTimeVariantLinkFactory
-    implements LinkFactory
-{
-
-    @Override
-    public Link createLink(Id<Link> id, Node from, Node to, Network network, double length,
-            double freespeed, double capacity, double nOfLanes)
-    {
-        return TimeVariantLinkImpl.createLinkWithVariableIntervalAttributes(id, from, to, network,
-                length, freespeed, capacity, nOfLanes);
-    }
-
+	@Override
+	public Link createLink(Id<Link> id, Node from, Node to, Network network, double length, double freespeed,
+			double capacity, double nOfLanes) {
+		return TimeVariantLinkImpl.createLinkWithVariableIntervalAttributes(id, from, to, network, length, freespeed,
+				capacity, nOfLanes);
+	}
 }

--- a/matsim/src/main/java/org/matsim/core/router/AStarLandmarks.java
+++ b/matsim/src/main/java/org/matsim/core/router/AStarLandmarks.java
@@ -32,7 +32,6 @@ import org.matsim.core.router.util.PreProcessLandmarks;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.utils.collections.RouterPriorityQueue;
-import org.matsim.core.utils.misc.Time;
 import org.matsim.vehicles.Vehicle;
 
 /**
@@ -153,7 +152,7 @@ public class AStarLandmarks extends AStarEuclidean {
 		double[] estTravelTimes = new double[actLandmarkCount];
 		this.activeLandmarkIndexes = new int[actLandmarkCount];
 		for (int i = 0; i < estTravelTimes.length; i++) {
-			estTravelTimes[i] = Time.getUndefinedTime();
+			estTravelTimes[i] = Double.NEGATIVE_INFINITY;
 		}
 		double tmpTravTime;
 		for (int i = 0; i < this.landmarks.length; i++) {

--- a/matsim/src/main/java/org/matsim/core/router/Dijkstra.java
+++ b/matsim/src/main/java/org/matsim/core/router/Dijkstra.java
@@ -20,6 +20,11 @@
 
 package org.matsim.core.router;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
@@ -33,13 +38,7 @@ import org.matsim.core.router.util.PreProcessDijkstra;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.utils.collections.RouterPriorityQueue;
-import org.matsim.core.utils.misc.Time;
 import org.matsim.vehicles.Vehicle;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Set;
 
 /**
  * Implementation of <a
@@ -205,9 +204,7 @@ import java.util.Set;
 	 * @param toNode
 	 *            The Node at which the route should end.
 	 * @param startTime
-	 *            The time at which the route should start. <i>Note:</i> Using
-	 *            {@link Time#getUndefinedTime()} does not imply "time is not relevant",
-	 *            rather, {@link Path#travelTime} will return {@link Double#NaN}.
+	 *            The time at which the route should start.
 	 * @see org.matsim.core.router.util.LeastCostPathCalculator#calcLeastCostPath(org.matsim.api.core.v01.network.Node, org.matsim.api.core.v01.network.Node, double, org.matsim.api.core.v01.population.Person, org.matsim.vehicles.Vehicle)
 	 */
 	@SuppressWarnings("unchecked")

--- a/matsim/src/main/java/org/matsim/core/router/TripRouter.java
+++ b/matsim/src/main/java/org/matsim/core/router/TripRouter.java
@@ -40,8 +40,9 @@ import org.matsim.core.api.internal.MatsimExtensionPoint;
 import org.matsim.core.config.Config;
 import org.matsim.core.gbl.Gbl;
 import org.matsim.core.population.PopulationUtils;
-import org.matsim.core.utils.misc.Time;
 import org.matsim.facilities.Facility;
+
+import com.google.common.base.Preconditions;
 
 /**
  * Class acting as an intermediate between clients needing to
@@ -208,10 +209,7 @@ public final class TripRouter implements MatsimExtensionPoint {
 	public static double calcEndOfPlanElement(
 			final double now,
 			final PlanElement pe, Config config) {
-
-		if (Time.isUndefinedTime(now)) {
-			throw new RuntimeException("got undefined now to update with plan element" + pe);
-		}
+		Preconditions.checkArgument(Double.isFinite(now));//probably unnecessary after switching to OptionalTime
 
 		if (pe instanceof Activity) {
 			Activity act = (Activity) pe;

--- a/matsim/src/main/java/org/matsim/core/scoring/functions/CharyparNagelLegScoring.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/functions/CharyparNagelLegScoring.java
@@ -34,7 +34,6 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.Route;
 import org.matsim.core.gbl.Gbl;
-import org.matsim.core.utils.misc.Time;
 import org.matsim.pt.PtConstants;
 
 /**
@@ -56,7 +55,7 @@ public class CharyparNagelLegScoring implements org.matsim.core.scoring.SumScori
 	private boolean nextEnterVehicleIsFirstOfTrip = true;
 	private boolean nextStartPtLegIsFirstOfTrip = true;
 	private boolean currentLegIsPtLeg = false;
-	private double lastActivityEndTime = Time.getUndefinedTime();
+	private double lastActivityEndTime = Double.NaN;
 	private final Set<String> ptModes;
 	
 	private Set<String> modesAlreadyConsideredForDailyConstants;

--- a/matsim/src/main/java/org/matsim/core/utils/misc/Time.java
+++ b/matsim/src/main/java/org/matsim/core/utils/misc/Time.java
@@ -40,7 +40,6 @@ public class Time {
 	 * time is given as {@link Time#UNDEFINED_TIME} then {@link Path#travelTime}
 	 * will return {@link Double#NaN}, even though the {@link TravelTime#getLinkTravelTime}
 	 * is independent of the start time. */
-	@Deprecated // rather use Time.isUndefinedTime( time ), since that opens up the path to a later change
 	// of the convention.  kai, nov'17
 	final static double UNDEFINED_TIME = Double.NEGATIVE_INFINITY;
 	/**
@@ -58,15 +57,6 @@ public class Time {
 
 	private final static String[] timeElements;
 	
-	public static double getUndefinedTime() {
-		// give the option to change the convention at some point in time.  kai, nov'17
-		return UNDEFINED_TIME ;
-	}
-	public static double getVeryLargeTime() {
-		// give the option to change the convention at some point in time.  kai, nov'17
-		return Long.MAX_VALUE ;
-	}
-
 	static {
 		timeElements = new String[60];
 		for (int i = 0; i < 10; i++) {

--- a/matsim/src/main/java/org/matsim/core/utils/misc/Time.java
+++ b/matsim/src/main/java/org/matsim/core/utils/misc/Time.java
@@ -58,11 +58,6 @@ public class Time {
 
 	private final static String[] timeElements;
 	
-	public static boolean isUndefinedTime( final double time ) {
-
-		// give the option to change the convention at some point in time.  kai, nov'17
-		return time==UNDEFINED_TIME ;
-	}
 	public static double getUndefinedTime() {
 		// give the option to change the convention at some point in time.  kai, nov'17
 		return UNDEFINED_TIME ;

--- a/matsim/src/main/java/org/matsim/core/utils/misc/Time.java
+++ b/matsim/src/main/java/org/matsim/core/utils/misc/Time.java
@@ -174,7 +174,7 @@ public class Time {
 	 * @throws IllegalArgumentException when the string cannot be interpreted as a valid time.
 	 */
 	public static final double parseTime(final String time) {
-		return parseTime(time, ':').orElse(UNDEFINED_TIME);
+		return parseTime(time, ':').seconds();
 	}
 
 	public static final OptionalTime parseOptionalTime(final String time) {

--- a/matsim/src/main/java/org/matsim/core/utils/misc/Time.java
+++ b/matsim/src/main/java/org/matsim/core/utils/misc/Time.java
@@ -105,8 +105,10 @@ public class Time {
 		if (TIMEFORMAT_SSSS.equals(timeformat)) {
 			return Long.toString((long)seconds);
 		}
+		if (seconds == UNDEFINED_TIME) {
+			return "undefined";
+		}
 		if (seconds < 0) {
-			if (seconds == UNDEFINED_TIME) return "undefined";
 			return "-" + writeTime(Math.abs(seconds), timeformat, separator);
 		}
 		double s = seconds;

--- a/matsim/src/main/java/org/matsim/deprecated/scoring/functions/CharyparNagelLegScoring.java
+++ b/matsim/src/main/java/org/matsim/deprecated/scoring/functions/CharyparNagelLegScoring.java
@@ -32,7 +32,6 @@ import org.matsim.api.core.v01.population.Route;
 import org.matsim.core.gbl.Gbl;
 import org.matsim.core.scoring.functions.ModeUtilityParameters;
 import org.matsim.core.scoring.functions.ScoringParameters;
-import org.matsim.core.utils.misc.Time;
 import org.matsim.deprecated.scoring.ScoringFunctionAccumulator.ArbitraryEventScoring;
 import org.matsim.deprecated.scoring.ScoringFunctionAccumulator.LegScoring;
 import org.matsim.pt.PtConstants;
@@ -61,7 +60,7 @@ public class CharyparNagelLegScoring implements LegScoring, ArbitraryEventScorin
 	private boolean nextEnterVehicleIsFirstOfTrip = true ;
 	private boolean nextStartPtLegIsFirstOfTrip = true ;
 	private boolean currentLegIsPtLeg = false;
-	private double lastActivityEndTime = Time.getUndefinedTime() ;
+	private double lastActivityEndTime = Double.NaN;
 	
 	@Deprecated // this version should not be used any more.  Instead the SumScoringFunction variant should be used.  kai, aug'18
 	public CharyparNagelLegScoring(final ScoringParameters params, Network network) {

--- a/matsim/src/main/java/org/matsim/pt/analysis/TransitLoad.java
+++ b/matsim/src/main/java/org/matsim/pt/analysis/TransitLoad.java
@@ -36,7 +36,6 @@ import org.matsim.core.api.experimental.events.VehicleArrivesAtFacilityEvent;
 import org.matsim.core.api.experimental.events.VehicleDepartsAtFacilityEvent;
 import org.matsim.core.api.experimental.events.handler.VehicleArrivesAtFacilityEventHandler;
 import org.matsim.core.api.experimental.events.handler.VehicleDepartsAtFacilityEventHandler;
-import org.matsim.core.utils.misc.Time;
 import org.matsim.pt.transitSchedule.api.Departure;
 import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
@@ -255,8 +254,8 @@ public class TransitLoad implements TransitDriverStartsEventHandler, VehicleArri
 	public static class StopInformation {
 		public short nOfEntering = 0;
 		public short nOfLeaving = 0;
-		public double arrivalTime = Time.getUndefinedTime();
-		public double departureTime = Time.getUndefinedTime();
+		public double arrivalTime = Double.NaN;
+		public double departureTime = Double.NaN;
 	}
 
 }

--- a/matsim/src/main/java/org/matsim/pt/router/TransitLeastCostPathTree.java
+++ b/matsim/src/main/java/org/matsim/pt/router/TransitLeastCostPathTree.java
@@ -39,7 +39,6 @@ import org.matsim.core.router.util.LeastCostPathCalculator.Path;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.utils.collections.PseudoRemovePriorityQueue;
 import org.matsim.core.utils.collections.RouterPriorityQueue;
-import org.matsim.core.utils.misc.Time;
 import org.matsim.pt.router.TransitRouterNetwork.TransitRouterNetworkLink;
 import org.matsim.pt.router.TransitRouterNetwork.TransitRouterNetworkNode;
 import org.matsim.pt.transitSchedule.api.TransitLine;
@@ -299,7 +298,7 @@ public class TransitLeastCostPathTree {
 				}
 
 				transferCost += ((TransitRouterNetworkTravelTimeAndDisutility) this.costFunction).defaultTransferCost(link,
-						Time.getUndefinedTime(),null,null);
+						Double.NEGATIVE_INFINITY,null,null);
 
 				downstreamLink = null;
 			} else {

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/MinimalTransferTimesImpl.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/MinimalTransferTimesImpl.java
@@ -19,15 +19,14 @@
 
 package org.matsim.pt.transitSchedule;
 
-import org.matsim.api.core.v01.Id;
-import org.matsim.core.utils.misc.Time;
-import org.matsim.pt.transitSchedule.api.MinimalTransferTimes;
-import org.matsim.pt.transitSchedule.api.TransitStopFacility;
-
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.pt.transitSchedule.api.MinimalTransferTimes;
+import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 
 /**
  * Default implementation of {@link org.matsim.pt.transitSchedule.api.MinimalTransferTimes}
@@ -40,7 +39,7 @@ class MinimalTransferTimesImpl implements MinimalTransferTimes {
 
 	@Override
 	public double set(Id<TransitStopFacility> fromStop, Id<TransitStopFacility> toStop, double seconds) {
-		if (Double.isNaN(seconds) || Time.isUndefinedTime(seconds)) {
+		if (Double.isNaN(seconds)) {
 			return remove(fromStop, toStop);
 		}
 		Map<Id<TransitStopFacility>, Double> innerMap = this.minimalTransferTimes.computeIfAbsent(fromStop, key -> new ConcurrentHashMap<>());

--- a/matsim/src/main/java/org/matsim/utils/leastcostpathtree/LeastCostPathTree.java
+++ b/matsim/src/main/java/org/matsim/utils/leastcostpathtree/LeastCostPathTree.java
@@ -20,6 +20,10 @@
 
 package org.matsim.utils.leastcostpathtree;
 
+import java.util.Comparator;
+import java.util.Map;
+import java.util.PriorityQueue;
+
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.IdMap;
 import org.matsim.api.core.v01.TransportMode;
@@ -36,13 +40,8 @@ import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.scenario.MutableScenario;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.trafficmonitoring.TravelTimeCalculator;
-import org.matsim.core.utils.misc.Time;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleUtils;
-
-import java.util.Comparator;
-import java.util.Map;
-import java.util.PriorityQueue;
 
 /**
  * Calculates a least-cost-path tree using Dijkstra's algorithm  for calculating a shortest-path
@@ -58,7 +57,7 @@ public class LeastCostPathTree {
 	// ////////////////////////////////////////////////////////////////////
 
 	private Node origin1 = null;
-	private double dTime = Time.getUndefinedTime();
+	private double dTime = Double.NaN;
 	
 	private final TravelTime ttFunction;
 	private final TravelDisutility tcFunction;

--- a/matsim/src/test/java/org/matsim/core/network/TimeVariantLinkImplTest.java
+++ b/matsim/src/test/java/org/matsim/core/network/TimeVariantLinkImplTest.java
@@ -28,7 +28,6 @@ import org.matsim.api.core.v01.network.NetworkFactory;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.core.network.NetworkChangeEvent.ChangeType;
 import org.matsim.core.network.NetworkChangeEvent.ChangeValue;
-import org.matsim.core.utils.misc.Time;
 import org.matsim.testcases.MatsimTestCase;
 
 /**
@@ -36,6 +35,8 @@ import org.matsim.testcases.MatsimTestCase;
  * @author laemmel
  */
 public class TimeVariantLinkImplTest extends MatsimTestCase {
+
+	private static final double TIME_BEFORE_FIRST_CHANGE_EVENTS = -99999;//when  base (default) link properties are used
 
 	/** Tests the method {@link NetworkUtils#getFreespeedTravelTime(Link, double)}.	 */
 	public void testGetFreespeedTravelTime(){
@@ -55,7 +56,7 @@ public class TimeVariantLinkImplTest extends MatsimTestCase {
 		final Node toNode1 = node4;
     		final Link link3 = NetworkUtils.createAndAddLink(network,Id.create("3", Link.class), fromNode1, toNode1, (double) 1000, 1.667, (double) 3600, (double) 1 );
     
-    		final double [] queryDates = {Time.getUndefinedTime(), 0., 1., 2., 3., 4.};
+    		final double [] queryDates = {TIME_BEFORE_FIRST_CHANGE_EVENTS, 0., 1., 2., 3., 4.};
     
     		// link1 change event absolute, undef. endtime
     		final double [] responsesLink1 = {1.667, 1.667, 10., 10., 10., 10.};
@@ -95,8 +96,8 @@ public class TimeVariantLinkImplTest extends MatsimTestCase {
     		TimeVariantLinkImpl link = (TimeVariantLinkImpl)NetworkUtils.createAndAddLink(network,Id.create("1", Link.class), fromNode, toNode, (double) 100, (double) 10, (double) 3600, (double) 1 );
     
     		// test base values
-    		assertEquals(10.0, link.getFreespeed(Time.getUndefinedTime()), EPSILON);
-    		assertEquals(10.0, NetworkUtils.getFreespeedTravelTime(link, Time.getUndefinedTime()), EPSILON);
+    		assertEquals(10.0, link.getFreespeed(TIME_BEFORE_FIRST_CHANGE_EVENTS), EPSILON);
+    		assertEquals(10.0, NetworkUtils.getFreespeedTravelTime(link, TIME_BEFORE_FIRST_CHANGE_EVENTS), EPSILON);
     
     		// add an absolute change
     		NetworkChangeEvent change = new NetworkChangeEvent(7*3600.0);
@@ -105,14 +106,14 @@ public class TimeVariantLinkImplTest extends MatsimTestCase {
     		link.applyEvent(change);
     
     		// do the tests
-    		assertEquals(10.0, link.getFreespeed(Time.getUndefinedTime()), EPSILON); // at undefined time, return base value
+    		assertEquals(10.0, link.getFreespeed(TIME_BEFORE_FIRST_CHANGE_EVENTS), EPSILON); // before first change event, return base value
     		assertEquals(10.0, link.getFreespeed(7*3600.0 - 1.0), EPSILON);  // one second before change, still base value
     		assertEquals(10.0, link.getFreespeed(7*3600.0 - 0.1), EPSILON);  // just before change, still base value
     		assertEquals(20.0, link.getFreespeed(7*3600.0), EPSILON); // just on time of change, new value
     		assertEquals(20.0, link.getFreespeed(8*3600.0), EPSILON); // some time later, still new value
     
     		// test derived values
-    		assertEquals(10.0, NetworkUtils.getFreespeedTravelTime(link, Time.getUndefinedTime()), EPSILON); // and now the same tests for the travel time
+    		assertEquals(10.0, NetworkUtils.getFreespeedTravelTime(link, TIME_BEFORE_FIRST_CHANGE_EVENTS), EPSILON); // and now the same tests for the travel time
     		assertEquals(10.0, NetworkUtils.getFreespeedTravelTime(link, 7*3600.0 - 1.0), EPSILON);
     		assertEquals(10.0, NetworkUtils.getFreespeedTravelTime(link, 7*3600.0 - 0.1), EPSILON);
     		assertEquals(5.0, NetworkUtils.getFreespeedTravelTime(link, 7*3600.0), EPSILON);
@@ -140,8 +141,8 @@ public class TimeVariantLinkImplTest extends MatsimTestCase {
     		TimeVariantLinkImpl link = (TimeVariantLinkImpl)NetworkUtils.createAndAddLink(network,Id.create("1", Link.class), fromNode, toNode, (double) 100, (double) 10, (double) 3600, (double) 1 );
     
     		// test base values
-    		assertEquals(10.0, link.getFreespeed(Time.getUndefinedTime()), EPSILON);
-    		assertEquals(10.0, NetworkUtils.getFreespeedTravelTime(link, Time.getUndefinedTime()), EPSILON);
+    		assertEquals(10.0, link.getFreespeed(TIME_BEFORE_FIRST_CHANGE_EVENTS), EPSILON);
+    		assertEquals(10.0, NetworkUtils.getFreespeedTravelTime(link, TIME_BEFORE_FIRST_CHANGE_EVENTS), EPSILON);
     
     		// add a relative change
     		NetworkChangeEvent change = new NetworkChangeEvent(7*3600.0);
@@ -150,14 +151,14 @@ public class TimeVariantLinkImplTest extends MatsimTestCase {
     		link.applyEvent(change);
     
     		// do the tests for the actual value
-    		assertEquals(10.0, link.getFreespeed(Time.getUndefinedTime()), EPSILON); // at undefined time, return base value
+    		assertEquals(10.0, link.getFreespeed(TIME_BEFORE_FIRST_CHANGE_EVENTS), EPSILON); // before first change event, return base value
     		assertEquals(10.0, link.getFreespeed(7*3600.0 - 1.0), EPSILON);  // one second before change, still base value
     		assertEquals(10.0, link.getFreespeed(7*3600.0 - 0.1), EPSILON);  // just before change, still base value
     		assertEquals(5.0, link.getFreespeed(7*3600.0), EPSILON); // just on time of change, new value
     		assertEquals(5.0, link.getFreespeed(8*3600.0), EPSILON); // some time later, still new value
     
     		// do tests for derived values
-    		assertEquals(10.0, NetworkUtils.getFreespeedTravelTime(link, Time.getUndefinedTime()), EPSILON); // and now the same tests for the travel time
+    		assertEquals(10.0, NetworkUtils.getFreespeedTravelTime(link, TIME_BEFORE_FIRST_CHANGE_EVENTS), EPSILON); // and now the same tests for the travel time
     		assertEquals(10.0, NetworkUtils.getFreespeedTravelTime(link, 7*3600.0 - 1.0), EPSILON);
     		assertEquals(10.0, NetworkUtils.getFreespeedTravelTime(link, 7*3600.0 - 0.1), EPSILON);
     		assertEquals(20.0, NetworkUtils.getFreespeedTravelTime(link, 7*3600.0), EPSILON);
@@ -185,8 +186,8 @@ public class TimeVariantLinkImplTest extends MatsimTestCase {
     		TimeVariantLinkImpl link = (TimeVariantLinkImpl)NetworkUtils.createAndAddLink(network,Id.create("1", Link.class), fromNode, toNode, (double) 100, (double) 10, (double) 3600, (double) 1 );
     
     		// test base values
-    		assertEquals(10.0, link.getFreespeed(Time.getUndefinedTime()), EPSILON);
-    		assertEquals(10.0, NetworkUtils.getFreespeedTravelTime(link, Time.getUndefinedTime()), EPSILON);
+    		assertEquals(10.0, link.getFreespeed(TIME_BEFORE_FIRST_CHANGE_EVENTS), EPSILON);
+    		assertEquals(10.0, NetworkUtils.getFreespeedTravelTime(link, TIME_BEFORE_FIRST_CHANGE_EVENTS), EPSILON);
     
     		// add some changes:
     		// - first a change event starting at 7am
@@ -222,7 +223,7 @@ public class TimeVariantLinkImplTest extends MatsimTestCase {
     		 */
     
     		// do the tests for the actual value
-    		assertEquals(10.0, link.getFreespeed(Time.getUndefinedTime()), EPSILON); // at undefined time, return base value
+    		assertEquals(10.0, link.getFreespeed(TIME_BEFORE_FIRST_CHANGE_EVENTS), EPSILON); // before first change event, return base value
     		assertEquals(10.0, link.getFreespeed(7*3600.0 - 1.0), EPSILON);
     		assertEquals(20.0, link.getFreespeed(7*3600.0), EPSILON);
     		assertEquals(20.0, link.getFreespeed(8*3600.0-1), EPSILON);
@@ -295,8 +296,8 @@ public class TimeVariantLinkImplTest extends MatsimTestCase {
     		TimeVariantLinkImpl link = (TimeVariantLinkImpl)NetworkUtils.createAndAddLink(network,Id.create("1", Link.class), fromNode, toNode, (double) 100, (double) 10, (double) 3600, (double) 1 );
     
     		// test base values
-    		assertEquals(3600.0, link.getCapacity(Time.getUndefinedTime()), EPSILON);
-    		assertEquals(1.0, link.getFlowCapacityPerSec(Time.getUndefinedTime()), EPSILON);
+    		assertEquals(3600.0, link.getCapacity(TIME_BEFORE_FIRST_CHANGE_EVENTS), EPSILON);
+    		assertEquals(1.0, link.getFlowCapacityPerSec(TIME_BEFORE_FIRST_CHANGE_EVENTS), EPSILON);
     
     		// add an absolute change
     		NetworkChangeEvent change = new NetworkChangeEvent(7*3600.0);
@@ -305,8 +306,8 @@ public class TimeVariantLinkImplTest extends MatsimTestCase {
     		link.applyEvent(change);
     
     		// do the tests
-    		assertEquals(3600.0, link.getCapacity(Time.getUndefinedTime()), EPSILON);
-    		assertEquals(1.0, link.getFlowCapacityPerSec(Time.getUndefinedTime()), EPSILON);
+    		assertEquals(3600.0, link.getCapacity(TIME_BEFORE_FIRST_CHANGE_EVENTS), EPSILON);
+    		assertEquals(1.0, link.getFlowCapacityPerSec(TIME_BEFORE_FIRST_CHANGE_EVENTS), EPSILON);
     		assertEquals(2.0, link.getFlowCapacityPerSec(7*3600), EPSILON);
     
     		// test derived values
@@ -334,7 +335,7 @@ public class TimeVariantLinkImplTest extends MatsimTestCase {
     		TimeVariantLinkImpl link = (TimeVariantLinkImpl)NetworkUtils.createAndAddLink(network,Id.create("1", Link.class), fromNode, toNode, (double) 100, (double) 10, (double) 3600, (double) 1 );
     
     		// test base values
-    		assertEquals(1.0, link.getNumberOfLanes(Time.getUndefinedTime()), EPSILON);
+    		assertEquals(1.0, link.getNumberOfLanes(TIME_BEFORE_FIRST_CHANGE_EVENTS), EPSILON);
     
     		// add an absolute change
     		NetworkChangeEvent change = new NetworkChangeEvent(7*3600.0);
@@ -343,7 +344,7 @@ public class TimeVariantLinkImplTest extends MatsimTestCase {
     		link.applyEvent(change);
     
     		// do the tests
-    		assertEquals(1.0, link.getNumberOfLanes(Time.getUndefinedTime()), EPSILON);
+    		assertEquals(1.0, link.getNumberOfLanes(TIME_BEFORE_FIRST_CHANGE_EVENTS), EPSILON);
     		assertEquals(2.0, link.getNumberOfLanes(7*3600), EPSILON);
     
     		// test derived values

--- a/matsim/src/test/java/org/matsim/core/utils/misc/TimeTest.java
+++ b/matsim/src/test/java/org/matsim/core/utils/misc/TimeTest.java
@@ -101,12 +101,12 @@ public class TimeTest extends TestCase {
 
 	public void testUndefined() {
 		// test writing
-		assertEquals("undefined", Time.writeTime(Time.getUndefinedTime()));
+		assertEquals("undefined", Time.writeTime(OptionalTime.undefined()));
 
 		// test reading
-		assertEquals(Time.getUndefinedTime(), Time.parseTime("undefined"), 0.0);
-		assertEquals(Time.getUndefinedTime(), Time.parseTime(""), 0.0);
-		assertEquals(Time.getUndefinedTime(), Time.parseTime(null), 0.0);
+		assertEquals(OptionalTime.undefined(), Time.parseOptionalTime("undefined"));
+		assertEquals(OptionalTime.undefined(), Time.parseOptionalTime(""));
+		assertEquals(OptionalTime.undefined(), Time.parseOptionalTime(null));
 	}
 
 	public void testSetDefault() {

--- a/matsim/src/test/java/org/matsim/integration/timevariantnetworks/QSimIntegrationTest.java
+++ b/matsim/src/test/java/org/matsim/integration/timevariantnetworks/QSimIntegrationTest.java
@@ -61,7 +61,6 @@ import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.population.routes.RouteUtils;
 import org.matsim.core.scenario.MutableScenario;
 import org.matsim.core.scenario.ScenarioUtils;
-import org.matsim.core.utils.misc.Time;
 import org.matsim.testcases.MatsimTestCase;
 import org.matsim.testcases.utils.EventsLogger;
 import org.matsim.vehicles.Vehicle;
@@ -345,10 +344,10 @@ public class QSimIntegrationTest extends MatsimTestCase {
 		private final Id<Link> linkId;
 		private Id<Vehicle> vehicleId1;
 		private Id<Vehicle> vehicleId2;
-		protected double person1enterTime = Time.getUndefinedTime();
-		protected double person1leaveTime = Time.getUndefinedTime();
-		protected double person2enterTime = Time.getUndefinedTime();
-		protected double person2leaveTime = Time.getUndefinedTime();
+		protected Double person1enterTime = null;
+		protected Double person1leaveTime = null;
+		protected Double person2enterTime = null;
+		protected Double person2leaveTime = null;
 
 		protected TestTravelTimeCalculator(final Id<Person> personId1, final Id<Person> personId2, final Id<Link> linkId) {
 			this.personId1 = personId1;


### PR DESCRIPTION
The last in the series of PRs, comes after: #970 

This is a collection of smaller commits with tiny changes addressing the removal of the remaining uses of the undefined time constant scattered all over the code.

Depending on the case, the undefined time has been replaced with NaN, -Inf or null (after boxing).