### PR TITLE
Extendible taxi task types

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/schedule/Task.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/schedule/Task.java
@@ -37,6 +37,7 @@ import org.matsim.contrib.dvrp.tracker.TaskTracker;
  */
 public interface Task {
 	interface TaskType {
+		String name();
 	}
 
 	enum TaskStatus {

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/vrpagent/AbstractTaskEvent.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/vrpagent/AbstractTaskEvent.java
@@ -70,7 +70,7 @@ public abstract class AbstractTaskEvent extends Event implements HasPersonId {
 	public Map<String, String> getAttributes() {
 		Map<String, String> attr = super.getAttributes();
 		attr.put(ATTRIBUTE_DVRP_VEHICLE, dvrpVehicleId + "");
-		attr.put(ATTRIBUTE_TASK_TYPE, taskType + "");
+		attr.put(ATTRIBUTE_TASK_TYPE, taskType.name());
 		attr.put(ATTRIBUTE_TASK_INDEX, taskIndex + "");
 		return attr;
 	}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/util/timeprofile/TimeProfiles.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/util/timeprofile/TimeProfiles.java
@@ -20,9 +20,16 @@
 package org.matsim.contrib.util.timeprofile;
 
 import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.DoubleSupplier;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.matsim.contrib.util.timeprofile.TimeProfileCollector.ProfileCalculator;
 
@@ -57,5 +64,15 @@ public class TimeProfiles {
 				return valueSupplier.get();
 			}
 		};
+	}
+
+	public static <T> ImmutableList<T> createExtendedHeader(ImmutableList<T> defaultColumns, Stream<T> columns,
+			Comparator<T> comparator) {
+		Set<T> defaultHeader = new HashSet<>(defaultColumns);
+		List<T> additionalColumns = columns.filter(Predicate.not(defaultHeader::contains))
+				.distinct()
+				.sorted(comparator)
+				.collect(Collectors.toList());
+		return ImmutableList.<T>builder().addAll(defaultColumns).addAll(additionalColumns).build();
 	}
 }

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/vrpagent/VrpAgentLogicTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/vrpagent/VrpAgentLogicTest.java
@@ -50,7 +50,8 @@ import org.mockito.ArgumentCaptor;
  * @author Michal Maciejewski (michalm)
  */
 public class VrpAgentLogicTest {
-	private static class TestTaskType implements TaskType {
+	private enum TestTaskType implements TaskType {
+		TYPE
 	}
 
 	private final EventsManager eventsManager = mock(EventsManager.class);
@@ -92,7 +93,7 @@ public class VrpAgentLogicTest {
 	public void testInitialActivity_planned() {
 		DynActivity initialActivity = dynAgentLogic.computeInitialActivity(null);
 
-		StayTask task0 = new StayTask(new TestTaskType(), 10, 90, startLink);
+		StayTask task0 = new StayTask(TestTaskType.TYPE, 10, 90, startLink);
 		vehicle.getSchedule().addTask(task0);
 
 		assertThat(initialActivity.getActivityType()).isEqualTo(BEFORE_SCHEDULE_ACTIVITY_TYPE);
@@ -104,7 +105,7 @@ public class VrpAgentLogicTest {
 	public void testInitialActivity_started_failure() {
 		DynActivity initialActivity = dynAgentLogic.computeInitialActivity(null);
 
-		StayTask task0 = new StayTask(new TestTaskType(), 10, 90, startLink);
+		StayTask task0 = new StayTask(TestTaskType.TYPE, 10, 90, startLink);
 		vehicle.getSchedule().addTask(task0);
 		vehicle.getSchedule().nextTask();
 
@@ -127,7 +128,7 @@ public class VrpAgentLogicTest {
 	@Test
 	public void testNextAction_planned_started() {
 		double time = 10;
-		StayTask task0 = new StayTask(new TestTaskType(), time, 90, startLink);
+		StayTask task0 = new StayTask(TestTaskType.TYPE, time, 90, startLink);
 		vehicle.getSchedule().addTask(task0);
 
 		DynActivity nextActivity = (DynActivity)dynAgentLogic.computeNextAction(null, time);
@@ -138,9 +139,9 @@ public class VrpAgentLogicTest {
 	@Test
 	public void testNextAction_started_started() {
 		double time = 50;
-		StayTask task0 = new StayTask(new TestTaskType(), 10, time, startLink);
+		StayTask task0 = new StayTask(TestTaskType.TYPE, 10, time, startLink);
 		vehicle.getSchedule().addTask(task0);
-		StayTask task1 = new StayTask(new TestTaskType(), time, 90, startLink);
+		StayTask task1 = new StayTask(TestTaskType.TYPE, time, 90, startLink);
 		vehicle.getSchedule().addTask(task1);
 		vehicle.getSchedule().nextTask();//current: task0
 
@@ -152,7 +153,7 @@ public class VrpAgentLogicTest {
 	@Test
 	public void testNextAction_started_completed() {
 		double time = 90;
-		StayTask task0 = new StayTask(new TestTaskType(), 10, time, startLink);
+		StayTask task0 = new StayTask(TestTaskType.TYPE, 10, time, startLink);
 		vehicle.getSchedule().addTask(task0);
 		vehicle.getSchedule().nextTask();//current: task0
 

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/util/stats/TimeBinSamplesTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/util/stats/TimeBinSamplesTest.java
@@ -26,7 +26,6 @@ import static org.matsim.contrib.util.stats.TimeBinSamples.taskSamples;
 import org.junit.Test;
 import org.matsim.contrib.dvrp.schedule.StayTask;
 import org.matsim.contrib.dvrp.schedule.Task;
-import org.matsim.contrib.dvrp.schedule.Task.TaskType;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -58,7 +57,6 @@ public class TimeBinSamplesTest {
 	}
 
 	private Task task(double beginTime, double endTime) {
-		return new StayTask(new TaskType() {
-		}, beginTime, endTime, null);
+		return new StayTask(() -> "name", beginTime, endTime, null);
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/ETaxiActionCreator.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/ETaxiActionCreator.java
@@ -43,7 +43,7 @@ public class ETaxiActionCreator implements VrpAgentLogic.DynActionCreator {
 	@Override
 	public DynAction createAction(DynAgent dynAgent, DvrpVehicle vehicle, double now) {
 		Task task = vehicle.getSchedule().getCurrentTask();
-		return task instanceof ETaxiChargingTask ?
+		return task.getTaskType().equals(ETaxiChargingTask.TYPE) ?
 				new ChargingActivity((ETaxiChargingTask)task) :
 				taxiActionCreator.createAction(dynAgent, vehicle, now);
 	}

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/ETaxiChargingTask.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/ETaxiChargingTask.java
@@ -22,11 +22,13 @@ package org.matsim.contrib.etaxi;
 import org.matsim.contrib.ev.dvrp.ChargingTaskImpl;
 import org.matsim.contrib.ev.fleet.ElectricVehicle;
 import org.matsim.contrib.ev.infrastructure.Charger;
-import org.matsim.contrib.taxi.schedule.TaxiStayTask;
+import org.matsim.contrib.taxi.schedule.TaxiTaskType;
 
 public class ETaxiChargingTask extends ChargingTaskImpl {
+	public static final TaxiTaskType TYPE = new TaxiTaskType("CHARGING", null);
+
 	public ETaxiChargingTask(double beginTime, double endTime, Charger charger, ElectricVehicle ev,
 			double totalEnergy) {
-		super(TaxiStayTask.TYPE, beginTime, endTime, charger, ev, totalEnergy);
+		super(TYPE, beginTime, endTime, charger, ev, totalEnergy);
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/ETaxiChargingTask.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/ETaxiChargingTask.java
@@ -22,11 +22,11 @@ package org.matsim.contrib.etaxi;
 import org.matsim.contrib.ev.dvrp.ChargingTaskImpl;
 import org.matsim.contrib.ev.fleet.ElectricVehicle;
 import org.matsim.contrib.ev.infrastructure.Charger;
-import org.matsim.contrib.taxi.schedule.TaxiTaskType;
+import org.matsim.contrib.taxi.schedule.TaxiStayTask;
 
 public class ETaxiChargingTask extends ChargingTaskImpl {
 	public ETaxiChargingTask(double beginTime, double endTime, Charger charger, ElectricVehicle ev,
 			double totalEnergy) {
-		super(TaxiTaskType.STAY, beginTime, endTime, charger, ev, totalEnergy);
+		super(TaxiStayTask.TYPE, beginTime, endTime, charger, ev, totalEnergy);
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/ETaxiScheduler.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/ETaxiScheduler.java
@@ -96,7 +96,7 @@ public class ETaxiScheduler extends TaxiScheduler {
 
 		if (currentTaskType.equals(ETaxiChargingTask.TYPE)) {
 			return 0;
-		} else if (currentTaskType.getBaseType() == EMPTY_DRIVE //
+		} else if (currentTaskType.getBaseType().get() == EMPTY_DRIVE //
 				&& Schedules.getNextTask(schedule).getTaskType().equals(ETaxiChargingTask.TYPE)) {
 			//drive task to charging station
 			if (taxiCfg.isVehicleDiversion()) {

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/ETaxiScheduler.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/ETaxiScheduler.java
@@ -19,6 +19,8 @@
 
 package org.matsim.contrib.etaxi;
 
+import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.getBaseType;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,7 +39,6 @@ import org.matsim.contrib.ev.fleet.ElectricVehicle;
 import org.matsim.contrib.ev.infrastructure.Charger;
 import org.matsim.contrib.taxi.run.TaxiConfigGroup;
 import org.matsim.contrib.taxi.schedule.TaxiStayTask;
-import org.matsim.contrib.taxi.schedule.TaxiTaskType;
 import org.matsim.contrib.taxi.scheduler.TaxiScheduler;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.router.util.LeastCostPathCalculator;
@@ -91,7 +92,7 @@ public class ETaxiScheduler extends TaxiScheduler {
 	@Override
 	protected Integer countUnremovablePlannedTasks(Schedule schedule) {
 		Task currentTask = schedule.getCurrentTask();
-		switch (((TaxiTaskType)currentTask.getTaskType())) {
+		switch (getBaseType(currentTask)) {
 			case EMPTY_DRIVE:
 				Task nextTask = Schedules.getNextTask(schedule);
 				if (!(nextTask instanceof ETaxiChargingTask)) {

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/assignment/AssignmentETaxiOptimizer.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/assignment/AssignmentETaxiOptimizer.java
@@ -79,7 +79,8 @@ import com.google.common.collect.Maps;
 public class AssignmentETaxiOptimizer extends AssignmentTaxiOptimizer {
 	public static AssignmentETaxiOptimizer create(EventsManager eventsManager, TaxiConfigGroup taxiCfg, Fleet fleet,
 			Network network, MobsimTimer timer, TravelTime travelTime, TravelDisutility travelDisutility,
-			ETaxiScheduler eScheduler, ScheduleTimingUpdater scheduleTimingUpdater, ChargingInfrastructure chargingInfrastructure) {
+			ETaxiScheduler eScheduler, ScheduleTimingUpdater scheduleTimingUpdater,
+			ChargingInfrastructure chargingInfrastructure) {
 		MultiNodePathCalculator multiNodeRouter = (MultiNodePathCalculator)new FastMultiNodeDijkstraFactory(
 				true).createPathCalculator(network, travelDisutility, travelTime);
 		BackwardMultiNodePathCalculator backwardMultiNodeRouter = (BackwardMultiNodePathCalculator)new BackwardFastMultiNodeDijkstraFactory(
@@ -87,8 +88,7 @@ public class AssignmentETaxiOptimizer extends AssignmentTaxiOptimizer {
 		LeastCostPathCalculator router = new FastAStarEuclideanFactory().createPathCalculator(network, travelDisutility,
 				travelTime);
 		return new AssignmentETaxiOptimizer(eventsManager, taxiCfg, fleet, timer, travelTime, eScheduler,
-				scheduleTimingUpdater,
-				chargingInfrastructure, multiNodeRouter, backwardMultiNodeRouter, router);
+				scheduleTimingUpdater, chargingInfrastructure, multiNodeRouter, backwardMultiNodeRouter, router);
 	}
 
 	private final AssignmentETaxiOptimizerParams params;
@@ -102,9 +102,10 @@ public class AssignmentETaxiOptimizer extends AssignmentTaxiOptimizer {
 	private final Map<Id<DvrpVehicle>, DvrpVehicle> scheduledForCharging;
 
 	public AssignmentETaxiOptimizer(EventsManager eventsManager, TaxiConfigGroup taxiCfg, Fleet fleet,
-			MobsimTimer timer, TravelTime travelTime, ETaxiScheduler eScheduler, ScheduleTimingUpdater scheduleTimingUpdater,
-			ChargingInfrastructure chargingInfrastructure, MultiNodePathCalculator multiNodeRouter,
-			BackwardMultiNodePathCalculator backwardMultiNodeRouter, LeastCostPathCalculator router) {
+			MobsimTimer timer, TravelTime travelTime, ETaxiScheduler eScheduler,
+			ScheduleTimingUpdater scheduleTimingUpdater, ChargingInfrastructure chargingInfrastructure,
+			MultiNodePathCalculator multiNodeRouter, BackwardMultiNodePathCalculator backwardMultiNodeRouter,
+			LeastCostPathCalculator router) {
 		super(eventsManager, taxiCfg, fleet, eScheduler, scheduleTimingUpdater,
 				new AssignmentRequestInserter(fleet, timer, travelTime, eScheduler,
 						((AssignmentETaxiOptimizerParams)taxiCfg.getTaxiOptimizerParams()).getAssignmentTaxiOptimizerParams(),
@@ -188,7 +189,7 @@ public class AssignmentETaxiOptimizer extends AssignmentTaxiOptimizer {
 	public void nextTask(DvrpVehicle vehicle) {
 		Schedule schedule = vehicle.getSchedule();
 		if (schedule.getStatus() == ScheduleStatus.STARTED) {
-			if (schedule.getCurrentTask() instanceof ETaxiChargingTask) {
+			if (schedule.getCurrentTask().getTaskType().equals(ETaxiChargingTask.TYPE)) {
 				if (scheduledForCharging.remove(vehicle.getId()) == null) {
 					throw new IllegalStateException();
 				}
@@ -205,7 +206,9 @@ public class AssignmentETaxiOptimizer extends AssignmentTaxiOptimizer {
 		double chargingPlanningHorizon = 10 * 60;// 10 minutes (should be longer than socCheckTimeStep)
 		double maxDepartureTime = timer.getTimeOfDay() + chargingPlanningHorizon;
 		Stream<DvrpVehicle> vehiclesBelowMinSocLevel = fleet.getVehicles()
-				.values().stream().filter(v -> isChargingSchedulable((EvDvrpVehicle)v, eScheduler, maxDepartureTime));
+				.values()
+				.stream()
+				.filter(v -> isChargingSchedulable((EvDvrpVehicle)v, eScheduler, maxDepartureTime));
 
 		// filter least charged vehicles
 		// assumption: all b.capacities are equal

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/rules/RuleBasedETaxiOptimizer.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/rules/RuleBasedETaxiOptimizer.java
@@ -19,16 +19,12 @@
 
 package org.matsim.contrib.etaxi.optimizer.rules;
 
-import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.STAY;
-
 import java.util.stream.Stream;
 
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
-import org.matsim.contrib.dvrp.schedule.Task;
-import org.matsim.contrib.etaxi.ETaxiChargingTask;
 import org.matsim.contrib.etaxi.ETaxiScheduler;
 import org.matsim.contrib.etaxi.optimizer.BestChargerFinder;
 import org.matsim.contrib.ev.dvrp.EvDvrpVehicle;
@@ -127,11 +123,6 @@ public class RuleBasedETaxiOptimizer extends RuleBasedTaxiOptimizer {
 				chargeIdleUnderchargedVehicles(Stream.of(eTaxi));
 			}
 		}
-	}
-
-	@Override
-	protected boolean isWaitStay(Task task) {
-		return STAY.isBaseTypeOf(task) && !(task instanceof ETaxiChargingTask);
 	}
 
 	private boolean isUndercharged(EvDvrpVehicle v) {

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/rules/RuleBasedETaxiOptimizer.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/rules/RuleBasedETaxiOptimizer.java
@@ -19,6 +19,8 @@
 
 package org.matsim.contrib.etaxi.optimizer.rules;
 
+import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.STAY;
+
 import java.util.stream.Stream;
 
 import org.matsim.api.core.v01.network.Network;
@@ -41,7 +43,6 @@ import org.matsim.contrib.taxi.optimizer.rules.RuleBasedRequestInserter;
 import org.matsim.contrib.taxi.optimizer.rules.RuleBasedTaxiOptimizer;
 import org.matsim.contrib.taxi.optimizer.rules.UnplannedRequestZonalRegistry;
 import org.matsim.contrib.taxi.run.TaxiConfigGroup;
-import org.matsim.contrib.taxi.schedule.TaxiTaskType;
 import org.matsim.contrib.zone.SquareGridSystem;
 import org.matsim.contrib.zone.ZonalSystem;
 import org.matsim.core.api.experimental.events.EventsManager;
@@ -52,17 +53,18 @@ import org.matsim.core.router.util.TravelTime;
 
 public class RuleBasedETaxiOptimizer extends RuleBasedTaxiOptimizer {
 	public static RuleBasedETaxiOptimizer create(EventsManager eventsManager, TaxiConfigGroup taxiCfg, Fleet fleet,
-			ETaxiScheduler eScheduler, ScheduleTimingUpdater scheduleTimingUpdater, Network network, MobsimTimer timer, TravelTime travelTime,
-			TravelDisutility travelDisutility, ChargingInfrastructure chargingInfrastructure) {
+			ETaxiScheduler eScheduler, ScheduleTimingUpdater scheduleTimingUpdater, Network network, MobsimTimer timer,
+			TravelTime travelTime, TravelDisutility travelDisutility, ChargingInfrastructure chargingInfrastructure) {
 		double cellSize = ((RuleBasedETaxiOptimizerParams)taxiCfg.getTaxiOptimizerParams()).getRuleBasedTaxiOptimizerParams()
 				.getCellSize();
-		return RuleBasedETaxiOptimizer.create(eventsManager, taxiCfg, fleet, eScheduler, scheduleTimingUpdater, network, timer, travelTime,
-				travelDisutility, chargingInfrastructure, new SquareGridSystem(network, cellSize));
+		return RuleBasedETaxiOptimizer.create(eventsManager, taxiCfg, fleet, eScheduler, scheduleTimingUpdater, network,
+				timer, travelTime, travelDisutility, chargingInfrastructure, new SquareGridSystem(network, cellSize));
 	}
 
 	public static RuleBasedETaxiOptimizer create(EventsManager eventsManager, TaxiConfigGroup taxiCfg, Fleet fleet,
-			ETaxiScheduler eScheduler, ScheduleTimingUpdater scheduleTimingUpdater, Network network, MobsimTimer timer, TravelTime travelTime,
-			TravelDisutility travelDisutility, ChargingInfrastructure chargingInfrastructure, ZonalSystem zonalSystem) {
+			ETaxiScheduler eScheduler, ScheduleTimingUpdater scheduleTimingUpdater, Network network, MobsimTimer timer,
+			TravelTime travelTime, TravelDisutility travelDisutility, ChargingInfrastructure chargingInfrastructure,
+			ZonalSystem zonalSystem) {
 		IdleTaxiZonalRegistry idleTaxiRegistry = new IdleTaxiZonalRegistry(zonalSystem, eScheduler);
 		UnplannedRequestZonalRegistry unplannedRequestRegistry = new UnplannedRequestZonalRegistry(zonalSystem);
 		BestDispatchFinder dispatchFinder = new BestDispatchFinder(eScheduler, network, timer, travelTime,
@@ -71,8 +73,8 @@ public class RuleBasedETaxiOptimizer extends RuleBasedTaxiOptimizer {
 				((RuleBasedETaxiOptimizerParams)taxiCfg.getTaxiOptimizerParams()).getRuleBasedTaxiOptimizerParams(),
 				idleTaxiRegistry, unplannedRequestRegistry);
 
-		return new RuleBasedETaxiOptimizer(eventsManager, taxiCfg, fleet, eScheduler, scheduleTimingUpdater, chargingInfrastructure,
-				idleTaxiRegistry, unplannedRequestRegistry, dispatchFinder, requestInserter);
+		return new RuleBasedETaxiOptimizer(eventsManager, taxiCfg, fleet, eScheduler, scheduleTimingUpdater,
+				chargingInfrastructure, idleTaxiRegistry, unplannedRequestRegistry, dispatchFinder, requestInserter);
 	}
 
 	// TODO MIN_RELATIVE_SOC should depend on the weather and time of day
@@ -83,10 +85,12 @@ public class RuleBasedETaxiOptimizer extends RuleBasedTaxiOptimizer {
 	private final IdleTaxiZonalRegistry idleTaxiRegistry;
 
 	public RuleBasedETaxiOptimizer(EventsManager eventsManager, TaxiConfigGroup taxiCfg, Fleet fleet,
-								   ETaxiScheduler eScheduler, ScheduleTimingUpdater scheduleTimingUpdater, ChargingInfrastructure chargingInfrastructure,
-								   IdleTaxiZonalRegistry idleTaxiRegistry, UnplannedRequestZonalRegistry unplannedRequestRegistry,
-								   BestDispatchFinder dispatchFinder, UnplannedRequestInserter requestInserter) {
-		super(eventsManager, taxiCfg, fleet, eScheduler, scheduleTimingUpdater, idleTaxiRegistry, unplannedRequestRegistry, requestInserter);
+			ETaxiScheduler eScheduler, ScheduleTimingUpdater scheduleTimingUpdater,
+			ChargingInfrastructure chargingInfrastructure, IdleTaxiZonalRegistry idleTaxiRegistry,
+			UnplannedRequestZonalRegistry unplannedRequestRegistry, BestDispatchFinder dispatchFinder,
+			UnplannedRequestInserter requestInserter) {
+		super(eventsManager, taxiCfg, fleet, eScheduler, scheduleTimingUpdater, idleTaxiRegistry,
+				unplannedRequestRegistry, requestInserter);
 		this.params = (RuleBasedETaxiOptimizerParams)taxiCfg.getTaxiOptimizerParams();
 		this.chargingInfrastructure = chargingInfrastructure;
 		this.eScheduler = eScheduler;
@@ -127,7 +131,7 @@ public class RuleBasedETaxiOptimizer extends RuleBasedTaxiOptimizer {
 
 	@Override
 	protected boolean isWaitStay(Task task) {
-		return task.getTaskType() == TaxiTaskType.STAY && !(task instanceof ETaxiChargingTask);
+		return STAY.isBaseTypeOf(task) && !(task instanceof ETaxiChargingTask);
 	}
 
 	private boolean isUndercharged(EvDvrpVehicle v) {

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/util/ETaxiStayTaskEndTimeCalculator.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/util/ETaxiStayTaskEndTimeCalculator.java
@@ -31,7 +31,7 @@ public class ETaxiStayTaskEndTimeCalculator extends TaxiStayTaskEndTimeCalculato
 
 	@Override
 	public double calcNewEndTime(DvrpVehicle vehicle, StayTask task, double newBeginTime) {
-		if (task instanceof ETaxiChargingTask) {
+		if (task.getTaskType().equals(ETaxiChargingTask.TYPE)) {
 			// FIXME underestimated due to the ongoing AUX/drive consumption
 			double duration = task.getEndTime() - task.getBeginTime();
 			return newBeginTime + duration;

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/DefaultTaxiOptimizer.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/DefaultTaxiOptimizer.java
@@ -19,6 +19,8 @@
 
 package org.matsim.contrib.taxi.optimizer;
 
+import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.OCCUPIED_DRIVE;
+
 import java.util.List;
 
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
@@ -29,7 +31,6 @@ import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
 import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.contrib.taxi.passenger.TaxiRequest;
 import org.matsim.contrib.taxi.run.TaxiConfigGroup;
-import org.matsim.contrib.taxi.schedule.TaxiTaskType;
 import org.matsim.contrib.taxi.scheduler.TaxiScheduler;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.framework.events.MobsimBeforeSimStepEvent;
@@ -52,7 +53,8 @@ public class DefaultTaxiOptimizer implements TaxiOptimizer {
 	private final ScheduleTimingUpdater scheduleTimingUpdater;
 
 	public DefaultTaxiOptimizer(EventsManager eventsManager, TaxiConfigGroup taxiCfg, Fleet fleet,
-			TaxiScheduler scheduler, ScheduleTimingUpdater scheduleTimingUpdater, UnplannedRequestInserter requestInserter) {
+			TaxiScheduler scheduler, ScheduleTimingUpdater scheduleTimingUpdater,
+			UnplannedRequestInserter requestInserter) {
 		this.fleet = fleet;
 		this.scheduler = scheduler;
 		this.scheduleTimingUpdater = scheduleTimingUpdater;
@@ -116,7 +118,7 @@ public class DefaultTaxiOptimizer implements TaxiOptimizer {
 	}
 
 	protected boolean doReoptimizeAfterNextTask(Task newCurrentTask) {
-		return !taxiCfg.isDestinationKnown() && newCurrentTask.getTaskType() == TaxiTaskType.OCCUPIED_DRIVE;
+		return !taxiCfg.isDestinationKnown() && OCCUPIED_DRIVE.isBaseTypeOf(newCurrentTask);
 	}
 
 	protected void setRequiresReoptimization(boolean requiresReoptimization) {

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/rules/RuleBasedTaxiOptimizer.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/rules/RuleBasedTaxiOptimizer.java
@@ -19,6 +19,8 @@
 
 package org.matsim.contrib.taxi.optimizer.rules;
 
+import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.STAY;
+
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.Fleet;
@@ -33,7 +35,6 @@ import org.matsim.contrib.taxi.optimizer.UnplannedRequestInserter;
 import org.matsim.contrib.taxi.passenger.TaxiRequest;
 import org.matsim.contrib.taxi.run.TaxiConfigGroup;
 import org.matsim.contrib.taxi.schedule.TaxiStayTask;
-import org.matsim.contrib.taxi.schedule.TaxiTaskType;
 import org.matsim.contrib.taxi.scheduler.TaxiScheduler;
 import org.matsim.contrib.zone.SquareGridSystem;
 import org.matsim.contrib.zone.ZonalSystem;
@@ -47,23 +48,23 @@ import org.matsim.core.router.util.TravelTime;
  */
 public class RuleBasedTaxiOptimizer extends DefaultTaxiOptimizer {
 	public static RuleBasedTaxiOptimizer create(EventsManager eventsManager, TaxiConfigGroup taxiCfg, Fleet fleet,
-			TaxiScheduler scheduler, ScheduleTimingUpdater scheduleTimingUpdater, Network network, MobsimTimer timer, TravelTime travelTime,
-			TravelDisutility travelDisutility) {
+			TaxiScheduler scheduler, ScheduleTimingUpdater scheduleTimingUpdater, Network network, MobsimTimer timer,
+			TravelTime travelTime, TravelDisutility travelDisutility) {
 		double cellSize = ((RuleBasedTaxiOptimizerParams)taxiCfg.getTaxiOptimizerParams()).getCellSize();
-		return create(eventsManager, taxiCfg, fleet, scheduler, scheduleTimingUpdater, network, timer, travelTime, travelDisutility,
-				new SquareGridSystem(network, cellSize));
+		return create(eventsManager, taxiCfg, fleet, scheduler, scheduleTimingUpdater, network, timer, travelTime,
+				travelDisutility, new SquareGridSystem(network, cellSize));
 	}
 
 	public static RuleBasedTaxiOptimizer create(EventsManager eventsManager, TaxiConfigGroup taxiCfg, Fleet fleet,
-			TaxiScheduler scheduler, ScheduleTimingUpdater scheduleTimingUpdater, Network network, MobsimTimer timer, TravelTime travelTime,
-			TravelDisutility travelDisutility, ZonalSystem zonalSystem) {
+			TaxiScheduler scheduler, ScheduleTimingUpdater scheduleTimingUpdater, Network network, MobsimTimer timer,
+			TravelTime travelTime, TravelDisutility travelDisutility, ZonalSystem zonalSystem) {
 		IdleTaxiZonalRegistry idleTaxiRegistry = new IdleTaxiZonalRegistry(zonalSystem, scheduler);
 		UnplannedRequestZonalRegistry unplannedRequestRegistry = new UnplannedRequestZonalRegistry(zonalSystem);
 		RuleBasedRequestInserter requestInserter = new RuleBasedRequestInserter(scheduler, timer, network, travelTime,
 				travelDisutility, ((RuleBasedTaxiOptimizerParams)taxiCfg.getTaxiOptimizerParams()), idleTaxiRegistry,
 				unplannedRequestRegistry);
-		return new RuleBasedTaxiOptimizer(eventsManager, taxiCfg, fleet, scheduler, scheduleTimingUpdater, idleTaxiRegistry,
-				unplannedRequestRegistry, requestInserter);
+		return new RuleBasedTaxiOptimizer(eventsManager, taxiCfg, fleet, scheduler, scheduleTimingUpdater,
+				idleTaxiRegistry, unplannedRequestRegistry, requestInserter);
 	}
 
 	private final TaxiScheduler scheduler;
@@ -71,8 +72,9 @@ public class RuleBasedTaxiOptimizer extends DefaultTaxiOptimizer {
 	private final UnplannedRequestZonalRegistry unplannedRequestRegistry;
 
 	public RuleBasedTaxiOptimizer(EventsManager eventsManager, TaxiConfigGroup taxiCfg, Fleet fleet,
-								  TaxiScheduler scheduler, ScheduleTimingUpdater scheduleTimingUpdater, IdleTaxiZonalRegistry idleTaxiRegistry,
-								  UnplannedRequestZonalRegistry unplannedRequestRegistry, UnplannedRequestInserter requestInserter) {
+			TaxiScheduler scheduler, ScheduleTimingUpdater scheduleTimingUpdater,
+			IdleTaxiZonalRegistry idleTaxiRegistry, UnplannedRequestZonalRegistry unplannedRequestRegistry,
+			UnplannedRequestInserter requestInserter) {
 		super(eventsManager, taxiCfg, fleet, scheduler, scheduleTimingUpdater, requestInserter);
 
 		this.scheduler = scheduler;
@@ -119,6 +121,6 @@ public class RuleBasedTaxiOptimizer extends DefaultTaxiOptimizer {
 	}
 
 	protected boolean isWaitStay(Task task) {
-		return task.getTaskType() == TaxiTaskType.STAY;
+		return STAY.isBaseTypeOf(task);
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/rules/RuleBasedTaxiOptimizer.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/rules/RuleBasedTaxiOptimizer.java
@@ -108,7 +108,7 @@ public class RuleBasedTaxiOptimizer extends DefaultTaxiOptimizer {
 		} else {
 			if (schedule.getCurrentTask().getTaskIdx() != 0) {// not first task
 				Task previousTask = Schedules.getPreviousTask(schedule);
-				if (isWaitStay(previousTask)) {
+				if (STAY.isBaseTypeOf(previousTask)) {
 					idleTaxiRegistry.removeVehicle(vehicle);
 				}
 			}
@@ -117,10 +117,6 @@ public class RuleBasedTaxiOptimizer extends DefaultTaxiOptimizer {
 
 	@Override
 	protected boolean doReoptimizeAfterNextTask(Task newCurrentTask) {
-		return isWaitStay(newCurrentTask);
-	}
-
-	protected boolean isWaitStay(Task task) {
-		return STAY.isBaseTypeOf(task);
+		return STAY.isBaseTypeOf(newCurrentTask);
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeQSimModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeQSimModule.java
@@ -109,8 +109,10 @@ public class TaxiModeQSimModule extends AbstractDvrpModeQSimModule {
 			public TaxiScheduler get() {
 				Fleet fleet = getModalInstance(Fleet.class);
 				Network network = getModalInstance(Network.class);
-				TravelDisutility travelDisutility = getModalInstance(TravelDisutilityFactory.class).createTravelDisutility(travelTime);
-				LeastCostPathCalculator router = new FastAStarLandmarksFactory(getConfig().global()).createPathCalculator(network, travelDisutility, travelTime);
+				TravelDisutility travelDisutility = getModalInstance(
+						TravelDisutilityFactory.class).createTravelDisutility(travelTime);
+				LeastCostPathCalculator router = new FastAStarLandmarksFactory(
+						getConfig().global()).createPathCalculator(network, travelDisutility, travelTime);
 				return new TaxiScheduler(taxiCfg, fleet, timer, travelTime, router);
 			}
 		}).asEagerSingleton();

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiDropoffTask.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiDropoffTask.java
@@ -19,16 +19,20 @@
 
 package org.matsim.contrib.taxi.schedule;
 
+import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.DROPOFF;
+
 import org.matsim.contrib.dvrp.schedule.StayTask;
 import org.matsim.contrib.taxi.passenger.TaxiRequest;
 
 import com.google.common.base.MoreObjects;
 
 public class TaxiDropoffTask extends StayTask {
+	public static final TaxiTaskType TYPE = new TaxiTaskType(DROPOFF);
+
 	private final TaxiRequest request;
 
 	public TaxiDropoffTask(double beginTime, double endTime, TaxiRequest request) {
-		super(TaxiTaskType.DROPOFF, beginTime, endTime, request.getToLink());
+		super(TYPE, beginTime, endTime, request.getToLink());
 		this.request = request;
 		request.setDropoffTask(this);
 	}

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiEmptyDriveTask.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiEmptyDriveTask.java
@@ -19,11 +19,15 @@
 
 package org.matsim.contrib.taxi.schedule;
 
+import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.EMPTY_DRIVE;
+
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.schedule.DriveTask;
 
 public class TaxiEmptyDriveTask extends DriveTask {
+	public static final TaxiTaskType TYPE = new TaxiTaskType(EMPTY_DRIVE);
+
 	public TaxiEmptyDriveTask(VrpPathWithTravelData path) {
-		super(TaxiTaskType.EMPTY_DRIVE, path);
+		super(TYPE, path);
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiPickupTask.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiPickupTask.java
@@ -19,16 +19,20 @@
 
 package org.matsim.contrib.taxi.schedule;
 
+import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.PICKUP;
+
 import org.matsim.contrib.dvrp.schedule.StayTask;
 import org.matsim.contrib.taxi.passenger.TaxiRequest;
 
 import com.google.common.base.MoreObjects;
 
 public class TaxiPickupTask extends StayTask {
+	public static final TaxiTaskType TYPE = new TaxiTaskType(PICKUP);
+
 	private final TaxiRequest request;
 
 	public TaxiPickupTask(double beginTime, double endTime, TaxiRequest request) {
-		super(TaxiTaskType.PICKUP, beginTime, endTime, request.getFromLink());
+		super(TYPE, beginTime, endTime, request.getFromLink());
 		this.request = request;
 		request.setPickupTask(this);
 	}

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiStayTask.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiStayTask.java
@@ -19,11 +19,15 @@
 
 package org.matsim.contrib.taxi.schedule;
 
+import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.STAY;
+
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.dvrp.schedule.StayTask;
 
 public class TaxiStayTask extends StayTask {
+	public static final TaxiTaskType TYPE = new TaxiTaskType(STAY);
+
 	public TaxiStayTask(double beginTime, double endTime, Link link) {
-		super(TaxiTaskType.STAY, beginTime, endTime, link);
+		super(TYPE, beginTime, endTime, link);
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiTaskBaseType.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiTaskBaseType.java
@@ -36,10 +36,10 @@ public enum TaxiTaskBaseType {
 	STAY;
 
 	public static TaxiTaskBaseType getBaseType(Task task) {
-		return ((TaxiTaskType)task.getTaskType()).getBaseType();
+		return ((TaxiTaskType)task.getTaskType()).getBaseType().get();
 	}
 
 	public boolean isBaseTypeOf(Task task) {
-		return ((TaxiTaskType)task.getTaskType()).getBaseType() == this;
+		return ((TaxiTaskType)task.getTaskType()).getBaseType().orElse(null) == this;
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiTaskBaseType.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiTaskBaseType.java
@@ -1,9 +1,9 @@
-/* *********************************************************************** *
+/*
+ * *********************************************************************** *
  * project: org.matsim.*
- *                                                                         *
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2013 by the members listed in the COPYING,        *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -15,23 +15,31 @@
  *   (at your option) any later version.                                   *
  *   See also COPYING, LICENSE and WARRANTY file                           *
  *                                                                         *
- * *********************************************************************** */
+ * *********************************************************************** *
+ */
 
 package org.matsim.contrib.taxi.schedule;
 
-import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.OCCUPIED_DRIVE;
+import org.matsim.contrib.dvrp.schedule.Task;
 
-import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
-import org.matsim.contrib.dvrp.schedule.DriveTask;
-import org.matsim.contrib.taxi.passenger.TaxiRequest;
+/**
+ * Defines the base set of task types supported by the default optimiser
+ *
+ * @author Michal Maciejewski (michalm)
+ */
+public enum TaxiTaskBaseType {
+	// not directly related to any customer (although may be related to serving a customer; e.g. a pickup drive)
+	EMPTY_DRIVE, //
+	// serving a customer (TaxiTaskWithRequest)
+	PICKUP, OCCUPIED_DRIVE, DROPOFF,//
+	// not directly related to any customer
+	STAY;
 
-public class TaxiOccupiedDriveTask extends DriveTask {
-	public static final TaxiTaskType TYPE = new TaxiTaskType(OCCUPIED_DRIVE);
+	public static TaxiTaskBaseType getBaseType(Task task) {
+		return ((TaxiTaskType)task.getTaskType()).getBaseType();
+	}
 
-	public TaxiOccupiedDriveTask(VrpPathWithTravelData path, TaxiRequest request) {
-		super(TYPE, path);
-		if (request.getFromLink() != path.getFromLink() && request.getToLink() != path.getToLink()) {
-			throw new IllegalArgumentException();
-		}
+	public boolean isBaseTypeOf(Task task) {
+		return ((TaxiTaskType)task.getTaskType()).getBaseType() == this;
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiTaskType.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiTaskType.java
@@ -21,8 +21,10 @@
 package org.matsim.contrib.taxi.schedule;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
 
 import org.matsim.contrib.dvrp.schedule.Task;
 
@@ -34,22 +36,22 @@ import com.google.common.base.MoreObjects;
 public class TaxiTaskType implements Task.TaskType {
 
 	private final String name;
-	// can be null if the task type requires a special handling which is not provided by the standard taxi algorithms
+
+	// can be empty if the task type requires a special handling which is not provided by the standard taxi algorithms
 	// (e.g. e-taxi charging task cannot be handled as 'STAY')
-	@Nullable
-	private final TaxiTaskBaseType baseType;
+	private final Optional<TaxiTaskBaseType> baseType;
 
 	private final int hash;
 
-	protected TaxiTaskType(TaxiTaskBaseType baseType) {
+	protected TaxiTaskType(@NotNull TaxiTaskBaseType baseType) {
 		this.name = baseType.name();
-		this.baseType = baseType;
+		this.baseType = Optional.of(baseType);
 		this.hash = Objects.hash(name, baseType);
 	}
 
 	public TaxiTaskType(String name, @Nullable TaxiTaskBaseType baseType) {
 		this.name = name;
-		this.baseType = baseType;
+		this.baseType = Optional.ofNullable(baseType);
 		this.hash = Objects.hash(name, baseType);
 	}
 
@@ -57,8 +59,7 @@ public class TaxiTaskType implements Task.TaskType {
 		return name;
 	}
 
-	@Nullable
-	public final TaxiTaskBaseType getBaseType() {
+	public final Optional<TaxiTaskBaseType> getBaseType() {
 		return baseType;
 	}
 
@@ -71,7 +72,7 @@ public class TaxiTaskType implements Task.TaskType {
 			return false;
 		}
 		TaxiTaskType taskType = (TaxiTaskType)o;
-		return hash == taskType.hash && baseType == taskType.baseType && Objects.equals(name, taskType.name);
+		return hash == taskType.hash && baseType.equals(taskType.baseType) && Objects.equals(name, taskType.name);
 	}
 
 	@Override

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiTaskType.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiTaskType.java
@@ -20,14 +20,67 @@
 
 package org.matsim.contrib.taxi.schedule;
 
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
 import org.matsim.contrib.dvrp.schedule.Task;
+
+import com.google.common.base.MoreObjects;
 
 /**
  * @author Michal Maciejewski (michalm)
  */
-public enum TaxiTaskType implements Task.TaskType {
-	EMPTY_DRIVE, // not directly related to any customer (although may be related to serving a customer; e.g. a
-	// pickup drive)
-	PICKUP, OCCUPIED_DRIVE, DROPOFF, // serving a customer (TaxiTaskWithRequest)
-	STAY// not directly related to any customer
+public class TaxiTaskType implements Task.TaskType {
+
+	private final String name;
+	// can be null if the task type requires a special handling which is not provided by the standard taxi algorithms
+	// (e.g. e-taxi charging task cannot be handled as 'STAY')
+	@Nullable
+	private final TaxiTaskBaseType baseType;
+
+	private final int hash;
+
+	protected TaxiTaskType(TaxiTaskBaseType baseType) {
+		this.name = baseType.name();
+		this.baseType = baseType;
+		this.hash = Objects.hash(name, baseType);
+	}
+
+	public TaxiTaskType(String name, @Nullable TaxiTaskBaseType baseType) {
+		this.name = name;
+		this.baseType = baseType;
+		this.hash = Objects.hash(name, baseType);
+	}
+
+	public final String name() {
+		return name;
+	}
+
+	@Nullable
+	public final TaxiTaskBaseType getBaseType() {
+		return baseType;
+	}
+
+	@Override
+	public final boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof TaxiTaskType)) {
+			return false;
+		}
+		TaxiTaskType taskType = (TaxiTaskType)o;
+		return hash == taskType.hash && baseType == taskType.baseType && Objects.equals(name, taskType.name);
+	}
+
+	@Override
+	public final int hashCode() {
+		return hash;
+	}
+
+	@Override
+	public String toString() {
+		return MoreObjects.toStringHelper(this).add("name", name).add("baseType", baseType).toString();
+	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiTaskTypes.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiTaskTypes.java
@@ -20,12 +20,14 @@
 
 package org.matsim.contrib.taxi.schedule;
 
+import org.matsim.contrib.dvrp.schedule.Task;
+
 import com.google.common.collect.ImmutableList;
 
 /**
  * @author Michal Maciejewski (michalm)
  */
 public class TaxiTaskTypes {
-	public static final ImmutableList<TaxiTaskType> DEFAULT_TAXI_TYPES = ImmutableList.of(TaxiEmptyDriveTask.TYPE,
+	public static final ImmutableList<Task.TaskType> DEFAULT_TAXI_TYPES = ImmutableList.of(TaxiEmptyDriveTask.TYPE,
 			TaxiPickupTask.TYPE, TaxiOccupiedDriveTask.TYPE, TaxiDropoffTask.TYPE, TaxiStayTask.TYPE);
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiTaskTypes.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiTaskTypes.java
@@ -1,9 +1,9 @@
-/* *********************************************************************** *
+/*
+ * *********************************************************************** *
  * project: org.matsim.*
- *                                                                         *
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2013 by the members listed in the COPYING,        *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -15,23 +15,17 @@
  *   (at your option) any later version.                                   *
  *   See also COPYING, LICENSE and WARRANTY file                           *
  *                                                                         *
- * *********************************************************************** */
+ * *********************************************************************** *
+ */
 
 package org.matsim.contrib.taxi.schedule;
 
-import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.OCCUPIED_DRIVE;
+import com.google.common.collect.ImmutableList;
 
-import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
-import org.matsim.contrib.dvrp.schedule.DriveTask;
-import org.matsim.contrib.taxi.passenger.TaxiRequest;
-
-public class TaxiOccupiedDriveTask extends DriveTask {
-	public static final TaxiTaskType TYPE = new TaxiTaskType(OCCUPIED_DRIVE);
-
-	public TaxiOccupiedDriveTask(VrpPathWithTravelData path, TaxiRequest request) {
-		super(TYPE, path);
-		if (request.getFromLink() != path.getFromLink() && request.getToLink() != path.getToLink()) {
-			throw new IllegalArgumentException();
-		}
-	}
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class TaxiTaskTypes {
+	public static final ImmutableList<TaxiTaskType> DEFAULT_TAXI_TYPES = ImmutableList.of(TaxiEmptyDriveTask.TYPE,
+			TaxiPickupTask.TYPE, TaxiOccupiedDriveTask.TYPE, TaxiDropoffTask.TYPE, TaxiStayTask.TYPE);
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/scheduler/TaxiStayTaskEndTimeCalculator.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/scheduler/TaxiStayTaskEndTimeCalculator.java
@@ -19,6 +19,7 @@
 package org.matsim.contrib.taxi.scheduler;
 
 import static org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater.REMOVE_STAY_TASK;
+import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.getBaseType;
 
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
@@ -26,7 +27,6 @@ import org.matsim.contrib.dvrp.schedule.Schedules;
 import org.matsim.contrib.dvrp.schedule.StayTask;
 import org.matsim.contrib.taxi.run.TaxiConfigGroup;
 import org.matsim.contrib.taxi.schedule.TaxiPickupTask;
-import org.matsim.contrib.taxi.schedule.TaxiTaskType;
 
 public class TaxiStayTaskEndTimeCalculator implements ScheduleTimingUpdater.StayTaskEndTimeCalculator {
 
@@ -38,7 +38,7 @@ public class TaxiStayTaskEndTimeCalculator implements ScheduleTimingUpdater.Stay
 
 	@Override
 	public double calcNewEndTime(DvrpVehicle vehicle, StayTask task, double newBeginTime) {
-		switch (((TaxiTaskType)task.getTaskType())) {
+		switch (getBaseType(task)) {
 			case STAY: {
 				if (Schedules.getLastTask(vehicle.getSchedule()).equals(task)) {// last task
 					// even if endTime=beginTime, do not remove this task!!! A DRT schedule should end with WAIT

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/util/chart/TaxiScheduleCharts.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/util/chart/TaxiScheduleCharts.java
@@ -1,5 +1,7 @@
 package org.matsim.contrib.taxi.util.chart;
 
+import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.*;
+
 import java.awt.Color;
 import java.util.Collection;
 
@@ -10,7 +12,7 @@ import org.matsim.contrib.dvrp.util.chart.ScheduleCharts.DescriptionCreator;
 import org.matsim.contrib.dvrp.util.chart.ScheduleCharts.PaintSelector;
 import org.matsim.contrib.taxi.schedule.TaxiDropoffTask;
 import org.matsim.contrib.taxi.schedule.TaxiPickupTask;
-import org.matsim.contrib.taxi.schedule.TaxiTaskType;
+import org.matsim.contrib.taxi.schedule.TaxiTaskBaseType;
 
 public class TaxiScheduleCharts {
 	public static JFreeChart chartSchedule(Collection<? extends DvrpVehicle> vehicles) {
@@ -20,10 +22,11 @@ public class TaxiScheduleCharts {
 	public static final DescriptionCreator TAXI_DESCRIPTION_CREATOR = task -> task.getTaskType() + "";
 
 	public static final DescriptionCreator TAXI_DESCRIPTION_WITH_PASSENGER_ID_CREATOR = task -> {
-		if (task.getTaskType() == TaxiTaskType.PICKUP) {
+		TaxiTaskBaseType baseType = getBaseType(task);
+		if (baseType == PICKUP) {
 			return task.getTaskType() + "_" + ((TaxiPickupTask)task).getRequest().getPassengerId();
 		}
-		if (task.getTaskType() == TaxiTaskType.DROPOFF) {
+		if (baseType == DROPOFF) {
 			return task.getTaskType() + "_" + ((TaxiDropoffTask)task).getRequest().getPassengerId();
 		}
 		return task.getTaskType() + "";
@@ -36,7 +39,7 @@ public class TaxiScheduleCharts {
 	private static final Color STAY_COLOR = new Color(0, 0, 100);
 
 	public static final PaintSelector TAXI_PAINT_SELECTOR = task -> {
-		switch (((TaxiTaskType)task.getTaskType())) {
+		switch (getBaseType(task)) {
 			case PICKUP:
 			case DROPOFF:
 				return PICKUP_DROPOFF_COLOR;

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/util/stats/TaxiStatsCalculator.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/util/stats/TaxiStatsCalculator.java
@@ -96,7 +96,7 @@ public class TaxiStatsCalculator {
 
 	private static double sumBaseTaskTypeDurations(Map<TaskType, Double> taskTypeDurations, TaxiTaskBaseType baseType) {
 		return EntryStream.of(taskTypeDurations)
-				.filterKeys(taskType -> ((TaxiTaskType)taskType).getBaseType() == baseType)
+				.filterKeys(taskType -> ((TaxiTaskType)taskType).getBaseType().orElse(null) == baseType)
 				.mapToDouble(Map.Entry::getValue)
 				.sum();
 	}

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/util/stats/TaxiStatsCalculator.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/util/stats/TaxiStatsCalculator.java
@@ -19,6 +19,8 @@
 
 package org.matsim.contrib.taxi.util.stats;
 
+import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.*;
+
 import java.util.Collection;
 import java.util.Map;
 import java.util.OptionalDouble;
@@ -26,16 +28,16 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
-import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.contrib.dvrp.schedule.Task.TaskType;
 import org.matsim.contrib.taxi.passenger.TaxiRequest;
 import org.matsim.contrib.taxi.schedule.TaxiPickupTask;
+import org.matsim.contrib.taxi.schedule.TaxiTaskBaseType;
 import org.matsim.contrib.taxi.schedule.TaxiTaskType;
 import org.matsim.contrib.util.stats.DurationStats;
 
 import com.google.common.collect.ImmutableList;
 
-import one.util.streamex.StreamEx;
+import one.util.streamex.EntryStream;
 
 public class TaxiStatsCalculator {
 	public static final String DAILY_STATS_ID = "daily";
@@ -75,21 +77,28 @@ public class TaxiStatsCalculator {
 	}
 
 	static OptionalDouble calculateEmptyDriveRatio(Map<TaskType, Double> taskTypeDurations) {
-		double empty = taskTypeDurations.getOrDefault(TaxiTaskType.EMPTY_DRIVE, 0.);
-		double occupied = taskTypeDurations.getOrDefault(TaxiTaskType.OCCUPIED_DRIVE, 0.);
+		double empty = sumBaseTaskTypeDurations(taskTypeDurations, EMPTY_DRIVE);
+		double occupied = sumBaseTaskTypeDurations(taskTypeDurations, OCCUPIED_DRIVE);
 		return (empty != 0 || occupied != 0) ? OptionalDouble.of(empty / (empty + occupied)) : OptionalDouble.empty();
 	}
 
 	static OptionalDouble calculateStayRatio(Map<TaskType, Double> taskTypeDurations) {
+		double stay = sumBaseTaskTypeDurations(taskTypeDurations, STAY);
 		double total = taskTypeDurations.values().stream().mapToDouble(Double::doubleValue).sum();
-		Double stay = taskTypeDurations.getOrDefault(TaxiTaskType.STAY, 0.);
 		return total != 0 ? OptionalDouble.of(stay / total) : OptionalDouble.empty();
 	}
 
 	static OptionalDouble calculateOccupiedDriveRatio(Map<TaskType, Double> taskTypeDurations) {
+		double occupied = sumBaseTaskTypeDurations(taskTypeDurations, OCCUPIED_DRIVE);
 		double total = taskTypeDurations.values().stream().mapToDouble(Double::doubleValue).sum();
-		double occupied = taskTypeDurations.getOrDefault(TaxiTaskType.OCCUPIED_DRIVE, 0.);
 		return total != 0 ? OptionalDouble.of(occupied / total) : OptionalDouble.empty();
+	}
+
+	private static double sumBaseTaskTypeDurations(Map<TaskType, Double> taskTypeDurations, TaxiTaskBaseType baseType) {
+		return EntryStream.of(taskTypeDurations)
+				.filterKeys(taskType -> ((TaxiTaskType)taskType).getBaseType() == baseType)
+				.mapToDouble(Map.Entry::getValue)
+				.sum();
 	}
 
 	private static void updateTaskDurations(TaxiStats stats, Map<TaskType, Double> taskTypeDurations) {
@@ -98,12 +107,12 @@ public class TaxiStatsCalculator {
 	}
 
 	private void updatePassengerWaitTimeStats(DvrpVehicle vehicle) {
-		for (Task task : StreamEx.of(vehicle.getSchedule().tasks()).filterBy(Task::getTaskType, TaxiTaskType.PICKUP)) {
+		vehicle.getSchedule().tasks().filter(task -> getBaseType(task) == PICKUP).forEach(task -> {
 			TaxiRequest req = ((TaxiPickupTask)task).getRequest();
 			double waitTime = Math.max(task.getBeginTime() - req.getEarliestStartTime(), 0);
 			int hour = (int)(req.getEarliestStartTime() / 3600);
 			getHourlyStats(hour).passengerWaitTime.addValue(waitTime);
 			dailyStats.passengerWaitTime.addValue(waitTime);
-		}
+		});
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/util/stats/TaxiStatsDumper.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/util/stats/TaxiStatsDumper.java
@@ -19,6 +19,8 @@
 
 package org.matsim.contrib.taxi.util.stats;
 
+import static org.matsim.contrib.taxi.schedule.TaxiTaskTypes.DEFAULT_TAXI_TYPES;
+
 import java.util.List;
 
 import org.matsim.contrib.dvrp.fleet.Fleet;
@@ -96,8 +98,7 @@ public class TaxiStatsDumper implements ShutdownListener, MobsimBeforeCleanupLis
 
 	private void writeDetailedStats(List<TaxiStats> taxiStats, int iteration) {
 		String prefix = controlerIO.getIterationFilename(iteration, "taxi_");
-
-		new TaxiStatsWriter(taxiStats).write(prefix + "stats_" + taxiCfg.getMode() + ".txt");
+		new TaxiStatsWriter(taxiStats, DEFAULT_TAXI_TYPES).write(prefix + "stats_" + taxiCfg.getMode() + ".txt");
 		new TaxiHistogramsWriter(taxiStats).write(prefix + "histograms_" + taxiCfg.getMode() + ".txt");
 	}
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/util/stats/TaxiStatsDumper.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/util/stats/TaxiStatsDumper.java
@@ -19,8 +19,6 @@
 
 package org.matsim.contrib.taxi.util.stats;
 
-import static org.matsim.contrib.taxi.schedule.TaxiTaskTypes.DEFAULT_TAXI_TYPES;
-
 import java.util.List;
 
 import org.matsim.contrib.dvrp.fleet.Fleet;
@@ -98,7 +96,7 @@ public class TaxiStatsDumper implements ShutdownListener, MobsimBeforeCleanupLis
 
 	private void writeDetailedStats(List<TaxiStats> taxiStats, int iteration) {
 		String prefix = controlerIO.getIterationFilename(iteration, "taxi_");
-		new TaxiStatsWriter(taxiStats, DEFAULT_TAXI_TYPES).write(prefix + "stats_" + taxiCfg.getMode() + ".txt");
+		new TaxiStatsWriter(taxiStats).write(prefix + "stats_" + taxiCfg.getMode() + ".txt");
 		new TaxiHistogramsWriter(taxiStats).write(prefix + "histograms_" + taxiCfg.getMode() + ".txt");
 	}
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/util/stats/TaxiStatsWriter.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/util/stats/TaxiStatsWriter.java
@@ -27,11 +27,15 @@ import org.matsim.contrib.util.CSVLineBuilder;
 import org.matsim.contrib.util.CompactCSVWriter;
 import org.matsim.core.utils.io.IOUtils;
 
+import com.google.common.collect.ImmutableList;
+
 public class TaxiStatsWriter {
 	private final List<TaxiStats> taxiStats;
+	private final ImmutableList<TaxiTaskType> taskTypes;
 
-	public TaxiStatsWriter(List<TaxiStats> taxiStats) {
+	public TaxiStatsWriter(List<TaxiStats> taxiStats, ImmutableList<TaxiTaskType> taskTypes) {
 		this.taxiStats = taxiStats;
+		this.taskTypes = taskTypes;
 	}
 
 	public void write(String file) {
@@ -104,14 +108,14 @@ public class TaxiStatsWriter {
 	private void writeTaskTypeSums(CompactCSVWriter writer) {
 		writer.writeNext("Total duration of tasks by type [h]");
 		CSVLineBuilder headerBuilder = new CSVLineBuilder().add("hour");
-		for (TaxiTaskType t : TaxiTaskType.values()) {
+		for (TaxiTaskType t : taskTypes) {
 			headerBuilder.add(t.name());
 		}
 		writer.writeNext(headerBuilder.add("all"));
 
 		for (TaxiStats s : taxiStats) {
 			CSVLineBuilder lineBuilder = new CSVLineBuilder().add(s.id);
-			for (TaxiTaskType t : TaxiTaskType.values()) {
+			for (TaxiTaskType t : taskTypes) {
 				lineBuilder.addf("%.2f", s.taskTypeDurations.getOrDefault(t, 0.) / 3600);
 			}
 			lineBuilder.addf("%.2f", s.calculateTotalDuration() / 3600);

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/util/stats/TaxiStatusTimeProfileCollectorProvider.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/util/stats/TaxiStatusTimeProfileCollectorProvider.java
@@ -19,6 +19,8 @@
 
 package org.matsim.contrib.taxi.util.stats;
 
+import static org.matsim.contrib.taxi.schedule.TaxiTaskTypes.DEFAULT_TAXI_TYPES;
+
 import java.awt.Color;
 
 import org.jfree.data.xy.DefaultTableXYDataset;
@@ -53,7 +55,7 @@ public class TaxiStatusTimeProfileCollectorProvider implements Provider<MobsimLi
 	@Override
 	public MobsimListener get() {
 		ProfileCalculator calc = TimeProfiles.combineProfileCalculators(
-				TaxiTimeProfiles.createCurrentTaxiTaskTypeCounter(fleet),
+				TaxiTimeProfiles.createCurrentTaxiTaskTypeCounter(fleet, DEFAULT_TAXI_TYPES),
 				TaxiTimeProfiles.createRequestsWithStatusCounter(requestCollector.getRequests().values(),
 						TaxiRequestStatus.UNPLANNED));
 
@@ -74,9 +76,9 @@ public class TaxiStatusTimeProfileCollectorProvider implements Provider<MobsimLi
 		});
 
 		if (matsimServices.getConfig().controler().isCreateGraphs()) {
-		  collector.setChartTypes(ChartType.Line, ChartType.StackedArea);
+			collector.setChartTypes(ChartType.Line, ChartType.StackedArea);
 		} else {
-		  collector.setChartTypes();
+			collector.setChartTypes();
 		}
 		return collector;
 	}

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/util/stats/TaxiStatusTimeProfileCollectorProvider.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/util/stats/TaxiStatusTimeProfileCollectorProvider.java
@@ -19,11 +19,10 @@
 
 package org.matsim.contrib.taxi.util.stats;
 
-import static org.matsim.contrib.taxi.schedule.TaxiTaskTypes.DEFAULT_TAXI_TYPES;
-
 import java.awt.Color;
 
 import org.jfree.data.xy.DefaultTableXYDataset;
+import org.jfree.data.xy.XYSeries;
 import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.taxi.passenger.SubmittedTaxiRequestsCollector;
 import org.matsim.contrib.taxi.passenger.TaxiRequest.TaxiRequestStatus;
@@ -55,7 +54,7 @@ public class TaxiStatusTimeProfileCollectorProvider implements Provider<MobsimLi
 	@Override
 	public MobsimListener get() {
 		ProfileCalculator calc = TimeProfiles.combineProfileCalculators(
-				TaxiTimeProfiles.createCurrentTaxiTaskTypeCounter(fleet, DEFAULT_TAXI_TYPES),
+				TaxiTimeProfiles.createCurrentTaxiTaskTypeCounter(fleet),
 				TaxiTimeProfiles.createRequestsWithStatusCounter(requestCollector.getRequests().values(),
 						TaxiRequestStatus.UNPLANNED));
 
@@ -68,10 +67,17 @@ public class TaxiStatusTimeProfileCollectorProvider implements Provider<MobsimLi
 					new Color(237, 125, 49), // PICKUP
 					new Color(165, 165, 165), // OCCUPIED_DRIVE
 					new Color(255, 192, 0), // DROPOFF
-					new Color(112, 173, 71), // STAY
-					new Color(37, 94, 145)); // UNPLANNED (requests)
+					new Color(112, 173, 71)); // STAY
+			DefaultTableXYDataset dataset = ((DefaultTableXYDataset)chart.getXYPlot().getDataset());
+
 			if (chartType == ChartType.StackedArea) {
-				((DefaultTableXYDataset)chart.getXYPlot().getDataset()).removeSeries(5);
+				// remove UNPLANNED
+				dataset.removeSeries(5);
+			} else {
+				// move UNPLANNED to the end
+				XYSeries unplannedSeries = dataset.getSeries(5);
+				dataset.removeSeries(5);
+				dataset.addSeries(unplannedSeries);
 			}
 		});
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/util/stats/TaxiTimeProfiles.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/util/stats/TaxiTimeProfiles.java
@@ -29,9 +29,10 @@ import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.optimizer.Request;
 import org.matsim.contrib.dvrp.schedule.Schedule.ScheduleStatus;
 import org.matsim.contrib.dvrp.schedule.ScheduleInquiry;
+import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.contrib.taxi.passenger.TaxiRequest.TaxiRequestStatus;
 import org.matsim.contrib.taxi.passenger.TaxiRequests;
-import org.matsim.contrib.taxi.schedule.TaxiTaskType;
+import org.matsim.contrib.taxi.schedule.TaxiTaskTypes;
 import org.matsim.contrib.util.timeprofile.TimeProfileCollector.ProfileCalculator;
 import org.matsim.contrib.util.timeprofile.TimeProfiles;
 
@@ -44,9 +45,10 @@ public class TaxiTimeProfiles {
 				() -> fleet.getVehicles().values().stream().filter(scheduleInquiry::isIdle).count());
 	}
 
-	public static ProfileCalculator createCurrentTaxiTaskTypeCounter(final Fleet fleet,
-			ImmutableList<TaxiTaskType> taskTypes) {
-		ImmutableList<String> header = taskTypes.stream().map(TaxiTaskType::name).collect(toImmutableList());
+	public static ProfileCalculator createCurrentTaxiTaskTypeCounter(final Fleet fleet) {
+		ImmutableList<String> header = TaxiTaskTypes.DEFAULT_TAXI_TYPES.stream()
+				.map(Task.TaskType::name)
+				.collect(toImmutableList());
 		return TimeProfiles.createProfileCalculator(header, () -> calculateTaxiTaskTypeCounts(fleet));
 	}
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/util/stats/TaxiTimeProfiles.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/util/stats/TaxiTimeProfiles.java
@@ -20,21 +20,15 @@
 package org.matsim.contrib.taxi.util.stats;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static java.util.stream.Collectors.counting;
-import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.*;
 
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Map;
-import java.util.Objects;
 
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.optimizer.Request;
 import org.matsim.contrib.dvrp.schedule.Schedule.ScheduleStatus;
 import org.matsim.contrib.dvrp.schedule.ScheduleInquiry;
-import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.contrib.taxi.passenger.TaxiRequest.TaxiRequestStatus;
 import org.matsim.contrib.taxi.passenger.TaxiRequests;
 import org.matsim.contrib.taxi.schedule.TaxiTaskType;
@@ -50,23 +44,21 @@ public class TaxiTimeProfiles {
 				() -> fleet.getVehicles().values().stream().filter(scheduleInquiry::isIdle).count());
 	}
 
-	public static ProfileCalculator createCurrentTaxiTaskTypeCounter(final Fleet fleet) {
-		ImmutableList<String> header = Arrays.stream(TaxiTaskType.values())
-				.map(Objects::toString)
-				.collect(toImmutableList());
+	public static ProfileCalculator createCurrentTaxiTaskTypeCounter(final Fleet fleet,
+			ImmutableList<TaxiTaskType> taskTypes) {
+		ImmutableList<String> header = taskTypes.stream().map(TaxiTaskType::name).collect(toImmutableList());
 		return TimeProfiles.createProfileCalculator(header, () -> calculateTaxiTaskTypeCounts(fleet));
 	}
 
 	public static ImmutableMap<String, Double> calculateTaxiTaskTypeCounts(Fleet fleet) {
-		Map<Task.TaskType, Long> countsByType = fleet.getVehicles()
+		return fleet.getVehicles()
 				.values()
 				.stream()
 				.map(DvrpVehicle::getSchedule)
 				.filter(schedule -> schedule.getStatus() == ScheduleStatus.STARTED)
-				.collect(groupingBy(schedule -> schedule.getCurrentTask().getTaskType(), counting()));
-
-		return Arrays.stream(TaxiTaskType.values())
-				.collect(toImmutableMap(Enum::name, type -> (double)countsByType.getOrDefault(type, 0L)));
+				.collect(collectingAndThen(
+						groupingBy(schedule -> schedule.getCurrentTask().getTaskType().name(), summingDouble(e -> 1)),
+						ImmutableMap::copyOf));
 	}
 
 	public static ProfileCalculator createRequestsWithStatusCounter(final Collection<? extends Request> requests,

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/vrpagent/TaxiActionCreator.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/vrpagent/TaxiActionCreator.java
@@ -19,6 +19,8 @@
 
 package org.matsim.contrib.taxi.vrpagent;
 
+import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.getBaseType;
+
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.passenger.PassengerEngine;
 import org.matsim.contrib.dvrp.passenger.SinglePassengerDropoffActivity;
@@ -34,7 +36,6 @@ import org.matsim.contrib.dynagent.IdleDynActivity;
 import org.matsim.contrib.taxi.run.TaxiConfigGroup;
 import org.matsim.contrib.taxi.schedule.TaxiDropoffTask;
 import org.matsim.contrib.taxi.schedule.TaxiPickupTask;
-import org.matsim.contrib.taxi.schedule.TaxiTaskType;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 
 /**
@@ -64,7 +65,7 @@ public class TaxiActionCreator implements VrpAgentLogic.DynActionCreator {
 	@Override
 	public DynAction createAction(DynAgent dynAgent, DvrpVehicle vehicle, double now) {
 		Task task = vehicle.getSchedule().getCurrentTask();
-		switch (((TaxiTaskType)task.getTaskType())) {
+		switch (getBaseType(task)) {
 			case EMPTY_DRIVE:
 			case OCCUPIED_DRIVE:
 				return legFactory.create(vehicle);


### PR DESCRIPTION
The motivation is to have a sealed original set of taxi sets, but at the same time being able to add new task types.

**Background:** The standard taxi optimisers operate on the fixed pre-defined set of tasks: `EMPTY_DRIVE`, `PICKUP`, `OCCUPIED_DRIVE`, `DROPOFF` and `STAY`. Using enums to represent task types has lots of advantages (type safety, efficient `switch` statements and `switch` expressions from Java 12), and one big drawback: this set cannot be extended (by adding new task types). So whenever we add a new task class (e.g. charging task) we need assign it one of the existing types (e.g. `STAY` for the charging task) and be very careful to override the handling for this specific task class. 

**Solution:**
1. Make `TaxiTaskType` an extendable class (so we can add charging tasks, for instance)
2. Create an enum type `TaxiTaskBaseType` that contains the limited set of base types that are understood by the standard taxi optimisers
3. Create non-standard types, such as the aforementioned charging task
4. Assign each `TaxiTaskType` a `TaxiTaskBaseType` or null (if they need a special handling).
5. Adapt the standard taxi optimisation algorithms to use the (sealed) base types for handling tasks. Tasks without the assigned base type will not be handled by the standard algorithms (an exception will be raised in order to avoid incorrect/fragile/ill-defined behaviour).
