### PR TITLE
customise TaskType of TaxiEmptyDriveTask (only base type must == EMPTY_DRIVE)

### DIFF
--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/ETaxiScheduler.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/ETaxiScheduler.java
@@ -48,6 +48,7 @@ import org.matsim.core.router.util.TravelTime;
 import com.google.inject.name.Named;
 
 public class ETaxiScheduler extends TaxiScheduler {
+	public static final TaxiTaskType DRIVE_TO_CHARGER = new TaxiTaskType("DRIVE_TO_CHARGER", EMPTY_DRIVE);
 
 	public ETaxiScheduler(TaxiConfigGroup taxiCfg, Fleet fleet, TaxiScheduleInquiry taxiScheduleInquiry,
 			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, LeastCostPathCalculator router) {
@@ -60,7 +61,7 @@ public class ETaxiScheduler extends TaxiScheduler {
 	public void scheduleCharging(DvrpVehicle vehicle, ElectricVehicle ev, Charger charger,
 			VrpPathWithTravelData vrpPath) {
 		Schedule schedule = vehicle.getSchedule();
-		divertOrAppendDrive(schedule, vrpPath);
+		divertOrAppendDrive(schedule, vrpPath, DRIVE_TO_CHARGER);
 
 		ChargingWithQueueingAndAssignmentLogic logic = (ChargingWithQueueingAndAssignmentLogic)charger.getLogic();
 		double chargingEndTime = vrpPath.getArrivalTime() + ChargingEstimations.estimateMaxWaitTimeForNextVehicle(

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiEmptyDriveTask.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiEmptyDriveTask.java
@@ -24,10 +24,13 @@ import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.EMPTY_DRIVE;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.schedule.DriveTask;
 
+import com.google.common.base.Preconditions;
+
 public class TaxiEmptyDriveTask extends DriveTask {
 	public static final TaxiTaskType TYPE = new TaxiTaskType(EMPTY_DRIVE);
 
-	public TaxiEmptyDriveTask(VrpPathWithTravelData path) {
-		super(TYPE, path);
+	public TaxiEmptyDriveTask(VrpPathWithTravelData path, TaxiTaskType taskType) {
+		super(taskType, path);
+		Preconditions.checkArgument(taskType.getBaseType().get() == EMPTY_DRIVE);
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/reconstruct/ScheduleBuilder.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/reconstruct/ScheduleBuilder.java
@@ -59,7 +59,7 @@ public class ScheduleBuilder {
 		if (currentRequest != null) {
 			tasks.add(new TaxiOccupiedDriveTask(vrpPath, currentRequest));
 		} else {
-			tasks.add(new TaxiEmptyDriveTask(vrpPath));
+			tasks.add(new TaxiEmptyDriveTask(vrpPath, TaxiEmptyDriveTask.TYPE));
 		}
 	}
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/scheduler/TaxiScheduler.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/scheduler/TaxiScheduler.java
@@ -46,6 +46,7 @@ import org.matsim.contrib.taxi.schedule.TaxiOccupiedDriveTask;
 import org.matsim.contrib.taxi.schedule.TaxiPickupTask;
 import org.matsim.contrib.taxi.schedule.TaxiStayTask;
 import org.matsim.contrib.taxi.schedule.TaxiTaskBaseType;
+import org.matsim.contrib.taxi.schedule.TaxiTaskType;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelTime;
 
@@ -88,7 +89,7 @@ public class TaxiScheduler {
 		}
 
 		Schedule schedule = vehicle.getSchedule();
-		divertOrAppendDrive(schedule, vrpPath);
+		divertOrAppendDrive(schedule, vrpPath, TaxiEmptyDriveTask.TYPE);
 
 		double pickupEndTime = Math.max(vrpPath.getArrivalTime(), request.getEarliestStartTime())
 				+ taxiCfg.getPickupDuration();
@@ -100,7 +101,7 @@ public class TaxiScheduler {
 		}
 	}
 
-	protected void divertOrAppendDrive(Schedule schedule, VrpPathWithTravelData vrpPath) {
+	protected void divertOrAppendDrive(Schedule schedule, VrpPathWithTravelData vrpPath, TaxiTaskType taskType) {
 		Task lastTask = Schedules.getLastTask(schedule);
 		switch (getBaseType(lastTask)) {
 			case EMPTY_DRIVE:
@@ -108,7 +109,7 @@ public class TaxiScheduler {
 				return;
 
 			case STAY:
-				scheduleDrive(schedule, (TaxiStayTask)lastTask, vrpPath);
+				scheduleDrive(schedule, (TaxiStayTask)lastTask, vrpPath, taskType);
 				return;
 
 			default:
@@ -124,7 +125,8 @@ public class TaxiScheduler {
 		((OnlineDriveTaskTracker)lastTask.getTaskTracker()).divertPath(vrpPath);
 	}
 
-	protected void scheduleDrive(Schedule schedule, TaxiStayTask lastTask, VrpPathWithTravelData vrpPath) {
+	protected void scheduleDrive(Schedule schedule, TaxiStayTask lastTask, VrpPathWithTravelData vrpPath,
+			TaxiTaskType taskType) {
 		switch (lastTask.getStatus()) {
 			case PLANNED:
 				if (lastTask.getBeginTime() == vrpPath.getDepartureTime()) { // waiting for 0 seconds!!!
@@ -145,7 +147,7 @@ public class TaxiScheduler {
 		}
 
 		if (vrpPath.getLinkCount() > 1) {
-			schedule.addTask(new TaxiEmptyDriveTask(vrpPath));
+			schedule.addTask(new TaxiEmptyDriveTask(vrpPath, taskType));
 		}
 	}
 


### PR DESCRIPTION
Additionally:
- introduce the `DRIVE_TO_CHARGER` task type, so we can differentiate such tasks from the standard "empty" drives to pickups  (both having `EMPTY_DRIVE` as the base type).