### PR TITLE
Feature/permissiblemodescalculatorinjected

### DIFF
--- a/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/replanning/CarsharingSubtourModeChoiceStrategy.java
+++ b/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/replanning/CarsharingSubtourModeChoiceStrategy.java
@@ -28,10 +28,9 @@ public class CarsharingSubtourModeChoiceStrategy implements PlanStrategy {
 		this.strategy = new PlanStrategyImpl(new RandomPlanSelector<Plan, Person>());
 
 		//addStrategyModule( new TripsToLegsModule(controler.getConfig() ) );   
-		SubtourModeChoice smc = new SubtourModeChoice(scenario.getConfig().global(), scenario.getConfig().subtourModeChoice());
 		CarsharingSubTourPermissableModesCalculator cpmc =
 				new CarsharingSubTourPermissableModesCalculator(scenario, scenario.getConfig().subtourModeChoice().getModes(), memberships);
-		smc.setPermissibleModesCalculator(cpmc);
+		SubtourModeChoice smc = new SubtourModeChoice(scenario.getConfig().global(), scenario.getConfig().subtourModeChoice(), cpmc);
 
 		addStrategyModule(smc);
 		addStrategyModule(new ReRoute(scenario, tripRouterProvider));

--- a/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/replanning/CarsharingSubtourModeChoiceStrategy.java
+++ b/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/replanning/CarsharingSubtourModeChoiceStrategy.java
@@ -1,5 +1,7 @@
 package org.matsim.contrib.carsharing.replanning;
 
+import com.google.inject.Inject;
+import javax.inject.Provider;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.population.HasPlansAndId;
 import org.matsim.api.core.v01.population.Person;
@@ -12,11 +14,7 @@ import org.matsim.core.replanning.ReplanningContext;
 import org.matsim.core.replanning.modules.ReRoute;
 import org.matsim.core.replanning.modules.SubtourModeChoice;
 import org.matsim.core.replanning.selectors.RandomPlanSelector;
-
-import com.google.inject.Inject;
 import org.matsim.core.router.TripRouter;
-
-import javax.inject.Provider;
 
 /**
  * Uses a TripsToLegModule to simplify trips before running subtour
@@ -27,16 +25,16 @@ public class CarsharingSubtourModeChoiceStrategy implements PlanStrategy {
 	private final PlanStrategyImpl strategy;
 	@Inject
 	public CarsharingSubtourModeChoiceStrategy(final Scenario scenario, Provider<TripRouter> tripRouterProvider, MembershipContainer memberships) {
-		this.strategy = new PlanStrategyImpl( new RandomPlanSelector<Plan, Person>() );
+		this.strategy = new PlanStrategyImpl(new RandomPlanSelector<Plan, Person>());
 
 		//addStrategyModule( new TripsToLegsModule(controler.getConfig() ) );   
-		SubtourModeChoice smc = new SubtourModeChoice(tripRouterProvider, scenario.getConfig().global(), scenario.getConfig().subtourModeChoice());
-		CarsharingSubTourPermissableModesCalculator cpmc = 
+		SubtourModeChoice smc = new SubtourModeChoice(scenario.getConfig().global(), scenario.getConfig().subtourModeChoice());
+		CarsharingSubTourPermissableModesCalculator cpmc =
 				new CarsharingSubTourPermissableModesCalculator(scenario, scenario.getConfig().subtourModeChoice().getModes(), memberships);
 		smc.setPermissibleModesCalculator(cpmc);
-		
-		addStrategyModule(smc );
-		addStrategyModule( new ReRoute(scenario, tripRouterProvider) );
+
+		addStrategyModule(smc);
+		addStrategyModule(new ReRoute(scenario, tripRouterProvider));
 	}
 
 	public void addStrategyModule(final PlanStrategyModule module) {

--- a/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/usage/replanning/strategies/GroupSubtourModeChoiceFactory.java
+++ b/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/usage/replanning/strategies/GroupSubtourModeChoiceFactory.java
@@ -30,6 +30,8 @@ import org.matsim.contrib.socnetsim.framework.replanning.modules.PlanLinkIdentif
 import org.matsim.contrib.socnetsim.framework.replanning.modules.PlanLinkIdentifier.Strong;
 import org.matsim.contrib.socnetsim.sharedvehicles.VehicleRessources;
 import org.matsim.contrib.socnetsim.usage.replanning.GroupPlanStrategyFactoryUtils;
+import org.matsim.core.population.algorithms.PermissibleModesCalculator;
+import org.matsim.core.population.algorithms.PermissibleModesCalculatorImpl;
 import org.matsim.core.replanning.modules.SubtourModeChoice;
 import org.matsim.core.router.TripRouter;
 
@@ -57,7 +59,7 @@ public class GroupSubtourModeChoiceFactory extends AbstractConfigurableSelection
 
 	@Override
 	public GroupPlanStrategy get() {
-		final GroupPlanStrategy strategy = instantiateStrategy( sc.getConfig() );
+		final GroupPlanStrategy strategy = instantiateStrategy(sc.getConfig());
 
 		// Why the hell did I put this here???
 		//strategy.addStrategyModule(
@@ -65,17 +67,17 @@ public class GroupSubtourModeChoiceFactory extends AbstractConfigurableSelection
 		//			sc.getConfig(),
 		//			planRoutingAlgorithmFactory,
 		//			tripRouterFactory ) );
-
+		PermissibleModesCalculator permissibleModesCalculator = new PermissibleModesCalculatorImpl(sc.getConfig());
 		strategy.addStrategyModule(
 				new IndividualBasedGroupStrategyModule(
 						new SubtourModeChoice(
-								sc.getConfig().global(), sc.getConfig().subtourModeChoice())));
+								sc.getConfig().global(), sc.getConfig().subtourModeChoice(), permissibleModesCalculator)));
 
 		// TODO: add an option to enable or disable this part?
 		final VehicleRessources vehicles =
 				(VehicleRessources) sc.getScenarioElement(
-					VehicleRessources.ELEMENT_NAME );
-		if ( vehicles != null ) {
+						VehicleRessources.ELEMENT_NAME);
+		if (vehicles != null) {
 			strategy.addStrategyModule(
 					GroupPlanStrategyFactoryUtils.createVehicleAllocationModule(
 							sc.getConfig(),

--- a/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/usage/replanning/strategies/GroupSubtourModeChoiceFactory.java
+++ b/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/usage/replanning/strategies/GroupSubtourModeChoiceFactory.java
@@ -19,21 +19,19 @@
  * *********************************************************************** */
 package org.matsim.contrib.socnetsim.usage.replanning.strategies;
 
+import com.google.inject.Inject;
+import com.google.inject.Provider;
 import org.matsim.api.core.v01.Scenario;
-import org.matsim.core.replanning.modules.SubtourModeChoice;
-import org.matsim.core.router.TripRouter;
-
 import org.matsim.contrib.socnetsim.framework.PlanRoutingAlgorithmFactory;
 import org.matsim.contrib.socnetsim.framework.population.JointPlans;
 import org.matsim.contrib.socnetsim.framework.replanning.GroupPlanStrategy;
-import org.matsim.contrib.socnetsim.usage.replanning.GroupPlanStrategyFactoryUtils;
 import org.matsim.contrib.socnetsim.framework.replanning.IndividualBasedGroupStrategyModule;
 import org.matsim.contrib.socnetsim.framework.replanning.modules.PlanLinkIdentifier;
 import org.matsim.contrib.socnetsim.framework.replanning.modules.PlanLinkIdentifier.Strong;
 import org.matsim.contrib.socnetsim.sharedvehicles.VehicleRessources;
-
-import com.google.inject.Inject;
-import com.google.inject.Provider;
+import org.matsim.contrib.socnetsim.usage.replanning.GroupPlanStrategyFactoryUtils;
+import org.matsim.core.replanning.modules.SubtourModeChoice;
+import org.matsim.core.router.TripRouter;
 
 /**
  * @author thibautd
@@ -70,8 +68,8 @@ public class GroupSubtourModeChoiceFactory extends AbstractConfigurableSelection
 
 		strategy.addStrategyModule(
 				new IndividualBasedGroupStrategyModule(
-					new SubtourModeChoice(
-							tripRouterProvider, sc.getConfig().global(), sc.getConfig().subtourModeChoice()) ) );
+						new SubtourModeChoice(
+								sc.getConfig().global(), sc.getConfig().subtourModeChoice())));
 
 		// TODO: add an option to enable or disable this part?
 		final VehicleRessources vehicles =

--- a/matsim/src/main/java/org/matsim/core/population/algorithms/PermissibleModesCalculatorImpl.java
+++ b/matsim/src/main/java/org/matsim/core/population/algorithms/PermissibleModesCalculatorImpl.java
@@ -24,32 +24,33 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-
+import javax.inject.Inject;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Plan;
+import org.matsim.core.config.Config;
 import org.matsim.core.population.PersonUtils;
 
 public final class PermissibleModesCalculatorImpl implements PermissibleModesCalculator {
+
 	private final List<String> availableModes;
 	private final List<String> availableModesWithoutCar;
 	private final boolean considerCarAvailability;
 
-	public PermissibleModesCalculatorImpl(
-			final String[] availableModes,
-			final boolean considerCarAvailability) {
-		this.availableModes = Arrays.asList(availableModes);
+	@Inject
+	public PermissibleModesCalculatorImpl(Config config) {
+		this.availableModes = Arrays.asList(config.subtourModeChoice().getModes());
 
-		if ( this.availableModes.contains( TransportMode.car ) ) {
-			final List<String> l = new ArrayList<String>( this.availableModes );
-			while ( l.remove( TransportMode.car ) ) {}
-			this.availableModesWithoutCar = Collections.unmodifiableList( l );
-		}
-		else {
+		if (this.availableModes.contains(TransportMode.car)) {
+			final List<String> l = new ArrayList<String>(this.availableModes);
+			while (l.remove(TransportMode.car)) {
+			}
+			this.availableModesWithoutCar = Collections.unmodifiableList(l);
+		} else {
 			this.availableModesWithoutCar = this.availableModes;
 		}
 
-		this.considerCarAvailability = considerCarAvailability;
+		this.considerCarAvailability = config.subtourModeChoice().considerCarAvailability();
 	}
 
 	@Override

--- a/matsim/src/main/java/org/matsim/core/replanning/modules/SubtourModeChoice.java
+++ b/matsim/src/main/java/org/matsim/core/replanning/modules/SubtourModeChoice.java
@@ -21,8 +21,6 @@
 package org.matsim.core.replanning.modules;
 
 
-import javax.inject.Provider;
-
 import org.matsim.core.config.groups.GlobalConfigGroup;
 import org.matsim.core.config.groups.SubtourModeChoiceConfigGroup;
 import org.matsim.core.gbl.MatsimRandom;
@@ -30,7 +28,6 @@ import org.matsim.core.population.algorithms.ChooseRandomLegModeForSubtour;
 import org.matsim.core.population.algorithms.PermissibleModesCalculator;
 import org.matsim.core.population.algorithms.PermissibleModesCalculatorImpl;
 import org.matsim.core.population.algorithms.PlanAlgorithm;
-import org.matsim.core.router.TripRouter;
 import org.matsim.core.router.TripStructureUtils;
 
 /**
@@ -52,45 +49,30 @@ import org.matsim.core.router.TripStructureUtils;
  * 
  */
 public class SubtourModeChoice extends AbstractMultithreadedModule {
-	
-	private final double probaForChangeSingleTripMode ;
-	
-	public enum Behavior { fromAllModesToSpecifiedModes, fromSpecifiedModesToSpecifiedModes }
-	private Behavior behavior = Behavior.fromSpecifiedModesToSpecifiedModes ;
+
+	private final double probaForChangeSingleTripMode;
+
+	public enum Behavior {fromAllModesToSpecifiedModes, fromSpecifiedModesToSpecifiedModes}
+
+	private Behavior behavior = Behavior.fromSpecifiedModesToSpecifiedModes;
 
 	private PermissibleModesCalculator permissibleModesCalculator;
-	
+
 	private final String[] chainBasedModes;
 	private final String[] modes;
-	
-	public SubtourModeChoice(Provider<TripRouter> tripRouterProvider, GlobalConfigGroup globalConfigGroup,
-							 SubtourModeChoiceConfigGroup subtourModeChoiceConfigGroup) {
+
+	public SubtourModeChoice(GlobalConfigGroup globalConfigGroup,
+			SubtourModeChoiceConfigGroup subtourModeChoiceConfigGroup) {
 		this(globalConfigGroup.getNumberOfThreads(),
 				subtourModeChoiceConfigGroup.getModes(),
 				subtourModeChoiceConfigGroup.getChainBasedModes(),
 				subtourModeChoiceConfigGroup.considerCarAvailability(),
-				subtourModeChoiceConfigGroup.getProbaForRandomSingleTripMode(),
-				tripRouterProvider
+				subtourModeChoiceConfigGroup.getProbaForRandomSingleTripMode()
 		);
-		this.setBehavior( subtourModeChoiceConfigGroup.getBehavior() );
+		this.setBehavior(subtourModeChoiceConfigGroup.getBehavior());
 	}
 
-	@Deprecated // tripRouterProvider element no longer necessary
-	public SubtourModeChoice(
-			final int numberOfThreads,
-			final String[] modes,
-			final String[] chainBasedModes,
-			final boolean considerCarAvailability,
-			double probaForChangeSingleTripMode,
-			Provider<TripRouter> tripRouterProvider) {
-		this(numberOfThreads,
-				modes,
-				chainBasedModes,
-				considerCarAvailability,
-				probaForChangeSingleTripMode);
-	}
-	
-	public SubtourModeChoice(
+	SubtourModeChoice(
 			final int numberOfThreads,
 			final String[] modes,
 			final String[] chainBasedModes,
@@ -100,7 +82,7 @@ public class SubtourModeChoice extends AbstractMultithreadedModule {
 		this.modes = modes.clone();
 		this.chainBasedModes = chainBasedModes.clone();
 		this.permissibleModesCalculator =
-			new PermissibleModesCalculatorImpl(
+				new PermissibleModesCalculatorImpl(
 					this.modes,
 					considerCarAvailability);
 		this.probaForChangeSingleTripMode = probaForChangeSingleTripMode;

--- a/matsim/src/main/java/org/matsim/core/replanning/modules/SubtourModeChoice.java
+++ b/matsim/src/main/java/org/matsim/core/replanning/modules/SubtourModeChoice.java
@@ -20,13 +20,11 @@
 
 package org.matsim.core.replanning.modules;
 
-
 import org.matsim.core.config.groups.GlobalConfigGroup;
 import org.matsim.core.config.groups.SubtourModeChoiceConfigGroup;
 import org.matsim.core.gbl.MatsimRandom;
 import org.matsim.core.population.algorithms.ChooseRandomLegModeForSubtour;
 import org.matsim.core.population.algorithms.PermissibleModesCalculator;
-import org.matsim.core.population.algorithms.PermissibleModesCalculatorImpl;
 import org.matsim.core.population.algorithms.PlanAlgorithm;
 import org.matsim.core.router.TripStructureUtils;
 
@@ -46,7 +44,7 @@ import org.matsim.core.router.TripStructureUtils;
  * If the plan initially violates this constraint, this module may (!) repair it. 
  * 
  * @author michaz
- * 
+ *
  */
 public class SubtourModeChoice extends AbstractMultithreadedModule {
 
@@ -56,18 +54,18 @@ public class SubtourModeChoice extends AbstractMultithreadedModule {
 
 	private Behavior behavior = Behavior.fromSpecifiedModesToSpecifiedModes;
 
-	private PermissibleModesCalculator permissibleModesCalculator;
+	private final PermissibleModesCalculator permissibleModesCalculator;
 
 	private final String[] chainBasedModes;
 	private final String[] modes;
 
 	public SubtourModeChoice(GlobalConfigGroup globalConfigGroup,
-			SubtourModeChoiceConfigGroup subtourModeChoiceConfigGroup) {
+			SubtourModeChoiceConfigGroup subtourModeChoiceConfigGroup, PermissibleModesCalculator permissibleModesCalculator) {
 		this(globalConfigGroup.getNumberOfThreads(),
 				subtourModeChoiceConfigGroup.getModes(),
 				subtourModeChoiceConfigGroup.getChainBasedModes(),
-				subtourModeChoiceConfigGroup.considerCarAvailability(),
-				subtourModeChoiceConfigGroup.getProbaForRandomSingleTripMode()
+				subtourModeChoiceConfigGroup.getProbaForRandomSingleTripMode(),
+				permissibleModesCalculator
 		);
 		this.setBehavior(subtourModeChoiceConfigGroup.getBehavior());
 	}
@@ -76,15 +74,12 @@ public class SubtourModeChoice extends AbstractMultithreadedModule {
 			final int numberOfThreads,
 			final String[] modes,
 			final String[] chainBasedModes,
-			final boolean considerCarAvailability,
-			double probaForChangeSingleTripMode) {
+			double probaForChangeSingleTripMode,
+			PermissibleModesCalculator permissibleModesCalculator) {
 		super(numberOfThreads);
 		this.modes = modes.clone();
 		this.chainBasedModes = chainBasedModes.clone();
-		this.permissibleModesCalculator =
-				new PermissibleModesCalculatorImpl(
-					this.modes,
-					considerCarAvailability);
+		this.permissibleModesCalculator = permissibleModesCalculator;
 		this.probaForChangeSingleTripMode = probaForChangeSingleTripMode;
 	}
 	
@@ -110,12 +105,5 @@ public class SubtourModeChoice extends AbstractMultithreadedModule {
 		return chooseRandomLegMode;
 	}
 
-	/**
-	 * Decides if a person may use a certain mode of transport. Can be used for car ownership.
-	 * 
-	 */
-	public void setPermissibleModesCalculator(PermissibleModesCalculator permissibleModesCalculator) {
-		this.permissibleModesCalculator = permissibleModesCalculator;
-	}
 
 }

--- a/matsim/src/main/java/org/matsim/core/replanning/strategies/DefaultPlanStrategiesModule.java
+++ b/matsim/src/main/java/org/matsim/core/replanning/strategies/DefaultPlanStrategiesModule.java
@@ -23,6 +23,10 @@
 package org.matsim.core.replanning.strategies;
 
 import com.google.inject.TypeLiteral;
+import java.util.HashSet;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Provider;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Person;
@@ -30,16 +34,13 @@ import org.matsim.api.core.v01.population.Plan;
 import org.matsim.core.config.groups.PlanCalcScoreConfigGroup;
 import org.matsim.core.config.groups.StrategyConfigGroup;
 import org.matsim.core.controler.AbstractModule;
+import org.matsim.core.population.algorithms.PermissibleModesCalculator;
+import org.matsim.core.population.algorithms.PermissibleModesCalculatorImpl;
 import org.matsim.core.replanning.selectors.ExpBetaPlanChanger;
 import org.matsim.core.replanning.selectors.ExpBetaPlanSelector;
 import org.matsim.core.replanning.selectors.PathSizeLogitSelector;
 import org.matsim.core.replanning.selectors.RandomPlanSelector;
 import org.matsim.core.replanning.selectors.WorstPlanForRemovalSelector;
-
-import javax.inject.Inject;
-import javax.inject.Provider;
-import java.util.HashSet;
-import java.util.Set;
 
 public class DefaultPlanStrategiesModule extends AbstractModule {
     private static final Logger log = Logger.getLogger( DefaultPlanStrategiesModule.class );
@@ -108,7 +109,8 @@ public class DefaultPlanStrategiesModule extends AbstractModule {
             addPlanStrategyBinding(DefaultStrategy.TimeAllocationMutator_ReRoute).toProvider(TimeAllocationMutatorReRoute.class);
         }
         if (usedStrategyNames.contains(DefaultStrategy.SubtourModeChoice)) {
-            addPlanStrategyBinding(DefaultStrategy.SubtourModeChoice).toProvider(SubtourModeChoice.class);
+			bind(PermissibleModesCalculator.class).to(PermissibleModesCalculatorImpl.class);
+			addPlanStrategyBinding(DefaultStrategy.SubtourModeChoice).toProvider(SubtourModeChoice.class);
         }
         if (usedStrategyNames.contains(DefaultStrategy.ChangeTripMode)) {
             addPlanStrategyBinding(DefaultStrategy.ChangeTripMode).toProvider(ChangeTripMode.class);

--- a/matsim/src/main/java/org/matsim/core/replanning/strategies/SubtourModeChoice.java
+++ b/matsim/src/main/java/org/matsim/core/replanning/strategies/SubtourModeChoice.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 import org.matsim.core.config.groups.GlobalConfigGroup;
 import org.matsim.core.config.groups.SubtourModeChoiceConfigGroup;
+import org.matsim.core.population.algorithms.PermissibleModesCalculator;
 import org.matsim.core.replanning.PlanStrategy;
 import org.matsim.core.replanning.PlanStrategyImpl;
 import org.matsim.core.replanning.PlanStrategyImpl.Builder;
@@ -37,11 +38,12 @@ public class SubtourModeChoice implements Provider<PlanStrategy> {
 	@Inject private GlobalConfigGroup globalConfigGroup;
 	@Inject private SubtourModeChoiceConfigGroup subtourModeChoiceConfigGroup;
 	@Inject private ActivityFacilities facilities;
+	@Inject private PermissibleModesCalculator permissibleModesCalculator;
 
-    @Override
+	@Override
 	public PlanStrategy get() {
 		PlanStrategyImpl.Builder builder = new Builder(new RandomPlanSelector<>());
-		builder.addStrategyModule(new org.matsim.core.replanning.modules.SubtourModeChoice(tripRouterProvider, globalConfigGroup, subtourModeChoiceConfigGroup));
+		builder.addStrategyModule(new org.matsim.core.replanning.modules.SubtourModeChoice(globalConfigGroup, subtourModeChoiceConfigGroup));
 		builder.addStrategyModule(new ReRoute(facilities, tripRouterProvider, globalConfigGroup));
 		return builder.build();
 	}

--- a/matsim/src/main/java/org/matsim/core/replanning/strategies/SubtourModeChoice.java
+++ b/matsim/src/main/java/org/matsim/core/replanning/strategies/SubtourModeChoice.java
@@ -43,7 +43,7 @@ public class SubtourModeChoice implements Provider<PlanStrategy> {
 	@Override
 	public PlanStrategy get() {
 		PlanStrategyImpl.Builder builder = new Builder(new RandomPlanSelector<>());
-		builder.addStrategyModule(new org.matsim.core.replanning.modules.SubtourModeChoice(globalConfigGroup, subtourModeChoiceConfigGroup));
+		builder.addStrategyModule(new org.matsim.core.replanning.modules.SubtourModeChoice(globalConfigGroup, subtourModeChoiceConfigGroup, permissibleModesCalculator));
 		builder.addStrategyModule(new ReRoute(facilities, tripRouterProvider, globalConfigGroup));
 		return builder.build();
 	}

--- a/matsim/src/main/java/org/matsim/core/replanning/strategies/SubtourModeChoice.java
+++ b/matsim/src/main/java/org/matsim/core/replanning/strategies/SubtourModeChoice.java
@@ -19,17 +19,17 @@
 
 package org.matsim.core.replanning.strategies;
 
+import javax.inject.Inject;
+import javax.inject.Provider;
 import org.matsim.core.config.groups.GlobalConfigGroup;
 import org.matsim.core.config.groups.SubtourModeChoiceConfigGroup;
 import org.matsim.core.replanning.PlanStrategy;
 import org.matsim.core.replanning.PlanStrategyImpl;
+import org.matsim.core.replanning.PlanStrategyImpl.Builder;
 import org.matsim.core.replanning.modules.ReRoute;
 import org.matsim.core.replanning.selectors.RandomPlanSelector;
 import org.matsim.core.router.TripRouter;
 import org.matsim.facilities.ActivityFacilities;
-
-import javax.inject.Inject;
-import javax.inject.Provider;
 
 public class SubtourModeChoice implements Provider<PlanStrategy> {
 
@@ -40,10 +40,10 @@ public class SubtourModeChoice implements Provider<PlanStrategy> {
 
     @Override
 	public PlanStrategy get() {
-		PlanStrategyImpl strategy = new PlanStrategyImpl(new RandomPlanSelector());
-		strategy.addStrategyModule(new org.matsim.core.replanning.modules.SubtourModeChoice(tripRouterProvider, globalConfigGroup, subtourModeChoiceConfigGroup));
-		strategy.addStrategyModule(new ReRoute(facilities, tripRouterProvider, globalConfigGroup));
-		return strategy;
+		PlanStrategyImpl.Builder builder = new Builder(new RandomPlanSelector<>());
+		builder.addStrategyModule(new org.matsim.core.replanning.modules.SubtourModeChoice(tripRouterProvider, globalConfigGroup, subtourModeChoiceConfigGroup));
+		builder.addStrategyModule(new ReRoute(facilities, tripRouterProvider, globalConfigGroup));
+		return builder.build();
 	}
 
 }

--- a/matsim/src/test/java/org/matsim/population/algorithms/ChooseRandomLegModeForSubtourComplexTripsTest.java
+++ b/matsim/src/test/java/org/matsim/population/algorithms/ChooseRandomLegModeForSubtourComplexTripsTest.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,6 +33,7 @@ import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Plan;
 import org.matsim.api.core.v01.population.PopulationFactory;
+import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.population.algorithms.ChooseRandomLegModeForSubtour;
 import org.matsim.core.population.algorithms.PermissibleModesCalculatorImpl;
@@ -461,16 +461,19 @@ public class ChooseRandomLegModeForSubtourComplexTripsTest {
 	
 	@Test
 	public void testMutatedTrips() {
+		Config config = ConfigUtils.createConfig();
+		config.subtourModeChoice().setModes(MODES);
+		config.subtourModeChoice().setConsiderCarAvailability(false);
 		final ChooseRandomLegModeForSubtour testee =
-			new ChooseRandomLegModeForSubtour(
-					new MainModeIdentifierImpl(),
-					new PermissibleModesCalculatorImpl( MODES , false ),
-					MODES,
-					CHAIN_BASED_MODES,
-					new Random( 20130225 ), SubtourModeChoice.Behavior.fromSpecifiedModesToSpecifiedModes,
-					probaForRandomSingleTripMode);
+				new ChooseRandomLegModeForSubtour(
+						new MainModeIdentifierImpl(),
+						new PermissibleModesCalculatorImpl(config),
+						MODES,
+						CHAIN_BASED_MODES,
+						new Random(20130225), SubtourModeChoice.Behavior.fromSpecifiedModesToSpecifiedModes,
+						probaForRandomSingleTripMode);
 
-		for ( Fixture f : createFixtures() ) {
+		for (Fixture f : createFixtures()) {
 			for (int i = 0; i < 5; i++) {
 				final Plan plan = f.createNewPlanInstance();
 				final int initNTrips = TripStructureUtils.getTrips( plan ).size();

--- a/matsim/src/test/java/org/matsim/population/algorithms/ChooseRandomLegModeForSubtourDiffModesTest.java
+++ b/matsim/src/test/java/org/matsim/population/algorithms/ChooseRandomLegModeForSubtourDiffModesTest.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,6 +34,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.Plan;
 import org.matsim.api.core.v01.population.PopulationFactory;
+import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.population.algorithms.ChooseRandomLegModeForSubtour;
 import org.matsim.core.population.algorithms.PermissibleModesCalculatorImpl;
@@ -112,16 +112,19 @@ public class ChooseRandomLegModeForSubtourDiffModesTest {
 	
 	@Test
 	public void testMutatedTrips() {
+		Config config = ConfigUtils.createConfig();
+		config.subtourModeChoice().setModes(MODES);
+		config.subtourModeChoice().setConsiderCarAvailability(false);
 		final ChooseRandomLegModeForSubtour testee =
-			new ChooseRandomLegModeForSubtour(
-					new MainModeIdentifierImpl(),
-					new PermissibleModesCalculatorImpl( MODES , false ),
-					MODES,
-					CHAIN_BASED_MODES,
-					new Random( 20130225 ), SubtourModeChoice.Behavior.fromSpecifiedModesToSpecifiedModes,
-					probaForRandomSingleTripMode);
+				new ChooseRandomLegModeForSubtour(
+						new MainModeIdentifierImpl(),
+						new PermissibleModesCalculatorImpl(config),
+						MODES,
+						CHAIN_BASED_MODES,
+						new Random(20130225), SubtourModeChoice.Behavior.fromSpecifiedModesToSpecifiedModes,
+						probaForRandomSingleTripMode);
 
-		for ( Fixture f : createFixtures() ) {
+		for (Fixture f : createFixtures()) {
 			for (int i = 0; i < 5; i++) {
 				final Plan plan = f.createNewPlanInstance();
 				final int initNTrips = TripStructureUtils.getTrips( plan ).size();

--- a/matsim/src/test/java/org/matsim/population/algorithms/PermissibleModesCalculatorImplTest.java
+++ b/matsim/src/test/java/org/matsim/population/algorithms/PermissibleModesCalculatorImplTest.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,6 +33,8 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Plan;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.population.PersonUtils;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.population.algorithms.PermissibleModesCalculator;
@@ -101,36 +102,37 @@ public class PermissibleModesCalculatorImplTest {
 
 	@Test
 	public void testWhenConsideringCarAvailability() throws Exception {
-		final List<String> modesWithCar = Arrays.asList( TransportMode.car , "rail" , "plane" );
-		final List<String> modesWithoutCar = Arrays.asList( "rail" , "plane" );
+		final List<String> modesWithCar = Arrays.asList(TransportMode.car, "rail", "plane");
+		final List<String> modesWithoutCar = Arrays.asList("rail", "plane");
+		Config config = ConfigUtils.createConfig();
+		config.subtourModeChoice().setModes(modesWithCar.toArray(new String[0]));
+		config.subtourModeChoice().setConsiderCarAvailability(true);
 
 		final PermissibleModesCalculator calculatorWithCarAvailability =
-			new PermissibleModesCalculatorImpl(
-					modesWithCar.toArray( new String[0] ),
-					true);
+				new PermissibleModesCalculatorImpl(config);
 
 		for (Fixture f : fixtures) {
 			assertListsAreCompatible(
 					f.name,
 					f.carAvail ? modesWithCar : modesWithoutCar,
-					calculatorWithCarAvailability.getPermissibleModes( f.plan ) );
+					calculatorWithCarAvailability.getPermissibleModes(f.plan));
 		}
 	}
 
 	@Test
 	public void testWhenNotConsideringCarAvailability() throws Exception {
-		final List<String> modesWithCar = Arrays.asList( TransportMode.car , "rail" , "plane" );
-
+		final List<String> modesWithCar = Arrays.asList(TransportMode.car, "rail", "plane");
+		Config config = ConfigUtils.createConfig();
+		config.subtourModeChoice().setModes(modesWithCar.toArray(new String[0]));
+		config.subtourModeChoice().setConsiderCarAvailability(false);
 		final PermissibleModesCalculator calculatorWithCarAvailability =
-			new PermissibleModesCalculatorImpl(
-					modesWithCar.toArray( new String[0] ),
-					false);
+				new PermissibleModesCalculatorImpl(config);
 
 		for (Fixture f : fixtures) {
 			assertListsAreCompatible(
 					f.name,
 					modesWithCar,
-					calculatorWithCarAvailability.getPermissibleModes( f.plan ) );
+					calculatorWithCarAvailability.getPermissibleModes(f.plan));
 		}
 	}
 


### PR DESCRIPTION
Allows an easier overwriting of the permissible Modes Calculator, previously one had to overwrite SubtourModeChoiceModule as a whole