### PR TITLE
Use task types in drt occupancy profiles

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtModeAnalysisModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtModeAnalysisModule.java
@@ -25,11 +25,12 @@ package org.matsim.contrib.drt.analysis;
 
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.drt.schedule.DrtStayTask;
 import org.matsim.contrib.drt.util.stats.DrtVehicleOccupancyProfileCalculator;
 import org.matsim.contrib.drt.util.stats.DrtVehicleOccupancyProfileWriter;
-import org.matsim.contrib.drt.vrpagent.DrtActionCreator;
 import org.matsim.contrib.dvrp.fleet.FleetSpecification;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
+import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.groups.QSimConfigGroup;
@@ -42,16 +43,16 @@ import com.google.common.collect.ImmutableSet;
  */
 public class DrtModeAnalysisModule extends AbstractDvrpModeModule {
 	private final DrtConfigGroup drtCfg;
-	private final ImmutableSet<String> nonOperatingActivities;
+	private final ImmutableSet<Task.TaskType> nonPassengerServingTaskTypes;
 
 	public DrtModeAnalysisModule(DrtConfigGroup drtCfg) {
-		this(drtCfg, ImmutableSet.of(DrtActionCreator.DRT_STAY_NAME));
+		this(drtCfg, ImmutableSet.of(DrtStayTask.TYPE));
 	}
 
-	public DrtModeAnalysisModule(DrtConfigGroup drtCfg, ImmutableSet<String> nonOperatingActivities) {
+	public DrtModeAnalysisModule(DrtConfigGroup drtCfg, ImmutableSet<Task.TaskType> nonPassengerServingTaskTypes) {
 		super(drtCfg.getMode());
 		this.drtCfg = drtCfg;
-		this.nonOperatingActivities = nonOperatingActivities;
+		this.nonPassengerServingTaskTypes = nonPassengerServingTaskTypes;
 	}
 
 	@Override
@@ -73,7 +74,7 @@ public class DrtModeAnalysisModule extends AbstractDvrpModeModule {
 		bindModal(DrtVehicleOccupancyProfileCalculator.class).toProvider(modalProvider(
 				getter -> new DrtVehicleOccupancyProfileCalculator(getter.getModal(FleetSpecification.class),
 						getter.get(EventsManager.class), 300, getter.get(QSimConfigGroup.class),
-						nonOperatingActivities)));
+						nonPassengerServingTaskTypes)));
 
 		addControlerListenerBinding().toProvider(modalProvider(
 				getter -> new DrtVehicleOccupancyProfileWriter(getter.get(MatsimServices.class), drtCfg,

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtModeAnalysisModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtModeAnalysisModule.java
@@ -25,7 +25,8 @@ package org.matsim.contrib.drt.analysis;
 
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
-import org.matsim.contrib.drt.schedule.DrtStayTask;
+import org.matsim.contrib.drt.schedule.DrtDriveTask;
+import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.drt.util.stats.DrtVehicleOccupancyProfileCalculator;
 import org.matsim.contrib.drt.util.stats.DrtVehicleOccupancyProfileWriter;
 import org.matsim.contrib.dvrp.fleet.FleetSpecification;
@@ -46,7 +47,7 @@ public class DrtModeAnalysisModule extends AbstractDvrpModeModule {
 	private final ImmutableSet<Task.TaskType> nonPassengerServingTaskTypes;
 
 	public DrtModeAnalysisModule(DrtConfigGroup drtCfg) {
-		this(drtCfg, ImmutableSet.of(DrtStayTask.TYPE));
+		this(drtCfg, ImmutableSet.of(DrtDriveTask.TYPE, DrtStopTask.TYPE));
 	}
 
 	public DrtModeAnalysisModule(DrtConfigGroup drtCfg, ImmutableSet<Task.TaskType> nonPassengerServingTaskTypes) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/util/stats/DrtVehicleOccupancyProfileCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/util/stats/DrtVehicleOccupancyProfileCalculator.java
@@ -22,25 +22,27 @@ import java.util.Map;
 
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.IdMap;
-import org.matsim.api.core.v01.events.ActivityEndEvent;
-import org.matsim.api.core.v01.events.ActivityStartEvent;
+import org.matsim.api.core.v01.events.Event;
 import org.matsim.api.core.v01.events.PersonEntersVehicleEvent;
 import org.matsim.api.core.v01.events.PersonLeavesVehicleEvent;
-import org.matsim.api.core.v01.events.handler.ActivityEndEventHandler;
-import org.matsim.api.core.v01.events.handler.ActivityStartEventHandler;
 import org.matsim.api.core.v01.events.handler.PersonEntersVehicleEventHandler;
 import org.matsim.api.core.v01.events.handler.PersonLeavesVehicleEventHandler;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicleSpecification;
 import org.matsim.contrib.dvrp.fleet.FleetSpecification;
+import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.contrib.dvrp.util.TimeDiscretizer;
-import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
+import org.matsim.contrib.dvrp.vrpagent.TaskEndedEvent;
+import org.matsim.contrib.dvrp.vrpagent.TaskEndedEventHandler;
+import org.matsim.contrib.dvrp.vrpagent.TaskStartedEvent;
+import org.matsim.contrib.dvrp.vrpagent.TaskStartedEventHandler;
 import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.api.internal.HasPersonId;
 import org.matsim.core.config.groups.QSimConfigGroup;
 import org.matsim.core.config.groups.QSimConfigGroup.EndtimeInterpretation;
+import org.matsim.vehicles.Vehicle;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -49,42 +51,24 @@ import com.google.common.collect.ImmutableSet;
  * @author michalm (Michal Maciejewski)
  */
 public class DrtVehicleOccupancyProfileCalculator
-		implements PersonEntersVehicleEventHandler, PersonLeavesVehicleEventHandler, ActivityStartEventHandler,
-		ActivityEndEventHandler {
+		implements PersonEntersVehicleEventHandler, PersonLeavesVehicleEventHandler, TaskStartedEventHandler,
+		TaskEndedEventHandler {
 
 	private static class VehicleState {
-		private static VehicleState nonOperating(double beginTime, String nonOperatingStateType) {
-			return new VehicleState(beginTime, Preconditions.checkNotNull(nonOperatingStateType), 0);
-		}
-
-		private static VehicleState operating(double beginTime, int occupancy) {
-			Preconditions.checkArgument(occupancy >= 0);
-			return new VehicleState(beginTime, null, occupancy);
-		}
-
-		private final double beginTime;
-		private final String nonOperatingStateType;//non-operating vehicle
-		private final int occupancy;//operating vehicle
-
-		private VehicleState(double beginTime, String nonOperatingStateType, int occupancy) {
-			this.beginTime = beginTime;
-			this.nonOperatingStateType = nonOperatingStateType;
-			this.occupancy = occupancy;
-			//maybe we could relax it in some situations, but that would also require adapting the charts
-			Preconditions.checkArgument(nonOperatingStateType == null || occupancy == 0,
-					"Vehicles not serving passengers must not be occupied ");
-		}
+		private Task.TaskType taskType;
+		private int occupancy;
+		private double beginTime;
 	}
 
 	private final TimeDiscretizer timeDiscretizer;
 
-	private final ImmutableMap<String, long[]> nonOperatingVehicleProfileInSeconds;
+	private final ImmutableMap<Task.TaskType, long[]> nonPassengerServingTaskProfilesInSeconds;
 	private final long[][] vehicleOccupancyProfilesInSeconds;
 
-	private final ImmutableMap<String, double[]> nonOperatingVehicleProfileNormalized;
-	private final double[][] vehicleOccupancyProfilesNormalized;
+	private final ImmutableMap<Task.TaskType, double[]> nonPassengerServingTaskProfiles;
+	private final double[][] vehicleOccupancyProfiles;
 
-	private final ImmutableSet<String> nonOperatingActivities;
+	private final ImmutableSet<Task.TaskType> nonPassengerServingTaskTypes;
 	private final Map<Id<DvrpVehicle>, VehicleState> vehicleStates = new IdMap<>(DvrpVehicle.class);
 
 	private final double analysisEndTime;
@@ -92,9 +76,9 @@ public class DrtVehicleOccupancyProfileCalculator
 	private final FleetSpecification fleet;
 
 	public DrtVehicleOccupancyProfileCalculator(FleetSpecification fleet, EventsManager events, int timeInterval,
-			QSimConfigGroup qsimConfig, ImmutableSet<String> nonOperatingActivities) {
+			QSimConfigGroup qsimConfig, ImmutableSet<Task.TaskType> nonPassengerServingTaskTypes) {
 		this.fleet = fleet;
-		this.nonOperatingActivities = nonOperatingActivities;
+		this.nonPassengerServingTaskTypes = nonPassengerServingTaskTypes;
 
 		events.addHandler(this);
 
@@ -121,27 +105,31 @@ public class DrtVehicleOccupancyProfileCalculator
 				.orElse(0);
 		int occupancyProfilesCount = maxCapacity + 1;
 		vehicleOccupancyProfilesInSeconds = new long[occupancyProfilesCount][timeDiscretizer.getIntervalCount()];
-		nonOperatingVehicleProfileInSeconds = nonOperatingActivities.stream()
+		nonPassengerServingTaskProfilesInSeconds = nonPassengerServingTaskTypes.stream()
 				.collect(ImmutableMap.toImmutableMap(v -> v, v -> new long[timeDiscretizer.getIntervalCount()]));
 
 		//TODO create and directly return the normalized profiles in consolidate()
-		vehicleOccupancyProfilesNormalized = new double[occupancyProfilesCount][timeDiscretizer.getIntervalCount()];
-		nonOperatingVehicleProfileNormalized = nonOperatingActivities.stream()
+		vehicleOccupancyProfiles = new double[occupancyProfilesCount][timeDiscretizer.getIntervalCount()];
+		nonPassengerServingTaskProfiles = nonPassengerServingTaskTypes.stream()
 				.collect(ImmutableMap.toImmutableMap(v -> v, v -> new double[timeDiscretizer.getIntervalCount()]));
 	}
 
 	public void consolidate() {
-		vehicleStates.values().forEach(state -> increment(state, analysisEndTime));
+		for (VehicleState state : vehicleStates.values()) {
+			if (state.taskType != null) {
+				increment(state, analysisEndTime);
+			}
+		}
 		vehicleStates.clear();
 
-		for (String activity : nonOperatingActivities) {
-			computeNormalizedProfiles(nonOperatingVehicleProfileInSeconds.get(activity),
-					nonOperatingVehicleProfileNormalized.get(activity));
+		for (Task.TaskType taskType : nonPassengerServingTaskTypes) {
+			computeNormalizedProfiles(nonPassengerServingTaskProfilesInSeconds.get(taskType),
+					nonPassengerServingTaskProfiles.get(taskType));
 		}
 
 		for (int occupancy = 0; occupancy < vehicleOccupancyProfilesInSeconds.length; occupancy++) {
 			computeNormalizedProfiles(vehicleOccupancyProfilesInSeconds[occupancy],
-					vehicleOccupancyProfilesNormalized[occupancy]);
+					vehicleOccupancyProfiles[occupancy]);
 		}
 	}
 
@@ -151,12 +139,12 @@ public class DrtVehicleOccupancyProfileCalculator
 		}
 	}
 
-	public Map<String, double[]> getNonOperatingVehicleProfiles() {
-		return nonOperatingVehicleProfileNormalized;
+	public Map<Task.TaskType, double[]> getNonPassengerServingTaskProfiles() {
+		return nonPassengerServingTaskProfiles;
 	}
 
 	public double[][] getVehicleOccupancyProfiles() {
-		return vehicleOccupancyProfilesNormalized;
+		return vehicleOccupancyProfiles;
 	}
 
 	public TimeDiscretizer getTimeDiscretizer() {
@@ -164,9 +152,16 @@ public class DrtVehicleOccupancyProfileCalculator
 	}
 
 	private void increment(VehicleState state, double endTime) {
-		long[] profile = state.nonOperatingStateType != null ?
-				nonOperatingVehicleProfileInSeconds.get(state.nonOperatingStateType) :
-				vehicleOccupancyProfilesInSeconds[state.occupancy];
+		Verify.verify(state.taskType != null);
+		Verify.verify(state.occupancy >= 0);
+
+		boolean servingPassengers = !nonPassengerServingTaskTypes.contains(state.taskType);
+		Verify.verify(servingPassengers || state.occupancy == 0,
+				"Vehicles not serving passengers must not be occupied");
+
+		long[] profile = servingPassengers ?
+				vehicleOccupancyProfilesInSeconds[state.occupancy] :
+				nonPassengerServingTaskProfilesInSeconds.get(state.taskType);
 		increment(profile, Math.min(state.beginTime, endTime), endTime);
 	}
 
@@ -193,66 +188,52 @@ public class DrtVehicleOccupancyProfileCalculator
 	/* Event handling starts here */
 
 	@Override
-	public void handleEvent(ActivityStartEvent event) {
-		if (nonOperatingActivities.contains(event.getActType())) {
-			vehicleStates.computeIfPresent(vehicleId(event.getPersonId()), (id, oldState) -> {
-				Verify.verify(oldState.nonOperatingStateType == null && oldState.occupancy == 0);
-				increment(oldState, event.getTime());
-				return VehicleState.nonOperating(event.getTime(), event.getActType());
-			});
-		} else if (event.getActType().equals(VrpAgentLogic.AFTER_SCHEDULE_ACTIVITY_TYPE)) {
-			vehicleStates.computeIfPresent(vehicleId(event.getPersonId()), (id, oldState) -> {
-				Verify.verify(oldState.nonOperatingStateType == null && oldState.occupancy == 0);
-				increment(oldState, event.getTime());
-				return null;
-			});
+	public void handleEvent(TaskStartedEvent event) {
+		if (event.getTaskIndex() == 0) {
+			if (fleet.getVehicleSpecifications().containsKey(event.getDvrpVehicleId())) {
+				VehicleState state = new VehicleState();
+				state.taskType = event.getTaskType();
+				state.beginTime = event.getTime();
+				vehicleStates.put(event.getDvrpVehicleId(), state);
+			}
+		} else {
+			VehicleState state = vehicleStates.get(event.getDvrpVehicleId());
+			if (state != null) {
+				state.taskType = event.getTaskType();
+				state.beginTime = event.getTime();
+			}
 		}
 	}
 
 	@Override
-	public void handleEvent(ActivityEndEvent event) {
-		if (event.getActType().equals(VrpAgentLogic.BEFORE_SCHEDULE_ACTIVITY_TYPE)) {
-			if (fleet.getVehicleSpecifications().containsKey(vehicleId(event.getPersonId()))) {
-				vehicleStates.put(vehicleId(event.getPersonId()), VehicleState.operating(event.getTime(), 0));
-			}
-		} else if (nonOperatingActivities.contains(event.getActType())) {
-			vehicleStates.computeIfPresent(vehicleId(event.getPersonId()), (id, oldState) -> {
-				Verify.verify(oldState.nonOperatingStateType.equals(event.getActType()));
-				increment(oldState, event.getTime());
-				return VehicleState.operating(event.getTime(), 0);
-			});
+	public void handleEvent(TaskEndedEvent event) {
+		VehicleState state = vehicleStates.get(event.getDvrpVehicleId());
+		if (state != null) {
+			increment(state, event.getTime());
+			state.taskType = null;
 		}
 	}
 
 	@Override
 	public void handleEvent(PersonEntersVehicleEvent event) {
-		vehicleStates.computeIfPresent(vehicleId(event.getVehicleId()), (id, oldState) -> {
-			if (isDriver(event.getPersonId(), id)) {
-				return oldState;//ignore the driver, no state change
-			}
-			Verify.verify(oldState.nonOperatingStateType == null);
-			increment(oldState, event.getTime());
-			return VehicleState.operating(event.getTime(), oldState.occupancy + 1);
-		});
+		processOccupancyChange(event, event.getVehicleId(), +1);
 	}
 
 	@Override
 	public void handleEvent(PersonLeavesVehicleEvent event) {
-		vehicleStates.computeIfPresent(vehicleId(event.getVehicleId()), (id, oldState) -> {
-			if (isDriver(event.getPersonId(), id)) {
-				return oldState;//ignore the driver, no state change
-			}
-			Verify.verify(oldState.nonOperatingStateType == null);
-			increment(oldState, event.getTime());
-			return VehicleState.operating(event.getTime(), oldState.occupancy - 1);
-		});
+		processOccupancyChange(event, event.getVehicleId(), -1);
 	}
 
-	private Id<DvrpVehicle> vehicleId(Id<?> id) {
-		return Id.create(id, DvrpVehicle.class);
+	private <E extends Event & HasPersonId> void processOccupancyChange(E event, Id<Vehicle> vehicleId, int change) {
+		VehicleState state = vehicleStates.get(Id.create(vehicleId, DvrpVehicle.class));
+		if (state != null && !isDriver(event.getPersonId(), vehicleId)) {
+			increment(state, event.getTime());
+			state.occupancy += change;
+			state.beginTime = event.getTime();
+		}
 	}
 
-	private boolean isDriver(Id<Person> personId, Id<DvrpVehicle> vehicleId) {
+	private boolean isDriver(Id<Person> personId, Id<Vehicle> vehicleId) {
 		return personId.equals(vehicleId);
 	}
 
@@ -260,12 +241,12 @@ public class DrtVehicleOccupancyProfileCalculator
 	public void reset(int iteration) {
 		vehicleStates.clear();
 
-		nonOperatingVehicleProfileInSeconds.values().forEach(profile -> Arrays.fill(profile, 0));
-		nonOperatingVehicleProfileNormalized.values().forEach(profile -> Arrays.fill(profile, 0));
+		nonPassengerServingTaskProfilesInSeconds.values().forEach(profile -> Arrays.fill(profile, 0));
+		nonPassengerServingTaskProfiles.values().forEach(profile -> Arrays.fill(profile, 0));
 
 		for (int k = 0; k < vehicleOccupancyProfilesInSeconds.length; k++) {
 			Arrays.fill(vehicleOccupancyProfilesInSeconds[k], 0);
-			Arrays.fill(vehicleOccupancyProfilesNormalized[k], 0);
+			Arrays.fill(vehicleOccupancyProfiles[k], 0);
 		}
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/util/stats/DrtVehicleOccupancyProfileWriter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/util/stats/DrtVehicleOccupancyProfileWriter.java
@@ -66,8 +66,10 @@ public class DrtVehicleOccupancyProfileWriter implements IterationEndsListener {
 		TimeDiscretizer timeDiscretizer = calculator.getTimeDiscretizer();
 		calculator.consolidate();
 
-		ImmutableMap<String, double[]> profiles = Stream.concat(
-				calculator.getNonOperatingVehicleProfiles().entrySet().stream(),
+		ImmutableMap<String, double[]> profiles = Stream.concat(calculator.getNonPassengerServingTaskProfiles()
+						.entrySet()
+						.stream()
+						.map(e -> Pair.of(e.getKey().name(), e.getValue())),
 				EntryStream.of(calculator.getVehicleOccupancyProfiles())
 						.map(e -> Pair.of(e.getKey() + " pax", e.getValue())))
 				.collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));

--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/MultiModeEDrtModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/MultiModeEDrtModule.java
@@ -25,8 +25,8 @@ import org.matsim.contrib.drt.routing.MultiModeDrtMainModeIdentifier;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.run.DrtModeModule;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
-import org.matsim.contrib.drt.vrpagent.DrtActionCreator;
-import org.matsim.contrib.ev.dvrp.ChargingActivity;
+import org.matsim.contrib.drt.schedule.DrtStayTask;
+import org.matsim.contrib.edrt.schedule.EDrtChargingTask;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.router.MainModeIdentifier;
 
@@ -46,8 +46,7 @@ public class MultiModeEDrtModule extends AbstractModule {
 		for (DrtConfigGroup drtCfg : multiModeDrtCfg.getModalElements()) {
 			install(new DrtModeModule(drtCfg));
 			installQSimModule(new EDrtModeQSimModule(drtCfg));
-			install(new DrtModeAnalysisModule(drtCfg,
-					ImmutableSet.of(DrtActionCreator.DRT_STAY_NAME, ChargingActivity.ACTIVITY_TYPE)));
+			install(new DrtModeAnalysisModule(drtCfg, ImmutableSet.of(DrtStayTask.TYPE, EDrtChargingTask.TYPE)));
 		}
 
 		bind(MainModeIdentifier.class).toInstance(new MultiModeDrtMainModeIdentifier(multiModeDrtCfg));

--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/MultiModeEDrtModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/MultiModeEDrtModule.java
@@ -25,12 +25,9 @@ import org.matsim.contrib.drt.routing.MultiModeDrtMainModeIdentifier;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.run.DrtModeModule;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
-import org.matsim.contrib.drt.schedule.DrtStayTask;
-import org.matsim.contrib.edrt.schedule.EDrtChargingTask;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.router.MainModeIdentifier;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 
 /**
@@ -46,7 +43,7 @@ public class MultiModeEDrtModule extends AbstractModule {
 		for (DrtConfigGroup drtCfg : multiModeDrtCfg.getModalElements()) {
 			install(new DrtModeModule(drtCfg));
 			installQSimModule(new EDrtModeQSimModule(drtCfg));
-			install(new DrtModeAnalysisModule(drtCfg, ImmutableSet.of(DrtStayTask.TYPE, EDrtChargingTask.TYPE)));
+			install(new DrtModeAnalysisModule(drtCfg));
 		}
 
 		bind(MainModeIdentifier.class).toInstance(new MultiModeDrtMainModeIdentifier(multiModeDrtCfg));


### PR DESCRIPTION
Task types contain more information and are also defined for legs (not only activities). So now we can generate nicer stats and plots that also include vehicle relocation (rebalancing).

![0 drt_occupancy_time_profiles_StackedArea_drt](https://user-images.githubusercontent.com/9891415/87052447-14ec2e80-c201-11ea-9bb5-7505ef5b03b3.png)
