### PR TITLE
Refactor drt event handlers

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/ZonalIdleVehicleCollector.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/ZonalIdleVehicleCollector.java
@@ -20,72 +20,69 @@
 package org.matsim.contrib.drt.analysis.zonal;
 
 import java.util.HashMap;
-import java.util.LinkedList;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
 
 import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.events.ActivityEndEvent;
-import org.matsim.api.core.v01.events.ActivityStartEvent;
-import org.matsim.api.core.v01.events.handler.ActivityEndEventHandler;
-import org.matsim.api.core.v01.events.handler.ActivityStartEventHandler;
-import org.matsim.contrib.drt.vrpagent.DrtActionCreator;
+import org.matsim.contrib.drt.schedule.DrtStayTask;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
-import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
-import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.contrib.dvrp.vrpagent.AbstractTaskEvent;
+import org.matsim.contrib.dvrp.vrpagent.TaskEndedEvent;
+import org.matsim.contrib.dvrp.vrpagent.TaskEndedEventHandler;
+import org.matsim.contrib.dvrp.vrpagent.TaskStartedEvent;
+import org.matsim.contrib.dvrp.vrpagent.TaskStartedEventHandler;
 
 /**
  * @author jbischoff
+ * @author Michal Maciejewski
  */
-public class ZonalIdleVehicleCollector implements ActivityStartEventHandler, ActivityEndEventHandler {
+public class ZonalIdleVehicleCollector implements TaskStartedEventHandler, TaskEndedEventHandler {
 
-	private final Map<String, LinkedList<Id<DvrpVehicle>>> vehiclesPerZone = new HashMap<>();
-	private final Map<Id<DvrpVehicle>, String> zonePerVehicle = new HashMap<>();
 	private final DrtZonalSystem zonalSystem;
+	private final String dvrpMode;
 
-	public ZonalIdleVehicleCollector(DrtZonalSystem zonalSystem) {
+	private final Map<String, Set<Id<DvrpVehicle>>> vehiclesPerZone = new HashMap<>();
+	private final Map<Id<DvrpVehicle>, String> zonePerVehicle = new HashMap<>();
+
+	public ZonalIdleVehicleCollector(String dvrpMode, DrtZonalSystem zonalSystem) {
+		this.dvrpMode = dvrpMode;
 		this.zonalSystem = zonalSystem;
-		for (String z : zonalSystem.getZones().keySet()) {
-			vehiclesPerZone.put(z, new LinkedList<>());
-		}
 	}
 
 	@Override
-	public void handleEvent(ActivityStartEvent event) {
-		if (event.getActType().equals(DrtActionCreator.DRT_STAY_NAME)) {
-			String zone = zonalSystem.getZoneForLinkId(event.getLinkId());
-			if (zone != null) {
-				Id<DvrpVehicle> vid = Id.create(event.getPersonId(), DvrpVehicle.class);
-				vehiclesPerZone.get(zone).add(vid);
-				zonePerVehicle.put(vid, zone);
-			}
-		}
-
-		if (event.getActType().equals(VrpAgentLogic.AFTER_SCHEDULE_ACTIVITY_TYPE)) {
-			String zone = zonalSystem.getZoneForLinkId(event.getLinkId());
-			if (zone != null) {
-				Id<DvrpVehicle> vid = Id.create(event.getPersonId(), DvrpVehicle.class);
-				zonePerVehicle.remove(vid);
-				vehiclesPerZone.get(zone).remove(vid);
-			}
-		}
-
+	public void handleEvent(TaskStartedEvent event) {
+		handleEvent(event, zone -> {
+			vehiclesPerZone.computeIfAbsent(zone, z -> new HashSet<>()).add(event.getDvrpVehicleId());
+			zonePerVehicle.put(event.getDvrpVehicleId(), zone);
+		});
 	}
 
 	@Override
-	public void handleEvent(ActivityEndEvent event) {
-		if (event.getActType().equals(DrtActionCreator.DRT_STAY_NAME)) {
+	public void handleEvent(TaskEndedEvent event) {
+		handleEvent(event, zone -> {
+			zonePerVehicle.remove(event.getDvrpVehicleId());
+			vehiclesPerZone.get(zone).remove(event.getDvrpVehicleId());
+		});
+	}
+
+	private void handleEvent(AbstractTaskEvent event, Consumer<String> handler) {
+		if (event.getDvrpMode().equals(dvrpMode) && event.getTaskType().equals(DrtStayTask.TYPE)) {
 			String zone = zonalSystem.getZoneForLinkId(event.getLinkId());
 			if (zone != null) {
-
-				Id<DvrpVehicle> vid = Id.create(event.getPersonId(), DvrpVehicle.class);
-				zonePerVehicle.remove(vid);
-				vehiclesPerZone.get(zone).remove(vid);
-
+				handler.accept(zone);
 			}
 		}
 	}
 
-	public LinkedList<Id<DvrpVehicle>> getIdleVehiclesPerZone(String zone) {
+	public Set<Id<DvrpVehicle>> getIdleVehiclesPerZone(String zone) {
 		return this.vehiclesPerZone.get(zone);
+	}
+
+	@Override
+	public void reset(int iteration) {
+		zonePerVehicle.clear();
+		vehiclesPerZone.clear();
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/ZonalIdleVehicleXYVisualiser.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/ZonalIdleVehicleXYVisualiser.java
@@ -26,16 +26,15 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import org.locationtech.jts.geom.Point;
-import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.events.ActivityEndEvent;
-import org.matsim.api.core.v01.events.ActivityStartEvent;
-import org.matsim.api.core.v01.events.handler.ActivityEndEventHandler;
-import org.matsim.api.core.v01.events.handler.ActivityStartEventHandler;
-import org.matsim.contrib.drt.vrpagent.DrtActionCreator;
-import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
-import org.matsim.contrib.dvrp.fleet.FleetSpecification;
+import org.matsim.contrib.drt.schedule.DrtStayTask;
+import org.matsim.contrib.dvrp.vrpagent.AbstractTaskEvent;
+import org.matsim.contrib.dvrp.vrpagent.TaskEndedEvent;
+import org.matsim.contrib.dvrp.vrpagent.TaskEndedEventHandler;
+import org.matsim.contrib.dvrp.vrpagent.TaskStartedEvent;
+import org.matsim.contrib.dvrp.vrpagent.TaskStartedEventHandler;
 import org.matsim.core.controler.MatsimServices;
 import org.matsim.core.controler.events.IterationEndsEvent;
 import org.matsim.core.controler.listener.IterationEndsListener;
@@ -43,72 +42,71 @@ import org.matsim.core.utils.collections.Tuple;
 
 import com.opencsv.CSVWriter;
 
-public class ZonalIdleVehicleXYVisualiser implements ActivityEndEventHandler, ActivityStartEventHandler, IterationEndsListener {
+public class ZonalIdleVehicleXYVisualiser
+		implements TaskStartedEventHandler, TaskEndedEventHandler, IterationEndsListener {
 
 	private final String mode;
 	private final DrtZonalSystem zonalSystem;
 	private final MatsimServices services;
-	private final FleetSpecification fleet;
 
 	private final Map<String, LinkedList<Tuple<Double, Integer>>> zoneEntries = new HashMap<>();
 
-
-	public ZonalIdleVehicleXYVisualiser(MatsimServices services, String mode, DrtZonalSystem zonalSystem, FleetSpecification fleet) {
+	public ZonalIdleVehicleXYVisualiser(MatsimServices services, String mode, DrtZonalSystem zonalSystem) {
 		this.services = services;
 		this.mode = mode;
 		this.zonalSystem = zonalSystem;
-		this.fleet = fleet;
 		initEntryMap();
 	}
 
 	private void initEntryMap() {
 		for (String z : zonalSystem.getZones().keySet()) {
-			LinkedList<Tuple<Double,Integer>> list = new LinkedList<>();
+			LinkedList<Tuple<Double, Integer>> list = new LinkedList<>();
 			list.add(new Tuple<>(0d, 0));
 			zoneEntries.put(z, list);
 		}
 	}
 
 	@Override
-	public void handleEvent(ActivityStartEvent event) {
-		if (event.getActType().equals(DrtActionCreator.DRT_STAY_NAME)) {
-			if(this.fleet.getVehicleSpecifications().containsKey(Id.create(event.getPersonId().toString(), DvrpVehicle.class))){
-				String zone = zonalSystem.getZoneForLinkId(event.getLinkId());
-				if (zone != null) {
-					LinkedList<Tuple<Double, Integer>> zoneTuples = zoneEntries.get(zone);
-					Integer oldNrOfVeh = zoneTuples.getLast().getSecond();
-					zoneTuples.add(new Tuple<>(event.getTime(), oldNrOfVeh + 1));
-				}
-			}
-		}
+	public void handleEvent(TaskStartedEvent event) {
+		handleEvent(event, zone -> {
+			LinkedList<Tuple<Double, Integer>> zoneTuples = zoneEntries.get(zone);
+			Integer oldNrOfVeh = zoneTuples.getLast().getSecond();
+			zoneTuples.add(new Tuple<>(event.getTime(), oldNrOfVeh + 1));
+		});
 	}
 
 	@Override
-	public void handleEvent(ActivityEndEvent event) {
-		if (event.getActType().equals(DrtActionCreator.DRT_STAY_NAME)) {
-			if(this.fleet.getVehicleSpecifications().containsKey(Id.create(event.getPersonId().toString(), DvrpVehicle.class))){
-				String zone = zonalSystem.getZoneForLinkId(event.getLinkId());
-				if (zone != null) {
-					LinkedList<Tuple<Double, Integer>> zoneTuples = zoneEntries.get(zone);
-					Integer oldNrOfVeh = zoneTuples.getLast().getSecond();
-					zoneTuples.add(new Tuple<>(event.getTime(), oldNrOfVeh - 1));
-				}
+	public void handleEvent(TaskEndedEvent event) {
+		handleEvent(event, zone -> {
+			LinkedList<Tuple<Double, Integer>> zoneTuples = zoneEntries.get(zone);
+			Integer oldNrOfVeh = zoneTuples.getLast().getSecond();
+			zoneTuples.add(new Tuple<>(event.getTime(), oldNrOfVeh - 1));
+		});
+	}
+
+	private void handleEvent(AbstractTaskEvent event, Consumer<String> handler) {
+		if (event.getDvrpMode().equals(mode) && event.getTaskType().equals(DrtStayTask.TYPE)) {
+			String zone = zonalSystem.getZoneForLinkId(event.getLinkId());
+			if (zone != null) {
+				handler.accept(zone);
 			}
 		}
 	}
 
 	@Override
 	public void notifyIterationEnds(IterationEndsEvent event) {
-		String filename = services.getControlerIO().getIterationFilename(services.getIterationNumber(), mode + "_idleVehiclesPerZoneXY.csv");
+		String filename = services.getControlerIO()
+				.getIterationFilename(services.getIterationNumber(), mode + "_idleVehiclesPerZoneXY.csv");
 
 		try {
 			CSVWriter writer = new CSVWriter(Files.newBufferedWriter(Paths.get(filename)), ';', '"', '"', "\n");
-			writer.writeNext(new String[]{"zone", "X", "Y", "time", "idleDRTVehicles"}, false);
-			this.zoneEntries.forEach( (zone, entriesList) -> {
+			writer.writeNext(new String[] { "zone", "X", "Y", "time", "idleDRTVehicles" }, false);
+			this.zoneEntries.forEach((zone, entriesList) -> {
 				Point p = zonalSystem.getZone(zone).getCentroid();
 				double x = p.getX();
 				double y = p.getY();
-				entriesList.forEach(entry -> writer.writeNext(new String[]{zone, "" + x, "" + y, "" + entry.getFirst(), "" + entry.getSecond()}, false));
+				entriesList.forEach(entry -> writer.writeNext(
+						new String[] { zone, "" + x, "" + y, "" + entry.getFirst(), "" + entry.getSecond() }, false));
 			});
 
 			writer.close();

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
@@ -140,8 +140,7 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 			bindModal(ZonalIdleVehicleXYVisualiser.class).
 					toProvider(modalProvider(
 							getter -> new ZonalIdleVehicleXYVisualiser(getter.get(MatsimServices.class),
-									drtCfg.getMode(), getter.getModal(DrtZonalSystem.class),
-									getter.getModal(FleetSpecification.class)))).asEagerSingleton();
+									drtCfg.getMode(), getter.getModal(DrtZonalSystem.class)))).asEagerSingleton();
 			addControlerListenerBinding().to(modalKey(ZonalIdleVehicleXYVisualiser.class));
 			addEventHandlerBinding().to(modalKey(ZonalIdleVehicleXYVisualiser.class));
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtTaskBaseType.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtTaskBaseType.java
@@ -35,6 +35,10 @@ public enum DrtTaskBaseType {
 	}
 
 	public boolean isBaseTypeOf(Task task) {
-		return ((DrtTaskType)task.getTaskType()).getBaseType().orElse(null) == this;
+		return isBaseTypeOf(task.getTaskType());
+	}
+
+	public boolean isBaseTypeOf(Task.TaskType taskType) {
+		return ((DrtTaskType)taskType).getBaseType().orElse(null) == this;
 	}
 }


### PR DESCRIPTION
Switch event handling from activity start/end events to task started/ended events. This is now possible after #1098. These task-oriented events are much handier for tracking dvrp vehicle states.