### PR TITLE
Extendable drt task types

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/VehicleDataEntryFactoryImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/VehicleDataEntryFactoryImpl.java
@@ -18,6 +18,9 @@
 
 package org.matsim.contrib.drt.optimizer;
 
+import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.STOP;
+import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.getBaseType;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,7 +31,6 @@ import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtDriveTask;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
 import org.matsim.contrib.drt.schedule.DrtStopTask;
-import org.matsim.contrib.drt.schedule.DrtTaskType;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.schedule.Schedule;
 import org.matsim.contrib.dvrp.schedule.Schedule.ScheduleStatus;
@@ -63,7 +65,7 @@ public class VehicleDataEntryFactoryImpl implements EntryFactory {
 		int nextTaskIdx;
 		if (schedule.getStatus() == ScheduleStatus.STARTED) {
 			startTask = schedule.getCurrentTask();
-			switch (((DrtTaskType)startTask.getTaskType())) {
+			switch (getBaseType(startTask)) {
 				case DRIVE:
 					DrtDriveTask driveTask = (DrtDriveTask)startTask;
 					LinkTimePair diversionPoint = ((OnlineDriveTaskTracker)driveTask.getTaskTracker()).getDiversionPoint();
@@ -97,7 +99,7 @@ public class VehicleDataEntryFactoryImpl implements EntryFactory {
 		List<? extends Task> tasks = schedule.getTasks();
 		List<DrtStopTask> stopTasks = new ArrayList<>();
 		for (Task task : tasks.subList(nextTaskIdx, tasks.size())) {
-			if (task.getTaskType() == DrtTaskType.STOP) {
+			if (STOP.isBaseTypeOf(task)) {
 				stopTasks.add((DrtStopTask)task);
 			}
 		}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/depot/Depots.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/depot/Depots.java
@@ -19,12 +19,14 @@
 
 package org.matsim.contrib.drt.optimizer.depot;
 
+import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.STAY;
+import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.STOP;
+
 import java.util.Comparator;
 import java.util.Set;
 
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
-import org.matsim.contrib.drt.schedule.DrtTaskType;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.schedule.Schedule;
 import org.matsim.contrib.dvrp.schedule.Schedule.ScheduleStatus;
@@ -45,13 +47,13 @@ public class Depots {
 
 		// current task is STAY
 		Task currentTask = schedule.getCurrentTask();
-		if (currentTask.getTaskType() != DrtTaskType.STAY) {
+		if (!STAY.isBaseTypeOf(currentTask)) {
 			return false;
 		}
 
 		// previous task was STOP
 		int previousTaskIdx = currentTask.getTaskIdx() - 1;
-		return (previousTaskIdx >= 0 && schedule.getTasks().get(previousTaskIdx).getTaskType() == DrtTaskType.STOP);
+		return (previousTaskIdx >= 0 && STOP.isBaseTypeOf(schedule.getTasks().get(previousTaskIdx)));
 	}
 
 	public static Link findStraightLineNearestDepot(DvrpVehicle vehicle, Set<Link> links) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculator.java
@@ -19,6 +19,8 @@
 
 package org.matsim.contrib.drt.optimizer.insertion;
 
+import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.STOP;
+
 import java.util.function.DoubleSupplier;
 import java.util.function.ToDoubleFunction;
 
@@ -31,7 +33,6 @@ import org.matsim.contrib.drt.routing.DefaultDrtRouteUpdater;
 import org.matsim.contrib.drt.routing.DrtRouteCreator;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
-import org.matsim.contrib.drt.schedule.DrtTaskType;
 import org.matsim.contrib.dvrp.schedule.Schedule;
 import org.matsim.contrib.dvrp.schedule.Schedule.ScheduleStatus;
 import org.matsim.contrib.dvrp.schedule.Schedules;
@@ -126,9 +127,8 @@ public class InsertionCostCalculator<D> {
 
 		// 'no detour' is also possible now for pickupIdx==0 if the currentTask is STOP
 		Schedule schedule = vEntry.vehicle.getSchedule();
-		boolean ongoingStopTask = pickupIdx == 0
-				&& schedule.getStatus() == ScheduleStatus.STARTED
-				&& schedule.getCurrentTask().getTaskType() == DrtTaskType.STOP;
+		boolean ongoingStopTask = pickupIdx == 0 && schedule.getStatus() == ScheduleStatus.STARTED//
+				&& STOP.isBaseTypeOf(schedule.getCurrentTask());
 
 		Link pickupPreviousLink = insertion.getPickup().previousLink;
 		if ((ongoingStopTask && drtRequest.getFromLink() == pickupPreviousLink) //

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtDriveTask.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtDriveTask.java
@@ -19,6 +19,8 @@
 
 package org.matsim.contrib.drt.schedule;
 
+import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.DRIVE;
+
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.schedule.DriveTask;
 
@@ -26,7 +28,9 @@ import org.matsim.contrib.dvrp.schedule.DriveTask;
  * @author michalm
  */
 public class DrtDriveTask extends DriveTask {
+	public static final DrtTaskType TYPE = new DrtTaskType(DRIVE);
+
 	public DrtDriveTask(VrpPathWithTravelData path) {
-		super(DrtTaskType.DRIVE, path);
+		super(TYPE, path);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtDriveTask.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtDriveTask.java
@@ -30,7 +30,7 @@ import org.matsim.contrib.dvrp.schedule.DriveTask;
 public class DrtDriveTask extends DriveTask {
 	public static final DrtTaskType TYPE = new DrtTaskType(DRIVE);
 
-	public DrtDriveTask(VrpPathWithTravelData path) {
-		super(TYPE, path);
+	public DrtDriveTask(VrpPathWithTravelData path, DrtTaskType taskType) {
+		super(taskType, path);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtStayTaskEndTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtStayTaskEndTimeCalculator.java
@@ -18,6 +18,7 @@
 
 package org.matsim.contrib.drt.schedule;
 
+import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.getBaseType;
 import static org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater.REMOVE_STAY_TASK;
 
 import org.matsim.contrib.drt.passenger.DrtRequest;
@@ -37,7 +38,7 @@ public class DrtStayTaskEndTimeCalculator implements ScheduleTimingUpdater.StayT
 
 	@Override
 	public double calcNewEndTime(DvrpVehicle vehicle, StayTask task, double newBeginTime) {
-		switch (((DrtTaskType)task.getTaskType())) {
+		switch (getBaseType(task)) {
 			case STAY: {
 				if (Schedules.getLastTask(vehicle.getSchedule()).equals(task)) {// last task
 					// even if endTime=beginTime, do not remove this task!!! A DRT schedule should end with WAIT

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtStopTask.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtStopTask.java
@@ -19,6 +19,8 @@
 
 package org.matsim.contrib.drt.schedule;
 
+import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.STOP;
+
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -39,11 +41,13 @@ import com.google.common.base.MoreObjects;
  * @author michalm
  */
 public class DrtStopTask extends StayTask {
+	public static final DrtTaskType TYPE = new DrtTaskType(STOP);
+
 	private final Map<Id<Request>, DrtRequest> dropoffRequests = new LinkedHashMap<>();
 	private final Map<Id<Request>, DrtRequest> pickupRequests = new LinkedHashMap<>();
 
 	public DrtStopTask(double beginTime, double endTime, Link link) {
-		super(DrtTaskType.STOP, beginTime, endTime, link);
+		super(TYPE, beginTime, endTime, link);
 	}
 
 	/**

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtTaskBaseType.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtTaskBaseType.java
@@ -1,9 +1,9 @@
-/* *********************************************************************** *
+/*
+ * *********************************************************************** *
  * project: org.matsim.*
- *                                                                         *
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2013 by the members listed in the COPYING,        *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -15,22 +15,26 @@
  *   (at your option) any later version.                                   *
  *   See also COPYING, LICENSE and WARRANTY file                           *
  *                                                                         *
- * *********************************************************************** */
+ * *********************************************************************** *
+ */
 
 package org.matsim.contrib.drt.schedule;
 
-import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.STAY;
-
-import org.matsim.api.core.v01.network.Link;
-import org.matsim.contrib.dvrp.schedule.StayTask;
+import org.matsim.contrib.dvrp.schedule.Task;
 
 /**
- * @author michalm
+ * @author Michal Maciejewski (michalm)
  */
-public class DrtStayTask extends StayTask {
-	public static final DrtTaskType TYPE = new DrtTaskType(STAY);
+public enum DrtTaskBaseType {
+	STAY, // idle
+	STOP, // stopped to drop off and pick up passengers
+	DRIVE; // driving with/without passengers
 
-	public DrtStayTask(double beginTime, double endTime, Link link) {
-		super(TYPE, beginTime, endTime, link);
+	public static DrtTaskBaseType getBaseType(Task task) {
+		return ((DrtTaskType)task.getTaskType()).getBaseType().get();
+	}
+
+	public boolean isBaseTypeOf(Task task) {
+		return ((DrtTaskType)task.getTaskType()).getBaseType().orElse(null) == this;
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtTaskFactory.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtTaskFactory.java
@@ -26,7 +26,7 @@ import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
  * @author michalm
  */
 public interface DrtTaskFactory {
-	DrtDriveTask createDriveTask(DvrpVehicle vehicle, VrpPathWithTravelData path);
+	DrtDriveTask createDriveTask(DvrpVehicle vehicle, VrpPathWithTravelData path, DrtTaskType drtTaskType);
 
 	DrtStopTask createStopTask(DvrpVehicle vehicle, double beginTime, double endTime, Link link);
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtTaskFactoryImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtTaskFactoryImpl.java
@@ -27,8 +27,8 @@ import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
  */
 public class DrtTaskFactoryImpl implements DrtTaskFactory {
 	@Override
-	public DrtDriveTask createDriveTask(DvrpVehicle vehicle, VrpPathWithTravelData path) {
-		return new DrtDriveTask(path);
+	public DrtDriveTask createDriveTask(DvrpVehicle vehicle, VrpPathWithTravelData path, DrtTaskType taskType) {
+		return new DrtDriveTask(path, taskType);
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtTaskType.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtTaskType.java
@@ -20,13 +20,66 @@
 
 package org.matsim.contrib.drt.schedule;
 
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
 import org.matsim.contrib.dvrp.schedule.Task;
+
+import com.google.common.base.MoreObjects;
 
 /**
  * @author Michal Maciejewski (michalm)
  */
-public enum DrtTaskType implements Task.TaskType {
-	STAY, // idle
-	STOP, // stopped to drop off and pick up passengers
-	DRIVE // driving with/without passengers
+public class DrtTaskType implements Task.TaskType {
+
+	private final String name;
+
+	// can be empty if the task type requires a special handling which is not provided by the standard DRT algorithms
+	private final Optional<DrtTaskBaseType> baseType;
+
+	private final int hash;
+
+	public DrtTaskType(@NotNull DrtTaskBaseType baseType) {
+		this.name = baseType.name();
+		this.baseType = Optional.of(baseType);
+		this.hash = Objects.hash(name, baseType);
+	}
+
+	public DrtTaskType(String name, @Nullable DrtTaskBaseType baseType) {
+		this.name = name;
+		this.baseType = Optional.ofNullable(baseType);
+		this.hash = Objects.hash(name, baseType);
+	}
+
+	@Override
+	public final String name() {
+		return name;
+	}
+
+	public final Optional<DrtTaskBaseType> getBaseType() {
+		return baseType;
+	}
+
+	@Override
+	public final boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (!(o instanceof DrtTaskType))
+			return false;
+		DrtTaskType that = (DrtTaskType)o;
+		return hash == that.hash && Objects.equals(baseType, that.baseType) && Objects.equals(name, that.name);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name, baseType, hash);
+	}
+
+	@Override
+	public String toString() {
+		return MoreObjects.toStringHelper(this).add("name", name).add("baseType", baseType).toString();
+	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DrtScheduleInquiry.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DrtScheduleInquiry.java
@@ -18,7 +18,8 @@
 
 package org.matsim.contrib.drt.scheduler;
 
-import org.matsim.contrib.drt.schedule.DrtTaskType;
+import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.STAY;
+
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.schedule.Schedule;
 import org.matsim.contrib.dvrp.schedule.Schedule.ScheduleStatus;
@@ -48,6 +49,6 @@ public class DrtScheduleInquiry implements ScheduleInquiry {
 
 		Task currentTask = schedule.getCurrentTask();
 		return currentTask.getTaskIdx() == schedule.getTaskCount() - 1 // last task (because no prebooking)
-				&& currentTask.getTaskType() == DrtTaskType.STAY;
+				&& STAY.isBaseTypeOf(currentTask);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/EmptyVehicleRelocator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/EmptyVehicleRelocator.java
@@ -19,10 +19,13 @@
 
 package org.matsim.contrib.drt.scheduler;
 
+import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.DRIVE;
+
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
 import org.matsim.contrib.drt.schedule.DrtTaskFactory;
+import org.matsim.contrib.drt.schedule.DrtTaskType;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.path.VrpPaths;
@@ -40,6 +43,8 @@ import com.google.inject.name.Named;
  * @author michalm
  */
 public class EmptyVehicleRelocator {
+	public static final DrtTaskType RELOCATE_VEHICLE_TASK_TYPE = new DrtTaskType("RELOCATE", DRIVE);
+
 	private final TravelTime travelTime;
 	private final MobsimTimer timer;
 	private final DrtTaskFactory taskFactory;
@@ -74,7 +79,7 @@ public class EmptyVehicleRelocator {
 		}
 
 		stayTask.setEndTime(vrpPath.getDepartureTime()); // finish STAY
-		schedule.addTask(taskFactory.createDriveTask(vehicle, vrpPath)); // add DRIVE
+		schedule.addTask(taskFactory.createDriveTask(vehicle, vrpPath, RELOCATE_VEHICLE_TASK_TYPE)); // add RELOCATE
 		// append STAY
 		schedule.addTask(taskFactory.createStayTask(vehicle, vrpPath.getArrivalTime(), vehicle.getServiceEndTime(),
 				vrpPath.getToLink()));

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/RequestInsertionScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/RequestInsertionScheduler.java
@@ -30,6 +30,7 @@ import org.matsim.contrib.drt.optimizer.VehicleData.Stop;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionWithDetourData;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.drt.schedule.DrtDriveTask;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
 import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.drt.schedule.DrtTaskFactory;
@@ -109,7 +110,7 @@ public class RequestInsertionScheduler {
 				if (request.getFromLink() != vehicleEntry.start.link) { // add a new drive task
 					VrpPathWithTravelData vrpPath = VrpPaths.createPath(vehicleEntry.start.link, request.getFromLink(),
 							vehicleEntry.start.time, insertion.getDetourToPickup(), travelTime);
-					beforePickupTask = taskFactory.createDriveTask(vehicleEntry.vehicle, vrpPath);
+					beforePickupTask = taskFactory.createDriveTask(vehicleEntry.vehicle, vrpPath, DrtDriveTask.TYPE);
 					schedule.addTask(currentTask.getTaskIdx() + 1, beforePickupTask);
 				} else { // no need for a new drive task
 					beforePickupTask = currentTask;
@@ -163,7 +164,8 @@ public class RequestInsertionScheduler {
 
 					VrpPathWithTravelData vrpPath = VrpPaths.createPath(request.getFromLink(), toLink,
 							stopTask.getEndTime(), insertion.getDetourFromPickup(), travelTime);
-					Task driveFromPickupTask = taskFactory.createDriveTask(vehicleEntry.vehicle, vrpPath);
+					Task driveFromPickupTask = taskFactory.createDriveTask(vehicleEntry.vehicle, vrpPath,
+							DrtDriveTask.TYPE);
 					schedule.addTask(stopTask.getTaskIdx() + 1, driveFromPickupTask);
 
 					// update timings
@@ -200,7 +202,7 @@ public class RequestInsertionScheduler {
 					// insert drive i->pickup
 					VrpPathWithTravelData vrpPath = VrpPaths.createPath(stayOrStopTask.getLink(), request.getFromLink(),
 							stayOrStopTask.getEndTime(), insertion.getDetourToPickup(), travelTime);
-					beforePickupTask = taskFactory.createDriveTask(vehicleEntry.vehicle, vrpPath);
+					beforePickupTask = taskFactory.createDriveTask(vehicleEntry.vehicle, vrpPath, DrtDriveTask.TYPE);
 					schedule.addTask(stayOrStopTask.getTaskIdx() + 1, beforePickupTask);
 				}
 			}
@@ -221,7 +223,7 @@ public class RequestInsertionScheduler {
 
 		VrpPathWithTravelData vrpPath = VrpPaths.createPath(request.getFromLink(), toLink, pickupStopTask.getEndTime(),
 				insertion.getDetourFromPickup(), travelTime);
-		Task driveFromPickupTask = taskFactory.createDriveTask(vehicleEntry.vehicle, vrpPath);
+		Task driveFromPickupTask = taskFactory.createDriveTask(vehicleEntry.vehicle, vrpPath, DrtDriveTask.TYPE);
 		schedule.addTask(taskIdx + 1, driveFromPickupTask);
 
 		// update timings
@@ -263,7 +265,7 @@ public class RequestInsertionScheduler {
 				// insert drive i->dropoff
 				VrpPathWithTravelData vrpPath = VrpPaths.createPath(stopTask.getLink(), request.getToLink(),
 						stopTask.getEndTime(), insertion.getDetourToDropoff(), travelTime);
-				driveToDropoffTask = taskFactory.createDriveTask(vehicleEntry.vehicle, vrpPath);
+				driveToDropoffTask = taskFactory.createDriveTask(vehicleEntry.vehicle, vrpPath, DrtDriveTask.TYPE);
 				schedule.addTask(stopTask.getTaskIdx() + 1, driveToDropoffTask);
 			}
 		}
@@ -295,7 +297,7 @@ public class RequestInsertionScheduler {
 
 			VrpPathWithTravelData vrpPath = VrpPaths.createPath(request.getToLink(), toLink, startTime + stopDuration,
 					insertion.getDetourFromDropoff(), travelTime);
-			Task driveFromDropoffTask = taskFactory.createDriveTask(vehicleEntry.vehicle, vrpPath);
+			Task driveFromDropoffTask = taskFactory.createDriveTask(vehicleEntry.vehicle, vrpPath, DrtDriveTask.TYPE);
 			schedule.addTask(taskIdx + 1, driveFromDropoffTask);
 
 			// update timings

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/RequestInsertionScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/RequestInsertionScheduler.java
@@ -19,6 +19,9 @@
 
 package org.matsim.contrib.drt.scheduler;
 
+import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.DRIVE;
+import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.STAY;
+
 import java.util.List;
 
 import org.matsim.api.core.v01.network.Link;
@@ -30,7 +33,6 @@ import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
 import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.drt.schedule.DrtTaskFactory;
-import org.matsim.contrib.drt.schedule.DrtTaskType;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
@@ -96,9 +98,7 @@ public class RequestInsertionScheduler {
 		Task currentTask = scheduleStatus == ScheduleStatus.PLANNED ? null : schedule.getCurrentTask();
 		Task beforePickupTask;
 
-		if (pickupIdx == 0
-				&& scheduleStatus != ScheduleStatus.PLANNED
-				&& currentTask.getTaskType() == DrtTaskType.DRIVE) {
+		if (pickupIdx == 0 && scheduleStatus != ScheduleStatus.PLANNED && DRIVE.isBaseTypeOf(currentTask)) {
 			LinkTimePair diversion = ((OnlineDriveTaskTracker)currentTask.getTaskTracker()).getDiversionPoint();
 			if (diversion != null) { // divert vehicle
 				beforePickupTask = currentTask;
@@ -122,7 +122,7 @@ public class RequestInsertionScheduler {
 				if (scheduleStatus == ScheduleStatus.PLANNED) {// PLANNED schedule
 					stayTask = (DrtStayTask)schedule.getTasks().get(0);
 					stayTask.setEndTime(stayTask.getBeginTime());// could get later removed with ScheduleTimingUpdater
-				} else if (currentTask.getTaskType() == DrtTaskType.STAY) {
+				} else if (STAY.isBaseTypeOf(currentTask)) {
 					stayTask = (DrtStayTask)currentTask; // ongoing stay task
 					double now = timer.getTimeOfDay();
 					if (stayTask.getEndTime() > now) { // stop stay task; a new stop/drive task can be inserted now

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/vrpagent/DrtActionCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/vrpagent/DrtActionCreator.java
@@ -19,8 +19,9 @@
 
 package org.matsim.contrib.drt.vrpagent;
 
+import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.getBaseType;
+
 import org.matsim.contrib.drt.schedule.DrtStopTask;
-import org.matsim.contrib.drt.schedule.DrtTaskType;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.passenger.BusStopActivity;
 import org.matsim.contrib.dvrp.passenger.PassengerEngine;
@@ -56,7 +57,7 @@ public class DrtActionCreator implements VrpAgentLogic.DynActionCreator {
 	@Override
 	public DynAction createAction(DynAgent dynAgent, DvrpVehicle vehicle, double now) {
 		Task task = vehicle.getSchedule().getCurrentTask();
-		switch (((DrtTaskType)task.getTaskType())) {
+		switch (getBaseType(task)) {
 			case DRIVE:
 				return legFactory.create(vehicle);
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/EDrtActionCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/EDrtActionCreator.java
@@ -35,6 +35,7 @@ import org.matsim.contrib.dynagent.DynAction;
 import org.matsim.contrib.dynagent.DynAgent;
 import org.matsim.contrib.edrt.schedule.EDrtChargingTask;
 import org.matsim.contrib.ev.dvrp.ChargingActivity;
+import org.matsim.contrib.ev.dvrp.ChargingTask;
 import org.matsim.contrib.ev.dvrp.EvDvrpVehicle;
 import org.matsim.contrib.ev.dvrp.tracker.OfflineETaskTracker;
 import org.matsim.contrib.ev.dvrp.tracker.OnlineEDriveTaskTracker;
@@ -55,9 +56,9 @@ public class EDrtActionCreator implements VrpAgentLogic.DynActionCreator {
 	@Override
 	public DynAction createAction(DynAgent dynAgent, DvrpVehicle vehicle, double now) {
 		Task task = vehicle.getSchedule().getCurrentTask();
-		if (task instanceof EDrtChargingTask) {
+		if (task.getTaskType().equals(EDrtChargingTask.TYPE)) {
 			task.initTaskTracker(new OfflineETaskTracker((EvDvrpVehicle)vehicle, timer));
-			return new ChargingActivity((EDrtChargingTask)task);
+			return new ChargingActivity((ChargingTask)task);
 		} else {
 			DynAction dynAction = drtActionCreator.createAction(dynAgent, vehicle, now);
 			if (task.getTaskTracker() == null) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/optimizer/EDrtVehicleDataEntryFactory.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/optimizer/EDrtVehicleDataEntryFactory.java
@@ -31,7 +31,7 @@ import org.matsim.contrib.dvrp.schedule.Schedule;
 import org.matsim.contrib.dvrp.schedule.Schedule.ScheduleStatus;
 import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.contrib.dvrp.schedule.Task.TaskStatus;
-import org.matsim.contrib.ev.dvrp.ChargingTask;
+import org.matsim.contrib.edrt.schedule.EDrtChargingTask;
 import org.matsim.contrib.ev.dvrp.ETask;
 import org.matsim.contrib.ev.dvrp.EvDvrpVehicle;
 import org.matsim.contrib.ev.dvrp.tracker.ETaskTracker;
@@ -71,7 +71,8 @@ public class EDrtVehicleDataEntryFactory implements EntryFactory {
 		int taskCount = schedule.getTaskCount();
 		if (taskCount > 1) {
 			Task oneBeforeLast = schedule.getTasks().get(taskCount - 2);
-			if (oneBeforeLast.getStatus() != TaskStatus.PERFORMED && oneBeforeLast instanceof ChargingTask) {
+			if (oneBeforeLast.getStatus() != TaskStatus.PERFORMED && oneBeforeLast.getTaskType()
+					.equals(EDrtChargingTask.TYPE)) {
 				return null;
 			}
 		}

--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/schedule/EDrtChargingTask.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/schedule/EDrtChargingTask.java
@@ -19,13 +19,13 @@
 
 package org.matsim.contrib.edrt.schedule;
 
-import org.matsim.contrib.drt.schedule.DrtTaskType;
+import org.matsim.contrib.drt.schedule.DrtStayTask;
 import org.matsim.contrib.ev.dvrp.ChargingTaskImpl;
 import org.matsim.contrib.ev.fleet.ElectricVehicle;
 import org.matsim.contrib.ev.infrastructure.Charger;
 
 public class EDrtChargingTask extends ChargingTaskImpl {
 	public EDrtChargingTask(double beginTime, double endTime, Charger charger, ElectricVehicle ev, double totalEnergy) {
-		super(DrtTaskType.STAY, beginTime, endTime, charger, ev, totalEnergy);
+		super(DrtStayTask.TYPE, beginTime, endTime, charger, ev, totalEnergy);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/schedule/EDrtChargingTask.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/schedule/EDrtChargingTask.java
@@ -19,13 +19,15 @@
 
 package org.matsim.contrib.edrt.schedule;
 
-import org.matsim.contrib.drt.schedule.DrtStayTask;
+import org.matsim.contrib.drt.schedule.DrtTaskType;
 import org.matsim.contrib.ev.dvrp.ChargingTaskImpl;
 import org.matsim.contrib.ev.fleet.ElectricVehicle;
 import org.matsim.contrib.ev.infrastructure.Charger;
 
 public class EDrtChargingTask extends ChargingTaskImpl {
+	public static final DrtTaskType TYPE = new DrtTaskType("CHARGING", null);
+
 	public EDrtChargingTask(double beginTime, double endTime, Charger charger, ElectricVehicle ev, double totalEnergy) {
-		super(DrtStayTask.TYPE, beginTime, endTime, charger, ev, totalEnergy);
+		super(TYPE, beginTime, endTime, charger, ev, totalEnergy);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/schedule/EDrtDriveTask.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/schedule/EDrtDriveTask.java
@@ -20,6 +20,7 @@
 package org.matsim.contrib.edrt.schedule;
 
 import org.matsim.contrib.drt.schedule.DrtDriveTask;
+import org.matsim.contrib.drt.schedule.DrtTaskType;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.ev.dvrp.ETask;
 
@@ -29,8 +30,8 @@ import org.matsim.contrib.ev.dvrp.ETask;
 public class EDrtDriveTask extends DrtDriveTask implements ETask {
 	private final double consumedEnergy;
 
-	public EDrtDriveTask(VrpPathWithTravelData path, double consumedEnergy) {
-		super(path);
+	public EDrtDriveTask(VrpPathWithTravelData path, DrtTaskType taskType, double consumedEnergy) {
+		super(path, taskType);
 		this.consumedEnergy = consumedEnergy;
 	}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/schedule/EDrtTaskFactoryImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/schedule/EDrtTaskFactoryImpl.java
@@ -20,6 +20,7 @@ package org.matsim.contrib.edrt.schedule;
 
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.schedule.DrtTaskFactory;
+import org.matsim.contrib.drt.schedule.DrtTaskType;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.ev.dvrp.EvDvrpVehicle;
@@ -32,10 +33,10 @@ import org.matsim.contrib.ev.infrastructure.Charger;
  */
 public class EDrtTaskFactoryImpl implements DrtTaskFactory {
 	@Override
-	public EDrtDriveTask createDriveTask(DvrpVehicle vehicle, VrpPathWithTravelData path) {
+	public EDrtDriveTask createDriveTask(DvrpVehicle vehicle, VrpPathWithTravelData path, DrtTaskType taskType) {
 		ElectricVehicle ev = ((EvDvrpVehicle)vehicle).getElectricVehicle();
 		double totalEnergy = VrpPathEnergyConsumptions.calcTotalEnergy(ev, path, path.getDepartureTime());
-		return new EDrtDriveTask(path, totalEnergy);
+		return new EDrtDriveTask(path, taskType, totalEnergy);
 	}
 
 	@Override

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/ChargingWithQueueingAndAssignmentLogic.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/ChargingWithQueueingAndAssignmentLogic.java
@@ -43,13 +43,13 @@ public class ChargingWithQueueingAndAssignmentLogic extends ChargingWithQueueing
 
 	public void assignVehicle(ElectricVehicle ev) {
 		if (assignedVehicles.put(ev.getId(), ev) != null) {
-			throw new IllegalArgumentException();
+			throw new IllegalArgumentException("Vehicle is already assigned: " + ev.getId());
 		}
 	}
 
 	public void unassignVehicle(ElectricVehicle ev) {
 		if (assignedVehicles.remove(ev.getId()) == null) {
-			throw new IllegalArgumentException();
+			throw new IllegalArgumentException("Vehicle was not assigned: " + ev.getId());
 		}
 	}
 

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/BatteryImpl.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/BatteryImpl.java
@@ -20,6 +20,7 @@
 
 package org.matsim.contrib.ev.fleet;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 
 public class BatteryImpl implements Battery {
@@ -45,5 +46,10 @@ public class BatteryImpl implements Battery {
 	public void setSoc(double soc) {
 		Preconditions.checkArgument(soc >= 0 && soc <= capacity, "SoC outside allowed range: %s", soc);
 		this.soc = soc;
+	}
+
+	@Override
+	public String toString() {
+		return MoreObjects.toStringHelper(this).add("capacity", capacity).add("soc", soc).toString();
 	}
 }

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleImpl.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleImpl.java
@@ -27,6 +27,7 @@ import org.matsim.contrib.ev.charging.ChargingPower;
 import org.matsim.contrib.ev.discharging.AuxEnergyConsumption;
 import org.matsim.contrib.ev.discharging.DriveEnergyConsumption;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 
 public class ElectricVehicleImpl implements ElectricVehicle {
@@ -85,5 +86,16 @@ public class ElectricVehicleImpl implements ElectricVehicle {
 	@Override
 	public ChargingPower getChargingPower() {
 		return chargingPower;
+	}
+
+	@Override
+	public String toString() {
+		return MoreObjects.toStringHelper(this)
+				.add("vehicleSpecification", vehicleSpecification)
+				.add("battery", battery)
+				.add("driveEnergyConsumption", driveEnergyConsumption.getClass())
+				.add("auxEnergyConsumption", auxEnergyConsumption.getClass())
+				.add("chargingPower", chargingPower.getClass())
+				.toString();
 	}
 }

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ImmutableElectricVehicleSpecification.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ImmutableElectricVehicleSpecification.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 
 import org.matsim.api.core.v01.Id;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 
 /**
@@ -87,6 +88,17 @@ public final class ImmutableElectricVehicleSpecification implements ElectricVehi
 	@Override
 	public double getBatteryCapacity() {
 		return batteryCapacity;
+	}
+
+	@Override
+	public String toString() {
+		return MoreObjects.toStringHelper(this)
+				.add("id", id)
+				.add("vehicleType", vehicleType)
+				.add("chargerTypes", chargerTypes)
+				.add("initialSoc", initialSoc)
+				.add("batteryCapacity", batteryCapacity)
+				.toString();
 	}
 
 	public static final class Builder {

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiTaskType.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiTaskType.java
@@ -55,6 +55,7 @@ public class TaxiTaskType implements Task.TaskType {
 		this.hash = Objects.hash(name, baseType);
 	}
 
+	@Override
 	public final String name() {
 		return name;
 	}


### PR DESCRIPTION
Similar change to the ones done for taxi in #1063 

Within this PR the following task types has been introduced:
 - `EmptyVehicleRelocator.RELOCATE_VEHICLE_TASK_TYPE` defined as `new DrtTaskType("RELOCATE", DRIVE);` ==> will be treated by the standard optimiser as a `DRIVE` task (the standard optimiser supports fleet rebalancing)
 - `EDrtChargingTask.TYPE` defined as `new DrtTaskType("CHARGING", null);` ==> will not be handled by the standard optimiser (must be handled by the e-DRT optimiser, otherwise an exception will be thrown inside the standard optimiser due to the undefined base type)
