### PR TITLE
handle drt departures outside of DrtZonalSystem

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/PreviousIterationDRTDemandEstimator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/PreviousIterationDRTDemandEstimator.java
@@ -73,7 +73,11 @@ public final class PreviousIterationDRTDemandEstimator implements ZonalDemandEst
 			Double bin = getBinForTime(event.getTime());
 
 			DrtZone zone = zonalSystem.getZoneForLinkId(event.getLinkId());
-			Preconditions.checkNotNull(zone, "No zone found for linkId %s", event.getLinkId().toString());
+			if (zone == null) {
+				//might be that somebody walks into the service area or that service area is larger/different than DrtZonalSystem...
+				logger.warn("No zone found for linkId " + event.getLinkId().toString());
+				return;
+			}
 
 			currentIterationDepartures.computeIfAbsent(bin, v -> new HashMap<>())
 					.computeIfAbsent(zone, z -> new MutableInt())


### PR DESCRIPTION
In situations where the service area is larger or different than the DrtZonalSystem, we might have drt departures outside of the DrtZonalSystem. We used to handle that by ignoring the departure in PreviousIterationDRTDemandEstimator. This PR is a return back to that logic.