### PR TITLE
EDrtStayTaskEndTimeCalculator

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/EDrtModeQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/EDrtModeQSimModule.java
@@ -35,7 +35,6 @@ import org.matsim.contrib.drt.optimizer.insertion.UnplannedRequestInserter;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.drt.passenger.DrtRequestCreator;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
-import org.matsim.contrib.drt.schedule.DrtStayTaskEndTimeCalculator;
 import org.matsim.contrib.drt.schedule.DrtTaskFactory;
 import org.matsim.contrib.drt.scheduler.DrtScheduleInquiry;
 import org.matsim.contrib.drt.scheduler.EmptyVehicleRelocator;
@@ -59,6 +58,7 @@ import org.matsim.contrib.edrt.EDrtActionCreator;
 import org.matsim.contrib.edrt.optimizer.EDrtOptimizer;
 import org.matsim.contrib.edrt.optimizer.EDrtVehicleDataEntryFactory;
 import org.matsim.contrib.edrt.optimizer.depot.NearestChargerAsDepot;
+import org.matsim.contrib.edrt.schedule.EDrtStayTaskEndTimeCalculator;
 import org.matsim.contrib.edrt.schedule.EDrtTaskFactoryImpl;
 import org.matsim.contrib.edrt.scheduler.EmptyVehicleChargingScheduler;
 import org.matsim.contrib.ev.infrastructure.ChargingInfrastructure;
@@ -173,7 +173,7 @@ public class EDrtModeQSimModule extends AbstractDvrpModeQSimModule {
 
 		bindModal(ScheduleTimingUpdater.class).toProvider(modalProvider(
 				getter -> new ScheduleTimingUpdater(getter.get(MobsimTimer.class),
-						new DrtStayTaskEndTimeCalculator(drtCfg)))).asEagerSingleton();
+						new EDrtStayTaskEndTimeCalculator(drtCfg)))).asEagerSingleton();
 
 		bindModal(VrpAgentLogic.DynActionCreator.class).
 				toProvider(modalProvider(getter -> new EDrtActionCreator(getter.getModal(PassengerEngine.class),

--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/schedule/EDrtStayTaskEndTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/schedule/EDrtStayTaskEndTimeCalculator.java
@@ -1,0 +1,41 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2007 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.edrt.schedule;
+
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.drt.schedule.DrtStayTaskEndTimeCalculator;
+import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
+import org.matsim.contrib.dvrp.schedule.StayTask;
+
+public class EDrtStayTaskEndTimeCalculator extends DrtStayTaskEndTimeCalculator {
+	public EDrtStayTaskEndTimeCalculator(DrtConfigGroup drtConfigGroup) {
+		super(drtConfigGroup);
+	}
+
+	@Override
+	public double calcNewEndTime(DvrpVehicle vehicle, StayTask task, double newBeginTime) {
+		if (task.getTaskType().equals(EDrtChargingTask.TYPE)) {
+			// FIXME underestimated due to the ongoing AUX/drive consumption
+			double duration = task.getEndTime() - task.getBeginTime();
+			return newBeginTime + duration;
+		} else {
+			return super.calcNewEndTime(vehicle, task, newBeginTime);
+		}
+	}
+}


### PR DESCRIPTION
Possibly the answer to #1132.
Basically it is copied and adopted from `ETaxiStayTaskEndTimeCalculator`.
Was not sure about whether to the check of TaskType is right or if the base type shoult be checked instead:
`if (task.getTaskType().equals(EDrtChargingTask.TYPE))`


