### PR TITLE
OSM Reader: Public link properties

### DIFF
--- a/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/OsmNetworkParser.java
+++ b/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/OsmNetworkParser.java
@@ -11,15 +11,14 @@ import java.nio.file.Path;
 import java.text.NumberFormat;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 
 class OsmNetworkParser {
 
-	private static Logger log = Logger.getLogger(OsmNetworkParser.class);
-	private static NumberFormat numberFormat = NumberFormat.getNumberInstance(Locale.UK);
+	private static final Logger log = Logger.getLogger(OsmNetworkParser.class);
+	private static final NumberFormat numberFormat = NumberFormat.getNumberInstance(Locale.UK);
 
 	private final CoordinateTransformation transformation;
 	private final Map<String, LinkProperties> linkProperties;
@@ -85,7 +84,7 @@ class OsmNetworkParser {
 			ProcessedOsmNode result = new ProcessedOsmNode(osmNode.getId(), filteredReferencingLinks, transformedCoord);
 			this.nodes.put(result.getId(), result);
 
-			if (nodes.size() % 10000 == 0) {
+			if (nodes.size() % 100000 == 0) {
 				log.info("Added " + numberFormat.format(nodes.size()) + " nodes");
 			}
 		}

--- a/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/OsmNetworkParser.java
+++ b/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/OsmNetworkParser.java
@@ -22,14 +22,14 @@ class OsmNetworkParser {
 	private static NumberFormat numberFormat = NumberFormat.getNumberInstance(Locale.UK);
 
 	private final CoordinateTransformation transformation;
-	private final ConcurrentMap<String, LinkProperties> linkProperties;
+	private final Map<String, LinkProperties> linkProperties;
 	private final BiPredicate<Coord, Integer> linkFilter;
 	final ExecutorService executor;
 	Map<Long, ProcessedOsmWay> ways;
 	Map<Long, ProcessedOsmNode> nodes;
 	Map<Long, List<ProcessedOsmWay>> nodeReferences;
 
-	OsmNetworkParser(CoordinateTransformation transformation, ConcurrentMap<String, LinkProperties> linkProperties, BiPredicate<Coord, Integer> linkFilter, ExecutorService executor) {
+	OsmNetworkParser(CoordinateTransformation transformation, Map<String, LinkProperties> linkProperties, BiPredicate<Coord, Integer> linkFilter, ExecutorService executor) {
 		this.transformation = transformation;
 		this.linkProperties = linkProperties;
 		this.linkFilter = linkFilter;

--- a/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/OsmNetworkParser.java
+++ b/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/OsmNetworkParser.java
@@ -127,43 +127,4 @@ class OsmNetworkParser {
 				.filter(way -> linkFilter.test(coord, way.getLinkProperties().hierachyLevel))
 				.collect(Collectors.toList());
 	}
-
-/*
-	static NodesAndWays parse(Path inputFile, ConcurrentMap<String, LinkProperties> linkPropertiesMap, CoordinateTransformation transformation, BiPredicate<Coord, Integer> linkFilter) {
-
-		log.info("start reading ways");
-
-		ExecutorService executor = Executors.newWorkStealingPool();
-		WaysPbfParser waysParser = new WaysPbfParser(executor, linkPropertiesMap);
-
-		try (InputStream fileInputStream = new FileInputStream(inputFile.toFile())) {
-			BufferedInputStream input = new BufferedInputStream(fileInputStream);
-			waysParser.parse(input);
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-
-		log.info("finished reading ways.");
-		log.info("Kept " + NumberFormat.getNumberInstance(Locale.US).format(waysParser.getWays().size()) + "/" +
-				NumberFormat.getNumberInstance(Locale.US).format(waysParser.getCounter()) + " ways");
-		log.info("Marked " + NumberFormat.getNumberInstance(Locale.US).format(waysParser.getNodes().size()) + " nodes to be kept");
-		log.info("starting to read nodes");
-
-		NodesPbfParser nodesParser = new NodesPbfParser(executor, linkFilter, waysParser.getNodes(), transformation);
-
-		try (InputStream fileInputStream = new FileInputStream(inputFile.toFile())) {
-
-			BufferedInputStream input = new BufferedInputStream(fileInputStream);
-			nodesParser.parse(input);
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-
-		log.info("finished reading nodes");
-		log.info("Kept " + NumberFormat.getNumberInstance(Locale.US).format(nodesParser.getNodes().size()) + "/"
-				+ NumberFormat.getNumberInstance(Locale.US).format(nodesParser.getCount()) + " nodes");
-
-		return new NodesAndWays(nodesParser.getNodes(), waysParser.getWays());
-	}
-	*/
 }

--- a/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/OsmSignalsParser.java
+++ b/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/OsmSignalsParser.java
@@ -31,7 +31,7 @@ class OsmSignalsParser extends OsmNetworkParser {
 		return signalizedNodes;
 	}
 
-	OsmSignalsParser(CoordinateTransformation transformation, ConcurrentMap<String, LinkProperties> linkProperties, BiPredicate<Coord, Integer> linkFilter, ExecutorService executor) {
+	OsmSignalsParser(CoordinateTransformation transformation, Map<String, LinkProperties> linkProperties, BiPredicate<Coord, Integer> linkFilter, ExecutorService executor) {
 		super(transformation, linkProperties, linkFilter, executor);
 	}
 


### PR DESCRIPTION
Made LinkProperties and some utility methods public, so they can be re-used for network creation.