### PR TITLE
added getter for modeHistories

### DIFF
--- a/matsim/src/main/java/org/matsim/analysis/ModeStatsControlerListener.java
+++ b/matsim/src/main/java/org/matsim/analysis/ModeStatsControlerListener.java
@@ -22,13 +22,8 @@ package org.matsim.analysis;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.TreeSet;
 
 import javax.inject.Inject;
 
@@ -193,4 +188,9 @@ ShutdownListener {
 		}
 
 	}
+
+	public Map<String, Map<Integer, Double>> getModeHistories() {
+		return Collections.unmodifiableMap( this.modeHistories ) ;
+	}
+
 }

--- a/matsim/src/main/java/org/matsim/analysis/ModeStatsControlerListener.java
+++ b/matsim/src/main/java/org/matsim/analysis/ModeStatsControlerListener.java
@@ -56,7 +56,7 @@ import org.matsim.core.utils.io.UncheckedIOException;
  *
  * @author mrieser
  */
-public class ModeStatsControlerListener implements StartupListener, IterationEndsListener, 
+public final class ModeStatsControlerListener implements StartupListener, IterationEndsListener,
 ShutdownListener {
 
 	public static final String FILENAME_MODESTATS = "modestats";
@@ -189,7 +189,7 @@ ShutdownListener {
 
 	}
 
-	public Map<String, Map<Integer, Double>> getModeHistories() {
+	public final Map<String, Map<Integer, Double>> getModeHistories() {
 		return Collections.unmodifiableMap( this.modeHistories ) ;
 	}
 


### PR DESCRIPTION
This pull request adds a getter method for modeHistories. I need access to this collection for the dynamicShutdown module I am working on. I did not change the access modifier of modeHistories to private, since I am not sure what effects that would have down the line. 