### PR TITLE
Demand Aggregators

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/FleetSizeWeightedByPopulationShareDemandAggregator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/FleetSizeWeightedByPopulationShareDemandAggregator.java
@@ -77,7 +77,8 @@ public final class FleetSizeWeightedByPopulationShareDemandAggregator implements
 	}
 
 	public ToIntFunction<String> getExpectedDemandForTimeBin(double time) {
-		return zoneId -> ( this.activitiesPerZone.getOrDefault(zoneId, 0).intValue() / totalNrActivities ) * fleetSize;
+		//decided to take Math.floor rather than Math.round as we want to avoid global undersupply which would 'paralyze' the rebalancing algorithm
+		return zoneId ->  (int) Math.floor( ( this.activitiesPerZone.getOrDefault(zoneId, 0).doubleValue() / totalNrActivities ) * fleetSize);
 	}
 
 	private void prepareZones() {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
@@ -33,7 +33,7 @@ import org.matsim.contrib.drt.analysis.zonal.DrtGridUtils;
 import org.matsim.contrib.drt.analysis.zonal.DrtZonalSystem;
 import org.matsim.contrib.drt.analysis.zonal.DrtZonalWaitTimesAnalyzer;
 import org.matsim.contrib.drt.analysis.zonal.EqualVehicleDensityZonalDemandAggregator;
-import org.matsim.contrib.drt.analysis.zonal.FirstActivityCountAsZonalDemandAggregator;
+import org.matsim.contrib.drt.analysis.zonal.FleetSizeWeightedByPopulationShareDemandAggregator;
 import org.matsim.contrib.drt.analysis.zonal.PreviousIterationZonalDRTDemandAggregator;
 import org.matsim.contrib.drt.analysis.zonal.TimeDependentActivityBasedZonalDemandAggregator;
 import org.matsim.contrib.drt.analysis.zonal.ZonalDemandAggregator;
@@ -121,14 +121,16 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 				addEventHandlerBinding().to(modalKey(TimeDependentActivityBasedZonalDemandAggregator.class));
 				break;
 			case EqualVehicleDensity:
+				// do not bind as eager singleton because fleet specification (fleet size) might change over the iterations (if using optDrt for example)
 				bindModal(ZonalDemandAggregator.class).toProvider(modalProvider(
 						getter -> new EqualVehicleDensityZonalDemandAggregator(getter.getModal(DrtZonalSystem.class),
-								getter.getModal(FleetSpecification.class)))).asEagerSingleton();
+								getter.getModal(FleetSpecification.class))));
 				break;
-			case FirstActivityCount:
+			case FleetSizeWeightedByPopulationShare:
+				// do not bind as eager singleton because fleet specification (fleet size) might change over the iterations (if using optDrt for example)
 				bindModal(ZonalDemandAggregator.class).toProvider(modalProvider(
-						getter -> new FirstActivityCountAsZonalDemandAggregator(getter.getModal(DrtZonalSystem.class),
-								getter.get(Population.class)))).asEagerSingleton();
+						getter -> new FleetSizeWeightedByPopulationShareDemandAggregator(getter.getModal(DrtZonalSystem.class),
+								getter.get(Population.class), getter.getModal(FleetSpecification.class))));
 				break;
 			default:
 				throw new IllegalArgumentException("do not know what to do with ZonalDemandAggregatorType="

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingParams.java
@@ -42,7 +42,7 @@ public final class MinCostFlowRebalancingParams extends ReflectiveConfigGroup {
 	public enum ZonalDemandAggregatorType {PreviousIteration,
 		TimeDependentActivityBased,
 		EqualVehicleDensity,
-		FirstActivityCount}
+		FleetSizeWeightedByPopulationShare}
 
 	public enum RebalancingZoneGeneration {GridFromNetwork, ShapeFile}
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
@@ -132,8 +132,8 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 	}
 
 	@Test
-	public void FirstActivityCountAsZonalDemandAggregatorTest(){
-		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.FirstActivityCount, "");
+	public void FleetSizeWeightedByPopulationShareDemandAggregatorTest(){
+		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.FleetSizeWeightedByPopulationShare, "");
 		controler.run();
 		ZonalDemandAggregator aggregator = controler.getInjector().getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
 		for(double ii = 0; ii < 16 * 3600; ii+=1800){

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
@@ -139,13 +139,13 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 		for(double ii = 0; ii < 16 * 3600; ii+=1800){
 			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
 			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 1", 0, demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 2", 99, demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 2", 2, demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
 			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 3", 0, demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 4", 99, demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 4", 2, demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
 			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 5", 0, demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
 			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 6", 0, demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
 			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 7", 0, demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 8", 99, demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 8", 2, demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
 		}
 	}
 


### PR DESCRIPTION
The population based demand estimator now scales the estimate value down by total number of inhabitants in drt service area and multiplies it with fleet size. The resulting demand estimate value represents the number of vehicle desired in that zone.
That is in line with the other Demand Aggregators and leads to a consistenst meaning/interpretation for the alpha parameter.
The alpha parameter can thus be interpreted as "how many vehicles do i want to relocate per estimated demand unit" where estimated demand unit is either vehicles or drt rides (depending on which DemandAggregator you chose).

Moreover, as fleet size is now possibly subject to change over iterations (when enabling optDrt - currently located in an external repository), demand aggregators relying on fleet size are not bound as eager singleton any more such that they are reconstructed every iteration. This is not a problem concerning run time (in the Open Berlin Scenario, construction of the FleetSizeWeightedByPopulationShareDemandAggregator takes roughly 4 seconds).

