### PR TITLE
Support dummy zones & refactor demand estimators

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZone.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZone.java
@@ -22,6 +22,8 @@ package org.matsim.contrib.drt.analysis.zonal;
 
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 import org.locationtech.jts.geom.prep.PreparedGeometry;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.network.Link;
@@ -31,25 +33,45 @@ import org.matsim.core.utils.geometry.geotools.MGC;
  * @author Michal Maciejewski (michalm)
  */
 public class DrtZone {
+	public static DrtZone createDummyZone(String id, List<Link> links, Coord centroid) {
+		return new DrtZone(id, null, links, centroid);
+	}
+
 	private final String id;
-	private final PreparedGeometry preparedGeometry;
+	@Nullable
+	private final PreparedGeometry preparedGeometry; //null for virtual/dummy zones
 	private final List<Link> links;
+	private final Coord centroid;
 
 	public DrtZone(String id, PreparedGeometry preparedGeometry, List<Link> links) {
+		this(id, preparedGeometry, links, MGC.point2Coord(preparedGeometry.getGeometry().getCentroid()));
+	}
+
+	private DrtZone(String id, @Nullable PreparedGeometry preparedGeometry, List<Link> links, Coord centroid) {
 		this.id = id;
 		this.preparedGeometry = preparedGeometry;
 		this.links = links;
+		this.centroid = centroid;
 	}
 
 	public String getId() {
 		return id;
 	}
 
+	@Nullable
 	public PreparedGeometry getPreparedGeometry() {
 		return preparedGeometry;
 	}
 
-	public Coord getCentroid() { return MGC.point2Coord(preparedGeometry.getGeometry().getCentroid());	}
+	public Coord getCentroid() {
+		return centroid;
+	}
 
-	public List<Link> getLinks() { return links; }
+	public List<Link> getLinks() {
+		return links;
+	}
+
+	boolean isDummy() {
+		return preparedGeometry == null;
+	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/EqualVehicleDensityZonalDemandEstimator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/EqualVehicleDensityZonalDemandEstimator.java
@@ -25,7 +25,7 @@ package org.matsim.contrib.drt.optimizer.rebalancing.demandestimator;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.ToIntFunction;
+import java.util.function.ToDoubleFunction;
 
 import javax.validation.constraints.NotNull;
 
@@ -54,17 +54,15 @@ public final class EqualVehicleDensityZonalDemandEstimator implements ZonalDeman
 		this.fleetSpecification = fleetSpecification;
 	}
 
-	public ToIntFunction<DrtZone> getExpectedDemandForTimeBin(double time) {
+	public ToDoubleFunction<DrtZone> getExpectedDemandForTimeBin(double time) {
 		return zone -> {
 			double areaShare = zoneAreaShares.getOrDefault(zone, 0.);
-			return (int)Math.floor(areaShare * this.fleetSpecification.getVehicleSpecifications().size());
+			return Math.floor(areaShare * this.fleetSpecification.getVehicleSpecifications().size());
 		};
 	}
 
 	private void initAreaShareMap(DrtZonalSystem zonalSystem) {
-		double areaSum = zonalSystem.getZones()
-				.values()
-				.stream()
+		double areaSum = zonalSystem.getZones().values().stream()
 				.mapToDouble(z -> z.getPreparedGeometry().getGeometry().getArea())
 				.sum();
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/FleetSizeWeightedByActivityEndsDemandEstimator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/FleetSizeWeightedByActivityEndsDemandEstimator.java
@@ -26,7 +26,7 @@ package org.matsim.contrib.drt.optimizer.rebalancing.demandestimator;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.ToIntFunction;
+import java.util.function.ToDoubleFunction;
 
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.log4j.Logger;
@@ -62,19 +62,21 @@ public final class FleetSizeWeightedByActivityEndsDemandEstimator
 	private final Map<Double, Map<DrtZone, MutableInt>> activityEndsPerTimeBinAndZone = new HashMap<>();
 	private static final MutableInt ZERO = new MutableInt(0);
 
-	public FleetSizeWeightedByActivityEndsDemandEstimator(DrtZonalSystem zonalSystem, FleetSpecification fleetSpecification, DrtConfigGroup drtCfg) {
+	public FleetSizeWeightedByActivityEndsDemandEstimator(DrtZonalSystem zonalSystem,
+			FleetSpecification fleetSpecification, DrtConfigGroup drtCfg) {
 		this.zonalSystem = zonalSystem;
 		this.fleetSpecification = fleetSpecification;
 		timeBinSize = drtCfg.getRebalancingParams().get().getInterval();
 	}
 
-	public ToIntFunction<DrtZone> getExpectedDemandForTimeBin(double time) {
+	public ToDoubleFunction<DrtZone> getExpectedDemandForTimeBin(double time) {
 		Double bin = getBinForTime(time);
 		int fleetSize = this.fleetSpecification.getVehicleSpecifications().size();
 		Map<DrtZone, MutableInt> expectedDemandForTimeBin = activityEndsPerTimeBinAndZone.getOrDefault(bin,
 				Collections.emptyMap());
 		int totalNrActivityEnds = expectedDemandForTimeBin.values().stream().mapToInt(MutableInt::intValue).sum();
-		return zone -> (int) Math.floor(fleetSize * (expectedDemandForTimeBin.getOrDefault(zone, ZERO).doubleValue() / totalNrActivityEnds)) ;
+		return zone -> Math.floor(
+				fleetSize * (expectedDemandForTimeBin.getOrDefault(zone, ZERO).doubleValue() / totalNrActivityEnds));
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/PreviousIterationDRTDemandEstimator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/PreviousIterationDRTDemandEstimator.java
@@ -26,7 +26,7 @@ package org.matsim.contrib.drt.optimizer.rebalancing.demandestimator;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.ToIntFunction;
+import java.util.function.ToDoubleFunction;
 
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.log4j.Logger;
@@ -100,7 +100,7 @@ public final class PreviousIterationDRTDemandEstimator implements ZonalDemandEst
 		return Math.floor(time / timeBinSize);
 	}
 
-	public ToIntFunction<DrtZone> getExpectedDemandForTimeBin(double time) {
+	public ToDoubleFunction<DrtZone> getExpectedDemandForTimeBin(double time) {
 		Double bin = getBinForTime(time);
 		Map<DrtZone, MutableInt> expectedDemandForTimeBin = previousIterationDepartures.getOrDefault(bin,
 				Collections.emptyMap());

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/ZonalDemandEstimator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/ZonalDemandEstimator.java
@@ -23,7 +23,7 @@
  */
 package org.matsim.contrib.drt.optimizer.rebalancing.demandestimator;
 
-import java.util.function.ToIntFunction;
+import java.util.function.ToDoubleFunction;
 
 import org.matsim.contrib.drt.analysis.zonal.DrtZone;
 
@@ -31,6 +31,5 @@ import org.matsim.contrib.drt.analysis.zonal.DrtZone;
  * @author jbischoff
  */
 public interface ZonalDemandEstimator {
-
-	ToIntFunction<DrtZone> getExpectedDemandForTimeBin(double time);
+	ToDoubleFunction<DrtZone> getExpectedDemandForTimeBin(double time);
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualRebalancableVehicleDistributionTargetCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualRebalancableVehicleDistributionTargetCalculator.java
@@ -25,6 +25,7 @@ import static java.util.stream.Collectors.toSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.ToDoubleFunction;
 import java.util.function.ToIntFunction;
 
 import org.apache.log4j.Logger;
@@ -54,11 +55,11 @@ public class EqualRebalancableVehicleDistributionTargetCalculator implements Reb
 	public ToIntFunction<DrtZone> calculate(double time, Map<DrtZone, List<DvrpVehicle>> rebalancableVehiclesPerZone) {
 		int numAvailableVehicles = rebalancableVehiclesPerZone.values().stream().mapToInt(List::size).sum();
 
-		ToIntFunction<DrtZone> currentDemandEstimator = demandEstimator.getExpectedDemandForTimeBin(time);
+		ToDoubleFunction<DrtZone> currentDemandEstimator = demandEstimator.getExpectedDemandForTimeBin(time);
 		Set<DrtZone> activeZones = zonalSystem.getZones()
 				.values()
 				.stream()
-				.filter(zone -> currentDemandEstimator.applyAsInt(zone) > 0)
+				.filter(zone -> currentDemandEstimator.applyAsDouble(zone) > 0)
 				.collect(toSet());
 
 		// TODO enable different methods for real time target generation by adding

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/LinearRebalancingTargetCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/LinearRebalancingTargetCalculator.java
@@ -22,6 +22,7 @@ package org.matsim.contrib.drt.optimizer.rebalancing.targetcalculator;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.ToDoubleFunction;
 import java.util.function.ToIntFunction;
 
 import org.matsim.contrib.drt.analysis.zonal.DrtZone;
@@ -47,7 +48,7 @@ public class LinearRebalancingTargetCalculator implements RebalancingTargetCalcu
 	@Override
 	public ToIntFunction<DrtZone> calculate(double time, Map<DrtZone, List<DvrpVehicle>> rebalancableVehiclesPerZone) {
 		// XXX this "time+60" (taken from old code) means probably "in the next time bin"
-		ToIntFunction<DrtZone> expectedDemandFunction = demandEstimator.getExpectedDemandForTimeBin(time + 60);
-		return zone -> (int)Math.round(alpha * expectedDemandFunction.applyAsInt(zone) + beta);
+		ToDoubleFunction<DrtZone> expectedDemandFunction = demandEstimator.getExpectedDemandForTimeBin(time + 60);
+		return zone -> (int)Math.round(alpha * expectedDemandFunction.applyAsDouble(zone) + beta);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/LinearRebalancingTargetCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/LinearRebalancingTargetCalculator.java
@@ -34,25 +34,20 @@ import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
  */
 public class LinearRebalancingTargetCalculator implements RebalancingTargetCalculator {
 	private final ZonalDemandEstimator demandEstimator;
-	private final MinCostFlowRebalancingStrategyParams params;
+	private final double alpha;
+	private final double beta;
 
 	public LinearRebalancingTargetCalculator(ZonalDemandEstimator demandEstimator,
 			MinCostFlowRebalancingStrategyParams params) {
 		this.demandEstimator = demandEstimator;
-		this.params = params;
+		alpha = params.getTargetAlpha();
+		beta = params.getTargetBeta();
 	}
 
 	@Override
 	public ToIntFunction<DrtZone> calculate(double time, Map<DrtZone, List<DvrpVehicle>> rebalancableVehiclesPerZone) {
 		// XXX this "time+60" (taken from old code) means probably "in the next time bin"
 		ToIntFunction<DrtZone> expectedDemandFunction = demandEstimator.getExpectedDemandForTimeBin(time + 60);
-
-		return zone -> {
-			var expectedDemand = expectedDemandFunction.applyAsInt(zone);
-			if (expectedDemand == 0) {
-				return 0;
-			}
-			return (int)Math.round(params.getTargetAlpha() * expectedDemand + params.getTargetBeta());
-		};
+		return zone -> (int)Math.round(alpha * expectedDemandFunction.applyAsInt(zone) + beta);
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/ZonalDemandEstimatorWithoutServiceAreaTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/ZonalDemandEstimatorWithoutServiceAreaTest.java
@@ -23,7 +23,7 @@ package org.matsim.contrib.drt.optimizer.rebalancing.demandestimator;
 import static org.junit.Assert.assertEquals;
 
 import java.net.URL;
-import java.util.function.ToIntFunction;
+import java.util.function.ToDoubleFunction;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -80,7 +80,7 @@ public class ZonalDemandEstimatorWithoutServiceAreaTest {
 				.getInstance(DvrpModes.key(ZonalDemandEstimator.class, "drt"));
 		DrtZonalSystem zonalSystem = controler.getInjector().getInstance(DvrpModes.key(DrtZonalSystem.class, "drt"));
 		for (double ii = 0; ii < 16 * 3600; ii += 1800) { //1800 is the rebalancing interval width
-			ToIntFunction<DrtZone> demandFunction = estimator.getExpectedDemandForTimeBin(
+			ToDoubleFunction<DrtZone> demandFunction = estimator.getExpectedDemandForTimeBin(
 					ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
 			assertDemand(demandFunction, zonalSystem, "1", ii, 1);
 			assertDemand(demandFunction, zonalSystem, "2", ii, 1);
@@ -93,11 +93,11 @@ public class ZonalDemandEstimatorWithoutServiceAreaTest {
 		}
 	}
 
-	private void assertDemand(ToIntFunction<DrtZone> demandFunction, DrtZonalSystem zonalSystem, String zoneId,
+	private void assertDemand(ToDoubleFunction<DrtZone> demandFunction, DrtZonalSystem zonalSystem, String zoneId,
 			double time, int expectedValue) {
 		DrtZone zone = zonalSystem.getZones().get(zoneId);
 		assertEquals("wrong estimation of demand at time=" + (time + 60) + " in zone " + zoneId, expectedValue,
-				demandFunction.applyAsInt(zone), MatsimTestUtils.EPSILON);
+				demandFunction.applyAsDouble(zone), MatsimTestUtils.EPSILON);
 	}
 
 	@Test
@@ -119,7 +119,7 @@ public class ZonalDemandEstimatorWithoutServiceAreaTest {
 				.getInstance(DvrpModes.key(ZonalDemandEstimator.class, "drt"));
 		DrtZonalSystem zonalSystem = controler.getInjector().getInstance(DvrpModes.key(DrtZonalSystem.class, "drt"));
 		for (double ii = 0; ii < 16 * 3600; ii += 1800) {
-			ToIntFunction<DrtZone> demandFunction = estimator.getExpectedDemandForTimeBin(
+			ToDoubleFunction<DrtZone> demandFunction = estimator.getExpectedDemandForTimeBin(
 					ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
 			assertDemand(demandFunction, zonalSystem, "1", ii, 2);
 			assertDemand(demandFunction, zonalSystem, "2", ii, 2);
@@ -141,7 +141,7 @@ public class ZonalDemandEstimatorWithoutServiceAreaTest {
 				.getInstance(DvrpModes.key(ZonalDemandEstimator.class, "drt"));
 		DrtZonalSystem zonalSystem = controler.getInjector().getInstance(DvrpModes.key(DrtZonalSystem.class, "drt"));
 		for (double ii = 1800; ii < 16 * 3600; ii += 1800) {
-			ToIntFunction<DrtZone> demandFunction = estimator.getExpectedDemandForTimeBin(
+			ToDoubleFunction<DrtZone> demandFunction = estimator.getExpectedDemandForTimeBin(
 					ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
 			assertDemand(demandFunction, zonalSystem, "1", ii, 0);
 			assertDemand(demandFunction, zonalSystem, "2", ii, 0);
@@ -157,13 +157,14 @@ public class ZonalDemandEstimatorWithoutServiceAreaTest {
 	@Test
 	public void PreviousIterationZonalDemandEstimatorWithSpeedUpModeTest() {
 		Controler controler = setupControler(
-				MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType.PreviousIterationDemand, "drt_teleportation", false);
+				MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType.PreviousIterationDemand,
+				"drt_teleportation", false);
 		controler.run();
 		ZonalDemandEstimator estimator = controler.getInjector()
 				.getInstance(DvrpModes.key(ZonalDemandEstimator.class, "drt"));
 		DrtZonalSystem zonalSystem = controler.getInjector().getInstance(DvrpModes.key(DrtZonalSystem.class, "drt"));
 		for (double ii = 1800; ii < 16 * 3600; ii += 1800) {
-			ToIntFunction<DrtZone> demandFunction = estimator.getExpectedDemandForTimeBin(
+			ToDoubleFunction<DrtZone> demandFunction = estimator.getExpectedDemandForTimeBin(
 					ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
 			assertDemand(demandFunction, zonalSystem, "1", ii, 0);
 			assertDemand(demandFunction, zonalSystem, "2", ii, 0);
@@ -179,13 +180,14 @@ public class ZonalDemandEstimatorWithoutServiceAreaTest {
 	@Test
 	public void FleetSizeWeightedByActivityEndsDemandEstimatorTest() {
 		Controler controler = setupControler(
-				MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType.FleetSizeWeightedByActivityEnds, "", false);
+				MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType.FleetSizeWeightedByActivityEnds, "",
+				false);
 		controler.run();
 		ZonalDemandEstimator estimator = controler.getInjector()
 				.getInstance(DvrpModes.key(ZonalDemandEstimator.class, "drt"));
 		DrtZonalSystem zonalSystem = controler.getInjector().getInstance(DvrpModes.key(DrtZonalSystem.class, "drt"));
 		for (double ii = 1800; ii < 16 * 3600; ii += 1800) {
-			ToIntFunction<DrtZone> demandFunction = estimator.getExpectedDemandForTimeBin(
+			ToDoubleFunction<DrtZone> demandFunction = estimator.getExpectedDemandForTimeBin(
 					ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
 			assertDemand(demandFunction, zonalSystem, "1", ii, 0);
 			assertDemand(demandFunction, zonalSystem, "2", ii, 2);
@@ -201,13 +203,14 @@ public class ZonalDemandEstimatorWithoutServiceAreaTest {
 	@Test
 	public void FleetSizeWeightedByPopulationShareDemandEstimatorTest() {
 		Controler controler = setupControler(
-				MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType.FleetSizeWeightedByPopulationShare, "", false);
+				MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType.FleetSizeWeightedByPopulationShare, "",
+				false);
 		controler.run();
 		ZonalDemandEstimator estimator = controler.getInjector()
 				.getInstance(DvrpModes.key(ZonalDemandEstimator.class, "drt"));
 		DrtZonalSystem zonalSystem = controler.getInjector().getInstance(DvrpModes.key(DrtZonalSystem.class, "drt"));
 		for (double ii = 0; ii < 16 * 3600; ii += 1800) {
-			ToIntFunction<DrtZone> demandFunction = estimator.getExpectedDemandForTimeBin(
+			ToDoubleFunction<DrtZone> demandFunction = estimator.getExpectedDemandForTimeBin(
 					ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
 			assertDemand(demandFunction, zonalSystem, "1", ii, 0);
 			assertDemand(demandFunction, zonalSystem, "2", ii, 2);
@@ -223,7 +226,8 @@ public class ZonalDemandEstimatorWithoutServiceAreaTest {
 	@Test
 	public void FleetSizeWeightedByPopulationShareDemandEstimatorFleetModificationTest() {
 		Controler controler = setupControler(
-				MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType.FleetSizeWeightedByPopulationShare, "", false);
+				MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType.FleetSizeWeightedByPopulationShare, "",
+				false);
 		// double number of vehicles after 0th iteration -> estimation of demand should double too (besides rounding issues)
 		controler.addOverridingModule(new AbstractDvrpModeModule("drt") {
 			@Override
@@ -239,7 +243,7 @@ public class ZonalDemandEstimatorWithoutServiceAreaTest {
 				.getInstance(DvrpModes.key(ZonalDemandEstimator.class, "drt"));
 		DrtZonalSystem zonalSystem = controler.getInjector().getInstance(DvrpModes.key(DrtZonalSystem.class, "drt"));
 		for (double ii = 0; ii < 16 * 3600; ii += 1800) {
-			ToIntFunction<DrtZone> demandFunction = estimator.getExpectedDemandForTimeBin(
+			ToDoubleFunction<DrtZone> demandFunction = estimator.getExpectedDemandForTimeBin(
 					ii + 60); //inside DRT, the demand is actually estimated for rebalancing time + 60 seconds..
 			assertDemand(demandFunction, zonalSystem, "1", ii, 0);
 			assertDemand(demandFunction, zonalSystem, "2", ii, 5);
@@ -253,7 +257,7 @@ public class ZonalDemandEstimatorWithoutServiceAreaTest {
 	}
 
 	private Controler setupControler(MinCostFlowRebalancingStrategyParams.ZonalDemandEstimatorType estimatorType,
-									 String drtSpeedUpModeForRebalancingConfiguration, boolean useServiceArea) {
+			String drtSpeedUpModeForRebalancingConfiguration, boolean useServiceArea) {
 		URL configUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("dvrp-grid"),
 				"eight_shared_taxi_config.xml");
 		Config config = ConfigUtils.loadConfig(configUrl, new MultiModeDrtConfigGroup(), new DvrpConfigGroup(),
@@ -262,10 +266,10 @@ public class ZonalDemandEstimatorWithoutServiceAreaTest {
 		DrtConfigGroup drtCfg = DrtConfigGroup.getSingleModeDrtConfig(config);
 		drtCfg.setDrtSpeedUpMode(drtSpeedUpModeForRebalancingConfiguration);
 
-		if(useServiceArea){
+		if (useServiceArea) {
 			throw new IllegalArgumentException("about to get implemented...");
-//			drtCfg.setOperationalScheme(DrtConfigGroup.OperationalScheme.serviceAreaBased);
-//			drtCfg.setDrtServiceAreaShapeFile("");
+			//			drtCfg.setOperationalScheme(DrtConfigGroup.OperationalScheme.serviceAreaBased);
+			//			drtCfg.setDrtServiceAreaShapeFile("");
 		}
 
 		MinCostFlowRebalancingStrategyParams rebalancingStrategyParams = new MinCostFlowRebalancingStrategyParams();


### PR DESCRIPTION
- support creating dummy zones (for including vehicles being outside the zonal system into the rebalancing procedure). The idea: when running rebalancing we could treat each of them as a dummy zone and even assume a reduced (negative??) cost of moving them to the actual DRT zones.
- remove special handling of `expectedDemand==0` from `LinearRebalancingTargetCalculator` (It was used in the past, when grid zones were generated also for areas without any links. Now such zones are filtered out, also for non-grid zonal systems)
- make `ZonalDemandEstimator` return `ToDoubleFunction` (instead of `ToIntFunction`). Demand predictions should be precise, not necessarily integer values (for a given area and time bin). It's the goal of the target calculator to come up with an integer number of vehicles per zone.