### PR TITLE
Always add a transfer between two pt legs.

### DIFF
--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorCore.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorCore.java
@@ -820,23 +820,18 @@ public class SwissRailRaptorCore {
             if (pe.initialStop != null && pe.initialStop.planElements != null) {
                 raptorRoute.addPlanElements(time, travelTime, pe.initialStop.planElements);
             } else if (pe.isTransfer) {
-                boolean differentFromTo = (fromStop == null || toStop == null) || (fromStop != toStop);
-                // do not create a transfer-leg if we stay at the same stop facility
-                if (differentFromTo) {
-                	// add (peCount > 2 || peCount == 2 && !pes.get(0).isTransfer) && to catch case of only access and egress 
-                	// legs without a real leg in between which was previously caught above by 
-                	// pes.size() == 2 && pes.get(0).isTransfer && pes.get(1).isTransfer
-                	//
-                	// in case of peCount < 2 there should be no effect, because peCount-2 < 0 and i will be 0, so i!=peCount - 2
-                	// TODO check
-                    if ((peCount > 2 || peCount == 2 && !pes.get(0).isTransfer) && i == peCount - 2 && !isIntermodal(pes.get(i+1).initialStop)) {
-                        // the second last element is a transfer, skip it so it gets merged into the egress_walk
-                        // but it can only be merged if it is not intermodal...
-                        continue;
-                    }
-                    String mode = TransportMode.walk;
-                    raptorRoute.addNonPt(fromStop, toStop, time, travelTime, pe.distance, mode);
+                // add (peCount > 2 || peCount == 2 && !pes.get(0).isTransfer) && to catch case of only access and egress
+                // legs without a real leg in between which was previously caught above by
+                // pes.size() == 2 && pes.get(0).isTransfer && pes.get(1).isTransfer
+                //
+                // in case of peCount < 2 there should be no effect, because peCount-2 < 0 and i will be 0, so i!=peCount - 2
+                if ((peCount > 2 || peCount == 2 && !pes.get(0).isTransfer) && i == peCount - 2 && !isIntermodal(pes.get(i+1).initialStop)) {
+                    // the second last element is a transfer, skip it so it gets merged into the egress_walk
+                    // but it can only be merged if it is not intermodal...
+                    continue;
                 }
+                String mode = TransportMode.walk;
+                raptorRoute.addNonPt(fromStop, toStop, time, travelTime, pe.distance, mode);
             } else {
                 TransitLine line = pe.toRouteStop.line;
                 TransitRoute route = pe.toRouteStop.route;

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorTest.java
@@ -315,19 +315,20 @@ public class SwissRailRaptorTest {
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
         Coord toCoord = new Coord(28100, 4950);
         List<Leg> legs = router.calcRoute(new FakeFacility( new Coord(3800, 5100)), new FakeFacility(toCoord), 5.0*3600 + 40.0*60, null);
-        assertEquals("wrong number of legs", 4, legs.size());
+        assertEquals("wrong number of legs", 5, legs.size());
         assertEquals(TransportMode.walk, legs.get(0).getMode());
         assertEquals(TransportMode.pt, legs.get(1).getMode());
-        assertEquals(TransportMode.pt, legs.get(2).getMode());
-        assertEquals(TransportMode.walk, legs.get(3).getMode());
+        assertEquals(TransportMode.walk, legs.get(2).getMode());
+        assertEquals(TransportMode.pt, legs.get(3).getMode());
+        assertEquals(TransportMode.walk, legs.get(4).getMode());
         assertTrue("expected TransitRoute in leg.", legs.get(1).getRoute() instanceof TransitPassengerRoute);
         TransitPassengerRoute ptRoute = (TransitPassengerRoute) legs.get(1).getRoute();
         assertEquals(Id.create("0", TransitStopFacility.class), ptRoute.getAccessStopId());
         assertEquals(Id.create("4", TransitStopFacility.class), ptRoute.getEgressStopId());
         assertEquals(f.blueLine.getId(), ptRoute.getLineId());
         assertEquals(Id.create("blue A > I", TransitRoute.class), ptRoute.getRouteId());
-        assertTrue("expected TransitRoute in leg.", legs.get(2).getRoute() instanceof TransitPassengerRoute);
-        ptRoute = (TransitPassengerRoute) legs.get(2).getRoute();
+        assertTrue("expected TransitRoute in leg.", legs.get(3).getRoute() instanceof TransitPassengerRoute);
+        ptRoute = (TransitPassengerRoute) legs.get(3).getRoute();
         assertEquals(Id.create("4", TransitStopFacility.class), ptRoute.getAccessStopId());
         assertEquals(Id.create("12", TransitStopFacility.class), ptRoute.getEgressStopId());
         assertEquals(f.redLine.getId(), ptRoute.getLineId());
@@ -613,24 +614,26 @@ public class SwissRailRaptorTest {
         Coord fromCoord = new Coord(5010, 1010);
         Coord toCoord = new Coord(5010, 5010);
         List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 8.0*3600-2*60, null);
-        assertEquals(5, legs.size());
+        assertEquals(7, legs.size());
         assertEquals(TransportMode.walk, legs.get(0).getMode());
         assertEquals(TransportMode.pt, legs.get(1).getMode());
-        assertEquals(TransportMode.pt, legs.get(2).getMode());
+        assertEquals(TransportMode.walk, legs.get(2).getMode());
         assertEquals(TransportMode.pt, legs.get(3).getMode());
         assertEquals(TransportMode.walk, legs.get(4).getMode());
+        assertEquals(TransportMode.pt, legs.get(5).getMode());
+        assertEquals(TransportMode.walk, legs.get(6).getMode());
         assertTrue("expected TransitRoute in leg.", legs.get(1).getRoute() instanceof TransitPassengerRoute);
         TransitPassengerRoute ptRoute = (TransitPassengerRoute) legs.get(1).getRoute();
         assertEquals(f.stop0.getId(), ptRoute.getAccessStopId());
         assertEquals(f.stop1.getId(), ptRoute.getEgressStopId());
         assertEquals(f.lineId0, ptRoute.getLineId());
-        assertTrue("expected TransitRoute in leg.", legs.get(2).getRoute() instanceof TransitPassengerRoute);
-        ptRoute = (TransitPassengerRoute) legs.get(2).getRoute();
+        assertTrue("expected TransitRoute in leg.", legs.get(3).getRoute() instanceof TransitPassengerRoute);
+        ptRoute = (TransitPassengerRoute) legs.get(3).getRoute();
         assertEquals(f.stop1.getId(), ptRoute.getAccessStopId());
         assertEquals(f.stop2.getId(), ptRoute.getEgressStopId());
         assertEquals(f.lineId1, ptRoute.getLineId());
-        assertTrue("expected TransitRoute in leg.", legs.get(3).getRoute() instanceof TransitPassengerRoute);
-        ptRoute = (TransitPassengerRoute) legs.get(3).getRoute();
+        assertTrue("expected TransitRoute in leg.", legs.get(5).getRoute() instanceof TransitPassengerRoute);
+        ptRoute = (TransitPassengerRoute) legs.get(5).getRoute();
         assertEquals(f.stop2.getId(), ptRoute.getAccessStopId());
         assertEquals(f.stop3.getId(), ptRoute.getEgressStopId());
         assertEquals(f.lineId3, ptRoute.getLineId());
@@ -652,16 +655,17 @@ public class SwissRailRaptorTest {
             System.out.println(leg);
         }
 
-        Assert.assertEquals(4, legs.size());
+        Assert.assertEquals(5, legs.size());
         Assert.assertEquals(TransportMode.walk, legs.get(0).getMode());
         Assert.assertEquals(TransportMode.pt, legs.get(1).getMode());
-        Assert.assertEquals(TransportMode.pt, legs.get(2).getMode());
-        Assert.assertEquals(TransportMode.walk, legs.get(3).getMode());
+        Assert.assertEquals(TransportMode.walk, legs.get(2).getMode());
+        Assert.assertEquals(TransportMode.pt, legs.get(3).getMode());
+        Assert.assertEquals(TransportMode.walk, legs.get(4).getMode());
 
         Assert.assertEquals(f.greenLine.getId(), ((TransitPassengerRoute) legs.get(1).getRoute()).getLineId());
         Assert.assertEquals(Id.create(23, TransitStopFacility.class), ((TransitPassengerRoute) legs.get(1).getRoute()).getAccessStopId());
-        Assert.assertEquals(f.greenLine.getId(), ((TransitPassengerRoute) legs.get(2).getRoute()).getLineId());
-        Assert.assertEquals(Id.create(20, TransitStopFacility.class), ((TransitPassengerRoute) legs.get(2).getRoute()).getEgressStopId());
+        Assert.assertEquals(f.greenLine.getId(), ((TransitPassengerRoute) legs.get(3).getRoute()).getLineId());
+        Assert.assertEquals(Id.create(20, TransitStopFacility.class), ((TransitPassengerRoute) legs.get(3).getRoute()).getEgressStopId());
     }
 
     @Test


### PR DESCRIPTION
Originally, the transfer leg (non_network_walk) was left out if the two
pt-legs ended and started at exactly the same TransitStopFacility, as in
this case the distance and thus the travel time were always 0. But now
with MinimalTransferTimes, the transfer time can actually be more than
zero seconds, so it makes sense to include these legs always. And also
for consistency and simplified analysis.