### PR TITLE
Fix DrtZonalSystem

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystem.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystem.java
@@ -51,6 +51,7 @@ public class DrtZonalSystem {
 		//geometries without links are skipped
 		Map<String, List<Link>> linksByGeometryId = StreamEx.of(network.getLinks().values())
 				.mapToEntry(l -> getGeometryIdForLink(l, geometries), l -> l)
+				.filterKeys(key -> key != null)
 				.grouping(toList());
 
 		//the zonal system contains only zones that have at least one link
@@ -70,6 +71,7 @@ public class DrtZonalSystem {
 	 */
 	private static String getGeometryIdForLink(Link link, Map<String, PreparedGeometry> geometries) {
 		//TODO use endNode.getCoord() ?
+		//TODO use fake zone (with no geometry) instead of null?
 		Point linkCoord = MGC.coord2Point(link.getCoord());
 		return geometries.entrySet()
 				.stream()

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategyParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategyParams.java
@@ -59,12 +59,12 @@ public final class MinCostFlowRebalancingStrategyParams extends ReflectiveConfig
 	static final String REBALANCING_TARGET_CALCULATOR_TYPE_EXP =
 			"Defines the calculator used for computing rebalancing targets per each zone"
 					+ " (i.e. number of the desired vehicles)."
-					+ " Can be one of [LinearRebalancingTarget, EqualRebalancableVehicleDistribution,"
+					+ " Can be one of [EstimatedDemand, EqualRebalancableVehicleDistribution,"
 					+ " EqualVehicleDensity, EqualVehiclesToPopulationRatio]."
 					+ " Current default is LinearRebalancingTarget";
 
-	public static final String ZONAL_DEMAND_AGGREGATOR_TYPE = "zonalDemandEstimatorType";
-	static final String ZONAL_DEMAND_AGGREGATOR_TYPE_EXP = "Defines the methodology for demand estimation."
+	public static final String ZONAL_DEMAND_ESTIMATOR_TYPE = "zonalDemandEstimatorType";
+	static final String ZONAL_DEMAND_ESTIMATOR_TYPE_EXP = "Defines the methodology for demand estimation."
 			+ " Can be one of [PreviousIterationDemand]. Current default is PreviousIterationDemand";
 
 	@NotNull
@@ -105,7 +105,7 @@ public final class MinCostFlowRebalancingStrategyParams extends ReflectiveConfig
 		Map<String, String> map = super.getComments();
 		map.put(TARGET_ALPHA, TARGET_ALPHA_EXP);
 		map.put(TARGET_BETA, TARGET_BETA_EXP);
-		map.put(ZONAL_DEMAND_AGGREGATOR_TYPE, ZONAL_DEMAND_AGGREGATOR_TYPE_EXP);
+		map.put(ZONAL_DEMAND_ESTIMATOR_TYPE, ZONAL_DEMAND_ESTIMATOR_TYPE_EXP);
 		return map;
 	}
 
@@ -158,17 +158,17 @@ public final class MinCostFlowRebalancingStrategyParams extends ReflectiveConfig
 	}
 
 	/**
-	 * @return -- {@value #ZONAL_DEMAND_AGGREGATOR_TYPE_EXP}
+	 * @return -- {@value #ZONAL_DEMAND_ESTIMATOR_TYPE_EXP}
 	 */
-	@StringGetter(ZONAL_DEMAND_AGGREGATOR_TYPE)
+	@StringGetter(ZONAL_DEMAND_ESTIMATOR_TYPE)
 	public ZonalDemandEstimatorType getZonalDemandEstimatorType() {
 		return zonalDemandEstimatorType;
 	}
 
 	/**
-	 * @param estimatorType -- {@value #ZONAL_DEMAND_AGGREGATOR_TYPE_EXP}
+	 * @param estimatorType -- {@value #ZONAL_DEMAND_ESTIMATOR_TYPE_EXP}
 	 */
-	@StringSetter(ZONAL_DEMAND_AGGREGATOR_TYPE)
+	@StringSetter(ZONAL_DEMAND_ESTIMATOR_TYPE)
 	public void setZonalDemandEstimatorType(ZonalDemandEstimatorType estimatorType) {
 		this.zonalDemandEstimatorType = estimatorType;
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -268,7 +268,7 @@ public final class DrtConfigGroup extends ReflectiveConfigGroup implements Modal
 		}
 
 		Verify.verify(getParameterSets(MinCostFlowRebalancingStrategyParams.SET_NAME).size() <= 1,
-				"More then one rebalancing parameter sets is specified");
+				"More than one rebalancing parameter sets is specified");
 
 		if (useModeFilteredSubnetwork) {
 			DvrpModeRoutingNetworkModule.checkUseModeFilteredSubnetworkAllowed(config, mode);


### PR DESCRIPTION
An exception was thrown in DrtZonalSystem.createFromPreparedGeometries() because grouping can not be performed for null keys. As we currently ecxplicitly allow for null return values in getGeometryIdForLink(), we need to filter null keys before grouping.