### PR TITLE
Add links to drt zones

### DIFF
--- a/contribs/drt/pom.xml
+++ b/contribs/drt/pom.xml
@@ -37,5 +37,11 @@
 			<version>3.15.0</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.8.1</version>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtGridUtils.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtGridUtils.java
@@ -28,10 +28,10 @@ import java.util.Map;
 
 import org.apache.log4j.Logger;
 import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.geom.prep.PreparedGeometry;
+import org.locationtech.jts.geom.prep.PreparedGeometryFactory;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.utils.misc.Counter;
@@ -40,13 +40,12 @@ import one.util.streamex.EntryStream;
 
 /**
  * @author jbischoff
- *
  */
 public class DrtGridUtils {
 
 	static final Logger log = Logger.getLogger(DrtGridUtils.class);
 
-	public static Map<String, Geometry> createGridFromNetwork(Network network, double cellsize) {
+	public static Map<String, PreparedGeometry> createGridFromNetwork(Network network, double cellsize) {
 		log.info("start creating grid from network");
 		double[] boundingbox = NetworkUtils.getBoundingBox(network.getNodes().values());
 		double minX = (Math.floor(boundingbox[0] / cellsize) * cellsize);
@@ -54,10 +53,10 @@ public class DrtGridUtils {
 		double minY = (Math.floor(boundingbox[1] / cellsize) * cellsize);
 		double maxY = (Math.ceil(boundingbox[3] / cellsize) * cellsize);
 		GeometryFactory gf = new GeometryFactory();
-		Map<String, Geometry> grid = new HashMap<>();
+		PreparedGeometryFactory preparedGeometryFactory = new PreparedGeometryFactory();
+		Map<String, PreparedGeometry> grid = new HashMap<>();
 		int cell = 0;
 		for (double lx = minX; lx < maxX; lx += cellsize) {
-
 			for (double by = minY; by < maxY; by += cellsize) {
 				cell++;
 				Coordinate p1 = new Coordinate(lx, by);
@@ -65,8 +64,8 @@ public class DrtGridUtils {
 				Coordinate p3 = new Coordinate(lx + cellsize, by + cellsize);
 				Coordinate p4 = new Coordinate(lx, by + cellsize);
 				Coordinate[] ca = { p1, p2, p3, p4, p1 };
-				Polygon p = new Polygon(gf.createLinearRing(ca), null, gf);
-				grid.put(cell + "", p);
+				Polygon polygon = new Polygon(gf.createLinearRing(ca), null, gf);
+				grid.put(cell + "", preparedGeometryFactory.create(polygon));
 			}
 		}
 		log.info("finished creating grid from network");
@@ -84,16 +83,17 @@ public class DrtGridUtils {
 	 * @param serviceAreaGeoms geometries that define the service area
 	 * @return
 	 */
-	public static Map<String, Geometry> createGridFromNetworkWithinServiceArea(Network network, double cellsize,
+	public static Map<String, PreparedGeometry> createGridFromNetworkWithinServiceArea(Network network, double cellsize,
 			List<PreparedGeometry> serviceAreaGeoms) {
-		Map<String, Geometry> grid = createGridFromNetwork(network, cellsize);
+		Map<String, PreparedGeometry> grid = createGridFromNetwork(network, cellsize);
 		log.info("total number of created grid zones = " + grid.size());
 
 		log.info("searching for grid zones within the drt service area...");
 		Counter counter = new Counter("dealt with zone ");
-		Map<String, Geometry> zonesWithinServiceArea = EntryStream.of(grid)
+		Map<String, PreparedGeometry> zonesWithinServiceArea = EntryStream.of(grid)
 				.peekKeys(id -> counter.incCounter())
-				.filterValues(cell -> serviceAreaGeoms.stream().anyMatch(serviceArea -> serviceArea.intersects(cell)))
+				.filterValues(cell -> serviceAreaGeoms.stream()
+						.anyMatch(serviceArea -> serviceArea.intersects(cell.getGeometry())))
 				.toMap();
 
 		log.info("number of remaining grid zones = " + zonesWithinServiceArea.size());

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtModeZonalSystemModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtModeZonalSystemModule.java
@@ -74,7 +74,8 @@ public class DrtModeZonalSystemModule extends AbstractDvrpModeModule {
 			}
 		})).asEagerSingleton();
 
-		bindModal(DrtZoneTargetLinkSelector.class).to(MostCentralDrtZoneTargetLinkSelector.class).asEagerSingleton();
+		bindModal(DrtZoneTargetLinkSelector.class).toProvider(modalProvider(getter ->
+				new MostCentralDrtZoneTargetLinkSelector(getter.getModal(DrtZonalSystem.class)))).asEagerSingleton();
 
 		//zonal analysis
 		bindModal(ZonalIdleVehicleXYVisualiser.class).

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtModeZonalSystemModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtModeZonalSystemModule.java
@@ -74,6 +74,8 @@ public class DrtModeZonalSystemModule extends AbstractDvrpModeModule {
 			}
 		})).asEagerSingleton();
 
+		bindModal(DrtZoneTargetLinkSelector.class).to(MostCentralDrtZoneTargetLinkSelector.class).asEagerSingleton();
+
 		//zonal analysis
 		bindModal(ZonalIdleVehicleXYVisualiser.class).
 				toProvider(modalProvider(

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtModeZonalSystemModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtModeZonalSystemModule.java
@@ -67,7 +67,7 @@ public class DrtModeZonalSystemModule extends AbstractDvrpModeModule {
 									loadPreparedGeometries(
 											drtCfg.getDrtServiceAreaShapeFileURL(getConfig().getContext()))) :
 							createGridFromNetwork(network, params.getCellSize());
-					return DrtZonalSystem.createFromGeometries(network, gridZones);
+					return DrtZonalSystem.createFromPreparedGeometries(network, gridZones);
 
 				default:
 					throw new RuntimeException("Unsupported zone generation");

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystem.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystem.java
@@ -19,11 +19,12 @@
 
 package org.matsim.contrib.drt.analysis.zonal;
 
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.function.BiFunction;
 
 import javax.annotation.Nullable;
 
@@ -48,9 +49,9 @@ public class DrtZonalSystem {
 	public static DrtZonalSystem createFromPreparedGeometries(Network network, Map<String, PreparedGeometry> geometries) {
 
 		//geometries without links are skipped
-		Map<String, Map<Id<Link>, Link>> linksByGeometryId = StreamEx.of(network.getLinks().values())
+		Map<String, List<Link>> linksByGeometryId = StreamEx.of(network.getLinks().values())
 				.mapToEntry(l -> getGeometryIdForLink(l, geometries), l -> l)
-				.grouping(toMap(Link::getId, l -> l));
+				.grouping(toList());
 
 		//the zonal system contains only zones that have at least one link
 		Map<String, DrtZone> zones = EntryStream.of(linksByGeometryId).mapKeyValue((id, links) -> {
@@ -85,7 +86,7 @@ public class DrtZonalSystem {
 		this.zones = zones;
 		this.link2zone = zones.values()
 				.stream()
-				.flatMap(zone -> zone.getLinks().values().stream().map(link -> Pair.of(link.getId(), zone)))
+				.flatMap(zone -> zone.getLinks().stream().map(link -> Pair.of(link.getId(), zone)))
 				.collect(toMap(Pair::getKey, Pair::getValue));
 	}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystem.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystem.java
@@ -21,11 +21,13 @@ package org.matsim.contrib.drt.analysis.zonal;
 
 import static java.util.stream.Collectors.toMap;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.BiFunction;
 
-import org.locationtech.jts.geom.Geometry;
+import javax.annotation.Nullable;
+
+import org.apache.commons.lang3.tuple.Pair;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.prep.PreparedGeometry;
 import org.matsim.api.core.v01.Id;
@@ -33,70 +35,74 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.core.utils.geometry.geotools.MGC;
 
-import javax.annotation.Nullable;
+import one.util.streamex.EntryStream;
+import one.util.streamex.StreamEx;
 
 /**
  * @author jbischoff
  * @author Michal Maciejewski (michalm)
  */
 public class DrtZonalSystem {
+
 	public static DrtZonalSystem createFromPreparedGeometries(Network network,
 			Map<String, PreparedGeometry> geometries) {
-		return new DrtZonalSystem(network, geometries.entrySet()
-				.stream()
-				.collect(toMap(Entry::getKey, e -> new DrtZone(e.getKey(), e.getValue()))));
+		//FIXME implement a search of the link closest to the centroid
+		return createFromPreparedGeometries(network, geometries, (geometry, links) -> links.values().iterator().next());
 	}
 
-	public static DrtZonalSystem createFromGeometries(Network network, Map<String, Geometry> geometries) {
-		return new DrtZonalSystem(network, geometries.entrySet()
-				.stream()
-				.collect(toMap(Entry::getKey, e -> new DrtZone(e.getKey(), e.getValue()))));
-	}
+	public static DrtZonalSystem createFromPreparedGeometries(Network network, Map<String, PreparedGeometry> geometries,
+			BiFunction<PreparedGeometry, Map<Id<Link>, Link>, Link> targetLinkSelector) {
 
-	private static final DrtZone NO_ZONE = new DrtZone(null, null, null, null);
+		//geometries without links are skipped
+		Map<String, Map<Id<Link>, Link>> linksByGeometryId = StreamEx.of(network.getLinks().values())
+				.mapToEntry(l -> getGeometryIdForLink(l, geometries), l -> l)
+				.grouping(toMap(Link::getId, l -> l));
 
-	private final Map<Id<Link>, DrtZone> link2zone = new HashMap<>();
-	private final Network network;
-	private final Map<String, DrtZone> zones;
+		//the zonal system contains only zones that have at least one link
+		Map<String, DrtZone> zones = EntryStream.of(linksByGeometryId).mapKeyValue((id, links) -> {
+			PreparedGeometry geometry = geometries.get(id);
+			return new DrtZone(id, geometry, targetLinkSelector.apply(geometry, links), links);
+		}).collect(toMap(DrtZone::getId, z -> z));
 
-	public DrtZonalSystem(Network network, Map<String, DrtZone> zones) {
-		this.network = network;
-		this.zones = zones;
+		return new DrtZonalSystem(zones);
 	}
 
 	/**
-	 *
+	 * @param link
+	 * @return the the {@code PreparedGeometry} that contains the {@code linkId}.
+	 * If a given link's {@code Coord} borders two or more cells, the allocation to a cell is random.
+	 * Result may be null in case the given link is outside of the service area.
+	 */
+	private static String getGeometryIdForLink(Link link, Map<String, PreparedGeometry> geometries) {
+		//TODO use endNode.getCoord() ?
+		Point linkCoord = MGC.coord2Point(link.getCoord());
+		return geometries.entrySet()
+				.stream()
+				.filter(e -> e.getValue().intersects(linkCoord))
+				.findAny()
+				.map(Entry::getKey)
+				.orElse(null);
+	}
+
+	private final Map<String, DrtZone> zones;
+	private final Map<Id<Link>, DrtZone> link2zone;
+
+	private DrtZonalSystem(Map<String, DrtZone> zones) {
+		this.zones = zones;
+		this.link2zone = zones.values()
+				.stream()
+				.flatMap(zone -> zone.getLinks().values().stream().map(link -> Pair.of(link.getId(), zone)))
+				.collect(toMap(Pair::getKey, Pair::getValue));
+	}
+
+	/**
 	 * @param linkId
 	 * @return the the {@code DrtZone} that contains the {@code linkId}. If the given link's {@code Coord} borders two or more cells, the allocation to a cell is random.
 	 * Result may be null in case the given link is outside of the service area.
-	 *
 	 */
 	@Nullable
 	public DrtZone getZoneForLinkId(Id<Link> linkId) {
-		DrtZone zone = link2zone.get(linkId);
-		if (zone != null) {
-			return zone == NO_ZONE ? null : zone;
-		}
-
-		Point linkCoord = MGC.coord2Point(network.getLinks().get(linkId).getCoord());
-		for (DrtZone z : zones.values()) {
-			if (intersects(z, linkCoord)) {
-				//if a link Coord borders two or more cells, the allocation to a cell is random.
-				// Seems hard to overcome, but most likely better than returning no zone at
-				// all and mostly not too relevant in non-grid networks.
-				// jb, june 2019
-				link2zone.put(linkId, z);
-				return z;
-			}
-		}
-
-		link2zone.put(linkId, NO_ZONE);
-		return null;
-	}
-
-	private boolean intersects(DrtZone zone, Point point) {
-		PreparedGeometry preparedGeometry = zone.getPreparedGeometry();
-		return preparedGeometry != null ? preparedGeometry.intersects(point) : zone.getGeometry().intersects(point);
+		return link2zone.get(linkId);
 	}
 
 	/**

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystem.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystem.java
@@ -41,17 +41,11 @@ import one.util.streamex.StreamEx;
 /**
  * @author jbischoff
  * @author Michal Maciejewski (michalm)
+ * @author Tilmann Schlenther (tschlenther)
  */
 public class DrtZonalSystem {
 
-	public static DrtZonalSystem createFromPreparedGeometries(Network network,
-			Map<String, PreparedGeometry> geometries) {
-		//FIXME implement a search of the link closest to the centroid
-		return createFromPreparedGeometries(network, geometries, (geometry, links) -> links.values().iterator().next());
-	}
-
-	public static DrtZonalSystem createFromPreparedGeometries(Network network, Map<String, PreparedGeometry> geometries,
-			BiFunction<PreparedGeometry, Map<Id<Link>, Link>, Link> targetLinkSelector) {
+	public static DrtZonalSystem createFromPreparedGeometries(Network network, Map<String, PreparedGeometry> geometries) {
 
 		//geometries without links are skipped
 		Map<String, Map<Id<Link>, Link>> linksByGeometryId = StreamEx.of(network.getLinks().values())
@@ -61,7 +55,7 @@ public class DrtZonalSystem {
 		//the zonal system contains only zones that have at least one link
 		Map<String, DrtZone> zones = EntryStream.of(linksByGeometryId).mapKeyValue((id, links) -> {
 			PreparedGeometry geometry = geometries.get(id);
-			return new DrtZone(id, geometry, targetLinkSelector.apply(geometry, links), links);
+			return new DrtZone(id, geometry, links);
 		}).collect(toMap(DrtZone::getId, z -> z));
 
 		return new DrtZonalSystem(zones);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZone.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZone.java
@@ -20,49 +20,46 @@
 
 package org.matsim.contrib.drt.analysis.zonal;
 
-import org.locationtech.jts.geom.Geometry;
+import java.util.Map;
+
 import org.locationtech.jts.geom.prep.PreparedGeometry;
 import org.matsim.api.core.v01.Coord;
-import org.matsim.core.utils.geometry.geotools.MGC;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
 
 /**
  * @author Michal Maciejewski (michalm)
  */
 public class DrtZone {
 	private final String id;
-	private final Geometry geometry;
 	private final PreparedGeometry preparedGeometry;
-	private final Coord centroid;
+	private final Link targetLink;
+	private final Map<Id<Link>, Link> links;
 
-	public DrtZone(String id, PreparedGeometry preparedGeometry) {
-		this(id, preparedGeometry.getGeometry(), preparedGeometry,
-				MGC.point2Coord(preparedGeometry.getGeometry().getCentroid()));
-	}
-
-	public DrtZone(String id, Geometry geometry) {
-		this(id, geometry, null, MGC.point2Coord(geometry.getCentroid()));
-	}
-
-	DrtZone(String id, Geometry geometry, PreparedGeometry preparedGeometry, Coord centroid) {
+	public DrtZone(String id, PreparedGeometry preparedGeometry, Link targetLink, Map<Id<Link>, Link> links) {
 		this.id = id;
-		this.geometry = geometry;
 		this.preparedGeometry = preparedGeometry;
-		this.centroid = centroid;
+		this.targetLink = targetLink;
+		this.links = links;
 	}
 
 	public String getId() {
 		return id;
 	}
 
-	public Geometry getGeometry() {
-		return geometry;
+	public PreparedGeometry getPreparedGeometry() {
+		return preparedGeometry;
+	}
+
+	public Link getTargetLink() {
+		return targetLink;
 	}
 
 	public Coord getCentroid() {
-		return centroid;
+		return targetLink.getCoord();
 	}
 
-	public PreparedGeometry getPreparedGeometry() {
-		return preparedGeometry;
+	public Map<Id<Link>, Link> getLinks() {
+		return links;
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZone.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZone.java
@@ -20,11 +20,10 @@
 
 package org.matsim.contrib.drt.analysis.zonal;
 
-import java.util.Map;
+import java.util.List;
 
 import org.locationtech.jts.geom.prep.PreparedGeometry;
 import org.matsim.api.core.v01.Coord;
-import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.core.utils.geometry.geotools.MGC;
 
@@ -34,9 +33,9 @@ import org.matsim.core.utils.geometry.geotools.MGC;
 public class DrtZone {
 	private final String id;
 	private final PreparedGeometry preparedGeometry;
-	private final Map<Id<Link>, Link> links;
+	private final List<Link> links;
 
-	public DrtZone(String id, PreparedGeometry preparedGeometry, Map<Id<Link>, Link> links) {
+	public DrtZone(String id, PreparedGeometry preparedGeometry, List<Link> links) {
 		this.id = id;
 		this.preparedGeometry = preparedGeometry;
 		this.links = links;
@@ -50,11 +49,7 @@ public class DrtZone {
 		return preparedGeometry;
 	}
 
-	public Coord getCentroid() {
-		return MGC.point2Coord(preparedGeometry.getGeometry().getCentroid());
-	}
+	public Coord getCentroid() { return MGC.point2Coord(preparedGeometry.getGeometry().getCentroid());	}
 
-	public Map<Id<Link>, Link> getLinks() {
-		return links;
-	}
+	public List<Link> getLinks() { return links; }
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZoneTargetLinkSelector.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZoneTargetLinkSelector.java
@@ -1,9 +1,9 @@
-/*
- * *********************************************************************** *
+/* *********************************************************************** *
  * project: org.matsim.*
+ *                                                                         *
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ * copyright       : (C) 2007 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -15,46 +15,14 @@
  *   (at your option) any later version.                                   *
  *   See also COPYING, LICENSE and WARRANTY file                           *
  *                                                                         *
- * *********************************************************************** *
- */
+ * *********************************************************************** */
 
 package org.matsim.contrib.drt.analysis.zonal;
 
-import java.util.Map;
-
-import org.locationtech.jts.geom.prep.PreparedGeometry;
-import org.matsim.api.core.v01.Coord;
-import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.core.utils.geometry.geotools.MGC;
 
-/**
- * @author Michal Maciejewski (michalm)
- */
-public class DrtZone {
-	private final String id;
-	private final PreparedGeometry preparedGeometry;
-	private final Map<Id<Link>, Link> links;
+public interface DrtZoneTargetLinkSelector {
 
-	public DrtZone(String id, PreparedGeometry preparedGeometry, Map<Id<Link>, Link> links) {
-		this.id = id;
-		this.preparedGeometry = preparedGeometry;
-		this.links = links;
-	}
+	Link selectTargetLinkFor(DrtZone zone);
 
-	public String getId() {
-		return id;
-	}
-
-	public PreparedGeometry getPreparedGeometry() {
-		return preparedGeometry;
-	}
-
-	public Coord getCentroid() {
-		return MGC.point2Coord(preparedGeometry.getGeometry().getCentroid());
-	}
-
-	public Map<Id<Link>, Link> getLinks() {
-		return links;
-	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZoneTargetLinkSelector.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZoneTargetLinkSelector.java
@@ -23,6 +23,6 @@ import org.matsim.api.core.v01.network.Link;
 
 public interface DrtZoneTargetLinkSelector {
 
-	Link selectTargetLinkFor(DrtZone zone);
+	Link selectTargetLink(DrtZone zone);
 
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/MostCentralDrtZoneTargetLinkSelector.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/MostCentralDrtZoneTargetLinkSelector.java
@@ -1,0 +1,51 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * Controler.java
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2007 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.drt.analysis.zonal;
+
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.core.network.NetworkUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MostCentralDrtZoneTargetLinkSelector implements DrtZoneTargetLinkSelector{
+
+	Map<DrtZone,Link> targetLinks = new HashMap<>();
+
+	@Override
+	public Link selectTargetLinkFor(DrtZone zone) {
+		if(this.targetLinks.containsKey(zone)) return this.targetLinks.get(zone);
+
+		Double minDistance = Double.MAX_VALUE;
+		Link closestLink = null;
+		for(Link link : zone.getLinks().values()){
+			// vehicle will be standing at the toNode, this is why we use toNode rather than getCoord
+			double dist = NetworkUtils.getEuclideanDistance(zone.getCentroid(), link.getToNode().getCoord());
+			if(dist < minDistance){
+				minDistance = dist;
+				closestLink = link;
+			}
+		}
+		if(closestLink == null) throw new RuntimeException("could not determin most central link for zone " + zone);
+		this.targetLinks.put(zone, closestLink);
+		return closestLink;
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/RandomDrtZoneTargetLinkSelector.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/RandomDrtZoneTargetLinkSelector.java
@@ -1,9 +1,10 @@
-/*
- * *********************************************************************** *
+/* *********************************************************************** *
  * project: org.matsim.*
+ * Controler.java
+ *                                                                         *
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ * copyright       : (C) 2007 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -15,46 +16,23 @@
  *   (at your option) any later version.                                   *
  *   See also COPYING, LICENSE and WARRANTY file                           *
  *                                                                         *
- * *********************************************************************** *
- */
+ * *********************************************************************** */
 
 package org.matsim.contrib.drt.analysis.zonal;
 
-import java.util.Map;
-
-import org.locationtech.jts.geom.prep.PreparedGeometry;
-import org.matsim.api.core.v01.Coord;
-import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.core.utils.geometry.geotools.MGC;
+import org.matsim.core.gbl.MatsimRandom;
 
-/**
- * @author Michal Maciejewski (michalm)
- */
-public class DrtZone {
-	private final String id;
-	private final PreparedGeometry preparedGeometry;
-	private final Map<Id<Link>, Link> links;
+import java.util.ArrayList;
+import java.util.Random;
 
-	public DrtZone(String id, PreparedGeometry preparedGeometry, Map<Id<Link>, Link> links) {
-		this.id = id;
-		this.preparedGeometry = preparedGeometry;
-		this.links = links;
+public class RandomDrtZoneTargetLinkSelector implements DrtZoneTargetLinkSelector{
+
+	private final Random random = MatsimRandom.getLocalInstance();
+
+	@Override
+	public Link selectTargetLinkFor(DrtZone zone) {
+		return new ArrayList<>(zone.getLinks().values()).get(random.nextInt(zone.getLinks().size()));
 	}
 
-	public String getId() {
-		return id;
-	}
-
-	public PreparedGeometry getPreparedGeometry() {
-		return preparedGeometry;
-	}
-
-	public Coord getCentroid() {
-		return MGC.point2Coord(preparedGeometry.getGeometry().getCentroid());
-	}
-
-	public Map<Id<Link>, Link> getLinks() {
-		return links;
-	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/RandomDrtZoneTargetLinkSelector.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/RandomDrtZoneTargetLinkSelector.java
@@ -23,16 +23,18 @@ package org.matsim.contrib.drt.analysis.zonal;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.core.gbl.MatsimRandom;
 
-import java.util.ArrayList;
 import java.util.Random;
 
+/**
+ * @author tschlenther
+ */
 public class RandomDrtZoneTargetLinkSelector implements DrtZoneTargetLinkSelector{
 
 	private final Random random = MatsimRandom.getLocalInstance();
 
 	@Override
-	public Link selectTargetLinkFor(DrtZone zone) {
-		return new ArrayList<>(zone.getLinks().values()).get(random.nextInt(zone.getLinks().size()));
+	public Link selectTargetLink(DrtZone zone) {
+		return zone.getLinks().get(random.nextInt(zone.getLinks().size()));
 	}
 
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/EqualVehicleDensityZonalDemandEstimator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/EqualVehicleDensityZonalDemandEstimator.java
@@ -49,7 +49,7 @@ public final class EqualVehicleDensityZonalDemandEstimator implements ZonalDeman
 	private final FleetSpecification fleetSpecification;
 
 	public EqualVehicleDensityZonalDemandEstimator(@NotNull DrtZonalSystem zonalSystem,
-												   @NotNull FleetSpecification fleetSpecification) {
+			@NotNull FleetSpecification fleetSpecification) {
 		initAreaShareMap(zonalSystem);
 		this.fleetSpecification = fleetSpecification;
 	}
@@ -62,10 +62,14 @@ public final class EqualVehicleDensityZonalDemandEstimator implements ZonalDeman
 	}
 
 	private void initAreaShareMap(DrtZonalSystem zonalSystem) {
-		double areaSum = zonalSystem.getZones().values().stream().mapToDouble(z -> z.getGeometry().getArea()).sum();
+		double areaSum = zonalSystem.getZones()
+				.values()
+				.stream()
+				.mapToDouble(z -> z.getPreparedGeometry().getGeometry().getArea())
+				.sum();
 
 		for (DrtZone zone : zonalSystem.getZones().values()) {
-			double areaShare = zone.getGeometry().getArea() / areaSum;
+			double areaShare = zone.getPreparedGeometry().getGeometry().getArea() / areaSum;
 			Preconditions.checkState(areaShare >= 0. && areaShare <= 1.);
 			zoneAreaShares.put(zone, areaShare);
 		}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/PreviousIterationDRTDemandEstimator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/PreviousIterationDRTDemandEstimator.java
@@ -43,8 +43,7 @@ import org.matsim.core.utils.misc.Time;
  *
  * @author jbischoff
  */
-public final class PreviousIterationDRTDemandEstimator
-		implements ZonalDemandEstimator, PersonDepartureEventHandler {
+public final class PreviousIterationDRTDemandEstimator implements ZonalDemandEstimator, PersonDepartureEventHandler {
 
 	private final DrtZonalSystem zonalSystem;
 	private final String mode;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/AggregatedMinCostRelocationCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/AggregatedMinCostRelocationCalculator.java
@@ -35,7 +35,6 @@ import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.schedule.Schedules;
 import org.matsim.contrib.util.distance.DistanceUtils;
 import org.matsim.core.network.NetworkUtils;
-import org.matsim.core.utils.geometry.geotools.MGC;
 
 /**
  * @author michalm
@@ -68,7 +67,7 @@ public class AggregatedMinCostRelocationCalculator implements MinCostRelocationC
 			List<DvrpVehicle> rebalancableVehicles = rebalancableVehiclesPerZone.get(r.getLeft());
 
 			DrtZone toZone = r.getMiddle();
-			Coord zoneCentroid = MGC.point2Coord(toZone.getGeometry().getCentroid());
+			Coord zoneCentroid = toZone.getCentroid();
 			Link destinationLink = NetworkUtils.getNearestLink(network, zoneCentroid);
 
 			int flow = r.getRight();

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/AggregatedMinCostRelocationCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/AggregatedMinCostRelocationCalculator.java
@@ -35,7 +35,6 @@ import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy.Relocati
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.schedule.Schedules;
 import org.matsim.contrib.util.distance.DistanceUtils;
-import org.matsim.core.network.NetworkUtils;
 
 /**
  * @author michalm
@@ -70,7 +69,7 @@ public class AggregatedMinCostRelocationCalculator implements MinCostRelocationC
 			List<DvrpVehicle> rebalancableVehicles = rebalancableVehiclesPerZone.get(r.getLeft());
 
 			DrtZone toZone = r.getMiddle();
-			Link targetLink = targetLinkSelector.selectTargetLinkFor(toZone);
+			Link targetLink = targetLinkSelector.selectTargetLink(toZone);
 
 			int flow = r.getRight();
 			for (int f = 0; f < flow; f++) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
@@ -23,6 +23,7 @@ package org.matsim.contrib.drt.optimizer.rebalancing.mincostflow;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Population;
 import org.matsim.contrib.drt.analysis.zonal.DrtZonalSystem;
+import org.matsim.contrib.drt.analysis.zonal.DrtZoneTargetLinkSelector;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingParams;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.drt.optimizer.rebalancing.demandestimator.EqualVehicleDensityZonalDemandEstimator;
@@ -76,7 +77,8 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 
 				bindModal(MinCostRelocationCalculator.class).toProvider(modalProvider(
 						getter -> new AggregatedMinCostRelocationCalculator(getter.getModal(DrtZonalSystem.class),
-								getter.getModal(Network.class)))).asEagerSingleton();
+								getter.getModal(Network.class),
+								getter.getModal(DrtZoneTargetLinkSelector.class)))).asEagerSingleton();
 			}
 		});
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/DrtGridUtilsTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/DrtGridUtilsTest.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.prep.PreparedGeometry;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
@@ -19,14 +20,14 @@ public class DrtGridUtilsTest {
 	@Test
 	public void test() {
 		Network network = createNetwork();
-		Map<String, Geometry> grid = DrtGridUtils.createGridFromNetwork(network, 100);
+		Map<String, PreparedGeometry> grid = DrtGridUtils.createGridFromNetwork(network, 100);
 
 		assertThat(grid).hasSize(100);
 
 		int cell = 1;
 		for (int col = 0; col < 10; col++) {
 			for (int row = 0; row < 10; row++) {
-				Geometry geometry = grid.get(cell + "");
+				Geometry geometry = grid.get(cell + "").getGeometry();
 
 				assertThat(geometry.getCoordinates()).containsExactly(//
 						new Coordinate(col * 100, row * 100),//

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystemTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystemTest.java
@@ -22,9 +22,7 @@ package org.matsim.contrib.drt.analysis.zonal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.matsim.contrib.drt.analysis.zonal.DrtGridUtilsTest.createNetwork;
-import static org.matsim.contrib.drt.analysis.zonal.DrtZonalSystem.createFromGeometries;
-
-import java.util.Map;
+import static org.matsim.contrib.drt.analysis.zonal.DrtZonalSystem.createFromPreparedGeometries;
 
 import org.junit.Test;
 import org.matsim.api.core.v01.Id;
@@ -36,21 +34,15 @@ public class DrtZonalSystemTest {
 
 	@Test
 	public void test_cellSize100() {
-		DrtZonalSystem drtZonalSystem = createFromGeometries(createNetwork(),
+		DrtZonalSystem drtZonalSystem = createFromPreparedGeometries(createNetwork(),
 				DrtGridUtils.createGridFromNetwork(createNetwork(), 100));
 		assertThat(drtZonalSystem.getZoneForLinkId(Id.createLinkId("ab")).getId()).isEqualTo("5");
 	}
 
 	@Test
 	public void test_cellSize700() {
-		DrtZonalSystem drtZonalSystem = createFromGeometries(createNetwork(),
+		DrtZonalSystem drtZonalSystem = createFromPreparedGeometries(createNetwork(),
 				DrtGridUtils.createGridFromNetwork(createNetwork(), 700));
 		assertThat(drtZonalSystem.getZoneForLinkId(Id.createLinkId("ab")).getId()).isEqualTo("1");
-	}
-
-	@Test
-	public void test_linkOutsideZonalSystem() {
-		DrtZonalSystem drtZonalSystem = new DrtZonalSystem(createNetwork(), Map.of());
-		assertThat(drtZonalSystem.getZoneForLinkId(Id.createLinkId("ab"))).isNull();
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/ZonalDemandEstimatorWithoutServiceAreaTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/ZonalDemandEstimatorWithoutServiceAreaTest.java
@@ -66,7 +66,7 @@ import org.matsim.vis.otfvis.OTFVisConfigGroup;
 public class ZonalDemandEstimatorWithoutServiceAreaTest {
 
 	//TODO write test with service area !!
-	// (with an service are, demand estimation zones are not spread over the entire network but restricted to the service are (plus a little surrounding))
+	// (with an service area, demand estimation zones are not spread over the entire network but restricted to the service are (plus a little surrounding))
 
 	@Rule
 	public MatsimTestUtils utils = new MatsimTestUtils();
@@ -74,12 +74,12 @@ public class ZonalDemandEstimatorWithoutServiceAreaTest {
 	@Test
 	public void EqualVehicleDensityZonalDemandEstimatorTest() {
 		Controler controler = setupControler(
-				MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType.EqualVehicleDensity, "");
+				MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType.EqualVehicleDensity, "", false);
 		controler.run();
 		ZonalDemandEstimator estimator = controler.getInjector()
 				.getInstance(DvrpModes.key(ZonalDemandEstimator.class, "drt"));
 		DrtZonalSystem zonalSystem = controler.getInjector().getInstance(DvrpModes.key(DrtZonalSystem.class, "drt"));
-		for (double ii = 0; ii < 16 * 3600; ii += 1800) {
+		for (double ii = 0; ii < 16 * 3600; ii += 1800) { //1800 is the rebalancing interval width
 			ToIntFunction<DrtZone> demandFunction = estimator.getExpectedDemandForTimeBin(
 					ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
 			assertDemand(demandFunction, zonalSystem, "1", ii, 1);
@@ -103,7 +103,7 @@ public class ZonalDemandEstimatorWithoutServiceAreaTest {
 	@Test
 	public void EqualVehicleDensityZonalDemandEstimatorFleetModificationTest() {
 		Controler controler = setupControler(
-				MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType.EqualVehicleDensity, "");
+				MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType.EqualVehicleDensity, "", false);
 		// double number of vehicles after 0th iteration -> estimation of demand should double too
 		controler.addOverridingModule(new AbstractDvrpModeModule("drt") {
 			@Override
@@ -135,7 +135,7 @@ public class ZonalDemandEstimatorWithoutServiceAreaTest {
 	@Test
 	public void PreviousIterationZonalDemandEstimatorTest() {
 		Controler controler = setupControler(
-				MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType.PreviousIterationDemand, "");
+				MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType.PreviousIterationDemand, "", false);
 		controler.run();
 		ZonalDemandEstimator estimator = controler.getInjector()
 				.getInstance(DvrpModes.key(ZonalDemandEstimator.class, "drt"));
@@ -157,7 +157,7 @@ public class ZonalDemandEstimatorWithoutServiceAreaTest {
 	@Test
 	public void PreviousIterationZonalDemandEstimatorWithSpeedUpModeTest() {
 		Controler controler = setupControler(
-				MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType.PreviousIterationDemand, "drt_teleportation");
+				MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType.PreviousIterationDemand, "drt_teleportation", false);
 		controler.run();
 		ZonalDemandEstimator estimator = controler.getInjector()
 				.getInstance(DvrpModes.key(ZonalDemandEstimator.class, "drt"));
@@ -179,7 +179,7 @@ public class ZonalDemandEstimatorWithoutServiceAreaTest {
 	@Test
 	public void FleetSizeWeightedByActivityEndsDemandEstimatorTest() {
 		Controler controler = setupControler(
-				MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType.FleetSizeWeightedByActivityEnds, "");
+				MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType.FleetSizeWeightedByActivityEnds, "", false);
 		controler.run();
 		ZonalDemandEstimator estimator = controler.getInjector()
 				.getInstance(DvrpModes.key(ZonalDemandEstimator.class, "drt"));
@@ -201,7 +201,7 @@ public class ZonalDemandEstimatorWithoutServiceAreaTest {
 	@Test
 	public void FleetSizeWeightedByPopulationShareDemandEstimatorTest() {
 		Controler controler = setupControler(
-				MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType.FleetSizeWeightedByPopulationShare, "");
+				MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType.FleetSizeWeightedByPopulationShare, "", false);
 		controler.run();
 		ZonalDemandEstimator estimator = controler.getInjector()
 				.getInstance(DvrpModes.key(ZonalDemandEstimator.class, "drt"));
@@ -223,7 +223,7 @@ public class ZonalDemandEstimatorWithoutServiceAreaTest {
 	@Test
 	public void FleetSizeWeightedByPopulationShareDemandEstimatorFleetModificationTest() {
 		Controler controler = setupControler(
-				MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType.FleetSizeWeightedByPopulationShare, "");
+				MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType.FleetSizeWeightedByPopulationShare, "", false);
 		// double number of vehicles after 0th iteration -> estimation of demand should double too (besides rounding issues)
 		controler.addOverridingModule(new AbstractDvrpModeModule("drt") {
 			@Override
@@ -253,7 +253,7 @@ public class ZonalDemandEstimatorWithoutServiceAreaTest {
 	}
 
 	private Controler setupControler(MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType estimatorType,
-			String drtSpeedUpModeForRebalancingConfiguration) {
+									 String drtSpeedUpModeForRebalancingConfiguration, boolean useServiceArea) {
 		URL configUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("dvrp-grid"),
 				"eight_shared_taxi_config.xml");
 		Config config = ConfigUtils.loadConfig(configUrl, new MultiModeDrtConfigGroup(), new DvrpConfigGroup(),
@@ -261,6 +261,12 @@ public class ZonalDemandEstimatorWithoutServiceAreaTest {
 
 		DrtConfigGroup drtCfg = DrtConfigGroup.getSingleModeDrtConfig(config);
 		drtCfg.setDrtSpeedUpMode(drtSpeedUpModeForRebalancingConfiguration);
+
+		if(useServiceArea){
+			throw new IllegalArgumentException("about to get implemented...");
+//			drtCfg.setOperationalScheme(DrtConfigGroup.OperationalScheme.serviceAreaBased);
+//			drtCfg.setDrtServiceAreaShapeFile("");
+		}
 
 		MinCostFlowRebalancingStrategyParams rebalancingStrategyParams = new MinCostFlowRebalancingStrategyParams();
 		rebalancingStrategyParams.setTargetAlpha(1);

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/VehicleChargingHandler.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/VehicleChargingHandler.java
@@ -49,12 +49,18 @@ import org.matsim.vehicles.Vehicle;
 
 import com.google.common.collect.ImmutableListMultimap;
 
+/**
+ * This is an events based approach to trigger vehicle charging. Vehicles will be charged as soon as a person begins a charging activity.
+ * <p>
+ * Do not use this class for charging DVRP vehicles (DynAgents). In that case, vehicle charging is simulated with ChargingActivity (DynActivity)
+ */
 public class VehicleChargingHandler
 		implements ActivityStartEventHandler, ActivityEndEventHandler, PersonLeavesVehicleEventHandler,
 		ChargingEndEventHandler, MobsimScopeEventHandler {
 
 	public static final String CHARGING_IDENTIFIER = " charging";
-	public static final String CHARGING_INTERACTION = PlanCalcScoreConfigGroup.createStageActivityType(CHARGING_IDENTIFIER);
+	public static final String CHARGING_INTERACTION = PlanCalcScoreConfigGroup.createStageActivityType(
+			CHARGING_IDENTIFIER);
 	private final Map<Id<Person>, Id<Vehicle>> lastVehicleUsed = new HashMap<>();
 	private final Map<Id<ElectricVehicle>, Id<Charger>> vehiclesAtChargers = new HashMap<>();
 


### PR DESCRIPTION
DrtZones have now information on all links inside of them.

@michalmac as you decided to include the field `Map<Id<Link>,Link>`, and as we already can think of at least 2 ways of setting a target link for a zone, i thought maybe we want to have a flexible way of determining a target link for each zone.
That way, we do not need a `targetLink` field inside `DrtZone`.
Instead, we have the interface `DrtZoneTargetLinkSelector` which is currently only used for rebalancing but could also be used for other purposes,
I implemented 2 variants: 

1. choose a random link (each time you query the selector)
2. always choose the most central link

default is 2.

I put the binding and the interface as well as both implementations into the zonal package.
If you think that this rather belongs into optimizer\rebalancing\mincostflow i am happy to move it (the binding would be done in the `DrtModeMinCostFlowRebalancingModule` instead of `DrtModeZonalSystemModule` then)

Please let me know if you think that putting the target link selection behind an interface is premature generalization.
