### PR TITLE
Drt rebalancing

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/ActivityLocationBasedZonalDemandAggregator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/ActivityLocationBasedZonalDemandAggregator.java
@@ -45,7 +45,7 @@ import org.matsim.pt.PtConstants;
  *
  * @author tschlenther
  */
-public class ActivityLocationBasedZonalDemandAggregator implements ZonalDemandAggregator, ActivityEndEventHandler {
+public final class ActivityLocationBasedZonalDemandAggregator implements ZonalDemandAggregator, ActivityEndEventHandler {
 
 	private final DrtZonalSystem zonalSystem;
 	private final int timeBinSize;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/EqualVehicleDensityZonalDemandAggregator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/EqualVehicleDensityZonalDemandAggregator.java
@@ -40,7 +40,7 @@ import org.matsim.contrib.dvrp.fleet.FleetSpecification;
  *
  * @author tschlenther
  */
-public class EqualVehicleDensityZonalDemandAggregator implements ZonalDemandAggregator {
+public final class EqualVehicleDensityZonalDemandAggregator implements ZonalDemandAggregator {
 
 	private final Map<String, MutableInt> vehiclesPerZone = new HashMap<>();
 	private static final MutableInt ZERO =  new MutableInt(0);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/FirstActivityCountAsZonalDemandAggregator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/FirstActivityCountAsZonalDemandAggregator.java
@@ -55,7 +55,7 @@ public final class FirstActivityCountAsZonalDemandAggregator implements ZonalDem
 	private final Map<Double, Map<String, MutableInt>> activityEndsPerTimeBinAndZone = new HashMap<>();
 	private static final MutableInt ZERO =  new MutableInt(0);
 
-	public FirstActivityCountAsZonalDemandAggregator(EventsManager eventsManager, DrtZonalSystem zonalSystem, Population population) {
+	public FirstActivityCountAsZonalDemandAggregator(DrtZonalSystem zonalSystem, Population population) {
 		this.zonalSystem = zonalSystem;
 		prepareZones();
 		countFirstActsPerZone(population);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/FirstActivityCountAsZonalDemandAggregator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/FirstActivityCountAsZonalDemandAggregator.java
@@ -1,0 +1,86 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2017 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+/**
+ *
+ */
+package org.matsim.contrib.drt.analysis.zonal;
+
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.apache.log4j.Logger;
+import org.matsim.api.core.v01.events.ActivityEndEvent;
+import org.matsim.api.core.v01.events.handler.ActivityEndEventHandler;
+import org.matsim.api.core.v01.population.Activity;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.drt.vrpagent.DrtActionCreator;
+import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.router.TripStructureUtils;
+import org.matsim.core.utils.misc.Time;
+import org.matsim.pt.PtConstants;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.ToIntFunction;
+
+/**
+ * Approximates population size per zone by counting first activites per zone in the selected plans.
+ * Should lead lead to rebalancing target values dependent on number of inhabitants.
+ *
+ * @author tschlenther
+ */
+public final class FirstActivityCountAsZonalDemandAggregator implements ZonalDemandAggregator {
+
+	private final DrtZonalSystem zonalSystem;
+	private final Map<Double, Map<String, MutableInt>> actEnds = new HashMap<>();
+	private Map<String, Integer> zonalDemand = new HashMap<>();
+	private final Map<Double, Map<String, MutableInt>> activityEndsPerTimeBinAndZone = new HashMap<>();
+	private static final MutableInt ZERO =  new MutableInt(0);
+
+	public FirstActivityCountAsZonalDemandAggregator(EventsManager eventsManager, DrtZonalSystem zonalSystem, Population population) {
+		this.zonalSystem = zonalSystem;
+		prepareZones();
+		countFirstActsPerZone(population);
+	}
+
+	private void countFirstActsPerZone(Population population) {
+		population.getPersons().values().stream()
+				.map(person -> person.getSelectedPlan().getPlanElements().get(0))
+				.forEach(element -> {
+					if (! (element instanceof Activity) ) throw new RuntimeException("first plan element is not an activity");
+					Activity activity = (Activity) element;
+					String zone = zonalSystem.getZoneForLinkId(activity.getLinkId());
+					Integer oldDemandValue = this.zonalDemand.get(zone);
+					this.zonalDemand.put(zone, oldDemandValue + 1);
+				});
+	}
+
+	public ToIntFunction<String> getExpectedDemandForTimeBin(double time) {
+		return zoneId -> this.zonalDemand.getOrDefault(zoneId, 0).intValue();
+	}
+
+	private void prepareZones() {
+		for (String zone : zonalSystem.getZones().keySet()) {
+			zonalDemand.put(zone, 0);
+		}
+	}
+
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/PreviousIterationZonalDRTDemandAggregator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/PreviousIterationZonalDRTDemandAggregator.java
@@ -41,7 +41,7 @@ import org.matsim.core.utils.misc.Time;
  *
  * @author jbischoff
  */
-public class PreviousIterationZonalDRTDemandAggregator implements ZonalDemandAggregator, PersonDepartureEventHandler {
+public final class PreviousIterationZonalDRTDemandAggregator implements ZonalDemandAggregator, PersonDepartureEventHandler {
 
 	private final DrtZonalSystem zonalSystem;
 	private final String mode;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/TimeDependentActivityBasedZonalDemandAggregator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/TimeDependentActivityBasedZonalDemandAggregator.java
@@ -45,7 +45,7 @@ import org.matsim.pt.PtConstants;
  *
  * @author tschlenther
  */
-public final class ActivityLocationBasedZonalDemandAggregator implements ZonalDemandAggregator, ActivityEndEventHandler {
+public final class TimeDependentActivityBasedZonalDemandAggregator implements ZonalDemandAggregator, ActivityEndEventHandler {
 
 	private final DrtZonalSystem zonalSystem;
 	private final int timeBinSize;
@@ -53,7 +53,7 @@ public final class ActivityLocationBasedZonalDemandAggregator implements ZonalDe
 	private final Map<Double, Map<String, MutableInt>> activityEndsPerTimeBinAndZone = new HashMap<>();
 	private static final MutableInt ZERO =  new MutableInt(0);
 
-	public ActivityLocationBasedZonalDemandAggregator(EventsManager eventsManager, DrtZonalSystem zonalSystem, DrtConfigGroup drtCfg) {
+	public TimeDependentActivityBasedZonalDemandAggregator(EventsManager eventsManager, DrtZonalSystem zonalSystem, DrtConfigGroup drtCfg) {
 		this.zonalSystem = zonalSystem;
 		timeBinSize = drtCfg.getMinCostFlowRebalancing().get().getInterval();
 		//self-registration

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/TimeDependentActivityBasedZonalDemandAggregator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/TimeDependentActivityBasedZonalDemandAggregator.java
@@ -40,7 +40,7 @@ import org.matsim.core.utils.misc.Time;
 import org.matsim.pt.PtConstants;
 
 /**
- * Aggregates all activity ends per iteration and returns the numbers from the previous iteration
+ * Aggregates all activity ends per zone and time bin in every iteration and returns the numbers from the previous iteration
  * as expected demand for the current iteration. This will lead to rebalancing target locations related to activity volume per zone.
  *
  * @author tschlenther

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.prep.PreparedGeometry;
 import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.population.Population;
 import org.matsim.contrib.drt.analysis.DrtRequestAnalyzer;
 import org.matsim.contrib.drt.analysis.zonal.*;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
@@ -98,21 +99,28 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 		});
 
 		switch (params.getZonalDemandAggregatorType()) {
-			case PreviousIterationZonalDemandAggregator:
+			case PreviousIteration:
 				bindModal(ZonalDemandAggregator.class).toProvider(modalProvider(
 						getter -> new PreviousIterationZonalDRTDemandAggregator(getter.get(EventsManager.class),
 								getter.getModal(DrtZonalSystem.class), drtCfg))).asEagerSingleton();
 				break;
-			case TimeDependentActivityBasedZonalDemandAggregator:
+			case TimeDependentActivityBased:
 				bindModal(ZonalDemandAggregator.class).toProvider(modalProvider(
 						getter -> new TimeDependentActivityBasedZonalDemandAggregator(getter.get(EventsManager.class),
 								getter.getModal(DrtZonalSystem.class), drtCfg))).asEagerSingleton();
 				break;
-			case EqualVehicleDensityZonalDemandAggregator:
+			case EqualVehicleDensity:
 				bindModal(ZonalDemandAggregator.class).toProvider(modalProvider(
 						getter -> new EqualVehicleDensityZonalDemandAggregator(getter.getModal(DrtZonalSystem.class),
 								getter.getModal(FleetSpecification.class)))).asEagerSingleton();
 				break;
+			case FirstActivityCount:
+				bindModal(ZonalDemandAggregator.class).toProvider(modalProvider(
+						getter -> new FirstActivityCountAsZonalDemandAggregator(getter.getModal(DrtZonalSystem.class),
+								getter.get(Population.class)))).asEagerSingleton();
+				break;
+			default:
+				throw new IllegalArgumentException("do not know what to do with ZonalDemandAggregatorType=" + params.getZonalDemandAggregatorType());
 		}
 
 		{

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
@@ -103,9 +103,9 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 						getter -> new PreviousIterationZonalDRTDemandAggregator(getter.get(EventsManager.class),
 								getter.getModal(DrtZonalSystem.class), drtCfg))).asEagerSingleton();
 				break;
-			case ActivityLocationBasedZonalDemandAggregator:
+			case TimeDependentActivityBasedZonalDemandAggregator:
 				bindModal(ZonalDemandAggregator.class).toProvider(modalProvider(
-						getter -> new ActivityLocationBasedZonalDemandAggregator(getter.get(EventsManager.class),
+						getter -> new TimeDependentActivityBasedZonalDemandAggregator(getter.get(EventsManager.class),
 								getter.getModal(DrtZonalSystem.class), drtCfg))).asEagerSingleton();
 				break;
 			case EqualVehicleDensityZonalDemandAggregator:

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingParams.java
@@ -26,6 +26,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.PositiveOrZero;
 
+import org.matsim.contrib.drt.analysis.zonal.ZonalDemandAggregator;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ReflectiveConfigGroup;
@@ -38,8 +39,10 @@ import com.google.common.base.Verify;
 public final class MinCostFlowRebalancingParams extends ReflectiveConfigGroup {
 	public static final String SET_NAME = "minCostFlowRebalancing";
 
-	public enum ZonalDemandAggregatorType {PreviousIterationZonalDemandAggregator,
-		TimeDependentActivityBasedZonalDemandAggregator, EqualVehicleDensityZonalDemandAggregator}
+	public enum ZonalDemandAggregatorType {PreviousIteration,
+		TimeDependentActivityBased,
+		EqualVehicleDensity,
+		FirstActivityCount}
 
 	public enum RebalancingZoneGeneration {GridFromNetwork, ShapeFile}
 
@@ -70,7 +73,7 @@ public final class MinCostFlowRebalancingParams extends ReflectiveConfigGroup {
 			+ " Depends on demand, supply and network. Often used with values in the range of 500 - 2000 m";
 
 	public static final String ZONAL_DEMAND_AGGREGATOR_TYPE = "zonalDemandAggregatorType";
-	static final String ZONAL_DEMAND_AGGREGATOR_TYPE_EXP = "Defines the methodology for demand estimation. Can be either PreviousIterationZonalDemandAggregator, TimeDependentActivityBasedZonalDemandAggregator or EqualVehicleDensityZonalDemandAggregator";
+	static final String ZONAL_DEMAND_AGGREGATOR_TYPE_EXP = "Defines the methodology for demand estimation. Can be one of either [PreviousIteration, TimeDependentActivityBased, EqualVehicleDensity, FirstActivityCount] Current default is PreviousIteration";
 
 	public static final String REBALANCING_ZONES_GENERATION = "rebalancingZonesGeneration";
 	static final String REBALANCING_ZONES_GENERATION_EXP = "Logic for generation of zones for demand estimation while rebalancing. Value can be GridFromNetwork or ShapeFile Default is GridFromNetwork";
@@ -99,7 +102,7 @@ public final class MinCostFlowRebalancingParams extends ReflectiveConfigGroup {
 	private double cellSize = Double.NaN;// [m]
 
 	@NotNull
-	private MinCostFlowRebalancingParams.ZonalDemandAggregatorType zonalDemandAggregatorType = ZonalDemandAggregatorType.PreviousIterationZonalDemandAggregator;
+	private MinCostFlowRebalancingParams.ZonalDemandAggregatorType zonalDemandAggregatorType = ZonalDemandAggregatorType.PreviousIteration;
 
 	@NotNull
 	private RebalancingZoneGeneration rebalancingZonesGeneration = RebalancingZoneGeneration.GridFromNetwork;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingParams.java
@@ -39,7 +39,7 @@ public final class MinCostFlowRebalancingParams extends ReflectiveConfigGroup {
 	public static final String SET_NAME = "minCostFlowRebalancing";
 
 	public enum ZonalDemandAggregatorType {PreviousIterationZonalDemandAggregator,
-		ActivityLocationBasedZonalDemandAggregator, EqualVehicleDensityZonalDemandAggregator}
+		TimeDependentActivityBasedZonalDemandAggregator, EqualVehicleDensityZonalDemandAggregator}
 
 	public enum RebalancingZoneGeneration {GridFromNetwork, ShapeFile}
 
@@ -70,7 +70,7 @@ public final class MinCostFlowRebalancingParams extends ReflectiveConfigGroup {
 			+ " Depends on demand, supply and network. Often used with values in the range of 500 - 2000 m";
 
 	public static final String ZONAL_DEMAND_AGGREGATOR_TYPE = "zonalDemandAggregatorType";
-	static final String ZONAL_DEMAND_AGGREGATOR_TYPE_EXP = "Defines the methodology for demand estimation. Can be either PreviousIterationZonalDemandAggregator, ActivityLocationBasedZonalDemandAggregator or EqualVehicleDensityZonalDemandAggregator";
+	static final String ZONAL_DEMAND_AGGREGATOR_TYPE_EXP = "Defines the methodology for demand estimation. Can be either PreviousIterationZonalDemandAggregator, TimeDependentActivityBasedZonalDemandAggregator or EqualVehicleDensityZonalDemandAggregator";
 
 	public static final String REBALANCING_ZONES_GENERATION = "rebalancingZonesGeneration";
 	static final String REBALANCING_ZONES_GENERATION_EXP = "Logic for generation of zones for demand estimation while rebalancing. Value can be GridFromNetwork or ShapeFile Default is GridFromNetwork";

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
@@ -61,7 +61,7 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 
 	@Test
 	public void EqualVehicleDensityZonalDemandAggregatorTest(){
-		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.EqualVehicleDensityZonalDemandAggregator, "");
+		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.EqualVehicleDensity, "");
 		controler.run();
 		ZonalDemandAggregator aggregator = controler.getInjector().getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
 		for(double ii = 0; ii < 16 * 3600; ii+=1800){
@@ -79,7 +79,7 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 
 	@Test
 	public void PreviousIterationZonalDemandAggregatorTest(){
-		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.PreviousIterationZonalDemandAggregator, "");
+		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.PreviousIteration, "");
 		controler.run();
 		ZonalDemandAggregator aggregator = controler.getInjector().getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
 		for(double ii = 1800; ii < 16 * 3600; ii+=1800){
@@ -97,7 +97,7 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 
 	@Test
 	public void PreviousIterationZonalDemandAggregatorWithSpeedUpModeTest(){
-		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.PreviousIterationZonalDemandAggregator, "drt_teleportation");
+		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.PreviousIteration, "drt_teleportation");
 		controler.run();
 		ZonalDemandAggregator aggregator = controler.getInjector().getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
 		for(double ii = 1800; ii < 16 * 3600; ii+=1800){
@@ -115,7 +115,7 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 
 	@Test
 	public void ActivityLocationBasedZonalDemandAggregatorTest(){
-		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.TimeDependentActivityBasedZonalDemandAggregator, "");
+		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.TimeDependentActivityBased, "");
 		controler.run();
 		ZonalDemandAggregator aggregator = controler.getInjector().getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
 		for(double ii = 1800; ii < 16 * 3600; ii+=1800){

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
@@ -131,6 +131,24 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 		}
 	}
 
+	@Test
+	public void FirstActivityCountAsZonalDemandAggregatorTest(){
+		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.FirstActivityCount, "");
+		controler.run();
+		ZonalDemandAggregator aggregator = controler.getInjector().getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
+		for(double ii = 0; ii < 16 * 3600; ii+=1800){
+			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 1", 0, demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 2", 99, demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 3", 0, demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 4", 99, demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 5", 0, demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 6", 0, demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 7", 0, demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 8", 99, demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
+		}
+	}
+
 	private Controler setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType aggregatorType, String drtSpeedUpModeForRebalancingConfiguration) {
 		URL configUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("dvrp-grid"), "eight_shared_taxi_config.xml");
 		Config config = ConfigUtils.loadConfig(configUrl, new MultiModeDrtConfigGroup(), new DvrpConfigGroup(),

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
@@ -115,7 +115,7 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 
 	@Test
 	public void ActivityLocationBasedZonalDemandAggregatorTest(){
-		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.ActivityLocationBasedZonalDemandAggregator, "");
+		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.TimeDependentActivityBasedZonalDemandAggregator, "");
 		controler.run();
 		ZonalDemandAggregator aggregator = controler.getInjector().getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
 		for(double ii = 1800; ii < 16 * 3600; ii+=1800){
@@ -180,7 +180,7 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 	 *	1	3	5	7
 	 *
 	 * 1) in the left column, there are half of the people, performing dummy - > car -> dummy
-	 *    That should lead to half of the drt vehicles rebalanced to the left column when using ActivityLocationBasedZonalDemandAggregator.
+	 *    That should lead to half of the drt vehicles rebalanced to the left column when using TimeDependentActivityBasedZonalDemandAggregator.
 	 * 2) in the right column, the other half of the people perform dummy -> drt -> dummy from top row to bottom row.
 	 * 	  That should lead to all drt vehicles rebalanced to the right column when using PreviousIterationZonalDRTDemandAggregator.
 	 * 3) in the center, there is nothing happening.

--- a/matsim/src/main/java/org/matsim/core/router/NetworkRoutingInclAccessEgressModule.java
+++ b/matsim/src/main/java/org/matsim/core/router/NetworkRoutingInclAccessEgressModule.java
@@ -356,7 +356,7 @@ public final class NetworkRoutingInclAccessEgressModule implements RoutingModule
 			Vehicle vehicle = scenario.getVehicles().getVehicles().get(vehicleId);
 			Path path = this.routeAlgo.calcLeastCostPath(startNode, endNode, depTime, person, vehicle);
 			if (path == null) {
-				throw new RuntimeException("No route found from node " + startNode.getId() + " to node " + endNode.getId() + ".");
+				throw new RuntimeException("No route found from node " + startNode.getId() + " to node " + endNode.getId() + " for mode " + mode + ".");
 			}
 
 			NetworkRoute route = this.populationFactory.getRouteFactories().createRoute(NetworkRoute.class, fromLink.getId(), toLink.getId());


### PR DESCRIPTION
1) New ZonalDemandAggregator that attempts to emulate population numbers by number of first activities per zone
2) test the new demandAggregator 
3) Shorten enum values for ZonalDemandAggregatorType

BTW, maybe we should rename *ZonalDemandAggregator to *ZonalDemandEstimator
...
