### PR TITLE
Drt-Speed-Up compatibility with drt rebalancing

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/PreviousIterationZonalDRTDemandAggregator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/PreviousIterationZonalDRTDemandAggregator.java
@@ -54,7 +54,7 @@ public class PreviousIterationZonalDRTDemandAggregator implements ZonalDemandAgg
 	public PreviousIterationZonalDRTDemandAggregator(EventsManager events, DrtZonalSystem zonalSystem, DrtConfigGroup drtCfg) {
 		this.zonalSystem = zonalSystem;
 		mode = drtCfg.getMode();
-		drtSpeedUpMode = drtCfg.getMinCostFlowRebalancing().get().getDrtSpeedUpMode();
+		drtSpeedUpMode = drtCfg.getDrtSpeedUpMode();
 		timeBinSize = drtCfg.getMinCostFlowRebalancing().get().getInterval();
 		events.addHandler(this);
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/PreviousIterationZonalDRTDemandAggregator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/PreviousIterationZonalDRTDemandAggregator.java
@@ -45,6 +45,7 @@ public class PreviousIterationZonalDRTDemandAggregator implements ZonalDemandAgg
 
 	private final DrtZonalSystem zonalSystem;
 	private final String mode;
+	private final String drtSpeedUpMode;
 	private final int timeBinSize;
 	private final Map<Double, Map<String, MutableInt>> departures = new HashMap<>();
 	private final Map<Double, Map<String, MutableInt>> previousIterationDepartures = new HashMap<>();
@@ -53,6 +54,7 @@ public class PreviousIterationZonalDRTDemandAggregator implements ZonalDemandAgg
 	public PreviousIterationZonalDRTDemandAggregator(EventsManager events, DrtZonalSystem zonalSystem, DrtConfigGroup drtCfg) {
 		this.zonalSystem = zonalSystem;
 		mode = drtCfg.getMode();
+		drtSpeedUpMode = drtCfg.getMinCostFlowRebalancing().get().getDrtSpeedUpMode();
 		timeBinSize = drtCfg.getMinCostFlowRebalancing().get().getInterval();
 		events.addHandler(this);
 	}
@@ -67,7 +69,7 @@ public class PreviousIterationZonalDRTDemandAggregator implements ZonalDemandAgg
 
 	@Override
 	public void handleEvent(PersonDepartureEvent event) {
-		if (event.getLegMode().equals(mode)) {
+		if (event.getLegMode().equals(mode) || event.getLegMode().equals(drtSpeedUpMode)) {
 			Double bin = getBinForTime(event.getTime());
 
 			String zoneId = zonalSystem.getZoneForLinkId(event.getLinkId());

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingParams.java
@@ -79,9 +79,6 @@ public final class MinCostFlowRebalancingParams extends ReflectiveConfigGroup {
 	private static final String REBALANCING_ZONES_SHAPE_FILE_EXP = "allows to configure rebalancing zones."
 			+ "Used with rebalancingZonesGeneration=ShapeFile";
 
-	public static final String DRT_SPEED_UP_MODE = "drtSpeedUpMode";
-	static final String DRT_SPEED_UP_MODE_EXP = "For PreviousIterationZonalDemandAggregator to work properly with the drt-speed-up module, also departures of the speed-up mode must be considered as drt mode departures. Set to the empty String \"\" if not using drt-speed-up (the default). Drt-speed-up module should set this automatically if used.";
-
 
 	@Positive
 	private int interval = 1800;// [s]
@@ -109,9 +106,6 @@ public final class MinCostFlowRebalancingParams extends ReflectiveConfigGroup {
 
 	@Nullable
 	private String rebalancingZonesShapeFile = null;
-
-	@NotNull
-	private String drtSpeedUpMode = "";
 
 	public MinCostFlowRebalancingParams() {
 		super(SET_NAME);
@@ -148,7 +142,6 @@ public final class MinCostFlowRebalancingParams extends ReflectiveConfigGroup {
 		map.put(ZONAL_DEMAND_AGGREGATOR_TYPE, ZONAL_DEMAND_AGGREGATOR_TYPE_EXP);
 		map.put(REBALANCING_ZONES_GENERATION, REBALANCING_ZONES_GENERATION_EXP);
 		map.put(REBALANCING_ZONES_SHAPE_FILE, REBALANCING_ZONES_SHAPE_FILE_EXP);
-		map.put(DRT_SPEED_UP_MODE, DRT_SPEED_UP_MODE_EXP);
 		return map;
 	}
 
@@ -295,16 +288,6 @@ public final class MinCostFlowRebalancingParams extends ReflectiveConfigGroup {
 	public MinCostFlowRebalancingParams setRebalancingZonesShapeFile(String rebalancingZonesShapeFile) {
 		this.rebalancingZonesShapeFile = rebalancingZonesShapeFile;
 		return this;
-	}
-
-	@StringGetter(DRT_SPEED_UP_MODE)
-	public String getDrtSpeedUpMode() {
-		return drtSpeedUpMode;
-	}
-
-	@StringSetter(DRT_SPEED_UP_MODE)
-	public void setDrtSpeedUpMode(String drtSpeedUpMode) {
-		this.drtSpeedUpMode = drtSpeedUpMode;
 	}
 
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingParams.java
@@ -79,6 +79,10 @@ public final class MinCostFlowRebalancingParams extends ReflectiveConfigGroup {
 	private static final String REBALANCING_ZONES_SHAPE_FILE_EXP = "allows to configure rebalancing zones."
 			+ "Used with rebalancingZonesGeneration=ShapeFile";
 
+	public static final String DRT_SPEED_UP_MODE = "drtSpeedUpMode";
+	static final String DRT_SPEED_UP_MODE_EXP = "For PreviousIterationZonalDemandAggregator to work properly with the drt-speed-up module, also departures of the speed-up mode must be considered as drt mode departures. Set to the empty String \"\" if not using drt-speed-up (the default). Drt-speed-up module should set this automatically if used.";
+
+
 	@Positive
 	private int interval = 1800;// [s]
 
@@ -105,6 +109,9 @@ public final class MinCostFlowRebalancingParams extends ReflectiveConfigGroup {
 
 	@Nullable
 	private String rebalancingZonesShapeFile = null;
+
+	@NotNull
+	private String drtSpeedUpMode = "";
 
 	public MinCostFlowRebalancingParams() {
 		super(SET_NAME);
@@ -138,6 +145,10 @@ public final class MinCostFlowRebalancingParams extends ReflectiveConfigGroup {
 		map.put(TARGET_ALPHA, TARGET_ALPHA_EXP);
 		map.put(TARGET_BETA, TARGET_BETA_EXP);
 		map.put(CELL_SIZE, CELL_SIZE_EXP);
+		map.put(ZONAL_DEMAND_AGGREGATOR_TYPE, ZONAL_DEMAND_AGGREGATOR_TYPE_EXP);
+		map.put(REBALANCING_ZONES_GENERATION, REBALANCING_ZONES_GENERATION_EXP);
+		map.put(REBALANCING_ZONES_SHAPE_FILE, REBALANCING_ZONES_SHAPE_FILE_EXP);
+		map.put(DRT_SPEED_UP_MODE, DRT_SPEED_UP_MODE_EXP);
 		return map;
 	}
 
@@ -284,6 +295,16 @@ public final class MinCostFlowRebalancingParams extends ReflectiveConfigGroup {
 	public MinCostFlowRebalancingParams setRebalancingZonesShapeFile(String rebalancingZonesShapeFile) {
 		this.rebalancingZonesShapeFile = rebalancingZonesShapeFile;
 		return this;
+	}
+
+	@StringGetter(DRT_SPEED_UP_MODE)
+	public String getDrtSpeedUpMode() {
+		return drtSpeedUpMode;
+	}
+
+	@StringSetter(DRT_SPEED_UP_MODE)
+	public void setDrtSpeedUpMode(String drtSpeedUpMode) {
+		this.drtSpeedUpMode = drtSpeedUpMode;
 	}
 
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -112,7 +112,7 @@ public final class DrtConfigGroup extends ReflectiveConfigGroup implements Modal
 
 	//TODO consider renaming maxWalkDistance to max access/egress distance (or even have 2 separate params)
 	public static final String MAX_WALK_DISTANCE = "maxWalkDistance";
-	static final String MAX_WALK_DISTANCE_EXP = "Maximum beeline distance (in meters) to next stop location in stopbased system for access/egress walk leg to/from drt. If no stop can be found within this maximum distance will return a direct walk of type drtMode_walk";
+	static final String MAX_WALK_DISTANCE_EXP = "Maximum beeline distance (in meters) to next stop location in stopbased system for access/egress walk leg to/from drt. If no stop can be found within this maximum distance will return null (in most cases caught by fallback routing module).";
 
 	public static final String ESTIMATED_DRT_SPEED = "estimatedDrtSpeed";
 	static final String ESTIMATED_DRT_SPEED_EXP =
@@ -142,6 +142,9 @@ public final class DrtConfigGroup extends ReflectiveConfigGroup implements Modal
 			"Number of threads used for parallel evaluation of request insertion into existing schedules."
 					+ " Scales well up to 4, due to path data provision, the most computationally intensive part,"
 					+ " using up to 4 threads. Default value is 'min(4, no. of cores available to JVM)'";
+
+	public static final String DRT_SPEED_UP_MODE = "drtSpeedUpMode";
+	static final String DRT_SPEED_UP_MODE_EXP = "For PreviousIterationZonalDemandAggregator in rebalancing to work properly with the drt-speed-up module, also departures of the speed-up mode must be considered as drt mode departures. Set to the empty String \"\" if not using drt-speed-up (the default). Drt-speed-up module should set this automatically if used.";
 
 	@NotBlank
 	private String mode = TransportMode.drt; // travel mode (passengers'/customers' perspective)
@@ -204,6 +207,9 @@ public final class DrtConfigGroup extends ReflectiveConfigGroup implements Modal
 
 	@NotNull
 	private DrtInsertionSearchParams drtInsertionSearchParams;
+
+	@NotNull
+	private String drtSpeedUpMode = "";
 
 	public DrtConfigGroup() {
 		super(GROUP_NAME);
@@ -281,6 +287,7 @@ public final class DrtConfigGroup extends ReflectiveConfigGroup implements Modal
 		map.put(REJECT_REQUEST_IF_MAX_WAIT_OR_TRAVEL_TIME_VIOLATED,
 				REJECT_REQUEST_IF_MAX_WAIT_OR_TRAVEL_TIME_VIOLATED_EXP);
 		map.put(DRT_SERVICE_AREA_SHAPE_FILE, DRT_SERVICE_AREA_SHAPE_FILE_EXP);
+		map.put(DRT_SPEED_UP_MODE, DRT_SPEED_UP_MODE_EXP);
 		return map;
 	}
 
@@ -608,6 +615,16 @@ public final class DrtConfigGroup extends ReflectiveConfigGroup implements Modal
 	public DrtConfigGroup setNumberOfThreads(final int numberOfThreads) {
 		this.numberOfThreads = numberOfThreads;
 		return this;
+	}
+
+	@StringGetter(DRT_SPEED_UP_MODE)
+	public String getDrtSpeedUpMode() {
+		return drtSpeedUpMode;
+	}
+
+	@StringSetter(DRT_SPEED_UP_MODE)
+	public void setDrtSpeedUpMode(String drtSpeedUpMode) {
+		this.drtSpeedUpMode = drtSpeedUpMode;
 	}
 
 	public double getAdvanceRequestPlanningHorizon() {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -617,12 +617,10 @@ public final class DrtConfigGroup extends ReflectiveConfigGroup implements Modal
 		return this;
 	}
 
-	@StringGetter(DRT_SPEED_UP_MODE)
 	public String getDrtSpeedUpMode() {
 		return drtSpeedUpMode;
 	}
 
-	@StringSetter(DRT_SPEED_UP_MODE)
 	public void setDrtSpeedUpMode(String drtSpeedUpMode) {
 		this.drtSpeedUpMode = drtSpeedUpMode;
 	}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
@@ -131,17 +131,17 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 		}
 	}
 
-	private Controler setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType aggregatorType, String drtSpeedUpModeForRebalancingConfigParams) {
+	private Controler setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType aggregatorType, String drtSpeedUpModeForRebalancingConfiguration) {
 		URL configUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("dvrp-grid"), "eight_shared_taxi_config.xml");
 		Config config = ConfigUtils.loadConfig(configUrl, new MultiModeDrtConfigGroup(), new DvrpConfigGroup(),
 				new OTFVisConfigGroup());
 
 		DrtConfigGroup drtCfg = DrtConfigGroup.getSingleModeDrtConfig(config);
+		drtCfg.setDrtSpeedUpMode(drtSpeedUpModeForRebalancingConfiguration);
 		MinCostFlowRebalancingParams rebalancingParams = new MinCostFlowRebalancingParams();
 		rebalancingParams.setCellSize(500);
 		rebalancingParams.setTargetAlpha(1);
 		rebalancingParams.setTargetBeta(0);
-		rebalancingParams.setDrtSpeedUpMode(drtSpeedUpModeForRebalancingConfigParams);
 		drtCfg.addParameterSet(rebalancingParams);
 		rebalancingParams.setZonalDemandAggregatorType(aggregatorType);
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
@@ -175,6 +175,9 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 
 	/**
 	 * we have eight zones, 2 rows 4 columns.
+	 * order of zones:
+	 *	2	4	6	8
+	 *	1	3	5	7
 	 *
 	 * 1) in the left column, there are half of the people, performing dummy - > car -> dummy
 	 *    That should lead to half of the drt vehicles rebalanced to the left column when using ActivityLocationBasedZonalDemandAggregator.

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
@@ -42,6 +42,8 @@ import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpModes;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.config.groups.PlanCalcScoreConfigGroup;
+import org.matsim.core.config.groups.PlansCalcRouteConfigGroup;
 import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.core.utils.io.IOUtils;
@@ -59,7 +61,7 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 
 	@Test
 	public void EqualVehicleDensityZonalDemandAggregatorTest(){
-		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.EqualVehicleDensityZonalDemandAggregator);
+		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.EqualVehicleDensityZonalDemandAggregator, "");
 		controler.run();
 		ZonalDemandAggregator aggregator = controler.getInjector().getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
 		for(double ii = 0; ii < 16 * 3600; ii+=1800){
@@ -77,7 +79,7 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 
 	@Test
 	public void PreviousIterationZonalDemandAggregatorTest(){
-		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.PreviousIterationZonalDemandAggregator);
+		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.PreviousIterationZonalDemandAggregator, "");
 		controler.run();
 		ZonalDemandAggregator aggregator = controler.getInjector().getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
 		for(double ii = 1800; ii < 16 * 3600; ii+=1800){
@@ -94,16 +96,16 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 	}
 
 	@Test
-	public void ActivityLocationBasedZonalDemandAggregatorTest(){
-		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.ActivityLocationBasedZonalDemandAggregator);
+	public void PreviousIterationZonalDemandAggregatorWithSpeedUpModeTest(){
+		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.PreviousIterationZonalDemandAggregator, "drt_teleportation");
 		controler.run();
 		ZonalDemandAggregator aggregator = controler.getInjector().getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
 		for(double ii = 1800; ii < 16 * 3600; ii+=1800){
 			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
 			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 1", 0, demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 2", 3, demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 2", 0, demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
 			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 3", 0, demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 4", 0, demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 4", 3, demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
 			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 5", 0, demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
 			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 6", 0, demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
 			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 7", 0, demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
@@ -111,7 +113,25 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 		}
 	}
 
-	private Controler setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType aggregatorType) {
+	@Test
+	public void ActivityLocationBasedZonalDemandAggregatorTest(){
+		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.ActivityLocationBasedZonalDemandAggregator, "");
+		controler.run();
+		ZonalDemandAggregator aggregator = controler.getInjector().getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
+		for(double ii = 1800; ii < 16 * 3600; ii+=1800){
+			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 1", 0, demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 2", 3, demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 3", 0, demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 4", 3, demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 5", 0, demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 6", 0, demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 7", 0, demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 8", 3, demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
+		}
+	}
+
+	private Controler setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType aggregatorType, String drtSpeedUpModeForRebalancingConfigParams) {
 		URL configUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("dvrp-grid"), "eight_shared_taxi_config.xml");
 		Config config = ConfigUtils.loadConfig(configUrl, new MultiModeDrtConfigGroup(), new DvrpConfigGroup(),
 				new OTFVisConfigGroup());
@@ -121,6 +141,7 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 		rebalancingParams.setCellSize(500);
 		rebalancingParams.setTargetAlpha(1);
 		rebalancingParams.setTargetBeta(0);
+		rebalancingParams.setDrtSpeedUpMode(drtSpeedUpModeForRebalancingConfigParams);
 		drtCfg.addParameterSet(rebalancingParams);
 		rebalancingParams.setZonalDemandAggregatorType(aggregatorType);
 
@@ -130,6 +151,20 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 		config.qsim().setStartTime(0.);
 		config.controler().setOverwriteFileSetting(OutputDirectoryHierarchy.OverwriteFileSetting.deleteDirectoryIfExists);
 		config.controler().setOutputDirectory(utils.getOutputDirectory());
+
+		PlansCalcRouteConfigGroup.ModeRoutingParams pseudoDrtSpeedUpModeRoutingParams = new PlansCalcRouteConfigGroup.ModeRoutingParams("drt_teleportation");
+		pseudoDrtSpeedUpModeRoutingParams.setBeelineDistanceFactor(1.3);
+		pseudoDrtSpeedUpModeRoutingParams.setTeleportedModeSpeed(8.0);
+		config.plansCalcRoute().addModeRoutingParams(pseudoDrtSpeedUpModeRoutingParams);
+
+		// if adding a new mode (drtSpeedUpMode), some default modes are deleted, so re-insert them...
+		PlansCalcRouteConfigGroup.ModeRoutingParams walkRoutingParams = new PlansCalcRouteConfigGroup.ModeRoutingParams(TransportMode.walk);
+		walkRoutingParams.setBeelineDistanceFactor(1.3);
+		walkRoutingParams.setTeleportedModeSpeed(3.0 / 3.6);
+		config.plansCalcRoute().addModeRoutingParams(walkRoutingParams);
+
+		PlanCalcScoreConfigGroup.ModeParams pseudoDrtSpeedUpModeScoreParams = new PlanCalcScoreConfigGroup.ModeParams("drt_teleportation");
+		config.planCalcScore().addModeParams(pseudoDrtSpeedUpModeScoreParams);
 
 		//this is the wrong way around (create controler before manipulating scenario...
 		Controler controler = DrtControlerCreator.createControler(config, false);
@@ -185,6 +220,24 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 
 			plan.addLeg(factory.createLeg(TransportMode.drt));
 			plan.addActivity(factory.createActivityFromLinkId("dummy", right2));
+
+			person.addPlan(plan);
+			population.addPerson(person);
+		}
+
+		Id<Link> center1 = Id.createLinkId(147);
+		Id<Link> center2 = Id.createLinkId(315);
+
+		for(int i = 1; i < 100; i++){
+			Person person = factory.createPerson(Id.createPersonId("centerColumn_" + i));
+
+			Plan plan = factory.createPlan();
+			Activity dummy1 = factory.createActivityFromLinkId("dummy", center1);
+			dummy1.setEndTime(i * 10 * 60);
+			plan.addActivity(dummy1);
+
+			plan.addLeg(factory.createLeg("drt_teleportation"));
+			plan.addActivity(factory.createActivityFromLinkId("dummy", center2));
 
 			person.addPlan(plan);
 			population.addPerson(person);


### PR DESCRIPTION
Motivation: Make PreviousIterationZonalDRTDemandAggregator compatible with drt-speed-up module.

To achieve that DepartureEvents of the drt-speed-up mode should be considered drt demand. Changes:
- add a param drtSpeedUpMode to rebalancing config
- consider DepartureEvents of the drt-speed-up in PreviousIterationZonalDRTDemandAggregator

I adapted the existing test, but I'm not sure whether zone 4 is really the right zone for the new "drt_teleportation" mode demand starting from link 147 (no way to graphically check this).