### PR TITLE
use target alpha in EqualVehicleDensityTargetCalculator

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
@@ -80,7 +80,7 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 					case EqualVehicleDensity:
 						bindModal(RebalancingTargetCalculator.class).toProvider(modalProvider(
 								getter -> new EqualVehicleDensityTargetCalculator(getter.getModal(DrtZonalSystem.class),
-										getter.getModal(FleetSpecification.class)))).asEagerSingleton();
+										getter.getModal(FleetSpecification.class), strategyParams))).asEagerSingleton();
 						break;
 
 					case EqualVehiclesToPopulationRatio:

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
@@ -87,7 +87,7 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 						bindModal(RebalancingTargetCalculator.class).toProvider(modalProvider(
 								getter -> new EqualVehiclesToPopulationRatioTargetCalculator(
 										getter.getModal(DrtZonalSystem.class), getter.get(Population.class),
-										getter.getModal(FleetSpecification.class)))).asEagerSingleton();
+										getter.getModal(FleetSpecification.class), strategyParams))).asEagerSingleton();
 						break;
 
 					default:

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehicleDensityTargetCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehicleDensityTargetCalculator.java
@@ -32,6 +32,7 @@ import javax.validation.constraints.NotNull;
 
 import org.matsim.contrib.drt.analysis.zonal.DrtZonalSystem;
 import org.matsim.contrib.drt.analysis.zonal.DrtZone;
+import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingStrategyParams;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.FleetSpecification;
 
@@ -48,18 +49,20 @@ public final class EqualVehicleDensityTargetCalculator implements RebalancingTar
 
 	private final Map<DrtZone, Double> zoneAreaShares = new HashMap<>();
 	private final FleetSpecification fleetSpecification;
+	private final double alpha;
 
 	public EqualVehicleDensityTargetCalculator(@NotNull DrtZonalSystem zonalSystem,
-			@NotNull FleetSpecification fleetSpecification) {
+			@NotNull FleetSpecification fleetSpecification, MinCostFlowRebalancingStrategyParams params) {
 		initAreaShareMap(zonalSystem);
 		this.fleetSpecification = fleetSpecification;
+		this.alpha = params.getTargetAlpha();
 	}
 
 	@Override
 	public ToIntFunction<DrtZone> calculate(double time, Map<DrtZone, List<DvrpVehicle>> rebalancableVehiclesPerZone) {
 		return zone -> {
 			double areaShare = zoneAreaShares.getOrDefault(zone, 0.);
-			return (int)Math.floor(areaShare * this.fleetSpecification.getVehicleSpecifications().size());
+			return (int)Math.floor(alpha * areaShare * this.fleetSpecification.getVehicleSpecifications().size());
 		};
 	}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehiclesToPopulationRatioTargetCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehiclesToPopulationRatioTargetCalculator.java
@@ -35,6 +35,7 @@ import org.matsim.api.core.v01.population.Activity;
 import org.matsim.api.core.v01.population.Population;
 import org.matsim.contrib.drt.analysis.zonal.DrtZonalSystem;
 import org.matsim.contrib.drt.analysis.zonal.DrtZone;
+import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingStrategyParams;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.FleetSpecification;
 
@@ -52,14 +53,16 @@ public final class EqualVehiclesToPopulationRatioTargetCalculator implements Reb
 	private final DrtZonalSystem zonalSystem;
 	private final FleetSpecification fleetSpecification;
 	private final Map<DrtZone, Integer> activitiesPerZone = new HashMap<>();
+	private final Double alpha;
 	private Integer totalNrActivities;
 
 	public EqualVehiclesToPopulationRatioTargetCalculator(DrtZonalSystem zonalSystem, Population population,
-			@NotNull FleetSpecification fleetSpecification) {
+														  @NotNull FleetSpecification fleetSpecification, MinCostFlowRebalancingStrategyParams params) {
 		this.zonalSystem = zonalSystem;
 		prepareZones();
 		countFirstActsPerZone(population);
 		this.fleetSpecification = fleetSpecification;
+		this.alpha = params.getTargetAlpha();
 	}
 
 	private void countFirstActsPerZone(Population population) {
@@ -91,7 +94,7 @@ public final class EqualVehiclesToPopulationRatioTargetCalculator implements Reb
 		//decided to take Math.floor rather than Math.round as we want to avoid global undersupply which would 'paralyze' the rebalancing algorithm
 		int fleetSize = this.fleetSpecification.getVehicleSpecifications().size();
 		return zoneId -> (int)Math.floor(
-				(this.activitiesPerZone.getOrDefault(zoneId, 0).doubleValue() / totalNrActivities) * fleetSize);
+				(this.activitiesPerZone.getOrDefault(zoneId, 0).doubleValue() / totalNrActivities) * fleetSize * alpha);
 	}
 
 	private void prepareZones() {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehicleDensityTargetCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehicleDensityTargetCalculatorTest.java
@@ -31,6 +31,7 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.analysis.zonal.DrtGridUtils;
 import org.matsim.contrib.drt.analysis.zonal.DrtZonalSystem;
 import org.matsim.contrib.drt.analysis.zonal.DrtZone;
+import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingStrategyParams;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.FleetSpecification;
@@ -58,22 +59,37 @@ public class EqualVehicleDensityTargetCalculatorTest {
 
 	@Test
 	public void calculate_oneVehiclePerZone() {
+		MinCostFlowRebalancingStrategyParams params = new MinCostFlowRebalancingStrategyParams();
+		params.setTargetAlpha(1);
 		ToIntFunction<DrtZone> demandFunction = new EqualVehicleDensityTargetCalculator(zonalSystem,
-				createFleetSpecification(8)).calculate(0, Map.of());
+				createFleetSpecification(8),params).calculate(0, Map.of());
+		zonalSystem.getZones().keySet().forEach(id -> assertTarget(demandFunction, zonalSystem, id, 1));
+	}
+
+	@Test
+	public void calculate_oneVehiclePerZoneEqualsHalfTheFleet() {
+		MinCostFlowRebalancingStrategyParams params = new MinCostFlowRebalancingStrategyParams();
+		params.setTargetAlpha(0.5);
+		ToIntFunction<DrtZone> demandFunction = new EqualVehicleDensityTargetCalculator(zonalSystem,
+				createFleetSpecification(16),params).calculate(0, Map.of());
 		zonalSystem.getZones().keySet().forEach(id -> assertTarget(demandFunction, zonalSystem, id, 1));
 	}
 
 	@Test
 	public void calculate_lessVehiclesThanZones() {
+		MinCostFlowRebalancingStrategyParams params = new MinCostFlowRebalancingStrategyParams();
+		params.setTargetAlpha(1);
 		ToIntFunction<DrtZone> demandFunction = new EqualVehicleDensityTargetCalculator(zonalSystem,
-				createFleetSpecification(7)).calculate(0, Map.of());
+				createFleetSpecification(7), params).calculate(0, Map.of());
 		zonalSystem.getZones().keySet().forEach(id -> assertTarget(demandFunction, zonalSystem, id, 0));
 	}
 
 	@Test
 	public void calculate_moreVehiclesThanZones() {
+		MinCostFlowRebalancingStrategyParams params = new MinCostFlowRebalancingStrategyParams();
+		params.setTargetAlpha(1);
 		ToIntFunction<DrtZone> demandFunction = new EqualVehicleDensityTargetCalculator(zonalSystem,
-				createFleetSpecification(9)).calculate(0, Map.of());
+				createFleetSpecification(9), params).calculate(0, Map.of());
 		zonalSystem.getZones().keySet().forEach(id -> assertTarget(demandFunction, zonalSystem, id, 1));
 	}
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehiclesToPopulationRatioTargetCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehiclesToPopulationRatioTargetCalculatorTest.java
@@ -38,6 +38,7 @@ import org.matsim.api.core.v01.population.PopulationFactory;
 import org.matsim.contrib.drt.analysis.zonal.DrtGridUtils;
 import org.matsim.contrib.drt.analysis.zonal.DrtZonalSystem;
 import org.matsim.contrib.drt.analysis.zonal.DrtZone;
+import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingStrategyParams;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.FleetSpecification;
@@ -65,9 +66,11 @@ public class EqualVehiclesToPopulationRatioTargetCalculatorTest {
 			DrtGridUtils.createGridFromNetwork(network, 500.));
 
 	@Test
-	public void testCalculate_oneVehiclePerZone() {
+	public void testCalculate_oneVehiclePerInhabitant() {
+		MinCostFlowRebalancingStrategyParams params = new MinCostFlowRebalancingStrategyParams();
+		params.setTargetAlpha(1);
 		ToIntFunction<DrtZone> demandFunction = new EqualVehiclesToPopulationRatioTargetCalculator(zonalSystem,
-				createPopulation(), createFleetSpecification(8)).calculate(0, Map.of());
+				createPopulation(), createFleetSpecification(8), params).calculate(0, Map.of());
 
 		assertTarget(demandFunction, zonalSystem, "1", 0);
 		assertTarget(demandFunction, zonalSystem, "2", 2);
@@ -80,9 +83,28 @@ public class EqualVehiclesToPopulationRatioTargetCalculatorTest {
 	}
 
 	@Test
-	public void testCalculate_twoVehiclesPerZone() {
+	public void testCalculate_halfAVehiclePerInhabitant() {
+		MinCostFlowRebalancingStrategyParams params = new MinCostFlowRebalancingStrategyParams();
+		params.setTargetAlpha(0.5);
 		ToIntFunction<DrtZone> demandFunction = new EqualVehiclesToPopulationRatioTargetCalculator(zonalSystem,
-				createPopulation(), createFleetSpecification(16)).calculate(0, Map.of());
+				createPopulation(), createFleetSpecification(8), params).calculate(0, Map.of());
+
+		assertTarget(demandFunction, zonalSystem, "1", 0);
+		assertTarget(demandFunction, zonalSystem, "2", 1);
+		assertTarget(demandFunction, zonalSystem, "3", 0);
+		assertTarget(demandFunction, zonalSystem, "4", 1);
+		assertTarget(demandFunction, zonalSystem, "5", 0);
+		assertTarget(demandFunction, zonalSystem, "6", 0);
+		assertTarget(demandFunction, zonalSystem, "7", 0);
+		assertTarget(demandFunction, zonalSystem, "8", 1);
+	}
+
+	@Test
+	public void testCalculate_twoVehiclesPerInhabitant() {
+		MinCostFlowRebalancingStrategyParams params = new MinCostFlowRebalancingStrategyParams();
+		params.setTargetAlpha(1);
+		ToIntFunction<DrtZone> demandFunction = new EqualVehiclesToPopulationRatioTargetCalculator(zonalSystem,
+				createPopulation(), createFleetSpecification(16), params).calculate(0, Map.of());
 
 		assertTarget(demandFunction, zonalSystem, "1", 0);
 		assertTarget(demandFunction, zonalSystem, "2", 5);


### PR DESCRIPTION
alpha controls the share of the fleet used for rebalancing. in some experiments we saw that it can be beneficial not to attempt to spread the entire fleet at each rebalancing time but rather redistribute half of it more frequently.