### PR TITLE
Freight: Parallel solving of VRPs

### DIFF
--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/utils/FreightUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/utils/FreightUtils.java
@@ -84,14 +84,15 @@ public class FreightUtils {
 
 		Carriers carriers = FreightUtils.getCarriers(scenario);
 
-		HashMap<Id<Carrier>, Integer> carrierServiceCounterMap = new HashMap<>();
+		HashMap<Id<Carrier>, Integer> carrierActivityCounterMap = new HashMap<>();
 
-		// Fill carrierServiceCounterMap
+		// Fill carrierActivityCounterMap -> basis for sorting the carriers by number of activities before solving in parallel
 		for (Carrier carrier : carriers.getCarriers().values()) {
-			carrierServiceCounterMap.put(carrier.getId(), carrier.getServices().size());
+			carrierActivityCounterMap.put(carrier.getId(), carrierActivityCounterMap.getOrDefault(carrier.getId(), 0) + carrier.getServices().size());
+			carrierActivityCounterMap.put(carrier.getId(), carrierActivityCounterMap.getOrDefault(carrier.getId(), 0) + carrier.getShipments().size());
 		}
 
-		HashMap<Id<Carrier>, Integer> sortedMap = carrierServiceCounterMap.entrySet().stream()
+		HashMap<Id<Carrier>, Integer> sortedMap = carrierActivityCounterMap.entrySet().stream()
 				.sorted(Collections.reverseOrder(Map.Entry.comparingByValue()))
 				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e2, LinkedHashMap::new));
 

--- a/contribs/freight/src/test/java/org/matsim/contrib/freight/jsprit/DistanceConstraintFromVehiclesFileTest.java
+++ b/contribs/freight/src/test/java/org/matsim/contrib/freight/jsprit/DistanceConstraintFromVehiclesFileTest.java
@@ -52,6 +52,7 @@ import javax.management.InvalidAttributeValueException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 
 /**
  *
@@ -76,10 +77,9 @@ public class DistanceConstraintFromVehiclesFileTest {
 	 * Option 1: Tour is possible with the vehicle with the small battery and the
 	 * vehicle with the small battery is cheaper
 	 *
-	 * @throws InvalidAttributeValueException
 	 */
 	@Test
-	public final void CarrierSmallBatteryTest_Version1() throws InvalidAttributeValueException {
+	public final void CarrierSmallBatteryTest_Version1() throws ExecutionException, InterruptedException {
 
 		Config config = ConfigUtils.createConfig();
 		config.controler().setOutputDirectory(testUtils.getOutputDirectory());
@@ -151,10 +151,9 @@ public class DistanceConstraintFromVehiclesFileTest {
 	 * Option 2: Tour is not possible with the vehicle with the small battery. Thats
 	 * why one vehicle with a large battery is used.
 	 *
-	 * @throws InvalidAttributeValueException
 	 */
 	@Test
-	public final void CarrierLargeBatteryTest_Version2() throws InvalidAttributeValueException {
+	public final void CarrierLargeBatteryTest_Version2() throws ExecutionException, InterruptedException {
 		Config config = ConfigUtils.createConfig();
 		config.controler().setOutputDirectory(testUtils.getOutputDirectory());
 		prepareConfig(config);
@@ -227,11 +226,10 @@ public class DistanceConstraintFromVehiclesFileTest {
 	 * Option 3: costs for using one long range vehicle are higher than the costs of
 	 * using two short range truck
 	 *
-	 * @throws InvalidAttributeValueException
 	 */
 
 	@Test
-	public final void Carrier2SmallBatteryTest_Version3() throws InvalidAttributeValueException {
+	public final void Carrier2SmallBatteryTest_Version3() throws ExecutionException, InterruptedException {
 		Config config = ConfigUtils.createConfig();
 		config.controler().setOutputDirectory(testUtils.getOutputDirectory());
 		prepareConfig(config);
@@ -309,11 +307,10 @@ public class DistanceConstraintFromVehiclesFileTest {
 	 * Therefore one diesel vehicle must be used and one vehicle with a small
 	 * battery.
 	 *
-	 * @throws InvalidAttributeValueException
 	 */
 
 	@Test
-	public final void CarrierWithAdditionalDieselVehicleTest_Version4() throws InvalidAttributeValueException {
+	public final void CarrierWithAdditionalDieselVehicleTest_Version4() throws ExecutionException, InterruptedException {
 		Config config = ConfigUtils.createConfig();
 		config.controler().setOutputDirectory(testUtils.getOutputDirectory());
 		prepareConfig(config);

--- a/contribs/freight/src/test/java/org/matsim/contrib/freight/jsprit/DistanceConstraintTest.java
+++ b/contribs/freight/src/test/java/org/matsim/contrib/freight/jsprit/DistanceConstraintTest.java
@@ -21,12 +21,6 @@
 
 package org.matsim.contrib.freight.jsprit;
 
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.management.InvalidAttributeValueException;
-
 import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -49,10 +43,14 @@ import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.utils.io.IOUtils;
 import org.matsim.examples.ExamplesUtils;
 import org.matsim.testcases.MatsimTestUtils;
-
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehicleUtils;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
 
 /**
  *
@@ -78,10 +76,10 @@ public class DistanceConstraintTest {
 	 * Option 1: Tour is possible with the vehicle with the small battery and the
 	 * vehicle with the small battery is cheaper
 	 *
-	 * @throws InvalidAttributeValueException
+	 * @throws ExecutionException, InterruptedException
 	 */
 	@Test
-	public final void CarrierSmallBatteryTest_Version1() throws InvalidAttributeValueException {
+	public final void CarrierSmallBatteryTest_Version1() throws ExecutionException, InterruptedException {
 
 		Config config = ConfigUtils.createConfig();
 		config.controler().setOutputDirectory(testUtils.getOutputDirectory());
@@ -158,10 +156,9 @@ public class DistanceConstraintTest {
 	 * Option 2: Tour is not possible with the vehicle with the small battery. Thats
 	 * why one vehicle with a large battery is used.
 	 *
-	 * @throws InvalidAttributeValueException
 	 */
 	@Test
-	public final void CarrierLargeBatteryTest_Version2() throws InvalidAttributeValueException {
+	public final void CarrierLargeBatteryTest_Version2() throws ExecutionException, InterruptedException {
 		Config config = ConfigUtils.createConfig();
 		config.controler().setOutputDirectory(testUtils.getOutputDirectory());
 		prepareConfig(config);
@@ -240,11 +237,10 @@ public class DistanceConstraintTest {
 	 * Option 3: costs for using one long range vehicle are higher than the costs of
 	 * using two short range truck
 	 *
-	 * @throws InvalidAttributeValueException
 	 */
 
 	@Test
-	public final void Carrier2SmallBatteryTest_Version3() throws InvalidAttributeValueException {
+	public final void Carrier2SmallBatteryTest_Version3() throws ExecutionException, InterruptedException {
 		Config config = ConfigUtils.createConfig();
 		config.controler().setOutputDirectory(testUtils.getOutputDirectory());
 		prepareConfig(config);
@@ -331,11 +327,10 @@ public class DistanceConstraintTest {
 	 * Therefore one diesel vehicle must be used and one vehicle with a small
 	 * battery.
 	 *
-	 * @throws InvalidAttributeValueException
 	 */
 
 	@Test
-	public final void CarrierWithAdditionalDieselVehicleTest_Version4() throws InvalidAttributeValueException {
+	public final void CarrierWithAdditionalDieselVehicleTest_Version4() throws ExecutionException, InterruptedException {
 		Config config = ConfigUtils.createConfig();
 		config.controler().setOutputDirectory(testUtils.getOutputDirectory());
 		prepareConfig(config);
@@ -431,11 +426,10 @@ public class DistanceConstraintTest {
 	 *
 	 * This option (5) is designed similar to option 2
 	 *
-	 * @throws InvalidAttributeValueException
 	 */
 
 	@Test
-	public final void CarrierWithShipmentsMidSizeBatteryTest_Version5() throws InvalidAttributeValueException {
+	public final void CarrierWithShipmentsMidSizeBatteryTest_Version5() throws ExecutionException, InterruptedException {
 		Config config = ConfigUtils.createConfig();
 		config.controler().setOutputDirectory(testUtils.getOutputDirectory());
 		prepareConfig(config);
@@ -511,11 +505,10 @@ public class DistanceConstraintTest {
 	 *
 	 * This option (6) is designed similar to option 5
 	 *
-	 * @throws InvalidAttributeValueException
 	 */
 
 	@Test
-	public final void CarrierWithShipmentsLargeBatteryTest_Version6() throws InvalidAttributeValueException {
+	public final void CarrierWithShipmentsLargeBatteryTest_Version6() throws ExecutionException, InterruptedException {
 		Config config = ConfigUtils.createConfig();
 		config.controler().setOutputDirectory(testUtils.getOutputDirectory());
 		prepareConfig(config);

--- a/contribs/freight/src/test/java/org/matsim/contrib/freight/jsprit/IntegrationIT.java
+++ b/contribs/freight/src/test/java/org/matsim/contrib/freight/jsprit/IntegrationIT.java
@@ -22,6 +22,7 @@ import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.testcases.MatsimTestUtils;
 
 import javax.management.InvalidAttributeValueException;
+import java.util.concurrent.ExecutionException;
 
 public class IntegrationIT {
 
@@ -29,7 +30,7 @@ public class IntegrationIT {
 	public MatsimTestUtils utils = new MatsimTestUtils();
 
 	@Test
-	public void testJsprit() throws InvalidAttributeValueException {
+	public void testJsprit() throws ExecutionException, InterruptedException {
 		final String networkFilename = utils.getClassInputDirectory() + "/merged-network-simplified.xml.gz";
 		final String vehicleTypeFilename = utils.getClassInputDirectory() + "/vehicleTypes.xml";
 		final String carrierFilename = utils.getClassInputDirectory() + "/carrier.xml";

--- a/contribs/freight/src/test/java/org/matsim/contrib/freight/utils/FreightUtilsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/contrib/freight/utils/FreightUtilsTest.java
@@ -20,6 +20,8 @@ package org.matsim.contrib.freight.utils;
 
 import java.net.URL;
 import java.util.Collection;
+import java.util.concurrent.ExecutionException;
+
 import org.apache.log4j.Logger;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -449,8 +451,8 @@ public class FreightUtilsTest {
 	/**
 	 * This test should lead to an exception, because the NumberOfJspritIterations is not set for carriers.
 	 */
-	@Test(expected = javax.management.InvalidAttributeValueException.class)
-	public void testRunJsprit_NoOfJsprtiIterationsMissing() throws InvalidAttributeValueException {
+	@Test(expected = java.util.concurrent.ExecutionException.class)
+	public void testRunJsprit_NoOfJsprtiIterationsMissing() throws ExecutionException, InterruptedException {
 		Config config = prepareConfig();
 		config.controler().setOutputDirectory(utils.getOutputDirectory());
 		Scenario scenario = ScenarioUtils.loadScenario(config);


### PR DESCRIPTION
Preliminary note: The (VRPs of the) different carriers are solved independently. 

This PR replaces the functionality of solving problems from "one after the other" to parallel handling of the carriers. This speeds up solving freight cases with more than one carrier  
Thanks to @tschlenther for providing this piece of code.

I added the number of shipments to counterMap, to ensure that the carriers are sorted by their number of total tasks (shipments or services) and not only by the number of services. @tschlenther : This is maybe something you should have a look at your code.