### PR TITLE
split rebalancing params into RebalancingParams and RebalancingStrategyParams

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/PreviousIterationZonalDRTDemandAggregator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/PreviousIterationZonalDRTDemandAggregator.java
@@ -55,7 +55,7 @@ public final class PreviousIterationZonalDRTDemandAggregator
 		this.zonalSystem = zonalSystem;
 		mode = drtCfg.getMode();
 		drtSpeedUpMode = drtCfg.getDrtSpeedUpMode();
-		timeBinSize = drtCfg.getMinCostFlowRebalancing().get().getInterval();
+		timeBinSize = drtCfg.getRebalancingParams().get().getInterval();
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/TimeDependentActivityBasedZonalDemandAggregator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/TimeDependentActivityBasedZonalDemandAggregator.java
@@ -55,7 +55,7 @@ public final class TimeDependentActivityBasedZonalDemandAggregator
 
 	public TimeDependentActivityBasedZonalDemandAggregator(DrtZonalSystem zonalSystem, DrtConfigGroup drtCfg) {
 		this.zonalSystem = zonalSystem;
-		timeBinSize = drtCfg.getMinCostFlowRebalancing().get().getInterval();
+		timeBinSize = drtCfg.getRebalancingParams().get().getInterval();
 	}
 
 	public ToIntFunction<String> getExpectedDemandForTimeBin(double time) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DefaultDrtOptimizer.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DefaultDrtOptimizer.java
@@ -27,9 +27,9 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.optimizer.depot.DepotFinder;
 import org.matsim.contrib.drt.optimizer.depot.Depots;
 import org.matsim.contrib.drt.optimizer.insertion.UnplannedRequestInserter;
+import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingParams;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy.Relocation;
-import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingParams;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
@@ -75,9 +75,7 @@ public class DefaultDrtOptimizer implements DrtOptimizer {
 		this.scheduleTimingUpdater = scheduleTimingUpdater;
 		this.relocator = relocator;
 		this.requestInserter = requestInserter;
-		rebalancingInterval = drtCfg.getMinCostFlowRebalancing()
-				.map(MinCostFlowRebalancingParams::getInterval)
-				.orElse(null);
+		rebalancingInterval = drtCfg.getRebalancingParams().map(RebalancingParams::getInterval).orElse(null);
 		unplannedRequests = RequestQueue.withLimitedAdvanceRequestPlanningHorizon(
 				drtCfg.getAdvanceRequestPlanningHorizon());
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
@@ -38,6 +38,7 @@ import org.matsim.contrib.drt.analysis.zonal.PreviousIterationZonalDRTDemandAggr
 import org.matsim.contrib.drt.analysis.zonal.TimeDependentActivityBasedZonalDemandAggregator;
 import org.matsim.contrib.drt.analysis.zonal.ZonalDemandAggregator;
 import org.matsim.contrib.drt.analysis.zonal.ZonalIdleVehicleXYVisualiser;
+import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingParams;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingStrategy.RebalancingTargetCalculator;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
@@ -61,11 +62,10 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 
 	@Override
 	public void install() {
-		MinCostFlowRebalancingParams params = drtCfg.getMinCostFlowRebalancing().orElseThrow();
+		RebalancingParams params = drtCfg.getRebalancingParams().orElseThrow();
 		bindModal(DrtZonalSystem.class).toProvider(modalProvider(getter -> {
 
-			if (params.getRebalancingZonesGeneration()
-					.equals(MinCostFlowRebalancingParams.RebalancingZoneGeneration.ShapeFile)) {
+			if (params.getRebalancingZonesGeneration().equals(RebalancingParams.RebalancingZoneGeneration.ShapeFile)) {
 				final List<PreparedGeometry> preparedGeometries = ShpGeometryUtils.loadPreparedGeometries(
 						params.getRebalancingZonesShapeFileURL(getConfig().getContext()));
 				Map<String, Geometry> zones = new HashMap<>();
@@ -86,6 +86,8 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 			return new DrtZonalSystem(getter.getModal(Network.class), params.getCellSize());
 		})).asEagerSingleton();
 
+		MinCostFlowRebalancingStrategyParams strategyParams = (MinCostFlowRebalancingStrategyParams)params.getRebalancingStrategyParams();
+
 		installQSimModule(new AbstractDvrpModeQSimModule(getMode()) {
 			@Override
 			protected void configureQSim() {
@@ -96,7 +98,7 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 
 				bindModal(RebalancingTargetCalculator.class).toProvider(modalProvider(
 						getter -> new LinearRebalancingTargetCalculator(getter.getModal(ZonalDemandAggregator.class),
-								params))).asEagerSingleton();
+								strategyParams))).asEagerSingleton();
 
 				bindModal(MinCostRelocationCalculator.class).toProvider(modalProvider(
 						getter -> new AggregatedMinCostRelocationCalculator(getter.getModal(DrtZonalSystem.class),
@@ -104,7 +106,7 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 			}
 		});
 
-		switch (params.getZonalDemandAggregatorType()) {
+		switch (strategyParams.getZonalDemandAggregatorType()) {
 			case PreviousIteration:
 				bindModal(PreviousIterationZonalDRTDemandAggregator.class).toProvider(modalProvider(
 						getter -> new PreviousIterationZonalDRTDemandAggregator(getter.getModal(DrtZonalSystem.class),
@@ -113,8 +115,8 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 				addEventHandlerBinding().to(modalKey(PreviousIterationZonalDRTDemandAggregator.class));
 				break;
 			case TimeDependentActivityBased:
-				bindModal(TimeDependentActivityBasedZonalDemandAggregator.class).toProvider(modalProvider(
-						getter -> new TimeDependentActivityBasedZonalDemandAggregator(
+				bindModal(TimeDependentActivityBasedZonalDemandAggregator.class).toProvider(
+						modalProvider(getter -> new TimeDependentActivityBasedZonalDemandAggregator(
 								getter.getModal(DrtZonalSystem.class), drtCfg))).asEagerSingleton();
 				bindModal(ZonalDemandAggregator.class).to(
 						modalKey(TimeDependentActivityBasedZonalDemandAggregator.class));
@@ -127,12 +129,13 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 				break;
 			case FleetSizeWeightedByPopulationShare:
 				bindModal(ZonalDemandAggregator.class).toProvider(modalProvider(
-						getter -> new FleetSizeWeightedByPopulationShareDemandAggregator(getter.getModal(DrtZonalSystem.class),
-								getter.get(Population.class), getter.getModal(FleetSpecification.class)))).asEagerSingleton();
+						getter -> new FleetSizeWeightedByPopulationShareDemandAggregator(
+								getter.getModal(DrtZonalSystem.class), getter.get(Population.class),
+								getter.getModal(FleetSpecification.class)))).asEagerSingleton();
 				break;
 			default:
 				throw new IllegalArgumentException("do not know what to do with ZonalDemandAggregatorType="
-						+ params.getZonalDemandAggregatorType());
+						+ strategyParams.getZonalDemandAggregatorType());
 		}
 
 		{

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/LinearRebalancingTargetCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/LinearRebalancingTargetCalculator.java
@@ -26,10 +26,10 @@ import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebal
  */
 public class LinearRebalancingTargetCalculator implements RebalancingTargetCalculator {
 	private final ZonalDemandAggregator demandAggregator;
-	private final MinCostFlowRebalancingParams params;
+	private final MinCostFlowRebalancingStrategyParams params;
 
 	public LinearRebalancingTargetCalculator(ZonalDemandAggregator demandAggregator,
-			MinCostFlowRebalancingParams params) {
+			MinCostFlowRebalancingStrategyParams params) {
 		this.demandAggregator = demandAggregator;
 		this.params = params;
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategy.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategy.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.analysis.zonal.DrtZonalSystem;
+import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingParams;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.Fleet;
@@ -48,11 +49,11 @@ public class MinCostFlowRebalancingStrategy implements RebalancingStrategy {
 	private final DrtZonalSystem zonalSystem;
 	private final Fleet fleet;
 	private final MinCostRelocationCalculator minCostRelocationCalculator;
-	private final MinCostFlowRebalancingParams params;
+	private final RebalancingParams params;
 
 	public MinCostFlowRebalancingStrategy(RebalancingTargetCalculator rebalancingTargetCalculator,
 			DrtZonalSystem zonalSystem, Fleet fleet, MinCostRelocationCalculator minCostRelocationCalculator,
-			MinCostFlowRebalancingParams params) {
+			RebalancingParams params) {
 		this.rebalancingTargetCalculator = rebalancingTargetCalculator;
 		this.zonalSystem = zonalSystem;
 		this.fleet = fleet;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategyParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategyParams.java
@@ -1,0 +1,127 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2018 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.drt.optimizer.rebalancing.mincostflow;
+
+import java.util.Map;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
+
+import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingParams;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ReflectiveConfigGroup;
+
+/**
+ * @author michalm
+ */
+public final class MinCostFlowRebalancingStrategyParams extends ReflectiveConfigGroup
+		implements RebalancingParams.RebalancingStrategyParams {
+	public static final String SET_NAME = "minCostFlowRebalancingStrategy";
+
+	public enum ZonalDemandAggregatorType {
+		PreviousIteration, TimeDependentActivityBased, EqualVehicleDensity, FirstActivityCount,
+		FleetSizeWeightedByPopulationShare
+	}
+
+	public static final String TARGET_ALPHA = "targetAlpha";
+	static final String TARGET_ALPHA_EXP = "alpha coefficient in linear target calculation."
+			+ " In general, should be lower than 1.0 to prevent over-reacting and high empty mileage.";
+
+	public static final String TARGET_BETA = "targetBeta";
+	static final String TARGET_BETA_EXP = "beta constant in linear target calculation."
+			+ " In general, should be lower than 1.0 to prevent over-reacting and high empty mileage.";
+
+	public static final String ZONAL_DEMAND_AGGREGATOR_TYPE = "zonalDemandAggregatorType";
+	static final String ZONAL_DEMAND_AGGREGATOR_TYPE_EXP = "Defines the methodology for demand estimation. Can be one of either [PreviousIteration, TimeDependentActivityBased, EqualVehicleDensity, FirstActivityCount] Current default is PreviousIteration";
+
+	@PositiveOrZero
+	private double targetAlpha = Double.NaN;
+
+	@PositiveOrZero
+	private double targetBeta = Double.NaN;
+
+	@NotNull
+	private MinCostFlowRebalancingStrategyParams.ZonalDemandAggregatorType zonalDemandAggregatorType = ZonalDemandAggregatorType.PreviousIteration;
+
+	public MinCostFlowRebalancingStrategyParams() {
+		super(SET_NAME);
+	}
+
+	@Override
+	protected void checkConsistency(Config config) {
+		super.checkConsistency(config);
+	}
+
+	@Override
+	public Map<String, String> getComments() {
+		Map<String, String> map = super.getComments();
+		map.put(TARGET_ALPHA, TARGET_ALPHA_EXP);
+		map.put(TARGET_BETA, TARGET_BETA_EXP);
+		map.put(ZONAL_DEMAND_AGGREGATOR_TYPE, ZONAL_DEMAND_AGGREGATOR_TYPE_EXP);
+		return map;
+	}
+
+	/**
+	 * @return -- {@value #TARGET_ALPHA_EXP}
+	 */
+	@StringGetter(TARGET_ALPHA)
+	public double getTargetAlpha() {
+		return targetAlpha;
+	}
+
+	/**
+	 * @param targetAlpha -- {@value #TARGET_ALPHA_EXP}
+	 */
+	@StringSetter(TARGET_ALPHA)
+	public void setTargetAlpha(double targetAlpha) {
+		this.targetAlpha = targetAlpha;
+	}
+
+	/**
+	 * @return -- {@value #TARGET_BETA_EXP}
+	 */
+	@StringGetter(TARGET_BETA)
+	public double getTargetBeta() {
+		return targetBeta;
+	}
+
+	/**
+	 * @param targetBeta -- {@value #TARGET_BETA_EXP}
+	 */
+	@StringSetter(TARGET_BETA)
+	public void setTargetBeta(double targetBeta) {
+		this.targetBeta = targetBeta;
+	}
+
+	/**
+	 * @return -- {@value #ZONAL_DEMAND_AGGREGATOR_TYPE_EXP}
+	 */
+	@StringGetter(ZONAL_DEMAND_AGGREGATOR_TYPE)
+	public ZonalDemandAggregatorType getZonalDemandAggregatorType() {
+		return zonalDemandAggregatorType;
+	}
+
+	/**
+	 * @param aggregatorType -- {@value #ZONAL_DEMAND_AGGREGATOR_TYPE_EXP}
+	 */
+	@StringSetter(ZONAL_DEMAND_AGGREGATOR_TYPE)
+	public void setZonalDemandAggregatorType(ZonalDemandAggregatorType aggregatorType) {
+		this.zonalDemandAggregatorType = aggregatorType;
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -29,8 +29,10 @@ import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Population;
 import org.matsim.contrib.drt.optimizer.rebalancing.NoRebalancingStrategy;
+import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingParams;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.DrtModeMinCostFlowRebalancingModule;
+import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingStrategyParams;
 import org.matsim.contrib.drt.routing.DefaultDrtRouteUpdater;
 import org.matsim.contrib.drt.routing.DrtRouteCreator;
 import org.matsim.contrib.drt.routing.DrtRouteUpdater;
@@ -87,8 +89,14 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 		install(new FleetModule(getMode(), drtCfg.getVehiclesFileUrl(getConfig().getContext()),
 				drtCfg.isChangeStartLinkToLastLinkInSchedule()));
 
-		if (drtCfg.getMinCostFlowRebalancing().isPresent()) {
-			install(new DrtModeMinCostFlowRebalancingModule(drtCfg));
+		if (drtCfg.getRebalancingParams().isPresent()) {
+			RebalancingParams rebalancingParams = drtCfg.getRebalancingParams().get();
+			if (rebalancingParams.getRebalancingStrategyParams() instanceof MinCostFlowRebalancingStrategyParams) {
+				install(new DrtModeMinCostFlowRebalancingModule(drtCfg));
+			} else {
+				throw new RuntimeException(
+						"Unsupported rebalancingStrategyParams: " + rebalancingParams.getRebalancingStrategyParams());
+			}
 		} else {
 			bindModal(RebalancingStrategy.class).to(NoRebalancingStrategy.class).asEagerSingleton();
 		}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
@@ -34,7 +34,8 @@ import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Plan;
 import org.matsim.api.core.v01.population.Population;
 import org.matsim.api.core.v01.population.PopulationFactory;
-import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingParams;
+import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingParams;
+import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingStrategyParams;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.run.DrtControlerCreator;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
@@ -67,184 +68,273 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 	public MatsimTestUtils utils = new MatsimTestUtils();
 
 	@Test
-	public void EqualVehicleDensityZonalDemandAggregatorTest(){
-		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.EqualVehicleDensity, "");
+	public void EqualVehicleDensityZonalDemandAggregatorTest() {
+		Controler controler = setupControler(
+				MinCostFlowRebalancingStrategyParams.ZonalDemandAggregatorType.EqualVehicleDensity, "");
 		controler.run();
-		ZonalDemandAggregator aggregator = controler.getInjector().getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
-		for(double ii = 0; ii < 16 * 3600; ii+=1800){
-			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 1", 1, demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 2", 1, demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 3", 1, demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 4", 1, demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 5", 1, demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 6", 1, demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 7", 1, demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 8", 1, demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
+		ZonalDemandAggregator aggregator = controler.getInjector()
+				.getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
+		for (double ii = 0; ii < 16 * 3600; ii += 1800) {
+			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(
+					ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 1", 1,
+					demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 2", 1,
+					demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 3", 1,
+					demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 4", 1,
+					demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 5", 1,
+					demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 6", 1,
+					demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 7", 1,
+					demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 8", 1,
+					demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
 		}
 	}
 
 	@Test
-	public void EqualVehicleDensityZonalDemandAggregatorFleetModificationTest(){
-		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.EqualVehicleDensity, "");
+	public void EqualVehicleDensityZonalDemandAggregatorFleetModificationTest() {
+		Controler controler = setupControler(
+				MinCostFlowRebalancingStrategyParams.ZonalDemandAggregatorType.EqualVehicleDensity, "");
 		// double number of vehicles after 0th iteration -> estimation of demand should double too
 		controler.addOverridingModule(new AbstractDvrpModeModule("drt") {
 			@Override
 			public void install() {
-				bindModal(FleetModifier.class).toProvider(modalProvider(
-						getter -> new FleetModifier(getter.getModal(FleetSpecification.class),8))).asEagerSingleton();
+				bindModal(FleetModifier.class).toProvider(
+						modalProvider(getter -> new FleetModifier(getter.getModal(FleetSpecification.class), 8)))
+						.asEagerSingleton();
 				addControlerListenerBinding().to(modalKey(FleetModifier.class));
 			}
 		});
 		controler.run();
-		ZonalDemandAggregator aggregator = controler.getInjector().getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
-		for(double ii = 0; ii < 16 * 3600; ii+=1800){
-			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 1", 2, demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 2", 2, demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 3", 2, demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 4", 2, demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 5", 2, demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 6", 2, demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 7", 2, demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 8", 2, demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
+		ZonalDemandAggregator aggregator = controler.getInjector()
+				.getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
+		for (double ii = 0; ii < 16 * 3600; ii += 1800) {
+			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(
+					ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 1", 2,
+					demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 2", 2,
+					demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 3", 2,
+					demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 4", 2,
+					demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 5", 2,
+					demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 6", 2,
+					demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 7", 2,
+					demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 8", 2,
+					demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
 		}
 	}
 
 	@Test
-	public void PreviousIterationZonalDemandAggregatorTest(){
-		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.PreviousIteration, "");
+	public void PreviousIterationZonalDemandAggregatorTest() {
+		Controler controler = setupControler(
+				MinCostFlowRebalancingStrategyParams.ZonalDemandAggregatorType.PreviousIteration, "");
 		controler.run();
-		ZonalDemandAggregator aggregator = controler.getInjector().getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
-		for(double ii = 1800; ii < 16 * 3600; ii+=1800){
-			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 1", 0, demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 2", 0, demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 3", 0, demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 4", 0, demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 5", 0, demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 6", 0, demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 7", 0, demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 8", 3, demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
+		ZonalDemandAggregator aggregator = controler.getInjector()
+				.getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
+		for (double ii = 1800; ii < 16 * 3600; ii += 1800) {
+			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(
+					ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 1", 0,
+					demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 2", 0,
+					demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 3", 0,
+					demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 4", 0,
+					demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 5", 0,
+					demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 6", 0,
+					demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 7", 0,
+					demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 8", 3,
+					demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
 		}
 	}
 
 	@Test
-	public void PreviousIterationZonalDemandAggregatorWithSpeedUpModeTest(){
-		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.PreviousIteration, "drt_teleportation");
+	public void PreviousIterationZonalDemandAggregatorWithSpeedUpModeTest() {
+		Controler controler = setupControler(
+				MinCostFlowRebalancingStrategyParams.ZonalDemandAggregatorType.PreviousIteration, "drt_teleportation");
 		controler.run();
-		ZonalDemandAggregator aggregator = controler.getInjector().getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
-		for(double ii = 1800; ii < 16 * 3600; ii+=1800){
-			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 1", 0, demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 2", 0, demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 3", 0, demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 4", 3, demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 5", 0, demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 6", 0, demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 7", 0, demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 8", 3, demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
+		ZonalDemandAggregator aggregator = controler.getInjector()
+				.getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
+		for (double ii = 1800; ii < 16 * 3600; ii += 1800) {
+			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(
+					ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 1", 0,
+					demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 2", 0,
+					demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 3", 0,
+					demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 4", 3,
+					demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 5", 0,
+					demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 6", 0,
+					demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 7", 0,
+					demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 8", 3,
+					demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
 		}
 	}
 
 	@Test
-	public void ActivityLocationBasedZonalDemandAggregatorTest(){
-		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.TimeDependentActivityBased, "");
+	public void ActivityLocationBasedZonalDemandAggregatorTest() {
+		Controler controler = setupControler(
+				MinCostFlowRebalancingStrategyParams.ZonalDemandAggregatorType.TimeDependentActivityBased, "");
 		controler.run();
-		ZonalDemandAggregator aggregator = controler.getInjector().getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
-		for(double ii = 1800; ii < 16 * 3600; ii+=1800){
-			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 1", 0, demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 2", 3, demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 3", 0, demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 4", 3, demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 5", 0, demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 6", 0, demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 7", 0, demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 8", 3, demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
+		ZonalDemandAggregator aggregator = controler.getInjector()
+				.getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
+		for (double ii = 1800; ii < 16 * 3600; ii += 1800) {
+			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(
+					ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 1", 0,
+					demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 2", 3,
+					demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 3", 0,
+					demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 4", 3,
+					demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 5", 0,
+					demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 6", 0,
+					demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 7", 0,
+					demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 8", 3,
+					demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
 		}
 	}
 
 	@Test
-	public void FleetSizeWeightedByPopulationShareDemandAggregatorTest(){
-		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.FleetSizeWeightedByPopulationShare, "");
+	public void FleetSizeWeightedByPopulationShareDemandAggregatorTest() {
+		Controler controler = setupControler(
+				MinCostFlowRebalancingStrategyParams.ZonalDemandAggregatorType.FleetSizeWeightedByPopulationShare, "");
 		controler.run();
-		ZonalDemandAggregator aggregator = controler.getInjector().getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
-		for(double ii = 0; ii < 16 * 3600; ii+=1800){
-			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 1", 0, demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
+		ZonalDemandAggregator aggregator = controler.getInjector()
+				.getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
+		for (double ii = 0; ii < 16 * 3600; ii += 1800) {
+			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(
+					ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 1", 0,
+					demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
 			// 99 activities of a 297 total at 8 vehicles: (99/297)*8 = 2.67
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 2", 2, demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 3", 0, demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 4", 2, demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 5", 0, demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 6", 0, demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 7", 0, demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 8", 2, demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 2", 2,
+					demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 3", 0,
+					demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 4", 2,
+					demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 5", 0,
+					demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 6", 0,
+					demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 7", 0,
+					demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 8", 2,
+					demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
 		}
 	}
 
 	@Test
-	public void FleetSizeWeightedByPopulationShareDemandAggregatorFleetModificationTest(){
-		Controler controler = setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType.FleetSizeWeightedByPopulationShare, "");
+	public void FleetSizeWeightedByPopulationShareDemandAggregatorFleetModificationTest() {
+		Controler controler = setupControler(
+				MinCostFlowRebalancingStrategyParams.ZonalDemandAggregatorType.FleetSizeWeightedByPopulationShare, "");
 		// double number of vehicles after 0th iteration -> estimation of demand should double too (besides rounding issues)
 		controler.addOverridingModule(new AbstractDvrpModeModule("drt") {
 			@Override
 			public void install() {
-				bindModal(FleetModifier.class).toProvider(modalProvider(
-						getter -> new FleetModifier(getter.getModal(FleetSpecification.class),8))).asEagerSingleton();
+				bindModal(FleetModifier.class).toProvider(
+						modalProvider(getter -> new FleetModifier(getter.getModal(FleetSpecification.class), 8)))
+						.asEagerSingleton();
 				addControlerListenerBinding().to(modalKey(FleetModifier.class));
 			}
 		});
 		controler.run();
-		ZonalDemandAggregator aggregator = controler.getInjector().getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
-		for(double ii = 0; ii < 16 * 3600; ii+=1800){
-			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 1", 0, demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
+		ZonalDemandAggregator aggregator = controler.getInjector()
+				.getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
+		for (double ii = 0; ii < 16 * 3600; ii += 1800) {
+			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(
+					ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 1", 0,
+					demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
 			// 99 activities of a 297 total at 16 vehicles: (99/297)*16 = 5.33
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 2", 5, demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 3", 0, demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 4", 5, demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 5", 0, demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 6", 0, demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 7", 0, demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii+60) + " in zone 8", 5, demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 2", 5,
+					demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 3", 0,
+					demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 4", 5,
+					demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 5", 0,
+					demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 6", 0,
+					demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 7", 0,
+					demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
+			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 8", 5,
+					demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
 		}
 	}
 
-	private Controler setupControler(MinCostFlowRebalancingParams.ZonalDemandAggregatorType aggregatorType, String drtSpeedUpModeForRebalancingConfiguration) {
-		URL configUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("dvrp-grid"), "eight_shared_taxi_config.xml");
+	private Controler setupControler(MinCostFlowRebalancingStrategyParams.ZonalDemandAggregatorType aggregatorType,
+			String drtSpeedUpModeForRebalancingConfiguration) {
+		URL configUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("dvrp-grid"),
+				"eight_shared_taxi_config.xml");
 		Config config = ConfigUtils.loadConfig(configUrl, new MultiModeDrtConfigGroup(), new DvrpConfigGroup(),
 				new OTFVisConfigGroup());
 
 		DrtConfigGroup drtCfg = DrtConfigGroup.getSingleModeDrtConfig(config);
 		drtCfg.setDrtSpeedUpMode(drtSpeedUpModeForRebalancingConfiguration);
-		MinCostFlowRebalancingParams rebalancingParams = new MinCostFlowRebalancingParams();
+
+		MinCostFlowRebalancingStrategyParams rebalancingStrategyParams = new MinCostFlowRebalancingStrategyParams();
+		rebalancingStrategyParams.setTargetAlpha(1);
+		rebalancingStrategyParams.setTargetBeta(0);
+		rebalancingStrategyParams.setZonalDemandAggregatorType(aggregatorType);
+
+		RebalancingParams rebalancingParams = new RebalancingParams();
 		rebalancingParams.setCellSize(500);
-		rebalancingParams.setTargetAlpha(1);
-		rebalancingParams.setTargetBeta(0);
+		rebalancingParams.addParameterSet(rebalancingStrategyParams);
 		drtCfg.addParameterSet(rebalancingParams);
-		rebalancingParams.setZonalDemandAggregatorType(aggregatorType);
 
 		drtCfg.setChangeStartLinkToLastLinkInSchedule(false); //do not take result from last iteration...
 
 		config.controler().setLastIteration(1);
 		config.qsim().setStartTime(0.);
-		config.controler().setOverwriteFileSetting(OutputDirectoryHierarchy.OverwriteFileSetting.deleteDirectoryIfExists);
+		config.controler()
+				.setOverwriteFileSetting(OutputDirectoryHierarchy.OverwriteFileSetting.deleteDirectoryIfExists);
 		config.controler().setOutputDirectory(utils.getOutputDirectory());
 
-		PlansCalcRouteConfigGroup.ModeRoutingParams pseudoDrtSpeedUpModeRoutingParams = new PlansCalcRouteConfigGroup.ModeRoutingParams("drt_teleportation");
+		PlansCalcRouteConfigGroup.ModeRoutingParams pseudoDrtSpeedUpModeRoutingParams = new PlansCalcRouteConfigGroup.ModeRoutingParams(
+				"drt_teleportation");
 		pseudoDrtSpeedUpModeRoutingParams.setBeelineDistanceFactor(1.3);
 		pseudoDrtSpeedUpModeRoutingParams.setTeleportedModeSpeed(8.0);
 		config.plansCalcRoute().addModeRoutingParams(pseudoDrtSpeedUpModeRoutingParams);
 
 		// if adding a new mode (drtSpeedUpMode), some default modes are deleted, so re-insert them...
-		PlansCalcRouteConfigGroup.ModeRoutingParams walkRoutingParams = new PlansCalcRouteConfigGroup.ModeRoutingParams(TransportMode.walk);
+		PlansCalcRouteConfigGroup.ModeRoutingParams walkRoutingParams = new PlansCalcRouteConfigGroup.ModeRoutingParams(
+				TransportMode.walk);
 		walkRoutingParams.setBeelineDistanceFactor(1.3);
 		walkRoutingParams.setTeleportedModeSpeed(3.0 / 3.6);
 		config.plansCalcRoute().addModeRoutingParams(walkRoutingParams);
 
-		PlanCalcScoreConfigGroup.ModeParams pseudoDrtSpeedUpModeScoreParams = new PlanCalcScoreConfigGroup.ModeParams("drt_teleportation");
+		PlanCalcScoreConfigGroup.ModeParams pseudoDrtSpeedUpModeScoreParams = new PlanCalcScoreConfigGroup.ModeParams(
+				"drt_teleportation");
 		config.planCalcScore().addModeParams(pseudoDrtSpeedUpModeScoreParams);
 
 		//this is the wrong way around (create controler before manipulating scenario...
@@ -253,21 +343,20 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 		return controler;
 	}
 
-
 	/**
 	 * we have eight zones, 2 rows 4 columns.
 	 * order of zones:
-	 *	2	4	6	8
-	 *	1	3	5	7
-	 *
+	 * 2	4	6	8
+	 * 1	3	5	7
+	 * <p>
 	 * 1) in the left column, there are half of the people, performing dummy - > car -> dummy
-	 *    That should lead to half of the drt vehicles rebalanced to the left column when using TimeDependentActivityBasedZonalDemandAggregator.
+	 * That should lead to half of the drt vehicles rebalanced to the left column when using TimeDependentActivityBasedZonalDemandAggregator.
 	 * 2) in the right column, the other half of the people perform dummy -> drt -> dummy from top row to bottom row.
-	 * 	  That should lead to all drt vehicles rebalanced to the right column when using PreviousIterationZonalDRTDemandAggregator.
+	 * That should lead to all drt vehicles rebalanced to the right column when using PreviousIterationZonalDRTDemandAggregator.
 	 * 3) in the center, there is nothing happening.
-	 *    But, when using EqualVehicleDensityZonalDemandAggregator, one vehicle should get sent to every zone..
+	 * But, when using EqualVehicleDensityZonalDemandAggregator, one vehicle should get sent to every zone..
 	 */
-	private void setupPopulation(Population population){
+	private void setupPopulation(Population population) {
 		//delete what's there
 		population.getPersons().clear();
 
@@ -276,7 +365,7 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 		Id<Link> left1 = Id.createLinkId(344);
 		Id<Link> left2 = Id.createLinkId(112);
 
-		for(int i = 1; i < 100; i++){
+		for (int i = 1; i < 100; i++) {
 			Person person = factory.createPerson(Id.createPersonId("leftColumn_" + i));
 
 			Plan plan = factory.createPlan();
@@ -294,7 +383,7 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 		Id<Link> right1 = Id.createLinkId(151);
 		Id<Link> right2 = Id.createLinkId(319);
 
-		for(int i = 1; i < 100; i++){
+		for (int i = 1; i < 100; i++) {
 			Person person = factory.createPerson(Id.createPersonId("rightColumn_" + i));
 
 			Plan plan = factory.createPlan();
@@ -312,7 +401,7 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 		Id<Link> center1 = Id.createLinkId(147);
 		Id<Link> center2 = Id.createLinkId(315);
 
-		for(int i = 1; i < 100; i++){
+		for (int i = 1; i < 100; i++) {
 			Person person = factory.createPerson(Id.createPersonId("centerColumn_" + i));
 
 			Plan plan = factory.createPlan();
@@ -341,11 +430,17 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 		public void notifyIterationEnds(IterationEndsEvent event) {
 			if (event.getIteration() == 0) {
 				// find any vehicle id to clone later
-				Id<DvrpVehicle> vehicleIdToBeCopied = fleetSpecification.getVehicleSpecifications().keySet().iterator().next();
-				DvrpVehicleSpecification dvrpVehicleSpecficationToBeCloned = fleetSpecification.getVehicleSpecifications().get(vehicleIdToBeCopied);
+				Id<DvrpVehicle> vehicleIdToBeCopied = fleetSpecification.getVehicleSpecifications()
+						.keySet()
+						.iterator()
+						.next();
+				DvrpVehicleSpecification dvrpVehicleSpecficationToBeCloned = fleetSpecification.getVehicleSpecifications()
+						.get(vehicleIdToBeCopied);
 
 				for (int vehicleCounter = 1; vehicleCounter <= numberOfVehiclesToAdd; vehicleCounter++) {
-					Id<DvrpVehicle> id = Id.create("optDrt_" + vehicleCounter + "_cloneOf_" + dvrpVehicleSpecficationToBeCloned.getId(), DvrpVehicle.class);
+					Id<DvrpVehicle> id = Id.create(
+							"optDrt_" + vehicleCounter + "_cloneOf_" + dvrpVehicleSpecficationToBeCloned.getId(),
+							DvrpVehicle.class);
 					DvrpVehicleSpecification newSpecification = ImmutableDvrpVehicleSpecification.newBuilder()
 							.id(id)
 							.serviceBeginTime(dvrpVehicleSpecficationToBeCloned.getServiceBeginTime())


### PR DESCRIPTION
Goal: simplify adding new rebalancing strategies.

The idea is to have a relatively generic parameter set (`RebalancingParams`) and then additionally define all strategy-specific params inside `RebalancingStrategyParams`.

Common params are:
- interval
- minServiceTime
- maxTimeBeforeIdle
- cellSize
- rebalancingZonesShapeFile
- rebalancingZonesGeneration

For the min-cost-flow rebalancing the specific params are: 
- targetAlpha
- targetBeta
- zonalDemandAggregatorType