### PR TITLE
Introduce DrtInsertionSearchParams

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
@@ -52,7 +52,7 @@ public class DefaultUnplannedRequestInserter implements UnplannedRequestInserter
 	private final VehicleData.EntryFactory vehicleDataEntryFactory;
 
 	private final ForkJoinPool forkJoinPool;
-	private final MultiVehicleInsertionProblem<PathData> insertionProblem;
+	private final DrtInsertionSearch<PathData> insertionProblem;
 
 	public DefaultUnplannedRequestInserter(DrtConfigGroup drtCfg, Fleet fleet, MobsimTimer mobsimTimer,
 			EventsManager eventsManager, RequestInsertionScheduler insertionScheduler,
@@ -67,7 +67,7 @@ public class DefaultUnplannedRequestInserter implements UnplannedRequestInserter
 		this.vehicleDataEntryFactory = vehicleDataEntryFactory;
 		this.forkJoinPool = forkJoinPoolHolder.getPool();
 
-		insertionProblem = new ParallelMultiVehicleInsertionProblem(pathDataProvider, drtCfg, mobsimTimer, forkJoinPool,
+		insertionProblem = new ExtensiveInsertionSearch(pathDataProvider, drtCfg, mobsimTimer, forkJoinPool,
 				penaltyCalculator);
 	}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 import java.util.concurrent.ForkJoinPool;
 
 import org.apache.log4j.Logger;
-import org.matsim.contrib.drt.optimizer.QSimScopeForkJoinPoolHolder;
 import org.matsim.contrib.drt.optimizer.VehicleData;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
@@ -52,23 +51,20 @@ public class DefaultUnplannedRequestInserter implements UnplannedRequestInserter
 	private final VehicleData.EntryFactory vehicleDataEntryFactory;
 
 	private final ForkJoinPool forkJoinPool;
-	private final DrtInsertionSearch<PathData> insertionProblem;
+	private final DrtInsertionSearch<PathData> insertionSearch;
 
 	public DefaultUnplannedRequestInserter(DrtConfigGroup drtCfg, Fleet fleet, MobsimTimer mobsimTimer,
 			EventsManager eventsManager, RequestInsertionScheduler insertionScheduler,
-			VehicleData.EntryFactory vehicleDataEntryFactory, PathDataProvider pathDataProvider,
-			InsertionCostCalculator.PenaltyCalculator penaltyCalculator,
-			QSimScopeForkJoinPoolHolder forkJoinPoolHolder) {
+			VehicleData.EntryFactory vehicleDataEntryFactory, DrtInsertionSearch<PathData> insertionSearch,
+			ForkJoinPool forkJoinPool) {
 		this.drtCfg = drtCfg;
 		this.fleet = fleet;
 		this.mobsimTimer = mobsimTimer;
 		this.eventsManager = eventsManager;
 		this.insertionScheduler = insertionScheduler;
 		this.vehicleDataEntryFactory = vehicleDataEntryFactory;
-		this.forkJoinPool = forkJoinPoolHolder.getPool();
-
-		insertionProblem = new ExtensiveInsertionSearch(pathDataProvider, drtCfg, mobsimTimer, forkJoinPool,
-				penaltyCalculator);
+		this.forkJoinPool = forkJoinPool;
+		this.insertionSearch = insertionSearch;
 	}
 
 	@Override
@@ -83,7 +79,7 @@ public class DefaultUnplannedRequestInserter implements UnplannedRequestInserter
 		Iterator<DrtRequest> reqIter = unplannedRequests.iterator();
 		while (reqIter.hasNext()) {
 			DrtRequest req = reqIter.next();
-			Optional<InsertionWithDetourData<PathData>> best = insertionProblem.findBestInsertion(req,
+			Optional<InsertionWithDetourData<PathData>> best = insertionSearch.findBestInsertion(req,
 					vData.getEntries());
 			if (best.isEmpty()) {
 				eventsManager.processEvent(

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
@@ -52,12 +52,13 @@ public class DefaultUnplannedRequestInserter implements UnplannedRequestInserter
 	private final VehicleData.EntryFactory vehicleDataEntryFactory;
 
 	private final ForkJoinPool forkJoinPool;
-	private final ParallelMultiVehicleInsertionProblem insertionProblem;
+	private final MultiVehicleInsertionProblem<PathData> insertionProblem;
 
 	public DefaultUnplannedRequestInserter(DrtConfigGroup drtCfg, Fleet fleet, MobsimTimer mobsimTimer,
 			EventsManager eventsManager, RequestInsertionScheduler insertionScheduler,
 			VehicleData.EntryFactory vehicleDataEntryFactory, PathDataProvider pathDataProvider,
-			InsertionCostCalculator.PenaltyCalculator penaltyCalculator, QSimScopeForkJoinPoolHolder forkJoinPoolHolder) {
+			InsertionCostCalculator.PenaltyCalculator penaltyCalculator,
+			QSimScopeForkJoinPoolHolder forkJoinPoolHolder) {
 		this.drtCfg = drtCfg;
 		this.fleet = fleet;
 		this.mobsimTimer = mobsimTimer;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourPathCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourPathCalculator.java
@@ -27,6 +27,6 @@ import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
 /**
  * @author michalm
  */
-public interface PathDataProvider {
-	DetourData<PathData> getPathData(DrtRequest drtRequest, List<Insertion> filteredInsertions);
+public interface DetourPathCalculator {
+	DetourData<PathData> calculatePaths(DrtRequest drtRequest, List<Insertion> filteredInsertions);
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DrtInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DrtInsertionSearch.java
@@ -27,6 +27,6 @@ import org.matsim.contrib.drt.passenger.DrtRequest;
 /**
  * @author michalm
  */
-public interface MultiVehicleInsertionProblem<D> {
+public interface DrtInsertionSearch<D> {
 	Optional<InsertionWithDetourData<D>> findBestInsertion(DrtRequest drtRequest, Collection<VehicleData.Entry> vData);
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DrtInsertionSearchParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DrtInsertionSearchParams.java
@@ -1,0 +1,32 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.optimizer.insertion;
+
+import org.matsim.core.config.ReflectiveConfigGroup;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public abstract class DrtInsertionSearchParams extends ReflectiveConfigGroup {
+	public DrtInsertionSearchParams(String paramSetName) {
+		super(paramSetName);
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearch.java
@@ -44,12 +44,12 @@ public class ExtensiveInsertionSearch implements DrtInsertionSearch<PathData> {
 
 	// step 2: finding best insertion
 	private final ForkJoinPool forkJoinPool;
-	private final PathDataProvider pathDataProvider;
+	private final DetourPathCalculator detourPathCalculator;
 	private final BestInsertionFinder<PathData> bestInsertionFinder;
 
-	public ExtensiveInsertionSearch(PathDataProvider pathDataProvider, DrtConfigGroup drtCfg, MobsimTimer timer,
+	public ExtensiveInsertionSearch(DetourPathCalculator detourPathCalculator, DrtConfigGroup drtCfg, MobsimTimer timer,
 			ForkJoinPool forkJoinPool, InsertionCostCalculator.PenaltyCalculator penaltyCalculator) {
-		this.pathDataProvider = pathDataProvider;
+		this.detourPathCalculator = detourPathCalculator;
 		this.forkJoinPool = forkJoinPool;
 
 		insertionParams = (ExtensiveInsertionSearchParams)drtCfg.getDrtInsertionSearchParams();
@@ -89,7 +89,7 @@ public class ExtensiveInsertionSearch implements DrtInsertionSearch<PathData> {
 				.map(InsertionWithDetourData::getInsertion).collect(Collectors.toList())).join();
 		filteredInsertions.addAll(kNearestInsertionsAtEndFilter.getNearestInsertionsAtEnd());
 
-		DetourData<PathData> pathData = pathDataProvider.getPathData(drtRequest, filteredInsertions);
+		DetourData<PathData> pathData = detourPathCalculator.calculatePaths(drtRequest, filteredInsertions);
 		//TODO could use a parallel stream within forkJoinPool, however the idea is to have as few filteredInsertions
 		// as possible, and then using a parallel stream does not make sense.
 		return bestInsertionFinder.findBestInsertion(drtRequest,

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearch.java
@@ -35,7 +35,7 @@ import org.matsim.core.mobsim.framework.MobsimTimer;
 /**
  * @author michalm
  */
-public class ParallelMultiVehicleInsertionProblem implements MultiVehicleInsertionProblem<PathData> {
+public class ExtensiveInsertionSearch implements DrtInsertionSearch<PathData> {
 	private final ExtensiveInsertionSearchParams insertionParams;
 
 	// step 1: initial filtering out feasible insertions
@@ -47,8 +47,8 @@ public class ParallelMultiVehicleInsertionProblem implements MultiVehicleInserti
 	private final PathDataProvider pathDataProvider;
 	private final BestInsertionFinder<PathData> bestInsertionFinder;
 
-	public ParallelMultiVehicleInsertionProblem(PathDataProvider pathDataProvider, DrtConfigGroup drtCfg,
-			MobsimTimer timer, ForkJoinPool forkJoinPool, InsertionCostCalculator.PenaltyCalculator penaltyCalculator) {
+	public ExtensiveInsertionSearch(PathDataProvider pathDataProvider, DrtConfigGroup drtCfg, MobsimTimer timer,
+			ForkJoinPool forkJoinPool, InsertionCostCalculator.PenaltyCalculator penaltyCalculator) {
 		this.pathDataProvider = pathDataProvider;
 		this.forkJoinPool = forkJoinPool;
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchParams.java
@@ -1,0 +1,63 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.optimizer.insertion;
+
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Positive;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class ExtensiveInsertionSearchParams extends DrtInsertionSearchParams {
+	public static final String SET_NAME = "ExtensiveInsertionSearch";
+
+	public static final String NEAREST_INSERTIONS_AT_END_LIMIT = "nearestInsertionsAtEndLimit";
+	@Positive
+	private int nearestInsertionsAtEndLimit = 40;
+
+	public static final String ADMISSIBLE_BEELINE_SPEED_FACTOR = "admissibleBeelineSpeedFactor";
+	@DecimalMin("1.0")
+	private double admissibleBeelineSpeedFactor = 1.5;
+
+	public ExtensiveInsertionSearchParams() {
+		super(SET_NAME);
+	}
+
+	@StringGetter(NEAREST_INSERTIONS_AT_END_LIMIT)
+	public int getNearestInsertionsAtEndLimit() {
+		return nearestInsertionsAtEndLimit;
+	}
+
+	@StringSetter(NEAREST_INSERTIONS_AT_END_LIMIT)
+	public void setNearestInsertionsAtEndLimit(int nearestInsertionsAtEndLimit) {
+		this.nearestInsertionsAtEndLimit = nearestInsertionsAtEndLimit;
+	}
+
+	@StringGetter(ADMISSIBLE_BEELINE_SPEED_FACTOR)
+	public double getAdmissibleBeelineSpeedFactor() {
+		return admissibleBeelineSpeedFactor;
+	}
+
+	@StringSetter(ADMISSIBLE_BEELINE_SPEED_FACTOR)
+	public void setAdmissibleBeelineSpeedFactor(double admissibleBeelineSpeedFactor) {
+		this.admissibleBeelineSpeedFactor = admissibleBeelineSpeedFactor;
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchQSimModule.java
@@ -1,0 +1,73 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.optimizer.insertion;
+
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.drt.optimizer.QSimScopeForkJoinPoolHolder;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.dvrp.path.OneToManyPathSearch;
+import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
+import org.matsim.contrib.dvrp.run.ModalProviders;
+import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
+import org.matsim.core.mobsim.framework.MobsimTimer;
+import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
+import org.matsim.core.router.util.TravelDisutility;
+import org.matsim.core.router.util.TravelTime;
+
+import com.google.inject.Inject;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Named;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class ExtensiveInsertionSearchQSimModule extends AbstractDvrpModeQSimModule {
+	private final DrtConfigGroup drtCfg;
+
+	public ExtensiveInsertionSearchQSimModule(DrtConfigGroup drtCfg) {
+		super(drtCfg.getMode());
+		this.drtCfg = drtCfg;
+	}
+
+	@Override
+	protected void configureQSim() {
+		bindModal(new TypeLiteral<DrtInsertionSearch<OneToManyPathSearch.PathData>>() {
+		}).toProvider(modalProvider(
+				getter -> new ExtensiveInsertionSearch(getter.getModal(PathDataProvider.class), drtCfg,
+						getter.get(MobsimTimer.class), getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool(),
+						getter.getModal(InsertionCostCalculator.PenaltyCalculator.class))));
+
+		addModalComponent(ParallelPathDataProvider.class, new ModalProviders.AbstractProvider<>(getMode()) {
+			@Inject
+			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
+			private TravelTime travelTime;
+
+			@Override
+			public ParallelPathDataProvider get() {
+				Network network = getModalInstance(Network.class);
+				TravelDisutility travelDisutility = getModalInstance(
+						TravelDisutilityFactory.class).createTravelDisutility(travelTime);
+				return new ParallelPathDataProvider(network, travelTime, travelDisutility, drtCfg);
+			}
+		});
+		bindModal(PathDataProvider.class).to(modalKey(ParallelPathDataProvider.class));
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchQSimModule.java
@@ -51,23 +51,23 @@ public class ExtensiveInsertionSearchQSimModule extends AbstractDvrpModeQSimModu
 	protected void configureQSim() {
 		bindModal(new TypeLiteral<DrtInsertionSearch<OneToManyPathSearch.PathData>>() {
 		}).toProvider(modalProvider(
-				getter -> new ExtensiveInsertionSearch(getter.getModal(PathDataProvider.class), drtCfg,
+				getter -> new ExtensiveInsertionSearch(getter.getModal(DetourPathCalculator.class), drtCfg,
 						getter.get(MobsimTimer.class), getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool(),
 						getter.getModal(InsertionCostCalculator.PenaltyCalculator.class))));
 
-		addModalComponent(ParallelPathDataProvider.class, new ModalProviders.AbstractProvider<>(getMode()) {
+		addModalComponent(MultiInsertionDetourPathCalculator.class, new ModalProviders.AbstractProvider<>(getMode()) {
 			@Inject
 			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
 			private TravelTime travelTime;
 
 			@Override
-			public ParallelPathDataProvider get() {
+			public MultiInsertionDetourPathCalculator get() {
 				Network network = getModalInstance(Network.class);
 				TravelDisutility travelDisutility = getModalInstance(
 						TravelDisutilityFactory.class).createTravelDisutility(travelTime);
-				return new ParallelPathDataProvider(network, travelTime, travelDisutility, drtCfg);
+				return new MultiInsertionDetourPathCalculator(network, travelTime, travelDisutility, drtCfg);
 			}
 		});
-		bindModal(PathDataProvider.class).to(modalKey(ParallelPathDataProvider.class));
+		bindModal(DetourPathCalculator.class).to(modalKey(MultiInsertionDetourPathCalculator.class));
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/KNearestInsertionsAtEndFilter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/KNearestInsertionsAtEndFilter.java
@@ -18,7 +18,7 @@
 
 package org.matsim.contrib.drt.optimizer.insertion;
 
-import static org.matsim.contrib.drt.optimizer.insertion.ParallelMultiVehicleInsertionProblem.OPTIMISTIC_BEELINE_SPEED_COEFF;
+import static org.matsim.contrib.drt.optimizer.insertion.ParallelMultiVehicleInsertionProblem.ADMISSIBLE_BEELINE_SPEED_FACTOR;
 
 import java.util.List;
 
@@ -55,9 +55,9 @@ class KNearestInsertionsAtEndFilter {
 		//i == j == stops.size()
 		double departureTime = vEntry.getWaypoint(i).getDepartureTime();
 
-		// x OPTIMISTIC_BEELINE_SPEED_COEFF to remove bias towards near but still busy vehicles
+		// x ADMISSIBLE_BEELINE_SPEED_FACTOR to remove bias towards near but still busy vehicles
 		// (timeToPickup is underestimated by this factor)
-		double timeDistance = departureTime + OPTIMISTIC_BEELINE_SPEED_COEFF * insertion.getDetourToPickup();
+		double timeDistance = departureTime + ADMISSIBLE_BEELINE_SPEED_FACTOR * insertion.getDetourToPickup();
 		addInsertionAtEndCandidate(insertion.getInsertion(), timeDistance);
 		return false;//skip now; the selected (i.e. K nearest) insertions will be added later
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/KNearestInsertionsAtEndFilter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/KNearestInsertionsAtEndFilter.java
@@ -18,8 +18,6 @@
 
 package org.matsim.contrib.drt.optimizer.insertion;
 
-import static org.matsim.contrib.drt.optimizer.insertion.ParallelMultiVehicleInsertionProblem.ADMISSIBLE_BEELINE_SPEED_FACTOR;
-
 import java.util.List;
 
 import org.matsim.contrib.drt.optimizer.VehicleData.Entry;
@@ -37,8 +35,11 @@ class KNearestInsertionsAtEndFilter {
 	// synchronised addition via addInsertionAtEndCandidate(Insertion insertionAtEnd, double timeDistance)
 	private final PartialSort<Insertion> nearestInsertionsAtEnd;
 
-	public KNearestInsertionsAtEndFilter(int k) {
+	private final double admissibleBeelineSpeedFactor;
+
+	public KNearestInsertionsAtEndFilter(int k, double admissibleBeelineSpeedFactor) {
 		nearestInsertionsAtEnd = new PartialSort<>(k);
+		this.admissibleBeelineSpeedFactor = admissibleBeelineSpeedFactor;
 	}
 
 	/**
@@ -57,7 +58,7 @@ class KNearestInsertionsAtEndFilter {
 
 		// x ADMISSIBLE_BEELINE_SPEED_FACTOR to remove bias towards near but still busy vehicles
 		// (timeToPickup is underestimated by this factor)
-		double timeDistance = departureTime + ADMISSIBLE_BEELINE_SPEED_FACTOR * insertion.getDetourToPickup();
+		double timeDistance = departureTime + admissibleBeelineSpeedFactor * insertion.getDetourToPickup();
 		addInsertionAtEndCandidate(insertion.getInsertion(), timeDistance);
 		return false;//skip now; the selected (i.e. K nearest) insertions will be added later
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/MultiInsertionDetourPathCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/MultiInsertionDetourPathCalculator.java
@@ -46,7 +46,7 @@ import org.matsim.core.router.util.TravelTime;
 /**
  * @author michalm
  */
-public class ParallelPathDataProvider implements PathDataProvider, MobsimBeforeCleanupListener {
+public class MultiInsertionDetourPathCalculator implements DetourPathCalculator, MobsimBeforeCleanupListener {
 
 	private static class DetourLinksSet {
 		final Map<Id<Link>, Link> pickupDetourStartLinks;
@@ -86,8 +86,9 @@ public class ParallelPathDataProvider implements PathDataProvider, MobsimBeforeC
 
 	private final ExecutorService executorService;
 
-	public ParallelPathDataProvider(Network network, @Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
-			TravelDisutility travelDisutility, DrtConfigGroup drtCfg) {
+	public MultiInsertionDetourPathCalculator(Network network,
+			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, TravelDisutility travelDisutility,
+			DrtConfigGroup drtCfg) {
 		toPickupPathSearch = OneToManyPathSearch.createBackwardSearch(network, travelTime, travelDisutility);
 		fromPickupPathSearch = OneToManyPathSearch.createForwardSearch(network, travelTime, travelDisutility);
 		toDropoffPathSearch = OneToManyPathSearch.createBackwardSearch(network, travelTime, travelDisutility);
@@ -97,7 +98,7 @@ public class ParallelPathDataProvider implements PathDataProvider, MobsimBeforeC
 	}
 
 	@Override
-	public DetourData<PathData> getPathData(DrtRequest drtRequest, List<Insertion> filteredInsertions) {
+	public DetourData<PathData> calculatePaths(DrtRequest drtRequest, List<Insertion> filteredInsertions) {
 		Link pickup = drtRequest.getFromLink();
 		Link dropoff = drtRequest.getToLink();
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ParallelMultiVehicleInsertionProblem.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ParallelMultiVehicleInsertionProblem.java
@@ -40,9 +40,9 @@ public class ParallelMultiVehicleInsertionProblem implements MultiVehicleInserti
 	// step 1: initial filtering out feasible insertions
 	// FIXME make it more flexible... 40 is way too big for many smaller scenarios, we may also want to reduce 1.5
 	private static final int NEAREST_INSERTIONS_AT_END_LIMIT = 40;
-	static final double OPTIMISTIC_BEELINE_SPEED_COEFF = 1.5;
-	private final InsertionCostCalculator<Double> approximateCostCalculator;
-	private final DetourTimesProvider optimisticDetourTimesProvider;
+	static final double ADMISSIBLE_BEELINE_SPEED_FACTOR = 1.5;
+	private final InsertionCostCalculator<Double> admissibleCostCalculator;
+	private final DetourTimesProvider admissibleDetourTimesProvider;
 
 	// step 2: finding best insertion
 	private final ForkJoinPool forkJoinPool;
@@ -54,15 +54,14 @@ public class ParallelMultiVehicleInsertionProblem implements MultiVehicleInserti
 		this.pathDataProvider = pathDataProvider;
 		this.forkJoinPool = forkJoinPool;
 
-		approximateCostCalculator = new InsertionCostCalculator<>(drtCfg, timer, penaltyCalculator,
-				Double::doubleValue);
+		admissibleCostCalculator = new InsertionCostCalculator<>(drtCfg, timer, penaltyCalculator, Double::doubleValue);
 
 		// TODO use more sophisticated DetourTimeEstimator
-		double optimisticBeelineSpeed = OPTIMISTIC_BEELINE_SPEED_COEFF * drtCfg.getEstimatedDrtSpeed()
+		double admissibleBeelineSpeed = ADMISSIBLE_BEELINE_SPEED_FACTOR * drtCfg.getEstimatedDrtSpeed()
 				/ drtCfg.getEstimatedBeelineDistanceFactor();
 
-		optimisticDetourTimesProvider = new DetourTimesProvider(
-				DetourTimeEstimator.createBeelineTimeEstimator(optimisticBeelineSpeed));
+		admissibleDetourTimesProvider = new DetourTimesProvider(
+				DetourTimeEstimator.createBeelineTimeEstimator(admissibleBeelineSpeed));
 
 		bestInsertionFinder = new BestInsertionFinder<>(
 				new InsertionCostCalculator<>(drtCfg, timer, penaltyCalculator, PathData::getTravelTime));
@@ -72,7 +71,7 @@ public class ParallelMultiVehicleInsertionProblem implements MultiVehicleInserti
 	public Optional<InsertionWithDetourData<PathData>> findBestInsertion(DrtRequest drtRequest,
 			Collection<Entry> vEntries) {
 		InsertionGenerator insertionGenerator = new InsertionGenerator();
-		DetourData<Double> timeData = optimisticDetourTimesProvider.getDetourData(drtRequest);
+		DetourData<Double> admissibleTimeData = admissibleDetourTimesProvider.getDetourData(drtRequest);
 		KNearestInsertionsAtEndFilter kNearestInsertionsAtEndFilter = new KNearestInsertionsAtEndFilter(
 				NEAREST_INSERTIONS_AT_END_LIMIT);
 
@@ -80,15 +79,15 @@ public class ParallelMultiVehicleInsertionProblem implements MultiVehicleInserti
 		List<Insertion> filteredInsertions = forkJoinPool.submit(() -> vEntries.parallelStream()
 				//generate feasible insertions (wrt occupancy limits)
 				.flatMap(e -> insertionGenerator.generateInsertions(drtRequest, e).stream())
-				//optimistic pre-filtering wrt (admissible cost function using an optimistic beeline speed coefficient)
-				.map(timeData::createInsertionWithDetourData)
-				.filter(insertion -> approximateCostCalculator.calculate(drtRequest, insertion)
+				//map insertions to insertions with admissible detour times (i.e. admissible beeline speed factor)
+				.map(admissibleTimeData::createInsertionWithDetourData)
+				//optimistic pre-filtering wrt admissible cost function
+				.filter(insertion -> admissibleCostCalculator.calculate(drtRequest, insertion)
 						< InsertionCostCalculator.INFEASIBLE_SOLUTION_COST)
-				//skip insertions at schedule ends (only selected will be added later)
+				//skip insertions at schedule ends (a subset of most promising "insertionsAtEnd" will be added later)
 				.filter(kNearestInsertionsAtEndFilter::filter)
-				//forget (approximated) detour times
-				.map(InsertionWithDetourData::getInsertion)
-				.collect(Collectors.toList())).join();
+				//forget (admissible) detour times
+				.map(InsertionWithDetourData::getInsertion).collect(Collectors.toList())).join();
 		filteredInsertions.addAll(kNearestInsertionsAtEndFilter.getNearestInsertionsAtEnd());
 
 		DetourData<PathData> pathData = pathDataProvider.getPathData(drtRequest, filteredInsertions);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -37,7 +37,7 @@ import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.contrib.drt.optimizer.insertion.DrtInsertionSearchParams;
 import org.matsim.contrib.drt.optimizer.insertion.ExtensiveInsertionSearchParams;
-import org.matsim.contrib.drt.optimizer.insertion.ParallelPathDataProvider;
+import org.matsim.contrib.drt.optimizer.insertion.MultiInsertionDetourPathCalculator;
 import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingParams;
 import org.matsim.contrib.dvrp.router.DvrpModeRoutingNetworkModule;
 import org.matsim.contrib.dvrp.run.Modal;
@@ -195,7 +195,7 @@ public final class DrtConfigGroup extends ReflectiveConfigGroup implements Modal
 
 	@Positive
 	private int numberOfThreads = Math.min(Runtime.getRuntime().availableProcessors(),
-			ParallelPathDataProvider.MAX_THREADS);
+			MultiInsertionDetourPathCalculator.MAX_THREADS);
 
 	@PositiveOrZero
 	private double advanceRequestPlanningHorizon = 0; // beta-feature; planning horizon for advance (prebooked) requests

--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/EDrtModeQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/EDrtModeQSimModule.java
@@ -27,9 +27,9 @@ import org.matsim.contrib.drt.optimizer.QSimScopeForkJoinPoolHolder;
 import org.matsim.contrib.drt.optimizer.VehicleData;
 import org.matsim.contrib.drt.optimizer.depot.DepotFinder;
 import org.matsim.contrib.drt.optimizer.insertion.DefaultUnplannedRequestInserter;
+import org.matsim.contrib.drt.optimizer.insertion.DrtInsertionSearch;
+import org.matsim.contrib.drt.optimizer.insertion.ExtensiveInsertionSearchQSimModule;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator;
-import org.matsim.contrib.drt.optimizer.insertion.ParallelPathDataProvider;
-import org.matsim.contrib.drt.optimizer.insertion.PathDataProvider;
 import org.matsim.contrib.drt.optimizer.insertion.UnplannedRequestInserter;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.drt.passenger.DrtRequestCreator;
@@ -46,6 +46,7 @@ import org.matsim.contrib.dvrp.passenger.PassengerEngine;
 import org.matsim.contrib.dvrp.passenger.PassengerEngineQSimModule;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestCreator;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestValidator;
+import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.ModalProviders;
@@ -68,6 +69,7 @@ import org.matsim.core.router.util.TravelTime;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import com.google.inject.TypeLiteral;
 import com.google.inject.name.Named;
 
 /**
@@ -125,9 +127,11 @@ public class EDrtModeQSimModule extends AbstractDvrpModeQSimModule {
 				getter -> new DefaultUnplannedRequestInserter(drtCfg, getter.getModal(Fleet.class),
 						getter.get(MobsimTimer.class), getter.get(EventsManager.class),
 						getter.getModal(RequestInsertionScheduler.class),
-						getter.getModal(VehicleData.EntryFactory.class), getter.getModal(PathDataProvider.class),
-						getter.getModal(InsertionCostCalculator.PenaltyCalculator.class),
-						getter.getModal(QSimScopeForkJoinPoolHolder.class)))).asEagerSingleton();
+						getter.getModal(VehicleData.EntryFactory.class),
+						getter.getModal(new TypeLiteral<DrtInsertionSearch<PathData>>() {
+						}), getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool()))).asEagerSingleton();
+
+		install(new ExtensiveInsertionSearchQSimModule(drtCfg));
 
 		bindModal(VehicleData.EntryFactory.class).toProvider(
 				EDrtVehicleDataEntryFactory.EDrtVehicleDataEntryFactoryProvider.class).asEagerSingleton();
@@ -169,21 +173,6 @@ public class EDrtModeQSimModule extends AbstractDvrpModeQSimModule {
 		bindModal(ScheduleTimingUpdater.class).toProvider(modalProvider(
 				getter -> new ScheduleTimingUpdater(getter.get(MobsimTimer.class),
 						new DrtStayTaskEndTimeCalculator(drtCfg)))).asEagerSingleton();
-
-		addModalComponent(ParallelPathDataProvider.class, new ModalProviders.AbstractProvider<>(getMode()) {
-			@Inject
-			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
-			private TravelTime travelTime;
-
-			@Override
-			public ParallelPathDataProvider get() {
-				Network network = getModalInstance(Network.class);
-				TravelDisutility travelDisutility = getModalInstance(
-						TravelDisutilityFactory.class).createTravelDisutility(travelTime);
-				return new ParallelPathDataProvider(network, travelTime, travelDisutility, drtCfg);
-			}
-		});
-		bindModal(PathDataProvider.class).to(modalKey(ParallelPathDataProvider.class));
 
 		bindModal(VrpAgentLogic.DynActionCreator.class).
 				toProvider(modalProvider(getter -> new EDrtActionCreator(getter.getModal(PassengerEngine.class),

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 
 import org.matsim.api.core.v01.TransportMode;
@@ -151,6 +152,7 @@ public final class TaxiConfigGroup extends ReflectiveConfigGroup implements Moda
 
 	private boolean breakSimulationIfNotAllRequestsServed = true;
 
+	@NotNull
 	private AbstractTaxiOptimizerParams taxiOptimizerParams;
 
 	public TaxiConfigGroup() {
@@ -440,10 +442,8 @@ public final class TaxiConfigGroup extends ReflectiveConfigGroup implements Moda
 	@Override
 	public void addParameterSet(ConfigGroup set) {
 		if (set instanceof AbstractTaxiOptimizerParams) {
-			if (taxiOptimizerParams != null) {
-				throw new IllegalStateException(
-						"Remove the existing taxi optimizer parameter set before adding a new one");
-			}
+			Preconditions.checkState(taxiOptimizerParams == null,
+					"Remove the existing taxi optimizer parameter set before adding a new one");
 			taxiOptimizerParams = (AbstractTaxiOptimizerParams)set;
 		}
 
@@ -453,9 +453,8 @@ public final class TaxiConfigGroup extends ReflectiveConfigGroup implements Moda
 	@Override
 	public boolean removeParameterSet(ConfigGroup set) {
 		if (set instanceof AbstractTaxiOptimizerParams) {
-			if (taxiOptimizerParams == null) {
-				throw new IllegalStateException("The existing taxi optimizer param set is null. Cannot remove it.");
-			}
+			Preconditions.checkState(taxiOptimizerParams != null,
+					"The existing taxi optimizer param set is null. Cannot remove it.");
 			taxiOptimizerParams = null;
 		}
 

--- a/contribs/vsp/src/test/java/org/matsim/integration/drtAndPt/PtAlongALine2Test.java
+++ b/contribs/vsp/src/test/java/org/matsim/integration/drtAndPt/PtAlongALine2Test.java
@@ -23,6 +23,7 @@ import org.matsim.api.core.v01.population.Plan;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.api.core.v01.population.Population;
 import org.matsim.api.core.v01.population.PopulationFactory;
+import org.matsim.contrib.drt.optimizer.insertion.ExtensiveInsertionSearchParams;
 import org.matsim.contrib.drt.routing.DrtRoute;
 import org.matsim.contrib.drt.routing.DrtRouteFactory;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
@@ -200,24 +201,41 @@ public class PtAlongALine2Test{
 
 			MultiModeDrtConfigGroup mm = ConfigUtils.addOrGetModule( config, MultiModeDrtConfigGroup.class );
 			{
-				mm.addParameterSet(
-						new DrtConfigGroup().setMode( TransportMode.drt ).setMaxTravelTimeAlpha( 2.0 )
-								    .setMaxTravelTimeBeta( 5. * 60. ).setStopDuration( 60. ).setMaxWaitTime( Double.MAX_VALUE )
-								    .setRejectRequestIfMaxWaitOrTravelTimeViolated( false ).setUseModeFilteredSubnetwork( true )
-								    .setEstimatedBeelineDistanceFactor(1.0).setEstimatedDrtSpeed(15)
-								    .setAdvanceRequestPlanningHorizon(99999));
+				DrtConfigGroup drtConfigGroup = new DrtConfigGroup().setMode(TransportMode.drt)
+						.setMaxTravelTimeAlpha(2.0)
+						.setMaxTravelTimeBeta(5. * 60.)
+						.setStopDuration(60.)
+						.setMaxWaitTime(Double.MAX_VALUE)
+						.setRejectRequestIfMaxWaitOrTravelTimeViolated(false)
+						.setUseModeFilteredSubnetwork(true)
+						.setEstimatedBeelineDistanceFactor(1.0)
+						.setEstimatedDrtSpeed(15)
+						.setAdvanceRequestPlanningHorizon(99999);
+				drtConfigGroup.addParameterSet(new ExtensiveInsertionSearchParams());
+				mm.addParameterSet(drtConfigGroup);
+
 			}
 			if ( drt2 ) {
-				mm.addParameterSet(
-						new DrtConfigGroup().setMode( "drt2" ).setMaxTravelTimeAlpha( 1.3 )
-								    .setMaxTravelTimeBeta( 5. * 60. ).setStopDuration( 60. ).setMaxWaitTime( Double.MAX_VALUE )
-								    .setRejectRequestIfMaxWaitOrTravelTimeViolated( false ).setUseModeFilteredSubnetwork( true ) );
+				DrtConfigGroup drtConfigGroup = new DrtConfigGroup().setMode("drt2")
+						.setMaxTravelTimeAlpha(1.3)
+						.setMaxTravelTimeBeta(5. * 60.)
+						.setStopDuration(60.)
+						.setMaxWaitTime(Double.MAX_VALUE)
+						.setRejectRequestIfMaxWaitOrTravelTimeViolated(false)
+						.setUseModeFilteredSubnetwork(true);
+				drtConfigGroup.addParameterSet(new ExtensiveInsertionSearchParams());
+				mm.addParameterSet(drtConfigGroup);
 			}
 			if ( drt3 ) {
-				mm.addParameterSet(
-						new DrtConfigGroup().setMode( "drt3" ).setMaxTravelTimeAlpha( 1.3 )
-								    .setMaxTravelTimeBeta( 5. * 60. ).setStopDuration( 60. ).setMaxWaitTime( Double.MAX_VALUE )
-								    .setRejectRequestIfMaxWaitOrTravelTimeViolated( false ).setUseModeFilteredSubnetwork( true ) );
+				DrtConfigGroup drtConfigGroup = new DrtConfigGroup().setMode("drt3")
+						.setMaxTravelTimeAlpha(1.3)
+						.setMaxTravelTimeBeta(5. * 60.)
+						.setStopDuration(60.)
+						.setMaxWaitTime(Double.MAX_VALUE)
+						.setRejectRequestIfMaxWaitOrTravelTimeViolated(false)
+						.setUseModeFilteredSubnetwork(true);
+				drtConfigGroup.addParameterSet(new ExtensiveInsertionSearchParams());
+				mm.addParameterSet(drtConfigGroup);
 			}
 
 			for( DrtConfigGroup drtConfigGroup : mm.getModalElements() ){

--- a/examples/scenarios/dvrp-grid/eight_shared_taxi_config.xml
+++ b/examples/scenarios/dvrp-grid/eight_shared_taxi_config.xml
@@ -3,6 +3,7 @@
 <config>
 	<module name="multiModeDrt">
 		<parameterset type="drt">
+			<parameterset type="ExtensiveInsertionSearch"/>
 			<param name="stopDuration" value="60"/>
 			<param name="maxWaitTime" value="900"/>
 			<param name="maxTravelTimeAlpha" value="1.3"/>

--- a/examples/scenarios/dvrp-grid/multi_mode_one_shared_taxi_config.xml
+++ b/examples/scenarios/dvrp-grid/multi_mode_one_shared_taxi_config.xml
@@ -3,6 +3,7 @@
 <config>
 	<module name="multiModeDrt">
 		<parameterset type="drt">
+			<parameterset type="ExtensiveInsertionSearch"/>
 			<param name="mode" value="drt_A"/>
 			<param name="stopDuration" value="60"/>
 			<param name="maxWaitTime" value="900"/>
@@ -14,6 +15,7 @@
 		</parameterset>
 
 		<parameterset type="drt">
+			<parameterset type="ExtensiveInsertionSearch"/>
 			<param name="mode" value="drt_B"/>
 			<param name="stopDuration" value="60"/>
 			<param name="maxWaitTime" value="900"/>
@@ -25,6 +27,7 @@
 		</parameterset>
 
 		<parameterset type="drt">
+			<parameterset type="ExtensiveInsertionSearch"/>
 			<param name="mode" value="drt_C"/>
 			<param name="stopDuration" value="60"/>
 			<param name="maxWaitTime" value="900"/>

--- a/examples/scenarios/dvrp-grid/one_shared_taxi_config.xml
+++ b/examples/scenarios/dvrp-grid/one_shared_taxi_config.xml
@@ -3,6 +3,7 @@
 <config>
 	<module name="multiModeDrt">
 		<parameterset type="drt">
+			<parameterset type="ExtensiveInsertionSearch"/>
 			<param name="stopDuration" value="60"/>
 			<param name="maxWaitTime" value="900"/>
 			<param name="maxTravelTimeAlpha" value="1.3"/>

--- a/examples/scenarios/dvrp-grid/one_taxi_and_one_shared_taxi_config.xml
+++ b/examples/scenarios/dvrp-grid/one_taxi_and_one_shared_taxi_config.xml
@@ -6,6 +6,7 @@
 
 	<module name="multiModeDrt">
 		<parameterset type="drt">
+			<parameterset type="ExtensiveInsertionSearch"/>
 			<param name="stopDuration" value="60"/>
 			<param name="maxWaitTime" value="900"/>
 			<param name="maxTravelTimeAlpha" value="1.3"/>

--- a/examples/scenarios/mielec/mielec_drt_config.xml
+++ b/examples/scenarios/mielec/mielec_drt_config.xml
@@ -3,6 +3,7 @@
 <config>
 	<module name="multiModeDrt">
 		<parameterset type="drt">
+			<parameterset type="ExtensiveInsertionSearch"/>
 			<param name="stopDuration" value="60"/>
 			<param name="maxWaitTime" value="600"/>
 			<param name="maxTravelTimeAlpha" value="1.3"/>

--- a/examples/scenarios/mielec/mielec_edrt_config.xml
+++ b/examples/scenarios/mielec/mielec_edrt_config.xml
@@ -3,6 +3,7 @@
 <config>
 	<module name="multiModeDrt">
 		<parameterset type="drt">
+			<parameterset type="ExtensiveInsertionSearch"/>
 			<param name="stopDuration" value="60"/>
 			<param name="maxWaitTime" value="600"/>
 			<param name="maxTravelTimeAlpha" value="1.3"/>

--- a/examples/scenarios/mielec/mielec_serviceArea_based_drt_config.xml
+++ b/examples/scenarios/mielec/mielec_serviceArea_based_drt_config.xml
@@ -3,6 +3,7 @@
 <config>
 	<module name="multiModeDrt">
 		<parameterset type="drt">
+			<parameterset type="ExtensiveInsertionSearch"/>
 			<param name="stopDuration" value="60"/>
 			<param name="maxWaitTime" value="600"/>
 			<param name="maxTravelTimeAlpha" value="1.3"/>

--- a/examples/scenarios/mielec/mielec_stop_based_drt_config.xml
+++ b/examples/scenarios/mielec/mielec_stop_based_drt_config.xml
@@ -3,6 +3,7 @@
 <config>
 	<module name="multiModeDrt">
 		<parameterset type="drt">
+			<parameterset type="ExtensiveInsertionSearch"/>
 			<param name="stopDuration" value="60"/>
 			<param name="maxWaitTime" value="600"/>
 			<param name="maxTravelTimeAlpha" value="1.3"/>


### PR DESCRIPTION
`DrtInsertionSearchParams` parameter set is specified per `DrtConfigGroup` and is meant to customise the `DrtInsertionSearch`, exactly the same as the taxi optimiser params are used to choose and parametrise the taxi optimiser.

The existing search procedure (renamed into `ExtensiveInsertionSearch` as it iterates through a quite comprehensive set of potential insertions) requires providing a `ExtensiveInsertionSearchParams` parameter set.

The following line was added to all DRT configs:
```
		<parameterset type="drt">
			<parameterset type="ExtensiveInsertionSearch"/>
			...
		</parameterset>
```
Adding this single line without specifying any parameters means that `ExtensiveInsertionSearch` will use the default values for parameters: `admissibleBeelineSpeedFactor` and `nearestInsertionsAtEndLimit`. These defaults are exactly as they were before this PR, but now they are not hard-coded as constants.