### PR TITLE
Demand aggregators point to FleetSpecification object and are bound as singletons

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/FleetSizeWeightedByPopulationShareDemandAggregator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/FleetSizeWeightedByPopulationShareDemandAggregator.java
@@ -26,8 +26,6 @@ import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.population.Activity;
 import org.matsim.api.core.v01.population.Population;
 import org.matsim.contrib.dvrp.fleet.FleetSpecification;
-import org.matsim.core.mobsim.framework.events.MobsimInitializedEvent;
-import org.matsim.core.mobsim.framework.listeners.MobsimInitializedListener;
 
 import javax.validation.constraints.NotNull;
 import java.util.HashMap;
@@ -56,7 +54,6 @@ public final class FleetSizeWeightedByPopulationShareDemandAggregator implements
 		prepareZones();
 		countFirstActsPerZone(population);
 		this.fleetSpecification = fleetSpecification;
-//		this.fleetSize = fleetSpecification.getVehicleSpecifications().size();
 	}
 
 	private void countFirstActsPerZone(Population population) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/FleetSizeWeightedByPopulationShareDemandAggregator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/FleetSizeWeightedByPopulationShareDemandAggregator.java
@@ -26,6 +26,8 @@ import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.population.Activity;
 import org.matsim.api.core.v01.population.Population;
 import org.matsim.contrib.dvrp.fleet.FleetSpecification;
+import org.matsim.core.mobsim.framework.events.MobsimInitializedEvent;
+import org.matsim.core.mobsim.framework.listeners.MobsimInitializedListener;
 
 import javax.validation.constraints.NotNull;
 import java.util.HashMap;
@@ -45,15 +47,16 @@ public final class FleetSizeWeightedByPopulationShareDemandAggregator implements
 	private static Logger log = Logger.getLogger(FleetSizeWeightedByPopulationShareDemandAggregator.class);
 
 	private final DrtZonalSystem zonalSystem;
+	private final FleetSpecification fleetSpecification;
 	private Map<String, Integer> activitiesPerZone = new HashMap<>();
-	private final int fleetSize;
 	private Integer totalNrActivities;
 
 	public FleetSizeWeightedByPopulationShareDemandAggregator(DrtZonalSystem zonalSystem, Population population, @NotNull FleetSpecification fleetSpecification) {
 		this.zonalSystem = zonalSystem;
 		prepareZones();
 		countFirstActsPerZone(population);
-		this.fleetSize = fleetSpecification.getVehicleSpecifications().size();
+		this.fleetSpecification = fleetSpecification;
+//		this.fleetSize = fleetSpecification.getVehicleSpecifications().size();
 	}
 
 	private void countFirstActsPerZone(Population population) {
@@ -78,6 +81,7 @@ public final class FleetSizeWeightedByPopulationShareDemandAggregator implements
 
 	public ToIntFunction<String> getExpectedDemandForTimeBin(double time) {
 		//decided to take Math.floor rather than Math.round as we want to avoid global undersupply which would 'paralyze' the rebalancing algorithm
+		int fleetSize = this.fleetSpecification.getVehicleSpecifications().size();
 		return zoneId ->  (int) Math.floor( ( this.activitiesPerZone.getOrDefault(zoneId, 0).doubleValue() / totalNrActivities ) * fleetSize);
 	}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
@@ -121,16 +121,14 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 				addEventHandlerBinding().to(modalKey(TimeDependentActivityBasedZonalDemandAggregator.class));
 				break;
 			case EqualVehicleDensity:
-				// do not bind as eager singleton because fleet specification (fleet size) might change over the iterations (if using optDrt for example)
 				bindModal(ZonalDemandAggregator.class).toProvider(modalProvider(
 						getter -> new EqualVehicleDensityZonalDemandAggregator(getter.getModal(DrtZonalSystem.class),
-								getter.getModal(FleetSpecification.class))));
+								getter.getModal(FleetSpecification.class)))).asEagerSingleton();
 				break;
 			case FleetSizeWeightedByPopulationShare:
-				// do not bind as eager singleton because fleet specification (fleet size) might change over the iterations (if using optDrt for example)
 				bindModal(ZonalDemandAggregator.class).toProvider(modalProvider(
 						getter -> new FleetSizeWeightedByPopulationShareDemandAggregator(getter.getModal(DrtZonalSystem.class),
-								getter.get(Population.class), getter.getModal(FleetSpecification.class))));
+								getter.get(Population.class), getter.getModal(FleetSpecification.class)))).asEagerSingleton();
 				break;
 			default:
 				throw new IllegalArgumentException("do not know what to do with ZonalDemandAggregatorType="


### PR DESCRIPTION
This PR reverts some of the changes in #1106:

All aggregators are bound as singleton (no need for multiple instantiation as pointer to FleetSpecification object stays up to date)
