### PR TITLE
SelectiveInsertionSearch prototype

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveDrtInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveDrtInsertionSearch.java
@@ -1,0 +1,97 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2017 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.drt.optimizer.insertion;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ForkJoinPool;
+
+import org.matsim.contrib.drt.optimizer.VehicleData.Entry;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
+import org.matsim.contrib.drt.passenger.DrtRequest;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
+import org.matsim.core.mobsim.framework.MobsimTimer;
+
+/**
+ * @author michalm
+ */
+public class SelectiveDrtInsertionSearch implements DrtInsertionSearch<PathData> {
+	private final SelectiveInsertionSearchParams insertionParams;
+
+	// step 1: initial filtering out feasible insertions
+	private final DetourTimesProvider admissibleDetourTimesProvider;
+	private final BestInsertionFinder<Double> initialInsertionFinder;
+
+	// step 2: finding best insertion
+	private final ForkJoinPool forkJoinPool;
+	private final DetourPathCalculator detourPathCalculator;
+	private final BestInsertionFinder<PathData> bestInsertionFinder;
+
+	public SelectiveDrtInsertionSearch(DetourPathCalculator detourPathCalculator, DrtConfigGroup drtCfg,
+			MobsimTimer timer, ForkJoinPool forkJoinPool, InsertionCostCalculator.PenaltyCalculator penaltyCalculator) {
+		this.detourPathCalculator = detourPathCalculator;
+		this.forkJoinPool = forkJoinPool;
+
+		insertionParams = (SelectiveInsertionSearchParams)drtCfg.getDrtInsertionSearchParams();
+
+		// TODO use more sophisticated DetourTimeEstimator
+		double admissibleBeelineSpeed = insertionParams.getAdmissibleBeelineSpeedFactor()
+				* drtCfg.getEstimatedDrtSpeed() / drtCfg.getEstimatedBeelineDistanceFactor();
+
+		admissibleDetourTimesProvider = new DetourTimesProvider(
+				DetourTimeEstimator.createBeelineTimeEstimator(admissibleBeelineSpeed));
+
+		initialInsertionFinder = new BestInsertionFinder<>(
+				new InsertionCostCalculator<>(drtCfg, timer, penaltyCalculator, Double::doubleValue));
+
+		bestInsertionFinder = new BestInsertionFinder<>(
+				new InsertionCostCalculator<>(drtCfg, timer, penaltyCalculator, PathData::getTravelTime));
+	}
+
+	@Override
+	public Optional<InsertionWithDetourData<PathData>> findBestInsertion(DrtRequest drtRequest,
+			Collection<Entry> vEntries) {
+		InsertionGenerator insertionGenerator = new InsertionGenerator();
+		DetourData<Double> admissibleTimeData = admissibleDetourTimesProvider.getDetourData(drtRequest);
+
+		// Parallel outer stream over vehicle entries. The inner stream (flatmap) is sequential.
+		Optional<Insertion> bestInsertion = forkJoinPool.submit(
+				// find best insertion given a stream of insertion with time data
+				() -> initialInsertionFinder.findBestInsertion(drtRequest,
+						//for each vehicle entry
+						vEntries.parallelStream()
+								//generate feasible insertions (wrt occupancy limits)
+								.flatMap(e -> insertionGenerator.generateInsertions(drtRequest, e).stream())
+								//map them to insertions with admissible detour times
+								.map(admissibleTimeData::createInsertionWithDetourData))
+						.map(InsertionWithDetourData::getInsertion)).join();
+
+		if (bestInsertion.isEmpty()) {
+			return Optional.empty();
+		}
+
+		//compute actual path
+		DetourData<PathData> pathData = detourPathCalculator.calculatePaths(drtRequest, List.of(bestInsertion.get()));
+		return bestInsertionFinder.findBestInsertion(drtRequest, bestInsertion.
+				stream().map(pathData::createInsertionWithDetourData));
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchParams.java
@@ -1,0 +1,48 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.optimizer.insertion;
+
+import javax.validation.constraints.DecimalMin;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class SelectiveInsertionSearchParams extends DrtInsertionSearchParams {
+	public static final String SET_NAME = "SelectiveInsertionSearch";
+
+	public static final String ADMISSIBLE_BEELINE_SPEED_FACTOR = "admissibleBeelineSpeedFactor";
+	@DecimalMin("1.0")
+	private double admissibleBeelineSpeedFactor = 1.5;
+
+	public SelectiveInsertionSearchParams() {
+		super(SET_NAME);
+	}
+
+	@StringGetter(ADMISSIBLE_BEELINE_SPEED_FACTOR)
+	public double getAdmissibleBeelineSpeedFactor() {
+		return admissibleBeelineSpeedFactor;
+	}
+
+	@StringSetter(ADMISSIBLE_BEELINE_SPEED_FACTOR)
+	public void setAdmissibleBeelineSpeedFactor(double admissibleBeelineSpeedFactor) {
+		this.admissibleBeelineSpeedFactor = admissibleBeelineSpeedFactor;
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchQSimModule.java
@@ -1,0 +1,73 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.optimizer.insertion;
+
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.drt.optimizer.QSimScopeForkJoinPoolHolder;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.dvrp.path.OneToManyPathSearch;
+import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
+import org.matsim.contrib.dvrp.run.ModalProviders;
+import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
+import org.matsim.core.mobsim.framework.MobsimTimer;
+import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
+import org.matsim.core.router.util.TravelDisutility;
+import org.matsim.core.router.util.TravelTime;
+
+import com.google.inject.Inject;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Named;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class SelectiveInsertionSearchQSimModule extends AbstractDvrpModeQSimModule {
+	private final DrtConfigGroup drtCfg;
+
+	public SelectiveInsertionSearchQSimModule(DrtConfigGroup drtCfg) {
+		super(drtCfg.getMode());
+		this.drtCfg = drtCfg;
+	}
+
+	@Override
+	protected void configureQSim() {
+		bindModal(new TypeLiteral<DrtInsertionSearch<OneToManyPathSearch.PathData>>() {
+		}).toProvider(modalProvider(
+				getter -> new SelectiveDrtInsertionSearch(getter.getModal(DetourPathCalculator.class), drtCfg,
+						getter.get(MobsimTimer.class), getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool(),
+						getter.getModal(InsertionCostCalculator.PenaltyCalculator.class))));
+
+		addModalComponent(SingleInsertionDetourPathCalculator.class, new ModalProviders.AbstractProvider<>(getMode()) {
+			@Inject
+			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
+			private TravelTime travelTime;
+
+			@Override
+			public SingleInsertionDetourPathCalculator get() {
+				Network network = getModalInstance(Network.class);
+				TravelDisutility travelDisutility = getModalInstance(
+						TravelDisutilityFactory.class).createTravelDisutility(travelTime);
+				return new SingleInsertionDetourPathCalculator(network, travelTime, travelDisutility, drtCfg);
+			}
+		});
+		bindModal(DetourPathCalculator.class).to(modalKey(SingleInsertionDetourPathCalculator.class));
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SingleInsertionDetourPathCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SingleInsertionDetourPathCalculator.java
@@ -1,0 +1,147 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.optimizer.insertion;
+
+import static org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
+import static org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
+import static org.matsim.contrib.dvrp.path.OneToManyPathSearch.createZeroPathData;
+import static org.matsim.contrib.dvrp.path.VrpPaths.FIRST_LINK_TT;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import javax.inject.Named;
+
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.drt.passenger.DrtRequest;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.dvrp.path.VrpPaths;
+import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
+import org.matsim.core.mobsim.framework.events.MobsimBeforeCleanupEvent;
+import org.matsim.core.mobsim.framework.listeners.MobsimBeforeCleanupListener;
+import org.matsim.core.router.FastAStarEuclideanFactory;
+import org.matsim.core.router.util.LeastCostPathCalculator;
+import org.matsim.core.router.util.LeastCostPathCalculator.Path;
+import org.matsim.core.router.util.TravelDisutility;
+import org.matsim.core.router.util.TravelTime;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Futures;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class SingleInsertionDetourPathCalculator implements DetourPathCalculator, MobsimBeforeCleanupListener {
+
+	private static final double OVERDO_FACTOR = 2;
+	public static final int MAX_THREADS = 4;
+
+	private final LeastCostPathCalculator toPickupPathSearch;
+	private final LeastCostPathCalculator fromPickupPathSearch;
+	private final LeastCostPathCalculator toDropoffPathSearch;
+	private final LeastCostPathCalculator fromDropoffPathSearch;
+
+	private final double stopDuration;
+
+	private final ExecutorService executorService;
+
+	public SingleInsertionDetourPathCalculator(Network network,
+			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, TravelDisutility travelDisutility,
+			DrtConfigGroup drtCfg) {
+		//TODO use Landmarks instead of AStarEuclidean
+		toPickupPathSearch = new FastAStarEuclideanFactory(OVERDO_FACTOR).createPathCalculator(network,
+				travelDisutility, travelTime);
+		fromPickupPathSearch = new FastAStarEuclideanFactory(OVERDO_FACTOR).createPathCalculator(network,
+				travelDisutility, travelTime);
+		toDropoffPathSearch = new FastAStarEuclideanFactory(OVERDO_FACTOR).createPathCalculator(network,
+				travelDisutility, travelTime);
+		fromDropoffPathSearch = new FastAStarEuclideanFactory(OVERDO_FACTOR).createPathCalculator(network,
+				travelDisutility, travelTime);
+		stopDuration = drtCfg.getStopDuration();
+		executorService = Executors.newFixedThreadPool(Math.min(drtCfg.getNumberOfThreads(), MAX_THREADS));
+	}
+
+	@Override
+	public DetourData<PathData> calculatePaths(DrtRequest drtRequest, List<Insertion> filteredInsertions) {
+		Link pickup = drtRequest.getFromLink();
+		Link dropoff = drtRequest.getToLink();
+
+		Preconditions.checkArgument(filteredInsertions.size() == 1);
+		Insertion insertion = filteredInsertions.get(0);
+
+		double earliestPickupTime = drtRequest.getEarliestStartTime(); // optimistic
+		double minTravelTime = 15 * 60; // FIXME inaccurate temp solution: fixed 15 min
+		double earliestDropoffTime = earliestPickupTime + minTravelTime + stopDuration;
+
+		// TODO use times from InsertionWithDetourData<Double> as approximate departure times for Dijkstra (will require
+		//  passing it as an argument, instead of Insertion)
+
+		Future<Map<Link, PathData>> pathsToPickupFuture = executorService.submit(
+				() -> Map.of(insertion.pickup.previousLink,
+						calcPathData(toPickupPathSearch, insertion.pickup.previousLink, pickup, earliestPickupTime)));
+
+		Future<Map<Link, PathData>> pathsFromPickupFuture = executorService.submit(
+				() -> Map.of(insertion.pickup.nextLink,
+						calcPathData(fromPickupPathSearch, pickup, insertion.pickup.nextLink, earliestPickupTime)));
+
+		Future<Map<Link, PathData>> pathsToDropoffFuture = insertion.dropoff.previousLink == null ?
+				Futures.immediateFuture(ImmutableMap.of()) :
+				executorService.submit(() -> Map.of(insertion.dropoff.previousLink,
+						calcPathData(toDropoffPathSearch, insertion.dropoff.previousLink, dropoff,
+								earliestDropoffTime)));
+
+		Future<Map<Link, PathData>> pathsFromDropoffFuture = insertion.dropoff.nextLink == null ?
+				Futures.immediateFuture(ImmutableMap.of()) :
+				executorService.submit(() -> Map.of(insertion.dropoff.nextLink,
+						calcPathData(fromDropoffPathSearch, dropoff, insertion.dropoff.nextLink, earliestDropoffTime)));
+
+		try {
+			return new DetourData<>(pathsToPickupFuture.get(), pathsFromPickupFuture.get(), pathsToDropoffFuture.get(),
+					pathsFromDropoffFuture.get());
+		} catch (InterruptedException | ExecutionException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public void notifyMobsimBeforeCleanup(@SuppressWarnings("rawtypes") MobsimBeforeCleanupEvent e) {
+		executorService.shutdown();
+	}
+
+	private PathData calcPathData(LeastCostPathCalculator router, Link fromLink, Link toLink, double departureTime) {
+		if (fromLink == toLink) {
+			return createZeroPathData(fromLink.getToNode());
+		}
+
+		Path path = router.calcLeastCostPath(fromLink.getToNode(), toLink.getFromNode(), departureTime + FIRST_LINK_TT,
+				null, null);
+		double firstAndLastLinkTT = FIRST_LINK_TT + VrpPaths.getLastLinkTT(toLink,
+				departureTime + FIRST_LINK_TT + path.travelTime);
+
+		return new PathData(path, firstAndLastLinkTT);
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -194,8 +194,7 @@ public final class DrtConfigGroup extends ReflectiveConfigGroup implements Modal
 	private boolean plotDetailedCustomerStats = true;
 
 	@Positive
-	private int numberOfThreads = Math.min(Runtime.getRuntime().availableProcessors(),
-			MultiInsertionDetourPathCalculator.MAX_THREADS);
+	private int numberOfThreads = Runtime.getRuntime().availableProcessors();
 
 	@PositiveOrZero
 	private double advanceRequestPlanningHorizon = 0; // beta-feature; planning horizon for advance (prebooked) requests

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -37,7 +37,7 @@ import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.contrib.drt.optimizer.insertion.DrtInsertionSearchParams;
 import org.matsim.contrib.drt.optimizer.insertion.ExtensiveInsertionSearchParams;
-import org.matsim.contrib.drt.optimizer.insertion.MultiInsertionDetourPathCalculator;
+import org.matsim.contrib.drt.optimizer.insertion.SelectiveInsertionSearchParams;
 import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingParams;
 import org.matsim.contrib.dvrp.router.DvrpModeRoutingNetworkModule;
 import org.matsim.contrib.dvrp.run.Modal;
@@ -642,6 +642,9 @@ public final class DrtConfigGroup extends ReflectiveConfigGroup implements Modal
 
 			case ExtensiveInsertionSearchParams.SET_NAME:
 				return new ExtensiveInsertionSearchParams();
+
+			case SelectiveInsertionSearchParams.SET_NAME:
+				return new SelectiveInsertionSearchParams();
 		}
 
 		return super.createParameterSet(type);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeQSimModule.java
@@ -30,8 +30,11 @@ import org.matsim.contrib.drt.optimizer.depot.DepotFinder;
 import org.matsim.contrib.drt.optimizer.depot.NearestStartLinkAsDepot;
 import org.matsim.contrib.drt.optimizer.insertion.DefaultUnplannedRequestInserter;
 import org.matsim.contrib.drt.optimizer.insertion.DrtInsertionSearch;
+import org.matsim.contrib.drt.optimizer.insertion.ExtensiveInsertionSearchParams;
 import org.matsim.contrib.drt.optimizer.insertion.ExtensiveInsertionSearchQSimModule;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator;
+import org.matsim.contrib.drt.optimizer.insertion.SelectiveInsertionSearchParams;
+import org.matsim.contrib.drt.optimizer.insertion.SelectiveInsertionSearchQSimModule;
 import org.matsim.contrib.drt.optimizer.insertion.UnplannedRequestInserter;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.drt.passenger.DrtRequestCreator;
@@ -107,7 +110,7 @@ public class DrtModeQSimModule extends AbstractDvrpModeQSimModule {
 						getter.getModal(new TypeLiteral<DrtInsertionSearch<PathData>>() {
 						}), getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool()))).asEagerSingleton();
 
-		install(new ExtensiveInsertionSearchQSimModule(drtCfg));
+		install(getInsertionSearchQSimModule(drtCfg));
 
 		bindModal(VehicleData.EntryFactory.class).toInstance(new VehicleDataEntryFactoryImpl(drtCfg));
 
@@ -167,5 +170,19 @@ public class DrtModeQSimModule extends AbstractDvrpModeQSimModule {
 		}).asEagerSingleton();
 
 		bindModal(VrpOptimizer.class).to(modalKey(DrtOptimizer.class));
+	}
+
+	public static AbstractDvrpModeQSimModule getInsertionSearchQSimModule(DrtConfigGroup drtCfg) {
+		switch (drtCfg.getDrtInsertionSearchParams().getName()) {
+			case ExtensiveInsertionSearchParams.SET_NAME:
+				return new ExtensiveInsertionSearchQSimModule(drtCfg);
+
+			case SelectiveInsertionSearchParams.SET_NAME:
+				return new SelectiveInsertionSearchQSimModule(drtCfg);
+
+			default:
+				throw new RuntimeException(
+						"Unsupported DRT insertion search type: " + drtCfg.getDrtInsertionSearchParams().getName());
+		}
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/DefaultTaxiOptimizerProvider.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/DefaultTaxiOptimizerProvider.java
@@ -56,8 +56,9 @@ public class DefaultTaxiOptimizerProvider implements Provider<TaxiOptimizer> {
 	private final ScheduleTimingUpdater scheduleTimingUpdater;
 
 	public DefaultTaxiOptimizerProvider(EventsManager eventsManager, TaxiConfigGroup taxiCfg, Fleet fleet,
-										Network network, MobsimTimer timer, @Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
-										TravelDisutility travelDisutility, TaxiScheduler scheduler, ScheduleTimingUpdater scheduleTimingUpdater, URL context) {
+			Network network, MobsimTimer timer, @Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
+			TravelDisutility travelDisutility, TaxiScheduler scheduler, ScheduleTimingUpdater scheduleTimingUpdater,
+			URL context) {
 		this.eventsManager = eventsManager;
 		this.taxiCfg = taxiCfg;
 		this.fleet = fleet;
@@ -76,16 +77,22 @@ public class DefaultTaxiOptimizerProvider implements Provider<TaxiOptimizer> {
 			case AssignmentTaxiOptimizerParams.SET_NAME:
 				return new AssignmentTaxiOptimizer(eventsManager, taxiCfg, fleet, network, timer, travelTime,
 						travelDisutility, scheduler, scheduleTimingUpdater);
+
 			case FifoTaxiOptimizerParams.SET_NAME:
 				return new FifoTaxiOptimizer(eventsManager, taxiCfg, fleet, network, timer, travelTime,
 						travelDisutility, scheduler, scheduleTimingUpdater);
+
 			case RuleBasedTaxiOptimizerParams.SET_NAME:
-				return RuleBasedTaxiOptimizer.create(eventsManager, taxiCfg, fleet, scheduler, scheduleTimingUpdater, network, timer,
-						travelTime, travelDisutility);
+				return RuleBasedTaxiOptimizer.create(eventsManager, taxiCfg, fleet, scheduler, scheduleTimingUpdater,
+						network, timer, travelTime, travelDisutility);
+
 			case ZonalTaxiOptimizerParams.SET_NAME:
-				return ZonalTaxiOptimizer.create(eventsManager, taxiCfg, fleet, scheduler, scheduleTimingUpdater, network, timer, travelTime,
-						travelDisutility, context);
+				return ZonalTaxiOptimizer.create(eventsManager, taxiCfg, fleet, scheduler, scheduleTimingUpdater,
+						network, timer, travelTime, travelDisutility, context);
+
+			default:
+				throw new RuntimeException(
+						"Unsupported taxi optimizer type: " + taxiCfg.getTaxiOptimizerParams().getName());
 		}
-		throw new RuntimeException("Unsupported taxi optimizer type: " + taxiCfg.getTaxiOptimizerParams().getName());
 	}
 }

--- a/contribs/vsp/pom.xml
+++ b/contribs/vsp/pom.xml
@@ -12,7 +12,7 @@
 	<name>vsp</name>
 
 	<properties>
-		<matsim.version>12.0-SNAPSHOT</matsim.version>
+		<matsim.version>13.0-SNAPSHOT</matsim.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
An alternative to `ExtensiveInsertionSearch`. It uses beeline distances to find the best potential insertion and then evaluates the selected one. Therefore per each request insertion, it runs 4 one-to-one least-cost path searches, instead of 4 many-to-one searches.

