### PR TITLE
Fixed the ParallelEventsManager

### DIFF
--- a/contribs/av/src/test/java/org/matsim/contrib/av/robotaxi/fares/taxi/TaxiFareHandlerTest.java
+++ b/contribs/av/src/test/java/org/matsim/contrib/av/robotaxi/fares/taxi/TaxiFareHandlerTest.java
@@ -118,7 +118,7 @@ public class TaxiFareHandlerTest {
 
 	private Network createNetwork(){
 		Network network = NetworkUtils.createNetwork();
-		Node n1 = NetworkUtils.createNode( Id.createNodeId(1), new Coord(0,0));
+		Node n1 = NetworkUtils.createNode(Id.createNodeId(1), new Coord(0,0));
 		Node n2 = NetworkUtils.createNode(Id.createNodeId(2), new Coord(2000,0));
 		Node n3 = NetworkUtils.createNode(Id.createNodeId(3), new Coord(2000,2000));
 		Node n4 = NetworkUtils.createNode(Id.createNodeId(4), new Coord(2100,2000));

--- a/matsim/src/main/java/org/matsim/core/events/ParallelEventsManager.java
+++ b/matsim/src/main/java/org/matsim/core/events/ParallelEventsManager.java
@@ -93,14 +93,14 @@ public final class ParallelEventsManager implements EventsManager {
 				this.eventsManagers.add(new EventsManagerImpl());
 			}
 			for (int i = 0; i < this.eventsHandlers.size(); i++) {
-				this.eventsManagers.get(this.eventsHandlers.size() % numOfThreads).addHandler(this.eventsHandlers.get(i));
+				this.eventsManagers.get(i % numOfThreads).addHandler(this.eventsHandlers.get(i));
 			}
 		}
 
 		// initialize runnables (threads that will execute the event managers)
 		for (int i = 0; i < this.eventsManagers.size(); i++) {
 			EventsManager eventsManager = this.eventsManagers.get(i);
-			ProcessEventsRunnable processEventsRunnable = new ProcessEventsRunnable(eventsManager);
+			ProcessEventsRunnable processEventsRunnable = new ProcessEventsRunnable(eventsManager, distributor);
 			distributor.runnables.add(processEventsRunnable);
 			processEventsRunnable.setDaemon(true);
 			processEventsRunnable.setUncaughtExceptionHandler(this.uncaughtExceptionHandler);
@@ -268,10 +268,21 @@ public final class ParallelEventsManager implements EventsManager {
 									distribute(events);
 									events = new EventArray(eventsArraySize);
 								}
-								// flush all runnables
-								for (ProcessEventsRunnable runnable : this.runnables) {
+
+								// We'll ask the ProcessEventsRunnables to flush
+								for (ProcessEventsRunnable runnable : this.runnables)
 									runnable.flush();
+
+								// Wait until all the ProcessEventsRunnables have finished flushing
+								boolean stillFlushing = true;
+								while (stillFlushing) {
+									this.wait(1);
+
+									stillFlushing = false;
+									for (ProcessEventsRunnable runnable : this.runnables)
+										stillFlushing |= runnable.isFlushing();
 								}
+
 								// termination criteria for the flush
 								if (eventQueue.isEmpty()) {
 									shouldFlush = false;
@@ -314,30 +325,47 @@ public final class ParallelEventsManager implements EventsManager {
 
 	private class ProcessEventsRunnable extends Thread {
 
+		private final Distributor distributor;
 		private final EventsManager eventsManager;
 		private final BlockingQueue<EventArray> eventsQueue;
-		private volatile boolean processing = false;
+		private boolean flush = false;
 
-		public ProcessEventsRunnable(EventsManager eventsManager) {
+		public ProcessEventsRunnable(EventsManager eventsManager, Distributor distributor) {
 			this.eventsManager = eventsManager;
 			this.eventsQueue = new LinkedBlockingQueue<>();
+			this.distributor = distributor;
 		}
 
-		public void flush() throws InterruptedException {
-			while (this.isAlive() && (!this.eventsQueue.isEmpty() || processing)) ;
+		public synchronized void flush() {
+			flush = true;
+		}
+
+		public boolean isFlushing() {
+			return flush && this.isAlive();
 		}
 
 		@Override
 		public void run() {
 			try {
 				while (true) {
-					EventArray events = this.eventsQueue.take();
+					EventArray events = this.eventsQueue.poll(10, TimeUnit.MILLISECONDS);
 
-					processing = true;
-					for (int i = 0; i < events.size(); i++) {
-						this.eventsManager.processEvent(events.get(i));
+					if (events != null) {
+						for (int i = 0; i < events.size(); i++) {
+							this.eventsManager.processEvent(events.get(i));
+						}
 					}
-					processing = false;
+
+					// If flush is over, then try to wake up distributor
+					if (flush && this.eventsQueue.isEmpty()) {
+						synchronized (this) {
+							flush = false;
+						}
+
+						synchronized (this.distributor) {
+							this.distributor.notify();
+						}
+					}
 				}
 			} catch (InterruptedException e) {
 				return;


### PR DESCRIPTION
Due to race conditions, the `ParallelEventsManager` would sometimes fail to properly `flush()` events that would themselves introduce new events in the Manager. This would mean that calling `flush()` would produce unexpected outcomes. This patch fixes these issues, and ensures that `flush()` now offers true synchronization barrier semantics, as well as proper event flush semantics.

This patch also fixes a small issue in the `ParallelEventsManager` where `EventHandler`s would be added to the same `EventsManager`. Now the `EventHandler`s should be uniformly distributed among the available `EventsManager`s.