### PR TITLE
Catch the exception and continue if stopwatch.txt could not be written.

### DIFF
--- a/matsim/src/main/java/org/matsim/core/controler/AbstractController.java
+++ b/matsim/src/main/java/org/matsim/core/controler/AbstractController.java
@@ -24,6 +24,7 @@ import org.matsim.analysis.IterationStopWatch;
 import org.matsim.core.config.Config;
 import org.matsim.core.controler.listener.ControlerListener;
 import org.matsim.core.gbl.MatsimRandom;
+import org.matsim.core.utils.io.UncheckedIOException;
 import org.matsim.utils.MemoryObserver;
 
 /*package*/ abstract class AbstractController {
@@ -161,7 +162,11 @@ import org.matsim.utils.MemoryObserver;
         });
 
         this.getStopwatch().endIteration();
-        this.getStopwatch().writeTextFile(this.getControlerIO().getOutputFilename("stopwatch"));
+        try {
+            this.getStopwatch().writeTextFile(this.getControlerIO().getOutputFilename("stopwatch"));
+        } catch (UncheckedIOException e) {
+            log.error("Could not write stopwatch file.", e);
+        }
         if (config.controler().isCreateGraphs()) {
             this.getStopwatch().writeGraphFile(this.getControlerIO().getOutputFilename("stopwatch"));
         }


### PR DESCRIPTION
That's hardly a reason to stop the run, and on some operating systems
just opening the file in an editor could already lead to an exception
as the file gets locked by the editor and can thus not be updated by MATSim.