### PR TITLE
Revert "presumably fix CalcLegTimesTest on Winodws"

### DIFF
--- a/matsim/src/main/java/org/matsim/analysis/CalcLegTimes.java
+++ b/matsim/src/main/java/org/matsim/analysis/CalcLegTimes.java
@@ -20,6 +20,13 @@
 
 package org.matsim.analysis;
 
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.util.Map;
+import java.util.TreeMap;
+
+import javax.inject.Inject;
+
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.IdMap;
 import org.matsim.api.core.v01.events.ActivityEndEvent;
@@ -35,12 +42,6 @@ import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.utils.io.IOUtils;
 import org.matsim.core.utils.io.UncheckedIOException;
 import org.matsim.core.utils.misc.Time;
-
-import javax.inject.Inject;
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.util.Map;
-import java.util.TreeMap;
 
 /**
  * @author mrieser
@@ -146,35 +147,36 @@ public class CalcLegTimes implements PersonDepartureEventHandler, PersonArrivalE
 		}
 	}
 
-	public void writeStats(final BufferedWriter out) throws UncheckedIOException {
+	public void writeStats(final java.io.Writer out) throws UncheckedIOException {
 		try {
-		boolean first = true;
-		for (Map.Entry<String, int[]> entry : this.legStats.entrySet()) {
-			String key = entry.getKey();
-			int[] counts = entry.getValue();
-			if (first) {
-				first = false;
-				out.write("pattern");
-				for (int i = 0; i < counts.length; i++) {
-					out.write("\t" + (i*SLOT_SIZE/60) + "+");
+			boolean first = true;
+			for (Map.Entry<String, int[]> entry : this.legStats.entrySet()) {
+				String key = entry.getKey();
+				int[] counts = entry.getValue();
+				if (first) {
+					first = false;
+					out.write("pattern");
+					for (int i = 0; i < counts.length; i++) {
+						out.write("\t" + (i * SLOT_SIZE / 60) + "+");
+					}
+					out.write("\n");
 				}
-				out.newLine();;
+				out.write(key);
+				for (int count : counts) {
+					out.write("\t" + count);
+				}
+				out.write("\n");
 			}
-			out.write(key);
-            for (int count : counts) {
-                out.write("\t" + count);
-            }
-			out.newLine();;
-		}
-		out.newLine();;
-		if (this.sumTrips == 0) {
-			out.write("average trip duration: no trips!");
-		} else {
-			out.write("average trip duration: "
-					+ (this.sumTripDurations / this.sumTrips) + " seconds = "
-					+ Time.writeTime(((int)(this.sumTripDurations / this.sumTrips))));
-		}
-		out.newLine();;
+			out.write("\n");
+			if (this.sumTrips == 0) {
+				out.write("average trip duration: no trips!");
+			} else {
+				out.write("average trip duration: "
+						+ (this.sumTripDurations / this.sumTrips)
+						+ " seconds = "
+						+ Time.writeTime(((int)(this.sumTripDurations / this.sumTrips))));
+			}
+			out.write("\n");
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);
 		} finally {


### PR DESCRIPTION
This reverts commit bcfa2aa9

The issue #1032 probably was caused by checking out the repo with `core.autocrlf=true` (i.e. always convert line endings to CRLF). This modifies the versioned "expected" output file to which the actual output file is compared in `CalcLegTimesTest`. Since we want to use `\n` in MATsim, it is best to set `core.autocrlf=input`