### PR TITLE
Experienced plans for postprocessing

### DIFF
--- a/matsim/src/main/java/org/matsim/core/scoring/EventsToLegs.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/EventsToLegs.java
@@ -19,28 +19,12 @@
 
 package org.matsim.core.scoring;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import com.google.inject.Inject;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
-import org.matsim.api.core.v01.events.LinkEnterEvent;
-import org.matsim.api.core.v01.events.PersonArrivalEvent;
-import org.matsim.api.core.v01.events.PersonDepartureEvent;
-import org.matsim.api.core.v01.events.PersonEntersVehicleEvent;
-import org.matsim.api.core.v01.events.TransitDriverStartsEvent;
-import org.matsim.api.core.v01.events.VehicleEntersTrafficEvent;
-import org.matsim.api.core.v01.events.VehicleLeavesTrafficEvent;
-import org.matsim.api.core.v01.events.handler.LinkEnterEventHandler;
-import org.matsim.api.core.v01.events.handler.PersonArrivalEventHandler;
-import org.matsim.api.core.v01.events.handler.PersonDepartureEventHandler;
-import org.matsim.api.core.v01.events.handler.PersonEntersVehicleEventHandler;
-import org.matsim.api.core.v01.events.handler.TransitDriverStartsEventHandler;
-import org.matsim.api.core.v01.events.handler.VehicleEntersTrafficEventHandler;
-import org.matsim.api.core.v01.events.handler.VehicleLeavesTrafficEventHandler;
+import org.matsim.api.core.v01.events.*;
+import org.matsim.api.core.v01.events.handler.*;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Leg;
@@ -61,7 +45,10 @@ import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 import org.matsim.vehicles.Vehicle;
 
-import com.google.inject.Inject;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Converts a stream of Events into a stream of Legs. Passes Legs to a single LegHandler which must be registered with this class.
@@ -164,7 +151,7 @@ public final class EventsToLegs
 
 	private List<LegHandler> legHandlers = new ArrayList<>();
 
-	EventsToLegs(Scenario scenario) {
+	public EventsToLegs(Scenario scenario) {
 		this.network = scenario.getNetwork();
 		if (scenario.getConfig().transit().isUseTransit()) {
 			this.transitSchedule = scenario.getTransitSchedule();

--- a/matsim/src/main/java/org/matsim/core/scoring/ExperiencedPlansServiceFactory.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/ExperiencedPlansServiceFactory.java
@@ -1,0 +1,35 @@
+
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * ExperiencedPlansServiceImpl.java
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2019 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.core.scoring;
+
+import org.matsim.api.core.v01.Scenario;
+
+public class ExperiencedPlansServiceFactory {
+
+    /*
+     This should only be needed in Postprocessing. The way to access Experienced Plans during a simulation is via dependency injection.
+     */
+    public static ExperiencedPlansService create(Scenario scenario, EventsToActivities eventsToActivities, EventsToLegs eventsToLegs) {
+        return new ExperiencedPlansServiceImpl(eventsToActivities, eventsToLegs, scenario);
+
+    }
+}

--- a/matsim/src/main/java/org/matsim/core/scoring/ExperiencedPlansServiceImpl.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/ExperiencedPlansServiceImpl.java
@@ -25,12 +25,8 @@ import com.google.inject.Inject;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.IdMap;
-import org.matsim.api.core.v01.population.Activity;
-import org.matsim.api.core.v01.population.Leg;
-import org.matsim.api.core.v01.population.Person;
-import org.matsim.api.core.v01.population.Plan;
-import org.matsim.api.core.v01.population.Population;
-import org.matsim.api.core.v01.population.PopulationWriter;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.population.*;
 import org.matsim.core.config.Config;
 import org.matsim.core.controler.ControlerListenerManager;
 import org.matsim.core.controler.events.IterationStartsEvent;
@@ -50,18 +46,29 @@ class ExperiencedPlansServiceImpl implements ExperiencedPlansService, EventsToLe
 	private final IdMap<Person, Plan> agentRecords = new IdMap<>(Person.class);
 
 	@Inject
-	ExperiencedPlansServiceImpl(ControlerListenerManager controlerListenerManager, EventsToActivities eventsToActivities, EventsToLegs eventsToLegs) {
-		controlerListenerManager.addControlerListener(new IterationStartsListener() {
-			@Override
-			public void notifyIterationStarts(IterationStartsEvent event) {
-				for (Person person : population.getPersons().values()) {
-					agentRecords.put(person.getId(), PopulationUtils.createPlan());
-				}
-			}
-		});
-		eventsToActivities.addActivityHandler(this);
-		eventsToLegs.addLegHandler(this);
-	}
+    ExperiencedPlansServiceImpl(ControlerListenerManager controlerListenerManager, EventsToActivities eventsToActivities, EventsToLegs eventsToLegs) {
+        controlerListenerManager.addControlerListener(new IterationStartsListener() {
+            @Override
+            public void notifyIterationStarts(IterationStartsEvent event) {
+                for (Person person : population.getPersons().values()) {
+                    agentRecords.put(person.getId(), PopulationUtils.createPlan());
+                }
+            }
+        });
+        eventsToActivities.addActivityHandler(this);
+        eventsToLegs.addLegHandler(this);
+    }
+
+    ExperiencedPlansServiceImpl(EventsToActivities eventsToActivities, EventsToLegs eventsToLegs, Scenario scenario) {
+        this.population = scenario.getPopulation();
+
+        for (Person person : population.getPersons().values()) {
+            agentRecords.put(person.getId(), PopulationUtils.createPlan());
+        }
+        eventsToActivities.addActivityHandler(this);
+        eventsToLegs.addLegHandler(this);
+        this.config = scenario.getConfig();
+    }
 
 	@Override
 	synchronized public void handleLeg(PersonExperiencedLeg o) {


### PR DESCRIPTION
Sometimes, there is a need to create experienced plans from finished simulation output, as they provide some very useful output, but are not written out by default.
This PR allows to do exactly this. 
A usage example will be pushed into code-examples afterwards.