### PR TITLE
Refactor rebalancing target calculator

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
@@ -25,9 +25,13 @@ import org.matsim.api.core.v01.population.Population;
 import org.matsim.contrib.drt.analysis.zonal.DrtZonalSystem;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingParams;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
-import org.matsim.contrib.drt.optimizer.rebalancing.demandestimator.*;
+import org.matsim.contrib.drt.optimizer.rebalancing.demandestimator.EqualVehicleDensityZonalDemandEstimator;
+import org.matsim.contrib.drt.optimizer.rebalancing.demandestimator.FleetSizeWeightedByActivityEndsDemandEstimator;
+import org.matsim.contrib.drt.optimizer.rebalancing.demandestimator.FleetSizeWeightedByPopulationShareDemandEstimator;
+import org.matsim.contrib.drt.optimizer.rebalancing.demandestimator.PreviousIterationDRTDemandEstimator;
 import org.matsim.contrib.drt.optimizer.rebalancing.demandestimator.ZonalDemandEstimator;
-import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingStrategy.RebalancingTargetCalculator;
+import org.matsim.contrib.drt.optimizer.rebalancing.targetcalculator.LinearRebalancingTargetCalculator;
+import org.matsim.contrib.drt.optimizer.rebalancing.targetcalculator.RebalancingTargetCalculator;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.fleet.FleetSpecification;
@@ -79,8 +83,7 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 			case FleetSizeWeightedByActivityEnds:
 				bindModal(FleetSizeWeightedByActivityEndsDemandEstimator.class).toProvider(modalProvider(
 						getter -> new FleetSizeWeightedByActivityEndsDemandEstimator(
-								getter.getModal(DrtZonalSystem.class),
-								getter.getModal(FleetSpecification.class),
+								getter.getModal(DrtZonalSystem.class), getter.getModal(FleetSpecification.class),
 								drtCfg))).asEagerSingleton();
 				bindModal(ZonalDemandEstimator.class).to(
 						modalKey(FleetSizeWeightedByActivityEndsDemandEstimator.class));

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
@@ -62,9 +62,17 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 								getter.getModal(DrtZonalSystem.class), getter.getModal(Fleet.class),
 								getter.getModal(MinCostRelocationCalculator.class), params))).asEagerSingleton();
 
-				bindModal(RebalancingTargetCalculator.class).toProvider(modalProvider(
-						getter -> new LinearRebalancingTargetCalculator(getter.getModal(ZonalDemandEstimator.class),
-								strategyParams))).asEagerSingleton();
+				switch (strategyParams.getRebalancingTargetCalculatorType()) {
+					case LinearRebalancingTarget:
+						bindModal(RebalancingTargetCalculator.class).toProvider(modalProvider(
+								getter -> new LinearRebalancingTargetCalculator(
+										getter.getModal(ZonalDemandEstimator.class), strategyParams)))
+								.asEagerSingleton();
+						break;
+					default:
+						throw new IllegalArgumentException("Unsupported rebalancingTargetCalculatorType="
+								+ strategyParams.getZonalDemandEstimatorType());
+				}
 
 				bindModal(MinCostRelocationCalculator.class).toProvider(modalProvider(
 						getter -> new AggregatedMinCostRelocationCalculator(getter.getModal(DrtZonalSystem.class),
@@ -101,8 +109,8 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 								getter.getModal(FleetSpecification.class)))).asEagerSingleton();
 				break;
 			default:
-				throw new IllegalArgumentException("do not know what to do with ZonalDemandEstimatorType="
-						+ strategyParams.getZonalDemandEstimatorType());
+				throw new IllegalArgumentException(
+						"Unsupported zonalDemandEstimatorType=" + strategyParams.getZonalDemandEstimatorType());
 		}
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategyParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategyParams.java
@@ -20,6 +20,7 @@ package org.matsim.contrib.drt.optimizer.rebalancing.mincostflow;
 
 import java.util.Map;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.PositiveOrZero;
 
@@ -34,6 +35,10 @@ public final class MinCostFlowRebalancingStrategyParams extends ReflectiveConfig
 		implements RebalancingParams.RebalancingStrategyParams {
 	public static final String SET_NAME = "minCostFlowRebalancingStrategy";
 
+	public enum RebalancingTargetCalculatorType {
+		LinearRebalancingTarget
+	}
+
 	public enum ZonalDemandEstimatorType {
 		PreviousIterationDemand, FleetSizeWeightedByActivityEnds, EqualVehicleDensity,
 		FleetSizeWeightedByPopulationShare
@@ -47,18 +52,29 @@ public final class MinCostFlowRebalancingStrategyParams extends ReflectiveConfig
 	static final String TARGET_BETA_EXP = "beta constant in linear target calculation."
 			+ " In general, should be lower than 1.0 to prevent over-reacting and high empty mileage.";
 
+	public static final String REBALANCING_TARGET_CALCULATOR_TYPE = "rebalancingTargetCalculatorType";
+	static final String REBALANCING_TARGET_CALCULATOR_TYPE_EXP =
+			"Defines the calculator used for computing rebalancing targets per each zone"
+					+ " (i.e. number of the desired vehicles). Current default is LinearRebalancingTarget";
+
 	public static final String ZONAL_DEMAND_AGGREGATOR_TYPE = "zonalDemandEstimatorType";
-	static final String ZONAL_DEMAND_AGGREGATOR_TYPE_EXP = "Defines the methodology for demand estimation. Can be one of [PreviousIterationDemand, FleetSizeWeightedByActivityEnds, EqualVehicleDensity," +
-			" FleetSizeWeightedByPopulationShare] Current default is PreviousIterationDemand";
-
-	@PositiveOrZero
-	private double targetAlpha = Double.NaN;
-
-	@PositiveOrZero
-	private double targetBeta = Double.NaN;
+	static final String ZONAL_DEMAND_AGGREGATOR_TYPE_EXP = "Defines the methodology for demand estimation."
+			+ " Can be one of [PreviousIterationDemand, FleetSizeWeightedByActivityEnds, EqualVehicleDensity,"
+			+ " FleetSizeWeightedByPopulationShare] Current default is PreviousIterationDemand";
 
 	@NotNull
-	private MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType zonalDemandEstimatorType = ZonalDemandEstimatorType.PreviousIterationDemand;
+	private RebalancingTargetCalculatorType rebalancingTargetCalculatorType = RebalancingTargetCalculatorType.LinearRebalancingTarget;
+
+	@Nullable
+	@PositiveOrZero
+	private Double targetAlpha = null;
+
+	@Nullable
+	@PositiveOrZero
+	private Double targetBeta = null;
+
+	@NotNull
+	private ZonalDemandEstimatorType zonalDemandEstimatorType = ZonalDemandEstimatorType.PreviousIterationDemand;
 
 	public MinCostFlowRebalancingStrategyParams() {
 		super(SET_NAME);
@@ -82,7 +98,7 @@ public final class MinCostFlowRebalancingStrategyParams extends ReflectiveConfig
 	 * @return -- {@value #TARGET_ALPHA_EXP}
 	 */
 	@StringGetter(TARGET_ALPHA)
-	public double getTargetAlpha() {
+	public Double getTargetAlpha() {
 		return targetAlpha;
 	}
 
@@ -98,7 +114,7 @@ public final class MinCostFlowRebalancingStrategyParams extends ReflectiveConfig
 	 * @return -- {@value #TARGET_BETA_EXP}
 	 */
 	@StringGetter(TARGET_BETA)
-	public double getTargetBeta() {
+	public Double getTargetBeta() {
 		return targetBeta;
 	}
 
@@ -111,6 +127,22 @@ public final class MinCostFlowRebalancingStrategyParams extends ReflectiveConfig
 	}
 
 	/**
+	 * @return -- {@value #REBALANCING_TARGET_CALCULATOR_TYPE_EXP}
+	 */
+	@StringGetter(REBALANCING_TARGET_CALCULATOR_TYPE)
+	public RebalancingTargetCalculatorType getRebalancingTargetCalculatorType() {
+		return rebalancingTargetCalculatorType;
+	}
+
+	/**
+	 * @param calculatorType -- {@value #REBALANCING_TARGET_CALCULATOR_TYPE_EXP}
+	 */
+	@StringSetter(REBALANCING_TARGET_CALCULATOR_TYPE)
+	public void setRebalancingTargetCalculatorType(RebalancingTargetCalculatorType calculatorType) {
+		this.rebalancingTargetCalculatorType = calculatorType;
+	}
+
+	/**
 	 * @return -- {@value #ZONAL_DEMAND_AGGREGATOR_TYPE_EXP}
 	 */
 	@StringGetter(ZONAL_DEMAND_AGGREGATOR_TYPE)
@@ -119,10 +151,10 @@ public final class MinCostFlowRebalancingStrategyParams extends ReflectiveConfig
 	}
 
 	/**
-	 * @param aggregatorType -- {@value #ZONAL_DEMAND_AGGREGATOR_TYPE_EXP}
+	 * @param estimatorType -- {@value #ZONAL_DEMAND_AGGREGATOR_TYPE_EXP}
 	 */
 	@StringSetter(ZONAL_DEMAND_AGGREGATOR_TYPE)
-	public void setZonalDemandEstimatorType(ZonalDemandEstimatorType aggregatorType) {
-		this.zonalDemandEstimatorType = aggregatorType;
+	public void setZonalDemandEstimatorType(ZonalDemandEstimatorType estimatorType) {
+		this.zonalDemandEstimatorType = estimatorType;
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/RebalancingTargetCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/RebalancingTargetCalculator.java
@@ -1,0 +1,35 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.optimizer.rebalancing.targetcalculator;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.ToIntFunction;
+
+import org.matsim.contrib.drt.analysis.zonal.DrtZone;
+import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public interface RebalancingTargetCalculator {
+	ToIntFunction<DrtZone> calculate(double time, Map<DrtZone, List<DvrpVehicle>> rebalancableVehiclesPerZone);
+}


### PR DESCRIPTION
- pass in rebalancable vehicles
- return `DrtZone -> Integer` mapping (instead of separate calls for each zone)
- configure the calculator type in `MinCostFlowRebalancingStrategyParams`
