### PR TITLE
Various Hermes PT improvements

### DIFF
--- a/matsim/src/main/java/org/matsim/analysis/IterationTravelStatsControlerListener.java
+++ b/matsim/src/main/java/org/matsim/analysis/IterationTravelStatsControlerListener.java
@@ -21,7 +21,11 @@
 
  package org.matsim.analysis;
 
-
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.log4j.Logger;
@@ -37,12 +41,6 @@ import org.matsim.core.controler.listener.IterationEndsListener;
 import org.matsim.core.controler.listener.ShutdownListener;
 import org.matsim.core.scoring.ExperiencedPlansService;
 import org.matsim.core.utils.io.IOUtils;
-
-import javax.inject.Inject;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 
 class IterationTravelStatsControlerListener implements IterationEndsListener, ShutdownListener {
 
@@ -77,6 +75,8 @@ class IterationTravelStatsControlerListener implements IterationEndsListener, Sh
         travelDistanceStats.addIteration(event.getIteration(), experiencedPlansService.getExperiencedPlans());
         pHbyModeCalculator.addIteration(event.getIteration(), experiencedPlansService.getExperiencedPlans());
         pkMbyModeCalculator.addIteration(event.getIteration(), experiencedPlansService.getExperiencedPlans());
+        pHbyModeCalculator.writeOutput();
+        pkMbyModeCalculator.writeOutput();
         final boolean writingTripsAtAll = config.controler().getWriteTripsInterval() > 0;
         final boolean regularWriteEvents = writingTripsAtAll && (event.getIteration() > 0 && event.getIteration() % config.controler().getWriteTripsInterval() == 0);
         if (regularWriteEvents || (writingTripsAtAll && event.getIteration() == 0)) {
@@ -90,9 +90,7 @@ class IterationTravelStatsControlerListener implements IterationEndsListener, Sh
 	@Override
 	public void notifyShutdown(ShutdownEvent event) {
 		travelDistanceStats.close();
-		// TODO: this way the statistics are written only at the end. Better after each iteration?
-        pHbyModeCalculator.writeOutput();
-        pkMbyModeCalculator.writeOutput();
+
         if (config.controler().getWriteTripsInterval() > 0) {
             writePersonsCSV();
         }

--- a/matsim/src/main/java/org/matsim/analysis/PHbyModeCalculator.java
+++ b/matsim/src/main/java/org/matsim/analysis/PHbyModeCalculator.java
@@ -28,11 +28,10 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
-
 import javax.inject.Inject;
-
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
+import org.apache.log4j.Logger;
 import org.jfree.chart.axis.CategoryLabelPositions;
 import org.matsim.api.core.v01.IdMap;
 import org.matsim.api.core.v01.population.Activity;
@@ -143,8 +142,8 @@ public class PHbyModeCalculator {
 
 
         } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+			Logger.getLogger(getClass()).error("Could not write PH Modestats.");
+		}
         if (writePng){
             String[] categories = new String[phtPerIteration.size()];
             int i = 0;

--- a/matsim/src/main/java/org/matsim/analysis/PKMbyModeCalculator.java
+++ b/matsim/src/main/java/org/matsim/analysis/PKMbyModeCalculator.java
@@ -20,18 +20,6 @@
 
 package org.matsim.analysis;
 
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVPrinter;
-import org.jfree.chart.axis.CategoryLabelPositions;
-import org.matsim.api.core.v01.IdMap;
-import org.matsim.api.core.v01.population.Leg;
-import org.matsim.api.core.v01.population.Person;
-import org.matsim.api.core.v01.population.Plan;
-import org.matsim.core.config.groups.ControlerConfigGroup;
-import org.matsim.core.controler.OutputDirectoryHierarchy;
-import org.matsim.core.utils.charts.StackedBarChart;
-
-import javax.inject.Inject;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -40,6 +28,18 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+import javax.inject.Inject;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.log4j.Logger;
+import org.jfree.chart.axis.CategoryLabelPositions;
+import org.matsim.api.core.v01.IdMap;
+import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Plan;
+import org.matsim.core.config.groups.ControlerConfigGroup;
+import org.matsim.core.controler.OutputDirectoryHierarchy;
+import org.matsim.core.utils.charts.StackedBarChart;
 
 /**
  * analyses passenger kilometer traveled based on experienced plans.
@@ -102,7 +102,7 @@ public class PKMbyModeCalculator {
 
 
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            Logger.getLogger(getClass()).error("Could not write PKM Modestats.");
         }
         if (writePng){
             String[] categories = new String[pmtPerIteration.size()];

--- a/matsim/src/main/java/org/matsim/core/mobsim/hermes/Realm.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/hermes/Realm.java
@@ -220,6 +220,19 @@ public class Realm {
             setEventVehicle(out, Agent.getPlanEvent(out.currPlan()), agent.id);
         }
 
+        // True is returned as the agent is already in the delayed list.
+        return true;
+    }
+
+    protected boolean processAgentStopDepart(Agent agent, long planentry) {
+        int routeid = Agent.getRoutePlanEntry(planentry);
+        int stopid = Agent.getStopPlanEntry(planentry);
+        int stopidx = Agent.getStopIndexPlanEntry(planentry);
+        int lineid = line_of_route[routeid];
+        Map<Integer, ArrayDeque<Agent>> agents_next_stops =
+                agent_stops.get(stopid).get(lineid);
+        ArrayList<Integer> next_stops = stops_in_route.get(routeid);
+
         // take agents
         for (int idx = stopidx; idx < next_stops.size(); idx++) {
             ArrayDeque<Agent> in_agents = agents_next_stops.get(next_stops.get(idx));
@@ -241,12 +254,6 @@ public class Realm {
             }
             in_agents.removeAll(removed);
         }
-
-        // True is returned as the agent is already in the delayed list.
-        return true;
-    }
-
-    protected boolean processAgentStopDepart(Agent agent, long planentry) {
         advanceAgentandSetEventTime(agent);
         // False is returned to force this agent to be processed in the next tick.
         // This will mean that the vehicle will be processed in the next tick.
@@ -322,22 +329,34 @@ public class Realm {
         HLink link = null;
 
         while (secs != HermesConfigGroup.SIM_STEPS) {
-            if (secs % 3600 == 0){
+            if (secs % 3600 == 0) {
                 log.info("Hermes running at " + Time.writeTime(secs));
             }
             while ((agent = delayedAgentsByWakeupTime.get(secs).poll()) != null) {
-                if (HermesConfigGroup.DEBUG_REALMS) log(secs, String.format("Processing agent %d", agent.id));
+                if (HermesConfigGroup.DEBUG_REALMS) {
+                    log(secs, String.format("Processing agent %d", agent.id));
+                }
                 routed += processAgentActivities(agent);
 
             }
-            delayedAgentsByWakeupTime.set(secs,null);
+            delayedAgentsByWakeupTime.set(secs, null);
+            //            if (si.isDeterministicPt()){
+            //                for (Event e : si.getDeterministicPtEvents().get(secs)){
+            //                    sorted_events.add(e);
+            //                }
+            //                si.getDeterministicPtEvents().get(secs).clear();
+            //            }
 
             while ((link = delayedLinksByWakeupTime.get(secs).poll()) != null) {
-                if (HermesConfigGroup.DEBUG_REALMS) log(secs, String.format("Processing link %d", link.id()));
+                if (HermesConfigGroup.DEBUG_REALMS) {
+                    log(secs, String.format("Processing link %d", link.id()));
+                }
                 routed += processLinks(link);
             }
-            delayedLinksByWakeupTime.set(secs,null);
-            if (HermesConfigGroup.DEBUG_REALMS && routed > 0) log(secs, String.format("Processed %d agents", routed));
+            delayedLinksByWakeupTime.set(secs, null);
+            if (HermesConfigGroup.DEBUG_REALMS && routed > 0) {
+                log(secs, String.format("Processed %d agents", routed));
+            }
             if (HermesConfigGroup.CONCURRENT_EVENT_PROCESSING && secs % 3600 == 0 && sorted_events.size() > 0) {
                 eventsManager.processEvents(sorted_events);
                 sorted_events = new EventArray();
@@ -349,7 +368,6 @@ public class Realm {
     }
 
     public void setEventTime(Agent agent, int eventid, int time, boolean lastevent) {
-        // TODO - is this check necessary? -> I am trying to remove all instances where it is zero...
         if (eventid != 0) {
         	EventArray agentevents = agent.events();
             Event event = agentevents.get(eventid);
@@ -364,7 +382,7 @@ public class Realm {
             // Fix delay for PT events.
             if (event instanceof VehicleArrivesAtFacilityEvent) {
                 VehicleArrivesAtFacilityEvent vaafe = (VehicleArrivesAtFacilityEvent) event;
-                vaafe.setTime(vaafe.getDelay());
+                vaafe.setDelay(vaafe.getTime() - vaafe.getDelay());
 
             }
             else if (event instanceof VehicleDepartsAtFacilityEvent) {

--- a/matsim/src/main/java/org/matsim/core/mobsim/hermes/Realm.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/hermes/Realm.java
@@ -340,12 +340,12 @@ public class Realm {
 
             }
             delayedAgentsByWakeupTime.set(secs, null);
-            //            if (si.isDeterministicPt()){
-            //                for (Event e : si.getDeterministicPtEvents().get(secs)){
-            //                    sorted_events.add(e);
-            //                }
-            //                si.getDeterministicPtEvents().get(secs).clear();
-            //            }
+            if (si.isDeterministicPt()) {
+                for (Event e : si.getDeterministicPtEvents().get(secs)) {
+                    sorted_events.add(e);
+                }
+                si.getDeterministicPtEvents().get(secs).clear();
+            }
 
             while ((link = delayedLinksByWakeupTime.get(secs).poll()) != null) {
                 if (HermesConfigGroup.DEBUG_REALMS) {

--- a/matsim/src/test/java/org/matsim/core/mobsim/hermes/HermesRoundaboutTest.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/hermes/HermesRoundaboutTest.java
@@ -71,7 +71,6 @@ public class HermesRoundaboutTest {
 		config.controler().setMobsim("hermes");
 		config.parallelEventHandling().setOneThreadPerHandler(true);
 		Scenario scenario = ScenarioUtils.createScenario(config);
-
 		buildRoundaboutNetwork(scenario);
 		buildPopulation(scenario);
 		final int[] eventsCount = new int[2];

--- a/matsim/src/test/java/org/matsim/core/mobsim/hermes/HermesTest.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/hermes/HermesTest.java
@@ -275,10 +275,10 @@ public class HermesTest {
 		Assert.assertEquals("wrong type of event.", TeleportationArrivalEvent.class, allEvents.get(2).getClass());
 		Assert.assertEquals("wrong type of event.", PersonArrivalEvent.class, allEvents.get(3).getClass());
 		Assert.assertEquals("wrong type of event.", ActivityStartEvent.class, allEvents.get(4).getClass());
-		Assert.assertEquals("wrong time in event.", 6.0*3600 + 0, allEvents.get(0).getTime(), MatsimTestCase.EPSILON);
-		Assert.assertEquals("wrong time in event.", 6.0*3600 + 0, allEvents.get(1).getTime(), MatsimTestCase.EPSILON);
-		Assert.assertEquals("wrong time in event.", 6.0*3600 + 15, allEvents.get(2).getTime(), MatsimTestCase.EPSILON);
-		Assert.assertEquals("wrong time in event.", 6.0*3600 + 15, allEvents.get(3).getTime(), MatsimTestCase.EPSILON);
+		Assert.assertEquals("wrong time in event.", 6.0 * 3600 + 0, allEvents.get(0).getTime(), MatsimTestCase.EPSILON);
+		Assert.assertEquals("wrong time in event.", 6.0 * 3600 + 0, allEvents.get(1).getTime(), MatsimTestCase.EPSILON);
+		Assert.assertEquals("wrong time in event.", 6.0 * 3600 + 14, allEvents.get(2).getTime(), MatsimTestCase.EPSILON);
+		Assert.assertEquals("wrong time in event.", 6.0 * 3600 + 14, allEvents.get(3).getTime(), MatsimTestCase.EPSILON);
 	}
 
 	/**


### PR DESCRIPTION
* make deterministic pt in hermes truely deterministic, independent of network used
* board passengers at departure time, not arrival time
Also (unrelated to the rest):
* write out pkm & ph mode stats after every iteration. makes analysis easier while run is running.