### PR TITLE
Support reading of map and collection object attributes

### DIFF
--- a/matsim/src/main/java/org/matsim/core/config/consistency/VspConfigConsistencyCheckerImpl.java
+++ b/matsim/src/main/java/org/matsim/core/config/consistency/VspConfigConsistencyCheckerImpl.java
@@ -244,7 +244,7 @@ public final class VspConfigConsistencyCheckerImpl implements ConfigConsistencyC
 		
 		// added feb'16
 		if ( config.plansCalcRoute().getAccessEgressType().equals(PlansCalcRouteConfigGroup.AccessEgressType.none) ) {
-			log.log( lvl, "found `plansCalcRoute.insertingAccessEgressWalk==false'; vsp should use `true' or talk to Kai. " ) ;
+			log.log( lvl, "found `PlansCalcRouteConfigGroup.AccessEgressType.none'; vsp should use `accessEgressModeToLink' or some other value or talk to Kai." ) ;
 		}
 		
 		// === qsim:

--- a/matsim/src/main/java/org/matsim/utils/objectattributes/ObjectAttributesConverter.java
+++ b/matsim/src/main/java/org/matsim/utils/objectattributes/ObjectAttributesConverter.java
@@ -66,7 +66,6 @@ public class ObjectAttributesConverter {
 
 	private AttributeConverter getConverter(String className) {
 		if (converters.containsKey(className)) return converters.get(className);
-
 		try {
 			Class<?> clazz = Class.forName(className);
 
@@ -75,10 +74,10 @@ public class ObjectAttributesConverter {
 				converters.put(className, converter);
 				return converter;
 			}
-			for (Class<?> anInterface : clazz.getInterfaces()) {
-				if(anInterface.equals(Map.class)) return this.converters.get(Map.class.getName());
-				if(anInterface.equals(Collection.class)) return this.converters.get(Collection.class.getName());
-			}
+
+			if(Map.class.isAssignableFrom(clazz)) return this.converters.get(Map.class.getName());
+			if(Collection.class.isAssignableFrom(clazz)) return this.converters.get(Collection.class.getName());
+
 			if (missingConverters.add(className)) {
 				log.warn("No AttributeConverter found for class " + className + ". Not all attribute values can be converted.");
 			}

--- a/matsim/src/main/java/org/matsim/utils/objectattributes/ObjectAttributesConverter.java
+++ b/matsim/src/main/java/org/matsim/utils/objectattributes/ObjectAttributesConverter.java
@@ -69,10 +69,15 @@ public class ObjectAttributesConverter {
 
 		try {
 			Class<?> clazz = Class.forName(className);
+
 			if (clazz.isEnum()) {
 				AttributeConverter converter = new EnumConverter(clazz);
 				converters.put(className, converter);
 				return converter;
+			}
+			for (Class<?> anInterface : clazz.getInterfaces()) {
+				if(anInterface.equals(Map.class)) return this.converters.get(Map.class.getName());
+				if(anInterface.equals(Collection.class)) return this.converters.get(Collection.class.getName());
 			}
 			if (missingConverters.add(className)) {
 				log.warn("No AttributeConverter found for class " + className + ". Not all attribute values can be converted.");


### PR DESCRIPTION
So far, only writing of map or collection object attributes has been supported.
By checking whether the given class of the object attribute is an implementation of java.util.Map or java.util.Collection the corresponding converter can be retrieved (after directly querying the converters map for the exact object attribute class).
That means, for an example, that now an object attribute with a denoted type "java.util.ArrayList" can be read in, if the the value is denoted in json syntax and elements are strings.

Moreover, a comment in `VspConfigConsistencyCheckerImpl` was updated.