### PR TITLE
RebalancingZoneGeneration

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
@@ -20,9 +20,9 @@
 
 package org.matsim.contrib.drt.optimizer.rebalancing.mincostflow;
 
-import com.google.inject.Inject;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.prep.PreparedGeometry;
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.api.core.v01.population.Population;
 import org.matsim.contrib.drt.analysis.zonal.*;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingStrategy.RebalancingTargetCalculator;
@@ -31,9 +31,13 @@ import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.fleet.FleetSpecification;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
-import org.matsim.contrib.dvrp.run.ModalProviders;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.controler.MatsimServices;
+import org.matsim.utils.gis.shp2matsim.ShpGeometryUtils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author michalm
@@ -50,7 +54,30 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 	public void install() {
 		MinCostFlowRebalancingParams params = drtCfg.getMinCostFlowRebalancing().get();
 		bindModal(DrtZonalSystem.class).toProvider(
-				modalProvider(getter -> new DrtZonalSystem(getter.getModal(Network.class), params.getCellSize())));
+				modalProvider(getter -> {
+
+					if(params.getRebalancingZonesGeneration().equals(MinCostFlowRebalancingParams.RebalancingZoneGeneration.ShapeFile)){
+						final List<PreparedGeometry> preparedGeometries = ShpGeometryUtils.loadPreparedGeometries(params.getRebalancingZonesShapeFileURL(getConfig().getContext()));
+						Map<String,Geometry> zones = new HashMap();
+						for (int i = 0; i < preparedGeometries.size(); i++) {
+							zones.put(""+ (i+1),preparedGeometries.get(i).getGeometry());
+						}
+						return new DrtZonalSystem(getter.getModal(Network.class),zones);
+					}
+
+					switch (drtCfg.getOperationalScheme()) {
+						case serviceAreaBased:
+							final List<PreparedGeometry> preparedGeometries = ShpGeometryUtils.loadPreparedGeometries(
+									drtCfg.getDrtServiceAreaShapeFileURL(getConfig().getContext()));
+							Network modalNetwork = getter.getModal(Network.class);
+							Map<String, Geometry> zones = DrtGridUtils.createGridFromNetworkWithinServiceArea(modalNetwork, params.getCellSize(), preparedGeometries);
+							return new DrtZonalSystem(modalNetwork, zones);
+						default:
+							return new DrtZonalSystem(getter.getModal(Network.class), params.getCellSize());
+					}
+				}));
+
+
 
 		installQSimModule(new AbstractDvrpModeQSimModule(getMode()) {
 			@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingParams.java
@@ -18,13 +18,18 @@
 
 package org.matsim.contrib.drt.optimizer.rebalancing.mincostflow;
 
+import java.net.URL;
 import java.util.Map;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.PositiveOrZero;
 
+import com.google.common.base.Verify;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ReflectiveConfigGroup;
 
 /**
@@ -35,6 +40,8 @@ public final class MinCostFlowRebalancingParams extends ReflectiveConfigGroup {
 
 	public static enum ZonalDemandAggregatorType {PreviousIterationZonalDemandAggregator,
 		ActivityLocationBasedZonalDemandAggregator, EqualVehicleDensityZonalDemandAggregator};
+
+	public enum RebalancingZoneGeneration {GridFromNetwork, ShapeFile}
 
 	public static final String INTERVAL = "interval";
 	static final String INTERVAL_EXP = "Specifies how often empty vehicle rebalancing is executed."
@@ -63,7 +70,14 @@ public final class MinCostFlowRebalancingParams extends ReflectiveConfigGroup {
 			+ " Depends on demand, supply and network. Often used with values in the range of 500 - 2000 m";
 
 	public static final String ZONAL_DEMAND_AGGREGATOR_TYPE = "zonalDemandAggregatorType";
-	static final String ZONAL_DEMAND_AGGREGATOR_TYPE_EXP = "see enum"; //TODO
+	static final String ZONAL_DEMAND_AGGREGATOR_TYPE_EXP = "Defines the methodology for demand estimation. Can be either PreviousIterationZonalDemandAggregator, ActivityLocationBasedZonalDemandAggregator or EqualVehicleDensityZonalDemandAggregator";
+
+	public static final String REBALANCING_ZONES_GENERATION = "rebalancingZonesGeneration";
+	static final String REBALANCING_ZONES_GENERATION_EXP = "Logic for generation of zones for demand estimation while rebalancing. Value can be GridFromNetwork or ShapeFile Default is GridFromNetwork";
+
+	private static final String REBALANCING_ZONES_SHAPE_FILE = "rebalancingZonesShapeFile";
+	private static final String REBALANCING_ZONES_SHAPE_FILE_EXP = "allows to configure rebalancing zones."
+			+ "Used with rebalancingZonesGeneration=ShapeFile";
 
 	@Positive
 	private int interval = 1800;// [s]
@@ -86,6 +100,12 @@ public final class MinCostFlowRebalancingParams extends ReflectiveConfigGroup {
 	@NotNull
 	private MinCostFlowRebalancingParams.ZonalDemandAggregatorType zonalDemandAggregatorType = ZonalDemandAggregatorType.PreviousIterationZonalDemandAggregator;
 
+	@NotNull
+	private RebalancingZoneGeneration rebalancingZonesGeneration = RebalancingZoneGeneration.GridFromNetwork;
+
+	@Nullable
+	private String rebalancingZonesShapeFile = null;
+
 	public MinCostFlowRebalancingParams() {
 		super(SET_NAME);
 	}
@@ -99,6 +119,14 @@ public final class MinCostFlowRebalancingParams extends ReflectiveConfigGroup {
 					+ " must be greater than "
 					+ MinCostFlowRebalancingParams.MAX_TIME_BEFORE_IDLE);
 		}
+
+		Verify.verify(
+				getRebalancingZonesGeneration() != RebalancingZoneGeneration.ShapeFile || getRebalancingZonesShapeFile() != null,
+				REBALANCING_ZONES_SHAPE_FILE
+						+ " must not be null when "
+						+ REBALANCING_ZONES_GENERATION
+						+ " is "
+						+ RebalancingZoneGeneration.ShapeFile);
 	}
 
 	@Override
@@ -222,5 +250,40 @@ public final class MinCostFlowRebalancingParams extends ReflectiveConfigGroup {
 	 */
 	@StringSetter(ZONAL_DEMAND_AGGREGATOR_TYPE)
 	public void setZonalDemandAggregatorType(ZonalDemandAggregatorType aggregatorType) { this.zonalDemandAggregatorType = aggregatorType; }
+
+	/**
+	 * @return -- {@value #REBALANCING_ZONES_GENERATION_EXP}
+	 */
+	@StringGetter(REBALANCING_ZONES_GENERATION)
+	public RebalancingZoneGeneration getRebalancingZonesGeneration() {
+		return rebalancingZonesGeneration;
+	}
+
+	/**
+	 * @param rebalancingZonesGeneration -- {@value #REBALANCING_ZONES_GENERATION_EXP}
+	 */
+	@StringSetter(REBALANCING_ZONES_GENERATION)
+	public void setRebalancingZonesGeneration(RebalancingZoneGeneration rebalancingZonesGeneration) { this.rebalancingZonesGeneration = rebalancingZonesGeneration; }
+
+	/**
+	 * @return {@link #REBALANCING_ZONES_SHAPE_FILE_EXP}
+	 */
+	@StringGetter(REBALANCING_ZONES_SHAPE_FILE)
+	public String getRebalancingZonesShapeFile() {
+		return rebalancingZonesShapeFile;
+	}
+
+	public URL getRebalancingZonesShapeFileURL(URL context) {
+		return ConfigGroup.getInputFileURL(context, rebalancingZonesShapeFile);
+	}
+
+	/**
+	 * @param rebalancingZonesShapeFile -- {@link #REBALANCING_ZONES_SHAPE_FILE_EXP}
+	 */
+	@StringSetter(REBALANCING_ZONES_SHAPE_FILE)
+	public MinCostFlowRebalancingParams setRebalancingZonesShapeFile(String rebalancingZonesShapeFile) {
+		this.rebalancingZonesShapeFile = rebalancingZonesShapeFile;
+		return this;
+	}
 
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
@@ -47,7 +47,10 @@ import java.net.URL;
 import java.util.*;
 import java.util.function.ToIntFunction;
 
-public class ZonalDemandAggregatorTest {
+public class ZonalDemandAggregatorWithoutServiceAreaTest {
+
+	//TODO write test with service area !!
+	// (with an service are, demand estimation zones are not spread over the entire network but restricted to the service are (plus a little surrounding))
 
 	@Rule
 	public MatsimTestUtils utils = new MatsimTestUtils();


### PR DESCRIPTION
zones for drt demand estimation can be read from a shape file. if they aren't, they are now restricted to the drt service area - if the latter is used. everything is configurable via MinCostFlowRebalancingParams