### PR TITLE
enable using DefaultPassengerEngine in multi-threaded QSim

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -229,7 +229,9 @@ public final class DrtConfigGroup extends ReflectiveConfigGroup implements Modal
 					+ "attempting to travel without vehicles being available.");
 		}
 
-		Verify.verify(config.qsim().getNumberOfThreads() == 1, "Only a single-threaded QSim allowed");
+		if (config.qsim().getNumberOfThreads() > 1) {
+			log.warn("EXPERIMENTAL FEATURE: Running DRT with a multi-threaded QSim");
+		}
 
 		Verify.verify(getMaxWaitTime() >= getStopDuration(),
 				MAX_WAIT_TIME + " must not be smaller than " + STOP_DURATION);

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/PassengerRequestCreator.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/PassengerRequestCreator.java
@@ -29,6 +29,19 @@ import org.matsim.contrib.dvrp.optimizer.Request;
  * @author michalm
  */
 public interface PassengerRequestCreator {
+	/**
+	 * Thread safety: This method can be called concurrently from multiple QSim worker threads.
+	 * Prefer stateless implementation, otherwise provide other ways to achieve thread-safety.
+	 *
+	 * @param id             request ID
+	 * @param passengerId    passenger ID
+	 * @param route          planned route (the required route type depends on the optimizer)
+	 * @param fromLink       start location
+	 * @param toLink         end location
+	 * @param departureTime  requested time of departure
+	 * @param submissionTime time at which request was submitted
+	 * @return
+	 */
 	PassengerRequest createRequest(Id<Request> id, Id<Person> passengerId, Route route, Link fromLink, Link toLink,
 			double departureTime, double submissionTime);
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/PassengerRequestValidator.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/PassengerRequestValidator.java
@@ -35,6 +35,9 @@ public interface PassengerRequestValidator {
 	 * constraints.
 	 * <p>
 	 * Preferred format for causes: underscores instead of spaces.
+	 * <p>
+	 * Thread safety: This method can be called concurrently from multiple QSim worker threads.
+	 * Prefer stateless implementation, otherwise provide other ways to achieve thread-safety.
 	 *
 	 * @param request to be validated
 	 * @return set containing causes of constraint violations. An empty set means the request fulfills all

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/passenger/SubmittedTaxiRequestsCollector.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/passenger/SubmittedTaxiRequestsCollector.java
@@ -20,15 +20,15 @@
 package org.matsim.contrib.taxi.passenger;
 
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.matsim.api.core.v01.Id;
 import org.matsim.contrib.dvrp.optimizer.Request;
 
 //TODO remove this class once taxi stats are refactored
 public class SubmittedTaxiRequestsCollector {
-	private final Map<Id<Request>, TaxiRequest> requests = new LinkedHashMap<>();
+	private final Map<Id<Request>, TaxiRequest> requests = new ConcurrentHashMap<>();
 
 	public Map<Id<Request>, ? extends TaxiRequest> getRequests() {
 		return Collections.unmodifiableMap(requests);

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
@@ -28,6 +28,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 
+import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.contrib.dvrp.router.DvrpModeRoutingNetworkModule;
 import org.matsim.contrib.dvrp.run.Modal;
@@ -44,6 +45,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 
 public final class TaxiConfigGroup extends ReflectiveConfigGroup implements Modal {
+	private static final Logger log = Logger.getLogger(TaxiConfigGroup.class);
+
 	public static final String GROUP_NAME = "taxi";
 
 	/**
@@ -153,7 +156,9 @@ public final class TaxiConfigGroup extends ReflectiveConfigGroup implements Moda
 	protected void checkConsistency(Config config) {
 		super.checkConsistency(config);
 
-		Verify.verify(config.qsim().getNumberOfThreads() == 1, "Only a single-threaded QSim allowed");
+		if (config.qsim().getNumberOfThreads() > 1) {
+			log.warn("EXPERIMENTAL FEATURE: Running taxi with a multi-threaded QSim");
+		}
 
 		Verify.verify(!isVehicleDiversion() || isOnlineVehicleTracker(),
 				TaxiConfigGroup.VEHICLE_DIVERSION + " requires " + TaxiConfigGroup.ONLINE_VEHICLE_TRACKER);

--- a/contribs/taxi/src/test/java/org/matsim/contrib/taxi/schedule/reconstruct/ScheduleReconstructionIT.java
+++ b/contribs/taxi/src/test/java/org/matsim/contrib/taxi/schedule/reconstruct/ScheduleReconstructionIT.java
@@ -19,17 +19,23 @@
 
 package org.matsim.contrib.taxi.schedule.reconstruct;
 
+import static java.util.stream.Collectors.toList;
+
 import java.net.URL;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.Fleet;
+import org.matsim.contrib.dvrp.optimizer.Request;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
@@ -116,7 +122,11 @@ public class ScheduleReconstructionIT {
 			SubmittedTaxiRequestsCollector requestCollector) {
 		Assert.assertNotEquals(fleet, scheduleReconstructor.getFleet());
 		compareVehicles(fleet.getVehicles().values(), scheduleReconstructor.getFleet().getVehicles().values());
-		compareRequests(requestCollector.getRequests().values(), scheduleReconstructor.taxiRequests.values());
+		compareRequests(sortRequests(requestCollector.getRequests()), sortRequests(scheduleReconstructor.taxiRequests));
+	}
+
+	private List<TaxiRequest> sortRequests(Map<Id<Request>, ? extends TaxiRequest> requestMap) {
+		return requestMap.values().stream().sorted(Comparator.comparing(TaxiRequest::getId)).collect(toList());
 	}
 
 	private void compareVehicles(Collection<? extends DvrpVehicle> originalVehs,


### PR DESCRIPTION
Adds synchronisation on the optimiser to:
- calling `VrpOptimiser.submitRequest()` from `DefaultPassengerEngine.validateAndSubmitRequest()`
- `VrpAgentLogic.computeNextAction()`

In many cases the synchronisation could be even more fine-grained and probably done entirely on the optimiser side. However, there are already some "unusual" corner cases (a few examples: (1) switching to "an idle task" is immediately converted into a relocation to the "globally" best depot, (2) submitting a request immediately calls global re-optimisation). So I think it is better to move the responsibility of synchronisation to the "framework" rather than requiring (or rather hoping) that each optimiser implementation would provide thread-safety on its own.

Final notes:
- request ID creation uses `AtomicInteger` (already added in the previous PR)
- calling `PassengerRequestValidator` or `PassengerRequestCreator` is not synchronised. In most cases, these operations are stateless. Otherwise a special measures should be provided to ensure their thread safety. A javadoc comment added to both interfaces.
