### PR TITLE
Flexible vehicle occupancy time profiles

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/util/stats/DrtVehicleOccupancyProfileCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/util/stats/DrtVehicleOccupancyProfileCalculator.java
@@ -17,6 +17,7 @@
  * *********************************************************************** */
 package org.matsim.contrib.drt.util.stats;
 
+import java.util.Arrays;
 import java.util.Map;
 
 import org.apache.commons.math3.stat.descriptive.rank.Max;
@@ -224,16 +225,12 @@ public class DrtVehicleOccupancyProfileCalculator
 	public void reset(int iteration) {
 		vehicleStates.clear();
 
-		for (int i = 0; i < idleVehicleProfileInSeconds.length; i++) {
-			idleVehicleProfileInSeconds[i] = 0;
-			idleVehicleProfileRelative[i] = 0;
-		}
+		Arrays.fill(idleVehicleProfileInSeconds, 0);
+		Arrays.fill(idleVehicleProfileRelative, 0);
 
 		for (int k = 0; k < vehicleOccupancyProfilesInSeconds.length; k++) {
-			for (int i = 0; i < vehicleOccupancyProfilesInSeconds[k].length; i++) {
-				vehicleOccupancyProfilesInSeconds[k][i] = 0;
-				vehicleOccupancyProfilesRelative[k][i] = 0;
-			}
+			Arrays.fill(vehicleOccupancyProfilesInSeconds[k], 0);
+			Arrays.fill(vehicleOccupancyProfilesRelative[k], 0);
 		}
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/util/stats/DrtVehicleOccupancyProfileCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/util/stats/DrtVehicleOccupancyProfileCalculator.java
@@ -19,8 +19,8 @@ package org.matsim.contrib.drt.util.stats;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 
-import org.apache.commons.math3.stat.descriptive.rank.Max;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.IdMap;
 import org.matsim.api.core.v01.events.ActivityEndEvent;
@@ -32,7 +32,6 @@ import org.matsim.api.core.v01.events.handler.ActivityStartEventHandler;
 import org.matsim.api.core.v01.events.handler.PersonEntersVehicleEventHandler;
 import org.matsim.api.core.v01.events.handler.PersonLeavesVehicleEventHandler;
 import org.matsim.api.core.v01.population.Person;
-import org.matsim.contrib.drt.vrpagent.DrtActionCreator;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicleSpecification;
 import org.matsim.contrib.dvrp.fleet.FleetSpecification;
@@ -43,6 +42,8 @@ import org.matsim.core.config.groups.QSimConfigGroup;
 import org.matsim.core.config.groups.QSimConfigGroup.EndtimeInterpretation;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * @author michalm (Michal Maciejewski)
@@ -52,27 +53,37 @@ public class DrtVehicleOccupancyProfileCalculator
 		ActivityEndEventHandler {
 
 	private static class VehicleState {
-		private final double beginTime;
-		private final boolean idle;
-		private final int occupancy;
+		private static VehicleState nonOperating(double beginTime, String nonOperatingStateType) {
+			return new VehicleState(beginTime, Objects.requireNonNull(nonOperatingStateType), 0);
+		}
 
-		private VehicleState(double beginTime, boolean idle, int occupancy) {
+		private static VehicleState operating(double beginTime, int occupancy) {
+			return new VehicleState(beginTime, null, occupancy);
+		}
+
+		private final double beginTime;
+		private final String nonOperatingStateType;//non-operating vehicle
+		private final int occupancy;//operating vehicle
+
+		private VehicleState(double beginTime, String nonOperatingStateType, int occupancy) {
 			this.beginTime = beginTime;
-			this.idle = idle;
+			this.nonOperatingStateType = nonOperatingStateType;
 			this.occupancy = occupancy;
 			//maybe we could relax it in some situations, but that would also require adapting the charts
-			Preconditions.checkArgument(!idle || occupancy == 0, "Idle vehicles must not be occupied ");
+			Preconditions.checkArgument(nonOperatingStateType == null || occupancy == 0,
+					"Vehicles not serving passengers must not be occupied ");
 		}
 	}
 
 	private final TimeDiscretizer timeDiscretizer;
 
-	private final long[] idleVehicleProfileInSeconds;
+	private final ImmutableMap<String, long[]> nonOperatingVehicleProfileInSeconds;
 	private final long[][] vehicleOccupancyProfilesInSeconds;
 
-	private final double[] idleVehicleProfileRelative;
-	private final double[][] vehicleOccupancyProfilesRelative;
+	private final ImmutableMap<String, double[]> nonOperatingVehicleProfileNormalized;
+	private final double[][] vehicleOccupancyProfilesNormalized;
 
+	private final ImmutableSet<String> nonOperatingActivities;
 	private final Map<Id<DvrpVehicle>, VehicleState> vehicleStates = new IdMap<>(DvrpVehicle.class);
 
 	private final double analysisEndTime;
@@ -80,59 +91,71 @@ public class DrtVehicleOccupancyProfileCalculator
 	private final FleetSpecification fleet;
 
 	public DrtVehicleOccupancyProfileCalculator(FleetSpecification fleet, EventsManager events, int timeInterval,
-			QSimConfigGroup qsimConfig) {
+			QSimConfigGroup qsimConfig, ImmutableSet<String> nonOperatingActivities) {
 		this.fleet = fleet;
+		this.nonOperatingActivities = nonOperatingActivities;
 
 		events.addHandler(this);
-
-		Max maxCapacity = new Max();
-		Max maxServiceTime = new Max();
-		for (DvrpVehicleSpecification v : fleet.getVehicleSpecifications().values()) {
-			maxCapacity.increment(v.getCapacity());
-			maxServiceTime.increment(v.getServiceEndTime());
-		}
 
 		if (qsimConfig.getSimEndtimeInterpretation() == EndtimeInterpretation.onlyUseEndtime && qsimConfig.getEndTime()
 				.isDefined()) {
 			analysisEndTime = qsimConfig.getEndTime().seconds();
 		} else {
-			analysisEndTime = maxServiceTime.getResult();
+			analysisEndTime = fleet.getVehicleSpecifications()
+					.values()
+					.stream()
+					.mapToDouble(DvrpVehicleSpecification::getServiceEndTime)
+					.max()
+					.orElse(0);
 		}
 
 		int intervalCount = (int)Math.ceil((analysisEndTime + 1) / timeInterval);
 		timeDiscretizer = new TimeDiscretizer(intervalCount * timeInterval, timeInterval, TimeDiscretizer.Type.ACYCLIC);
 
-		int occupancyProfilesCount = (int)maxCapacity.getResult() + 1;
+		int maxCapacity = fleet.getVehicleSpecifications()
+				.values()
+				.stream()
+				.mapToInt(DvrpVehicleSpecification::getCapacity)
+				.max()
+				.orElse(0);
+		int occupancyProfilesCount = maxCapacity + 1;
 		vehicleOccupancyProfilesInSeconds = new long[occupancyProfilesCount][timeDiscretizer.getIntervalCount()];
-		idleVehicleProfileInSeconds = new long[timeDiscretizer.getIntervalCount()];
+		nonOperatingVehicleProfileInSeconds = nonOperatingActivities.stream()
+				.collect(ImmutableMap.toImmutableMap(v -> v, v -> new long[timeDiscretizer.getIntervalCount()]));
 
-		vehicleOccupancyProfilesRelative = new double[occupancyProfilesCount][timeDiscretizer.getIntervalCount()];
-		idleVehicleProfileRelative = new double[timeDiscretizer.getIntervalCount()];
+		//TODO create and directly return the normalized profiles in consolidate()
+		vehicleOccupancyProfilesNormalized = new double[occupancyProfilesCount][timeDiscretizer.getIntervalCount()];
+		nonOperatingVehicleProfileNormalized = nonOperatingActivities.stream()
+				.collect(ImmutableMap.toImmutableMap(v -> v, v -> new double[timeDiscretizer.getIntervalCount()]));
 	}
 
 	public void consolidate() {
 		vehicleStates.values().forEach(state -> increment(state, analysisEndTime));
 		vehicleStates.clear();
 
-		for (int t = 0; t < timeDiscretizer.getIntervalCount(); t++) {
-			idleVehicleProfileRelative[t] = (double)idleVehicleProfileInSeconds[t] / timeDiscretizer.getTimeInterval();
-			for (int o = 0; o < vehicleOccupancyProfilesInSeconds.length; o++) {
-				vehicleOccupancyProfilesRelative[o][t] = (double)vehicleOccupancyProfilesInSeconds[o][t]
-						/ timeDiscretizer.getTimeInterval();
-			}
+		for (String activity : nonOperatingActivities) {
+			computeNormalizedProfiles(nonOperatingVehicleProfileInSeconds.get(activity),
+					nonOperatingVehicleProfileNormalized.get(activity));
+		}
+
+		for (int occupancy = 0; occupancy < vehicleOccupancyProfilesInSeconds.length; occupancy++) {
+			computeNormalizedProfiles(vehicleOccupancyProfilesInSeconds[occupancy],
+					vehicleOccupancyProfilesNormalized[occupancy]);
 		}
 	}
 
-	public int getMaxCapacity() {
-		return vehicleOccupancyProfilesInSeconds.length - 1;
+	private void computeNormalizedProfiles(long[] profileInSeconds, double[] normalizedProfile) {
+		for (int t = 0; t < timeDiscretizer.getIntervalCount(); t++) {
+			normalizedProfile[t] = (double)profileInSeconds[t] / timeDiscretizer.getTimeInterval();
+		}
 	}
 
-	public double[] getIdleVehicleProfile() {
-		return idleVehicleProfileRelative;
+	public Map<String, double[]> getIdleVehicleProfile() {
+		return nonOperatingVehicleProfileNormalized;
 	}
 
 	public double[][] getVehicleOccupancyProfiles() {
-		return vehicleOccupancyProfilesRelative;
+		return vehicleOccupancyProfilesNormalized;
 	}
 
 	public TimeDiscretizer getTimeDiscretizer() {
@@ -140,7 +163,9 @@ public class DrtVehicleOccupancyProfileCalculator
 	}
 
 	private void increment(VehicleState state, double endTime) {
-		long[] profile = state.idle ? idleVehicleProfileInSeconds : vehicleOccupancyProfilesInSeconds[state.occupancy];
+		long[] profile = state.nonOperatingStateType != null ?
+				nonOperatingVehicleProfileInSeconds.get(state.nonOperatingStateType) :
+				vehicleOccupancyProfilesInSeconds[state.occupancy];
 		increment(profile, Math.min(state.beginTime, endTime), endTime);
 	}
 
@@ -164,10 +189,10 @@ public class DrtVehicleOccupancyProfileCalculator
 
 	@Override
 	public void handleEvent(ActivityStartEvent event) {
-		if (event.getActType().equals(DrtActionCreator.DRT_STAY_NAME)) {
+		if (nonOperatingActivities.contains(event.getActType())) {
 			vehicleStates.computeIfPresent(vehicleId(event.getPersonId()), (id, oldState) -> {
 				increment(oldState, event.getTime());
-				return new VehicleState(event.getTime(), true, oldState.occupancy);
+				return VehicleState.nonOperating(event.getTime(), event.getActType());
 			});
 		} else if (event.getActType().equals(VrpAgentLogic.AFTER_SCHEDULE_ACTIVITY_TYPE)) {
 			vehicleStates.computeIfPresent(vehicleId(event.getPersonId()), (id, oldState) -> {
@@ -181,12 +206,12 @@ public class DrtVehicleOccupancyProfileCalculator
 	public void handleEvent(ActivityEndEvent event) {
 		if (event.getActType().equals(VrpAgentLogic.BEFORE_SCHEDULE_ACTIVITY_TYPE)) {
 			if (fleet.getVehicleSpecifications().containsKey(vehicleId(event.getPersonId()))) {
-				vehicleStates.put(vehicleId(event.getPersonId()), new VehicleState(event.getTime(), false, 0));
+				vehicleStates.put(vehicleId(event.getPersonId()), VehicleState.operating(event.getTime(), 0));
 			}
-		} else if (event.getActType().equals(DrtActionCreator.DRT_STAY_NAME)) {
+		} else if (nonOperatingActivities.contains(event.getActType())) {
 			vehicleStates.computeIfPresent(vehicleId(event.getPersonId()), (id, oldState) -> {
 				increment(oldState, event.getTime());
-				return new VehicleState(event.getTime(), false, oldState.occupancy);
+				return VehicleState.operating(event.getTime(), 0);
 			});
 		}
 	}
@@ -198,7 +223,7 @@ public class DrtVehicleOccupancyProfileCalculator
 				return oldState;//ignore the driver, no state change
 			}
 			increment(oldState, event.getTime());
-			return new VehicleState(event.getTime(), oldState.idle, oldState.occupancy + 1);
+			return VehicleState.operating(event.getTime(), oldState.occupancy + 1);
 		});
 	}
 
@@ -209,7 +234,7 @@ public class DrtVehicleOccupancyProfileCalculator
 				return oldState;//ignore the driver, no state change
 			}
 			increment(oldState, event.getTime());
-			return new VehicleState(event.getTime(), oldState.idle, oldState.occupancy - 1);
+			return VehicleState.operating(event.getTime(), oldState.occupancy - 1);
 		});
 	}
 
@@ -225,12 +250,12 @@ public class DrtVehicleOccupancyProfileCalculator
 	public void reset(int iteration) {
 		vehicleStates.clear();
 
-		Arrays.fill(idleVehicleProfileInSeconds, 0);
-		Arrays.fill(idleVehicleProfileRelative, 0);
+		nonOperatingVehicleProfileInSeconds.values().forEach(profile -> Arrays.fill(profile, 0));
+		nonOperatingVehicleProfileNormalized.values().forEach(profile -> Arrays.fill(profile, 0));
 
 		for (int k = 0; k < vehicleOccupancyProfilesInSeconds.length; k++) {
 			Arrays.fill(vehicleOccupancyProfilesInSeconds[k], 0);
-			Arrays.fill(vehicleOccupancyProfilesRelative[k], 0);
+			Arrays.fill(vehicleOccupancyProfilesNormalized[k], 0);
 		}
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/util/stats/DrtVehicleOccupancyProfileCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/util/stats/DrtVehicleOccupancyProfileCalculator.java
@@ -151,7 +151,7 @@ public class DrtVehicleOccupancyProfileCalculator
 		}
 	}
 
-	public Map<String, double[]> getIdleVehicleProfile() {
+	public Map<String, double[]> getNonOperatingVehicleProfiles() {
 		return nonOperatingVehicleProfileNormalized;
 	}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/util/stats/DrtVehicleOccupancyProfileWriter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/util/stats/DrtVehicleOccupancyProfileWriter.java
@@ -65,7 +65,7 @@ public class DrtVehicleOccupancyProfileWriter implements IterationEndsListener {
 		TimeDiscretizer timeDiscretizer = calculator.getTimeDiscretizer();
 		calculator.consolidate();
 
-		ImmutableMap<String, double[]> profiles = Stream.concat(calculator.getIdleVehicleProfile().entrySet().stream(),
+		ImmutableMap<String, double[]> profiles = Stream.concat(calculator.getNonOperatingVehicleProfiles().entrySet().stream(),
 				EntryStream.of(calculator.getVehicleOccupancyProfiles())
 						.map(e -> Pair.of(e.getKey() + " pax", e.getValue())))
 				.collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/util/stats/DrtVehicleOccupancyProfileWriter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/util/stats/DrtVehicleOccupancyProfileWriter.java
@@ -17,8 +17,13 @@
  * *********************************************************************** */
 package org.matsim.contrib.drt.util.stats;
 
-import java.util.stream.IntStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Stream;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.jfree.chart.JFreeChart;
 import org.jfree.data.xy.DefaultTableXYDataset;
 import org.jfree.data.xy.XYSeries;
@@ -32,6 +37,11 @@ import org.matsim.core.controler.events.IterationEndsEvent;
 import org.matsim.core.controler.listener.IterationEndsListener;
 import org.matsim.core.utils.io.IOUtils;
 import org.matsim.core.utils.misc.Time;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+
+import one.util.streamex.EntryStream;
 
 /**
  * @author michalm (Michal Maciejewski)
@@ -55,60 +65,42 @@ public class DrtVehicleOccupancyProfileWriter implements IterationEndsListener {
 		TimeDiscretizer timeDiscretizer = calculator.getTimeDiscretizer();
 		calculator.consolidate();
 
+		ImmutableMap<String, double[]> profiles = Stream.concat(calculator.getIdleVehicleProfile().entrySet().stream(),
+				EntryStream.of(calculator.getVehicleOccupancyProfiles())
+						.map(e -> Pair.of(e.getKey() + " pax", e.getValue())))
+				.collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
+
 		String file = filename(OUTPUT_FILE);
 		String timeFormat = timeDiscretizer.getTimeInterval() % 60 == 0 ? Time.TIMEFORMAT_HHMM : Time.TIMEFORMAT_HHMMSS;
 
 		try (CompactCSVWriter writer = new CompactCSVWriter(IOUtils.getBufferedWriter(file + ".txt"))) {
-			String[] paxHeader = IntStream.rangeClosed(0, calculator.getMaxCapacity()).mapToObj(i -> i + " pax")
-					.toArray(String[]::new);
-			writer.writeNext("time", "stay", paxHeader);
-
-			for (int i = 0; i < timeDiscretizer.getIntervalCount(); i++) {
-				int time = i * timeDiscretizer.getTimeInterval();
-				String idleVehicles = calculator.getIdleVehicleProfile()[i] + "";
-				writer.writeNext(Time.writeTime(time, timeFormat), idleVehicles,
-						getOccupancyValues(calculator.getVehicleOccupancyProfiles(), i));
-			}
+			String[] profileHeader = profiles.keySet().toArray(new String[0]);
+			writer.writeNext("time", profileHeader);
+			timeDiscretizer.forEach(
+					(bin, time) -> writer.writeNext(Time.writeTime(time, timeFormat), getCells(profiles, bin)));
 		}
 
 		if (this.matsimServices.getConfig().controler().isCreateGraphs()) {
-			DefaultTableXYDataset createXYDataset = createXYDataset(calculator);
-			generateImage(createXYDataset, TimeProfileCharts.ChartType.Line);
-			generateImage(createXYDataset, TimeProfileCharts.ChartType.StackedArea);
+			DefaultTableXYDataset xyDataset = createXYDataset(timeDiscretizer, profiles);
+			generateImage(xyDataset, TimeProfileCharts.ChartType.Line);
+			generateImage(xyDataset, TimeProfileCharts.ChartType.StackedArea);
 		}
 	}
 
-	private String[] getOccupancyValues(double[][] vehicleOccupancyProfiles, int idx) {
-		String[] values = new String[vehicleOccupancyProfiles.length];
-		for (int i = 0; i < values.length; i++) {
-			values[i] = vehicleOccupancyProfiles[i][idx] + "";
-		}
-		return values;
+	private String[] getCells(Map<String, double[]> profiles, int idx) {
+		return profiles.values().stream().map(values -> values[idx] + "").toArray(String[]::new);
 	}
 
-	private DefaultTableXYDataset createXYDataset(DrtVehicleOccupancyProfileCalculator calculator) {
-		TimeDiscretizer timeDiscretizer = calculator.getTimeDiscretizer();
-		double[] idleVehicleProfile = calculator.getIdleVehicleProfile();
-		double[][] vehicleOccupancyProfiles = calculator.getVehicleOccupancyProfiles();
-
-		XYSeries[] seriesArray = new XYSeries[1 + vehicleOccupancyProfiles.length];
-		seriesArray[0] = new XYSeries("stay", false, false);
-		for (int s = 0; s < vehicleOccupancyProfiles.length; s++) {
-			seriesArray[1 + s] = new XYSeries(s + " pax", false, false);
-		}
-
-		for (int i = 0; i < timeDiscretizer.getIntervalCount(); i++) {
-			double hour = ((double) (i * timeDiscretizer.getTimeInterval())) / 3600;
-			seriesArray[0].add(hour, idleVehicleProfile[i]);
-			for (int s = 0; s < vehicleOccupancyProfiles.length; s++) {
-				seriesArray[1 + s].add(hour, vehicleOccupancyProfiles[s][i]);
-			}
-		}
+	private DefaultTableXYDataset createXYDataset(TimeDiscretizer timeDiscretizer, Map<String, double[]> profiles) {
+		List<XYSeries> seriesList = new ArrayList<>(profiles.size());
+		profiles.forEach((name, profile) -> {
+			XYSeries series = new XYSeries(name, true, false);
+			timeDiscretizer.forEach((bin, time) -> series.add(((double)time) / 3600, profile[bin]));
+			seriesList.add(series);
+		});
 
 		DefaultTableXYDataset dataset = new DefaultTableXYDataset();
-		for (int s = seriesArray.length - 1; s >= 0; s--) {
-			dataset.addSeries(seriesArray[s]);
-		}
+		Lists.reverse(seriesList).forEach(dataset::addSeries);
 		return dataset;
 	}
 
@@ -119,7 +111,7 @@ public class DrtVehicleOccupancyProfileWriter implements IterationEndsListener {
 	}
 
 	private String filename(String prefix) {
-		return matsimServices.getControlerIO().getIterationFilename(matsimServices.getIterationNumber(),
-				prefix + "_" + drtCfg.getMode());
+		return matsimServices.getControlerIO()
+				.getIterationFilename(matsimServices.getIterationNumber(), prefix + "_" + drtCfg.getMode());
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/MultiModeEDrtModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/MultiModeEDrtModule.java
@@ -25,9 +25,12 @@ import org.matsim.contrib.drt.routing.MultiModeDrtMainModeIdentifier;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.run.DrtModeModule;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
+import org.matsim.contrib.drt.vrpagent.DrtActionCreator;
+import org.matsim.contrib.ev.dvrp.ChargingActivity;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.router.MainModeIdentifier;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 
 /**
@@ -43,7 +46,8 @@ public class MultiModeEDrtModule extends AbstractModule {
 		for (DrtConfigGroup drtCfg : multiModeDrtCfg.getModalElements()) {
 			install(new DrtModeModule(drtCfg));
 			installQSimModule(new EDrtModeQSimModule(drtCfg));
-			install(new DrtModeAnalysisModule(drtCfg));
+			install(new DrtModeAnalysisModule(drtCfg,
+					ImmutableSet.of(DrtActionCreator.DRT_STAY_NAME, ChargingActivity.ACTIVITY_TYPE)));
 		}
 
 		bind(MainModeIdentifier.class).toInstance(new MultiModeDrtMainModeIdentifier(multiModeDrtCfg));

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/util/TimeDiscretizer.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/util/TimeDiscretizer.java
@@ -95,4 +95,14 @@ public class TimeDiscretizer {
 	public int getIntervalCount() {
 		return intervalCount;
 	}
+
+	public interface TimeBinConsumer {
+		void accept(int bin, int time);
+	}
+
+	public void forEach(TimeBinConsumer consumer) {
+		for (int i = 0; i < intervalCount; i++) {
+			consumer.accept(i, i * timeInterval);
+		}
+	}
 }

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/ChargingActivity.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/dvrp/ChargingActivity.java
@@ -24,14 +24,14 @@ import org.matsim.contrib.ev.charging.ChargingWithQueueingAndAssignmentLogic;
 import org.matsim.contrib.ev.fleet.ElectricVehicle;
 
 public class ChargingActivity implements DynActivity {
-	private static final String CHARGING_ACTIVITY_TYPE = "ChargingActivity";
+	public static final String ACTIVITY_TYPE = "Charging";
 
 	private final ChargingTask chargingTask;
 	private double endTime = END_ACTIVITY_LATER;
 
 	private enum State {
 		init, queued, plugged, unplugged
-	};
+	}
 
 	private State state = State.init;
 
@@ -41,7 +41,7 @@ public class ChargingActivity implements DynActivity {
 
 	@Override
 	public String getActivityType() {
-		return CHARGING_ACTIVITY_TYPE;
+		return ACTIVITY_TYPE;
 	}
 
 	@Override


### PR DESCRIPTION
Now we can plot different activities not related to serving passengers (non-operating activities), such as charging:

![0 drt_occupancy_time_profiles_StackedArea_drt](https://user-images.githubusercontent.com/9891415/84892162-5e7fa880-b09d-11ea-9138-5d53a5926a13.png)

