### PR TITLE
Switch from euclidean to landmarks

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -156,8 +156,7 @@ public final class DrtConfigGroup extends ReflectiveConfigGroup implements Modal
 
 	// max arrival time defined as:
 	// maxTravelTimeAlpha * unshared_ride_travel_time(fromLink, toLink) + maxTravelTimeBeta,
-	// where unshared_ride_travel_time(fromLink, toLink) is calculated with FastAStarEuclidean
-	// (hence AStarEuclideanOverdoFactor needs to be specified)
+	// where unshared_ride_travel_time(fromLink, toLink) is calculated during replanning (see: DrtRouteCreator)
 	@DecimalMin("1.0")
 	private double maxTravelTimeAlpha = Double.NaN;// [-]
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -52,7 +52,7 @@ import org.matsim.contrib.dvrp.run.ModalProviders;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
-import org.matsim.core.router.FastAStarEuclideanFactory;
+import org.matsim.core.router.FastAStarLandmarksFactory;
 import org.matsim.core.router.RoutingModule;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
 import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
@@ -93,6 +93,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 			bindModal(RebalancingStrategy.class).to(NoRebalancingStrategy.class).asEagerSingleton();
 		}
 
+		//this is a customised version of DvrpModeRoutingModule.install()
 		addRoutingModuleBinding(getMode()).toProvider(new DvrpRoutingModuleProvider(getMode()));// not singleton
 		modalMapBinder(DvrpRoutingModuleProvider.Stage.class, RoutingModule.class).addBinding(
 				DvrpRoutingModuleProvider.Stage.MAIN)
@@ -141,15 +142,14 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 		@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
 		private TravelTime travelTime;
 
-		// Euclidean with overdoFactor > 1.0 could lead to 'experiencedTT < unsharedRideTT',
-		// while the benefit would be a marginal reduction of computation time ==> so stick to 1.0
-		private final LeastCostPathCalculatorFactory leastCostPathCalculatorFactory = new FastAStarEuclideanFactory();
+		private final LeastCostPathCalculatorFactory leastCostPathCalculatorFactory;
 
 		private final DrtConfigGroup drtCfg;
 
 		private DrtRouteCreatorProvider(DrtConfigGroup drtCfg) {
 			super(drtCfg.getMode());
 			this.drtCfg = drtCfg;
+			leastCostPathCalculatorFactory = new FastAStarLandmarksFactory(drtCfg.getNumberOfThreads());
 		}
 
 		@Override

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/ETaxiScheduler.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/ETaxiScheduler.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
@@ -41,16 +40,16 @@ import org.matsim.contrib.taxi.schedule.TaxiStayTask;
 import org.matsim.contrib.taxi.schedule.TaxiTaskType;
 import org.matsim.contrib.taxi.scheduler.TaxiScheduler;
 import org.matsim.core.mobsim.framework.MobsimTimer;
-import org.matsim.core.router.util.TravelDisutility;
+import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelTime;
 
 import com.google.inject.name.Named;
 
 public class ETaxiScheduler extends TaxiScheduler {
 
-	public ETaxiScheduler(TaxiConfigGroup taxiCfg, Fleet fleet, Network network, MobsimTimer timer,
-			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, TravelDisutility travelDisutility) {
-		super(taxiCfg, fleet, network, timer, travelTime, travelDisutility);
+	public ETaxiScheduler(TaxiConfigGroup taxiCfg, Fleet fleet, MobsimTimer timer,
+			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, LeastCostPathCalculator router) {
+		super(taxiCfg, fleet, timer, travelTime, router);
 	}
 
 	// FIXME underestimated due to the ongoing AUX/drive consumption

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.Map;
 
 import javax.annotation.Nullable;
-import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
@@ -86,12 +85,6 @@ public final class TaxiConfigGroup extends ReflectiveConfigGroup implements Moda
 	public static final String DROPOFF_DURATION = "dropoffDuration";
 	static final String DROPOFF_DURATION_EXP = "Dropoff duration. Must be positive.";
 
-	public static final String A_STAR_EUCLIDEAN_OVERDO_FACTOR = "AStarEuclideanOverdoFactor";
-	static final String A_STAR_EUCLIDEAN_OVERDO_FACTOR_EXP =
-			"Used in AStarEuclidean for shortest path search for occupied drives. Default value is 1.0. "
-					+ "Values above 1.0 (typically, 1.5 to 3.0) speed up search, "
-					+ "but at the cost of obtaining longer paths";
-
 	public static final String ONLINE_VEHICLE_TRACKER = "onlineVehicleTracker";
 	static final String ONLINE_VEHICLE_TRACKER_EXP =
 			"If true, vehicles are (GPS-like) monitored while moving. This helps in getting more accurate "
@@ -138,9 +131,6 @@ public final class TaxiConfigGroup extends ReflectiveConfigGroup implements Moda
 	@Positive
 	private double dropoffDuration = Double.NaN;// seconds
 
-	@DecimalMin("1.0")
-	private double AStarEuclideanOverdoFactor = 2.;
-
 	private boolean onlineVehicleTracker = false;
 	private boolean changeStartLinkToLastLinkInSchedule = false;
 
@@ -182,7 +172,6 @@ public final class TaxiConfigGroup extends ReflectiveConfigGroup implements Moda
 		map.put(VEHICLE_DIVERSION, VEHICLE_DIVERSION_EXP);
 		map.put(PICKUP_DURATION, PICKUP_DURATION_EXP);
 		map.put(DROPOFF_DURATION, DROPOFF_DURATION_EXP);
-		map.put(A_STAR_EUCLIDEAN_OVERDO_FACTOR, A_STAR_EUCLIDEAN_OVERDO_FACTOR_EXP);
 		map.put(ONLINE_VEHICLE_TRACKER, ONLINE_VEHICLE_TRACKER_EXP);
 		map.put(CHANGE_START_LINK_TO_LAST_LINK_IN_SCHEDULE, CHANGE_START_LINK_TO_LAST_LINK_IN_SCHEDULE_EXP);
 		map.put(TAXIS_FILE, TAXIS_FILE_EXP);
@@ -293,23 +282,6 @@ public final class TaxiConfigGroup extends ReflectiveConfigGroup implements Moda
 	@StringSetter(DROPOFF_DURATION)
 	public TaxiConfigGroup setDropoffDuration(double dropoffDuration) {
 		this.dropoffDuration = dropoffDuration;
-		return this;
-	}
-
-	/**
-	 * @return {@value #A_STAR_EUCLIDEAN_OVERDO_FACTOR_EXP}
-	 */
-	@StringGetter(A_STAR_EUCLIDEAN_OVERDO_FACTOR)
-	public double getAStarEuclideanOverdoFactor() {
-		return AStarEuclideanOverdoFactor;
-	}
-
-	/**
-	 * @param aStarEuclideanOverdoFactor {@value #A_STAR_EUCLIDEAN_OVERDO_FACTOR_EXP}
-	 */
-	@StringSetter(A_STAR_EUCLIDEAN_OVERDO_FACTOR)
-	public TaxiConfigGroup setAStarEuclideanOverdoFactor(double aStarEuclideanOverdoFactor) {
-		AStarEuclideanOverdoFactor = aStarEuclideanOverdoFactor;
 		return this;
 	}
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeModule.java
@@ -31,7 +31,7 @@ import org.matsim.contrib.dvrp.run.QSimScopeObjectListenerModule;
 import org.matsim.contrib.taxi.util.stats.TaxiStatsDumper;
 import org.matsim.core.controler.IterationCounter;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
-import org.matsim.core.router.AStarEuclideanFactory;
+import org.matsim.core.router.FastAStarLandmarksFactory;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
 
 /**
@@ -52,13 +52,13 @@ public final class TaxiModeModule extends AbstractDvrpModeModule {
 		install(new DvrpModeRoutingNetworkModule(getMode(), taxiCfg.isUseModeFilteredSubnetwork()));
 		bindModal(TravelDisutilityFactory.class).toInstance(TimeAsTravelDisutility::new);
 
-		install(new DvrpModeRoutingModule(getMode(),
-				new AStarEuclideanFactory(taxiCfg.getAStarEuclideanOverdoFactor())));
+		install(new DvrpModeRoutingModule(getMode(), new FastAStarLandmarksFactory(getConfig().global())));
 
 		install(new FleetModule(getMode(), taxiCfg.getTaxisFileUrl(getConfig().getContext()),
 				taxiCfg.isChangeStartLinkToLastLinkInSchedule()));
 
-		install(QSimScopeObjectListenerModule.builder(TaxiStatsDumper.class).mode(getMode())
+		install(QSimScopeObjectListenerModule.builder(TaxiStatsDumper.class)
+				.mode(getMode())
 				.objectClass(Fleet.class)
 				.listenerCreator(getter -> new TaxiStatsDumper(taxiCfg, getter.get(OutputDirectoryHierarchy.class),
 						getter.get(IterationCounter.class)))

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeQSimModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeQSimModule.java
@@ -47,7 +47,9 @@ import org.matsim.contrib.taxi.vrpagent.TaxiActionCreator;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.controler.MatsimServices;
 import org.matsim.core.mobsim.framework.MobsimTimer;
+import org.matsim.core.router.FastAStarLandmarksFactory;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
+import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
 
@@ -110,7 +112,9 @@ public class TaxiModeQSimModule extends AbstractDvrpModeQSimModule {
 						Network network = getModalInstance(Network.class);
 						TravelDisutility travelDisutility = getModalInstance(
 								TravelDisutilityFactory.class).createTravelDisutility(travelTime);
-						return new TaxiScheduler(taxiCfg, fleet, network, timer, travelTime, travelDisutility);
+						LeastCostPathCalculator router = new FastAStarLandmarksFactory(
+								getConfig().global()).createPathCalculator(network, travelDisutility, travelTime);
+						return new TaxiScheduler(taxiCfg, fleet, timer, travelTime, router);
 					}
 				}).asEagerSingleton();
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/scheduler/TaxiScheduler.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/scheduler/TaxiScheduler.java
@@ -23,20 +23,17 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelDataImpl;
 import org.matsim.contrib.dvrp.path.VrpPaths;
-import org.matsim.contrib.dvrp.schedule.DriveTask;
 import org.matsim.contrib.dvrp.schedule.Schedule;
 import org.matsim.contrib.dvrp.schedule.Schedule.ScheduleStatus;
 import org.matsim.contrib.dvrp.schedule.Schedules;
 import org.matsim.contrib.dvrp.schedule.StayTask;
 import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.contrib.dvrp.tracker.OnlineDriveTaskTracker;
-import org.matsim.contrib.dvrp.tracker.TaskTrackers;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.dvrp.util.LinkTimePair;
 import org.matsim.contrib.taxi.passenger.TaxiRequest;
@@ -49,9 +46,7 @@ import org.matsim.contrib.taxi.schedule.TaxiPickupTask;
 import org.matsim.contrib.taxi.schedule.TaxiStayTask;
 import org.matsim.contrib.taxi.schedule.TaxiTaskType;
 import org.matsim.core.mobsim.framework.MobsimTimer;
-import org.matsim.core.router.FastAStarEuclideanFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
-import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
 
 import com.google.inject.name.Named;
@@ -63,15 +58,14 @@ public class TaxiScheduler implements TaxiScheduleInquiry {
 	private final TravelTime travelTime;
 	private final LeastCostPathCalculator router;
 
-	public TaxiScheduler(TaxiConfigGroup taxiCfg, Fleet fleet, Network network, MobsimTimer timer,
-			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, TravelDisutility travelDisutility) {
+	public TaxiScheduler(TaxiConfigGroup taxiCfg, Fleet fleet, MobsimTimer timer,
+			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, LeastCostPathCalculator router) {
 		this.taxiCfg = taxiCfg;
 		this.fleet = fleet;
 		this.timer = timer;
 		this.travelTime = travelTime;
+		this.router = router;
 
-		router = new FastAStarEuclideanFactory(taxiCfg.getAStarEuclideanOverdoFactor()).createPathCalculator(network,
-				travelDisutility, travelTime);
 		initFleet();
 	}
 

--- a/contribs/taxi/src/test/java/org/matsim/contrib/taxi/optimizer/TaxiOptimizerTests.java
+++ b/contribs/taxi/src/test/java/org/matsim/contrib/taxi/optimizer/TaxiOptimizerTests.java
@@ -40,16 +40,14 @@ public class TaxiOptimizerTests {
 		final boolean vehicleDiversion;
 		final double pickupDuration;
 		final double dropoffDuration;
-		final double AStarEuclideanOverdoFactor;
 		final boolean onlineVehicleTracker;
 
 		private TaxiConfigVariant(boolean destinationKnown, boolean vehicleDiversion, double pickupDuration,
-				double dropoffDuration, double AStarEuclideanOverdoFactor, boolean onlineVehicleTracker) {
+				double dropoffDuration, boolean onlineVehicleTracker) {
 			this.destinationKnown = destinationKnown;
 			this.vehicleDiversion = vehicleDiversion;
 			this.pickupDuration = pickupDuration;
 			this.dropoffDuration = dropoffDuration;
-			this.AStarEuclideanOverdoFactor = AStarEuclideanOverdoFactor;
 			this.onlineVehicleTracker = onlineVehicleTracker;
 		}
 
@@ -58,7 +56,6 @@ public class TaxiOptimizerTests {
 			taxiCfg.setVehicleDiversion(vehicleDiversion);
 			taxiCfg.setPickupDuration(pickupDuration);
 			taxiCfg.setDropoffDuration(dropoffDuration);
-			taxiCfg.setAStarEuclideanOverdoFactor(AStarEuclideanOverdoFactor);
 			taxiCfg.setOnlineVehicleTracker(onlineVehicleTracker);
 		}
 	}
@@ -67,17 +64,17 @@ public class TaxiOptimizerTests {
 		List<TaxiConfigVariant> variants = new ArrayList<>();
 
 		// onlineVehicleTracker == false ==> vehicleDiversion == false
-		variants.add(new TaxiConfigVariant(false, false, 120, 60, 1.5, false));
-		variants.add(new TaxiConfigVariant(true, false, 1, 1, 1.5, false));
+		variants.add(new TaxiConfigVariant(false, false, 120, 60, false));
+		variants.add(new TaxiConfigVariant(true, false, 1, 1, false));
 
 		if (diversionSupported) {
 			// onlineVehicleTracker == true
-			variants.add(new TaxiConfigVariant(false, true, 1, 1, 1.5, true));
-			variants.add(new TaxiConfigVariant(true, true, 120, 60, 1.5, true));
+			variants.add(new TaxiConfigVariant(false, true, 1, 1, true));
+			variants.add(new TaxiConfigVariant(true, true, 120, 60, true));
 		} else {
 			// onlineVehicleTracker == true
-			variants.add(new TaxiConfigVariant(false, false, 1, 1, 1.5, true));
-			variants.add(new TaxiConfigVariant(true, false, 120, 60, 1.5, true));
+			variants.add(new TaxiConfigVariant(false, false, 1, 1, true));
+			variants.add(new TaxiConfigVariant(true, false, 120, 60, true));
 		}
 
 		return variants;


### PR DESCRIPTION
In:
- replanning (drt and taxi legs)
- DVRP optimiser (taxi occupied trips)

As a result: `AStarEuclideanOverdoFactor` is removed from `TaxiConfigGroup`