### PR TITLE
Standardise multi mode dvrp use

### DIFF
--- a/contribs/av/src/main/java/org/matsim/contrib/av/intermodal/RunTaxiPTIntermodalExample.java
+++ b/contribs/av/src/main/java/org/matsim/contrib/av/intermodal/RunTaxiPTIntermodalExample.java
@@ -32,7 +32,6 @@ import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
 import org.matsim.contrib.otfvis.OTFVisLiveModule;
 import org.matsim.contrib.taxi.run.MultiModeTaxiConfigGroup;
 import org.matsim.contrib.taxi.run.MultiModeTaxiModule;
-import org.matsim.contrib.taxi.run.TaxiConfigGroup;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.Controler;
@@ -54,32 +53,30 @@ public class RunTaxiPTIntermodalExample {
 
 		config.controler().setOverwriteFileSetting(OverwriteFileSetting.deleteDirectoryIfExists);
 		config.plansCalcRoute().setInsertingAccessEgressWalk(true);
-		
+
 		SwissRailRaptorConfigGroup srrConfig = new SwissRailRaptorConfigGroup();
 		srrConfig.setUseIntermodalAccessEgress(true);
 		srrConfig.setIntermodalAccessEgressModeSelection(IntermodalAccessEgressModeSelection.RandomSelectOneModePerRoutingRequestAndDirection);
-		
+
 		IntermodalAccessEgressParameterSet paramSetTaxi = new IntermodalAccessEgressParameterSet();
 		paramSetTaxi.setMode(TransportMode.taxi);
 		paramSetTaxi.setInitialSearchRadius(15000);
 		paramSetTaxi.setMaxRadius(20000);
 		paramSetTaxi.setSearchExtensionRadius(0.1);
 		srrConfig.addIntermodalAccessEgress(paramSetTaxi);
-		
+
 		IntermodalAccessEgressParameterSet paramSetWalk = new IntermodalAccessEgressParameterSet();
 		paramSetWalk.setMode(TransportMode.walk);
 		paramSetWalk.setInitialSearchRadius(1000);
 		paramSetWalk.setMaxRadius(1000);
 		paramSetWalk.setSearchExtensionRadius(0.1);
 		srrConfig.addIntermodalAccessEgress(paramSetWalk);
-		
+
 		config.addModule(srrConfig);
 
 		OTFVisConfigGroup otfvis = new OTFVisConfigGroup();
 		otfvis.setDrawNonMovingItems(true);
 		config.addModule(otfvis);
-
-		String mode = TaxiConfigGroup.getSingleModeTaxiConfig(config).getMode();
 
 		// ---
 		Scenario scenario = ScenarioUtils.loadScenario(config);
@@ -87,7 +84,7 @@ public class RunTaxiPTIntermodalExample {
 		Controler controler = new Controler(scenario);
 
 		controler.addOverridingModule(new DvrpModule());
-		controler.configureQSimComponents(DvrpQSimComponents.activateModes(mode));
+		controler.configureQSimComponents(DvrpQSimComponents.activateAllModes(MultiModeTaxiConfigGroup.get(config)));
 
 		controler.addOverridingModule(new MultiModeTaxiModule());
 

--- a/contribs/av/src/main/java/org/matsim/contrib/av/robotaxi/run/RunDrtAndTaxiExample.java
+++ b/contribs/av/src/main/java/org/matsim/contrib/av/robotaxi/run/RunDrtAndTaxiExample.java
@@ -23,7 +23,6 @@ package org.matsim.contrib.av.robotaxi.run;
 import java.net.URL;
 
 import org.matsim.api.core.v01.Scenario;
-import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.run.DrtControlerCreator;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
 import org.matsim.contrib.drt.run.MultiModeDrtModule;
@@ -33,7 +32,6 @@ import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
 import org.matsim.contrib.otfvis.OTFVisLiveModule;
 import org.matsim.contrib.taxi.run.MultiModeTaxiConfigGroup;
 import org.matsim.contrib.taxi.run.MultiModeTaxiModule;
-import org.matsim.contrib.taxi.run.TaxiConfigGroup;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.Controler;
@@ -56,10 +54,9 @@ public class RunDrtAndTaxiExample {
 		controler.addOverridingModule(new MultiModeDrtModule());
 		controler.addOverridingModule(new MultiModeTaxiModule());
 
-		String taxiMode = TaxiConfigGroup.getSingleModeTaxiConfig(controler.getConfig()).getMode();
-		String drtMode = DrtConfigGroup.getSingleModeDrtConfig(controler.getConfig()).getMode();
 		controler.addOverridingModule(new DvrpModule());
-		controler.configureQSimComponents(DvrpQSimComponents.activateModes(taxiMode, drtMode));
+		controler.configureQSimComponents(DvrpQSimComponents.activateAllModes(MultiModeTaxiConfigGroup.get(config),
+				MultiModeDrtConfigGroup.get(config)));
 
 		if (otfvis) {
 			controler.addOverridingModule(new OTFVisLiveModule());

--- a/contribs/av/src/main/java/org/matsim/contrib/av/robotaxi/run/RunRobotaxiExample.java
+++ b/contribs/av/src/main/java/org/matsim/contrib/av/robotaxi/run/RunRobotaxiExample.java
@@ -21,20 +21,14 @@ package org.matsim.contrib.av.robotaxi.run;
 
 import java.net.URL;
 
-import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.av.robotaxi.fares.taxi.TaxiFareModule;
 import org.matsim.contrib.av.robotaxi.fares.taxi.TaxiFaresConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
-import org.matsim.contrib.dvrp.run.DvrpModule;
-import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
-import org.matsim.contrib.otfvis.OTFVisLiveModule;
 import org.matsim.contrib.taxi.run.MultiModeTaxiConfigGroup;
-import org.matsim.contrib.taxi.run.MultiModeTaxiModule;
-import org.matsim.contrib.taxi.run.TaxiConfigGroup;
+import org.matsim.contrib.taxi.run.TaxiControlerCreator;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.Controler;
-import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.vis.otfvis.OTFVisConfigGroup;
 
 public class RunRobotaxiExample {
@@ -46,20 +40,8 @@ public class RunRobotaxiExample {
 	}
 
 	public static Controler createControler(Config config, boolean otfvis) {
-		String mode = TaxiConfigGroup.getSingleModeTaxiConfig(config).getMode();
-
-		Scenario scenario = ScenarioUtils.loadScenario(config);
-
-		Controler controler = new Controler(scenario);
+		Controler controler = TaxiControlerCreator.createControler(config, otfvis);
 		controler.addOverridingModule(new TaxiFareModule());
-		controler.addOverridingModule(new DvrpModule());
-		controler.addOverridingModule(new MultiModeTaxiModule());
-		controler.configureQSimComponents(DvrpQSimComponents.activateModes(mode));
-
-		if (otfvis) {
-			controler.addOverridingModule(new OTFVisLiveModule());
-		}
-
 		return controler;
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtControlerCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtControlerCreator.java
@@ -59,9 +59,9 @@ public final class DrtControlerCreator {
 	 * @param otfvis
 	 * @return
 	 */
-	public static Controler createControlerWithSingleModeDrt(Config config, boolean otfvis) {
-		DrtConfigGroup drtCfg = DrtConfigGroup.getSingleModeDrtConfig(config);
-		DrtConfigs.adjustDrtConfig(drtCfg, config.planCalcScore(), config.plansCalcRoute());
+	public static Controler createControler(Config config, boolean otfvis) {
+		MultiModeDrtConfigGroup multiModeDrtConfig = MultiModeDrtConfigGroup.get(config);
+		DrtConfigs.adjustMultiModeDrtConfig(multiModeDrtConfig, config.planCalcScore(), config.plansCalcRoute());
 
 		Scenario scenario = createScenarioWithDrtRouteFactory(config);
 		ScenarioUtils.loadScenario(scenario);
@@ -69,7 +69,7 @@ public final class DrtControlerCreator {
 		Controler controler = new Controler(scenario);
 		controler.addOverridingModule(new DvrpModule());
 		controler.addOverridingModule(new MultiModeDrtModule());
-		controler.configureQSimComponents(DvrpQSimComponents.activateModes(drtCfg.getMode()));
+		controler.configureQSimComponents(DvrpQSimComponents.activateAllModes(multiModeDrtConfig));
 
 		if (otfvis) {
 			controler.addOverridingModule(new OTFVisLiveModule());

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/RunDrtScenario.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/RunDrtScenario.java
@@ -33,7 +33,7 @@ public class RunDrtScenario {
 	public static void run(String configFile, boolean otfvis) {
 		Config config = ConfigUtils.loadConfig(configFile, new MultiModeDrtConfigGroup(), new DvrpConfigGroup(),
 				new OTFVisConfigGroup());
-		DrtControlerCreator.createControlerWithSingleModeDrt(config, otfvis).run();
+		DrtControlerCreator.createControler(config, otfvis).run();
 	}
 
 	public static void main(String[] args) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/examples/RunDrtExample.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/examples/RunDrtExample.java
@@ -30,6 +30,6 @@ import org.matsim.core.config.Config;
  */
 public class RunDrtExample {
 	public static void run(Config config, boolean otfvis) {
-		DrtControlerCreator.createControlerWithSingleModeDrt(config, otfvis).run();
+		DrtControlerCreator.createControler(config, otfvis).run();
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/examples/RunMultiModeDrtExample.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/examples/RunMultiModeDrtExample.java
@@ -22,19 +22,11 @@ package org.matsim.contrib.drt.run.examples;
 
 import java.net.URL;
 
-import org.matsim.api.core.v01.Scenario;
-import org.matsim.contrib.drt.run.DrtConfigs;
 import org.matsim.contrib.drt.run.DrtControlerCreator;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
-import org.matsim.contrib.drt.run.MultiModeDrtModule;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
-import org.matsim.contrib.dvrp.run.DvrpModule;
-import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
-import org.matsim.contrib.otfvis.OTFVisLiveModule;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
-import org.matsim.core.controler.Controler;
-import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.vis.otfvis.OTFVisConfigGroup;
 
 /**
@@ -44,22 +36,6 @@ public class RunMultiModeDrtExample {
 	public static void run(URL configUrl, boolean otfvis, int lastIteration) {
 		Config config = ConfigUtils.loadConfig(configUrl, new MultiModeDrtConfigGroup(), new DvrpConfigGroup(),
 				new OTFVisConfigGroup());
-
-		DrtConfigs.adjustMultiModeDrtConfig(MultiModeDrtConfigGroup.get(config), config.planCalcScore(), config.plansCalcRoute());
-
-		Scenario scenario = DrtControlerCreator.createScenarioWithDrtRouteFactory(config);
-		ScenarioUtils.loadScenario(scenario);
-
-		Controler controler = new Controler(scenario);
-
-		controler.addOverridingModule(new MultiModeDrtModule());
-		controler.addOverridingModule(new DvrpModule());
-		controler.configureQSimComponents(DvrpQSimComponents.activateAllModes(MultiModeDrtConfigGroup.get(config)));
-
-		if (otfvis) {
-			controler.addOverridingModule(new OTFVisLiveModule());
-		}
-
-		controler.run();
+		DrtControlerCreator.createControler(config, otfvis).run();
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/examples/RunOneSharedTaxiExample.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/examples/RunOneSharedTaxiExample.java
@@ -37,6 +37,6 @@ public class RunOneSharedTaxiExample {
 				new OTFVisConfigGroup());
 		config.controler().setLastIteration(lastIteration);
 		config.controler().setWriteEventsInterval(lastIteration);
-		DrtControlerCreator.createControlerWithSingleModeDrt(config, otfvis).run();
+		DrtControlerCreator.createControler(config, otfvis).run();
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
@@ -20,14 +20,20 @@
 
 package org.matsim.contrib.drt.analysis.zonal;
 
-import org.apache.commons.lang3.mutable.MutableInt;
+import java.net.URL;
+import java.util.function.ToIntFunction;
+
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.api.core.v01.population.*;
+import org.matsim.api.core.v01.population.Activity;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Plan;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.api.core.v01.population.PopulationFactory;
 import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingParams;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.run.DrtControlerCreator;
@@ -42,10 +48,6 @@ import org.matsim.core.utils.io.IOUtils;
 import org.matsim.examples.ExamplesUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vis.otfvis.OTFVisConfigGroup;
-
-import java.net.URL;
-import java.util.*;
-import java.util.function.ToIntFunction;
 
 public class ZonalDemandAggregatorWithoutServiceAreaTest {
 
@@ -130,7 +132,7 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 		config.controler().setOutputDirectory(utils.getOutputDirectory());
 
 		//this is the wrong way around (create controler before manipulating scenario...
-		Controler controler = DrtControlerCreator.createControlerWithSingleModeDrt(config, false);
+		Controler controler = DrtControlerCreator.createControler(config, false);
 		setupPopulation(controler.getScenario().getPopulation());
 		return controler;
 	}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpQSimComponents.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpQSimComponents.java
@@ -20,6 +20,8 @@
 
 package org.matsim.contrib.dvrp.run;
 
+import java.util.Arrays;
+
 import org.matsim.contrib.dynagent.run.DynActivityEngine;
 import org.matsim.core.mobsim.qsim.PreplanningEngineQSimModule;
 import org.matsim.core.mobsim.qsim.components.QSimComponentsConfigurator;
@@ -39,7 +41,7 @@ public class DvrpQSimComponents {
 		};
 	}
 
-	public static QSimComponentsConfigurator activateAllModes(MultiModal<?> multiModal) {
-		return activateModes(multiModal.modes().toArray(String[]::new));
+	public static QSimComponentsConfigurator activateAllModes(MultiModal<?>... multiModal) {
+		return activateModes(Arrays.stream(multiModal).flatMap(MultiModal::modes).toArray(String[]::new));
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/RunTaxiScenario.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/RunTaxiScenario.java
@@ -30,6 +30,6 @@ public class RunTaxiScenario {
 	public static void run(URL configUrl, boolean otfvis) {
 		Config config = ConfigUtils.loadConfig(configUrl, new MultiModeTaxiConfigGroup(), new DvrpConfigGroup(),
 				new OTFVisConfigGroup());
-		TaxiControlerCreator.createControlerWithSingleModeTaxi(config, otfvis).run();
+		TaxiControlerCreator.createControler(config, otfvis).run();
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiControlerCreator.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiControlerCreator.java
@@ -39,14 +39,13 @@ public class TaxiControlerCreator {
 	 * @param otfvis
 	 * @return
 	 */
-	public static Controler createControlerWithSingleModeTaxi(Config config, boolean otfvis) {
+	public static Controler createControler(Config config, boolean otfvis) {
 		Scenario scenario = ScenarioUtils.loadScenario(config);
 		Controler controler = new Controler(scenario);
 
 		controler.addOverridingModule(new DvrpModule());
 		controler.addOverridingModule(new MultiModeTaxiModule());
-		controler.configureQSimComponents(
-				DvrpQSimComponents.activateModes(TaxiConfigGroup.getSingleModeTaxiConfig(controler.getConfig()).getMode()));
+		controler.configureQSimComponents(DvrpQSimComponents.activateAllModes(MultiModeTaxiConfigGroup.get(config)));
 
 		if (otfvis) {
 			controler.addOverridingModule(new OTFVisLiveModule());

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/examples/RunMultiModeTaxiExample.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/examples/RunMultiModeTaxiExample.java
@@ -22,17 +22,11 @@ package org.matsim.contrib.taxi.run.examples;
 
 import java.net.URL;
 
-import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
-import org.matsim.contrib.dvrp.run.DvrpModule;
-import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
-import org.matsim.contrib.otfvis.OTFVisLiveModule;
 import org.matsim.contrib.taxi.run.MultiModeTaxiConfigGroup;
-import org.matsim.contrib.taxi.run.MultiModeTaxiModule;
+import org.matsim.contrib.taxi.run.TaxiControlerCreator;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
-import org.matsim.core.controler.Controler;
-import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.vis.otfvis.OTFVisConfigGroup;
 
 public class RunMultiModeTaxiExample {
@@ -42,21 +36,6 @@ public class RunMultiModeTaxiExample {
 				new OTFVisConfigGroup());
 		config.controler().setLastIteration(lastIteration);
 
-		// load scenario
-		Scenario scenario = ScenarioUtils.loadScenario(config);
-
-		// setup controler
-		Controler controler = new Controler(scenario);
-
-		controler.addOverridingModule(new MultiModeTaxiModule());
-		controler.addOverridingModule(new DvrpModule());
-		controler.configureQSimComponents(DvrpQSimComponents.activateAllModes(MultiModeTaxiConfigGroup.get(config)));
-
-		if (otfvis) {
-			controler.addOverridingModule(new OTFVisLiveModule()); // OTFVis visualisation
-		}
-
-		// run simulation
-		controler.run();
+		TaxiControlerCreator.createControler(config, otfvis).run();
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/examples/RunTaxiExample.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/examples/RunTaxiExample.java
@@ -21,18 +21,11 @@ package org.matsim.contrib.taxi.run.examples;
 
 import java.net.URL;
 
-import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
-import org.matsim.contrib.dvrp.run.DvrpModule;
-import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
-import org.matsim.contrib.otfvis.OTFVisLiveModule;
 import org.matsim.contrib.taxi.run.MultiModeTaxiConfigGroup;
-import org.matsim.contrib.taxi.run.MultiModeTaxiModule;
-import org.matsim.contrib.taxi.run.TaxiConfigGroup;
+import org.matsim.contrib.taxi.run.TaxiControlerCreator;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
-import org.matsim.core.controler.Controler;
-import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.vis.otfvis.OTFVisConfigGroup;
 
 public class RunTaxiExample {
@@ -41,22 +34,6 @@ public class RunTaxiExample {
 		Config config = ConfigUtils.loadConfig(configUrl, new MultiModeTaxiConfigGroup(), new DvrpConfigGroup(),
 				new OTFVisConfigGroup());
 		config.controler().setLastIteration(lastIteration);
-		String mode = TaxiConfigGroup.getSingleModeTaxiConfig(config).getMode();
-
-		// load scenario
-		Scenario scenario = ScenarioUtils.loadScenario(config);
-
-		// setup controler
-		Controler controler = new Controler(scenario);
-		controler.addOverridingModule(new DvrpModule());
-		controler.addOverridingModule(new MultiModeTaxiModule());
-		controler.configureQSimComponents(DvrpQSimComponents.activateModes(mode));
-
-		if (otfvis) {
-			controler.addOverridingModule(new OTFVisLiveModule()); // OTFVis visualisation
-		}
-
-		// run simulation
-		controler.run();
+		TaxiControlerCreator.createControler(config, otfvis).run();
 	}
 }

--- a/contribs/taxi/src/test/java/org/matsim/contrib/taxi/run/RunTaxiScenarioTestIT.java
+++ b/contribs/taxi/src/test/java/org/matsim/contrib/taxi/run/RunTaxiScenarioTestIT.java
@@ -53,6 +53,6 @@ public class RunTaxiScenarioTestIT {
 		TaxiConfigGroup.getSingleModeTaxiConfig(config).setTaxisFile(taxisFile);
 		config.controler().setOutputDirectory(utils.getOutputDirectory());
 		config.controler().setDumpDataAtEnd(false);
-		TaxiControlerCreator.createControlerWithSingleModeTaxi(config, false).run();
+		TaxiControlerCreator.createControler(config, false).run();
 	}
 }


### PR DESCRIPTION
- adapt `Drt/TaxiControlerCreator` to the multi-mode case
- reduce code duplication
- reduce the use of `TaxiConfigGroup.getSingleModeTaxiConfig()`
