### PR TITLE
Introduce drt zone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,11 +82,12 @@ env:
      - MODULE=contribs/signals
      - MODULE=contribs/bicycle
      - MODULE=contribs/cadytsIntegration
+     - MODULE=contribs/drt
+     - MODULE=contribs/discrete_mode_choice
      - MODULE=contribs/carsharing
      - MODULE=contribs/commercialTrafficApplications
-     - MODULE=contribs/drt
-     - MODULE=contribs/locationchoice
      - MODULE=contribs/av
+     - MODULE=contribs/locationchoice
      - MODULE=contribs/ev
      - MODULE=contribs/dvrp
      - MODULE=contribs/emissions
@@ -108,6 +109,5 @@ env:
      - MODULE=contribs/hybridsim
      - MODULE=contribs/otfvis
      - MODULE=contribs/osm
-     - MODULE=contribs/discrete_mode_choice
   global:
     - MAVEN_OPTS="-Xmx2g"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
   matrix:
     - JAVA_HOME: C:\Program Files\Java\jdk11
   fast_finish: true
-image: Visual Studio 2019
+
 install:
   - cmd: SET MAVEN_OPTS=-Xmx2g
   - cmd: SET JAVA_OPTS=-Xmx2g

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystem.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystem.java
@@ -19,14 +19,14 @@
 
 package org.matsim.contrib.drt.analysis.zonal;
 
-import java.util.LinkedHashMap;
+import static java.util.stream.Collectors.toMap;
+
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.log4j.Logger;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Point;
-import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
@@ -34,65 +34,52 @@ import org.matsim.core.utils.geometry.geotools.MGC;
 
 /**
  * @author jbischoff
+ * @author Michal Maciejewski (michalm)
  */
 public class DrtZonalSystem {
+	private static final DrtZone NO_ZONE = new DrtZone(null, null, null);
 
-	private final Map<Id<Link>, String> link2zone = new LinkedHashMap<>();
+	private final Map<Id<Link>, DrtZone> link2zone = new HashMap<>();
 	private final Network network;
-	private final Map<String, Geometry> zones;
+	private final Map<String, DrtZone> zones;
 
 	public DrtZonalSystem(Network network, double cellSize) {
+		this(network, DrtGridUtils.createGridFromNetwork(network, cellSize));
+	}
+
+	public DrtZonalSystem(Network network, Map<String, Geometry> geometries) {
 		this.network = network;
-		zones = DrtGridUtils.createGridFromNetwork(network, cellSize);
-
+		this.zones = geometries.entrySet()
+				.stream()
+				.collect(toMap(Entry::getKey, e -> new DrtZone(e.getKey(), e.getValue())));
 	}
 
-	public DrtZonalSystem(Network network, Map<String, Geometry> zones) {
-		this.network = network;
-		this.zones = zones;
-
-	}
-
-	public Geometry getZone(String zone) {
-		return zones.get(zone);
-	}
-
-	public String getZoneForLinkId(Id<Link> linkId) {
-		if (this.link2zone.containsKey(linkId)) {
-			return link2zone.get(linkId);
+	public DrtZone getZoneForLinkId(Id<Link> linkId) {
+		DrtZone zone = link2zone.get(linkId);
+		if (zone != null) {
+			return zone == NO_ZONE ? null : zone;
 		}
 
 		Point linkCoord = MGC.coord2Point(network.getLinks().get(linkId).getCoord());
-
-		for (Entry<String, Geometry> e : zones.entrySet()) {
-			if (e.getValue().intersects(linkCoord)) {
+		for (DrtZone z : zones.values()) {
+			if (z.getGeometry().intersects(linkCoord)) {
 				//if a link Coord borders two or more cells, the allocation to a cell is random.
 				// Seems hard to overcome, but most likely better than returning no zone at
 				// all and mostly not too relevant in non-grid networks.
 				// jb, june 2019
-				link2zone.put(linkId, e.getKey());
-				return e.getKey();
+				link2zone.put(linkId, z);
+				return z;
 			}
 		}
-		link2zone.put(linkId, null);
-		return null;
 
+		link2zone.put(linkId, NO_ZONE);
+		return null;
 	}
 
 	/**
 	 * @return the zones
 	 */
-	public Map<String, Geometry> getZones() {
+	public Map<String, DrtZone> getZones() {
 		return zones;
-	}
-
-	public Coord getZoneCentroid(String zoneId) {
-
-		Geometry zone = zones.get(zoneId);
-		if (zone == null) {
-			Logger.getLogger(getClass()).error("Zone " + zoneId + " not found.");
-			return null;
-		}
-		return MGC.point2Coord(zone.getCentroid());
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalWaitTimesAnalyzer.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalWaitTimesAnalyzer.java
@@ -119,13 +119,11 @@ public final class DrtZonalWaitTimesAnalyzer implements IterationEndsListener, D
 		Map<String, DescriptiveStatistics> zoneStats = new HashMap<>();
 		for (Id<Request> requestId : requestAnalyzer.getWaitTimeCompare().keySet()) {
 			DrtRequestSubmittedEvent submission = this.submittedRequests.get(requestId);
-			String zoneStr = zones.getZoneForLinkId(submission.getFromLinkId());
-			if (zoneStr != null) {
+			DrtZone zone = zones.getZoneForLinkId(submission.getFromLinkId());
+			final String zoneStr;
+			if (zone != null) {
 				//request submission inside drtServiceArea
-				zoneStr += delimiter + zones.getZones().get(zoneStr).getCentroid().getX() + delimiter + zones.getZones()
-						.get(zoneStr)
-						.getCentroid()
-						.getY();
+				zoneStr = zone.getId() + delimiter + zone.getCentroid().getX() + delimiter + zone.getCentroid().getY();
 			} else {
 				zoneStr = "outsideOfDrtZonalSystem;-;-";
 			}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZone.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZone.java
@@ -1,9 +1,9 @@
-/* *********************************************************************** *
+/*
+ * *********************************************************************** *
  * project: org.matsim.*
- *                                                                         *
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2017 by the members listed in the COPYING,        *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -15,19 +15,44 @@
  *   (at your option) any later version.                                   *
  *   See also COPYING, LICENSE and WARRANTY file                           *
  *                                                                         *
- * *********************************************************************** */
-
-/**
- *
+ * *********************************************************************** *
  */
+
 package org.matsim.contrib.drt.analysis.zonal;
 
-import java.util.function.ToIntFunction;
+import org.locationtech.jts.geom.Geometry;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.core.utils.geometry.geotools.MGC;
 
 /**
- * @author jbischoff
+ * @author Michal Maciejewski (michalm)
  */
-public interface ZonalDemandAggregator {
+public class DrtZone {
+	private final String id;
+	private final Geometry geometry;
+	private final Coord centroid;
 
-	ToIntFunction<DrtZone> getExpectedDemandForTimeBin(double time);
+	public DrtZone(String id, Geometry geometry) {
+		this(id, geometry, MGC.point2Coord(geometry.getCentroid()));
+	}
+
+	public DrtZone(String id, Geometry geometry, Coord centroid) {
+		this.id = id;
+		this.geometry = geometry;
+		this.centroid = centroid;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public Geometry getGeometry() {
+		return geometry;
+	}
+
+	public Coord getCentroid() {
+		return centroid;
+	}
+
+	//TODO add Link closest to geometry.centroid
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/ZonalIdleVehicleCollector.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/ZonalIdleVehicleCollector.java
@@ -43,8 +43,8 @@ public class ZonalIdleVehicleCollector implements TaskStartedEventHandler, TaskE
 	private final DrtZonalSystem zonalSystem;
 	private final String dvrpMode;
 
-	private final Map<String, Set<Id<DvrpVehicle>>> vehiclesPerZone = new HashMap<>();
-	private final Map<Id<DvrpVehicle>, String> zonePerVehicle = new HashMap<>();
+	private final Map<DrtZone, Set<Id<DvrpVehicle>>> vehiclesPerZone = new HashMap<>();
+	private final Map<Id<DvrpVehicle>, DrtZone> zonePerVehicle = new HashMap<>();
 
 	public ZonalIdleVehicleCollector(String dvrpMode, DrtZonalSystem zonalSystem) {
 		this.dvrpMode = dvrpMode;
@@ -67,16 +67,16 @@ public class ZonalIdleVehicleCollector implements TaskStartedEventHandler, TaskE
 		});
 	}
 
-	private void handleEvent(AbstractTaskEvent event, Consumer<String> handler) {
+	private void handleEvent(AbstractTaskEvent event, Consumer<DrtZone> handler) {
 		if (event.getDvrpMode().equals(dvrpMode) && event.getTaskType().equals(DrtStayTask.TYPE)) {
-			String zone = zonalSystem.getZoneForLinkId(event.getLinkId());
+			DrtZone zone = zonalSystem.getZoneForLinkId(event.getLinkId());
 			if (zone != null) {
 				handler.accept(zone);
 			}
 		}
 	}
 
-	public Set<Id<DvrpVehicle>> getIdleVehiclesPerZone(String zone) {
+	public Set<Id<DvrpVehicle>> getIdleVehiclesPerZone(DrtZone zone) {
 		return this.vehiclesPerZone.get(zone);
 	}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/LinearRebalancingTargetCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/LinearRebalancingTargetCalculator.java
@@ -18,6 +18,7 @@
 
 package org.matsim.contrib.drt.optimizer.rebalancing.mincostflow;
 
+import org.matsim.contrib.drt.analysis.zonal.DrtZone;
 import org.matsim.contrib.drt.analysis.zonal.ZonalDemandAggregator;
 import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingStrategy.RebalancingTargetCalculator;
 
@@ -36,7 +37,7 @@ public class LinearRebalancingTargetCalculator implements RebalancingTargetCalcu
 
 	// FIXME targets should be calculated more intelligently
 	@Override
-	public int estimate(String zone, double time) {
+	public int estimate(DrtZone zone, double time) {
 		// XXX this "time+60" (taken from old code) means probably "in the next time bin"
 		int expectedDemand = demandAggregator.getExpectedDemandForTimeBin(time + 60).applyAsInt(zone);
 		if (expectedDemand == 0) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategy.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategy.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.analysis.zonal.DrtZonalSystem;
+import org.matsim.contrib.drt.analysis.zonal.DrtZone;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingParams;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
@@ -42,7 +43,7 @@ import org.matsim.contrib.dvrp.schedule.Task.TaskStatus;
  */
 public class MinCostFlowRebalancingStrategy implements RebalancingStrategy {
 	public interface RebalancingTargetCalculator {
-		int estimate(String zone, double time);
+		int estimate(DrtZone zone, double time);
 	}
 
 	private final RebalancingTargetCalculator rebalancingTargetCalculator;
@@ -63,21 +64,21 @@ public class MinCostFlowRebalancingStrategy implements RebalancingStrategy {
 
 	@Override
 	public List<Relocation> calcRelocations(Stream<? extends DvrpVehicle> rebalancableVehicles, double time) {
-		Map<String, List<DvrpVehicle>> rebalancableVehiclesPerZone = groupRebalancableVehicles(rebalancableVehicles,
+		Map<DrtZone, List<DvrpVehicle>> rebalancableVehiclesPerZone = groupRebalancableVehicles(rebalancableVehicles,
 				time);
 		if (rebalancableVehiclesPerZone.isEmpty()) {
 			return Collections.emptyList();
 		}
-		Map<String, List<DvrpVehicle>> soonIdleVehiclesPerZone = groupSoonIdleVehicles(time);
+		Map<DrtZone, List<DvrpVehicle>> soonIdleVehiclesPerZone = groupSoonIdleVehicles(time);
 		return calculateMinCostRelocations(time, rebalancableVehiclesPerZone, soonIdleVehiclesPerZone);
 	}
 
-	private Map<String, List<DvrpVehicle>> groupRebalancableVehicles(Stream<? extends DvrpVehicle> rebalancableVehicles,
-			double time) {
-		Map<String, List<DvrpVehicle>> rebalancableVehiclesPerZone = new HashMap<>();
+	private Map<DrtZone, List<DvrpVehicle>> groupRebalancableVehicles(
+			Stream<? extends DvrpVehicle> rebalancableVehicles, double time) {
+		Map<DrtZone, List<DvrpVehicle>> rebalancableVehiclesPerZone = new HashMap<>();
 		rebalancableVehicles.filter(v -> v.getServiceEndTime() > time + params.getMinServiceTime()).forEach(v -> {
 			Link link = ((StayTask)v.getSchedule().getCurrentTask()).getLink();
-			String zone = zonalSystem.getZoneForLinkId(link.getId());
+			DrtZone zone = zonalSystem.getZoneForLinkId(link.getId());
 			if (zone != null) {
 				// zonePerVehicle.put(v.getId(), zone);
 				rebalancableVehiclesPerZone.computeIfAbsent(zone, z -> new ArrayList<>()).add(v);
@@ -87,15 +88,15 @@ public class MinCostFlowRebalancingStrategy implements RebalancingStrategy {
 	}
 
 	// also include vehicles being right now relocated or recharged
-	private Map<String, List<DvrpVehicle>> groupSoonIdleVehicles(double time) {
-		Map<String, List<DvrpVehicle>> soonIdleVehiclesPerZone = new HashMap<>();
+	private Map<DrtZone, List<DvrpVehicle>> groupSoonIdleVehicles(double time) {
+		Map<DrtZone, List<DvrpVehicle>> soonIdleVehiclesPerZone = new HashMap<>();
 		for (DvrpVehicle v : fleet.getVehicles().values()) {
 			Schedule s = v.getSchedule();
 			StayTask stayTask = (StayTask)Schedules.getLastTask(s);
 			if (stayTask.getStatus() == TaskStatus.PLANNED
 					&& stayTask.getBeginTime() < time + params.getMaxTimeBeforeIdle()
 					&& v.getServiceEndTime() > time + params.getMinServiceTime()) {
-				String zone = zonalSystem.getZoneForLinkId(stayTask.getLink().getId());
+				DrtZone zone = zonalSystem.getZoneForLinkId(stayTask.getLink().getId());
 				if (zone != null) {
 					soonIdleVehiclesPerZone.computeIfAbsent(zone, z -> new ArrayList<>()).add(v);
 				}
@@ -105,12 +106,12 @@ public class MinCostFlowRebalancingStrategy implements RebalancingStrategy {
 	}
 
 	private List<Relocation> calculateMinCostRelocations(double time,
-			Map<String, List<DvrpVehicle>> rebalancableVehiclesPerZone,
-			Map<String, List<DvrpVehicle>> soonIdleVehiclesPerZone) {
-		List<Pair<String, Integer>> supply = new ArrayList<>();
-		List<Pair<String, Integer>> demand = new ArrayList<>();
+			Map<DrtZone, List<DvrpVehicle>> rebalancableVehiclesPerZone,
+			Map<DrtZone, List<DvrpVehicle>> soonIdleVehiclesPerZone) {
+		List<Pair<DrtZone, Integer>> supply = new ArrayList<>();
+		List<Pair<DrtZone, Integer>> demand = new ArrayList<>();
 
-		for (String z : zonalSystem.getZones().keySet()) {
+		for (DrtZone z : zonalSystem.getZones().values()) {
 			int rebalancable = rebalancableVehiclesPerZone.getOrDefault(z, Collections.emptyList()).size();
 			int soonIdle = soonIdleVehiclesPerZone.getOrDefault(z, Collections.emptyList()).size();
 			int target = rebalancingTargetCalculator.estimate(z, time);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostRelocationCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostRelocationCalculator.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.matsim.contrib.drt.analysis.zonal.DrtZone;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy.Relocation;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 
@@ -29,6 +30,6 @@ import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
  * @author michalm
  */
 public interface MinCostRelocationCalculator {
-	List<Relocation> calcRelocations(List<Pair<String, Integer>> supply, List<Pair<String, Integer>> demand,
-			Map<String, List<DvrpVehicle>> rebalancableVehiclesPerZone);
+	List<Relocation> calcRelocations(List<Pair<DrtZone, Integer>> supply, List<Pair<DrtZone, Integer>> demand,
+			Map<DrtZone, List<DvrpVehicle>> rebalancableVehiclesPerZone);
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/DrtGridUtilsTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/DrtGridUtilsTest.java
@@ -1,9 +1,12 @@
 package org.matsim.contrib.drt.analysis.zonal;
 
-import org.junit.Assert;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
 import org.junit.Test;
+import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.Point;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
@@ -11,32 +14,40 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.core.network.NetworkUtils;
 
-import java.util.Map;
-
 public class DrtGridUtilsTest {
 
 	@Test
 	public void test() {
 		Network network = createNetwork();
-		Map<String,Geometry> grid = DrtGridUtils.createGridFromNetwork(network, 100);
-		Assert.assertEquals(100,grid.size());
-		Geometry cell100 = grid.get("100");
-		Point p = cell100.getCentroid();
-		Assert.assertEquals(950, p.getX(),0.00001);
-		Assert.assertEquals(950, p.getY(),0.00001);
+		Map<String, Geometry> grid = DrtGridUtils.createGridFromNetwork(network, 100);
 
-		DrtZonalSystem drtZonalSystem = new DrtZonalSystem(network, 100);
-		Assert.assertEquals("5", drtZonalSystem.getZoneForLinkId(Id.createLinkId("ab")));
-		DrtZonalSystem drtZonalSystem2 = new DrtZonalSystem(network, 700);
-		Assert.assertEquals("1", drtZonalSystem2.getZoneForLinkId(Id.createLinkId("ab")));
+		assertThat(grid).hasSize(100);
+
+		int cell = 1;
+		for (int col = 0; col < 10; col++) {
+			for (int row = 0; row < 10; row++) {
+				Geometry geometry = grid.get(cell + "");
+
+				assertThat(geometry.getCoordinates()).containsExactly(//
+						new Coordinate(col * 100, row * 100),//
+						new Coordinate(col * 100 + 100, row * 100),//
+						new Coordinate(col * 100 + 100, row * 100 + 100),//
+						new Coordinate(col * 100, row * 100 + 100),//
+						new Coordinate(col * 100, row * 100));
+				assertThat(geometry.getCentroid().getCoordinate()).isEqualTo(
+						new Coordinate(col * 100 + 50, row * 100 + 50));
+
+				cell++;
+			}
+		}
 	}
 
-	private Network createNetwork(){
+	static Network createNetwork() {
 		Network network = NetworkUtils.createNetwork();
-		Node a = network.getFactory().createNode(Id.createNodeId("a"), new Coord(0,0));
-		Node b = network.getFactory().createNode(Id.createNodeId("b"), new Coord(0,1000));
-		Node c = network.getFactory().createNode(Id.createNodeId("c"), new Coord(1000,1000));
-		Node d = network.getFactory().createNode(Id.createNodeId("d"), new Coord(1000,0));
+		Node a = network.getFactory().createNode(Id.createNodeId("a"), new Coord(0, 0));
+		Node b = network.getFactory().createNode(Id.createNodeId("b"), new Coord(0, 1000));
+		Node c = network.getFactory().createNode(Id.createNodeId("c"), new Coord(1000, 1000));
+		Node d = network.getFactory().createNode(Id.createNodeId("d"), new Coord(1000, 0));
 		network.addNode(a);
 		network.addNode(b);
 		network.addNode(c);
@@ -52,5 +63,4 @@ public class DrtGridUtilsTest {
 		network.addLink(da);
 		return network;
 	}
-
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystemTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystemTest.java
@@ -1,0 +1,52 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.analysis.zonal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.matsim.api.core.v01.Id;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class DrtZonalSystemTest {
+
+	@Test
+	public void test_cellSize100() {
+		DrtZonalSystem drtZonalSystem = new DrtZonalSystem(DrtGridUtilsTest.createNetwork(), 100);
+		assertThat(drtZonalSystem.getZoneForLinkId(Id.createLinkId("ab")).getId()).isEqualTo("5");
+	}
+
+	@Test
+	public void test_cellSize700() {
+		DrtZonalSystem drtZonalSystem = new DrtZonalSystem(DrtGridUtilsTest.createNetwork(), 700);
+		assertThat(drtZonalSystem.getZoneForLinkId(Id.createLinkId("ab")).getId()).isEqualTo("1");
+	}
+
+	@Test
+	public void test_linkOutsideZonalSystem() {
+		DrtZonalSystem drtZonalSystem = new DrtZonalSystem(DrtGridUtilsTest.createNetwork(), Map.of());
+		assertThat(drtZonalSystem.getZoneForLinkId(Id.createLinkId("ab"))).isNull();
+	}
+}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/ZonalDemandAggregatorWithoutServiceAreaTest.java
@@ -20,10 +20,11 @@
 
 package org.matsim.contrib.drt.analysis.zonal;
 
+import static org.junit.Assert.assertEquals;
+
 import java.net.URL;
 import java.util.function.ToIntFunction;
 
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.matsim.api.core.v01.Id;
@@ -74,26 +75,26 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 		controler.run();
 		ZonalDemandAggregator aggregator = controler.getInjector()
 				.getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
+		DrtZonalSystem zonalSystem = controler.getInjector().getInstance(DvrpModes.key(DrtZonalSystem.class, "drt"));
 		for (double ii = 0; ii < 16 * 3600; ii += 1800) {
-			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(
+			ToIntFunction<DrtZone> demandFunction = aggregator.getExpectedDemandForTimeBin(
 					ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 1", 1,
-					demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 2", 1,
-					demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 3", 1,
-					demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 4", 1,
-					demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 5", 1,
-					demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 6", 1,
-					demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 7", 1,
-					demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 8", 1,
-					demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
+			assertDemand(demandFunction, zonalSystem, "1", ii, 1);
+			assertDemand(demandFunction, zonalSystem, "2", ii, 1);
+			assertDemand(demandFunction, zonalSystem, "3", ii, 1);
+			assertDemand(demandFunction, zonalSystem, "4", ii, 1);
+			assertDemand(demandFunction, zonalSystem, "5", ii, 1);
+			assertDemand(demandFunction, zonalSystem, "6", ii, 1);
+			assertDemand(demandFunction, zonalSystem, "7", ii, 1);
+			assertDemand(demandFunction, zonalSystem, "8", ii, 1);
 		}
+	}
+
+	private void assertDemand(ToIntFunction<DrtZone> demandFunction, DrtZonalSystem zonalSystem, String zoneId,
+			double time, int expectedValue) {
+		DrtZone zone = zonalSystem.getZones().get(zoneId);
+		assertEquals("wrong estimation of demand at time=" + (time + 60) + " in zone " + zoneId, expectedValue,
+				demandFunction.applyAsInt(zone), MatsimTestUtils.EPSILON);
 	}
 
 	@Test
@@ -113,25 +114,18 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 		controler.run();
 		ZonalDemandAggregator aggregator = controler.getInjector()
 				.getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
+		DrtZonalSystem zonalSystem = controler.getInjector().getInstance(DvrpModes.key(DrtZonalSystem.class, "drt"));
 		for (double ii = 0; ii < 16 * 3600; ii += 1800) {
-			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(
+			ToIntFunction<DrtZone> demandFunction = aggregator.getExpectedDemandForTimeBin(
 					ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 1", 2,
-					demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 2", 2,
-					demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 3", 2,
-					demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 4", 2,
-					demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 5", 2,
-					demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 6", 2,
-					demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 7", 2,
-					demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 8", 2,
-					demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
+			assertDemand(demandFunction, zonalSystem, "1", ii, 2);
+			assertDemand(demandFunction, zonalSystem, "2", ii, 2);
+			assertDemand(demandFunction, zonalSystem, "3", ii, 2);
+			assertDemand(demandFunction, zonalSystem, "4", ii, 2);
+			assertDemand(demandFunction, zonalSystem, "5", ii, 2);
+			assertDemand(demandFunction, zonalSystem, "6", ii, 2);
+			assertDemand(demandFunction, zonalSystem, "7", ii, 2);
+			assertDemand(demandFunction, zonalSystem, "8", ii, 2);
 		}
 	}
 
@@ -142,25 +136,18 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 		controler.run();
 		ZonalDemandAggregator aggregator = controler.getInjector()
 				.getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
+		DrtZonalSystem zonalSystem = controler.getInjector().getInstance(DvrpModes.key(DrtZonalSystem.class, "drt"));
 		for (double ii = 1800; ii < 16 * 3600; ii += 1800) {
-			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(
+			ToIntFunction<DrtZone> demandFunction = aggregator.getExpectedDemandForTimeBin(
 					ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 1", 0,
-					demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 2", 0,
-					demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 3", 0,
-					demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 4", 0,
-					demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 5", 0,
-					demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 6", 0,
-					demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 7", 0,
-					demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 8", 3,
-					demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
+			assertDemand(demandFunction, zonalSystem, "1", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "2", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "3", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "4", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "5", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "6", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "7", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "8", ii, 3);
 		}
 	}
 
@@ -171,25 +158,18 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 		controler.run();
 		ZonalDemandAggregator aggregator = controler.getInjector()
 				.getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
+		DrtZonalSystem zonalSystem = controler.getInjector().getInstance(DvrpModes.key(DrtZonalSystem.class, "drt"));
 		for (double ii = 1800; ii < 16 * 3600; ii += 1800) {
-			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(
+			ToIntFunction<DrtZone> demandFunction = aggregator.getExpectedDemandForTimeBin(
 					ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 1", 0,
-					demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 2", 0,
-					demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 3", 0,
-					demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 4", 3,
-					demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 5", 0,
-					demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 6", 0,
-					demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 7", 0,
-					demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 8", 3,
-					demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
+			assertDemand(demandFunction, zonalSystem, "1", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "2", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "3", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "4", ii, 3);
+			assertDemand(demandFunction, zonalSystem, "5", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "6", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "7", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "8", ii, 3);
 		}
 	}
 
@@ -200,25 +180,18 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 		controler.run();
 		ZonalDemandAggregator aggregator = controler.getInjector()
 				.getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
+		DrtZonalSystem zonalSystem = controler.getInjector().getInstance(DvrpModes.key(DrtZonalSystem.class, "drt"));
 		for (double ii = 1800; ii < 16 * 3600; ii += 1800) {
-			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(
+			ToIntFunction<DrtZone> demandFunction = aggregator.getExpectedDemandForTimeBin(
 					ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 1", 0,
-					demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 2", 3,
-					demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 3", 0,
-					demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 4", 3,
-					demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 5", 0,
-					demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 6", 0,
-					demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 7", 0,
-					demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 8", 3,
-					demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
+			assertDemand(demandFunction, zonalSystem, "1", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "2", ii, 3);
+			assertDemand(demandFunction, zonalSystem, "3", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "4", ii, 3);
+			assertDemand(demandFunction, zonalSystem, "5", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "6", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "7", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "8", ii, 3);
 		}
 	}
 
@@ -229,26 +202,18 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 		controler.run();
 		ZonalDemandAggregator aggregator = controler.getInjector()
 				.getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
+		DrtZonalSystem zonalSystem = controler.getInjector().getInstance(DvrpModes.key(DrtZonalSystem.class, "drt"));
 		for (double ii = 0; ii < 16 * 3600; ii += 1800) {
-			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(
+			ToIntFunction<DrtZone> demandFunction = aggregator.getExpectedDemandForTimeBin(
 					ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 1", 0,
-					demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
-			// 99 activities of a 297 total at 8 vehicles: (99/297)*8 = 2.67
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 2", 2,
-					demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 3", 0,
-					demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 4", 2,
-					demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 5", 0,
-					demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 6", 0,
-					demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 7", 0,
-					demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 8", 2,
-					demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
+			assertDemand(demandFunction, zonalSystem, "1", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "2", ii, 2);
+			assertDemand(demandFunction, zonalSystem, "3", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "4", ii, 2);
+			assertDemand(demandFunction, zonalSystem, "5", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "6", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "7", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "8", ii, 2);
 		}
 	}
 
@@ -269,26 +234,18 @@ public class ZonalDemandAggregatorWithoutServiceAreaTest {
 		controler.run();
 		ZonalDemandAggregator aggregator = controler.getInjector()
 				.getInstance(DvrpModes.key(ZonalDemandAggregator.class, "drt"));
+		DrtZonalSystem zonalSystem = controler.getInjector().getInstance(DvrpModes.key(DrtZonalSystem.class, "drt"));
 		for (double ii = 0; ii < 16 * 3600; ii += 1800) {
-			ToIntFunction<String> demandFunction = aggregator.getExpectedDemandForTimeBin(
+			ToIntFunction<DrtZone> demandFunction = aggregator.getExpectedDemandForTimeBin(
 					ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 1", 0,
-					demandFunction.applyAsInt("1"), MatsimTestUtils.EPSILON);
-			// 99 activities of a 297 total at 16 vehicles: (99/297)*16 = 5.33
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 2", 5,
-					demandFunction.applyAsInt("2"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 3", 0,
-					demandFunction.applyAsInt("3"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 4", 5,
-					demandFunction.applyAsInt("4"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 5", 0,
-					demandFunction.applyAsInt("5"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 6", 0,
-					demandFunction.applyAsInt("6"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 7", 0,
-					demandFunction.applyAsInt("7"), MatsimTestUtils.EPSILON);
-			Assert.assertEquals("wrong estimation of demand at time=" + (ii + 60) + " in zone 8", 5,
-					demandFunction.applyAsInt("8"), MatsimTestUtils.EPSILON);
+			assertDemand(demandFunction, zonalSystem, "1", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "2", ii, 5);
+			assertDemand(demandFunction, zonalSystem, "3", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "4", ii, 5);
+			assertDemand(demandFunction, zonalSystem, "5", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "6", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "7", ii, 0);
+			assertDemand(demandFunction, zonalSystem, "8", ii, 5);
 		}
 	}
 


### PR DESCRIPTION
It replaces `String` that was used for representing zones. As a result, many methods have now more meaningful signatures. Also some places in code are simplified as DrtZone gives access to further data (no need to query the `ZonalSystem`).