### PR TITLE
Improve selective insertion search

### DIFF
--- a/contribs/accessibility/pom.xml
+++ b/contribs/accessibility/pom.xml
@@ -80,7 +80,7 @@
 <!--		<dependency>-->
 <!--			<groupId>org.matsim.contrib</groupId>-->
 <!--			<artifactId>dvrp</artifactId>-->
-<!--			<version>12.0-SNAPSHOT</version>-->
+<!--			<version>13.0-SNAPSHOT</version>-->
 <!--		</dependency>-->
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveDrtInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveDrtInsertionSearch.java
@@ -38,7 +38,7 @@ public class SelectiveDrtInsertionSearch implements DrtInsertionSearch<PathData>
 	private final SelectiveInsertionSearchParams insertionParams;
 
 	// step 1: initial filtering out feasible insertions
-	private final DetourTimesProvider admissibleDetourTimesProvider;
+	private final DetourTimesProvider restrictiveDetourTimesProvider;
 	private final BestInsertionFinder<Double> initialInsertionFinder;
 
 	// step 2: finding best insertion
@@ -54,11 +54,11 @@ public class SelectiveDrtInsertionSearch implements DrtInsertionSearch<PathData>
 		insertionParams = (SelectiveInsertionSearchParams)drtCfg.getDrtInsertionSearchParams();
 
 		// TODO use more sophisticated DetourTimeEstimator
-		double admissibleBeelineSpeed = insertionParams.getAdmissibleBeelineSpeedFactor()
+		double restrictiveBeelineSpeed = insertionParams.getRestrictiveBeelineSpeedFactor()
 				* drtCfg.getEstimatedDrtSpeed() / drtCfg.getEstimatedBeelineDistanceFactor();
 
-		admissibleDetourTimesProvider = new DetourTimesProvider(
-				DetourTimeEstimator.createBeelineTimeEstimator(admissibleBeelineSpeed));
+		restrictiveDetourTimesProvider = new DetourTimesProvider(
+				DetourTimeEstimator.createBeelineTimeEstimator(restrictiveBeelineSpeed));
 
 		initialInsertionFinder = new BestInsertionFinder<>(
 				new InsertionCostCalculator<>(drtCfg, timer, penaltyCalculator, Double::doubleValue));
@@ -71,7 +71,7 @@ public class SelectiveDrtInsertionSearch implements DrtInsertionSearch<PathData>
 	public Optional<InsertionWithDetourData<PathData>> findBestInsertion(DrtRequest drtRequest,
 			Collection<Entry> vEntries) {
 		InsertionGenerator insertionGenerator = new InsertionGenerator();
-		DetourData<Double> admissibleTimeData = admissibleDetourTimesProvider.getDetourData(drtRequest);
+		DetourData<Double> restrictiveTimeData = restrictiveDetourTimesProvider.getDetourData(drtRequest);
 
 		// Parallel outer stream over vehicle entries. The inner stream (flatmap) is sequential.
 		Optional<Insertion> bestInsertion = forkJoinPool.submit(
@@ -82,7 +82,7 @@ public class SelectiveDrtInsertionSearch implements DrtInsertionSearch<PathData>
 								//generate feasible insertions (wrt occupancy limits)
 								.flatMap(e -> insertionGenerator.generateInsertions(drtRequest, e).stream())
 								//map them to insertions with admissible detour times
-								.map(admissibleTimeData::createInsertionWithDetourData))
+								.map(restrictiveTimeData::createInsertionWithDetourData))
 						.map(InsertionWithDetourData::getInsertion)).join();
 
 		if (bestInsertion.isEmpty()) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearch.java
@@ -34,7 +34,7 @@ import org.matsim.core.mobsim.framework.MobsimTimer;
 /**
  * @author michalm
  */
-public class SelectiveDrtInsertionSearch implements DrtInsertionSearch<PathData> {
+public class SelectiveInsertionSearch implements DrtInsertionSearch<PathData> {
 	private final SelectiveInsertionSearchParams insertionParams;
 
 	// step 1: initial filtering out feasible insertions
@@ -46,8 +46,8 @@ public class SelectiveDrtInsertionSearch implements DrtInsertionSearch<PathData>
 	private final DetourPathCalculator detourPathCalculator;
 	private final BestInsertionFinder<PathData> bestInsertionFinder;
 
-	public SelectiveDrtInsertionSearch(DetourPathCalculator detourPathCalculator, DrtConfigGroup drtCfg,
-			MobsimTimer timer, ForkJoinPool forkJoinPool, InsertionCostCalculator.PenaltyCalculator penaltyCalculator) {
+	public SelectiveInsertionSearch(DetourPathCalculator detourPathCalculator, DrtConfigGroup drtCfg, MobsimTimer timer,
+			ForkJoinPool forkJoinPool, InsertionCostCalculator.PenaltyCalculator penaltyCalculator) {
 		this.detourPathCalculator = detourPathCalculator;
 		this.forkJoinPool = forkJoinPool;
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchParams.java
@@ -20,7 +20,7 @@
 
 package org.matsim.contrib.drt.optimizer.insertion;
 
-import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Positive;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -28,21 +28,23 @@ import javax.validation.constraints.DecimalMin;
 public class SelectiveInsertionSearchParams extends DrtInsertionSearchParams {
 	public static final String SET_NAME = "SelectiveInsertionSearch";
 
-	public static final String ADMISSIBLE_BEELINE_SPEED_FACTOR = "admissibleBeelineSpeedFactor";
-	@DecimalMin("1.0")
-	private double admissibleBeelineSpeedFactor = 1.5;
+	public static final String RESTRICTIVE_BEELINE_SPEED_FACTOR = "restrictiveBeelineSpeedFactor";
+	//use values that underestimate the actual speed, so the risk that the pre-filtering returns an insertion that
+	//violates time windows constraints (for existing passengers, given the actual path)
+	@Positive
+	private double restrictiveBeelineSpeedFactor = 0.5;
 
 	public SelectiveInsertionSearchParams() {
 		super(SET_NAME);
 	}
 
-	@StringGetter(ADMISSIBLE_BEELINE_SPEED_FACTOR)
-	public double getAdmissibleBeelineSpeedFactor() {
-		return admissibleBeelineSpeedFactor;
+	@StringGetter(RESTRICTIVE_BEELINE_SPEED_FACTOR)
+	public double getRestrictiveBeelineSpeedFactor() {
+		return restrictiveBeelineSpeedFactor;
 	}
 
-	@StringSetter(ADMISSIBLE_BEELINE_SPEED_FACTOR)
-	public void setAdmissibleBeelineSpeedFactor(double admissibleBeelineSpeedFactor) {
-		this.admissibleBeelineSpeedFactor = admissibleBeelineSpeedFactor;
+	@StringSetter(RESTRICTIVE_BEELINE_SPEED_FACTOR)
+	public void setRestrictiveBeelineSpeedFactor(double restrictiveBeelineSpeedFactor) {
+		this.restrictiveBeelineSpeedFactor = restrictiveBeelineSpeedFactor;
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchQSimModule.java
@@ -51,7 +51,7 @@ public class SelectiveInsertionSearchQSimModule extends AbstractDvrpModeQSimModu
 	protected void configureQSim() {
 		bindModal(new TypeLiteral<DrtInsertionSearch<OneToManyPathSearch.PathData>>() {
 		}).toProvider(modalProvider(
-				getter -> new SelectiveDrtInsertionSearch(getter.getModal(DetourPathCalculator.class), drtCfg,
+				getter -> new SelectiveInsertionSearch(getter.getModal(DetourPathCalculator.class), drtCfg,
 						getter.get(MobsimTimer.class), getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool(),
 						getter.getModal(InsertionCostCalculator.PenaltyCalculator.class))));
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SingleInsertionDetourPathCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SingleInsertionDetourPathCalculator.java
@@ -42,7 +42,7 @@ import org.matsim.contrib.dvrp.path.VrpPaths;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.core.mobsim.framework.events.MobsimBeforeCleanupEvent;
 import org.matsim.core.mobsim.framework.listeners.MobsimBeforeCleanupListener;
-import org.matsim.core.router.FastAStarEuclideanFactory;
+import org.matsim.core.router.FastAStarLandmarksFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.LeastCostPathCalculator.Path;
 import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
@@ -58,7 +58,6 @@ import com.google.common.util.concurrent.Futures;
  */
 public class SingleInsertionDetourPathCalculator implements DetourPathCalculator, MobsimBeforeCleanupListener {
 
-	private static final double OVERDO_FACTOR = 2;
 	public static final int MAX_THREADS = 4;
 
 	private final LeastCostPathCalculator toPickupPathSearch;
@@ -73,8 +72,8 @@ public class SingleInsertionDetourPathCalculator implements DetourPathCalculator
 	public SingleInsertionDetourPathCalculator(Network network,
 			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, TravelDisutility travelDisutility,
 			DrtConfigGroup drtCfg) {
-		//TODO use Landmarks instead of AStarEuclidean
-		LeastCostPathCalculatorFactory pathCalculatorFactory = new FastAStarEuclideanFactory(OVERDO_FACTOR);
+		LeastCostPathCalculatorFactory pathCalculatorFactory = new FastAStarLandmarksFactory(
+				drtCfg.getNumberOfThreads());
 		toPickupPathSearch = pathCalculatorFactory.createPathCalculator(network, travelDisutility, travelTime);
 		fromPickupPathSearch = pathCalculatorFactory.createPathCalculator(network, travelDisutility, travelTime);
 		toDropoffPathSearch = pathCalculatorFactory.createPathCalculator(network, travelDisutility, travelTime);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SingleInsertionDetourPathCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SingleInsertionDetourPathCalculator.java
@@ -45,6 +45,7 @@ import org.matsim.core.mobsim.framework.listeners.MobsimBeforeCleanupListener;
 import org.matsim.core.router.FastAStarEuclideanFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.LeastCostPathCalculator.Path;
+import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
 
@@ -73,14 +74,11 @@ public class SingleInsertionDetourPathCalculator implements DetourPathCalculator
 			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, TravelDisutility travelDisutility,
 			DrtConfigGroup drtCfg) {
 		//TODO use Landmarks instead of AStarEuclidean
-		toPickupPathSearch = new FastAStarEuclideanFactory(OVERDO_FACTOR).createPathCalculator(network,
-				travelDisutility, travelTime);
-		fromPickupPathSearch = new FastAStarEuclideanFactory(OVERDO_FACTOR).createPathCalculator(network,
-				travelDisutility, travelTime);
-		toDropoffPathSearch = new FastAStarEuclideanFactory(OVERDO_FACTOR).createPathCalculator(network,
-				travelDisutility, travelTime);
-		fromDropoffPathSearch = new FastAStarEuclideanFactory(OVERDO_FACTOR).createPathCalculator(network,
-				travelDisutility, travelTime);
+		LeastCostPathCalculatorFactory pathCalculatorFactory = new FastAStarEuclideanFactory(OVERDO_FACTOR);
+		toPickupPathSearch = pathCalculatorFactory.createPathCalculator(network, travelDisutility, travelTime);
+		fromPickupPathSearch = pathCalculatorFactory.createPathCalculator(network, travelDisutility, travelTime);
+		toDropoffPathSearch = pathCalculatorFactory.createPathCalculator(network, travelDisutility, travelTime);
+		fromDropoffPathSearch = pathCalculatorFactory.createPathCalculator(network, travelDisutility, travelTime);
 		stopDuration = drtCfg.getStopDuration();
 		executorService = Executors.newFixedThreadPool(Math.min(drtCfg.getNumberOfThreads(), MAX_THREADS));
 	}

--- a/contribs/freight/pom.xml
+++ b/contribs/freight/pom.xml
@@ -10,7 +10,7 @@
 	<name>freight</name>
 
 	<properties>
-		<matsim.version>12.0-SNAPSHOT</matsim.version>
+		<matsim.version>13.0-SNAPSHOT</matsim.version>
 	</properties>
 
 	<build>

--- a/contribs/integration/pom.xml
+++ b/contribs/integration/pom.xml
@@ -20,7 +20,7 @@
 		<!--<matsim.version>0.11.0-2019w01-SNAPSHOT</matsim.version>-->
 
 		<!--development head:-->
-		<matsim.version>12.0-SNAPSHOT</matsim.version>
+		<matsim.version>13.0-SNAPSHOT</matsim.version>
 	</properties>
 
 	<build>


### PR DESCRIPTION
After running some experiments, it turned out that the beeline metric used to (pre)select the best insertion may lead to selecting an insertion that violates the time windows for already accepted requests, which in the end leads to rejecting the newly submitted request.

Therefore, the beeline metric should be rather restrictive (below 1.0) than admissible (above 1.0) to avoid such situations. This gives slight preference towards appending new requests at the end of vehicle schedules and reduces the risk of (pre)selecting an infeasible insertion. This also gives more balanced utilisation of vehicles across the whole fleet. On the other hand, it may reduce ride sharing rates.

Replacing the beeline metric with a more precise travel time estimation is definitely worth some investigation. For the time being, the selective insertion search requires some care when deciding on the beeline metric parameters.

===

**Impact on computation times of the new insertion search**

I used the old 10% Berlin scenario, where all private cars are replaced by autonomous taxis (this study has been often used for benchmarking in the past). In this scenario, about 280k DRT trips are served by 6k vehicles.

With the new selective insertion search, one iteration of QSim takes about 20 minutes on my laptop, which is only about 20% of the computation time when the extensive insertion search is used. This makes the DRT simulation speed comparable to the one of taxi.