### PR TITLE
add support for qsim-scoped event handlers

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/EvModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/EvModule.java
@@ -31,9 +31,6 @@ public class EvModule extends AbstractModule {
 
 	@Override
 	public void install() {
-		bind(MobsimScopeEventHandling.class).asEagerSingleton();
-		addControlerListenerBinding().to(MobsimScopeEventHandling.class);
-
 		install(new ElectricFleetModule());
 		install(new ChargingInfrastructureModule());
 		install(new ChargingModule());

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/VehicleChargingHandler.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/VehicleChargingHandler.java
@@ -38,14 +38,13 @@ import org.matsim.api.core.v01.events.handler.ActivityStartEventHandler;
 import org.matsim.api.core.v01.events.handler.PersonLeavesVehicleEventHandler;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
-import org.matsim.contrib.ev.MobsimScopeEventHandler;
-import org.matsim.contrib.ev.MobsimScopeEventHandling;
 import org.matsim.contrib.ev.fleet.ElectricFleet;
 import org.matsim.contrib.ev.fleet.ElectricVehicle;
 import org.matsim.contrib.ev.infrastructure.Charger;
 import org.matsim.contrib.ev.infrastructure.ChargingInfrastructure;
 import org.matsim.contrib.ev.infrastructure.ChargingInfrastructures;
 import org.matsim.core.config.groups.PlanCalcScoreConfigGroup;
+import org.matsim.core.events.MobsimScopeEventHandler;
 import org.matsim.vehicles.Vehicle;
 
 import com.google.common.collect.ImmutableListMultimap;
@@ -64,12 +63,10 @@ public class VehicleChargingHandler
 	private final ImmutableListMultimap<Id<Link>, Charger> chargersAtLinks;
 
 	@Inject
-	public VehicleChargingHandler(ChargingInfrastructure chargingInfrastructure, ElectricFleet electricFleet,
-			MobsimScopeEventHandling events) {
+	public VehicleChargingHandler(ChargingInfrastructure chargingInfrastructure, ElectricFleet electricFleet) {
 		this.chargingInfrastructure = chargingInfrastructure;
 		this.electricFleet = electricFleet;
 		chargersAtLinks = ChargingInfrastructures.getChargersAtLinks(chargingInfrastructure);
-		events.addMobsimScopeHandler(this);
 	}
 
 	/**

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/AuxDischargingHandler.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/AuxDischargingHandler.java
@@ -30,9 +30,8 @@ import org.matsim.api.core.v01.events.handler.ActivityStartEventHandler;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.ev.EvConfigGroup;
-import org.matsim.contrib.ev.MobsimScopeEventHandler;
-import org.matsim.contrib.ev.MobsimScopeEventHandling;
 import org.matsim.contrib.ev.fleet.ElectricVehicle;
+import org.matsim.core.events.MobsimScopeEventHandler;
 import org.matsim.core.mobsim.framework.events.MobsimAfterSimStepEvent;
 import org.matsim.core.mobsim.framework.listeners.MobsimAfterSimStepListener;
 
@@ -75,11 +74,9 @@ public class AuxDischargingHandler
 	private final ConcurrentMap<Id<Person>, VehicleAndLink> vehicles = new ConcurrentHashMap<>();
 
 	@Inject
-	public AuxDischargingHandler(VehicleProvider vehicleProvider, EvConfigGroup evCfg,
-			MobsimScopeEventHandling events) {
+	public AuxDischargingHandler(VehicleProvider vehicleProvider, EvConfigGroup evCfg) {
 		this.vehicleProvider = vehicleProvider;
 		this.auxDischargeTimeStep = evCfg.getAuxDischargeTimeStep();
-		events.addMobsimScopeHandler(this);
 	}
 
 	@Override

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DischargingModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DischargingModule.java
@@ -39,7 +39,10 @@ public class DischargingModule extends AbstractModule {
 			@Override
 			protected void configureQSim() {
 				this.bind(DriveDischargingHandler.class).asEagerSingleton();
+				addMobsimScopeEventHandlerBinding().to(DriveDischargingHandler.class);
+
 				this.bind(AuxDischargingHandler.class).asEagerSingleton();
+				addMobsimScopeEventHandlerBinding().to(AuxDischargingHandler.class);
 				this.addQSimComponentBinding(EvModule.EV_COMPONENT).to(AuxDischargingHandler.class);
 
 				//by default, no vehicle will be AUX-discharged when not moving

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DriveDischargingHandler.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DriveDischargingHandler.java
@@ -32,10 +32,9 @@ import org.matsim.api.core.v01.events.handler.VehicleLeavesTrafficEventHandler;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.ev.EvConfigGroup;
-import org.matsim.contrib.ev.MobsimScopeEventHandler;
-import org.matsim.contrib.ev.MobsimScopeEventHandling;
 import org.matsim.contrib.ev.fleet.ElectricFleet;
 import org.matsim.contrib.ev.fleet.ElectricVehicle;
+import org.matsim.core.events.MobsimScopeEventHandler;
 import org.matsim.vehicles.Vehicle;
 
 import com.google.inject.Inject;
@@ -70,12 +69,10 @@ public class DriveDischargingHandler
 	private final Map<Id<Link>, Double> energyConsumptionPerLink = new HashMap<>();
 
 	@Inject
-	public DriveDischargingHandler(ElectricFleet data, Network network, EvConfigGroup evCfg,
-			MobsimScopeEventHandling events) {
+	public DriveDischargingHandler(ElectricFleet data, Network network, EvConfigGroup evCfg) {
 		this.network = network;
 		eVehicles = data.getElectricVehicles();
 		evDrives = new HashMap<>(eVehicles.size() / 10);
-		events.addMobsimScopeHandler(this);
 	}
 
 	@Override

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/example/RunEvExample.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/example/RunEvExample.java
@@ -79,6 +79,7 @@ public class RunEvExample {
 					@Override
 					protected void configureQSim() {
 						bind(VehicleChargingHandler.class).asEagerSingleton();
+						addMobsimScopeEventHandlerBinding().to(VehicleChargingHandler.class);
 					}
 				});
 			}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/example/RunEvExamplewithLTHConsumptionModel.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/example/RunEvExamplewithLTHConsumptionModel.java
@@ -21,6 +21,10 @@ package org.matsim.contrib.ev.example;/*
  * created by jbischoff, 19.03.2019
  */
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
@@ -42,10 +46,6 @@ import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.vehicles.VehicleType;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
 
 /**
  * Runs a sample EV run using a vehicle consumption model designed at LTH in Lund which takes the speed and the slope of a link into account.
@@ -100,6 +100,7 @@ public class RunEvExamplewithLTHConsumptionModel {
 					@Override
 					protected void configureQSim() {
 						bind(VehicleChargingHandler.class).asEagerSingleton();
+						addMobsimScopeEventHandlerBinding().to(VehicleChargingHandler.class);
 					}
 				});
 			}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/stats/ChargerPowerCollector.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/stats/ChargerPowerCollector.java
@@ -29,8 +29,6 @@ import java.util.Map;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.matsim.api.core.v01.Id;
 import org.matsim.contrib.ev.EvUnits;
-import org.matsim.contrib.ev.MobsimScopeEventHandler;
-import org.matsim.contrib.ev.MobsimScopeEventHandling;
 import org.matsim.contrib.ev.charging.ChargingEndEvent;
 import org.matsim.contrib.ev.charging.ChargingEndEventHandler;
 import org.matsim.contrib.ev.charging.ChargingStartEvent;
@@ -39,6 +37,7 @@ import org.matsim.contrib.ev.fleet.ElectricFleet;
 import org.matsim.contrib.ev.fleet.ElectricVehicle;
 import org.matsim.contrib.ev.infrastructure.Charger;
 import org.matsim.contrib.ev.infrastructure.ChargingInfrastructure;
+import org.matsim.core.events.MobsimScopeEventHandler;
 import org.matsim.core.utils.misc.Time;
 
 import com.google.inject.Inject;
@@ -53,11 +52,9 @@ public class ChargerPowerCollector
 	private final List<ChargingLogEntry> logList = new ArrayList<>();
 
 	@Inject
-	public ChargerPowerCollector(ElectricFleet fleet, ChargingInfrastructure chargingInfrastructure,
-			MobsimScopeEventHandling events) {
+	public ChargerPowerCollector(ElectricFleet fleet, ChargingInfrastructure chargingInfrastructure) {
 		this.fleet = fleet;
 		this.chargingInfrastructure = chargingInfrastructure;
-		events.addMobsimScopeHandler(this);
 	}
 
 	@Override

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/stats/EvStatsModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/stats/EvStatsModule.java
@@ -50,7 +50,9 @@ public class EvStatsModule extends AbstractModule {
 					addQSimComponentBinding(EvModule.EV_COMPONENT).toProvider(
 							VehicleTypeAggregatedSocTimeProfileCollectorProvider.class);
 					addQSimComponentBinding(EvModule.EV_COMPONENT).to(EvMobsimListener.class);
+
 					bind(ChargerPowerCollector.class).asEagerSingleton();
+					addMobsimScopeEventHandlerBinding().to(ChargerPowerCollector.class);
 					// add more time profiles if necessary
 				}
 			}

--- a/matsim/pom.xml
+++ b/matsim/pom.xml
@@ -429,6 +429,12 @@
 			<artifactId>jackson-core</artifactId>
 			<version>2.10.2</version>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>3.3.3</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<properties>

--- a/matsim/src/main/java/org/matsim/core/events/MobsimScopeEventHandler.java
+++ b/matsim/src/main/java/org/matsim/core/events/MobsimScopeEventHandler.java
@@ -1,0 +1,49 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.core.events;
+
+import org.matsim.core.events.handler.EventHandler;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public interface MobsimScopeEventHandler extends EventHandler {
+	/**
+	 * Under normal circumstances, this method will never be called. All mobsim-scoped event handlers are removed
+	 * on AfterMobsimEvent, so before the new mobsim initialisation phase.
+	 *
+	 * @param iteration the up-coming iteration from which up-coming events will be from.
+	 */
+	@Deprecated //made deprecated to minimise chances someone overrides this method (cannot be final)
+	@Override
+	default void reset(int iteration) {
+		throw new IllegalStateException("This handler should have been unregistered on AfterMobsimEvent");
+	}
+
+	/**
+	 * Gives the event handler the possibility to clean up its internal state.
+	 * This method is called directly after the handler is removed from event handlers (on AfterMobsimEvent).
+	 *
+	 * @param iteration the iteration in which the handler was instantiated
+	 */
+	default void cleanupAfterMobsim(int iteration) {
+	}
+}

--- a/matsim/src/main/java/org/matsim/core/events/MobsimScopeEventHandling.java
+++ b/matsim/src/main/java/org/matsim/core/events/MobsimScopeEventHandling.java
@@ -3,7 +3,7 @@
  * project: org.matsim.*
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2019 by the members listed in the COPYING,        *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -18,7 +18,7 @@
  * *********************************************************************** *
  */
 
-package org.matsim.contrib.ev;
+package org.matsim.core.events;
 
 import java.util.Collection;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -54,6 +54,7 @@ public class MobsimScopeEventHandling implements AfterMobsimListener {
 	@Override
 	public void notifyAfterMobsim(AfterMobsimEvent event) {
 		eventHandlers.forEach(eventsManager::removeHandler);
+		eventHandlers.forEach(eventHandler -> eventHandler.cleanupAfterMobsim(event.getIteration()));
 		eventHandlers.clear();
 	}
 }

--- a/matsim/src/main/java/org/matsim/core/mobsim/DefaultMobsimModule.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/DefaultMobsimModule.java
@@ -25,6 +25,7 @@ package org.matsim.core.mobsim;
 import org.matsim.core.config.groups.ControlerConfigGroup;
 import org.matsim.core.config.groups.ExternalMobimConfigGroup;
 import org.matsim.core.controler.AbstractModule;
+import org.matsim.core.events.MobsimScopeEventHandlingModule;
 import org.matsim.core.mobsim.external.ExternalMobsim;
 import org.matsim.core.mobsim.hermes.HermesProvider;
 import org.matsim.core.mobsim.jdeqsim.JDEQSimulation;
@@ -38,15 +39,18 @@ public class DefaultMobsimModule extends AbstractModule {
 //            bind(  RelativePositionOfEntryExitOnLink.class ).toInstance( () -> 1. );
         } else if (getConfig().controler().getMobsim().equals(ControlerConfigGroup.MobsimType.JDEQSim.toString())) {
             bindMobsim().to(JDEQSimulation.class);
-//            bind(  RelativePositionOfEntryExitOnLink.class ).toInstance( () -> 0. );
+            //            bind(  RelativePositionOfEntryExitOnLink.class ).toInstance( () -> 0. );
         } else if (getConfig().controler().getMobsim().equals(ControlerConfigGroup.MobsimType.hermes.toString())) {
             bindMobsim().toProvider(HermesProvider.class);
-        } else if (getConfig().getModule(ExternalMobimConfigGroup.GROUP_NAME) != null &&
-                ((ExternalMobimConfigGroup) getConfig().getModule(ExternalMobimConfigGroup.GROUP_NAME)).getExternalExe() != null) {
+        } else if (getConfig().getModule(ExternalMobimConfigGroup.GROUP_NAME) != null
+                && ((ExternalMobimConfigGroup)getConfig().getModule(
+                ExternalMobimConfigGroup.GROUP_NAME)).getExternalExe() != null) {
             bindMobsim().to(ExternalMobsim.class);
             // since we do not know what the external mobsim does here, we leave it open, which should force the user to fill this with meaning.  ???  kai,
             // nov'19
         }
+
+        install(new MobsimScopeEventHandlingModule());
     }
 //    public interface RelativePositionOfEntryExitOnLink{
 //        double get() ;

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/AbstractQSimModule.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/AbstractQSimModule.java
@@ -19,18 +19,19 @@
  *                                                                         *
  * *********************************************************************** */
 
- package org.matsim.core.mobsim.qsim;
+package org.matsim.core.mobsim.qsim;
 
 import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.List;
 
-import com.google.inject.multibindings.Multibinder;
+import org.matsim.core.events.MobsimScopeEventHandler;
 import org.matsim.core.mobsim.framework.AbstractMobsimModule;
 import org.matsim.core.mobsim.qsim.components.QSimComponent;
 
 import com.google.inject.Module;
 import com.google.inject.binder.LinkedBindingBuilder;
+import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
 import com.google.inject.util.Modules;
 
@@ -49,11 +50,12 @@ public abstract class AbstractQSimModule extends AbstractMobsimModule {
 
 	@Deprecated // for experts only
 	protected LinkedBindingBuilder<QSimComponent> addQSimComponentBinding(Class<? extends Annotation> annotationClass) {
-		Multibinder<QSimComponent> multibinder = Multibinder.newSetBinder(binder(), QSimComponent.class, annotationClass);
+		Multibinder<QSimComponent> multibinder = Multibinder.newSetBinder(binder(), QSimComponent.class,
+				annotationClass);
 		multibinder.permitDuplicates();
 		return multibinder.addBinding();
 	}
-	
+
 	protected LinkedBindingBuilder<QSimComponent> addQSimComponentBinding(String name) {
 		return addQSimComponentBinding(Names.named(name));
 	}
@@ -64,8 +66,12 @@ public abstract class AbstractQSimModule extends AbstractMobsimModule {
 		addQSimComponentBinding(name).to(componentClass);
 	}
 
+	protected LinkedBindingBuilder<MobsimScopeEventHandler> addMobsimScopeEventHandlerBinding() {
+		return Multibinder.newSetBinder(binder(), MobsimScopeEventHandler.class).addBinding();
+	}
+
 	protected abstract void configureQSim();
-	
+
 	protected void install(AbstractQSimModule module) {
 		module.setParent(this);
 		super.install(module);

--- a/matsim/src/test/java/org/matsim/core/events/MobsimScopeEventHandlingTest.java
+++ b/matsim/src/test/java/org/matsim/core/events/MobsimScopeEventHandlingTest.java
@@ -1,0 +1,67 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.core.events;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.Test;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.controler.events.AfterMobsimEvent;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class MobsimScopeEventHandlingTest {
+	private final EventsManager eventsManager = mock(EventsManager.class);
+	private final MobsimScopeEventHandling eventHandling = new MobsimScopeEventHandling(eventsManager);
+	private final MobsimScopeEventHandler handler = mock(MobsimScopeEventHandler.class);
+
+	@Test
+	public void test_addMobsimScopeHandler() {
+		eventHandling.addMobsimScopeHandler(handler);
+
+		verify(eventsManager, times(1)).addHandler(argThat(arg -> arg == handler));
+	}
+
+	@Test
+	public void test_notifyAfterMobsim_oneHandler() {
+		eventHandling.addMobsimScopeHandler(handler);
+		eventHandling.notifyAfterMobsim(new AfterMobsimEvent(null, 99));
+
+		verify(eventsManager, times(1)).removeHandler(argThat(arg -> arg == handler));
+		verify(handler, times(1)).cleanupAfterMobsim(intThat(arg -> arg == 99));
+	}
+
+	@Test
+	public void test_notifyAfterMobsim_noHandlersAfterRemoval() {
+		eventHandling.addMobsimScopeHandler(handler);
+		eventHandling.notifyAfterMobsim(new AfterMobsimEvent(null, 99));
+
+		verify(eventsManager, times(1)).removeHandler(any());
+		verify(handler, times(1)).cleanupAfterMobsim(anyInt());
+
+		//no handlers in this iteration, so no new calls to removeHandler() and cleanupAfterMobsim()
+		eventHandling.notifyAfterMobsim(new AfterMobsimEvent(null, 100));
+
+		verify(eventsManager, times(1)).removeHandler(any());
+		verify(handler, times(1)).cleanupAfterMobsim(anyInt());
+	}
+}


### PR DESCRIPTION
Some event handlers are created before each mobsim (i.e. bound inside `AbstractQSimModule`s), mainly because they operate on data which is also created just before the mobsim. This is typical in DVRP, EV and related modules. Such handlers need to be removed after the mobsim ends.

This PR simplifies/standardises adding and removing such handlers. To add such a handler, use `AbstractQSimModule.addMobsimScopeEventHandlerBinding()` in exactly the same way "typical" handlers are added via `AbstractModule.addEventHandlerBinding()` and declare it as `MobsimScopeEventHandler` (which is a sub-interface of `EventHandler`). The rest happens automatically.

