### PR TITLE
Make preserveNodeWithId work

### DIFF
--- a/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/OsmNetworkParser.java
+++ b/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/OsmNetworkParser.java
@@ -72,13 +72,19 @@ class OsmNetworkParser {
 
 		if (nodeReferences.containsKey(osmNode.getId())) {
 
-			if (osmNode.getId() == 51414415 || osmNode.getId() == 51414416) {
-				log.info("stop it");
-			}
-
 			List<ProcessedOsmWay> waysThatReferenceNode = nodeReferences.get(osmNode.getId());
 			Coord transformedCoord = transformation.transform(new Coord(osmNode.getLongitude(), osmNode.getLatitude()));
 
+			// 'testWhetherReferencingLinksAreInFilter' may be expensive because it might include a test whether the
+			// supplied coordinate is within a shape. Therefore we want to test as few cases as possible. Two cases are tested anyway:
+			//   1. if more than one way references this node, this node is an intersection and a possible end node for a
+			//      matsim link.
+			//   2. if this node is either the start- or end node of a referencing way which makes it a candidate for a node
+			//      in a matsim link as well
+			//
+			// if a way has both ends outside the filter and no intersections within the filter it will not be included
+			// in the final network. I think this is unlikely in real world scenarios, so I think we can live with this
+			// to achieve faster execution
 			List<ProcessedOsmWay> filteredReferencingLinks;
 			if (waysThatReferenceNode.size() > 1 || isEndNodeOfReferencingLink(osmNode, waysThatReferenceNode.get(0)))
 				filteredReferencingLinks = testWhetherReferencingLinksAreInFilter(transformedCoord, waysThatReferenceNode);

--- a/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/OsmNetworkParser.java
+++ b/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/OsmNetworkParser.java
@@ -72,6 +72,10 @@ class OsmNetworkParser {
 
 		if (nodeReferences.containsKey(osmNode.getId())) {
 
+			if (osmNode.getId() == 51414415 || osmNode.getId() == 51414416) {
+				log.info("stop it");
+			}
+
 			List<ProcessedOsmWay> waysThatReferenceNode = nodeReferences.get(osmNode.getId());
 			Coord transformedCoord = transformation.transform(new Coord(osmNode.getLongitude(), osmNode.getLatitude()));
 

--- a/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/SupersonicOsmNetworkReader.java
+++ b/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/SupersonicOsmNetworkReader.java
@@ -121,7 +121,11 @@ public class SupersonicOsmNetworkReader {
     }
 
     private boolean isCreateSegment(ProcessedOsmNode from, ProcessedOsmNode to, ProcessedOsmWay way) {
-        return (to.isIntersection() || to.getId() == way.getEndNodeId() || preserveNodeWithId.test(to.getId()))
+
+        // if the user wants to have this node, then he should get it no matter what the other conditions are.
+        if (preserveNodeWithId.test(to.getId())) return true;
+
+        return (to.isIntersection() || to.getId() == way.getEndNodeId())
                 && (to.isWayReferenced(way.getId()) || from.isWayReferenced(way.getId()));
     }
 

--- a/contribs/osm/src/test/java/org/matsim/contrib/osm/networkReader/OsmBicycleReaderTest.java
+++ b/contribs/osm/src/test/java/org/matsim/contrib/osm/networkReader/OsmBicycleReaderTest.java
@@ -51,7 +51,7 @@ public class OsmBicycleReaderTest {
 		assertEquals(2, network.getNodes().size());
 
 		// check for all the tags
-		Link link = network.getLinks().get(Id.createLinkId("10001f"));
+		Link link = network.getLinks().get(Id.createLinkId("10002f"));
 		assertPresentAndEqual(link, OsmTags.SURFACE, surface);
 		assertPresentAndEqual(link, OsmTags.SMOOTHNESS, smoothness);
 		assertPresentAndEqual(link, OsmTags.CYCLEWAY, cycleway);
@@ -77,7 +77,7 @@ public class OsmBicycleReaderTest {
 		assertEquals(2, network.getNodes().size());
 
 		// check for all the tags
-		Link link = network.getLinks().get(Id.createLinkId("10001f"));
+		Link link = network.getLinks().get(Id.createLinkId("10002f"));
 		assertPresentAndEqual(link, OsmTags.SURFACE, "asphalt");
 	}
 
@@ -100,7 +100,7 @@ public class OsmBicycleReaderTest {
 		assertEquals(2, network.getNodes().size());
 
 		// check for all the tags
-		Link link = network.getLinks().get(Id.createLinkId("10001f"));
+		Link link = network.getLinks().get(Id.createLinkId("10002f"));
 		assertFalse(link.getAllowedModes().contains(TransportMode.bike));
 		assertTrue(link.getAllowedModes().contains(TransportMode.car));
 	}
@@ -124,7 +124,7 @@ public class OsmBicycleReaderTest {
 		assertEquals(2, network.getNodes().size());
 
 		// check for all the tags
-		Link link = network.getLinks().get(Id.createLinkId("10001f"));
+		Link link = network.getLinks().get(Id.createLinkId("10002f"));
 		assertTrue(link.getAllowedModes().contains(TransportMode.bike));
 		assertFalse(link.getAllowedModes().contains(TransportMode.car));
 	}
@@ -152,11 +152,11 @@ public class OsmBicycleReaderTest {
 		assertEquals(2, network.getLinks().size());
 		assertEquals(2, network.getNodes().size());
 
-		Link forward = network.getLinks().get(Id.createLinkId("10001f"));
+		Link forward = network.getLinks().get(Id.createLinkId("10002f"));
 		assertTrue(forward.getAllowedModes().contains(TransportMode.car));
 		assertTrue(forward.getAllowedModes().contains(TransportMode.bike));
 
-		Link reverse = network.getLinks().get(Id.createLinkId("10001f_bike-reverse"));
+		Link reverse = network.getLinks().get(Id.createLinkId("10002f_bike-reverse"));
 		assertFalse(reverse.getAllowedModes().contains(TransportMode.car));
 		assertTrue(reverse.getAllowedModes().contains(TransportMode.bike));
 		assertPresentAndEqual(reverse, OsmTags.SURFACE, surface);
@@ -185,11 +185,11 @@ public class OsmBicycleReaderTest {
 		assertEquals(2, network.getLinks().size());
 		assertEquals(2, network.getNodes().size());
 
-		Link forward = network.getLinks().get(Id.createLinkId("10001f"));
+		Link forward = network.getLinks().get(Id.createLinkId("10002f"));
 		assertTrue(forward.getAllowedModes().contains(TransportMode.car));
 		assertTrue(forward.getAllowedModes().contains(TransportMode.bike));
 
-		Link reverse = network.getLinks().get(Id.createLinkId("10001f_bike-reverse"));
+		Link reverse = network.getLinks().get(Id.createLinkId("10002f_bike-reverse"));
 		assertFalse(reverse.getAllowedModes().contains(TransportMode.car));
 		assertTrue(reverse.getAllowedModes().contains(TransportMode.bike));
 		assertPresentAndEqual(reverse, OsmTags.SURFACE, surface);
@@ -218,12 +218,12 @@ public class OsmBicycleReaderTest {
 		assertEquals(2, network.getLinks().size());
 		assertEquals(2, network.getNodes().size());
 
-		Link forward = network.getLinks().get(Id.createLinkId("10001r_bike-reverse"));
+		Link forward = network.getLinks().get(Id.createLinkId("10002r_bike-reverse"));
 		assertFalse(forward.getAllowedModes().contains(TransportMode.car));
 		assertTrue(forward.getAllowedModes().contains(TransportMode.bike));
 		assertPresentAndEqual(forward, OsmTags.SURFACE, surface);
 
-		Link reverse = network.getLinks().get(Id.createLinkId("10001r"));
+		Link reverse = network.getLinks().get(Id.createLinkId("10002r"));
 		assertTrue(reverse.getAllowedModes().contains(TransportMode.car));
 		assertTrue(reverse.getAllowedModes().contains(TransportMode.bike));
 		assertPresentAndEqual(reverse, OsmTags.SURFACE, surface);

--- a/contribs/osm/src/test/java/org/matsim/contrib/osm/networkReader/OsmNetworkParserTest.java
+++ b/contribs/osm/src/test/java/org/matsim/contrib/osm/networkReader/OsmNetworkParserTest.java
@@ -47,7 +47,7 @@ public class OsmNetworkParserTest {
 
 		assertEquals(osmWay.getId(), processedOsmWay.getId());
 		assertEquals(1, processedOsmWay.getStartNode());
-		assertEquals(3, processedOsmWay.getEndNodeId());
+		assertEquals(4, processedOsmWay.getEndNodeId());
 		assertTrue(processedOsmWay.getTags().containsKey(OsmTags.HIGHWAY));
 		assertEquals(OsmTags.MOTORWAY, processedOsmWay.getTags().get(OsmTags.HIGHWAY));
 
@@ -55,7 +55,8 @@ public class OsmNetworkParserTest {
 		assertEquals(singleLink.getNodes().size(), parser.getNodes().size());
 		assertEquals(1, parser.getNodes().get(1L).getFilteredReferencedWays().size());
 		assertEquals(0, parser.getNodes().get(2L).getFilteredReferencedWays().size());
-		assertEquals(1, parser.getNodes().get(3L).getFilteredReferencedWays().size());
+		assertEquals(0, parser.getNodes().get(3L).getFilteredReferencedWays().size());
+		assertEquals(1, parser.getNodes().get(4L).getFilteredReferencedWays().size());
 	}
 
 	@Test
@@ -72,13 +73,16 @@ public class OsmNetworkParserTest {
 		assertEquals(2, ways.size());
 
 		Map<Long, ProcessedOsmNode> nodes = parser.getNodes();
-		assertEquals(5, nodes.size());
+		assertEquals(17, nodes.size());
 
-		assertEquals(2, nodes.get(2L).getFilteredReferencedWays().size());
-		assertEquals(1, nodes.get(1L).getFilteredReferencedWays().size());
-		assertEquals(1, nodes.get(1L).getFilteredReferencedWays().size());
-		assertEquals(1, nodes.get(1L).getFilteredReferencedWays().size());
-		assertEquals(1, nodes.get(1L).getFilteredReferencedWays().size());
+		for (var node : nodes.values()) {
+			if (node.getId() == 5L) // the intersection
+				assertEquals(2, node.getFilteredReferencedWays().size());
+			else if (node.getId() == 9L || node.getId() == 1L || node.getId() == 10L || node.getId() == 17L) // the end nodes
+				assertEquals(1, node.getFilteredReferencedWays().size());
+			else // all in-between nodes
+				assertEquals(0, node.getFilteredReferencedWays().size());
+		}
 	}
 
 	@Test
@@ -97,15 +101,15 @@ public class OsmNetworkParserTest {
 		Map<Long, ProcessedOsmNode> nodes = parser.getNodes();
 
 		// we expect all nodes to be stored
-		assertEquals(5, nodes.size());
+		assertEquals(17, nodes.size());
 
 		// all nodes should be referenced only by the motorway
 		for (ProcessedOsmNode node : nodes.values()) {
-			if (node.getId() == 4 || node.getId() == 5) {
-				assertEquals(0, node.getFilteredReferencedWays().size());
-			} else {
+			if (node.getId() == 1 || node.getId() == 5 || node.getId() == 9) {
 				assertEquals(1, node.getFilteredReferencedWays().size());
 				assertEquals(twoIntersectingLinks.getWays().get(0).getId(), node.getFilteredReferencedWays().get(0).getId());
+			} else {
+				assertEquals(0, node.getFilteredReferencedWays().size());
 			}
 		}
 	}
@@ -126,7 +130,7 @@ public class OsmNetworkParserTest {
 		Map<Long, ProcessedOsmNode> nodes = parser.getNodes();
 
 		// we want all three nodes of the way
-		assertEquals(3, nodes.size());
+		assertEquals(4, nodes.size());
 
 		OsmNode node1 = singleLink.getNodes().get(0);
 		Coord transformedNode1 = atlantis.transform(new Coord(node1.getLatitude(), node1.getLongitude()));

--- a/contribs/osm/src/test/java/org/matsim/contrib/osm/networkReader/OsmSignalsParserTest.java
+++ b/contribs/osm/src/test/java/org/matsim/contrib/osm/networkReader/OsmSignalsParserTest.java
@@ -57,7 +57,7 @@ public class OsmSignalsParserTest {
 		parser.parse(file);
 
 		assertEquals(1, parser.getWays().size());
-		assertEquals(3, parser.getNodes().size());
+		assertEquals(4, parser.getNodes().size());
 		assertEquals(1, parser.getSignalizedNodes().size());
 		assertEquals(0, parser.getNodeRestrictions().size());
 
@@ -91,7 +91,7 @@ public class OsmSignalsParserTest {
 		parser.parse(file);
 
 		assertEquals(1, parser.getWays().size());
-		assertEquals(3, parser.getNodes().size());
+		assertEquals(4, parser.getNodes().size());
 		assertEquals(1, parser.getSignalizedNodes().size());
 		assertEquals(0, parser.getNodeRestrictions().size());
 
@@ -125,7 +125,7 @@ public class OsmSignalsParserTest {
 		parser.parse(file);
 
 		assertEquals(1, parser.getWays().size());
-		assertEquals(3, parser.getNodes().size());
+		assertEquals(4, parser.getNodes().size());
 		assertEquals(0, parser.getSignalizedNodes().size());
 		assertEquals(0, parser.getNodeRestrictions().size());
 	}
@@ -145,7 +145,7 @@ public class OsmSignalsParserTest {
 		parser.parse(file);
 
 		assertEquals(1, parser.getWays().size());
-		assertEquals(3, parser.getNodes().size());
+		assertEquals(4, parser.getNodes().size());
 		assertEquals(0, parser.getSignalizedNodes().size());
 		assertEquals(0, parser.getNodeRestrictions().size());
 	}
@@ -166,7 +166,7 @@ public class OsmSignalsParserTest {
 		parser.parse(file);
 
 		assertEquals(2, parser.getWays().size());
-		assertEquals(5, parser.getNodes().size());
+		assertEquals(17, parser.getNodes().size());
 		assertEquals(0, parser.getSignalizedNodes().size());
 		assertEquals(1, parser.getNodeRestrictions().size());
 
@@ -193,7 +193,7 @@ public class OsmSignalsParserTest {
 		parser.parse(file);
 
 		assertEquals(2, parser.getWays().size());
-		assertEquals(5, parser.getNodes().size());
+		assertEquals(17, parser.getNodes().size());
 		assertEquals(0, parser.getSignalizedNodes().size());
 		assertEquals(1, parser.getNodeRestrictions().size());
 

--- a/contribs/osm/src/test/java/org/matsim/contrib/osm/networkReader/SupersonicOsmNetworkReaderTest.java
+++ b/contribs/osm/src/test/java/org/matsim/contrib/osm/networkReader/SupersonicOsmNetworkReaderTest.java
@@ -58,6 +58,7 @@ public class SupersonicOsmNetworkReaderTest {
 		}
 	}
 
+	@SuppressWarnings("ConstantConditions")
 	@Test
 	public void singleLink() {
 
@@ -80,12 +81,14 @@ public class SupersonicOsmNetworkReaderTest {
 		OsmNode node1 = singleLink.getNodes().get(0);
 		OsmNode node2 = singleLink.getNodes().get(1);
 		OsmNode node3 = singleLink.getNodes().get(2);
+		OsmNode node4 = singleLink.getNodes().get(3);
 		OsmWay way = singleLink.getWays().get(0);
 
 		Link link = network.getLinks().values().iterator().next(); // get the only link
 		double expectedLengthPart1 = CoordUtils.calcEuclideanDistance(new Coord(node1.getLongitude(), node1.getLatitude()), new Coord(node2.getLongitude(), node2.getLatitude()));
 		double expectedLengthPart2 = CoordUtils.calcEuclideanDistance(new Coord(node2.getLongitude(), node2.getLatitude()), new Coord(node3.getLongitude(), node3.getLatitude()));
-		assertEquals(expectedLengthPart1 + expectedLengthPart2, link.getLength(), 0);
+		double expectedLengthPart3 = CoordUtils.calcEuclideanDistance(new Coord(node3.getLongitude(), node3.getLatitude()), new Coord(node4.getLongitude(), node4.getLatitude()));
+		assertEquals(expectedLengthPart1 + expectedLengthPart2 + expectedLengthPart3, link.getLength(), 0);
 
 		LinkProperties linkProperties = LinkProperties.createMotorway();
 		assertEquals(linkProperties.freespeed, link.getFreespeed(), 0);
@@ -101,8 +104,9 @@ public class SupersonicOsmNetworkReaderTest {
 		assertEquals(MOTORWAY, link.getAttributes().getAttribute(NetworkUtils.TYPE));
 	}
 
+	@SuppressWarnings("ConstantConditions")
 	@Test
-	public void singleLinkPreserveMiddleNode() {
+	public void singleLinkPreserveMiddleNodes() {
 
 		Utils.OsmData singleLink = Utils.createSingleLink();
 
@@ -112,15 +116,15 @@ public class SupersonicOsmNetworkReaderTest {
 
 		Network network = new SupersonicOsmNetworkReader.Builder()
 				.setCoordinateTransformation(transformation)
-				.setPreserveNodeWithId(id -> id == 2)
+				.setPreserveNodeWithId(id -> true)
 				.build()
 				.read(file);
 
-		assertEquals(2, network.getLinks().size());
-		assertEquals(3, network.getNodes().size());
+		assertEquals(3, network.getLinks().size());
+		assertEquals(4, network.getNodes().size());
 
 		// now, test that the link has all the required properties
-		Link link = network.getLinks().values().iterator().next(); // get the only link
+		Link link = network.getLinks().get(Id.createLinkId("10001f"));
 
 		LinkProperties linkProperties = LinkProperties.createMotorway();
 		assertEquals(linkProperties.freespeed, link.getFreespeed(), 0);
@@ -468,42 +472,48 @@ public class SupersonicOsmNetworkReaderTest {
 	@Test
 	public void twoIntersectingLinks() {
 
-		final List<Tag> tags = Collections.singletonList(new Tag("highway", MOTORWAY));
-		final List<OsmNode> nodes = Arrays.asList(new Node(1, 0, 0), new Node(2, 1, 1), new Node(3, 2, 2),
-				new Node(4, 0, 2), new Node(5, 2, 0));
-		final List<OsmWay> ways = Arrays.asList(new Way(1, new TLongArrayList(new long[]{1, 2, 3}), tags),
-				new Way(2, new TLongArrayList(new long[]{4, 2, 5}), tags));
-		final Path file = Paths.get(matsimTestUtils.getOutputDirectory(), "two-intersecting-links.pbf");
-		writeOsmData(nodes, ways, file);
+		var twoLinks = Utils.createTwoIntersectingLinksWithDifferentLevels();
+		var file = Paths.get(matsimTestUtils.getOutputDirectory(), "two-intersecting-links.pbf");
+		Utils.writeOsmData(twoLinks, file);
 
-		Network network = new SupersonicOsmNetworkReader.Builder()
+		var network = new SupersonicOsmNetworkReader.Builder()
 				.setCoordinateTransformation(transformation)
 				.build()
 				.read(file);
 
 		assertEquals(5, network.getNodes().size());
-		assertEquals(4, network.getLinks().size());
+		assertEquals(6, network.getLinks().size());
 
 		// check whether the links were correctly split
-		Link link1 = network.getLinks().get(Id.createLinkId("10000f"));
+		Link link1 = network.getLinks().get(Id.createLinkId("10003f"));
 		assertEquals(Id.createNodeId(1), link1.getFromNode().getId());
-		assertEquals(Id.createNodeId(2), link1.getToNode().getId());
+		assertEquals(Id.createNodeId(5), link1.getToNode().getId());
 		assertEquals(CoordUtils.calcEuclideanDistance(link1.getFromNode().getCoord(), link1.getToNode().getCoord()), link1.getLength(), 0);
 
-		Link link2 = network.getLinks().get(Id.createLinkId("10001f"));
-		assertEquals(Id.createNodeId(2), link2.getFromNode().getId());
-		assertEquals(Id.createNodeId(3), link2.getToNode().getId());
+		Link link2 = network.getLinks().get(Id.createLinkId("10007f"));
+		assertEquals(Id.createNodeId(5), link2.getFromNode().getId());
+		assertEquals(Id.createNodeId(9), link2.getToNode().getId());
 		assertEquals(CoordUtils.calcEuclideanDistance(link2.getFromNode().getCoord(), link2.getToNode().getCoord()), link2.getLength(), 0);
 
-		Link link3 = network.getLinks().get(Id.createLinkId("20000f"));
-		assertEquals(Id.createNodeId(4), link3.getFromNode().getId());
-		assertEquals(Id.createNodeId(2), link3.getToNode().getId());
+		Link link3 = network.getLinks().get(Id.createLinkId("20003f"));
+		assertEquals(Id.createNodeId(10), link3.getFromNode().getId());
+		assertEquals(Id.createNodeId(5), link3.getToNode().getId());
 		assertEquals(CoordUtils.calcEuclideanDistance(link3.getFromNode().getCoord(), link3.getToNode().getCoord()), link3.getLength(), 0);
 
-		Link link4 = network.getLinks().get(Id.createLinkId("20001f"));
-		assertEquals(Id.createNodeId(2), link4.getFromNode().getId());
-		assertEquals(Id.createNodeId(5), link4.getToNode().getId());
+		Link link4 = network.getLinks().get(Id.createLinkId("20007f"));
+		assertEquals(Id.createNodeId(5), link4.getFromNode().getId());
+		assertEquals(Id.createNodeId(17), link4.getToNode().getId());
 		assertEquals(CoordUtils.calcEuclideanDistance(link4.getFromNode().getCoord(), link4.getToNode().getCoord()), link4.getLength(), 0);
+
+		Link link5 = network.getLinks().get(Id.createLinkId("20007r"));
+		assertEquals(Id.createNodeId(17), link5.getFromNode().getId());
+		assertEquals(Id.createNodeId(5), link5.getToNode().getId());
+		assertEquals(CoordUtils.calcEuclideanDistance(link5.getFromNode().getCoord(), link5.getToNode().getCoord()), link5.getLength(), 0);
+
+		Link link6 = network.getLinks().get(Id.createLinkId("20003r"));
+		assertEquals(Id.createNodeId(5), link6.getFromNode().getId());
+		assertEquals(Id.createNodeId(10), link6.getToNode().getId());
+		assertEquals(CoordUtils.calcEuclideanDistance(link6.getFromNode().getCoord(), link6.getToNode().getCoord()), link6.getLength(), 0);
 	}
 
 	@Test

--- a/contribs/osm/src/test/java/org/matsim/contrib/osm/networkReader/Utils.java
+++ b/contribs/osm/src/test/java/org/matsim/contrib/osm/networkReader/Utils.java
@@ -20,10 +20,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -82,23 +79,64 @@ public class Utils {
 		Node node1 = new Node(1, 0, 0);
 		Node node2 = new Node(2, 100, 100);
 		Node node3 = new Node(3, 0, 200);
-		TLongArrayList nodeReference = new TLongArrayList(new long[]{node1.getId(), node2.getId(), node3.getId()});
+		Node node4 = new Node(4, 50, 150);
+		TLongArrayList nodeReference = new TLongArrayList(new long[]{node1.getId(), node2.getId(), node3.getId(), node4.getId()});
 		Way way = new Way(1, nodeReference, tags);
 
-		return new OsmData(Arrays.asList(node1, node2, node3), Collections.singletonList(way), Collections.emptyList());
+		return new OsmData(Arrays.asList(node1, node2, node3, node4), Collections.singletonList(way), Collections.emptyList());
 	}
 
 	static OsmData createTwoIntersectingLinksWithDifferentLevels() {
+
+		// way 1 will go diagonally from bottom left to upper right
 		Node node1 = new Node(1, 0, 0);
-		Node node2 = new Node(2, 100, 100);
-		Node node3 = new Node(3, 0, 200);
-		Node node4 = new Node(4, 200, 0);
-		Node node5 = new Node(5, 200, 200);
-		TLongArrayList nodeReferenceForWay1 = new TLongArrayList(new long[]{node1.getId(), node2.getId(), node3.getId()});
-		TLongArrayList nodeReferenceForWay2 = new TLongArrayList(new long[]{node4.getId(), node2.getId(), node5.getId()});
+		Node node2 = new Node(2, 25, 25);
+		Node node3 = new Node(3, 50, 50);
+		Node node4 = new Node(4, 75, 75);
+		Node node5 = new Node (5, 100, 100);
+		Node node6 = new Node(6, 125, 125);
+		Node node7 = new Node(7, 150, 150);
+		Node node8 = new Node(8, 175, 175);
+		Node node9 = new Node(9, 200, 200);
+
+		// way 2 will go diagonally from top left to bottom right
+		Node node10 = new Node(10, 0, 200);
+		Node node11 = new Node(11, 25, 175);
+		Node node12 = new Node(12, 50, 150);
+		Node node13 = new Node(13, 75, 125);
+		// 100,100 will be node 5
+		Node node14 = new Node(14, 125, 75);
+		Node node15 = new Node(15, 150, 50);
+		Node node16 = new Node(16, 175, 25);
+		Node node17 = new Node(17, 200, 0);
+
+		List<OsmNode> nodes = new ArrayList<>();
+		nodes.add(node1);
+		nodes.add(node2);
+		nodes.add(node3);
+		nodes.add(node4);
+		nodes.add(node5);
+		nodes.add(node6);
+		nodes.add(node7);
+		nodes.add(node8);
+		nodes.add(node9);
+		nodes.add(node10);
+		nodes.add(node11);
+		nodes.add(node12);
+		nodes.add(node13);
+		nodes.add(node14);
+		nodes.add(node15);
+		nodes.add(node16);
+		nodes.add(node17);
+
+		TLongArrayList nodeReferenceForWay1 = new TLongArrayList(new long[]{node1.getId(), node2.getId(), node3.getId(),
+				node4.getId(), node5.getId(), node6.getId(), node7.getId(), node8.getId(), node9.getId()});
+
+		TLongArrayList nodeReferenceForWay2 = new TLongArrayList(new long[]{node10.getId(), node11.getId(), node12.getId(),
+				node13.getId(), node5.getId(), node14.getId(), node15.getId(), node16.getId(), node17.getId()});
 		Way way1 = new Way(1, nodeReferenceForWay1, Collections.singletonList(new Tag(OsmTags.HIGHWAY, Utils.MOTORWAY)));
 		Way way2 = new Way(2, nodeReferenceForWay2, Collections.singletonList(new Tag(OsmTags.HIGHWAY, Utils.TERTIARY)));
-		return new OsmData(Arrays.asList(node1, node2, node3, node4, node5), Arrays.asList(way1, way2));
+		return new OsmData(nodes, Arrays.asList(way1, way2));
 	}
 
 	static OsmData createGridWithDifferentLevels() {
@@ -184,7 +222,7 @@ public class Utils {
 		private final List<OsmRelation> relations;
 
 		public OsmData(List<OsmNode> nodes, List<OsmWay> ways) {
-			this(nodes, ways, null);
+			this(nodes, ways, Collections.emptyList());
 		}
 
 		public OsmData(List<OsmNode> nodes, List<OsmWay> ways, List<OsmRelation> relations) {


### PR DESCRIPTION
Make sure the 'preserveNodeWithId' filter takes precedence over the spatial filter.

  * Fix unit tests to actually test this feature. The test osm-networks were not complex enough, so the tests didn't catch this case
  * A lot of test fixing due to the more complex example osm-networks