### PR TITLE
Vehicle types in DVRP

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
@@ -35,6 +35,7 @@ import org.matsim.core.controler.MatsimServices;
 import org.matsim.core.controler.events.IterationEndsEvent;
 import org.matsim.core.controler.listener.IterationEndsListener;
 import org.matsim.core.utils.io.IOUtils;
+import org.matsim.vehicles.Vehicles;
 
 /**
  * @author jbischoff
@@ -53,7 +54,7 @@ public class DrtAnalysisControlerListener implements IterationEndsListener {
 	private final DecimalFormat format = new DecimalFormat();
 	private final int maxcap;
 
-	public DrtAnalysisControlerListener(Config config, DrtConfigGroup drtCfg, FleetSpecification fleet,
+	public DrtAnalysisControlerListener(Config config, DrtConfigGroup drtCfg, FleetSpecification fleet, Vehicles vehicles,
 										DrtPassengerAndVehicleStats drtPassengerStats, MatsimServices matsimServices, Network network,
 										DrtRequestAnalyzer drtRequestAnalyzer) {
 		this.drtPassengerStats = drtPassengerStats;
@@ -63,7 +64,7 @@ public class DrtAnalysisControlerListener implements IterationEndsListener {
 		this.drtCfg = drtCfg;
 		this.qSimCfg = config.qsim();
 		runId = config.controler().getRunId();
-		maxcap = DrtTripsAnalyser.findMaxVehicleCapacity(fleet);
+		maxcap = DrtTripsAnalyser.findMaxVehicleCapacity(fleet, vehicles);
 
 		format.setDecimalFormatSymbols(new DecimalFormatSymbols(Locale.US));
 		format.setMinimumIntegerDigits(1);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtModeAnalysisModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtModeAnalysisModule.java
@@ -33,6 +33,7 @@ import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.controler.MatsimServices;
+import org.matsim.vehicles.Vehicles;
 
 /**
  * @author michalm (Michal Maciejewski)
@@ -48,8 +49,9 @@ public class DrtModeAnalysisModule extends AbstractDvrpModeModule {
 	@Override
 	public void install() {
 		bindModal(DrtPassengerAndVehicleStats.class).toProvider(modalProvider(
-				getter -> new DrtPassengerAndVehicleStats(getter.get(Network.class), getter.get(EventsManager.class), drtCfg,
-						getter.getModal(FleetSpecification.class)))).asEagerSingleton();
+				getter -> new DrtPassengerAndVehicleStats(getter.get(Network.class), getter.get(Vehicles.class),
+						getter.get(EventsManager.class), drtCfg, getter.getModal(FleetSpecification.class))))
+				.asEagerSingleton();
 
 		bindModal(DrtRequestAnalyzer.class).toProvider(modalProvider(
 				getter -> new DrtRequestAnalyzer(getter.get(EventsManager.class), getter.get(Network.class), drtCfg)))
@@ -57,9 +59,10 @@ public class DrtModeAnalysisModule extends AbstractDvrpModeModule {
 
 		addControlerListenerBinding().toProvider(modalProvider(
 				getter -> new DrtAnalysisControlerListener(getter.get(Config.class), drtCfg,
-						getter.getModal(FleetSpecification.class), getter.getModal(DrtPassengerAndVehicleStats.class),
-						getter.get(MatsimServices.class), getter.get(Network.class),
-						getter.getModal(DrtRequestAnalyzer.class)))).asEagerSingleton();
+						getter.getModal(FleetSpecification.class), getter.get(Vehicles.class),
+						getter.getModal(DrtPassengerAndVehicleStats.class), getter.get(MatsimServices.class),
+						getter.get(Network.class), getter.getModal(DrtRequestAnalyzer.class))))
+				.asEagerSingleton();
 
 		installQSimModule(new AbstractDvrpModeQSimModule(getMode()) {
 			@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtPassengerAndVehicleStats.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtPassengerAndVehicleStats.java
@@ -45,6 +45,7 @@ import org.matsim.contrib.dvrp.passenger.PassengerRequestRejectedEvent;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestRejectedEventHandler;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.vehicles.Vehicle;
+import org.matsim.vehicles.Vehicles;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -69,13 +70,15 @@ public class DrtPassengerAndVehicleStats
 	private final Map<Id<Request>, Id<Person>> request2person = new HashMap<>();
 	private final String mode;
 	private final Network network;
+	private final Vehicles vehicles;
 	private Set<Id<Vehicle>> monitoredVehicles;
 	private final FleetSpecification fleetSpecification;
 
-	public DrtPassengerAndVehicleStats(Network network, EventsManager events, DrtConfigGroup drtCfg,
+	public DrtPassengerAndVehicleStats(Network network, Vehicles vehicles, EventsManager events, DrtConfigGroup drtCfg,
 									   FleetSpecification fleetSpecification) {
 		this.mode = drtCfg.getMode();
 		this.network = network;
+		this.vehicles = vehicles;
 		events.addHandler(this);
 		this.fleetSpecification = fleetSpecification;
 		
@@ -99,7 +102,7 @@ public class DrtPassengerAndVehicleStats
 
 
 	private void initializeVehicles() {
-		int maxcap = DrtTripsAnalyser.findMaxVehicleCapacity(fleetSpecification);
+		int maxcap = DrtTripsAnalyser.findMaxVehicleCapacity(fleetSpecification, vehicles);
 		this.monitoredVehicles = fleetSpecification.getVehicleSpecifications()
 				.keySet()
 				.stream()

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtTripsAnalyser.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtTripsAnalyser.java
@@ -59,12 +59,12 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
-import org.matsim.contrib.dvrp.fleet.DvrpVehicleSpecification;
 import org.matsim.contrib.dvrp.fleet.FleetSpecification;
 import org.matsim.contrib.util.chart.ChartSaveUtils;
 import org.matsim.core.utils.io.IOUtils;
 import org.matsim.core.utils.misc.Time;
 import org.matsim.vehicles.Vehicle;
+import org.matsim.vehicles.Vehicles;
 
 /**
  * @author jbischoff
@@ -508,11 +508,11 @@ public class DrtTripsAnalyser {
 	 * @param fleet
 	 * @return
 	 */
-	public static int findMaxVehicleCapacity(FleetSpecification fleet) {
+	public static int findMaxVehicleCapacity(FleetSpecification fleet, Vehicles vehicles) {
 		return fleet.getVehicleSpecifications()
 				.values()
 				.stream()
-				.mapToInt(DvrpVehicleSpecification::getCapacity)
+				.mapToInt(v -> vehicles.getVehicleTypes().get(v.getVehicleTypeId()).getCapacity().getSeats())
 				.max()
 				.getAsInt();
 	}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
@@ -36,6 +36,8 @@ import org.matsim.contrib.dvrp.fleet.DvrpVehicleImpl;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicleSpecification;
 import org.matsim.contrib.dvrp.fleet.ImmutableDvrpVehicleSpecification;
 import org.matsim.testcases.fakes.FakeLink;
+import org.matsim.vehicles.VehicleType;
+import org.matsim.vehicles.VehicleUtils;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -45,6 +47,12 @@ import com.google.common.collect.ImmutableList;
  */
 public class InsertionGeneratorTest {
 	private static final int CAPACITY = 4;
+	private static final VehicleType VEHICLE_TYPE;
+	
+	static {
+		VEHICLE_TYPE = VehicleUtils.createVehicleType(Id.create("test", VehicleType.class));
+		VEHICLE_TYPE.getCapacity().setSeats(CAPACITY);
+	}
 
 	private final Link fromLink = link("from");
 	private final Link toLink = link("to");
@@ -53,12 +61,12 @@ public class InsertionGeneratorTest {
 	private final Link depotLink = link("depot");
 	private final DvrpVehicleSpecification vehicleSpecification = ImmutableDvrpVehicleSpecification.newBuilder()
 			.id(Id.create("v1", DvrpVehicle.class))
-			.capacity(CAPACITY)
+			.vehicleTypeId(VEHICLE_TYPE.getId())
 			.startLinkId(depotLink.getId())
 			.serviceBeginTime(0)
 			.serviceEndTime(24 * 3600)
 			.build();
-	private final DvrpVehicle vehicle = new DvrpVehicleImpl(vehicleSpecification, depotLink);
+	private final DvrpVehicle vehicle = new DvrpVehicleImpl(vehicleSpecification, VEHICLE_TYPE, depotLink);
 
 	@Test
 	public void generateInsertions_startEmpty_noStops() {

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/benchmark/DvrpBenchmarkModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/benchmark/DvrpBenchmarkModule.java
@@ -23,13 +23,10 @@ import org.matsim.contrib.dvrp.fleet.DvrpVehicleLookup;
 import org.matsim.contrib.dvrp.passenger.PassengerModule;
 import org.matsim.contrib.dvrp.router.DvrpGlobalRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.run.MobsimTimerProvider;
-import org.matsim.contrib.dvrp.vrpagent.VrpAgentSourceQSimModule;
 import org.matsim.contrib.dynagent.run.DynActivityEngine;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
-import org.matsim.vehicles.VehicleType;
-import org.matsim.vehicles.VehicleUtils;
 
 import com.google.inject.name.Names;
 
@@ -39,9 +36,6 @@ import com.google.inject.name.Names;
 public class DvrpBenchmarkModule extends AbstractModule {
 	@Override
 	public void install() {
-		bind(VehicleType.class).annotatedWith(Names.named(VrpAgentSourceQSimModule.DVRP_VEHICLE_TYPE))
-				.toInstance(VehicleUtils.getDefaultVehicleType());
-
 		install(new DvrpBenchmarkTravelTimeModule());// fixed travel times
 
 		bind(Network.class).annotatedWith(Names.named(DvrpGlobalRoutingNetworkProvider.DVRP_ROUTING))

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/OneTruckModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/OneTruckModule.java
@@ -35,8 +35,6 @@ import org.matsim.contrib.dvrp.vrpagent.VrpAgentSourceQSimModule;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehicleUtils;
 
-import com.google.inject.name.Names;
-
 /**
  * @author Michal Maciejewski (michalm)
  */
@@ -53,8 +51,6 @@ public class OneTruckModule extends AbstractDvrpModeModule {
 		DvrpModes.registerDvrpMode(binder(), getMode());
 		install(new DvrpModeRoutingNetworkModule(getMode(), false));
 
-		bind(VehicleType.class).annotatedWith(Names.named(VrpAgentSourceQSimModule.DVRP_VEHICLE_TYPE))
-				.toInstance(createTruckType());
 		install(new FleetModule(getMode(), fleetSpecificationUrl));
 
 		installQSimModule(new AbstractDvrpModeQSimModule(getMode()) {
@@ -69,7 +65,7 @@ public class OneTruckModule extends AbstractDvrpModeModule {
 		});
 	}
 
-	private static VehicleType createTruckType() {
+	public static VehicleType createTruckType() {
 		VehicleType truckType = VehicleUtils.getFactory().createVehicleType(Id.create("truckType", VehicleType.class));
 		truckType.setLength(15.);
 		truckType.setPcuEquivalents(2.5);

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/RunOneTruckExample.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/RunOneTruckExample.java
@@ -32,6 +32,7 @@ import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.Controler;
 import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.vehicles.Vehicles;
 import org.matsim.vis.otfvis.OTFVisConfigGroup;
 
 /**
@@ -45,7 +46,11 @@ public final class RunOneTruckExample {
 
 		// load scenario
 		Scenario scenario = ScenarioUtils.loadScenario(config);
-
+		
+		// set up vehicle type
+		Vehicles vehicles = scenario.getVehicles();
+		vehicles.addVehicleType(OneTruckModule.createTruckType());
+		
 		// setup controler
 		Controler controler = new Controler(scenario);
 		controler.addOverridingModule(new DvrpModule());

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/DvrpVehicle.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/DvrpVehicle.java
@@ -23,6 +23,7 @@ package org.matsim.contrib.dvrp.fleet;
 import org.matsim.api.core.v01.Identifiable;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.dvrp.schedule.Schedule;
+import org.matsim.vehicles.VehicleType;
 
 /**
  * DvrpVehicle is created from DvrpVehicleSpecification.
@@ -62,4 +63,9 @@ public interface DvrpVehicle extends Identifiable<DvrpVehicle> {
 	 * </ul>
 	 */
 	Schedule getSchedule();
+	
+	/**
+	 * @return the {@link VehicleType} of the vehicle
+	 */
+	VehicleType getVehicleType();
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/DvrpVehicleImpl.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/DvrpVehicleImpl.java
@@ -23,6 +23,7 @@ package org.matsim.contrib.dvrp.fleet;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.dvrp.schedule.Schedule;
+import org.matsim.vehicles.VehicleType;
 
 import com.google.common.base.MoreObjects;
 
@@ -33,8 +34,9 @@ public class DvrpVehicleImpl implements DvrpVehicle {
 	private final DvrpVehicleSpecification specification;
 	private final Link startLink;
 	private final Schedule schedule;
+	private final VehicleType vehicleType;
 
-	public DvrpVehicleImpl(DvrpVehicleSpecification specification, Link startLink) {
+	public DvrpVehicleImpl(DvrpVehicleSpecification specification, VehicleType vehicleType, Link startLink) {
 		if (startLink == null) {
 			throw new RuntimeException("Start link "
 					+ specification.getStartLinkId()
@@ -48,6 +50,7 @@ public class DvrpVehicleImpl implements DvrpVehicle {
 		}
 		this.specification = specification;
 		this.startLink = startLink;
+		this.vehicleType = vehicleType;
 		schedule = Schedule.create(specification);
 	}
 
@@ -63,7 +66,7 @@ public class DvrpVehicleImpl implements DvrpVehicle {
 
 	@Override
 	public int getCapacity() {
-		return specification.getCapacity();
+		return vehicleType.getCapacity().getSeats();
 	}
 
 	@Override
@@ -79,6 +82,11 @@ public class DvrpVehicleImpl implements DvrpVehicle {
 	@Override
 	public Schedule getSchedule() {
 		return schedule;
+	}
+	
+	@Override
+	public VehicleType getVehicleType() {
+	    return vehicleType;
 	}
 
 	@Override

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/DvrpVehicleSpecification.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/DvrpVehicleSpecification.java
@@ -23,6 +23,7 @@ package org.matsim.contrib.dvrp.fleet;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Identifiable;
 import org.matsim.api.core.v01.network.Link;
+import org.matsim.vehicles.VehicleType;
 
 /**
  * DvrpVehicleSpecification is assumed to be immutable.
@@ -41,11 +42,6 @@ public interface DvrpVehicleSpecification extends Identifiable<DvrpVehicle> {
 	Id<Link> getStartLinkId();
 
 	/**
-	 * @return vehicle capacity
-	 */
-	int getCapacity();
-
-	/**
 	 * @return vehicle operations start time
 	 */
 	double getServiceBeginTime();
@@ -54,4 +50,9 @@ public interface DvrpVehicleSpecification extends Identifiable<DvrpVehicle> {
 	 * @return vehicle operations end time
 	 */
 	double getServiceEndTime();
+	
+	/**
+	 * @return id of the {@link VehicleType}
+	 */
+	Id<VehicleType> getVehicleTypeId();
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/FleetModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/FleetModule.java
@@ -27,6 +27,7 @@ import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.ModalProviders;
 import org.matsim.contrib.dvrp.run.QSimScopeObjectListenerModule;
+import org.matsim.vehicles.Vehicles;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -58,6 +59,7 @@ public class FleetModule extends AbstractDvrpModeModule {
 			protected void configureQSim() {
 				bindModal(Fleet.class).toProvider(ModalProviders.createProvider(getMode(),
 						getter -> Fleets.createDefaultFleet(getter.getModal(FleetSpecification.class),
+								getter.get(Vehicles.class),
 								getter.getModal(Network.class).getLinks()::get))).asEagerSingleton();
 			}
 		});

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/FleetReader.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/FleetReader.java
@@ -25,6 +25,8 @@ import java.util.Stack;
 
 import org.matsim.api.core.v01.Id;
 import org.matsim.core.utils.io.MatsimXmlParser;
+import org.matsim.vehicles.VehicleType;
+import org.matsim.vehicles.VehicleUtils;
 import org.xml.sax.Attributes;
 
 /**
@@ -32,8 +34,6 @@ import org.xml.sax.Attributes;
  */
 public class FleetReader extends MatsimXmlParser {
 	private static final String VEHICLE = "vehicle";
-
-	private static final int DEFAULT_CAPACITY = 1;
 
 	private final FleetSpecification fleet;
 
@@ -56,18 +56,14 @@ public class FleetReader extends MatsimXmlParser {
 		return ImmutableDvrpVehicleSpecification.newBuilder()
 				.id(Id.create(atts.getValue("id"), DvrpVehicle.class))
 				.startLinkId(Id.createLinkId(atts.getValue("start_link")))
-				.capacity(getCapacity(atts.getValue("capacity")))
+				.vehicleTypeId(getVehicleTypeId(atts.getValue("vehicleTypeId")))
 				.serviceBeginTime(Double.parseDouble(atts.getValue("t_0")))
 				.serviceEndTime(Double.parseDouble(atts.getValue("t_1")))
 				.build();
 	}
 
-	private static int getCapacity(String capacityAttribute) {
-		double capacity = Double.parseDouble(Optional.ofNullable(capacityAttribute).orElse(DEFAULT_CAPACITY + ""));
-		if ((int)capacity != capacity) {
-			//for backwards compatibility: use double when reading files (capacity used to be double)
-			throw new IllegalArgumentException("capacity must be an integer value");
-		}
-		return (int)capacity;
+	private static Id<VehicleType> getVehicleTypeId(String attribute) {
+		return Optional.ofNullable(attribute).map(id -> Id.create(id, VehicleType.class))
+				.orElse(VehicleUtils.getDefaultVehicleType().getId());
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/FleetWriter.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/FleetWriter.java
@@ -40,7 +40,7 @@ public class FleetWriter extends MatsimXmlWriter {
 
 	public void write(String file) {
 		openFile(file);
-		writeDoctype("vehicles", "http://matsim.org/files/dtd/dvrp_vehicles_v1.dtd");
+		writeDoctype("vehicles", "http://matsim.org/files/dtd/dvrp_vehicles_v2.dtd");
 		writeStartTag("vehicles", Collections.emptyList());
 		this.vehicleSpecifications.forEach(this::writeVehicle);
 		writeEndTag("vehicles");
@@ -50,7 +50,7 @@ public class FleetWriter extends MatsimXmlWriter {
 	private synchronized void writeVehicle(DvrpVehicleSpecification vehicle) {
 		List<Tuple<String, String>> attributes = Arrays.asList(Tuple.of("id", vehicle.getId().toString()),
 				Tuple.of("start_link", vehicle.getStartLinkId() + ""), Tuple.of("t_0", vehicle.getServiceBeginTime() + ""),
-				Tuple.of("t_1", vehicle.getServiceEndTime() + ""), Tuple.of("capacity", vehicle.getCapacity() + ""));
+				Tuple.of("t_1", vehicle.getServiceEndTime() + ""), Tuple.of("vehicleTypeId", vehicle.getVehicleTypeId() + ""));
 		writeStartTag("vehicle", attributes, true);
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/Fleets.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/Fleets.java
@@ -25,6 +25,7 @@ import java.util.function.Function;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.util.LinkProvider;
+import org.matsim.vehicles.Vehicles;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -32,9 +33,9 @@ import com.google.common.collect.ImmutableMap;
  * @author michalm
  */
 public class Fleets {
-	public static Fleet createDefaultFleet(FleetSpecification fleetSpecification, LinkProvider<Id<Link>> linkProvider) {
+	public static Fleet createDefaultFleet(FleetSpecification fleetSpecification, Vehicles vehicles, LinkProvider<Id<Link>> linkProvider) {
 		return createCustomFleet(fleetSpecification,
-				s -> new DvrpVehicleImpl(s, linkProvider.apply(s.getStartLinkId())));
+				s -> new DvrpVehicleImpl(s, vehicles.getVehicleTypes().get(s.getVehicleTypeId()), linkProvider.apply(s.getStartLinkId())));
 	}
 
 	public static Fleet createCustomFleet(FleetSpecification fleetSpecification,

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/ImmutableDvrpVehicleSpecification.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/ImmutableDvrpVehicleSpecification.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
+import org.matsim.vehicles.VehicleType;
 
 import com.google.common.base.MoreObjects;
 
@@ -35,7 +36,7 @@ import com.google.common.base.MoreObjects;
 public final class ImmutableDvrpVehicleSpecification implements DvrpVehicleSpecification {
 	private final Id<DvrpVehicle> id;
 	private final Id<Link> startLinkId;
-	private final int capacity;
+	private final Id<VehicleType> vehicleTypeId;
 
 	// time window
 	private final double serviceBeginTime;
@@ -44,7 +45,7 @@ public final class ImmutableDvrpVehicleSpecification implements DvrpVehicleSpeci
 	private ImmutableDvrpVehicleSpecification(Builder builder) {
 		id = Objects.requireNonNull(builder.id);
 		startLinkId = Objects.requireNonNull(builder.startLinkId);
-		capacity = Objects.requireNonNull(builder.capacity);
+		vehicleTypeId = Objects.requireNonNull(builder.vehicleTypeId);
 		serviceBeginTime = Objects.requireNonNull(builder.serviceBeginTime);
 		serviceEndTime = Objects.requireNonNull(builder.serviceEndTime);
 	}
@@ -57,7 +58,6 @@ public final class ImmutableDvrpVehicleSpecification implements DvrpVehicleSpeci
 		Builder builder = new Builder();
 		builder.id = copy.getId();
 		builder.startLinkId = copy.getStartLinkId();
-		builder.capacity = copy.getCapacity();
 		builder.serviceBeginTime = copy.getServiceBeginTime();
 		builder.serviceEndTime = copy.getServiceEndTime();
 		return builder;
@@ -74,11 +74,6 @@ public final class ImmutableDvrpVehicleSpecification implements DvrpVehicleSpeci
 	}
 
 	@Override
-	public int getCapacity() {
-		return capacity;
-	}
-
-	@Override
 	public double getServiceBeginTime() {
 		return serviceBeginTime;
 	}
@@ -87,13 +82,18 @@ public final class ImmutableDvrpVehicleSpecification implements DvrpVehicleSpeci
 	public double getServiceEndTime() {
 		return serviceEndTime;
 	}
+	
+    @Override
+    public Id<VehicleType> getVehicleTypeId() {
+        return vehicleTypeId;
+    }
 
 	@Override
 	public String toString() {
 		return MoreObjects.toStringHelper(this)
 				.add("id", id)
 				.add("startLinkId", startLinkId)
-				.add("capacity", capacity)
+				.add("vehicleTypeId", vehicleTypeId)
 				.add("serviceBeginTime", serviceBeginTime)
 				.add("serviceEndTime", serviceEndTime)
 				.toString();
@@ -102,7 +102,7 @@ public final class ImmutableDvrpVehicleSpecification implements DvrpVehicleSpeci
 	public static final class Builder {
 		private Id<DvrpVehicle> id;
 		private Id<Link> startLinkId;
-		private Integer capacity;
+		private Id<VehicleType> vehicleTypeId;
 		private Double serviceBeginTime;
 		private Double serviceEndTime;
 
@@ -119,8 +119,8 @@ public final class ImmutableDvrpVehicleSpecification implements DvrpVehicleSpeci
 			return this;
 		}
 
-		public Builder capacity(int val) {
-			capacity = val;
+		public Builder vehicleTypeId(Id<VehicleType> val) {
+		    vehicleTypeId = val;
 			return this;
 		}
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/VehicleStartLinkToLastLinkUpdater.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/VehicleStartLinkToLastLinkUpdater.java
@@ -59,7 +59,7 @@ public class VehicleStartLinkToLastLinkUpdater
 				.map(v -> ImmutableDvrpVehicleSpecification.newBuilder()
 						.id(v.getId())
 						.startLinkId(Schedules.getLastLinkInSchedule(v).getId())
-						.capacity(v.getCapacity())
+						.vehicleTypeId(v.getVehicleType().getId())
 						.serviceBeginTime(v.getServiceBeginTime())
 						.serviceEndTime(v.getServiceEndTime())
 						.build())

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpModule.java
@@ -25,13 +25,10 @@ import org.matsim.contrib.dvrp.passenger.PassengerModule;
 import org.matsim.contrib.dvrp.router.DvrpGlobalRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentQueryHelper;
-import org.matsim.contrib.dvrp.vrpagent.VrpAgentSourceQSimModule;
 import org.matsim.contrib.dynagent.run.DynActivityEngine;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
-import org.matsim.vehicles.VehicleType;
-import org.matsim.vehicles.VehicleUtils;
 import org.matsim.vis.otfvis.OnTheFlyServer.NonPlanAgentQueryHelper;
 
 import com.google.inject.name.Names;
@@ -49,9 +46,6 @@ public final class DvrpModule extends AbstractModule {
 	public void install() {
 		// Visualisation of schedules for DVRP DynAgents
 		bind(NonPlanAgentQueryHelper.class).to(VrpAgentQueryHelper.class);
-
-		bind(VehicleType.class).annotatedWith(Names.named(VrpAgentSourceQSimModule.DVRP_VEHICLE_TYPE))
-				.toInstance(VehicleUtils.getDefaultVehicleType());
 
 		install(new DvrpTravelTimeModule());
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/vrpagent/VrpAgentSource.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/vrpagent/VrpAgentSource.java
@@ -30,7 +30,6 @@ import org.matsim.core.mobsim.framework.AgentSource;
 import org.matsim.core.mobsim.qsim.QSim;
 import org.matsim.core.mobsim.qsim.qnetsimengine.QVehicle;
 import org.matsim.core.mobsim.qsim.qnetsimengine.QVehicleImpl;
-import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehiclesFactory;
 
 public class VrpAgentSource implements AgentSource {
@@ -38,15 +37,12 @@ public class VrpAgentSource implements AgentSource {
 	private final Fleet fleet;
 	private final VrpOptimizer optimizer;
 	private final QSim qSim;
-	private final VehicleType vehicleType;
 
-	public VrpAgentSource(DynActionCreator nextActionCreator, Fleet fleet, VrpOptimizer optimizer, QSim qSim,
-			VehicleType vehicleType) {
+	public VrpAgentSource(DynActionCreator nextActionCreator, Fleet fleet, VrpOptimizer optimizer, QSim qSim) {
 		this.nextActionCreator = nextActionCreator;
 		this.fleet = fleet;
 		this.optimizer = optimizer;
 		this.qSim = qSim;
-		this.vehicleType = vehicleType;
 	}
 
 	@Override
@@ -61,7 +57,7 @@ public class VrpAgentSource implements AgentSource {
 			DynAgent vrpAgent = new DynAgent(Id.createPersonId(id), startLinkId, qSim.getEventsManager(),
 					vrpAgentLogic);
 			QVehicle mobsimVehicle = new QVehicleImpl(
-					vehicleFactory.createVehicle(Id.create(id, org.matsim.vehicles.Vehicle.class), vehicleType));
+					vehicleFactory.createVehicle(Id.create(id, org.matsim.vehicles.Vehicle.class), vrpVeh.getVehicleType()));
 			vrpAgent.setVehicle(mobsimVehicle);
 			mobsimVehicle.setDriver(vrpAgent);
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/vrpagent/VrpAgentSourceQSimModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/vrpagent/VrpAgentSourceQSimModule.java
@@ -25,14 +25,10 @@ import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.ModalProviders;
 import org.matsim.core.mobsim.qsim.QSim;
-import org.matsim.vehicles.VehicleType;
 
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 
 public class VrpAgentSourceQSimModule extends AbstractDvrpModeQSimModule {
-	public static final String DVRP_VEHICLE_TYPE = "dvrp_vehicle_type";
-
 	public VrpAgentSourceQSimModule(String mode) {
 		super(mode);
 	}
@@ -43,14 +39,10 @@ public class VrpAgentSourceQSimModule extends AbstractDvrpModeQSimModule {
 			@Inject
 			private QSim qSim;
 
-			@Inject
-			@Named(DVRP_VEHICLE_TYPE)
-			private VehicleType vehicleType;
-
 			@Override
 			public VrpAgentSource get() {
 				return new VrpAgentSource(getModalInstance(VrpAgentLogic.DynActionCreator.class),
-						getModalInstance(Fleet.class), getModalInstance(VrpOptimizer.class), qSim, vehicleType);
+						getModalInstance(Fleet.class), getModalInstance(VrpOptimizer.class), qSim);
 			}
 		});
 	}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/EvDvrpFleetQSimModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/EvDvrpFleetQSimModule.java
@@ -28,6 +28,7 @@ import org.matsim.contrib.dvrp.fleet.Fleets;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.ModalProviders;
 import org.matsim.contrib.ev.fleet.ElectricFleet;
+import org.matsim.vehicles.Vehicles;
 
 import com.google.inject.Inject;
 
@@ -45,13 +46,17 @@ public class EvDvrpFleetQSimModule extends AbstractDvrpModeQSimModule {
 			@Inject
 			private ElectricFleet evFleet;
 
+			@Inject
+			private Vehicles vehicles;
+
 			@Override
 			public Fleet get() {
 				FleetSpecification fleetSpecification = getModalInstance(FleetSpecification.class);
 				Network network = getModalInstance(Network.class);
 				return Fleets.createCustomFleet(fleetSpecification,
-						s -> EvDvrpVehicle.create(new DvrpVehicleImpl(s, network.getLinks().get(s.getStartLinkId())),
-								evFleet));
+						s -> EvDvrpVehicle
+								.create(new DvrpVehicleImpl(s, vehicles.getVehicleTypes().get(s.getVehicleTypeId()),
+										network.getLinks().get(s.getStartLinkId())), evFleet));
 
 			}
 		}).asEagerSingleton();

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/EvDvrpVehicle.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/EvDvrpVehicle.java
@@ -24,6 +24,7 @@ import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.schedule.Schedule;
 import org.matsim.contrib.ev.fleet.ElectricFleet;
 import org.matsim.contrib.ev.fleet.ElectricVehicle;
+import org.matsim.vehicles.VehicleType;
 
 /**
  * @author michalm
@@ -74,5 +75,10 @@ public class EvDvrpVehicle implements DvrpVehicle {
 	@Override
 	public Schedule getSchedule() {
 		return vehicle.getSchedule();
+	}
+
+	@Override
+	public VehicleType getVehicleType() {
+		return vehicle.getVehicleType();
 	}
 }

--- a/examples/scenarios/dvrp-grid/one_truck_vehicles.xml
+++ b/examples/scenarios/dvrp-grid/one_truck_vehicles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
-<!DOCTYPE vehicles SYSTEM "http://matsim.org/files/dtd/dvrp_vehicles_v1.dtd">
+<!DOCTYPE vehicles SYSTEM "http://matsim.org/files/dtd/dvrp_vehicles_v2.dtd">
 
 <vehicles>
-	<vehicle id="truck_one" start_link="215" t_0="0" t_1="8000"/>
+	<vehicle id="truck_one" vehicle_type_id="truckType" start_link="215" t_0="0" t_1="8000"/>
 </vehicles>

--- a/matsim/src/main/resources/dtd/dvrp_vehicles_v2.dtd
+++ b/matsim/src/main/resources/dtd/dvrp_vehicles_v2.dtd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- ============================================================ -->
+
+<!-- For further information or questions, please contact
+     Michal Maciejewski, maciejewski at vsp dot tu-berlin dot de -->
+
+<!-- ============================================================ -->
+
+<!ELEMENT vehicles (vehicle)*>
+
+<!ELEMENT vehicle EMPTY>
+
+<!ATTLIST vehicle
+	id          		CDATA   #REQUIRED
+	start_link  		CDATA   #REQUIRED
+	vehicle_type_id    	CDATA   #IMPLIED
+	t_0         		CDATA   #REQUIRED
+	t_1         		CDATA   #REQUIRED>


### PR DESCRIPTION
Attempt to add vehicle types to DVRP, which may be useful for fleets with varying vehicles sizes. Probably also useful for later emissions analysis, etc. 

Tests in `dvrp` are running, but not yet in downstream contribs. I first want to check, if you think this is a good way to go (defining the type per vehicle), or do you see a better alternative, @michalmac ?

Currently, I removed the `capacity` attribute from the fleet files / FleetSpecification and added a `vehicleTypeId` attribute.

Probably, then we would also need to define `FleetReader_v1`, and `FleetReader_v2`.

And I'm not sure how this relates to the `ev` contrib, because I saw something like `battery_capacity`, which is defined in a separate file, and not in the central vehicles file. Is there a general strategy?