### PR TITLE
cold emission handler must be added to events manager

### DIFF
--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/ColdEmissionHandler.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/ColdEmissionHandler.java
@@ -69,7 +69,7 @@ final class ColdEmissionHandler implements LinkLeaveEventHandler, VehicleLeavesT
                         ConfigUtils.addOrGetModule( scenario.getConfig(), EmissionsConfigGroup.class ), coldPollutants, eventsManager );
         this.scenario = scenario;
         this.emissionsConfigGroup = ConfigUtils.addOrGetModule( scenario.getConfig(), EmissionsConfigGroup.class );
-
+        eventsManager.addHandler( this );
     }
 
         @Override


### PR DESCRIPTION
cold emission handler must be added to the events manager to throw cold emission events. I think it was accidentally removed.


@joemolloy @kainagel 