### PR TITLE
Only multi-mode fares configs

### DIFF
--- a/contribs/av/src/main/java/org/matsim/contrib/av/robotaxi/fares/drt/DrtFareConfigGroup.java
+++ b/contribs/av/src/main/java/org/matsim/contrib/av/robotaxi/fares/drt/DrtFareConfigGroup.java
@@ -24,7 +24,6 @@ package org.matsim.contrib.av.robotaxi.fares.drt;
 
 import java.util.Map;
 
-import org.matsim.core.config.Config;
 import org.matsim.core.config.ReflectiveConfigGroup;
 
 /**
@@ -54,10 +53,6 @@ public final class DrtFareConfigGroup extends ReflectiveConfigGroup {
 
     }
 
-    public static DrtFareConfigGroup get(Config config) {
-        return (DrtFareConfigGroup) config.getModules().get(GROUP_NAME);
-    }
-
     @Override
     public Map<String, String> getComments() {
         Map<String, String> map = super.getComments();
@@ -80,7 +75,7 @@ public final class DrtFareConfigGroup extends ReflectiveConfigGroup {
     public void setBasefare(double basefare) {
         this.basefare = basefare;
     }
-    
+
     @StringGetter(MINFARE_PER_TRIP)
     public double getMinFarePerTrip() {
         return minFarePerTrip;

--- a/contribs/av/src/main/java/org/matsim/contrib/av/robotaxi/fares/drt/DrtFareModule.java
+++ b/contribs/av/src/main/java/org/matsim/contrib/av/robotaxi/fares/drt/DrtFareModule.java
@@ -21,19 +21,18 @@ package org.matsim.contrib.av.robotaxi.fares.drt;/*
  * created by jbischoff, 11.12.2018
  */
 
+import javax.inject.Inject;
+
 import org.matsim.core.controler.AbstractModule;
 
 public class DrtFareModule extends AbstractModule {
-    @Override
-    public void install() {
-        if ((getConfig().getModules().containsKey(DrtFareConfigGroup.GROUP_NAME)) && (getConfig().getModules().containsKey(DrtFaresConfigGroup.GROUP_NAME))) {
-            throw new RuntimeException("Both drtfare and drtfares - config groups are specified. Please use only one of them in your config file and restart");
-        }
-        if (getConfig().getModules().containsKey(DrtFareConfigGroup.GROUP_NAME)) {
-            addEventHandlerBinding().toInstance(new DrtFareHandler(DrtFareConfigGroup.get(getConfig())));
-        } else {
-            DrtFaresConfigGroup drtFaresConfigGroup = DrtFaresConfigGroup.get(getConfig());
-            drtFaresConfigGroup.getDrtFareConfigGroups().forEach(drtFareConfigGroup -> addEventHandlerBinding().toInstance(new DrtFareHandler(drtFareConfigGroup)));
-        }
-    }
+	@Inject
+	private DrtFaresConfigGroup drtFaresConfigGroup;
+
+	@Override
+	public void install() {
+		for (DrtFareConfigGroup drtFareCfg : drtFaresConfigGroup.getDrtFareConfigGroups()) {
+			addEventHandlerBinding().toInstance(new DrtFareHandler(drtFareCfg));
+		}
+	}
 }

--- a/contribs/av/src/main/java/org/matsim/contrib/av/robotaxi/fares/taxi/TaxiFareConfigGroup.java
+++ b/contribs/av/src/main/java/org/matsim/contrib/av/robotaxi/fares/taxi/TaxiFareConfigGroup.java
@@ -18,19 +18,18 @@
  * *********************************************************************** */
 
 /**
- * 
+ *
  */
 package org.matsim.contrib.av.robotaxi.fares.taxi;
 
 import java.util.Map;
 
-import org.matsim.core.config.Config;
 import org.matsim.core.config.ReflectiveConfigGroup;
 
 /**
  * @author  jbischoff
  * Config Group to set taxi or drt fares.
- * 
+ *
  */
 public final class TaxiFareConfigGroup extends ReflectiveConfigGroup {
 
@@ -49,15 +48,12 @@ public final class TaxiFareConfigGroup extends ReflectiveConfigGroup {
 	private double timeFare_h;
 	private double distanceFare_m;
 	private String mode = "taxi";
-	
+
 	public TaxiFareConfigGroup() {
 		super(GROUP_NAME);
 
 	}
-	public static TaxiFareConfigGroup get(Config config) {
-        return (TaxiFareConfigGroup) config.getModules().get(GROUP_NAME);
-	}
-	
+
     @Override
     public Map<String, String> getComments()
     {
@@ -71,7 +67,7 @@ public final class TaxiFareConfigGroup extends ReflectiveConfigGroup {
 		return map;
     }
 
-	
+
 	@StringGetter(BASEFARE)
 	public double getBasefare() {
 		return basefare;
@@ -81,7 +77,7 @@ public final class TaxiFareConfigGroup extends ReflectiveConfigGroup {
 	public void setBasefare(double basefare) {
 		this.basefare = basefare;
 	}
-	
+
     @StringGetter(MINFARE_PER_TRIP)
     public double getMinFarePerTrip() {
         return minFarePerTrip;
@@ -123,12 +119,12 @@ public final class TaxiFareConfigGroup extends ReflectiveConfigGroup {
 	public void setDistanceFare_m(double distanceFare_m) {
 		this.distanceFare_m = distanceFare_m;
 	}
-	
+
 	@StringGetter(MODE)
 	public String getMode() {
 		return mode;
 	}
-	
+
 	@StringSetter(MODE)
 	public void setMode(String mode) {
 		this.mode = mode;

--- a/contribs/av/src/main/java/org/matsim/contrib/av/robotaxi/fares/taxi/TaxiFareModule.java
+++ b/contribs/av/src/main/java/org/matsim/contrib/av/robotaxi/fares/taxi/TaxiFareModule.java
@@ -21,19 +21,18 @@ package org.matsim.contrib.av.robotaxi.fares.taxi;/*
  * created by jbischoff, 11.12.2018
  */
 
+import javax.inject.Inject;
+
 import org.matsim.core.controler.AbstractModule;
 
 public class TaxiFareModule extends AbstractModule {
-    @Override
-    public void install() {
-        if ((getConfig().getModules().containsKey(TaxiFareConfigGroup.GROUP_NAME)) && (getConfig().getModules().containsKey(TaxiFaresConfigGroup.GROUP_NAME))) {
-            throw new RuntimeException("Both taxifare and taxifares - config groups are specified. Please use only one of them in your config file and restart");
-        }
-        if (getConfig().getModules().containsKey(TaxiFareConfigGroup.GROUP_NAME)) {
-            addEventHandlerBinding().toInstance(new TaxiFareHandler(TaxiFareConfigGroup.get(getConfig())));
-        } else {
-            TaxiFaresConfigGroup taxiFaresConfigGroup = TaxiFaresConfigGroup.get(getConfig());
-            taxiFaresConfigGroup.getTaxiFareConfigGroups().forEach(taxiFareConfigGroup -> addEventHandlerBinding().toInstance(new TaxiFareHandler(taxiFareConfigGroup)));
-        }
-    }
+	@Inject
+	private TaxiFaresConfigGroup taxiFaresConfigGroup;
+
+	@Override
+	public void install() {
+		for (TaxiFareConfigGroup taxiFareCfg : taxiFaresConfigGroup.getTaxiFareConfigGroups()) {
+			addEventHandlerBinding().toInstance(new TaxiFareHandler(taxiFareCfg));
+		}
+	}
 }


### PR DESCRIPTION
(both for taxi and drt)

This means single-mode fare configs need to be enclosed by the  multi-mode one (parent config group).