### PR TITLE
Improvements in drt target calculators

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystem.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystem.java
@@ -25,6 +25,7 @@ import static java.util.stream.Collectors.toMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import javax.annotation.Nullable;
 
@@ -46,12 +47,13 @@ import one.util.streamex.StreamEx;
  */
 public class DrtZonalSystem {
 
-	public static DrtZonalSystem createFromPreparedGeometries(Network network, Map<String, PreparedGeometry> geometries) {
+	public static DrtZonalSystem createFromPreparedGeometries(Network network,
+			Map<String, PreparedGeometry> geometries) {
 
 		//geometries without links are skipped
 		Map<String, List<Link>> linksByGeometryId = StreamEx.of(network.getLinks().values())
 				.mapToEntry(l -> getGeometryIdForLink(l, geometries), l -> l)
-				.filterKeys(key -> key != null)
+				.filterKeys(Objects::nonNull)
 				.grouping(toList());
 
 		//the zonal system contains only zones that have at least one link
@@ -69,9 +71,9 @@ public class DrtZonalSystem {
 	 * If a given link's {@code Coord} borders two or more cells, the allocation to a cell is random.
 	 * Result may be null in case the given link is outside of the service area.
 	 */
+	@Nullable
 	private static String getGeometryIdForLink(Link link, Map<String, PreparedGeometry> geometries) {
 		//TODO use endNode.getCoord() ?
-		//TODO use fake zone (with no geometry) instead of null?
 		Point linkCoord = MGC.coord2Point(link.getCoord());
 		return geometries.entrySet()
 				.stream()

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
@@ -66,8 +66,7 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 					case EstimatedDemand:
 						bindModal(RebalancingTargetCalculator.class).toProvider(modalProvider(
 								getter -> new DemandEstimatorAsTargetCalculator(
-										getter.getModal(ZonalDemandEstimator.class), strategyParams)))
-								.asEagerSingleton();
+										getter.getModal(ZonalDemandEstimator.class)))).asEagerSingleton();
 						break;
 
 					case EqualRebalancableVehicleDistribution:

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategy.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategy.java
@@ -111,12 +111,15 @@ public class MinCostFlowRebalancingStrategy implements RebalancingStrategy {
 			Map<DrtZone, List<DvrpVehicle>> soonIdleVehiclesPerZone) {
 		ToDoubleFunction<DrtZone> targetFunction = rebalancingTargetCalculator.calculate(time,
 				rebalancableVehiclesPerZone);
+		var minCostFlowRebalancingStrategyParams = (MinCostFlowRebalancingStrategyParams)params.getRebalancingStrategyParams();
+		double alpha = minCostFlowRebalancingStrategyParams.getTargetAlpha();
+		double beta = minCostFlowRebalancingStrategyParams.getTargetBeta();
 
 		List<DrtZoneVehicleSurplus> vehicleSurpluses = zonalSystem.getZones().values().stream().map(z -> {
 			int rebalancable = rebalancableVehiclesPerZone.getOrDefault(z, List.of()).size();
 			int soonIdle = soonIdleVehiclesPerZone.getOrDefault(z, List.of()).size();
-			int surplus = Math.min(rebalancable + soonIdle - (int)Math.floor(targetFunction.applyAsDouble(z)),
-					rebalancable);
+			int target = (int)Math.floor(alpha * targetFunction.applyAsDouble(z) + beta);
+			int surplus = Math.min(rebalancable + soonIdle - target, rebalancable);
 			return new DrtZoneVehicleSurplus(z, surplus);
 		}).collect(toList());
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategy.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategy.java
@@ -25,7 +25,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.ToIntFunction;
+import java.util.function.ToDoubleFunction;
 import java.util.stream.Stream;
 
 import org.matsim.api.core.v01.network.Link;
@@ -109,13 +109,14 @@ public class MinCostFlowRebalancingStrategy implements RebalancingStrategy {
 	private List<Relocation> calculateMinCostRelocations(double time,
 			Map<DrtZone, List<DvrpVehicle>> rebalancableVehiclesPerZone,
 			Map<DrtZone, List<DvrpVehicle>> soonIdleVehiclesPerZone) {
-		ToIntFunction<DrtZone> targetFunction = rebalancingTargetCalculator.calculate(time,
+		ToDoubleFunction<DrtZone> targetFunction = rebalancingTargetCalculator.calculate(time,
 				rebalancableVehiclesPerZone);
 
 		List<DrtZoneVehicleSurplus> vehicleSurpluses = zonalSystem.getZones().values().stream().map(z -> {
 			int rebalancable = rebalancableVehiclesPerZone.getOrDefault(z, List.of()).size();
 			int soonIdle = soonIdleVehiclesPerZone.getOrDefault(z, List.of()).size();
-			int surplus = Math.min(rebalancable + soonIdle - targetFunction.applyAsInt(z), rebalancable);
+			int surplus = Math.min(rebalancable + soonIdle - (int)Math.floor(targetFunction.applyAsDouble(z)),
+					rebalancable);
 			return new DrtZoneVehicleSurplus(z, surplus);
 		}).collect(toList());
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategyParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategyParams.java
@@ -70,13 +70,11 @@ public final class MinCostFlowRebalancingStrategyParams extends ReflectiveConfig
 	@NotNull
 	private RebalancingTargetCalculatorType rebalancingTargetCalculatorType = RebalancingTargetCalculatorType.EstimatedDemand;
 
-	@Nullable
 	@PositiveOrZero
-	private Double targetAlpha = null;
+	private double targetAlpha = Double.NaN;
 
-	@Nullable
 	@PositiveOrZero
-	private Double targetBeta = null;
+	private double targetBeta = Double.NaN;
 
 	@Nullable //required only if rebalancingTargetCalculatorType == EstimatedDemand
 	private ZonalDemandEstimatorType zonalDemandEstimatorType = ZonalDemandEstimatorType.PreviousIterationDemand;
@@ -92,8 +90,6 @@ public final class MinCostFlowRebalancingStrategyParams extends ReflectiveConfig
 		if (rebalancingTargetCalculatorType == RebalancingTargetCalculatorType.EstimatedDemand) {
 			checkState(zonalDemandEstimatorType != null,
 					"zonalDemandEstimatorType is required if EstimatedDemand is used as rebalancing target");
-			checkState(targetAlpha != null, "targetAlpha is required if EstimatedDemand is used as rebalancing target");
-			checkState(targetBeta != null, "targetBeta is required if EstimatedDemand is used as rebalancing target");
 		}
 //		not possible to set zonalDemandEstimatorType because the the switch in DrtModeMinCostFlowRebalancingModule will lead to a NullPointer
 //		else {
@@ -115,7 +111,7 @@ public final class MinCostFlowRebalancingStrategyParams extends ReflectiveConfig
 	 * @return -- {@value #TARGET_ALPHA_EXP}
 	 */
 	@StringGetter(TARGET_ALPHA)
-	public Double getTargetAlpha() {
+	public double getTargetAlpha() {
 		return targetAlpha;
 	}
 
@@ -131,7 +127,7 @@ public final class MinCostFlowRebalancingStrategyParams extends ReflectiveConfig
 	 * @return -- {@value #TARGET_BETA_EXP}
 	 */
 	@StringGetter(TARGET_BETA)
-	public Double getTargetBeta() {
+	public double getTargetBeta() {
 		return targetBeta;
 	}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/DemandEstimatorAsTargetCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/DemandEstimatorAsTargetCalculator.java
@@ -23,7 +23,6 @@ package org.matsim.contrib.drt.optimizer.rebalancing.targetcalculator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.ToDoubleFunction;
-import java.util.function.ToIntFunction;
 
 import org.matsim.contrib.drt.analysis.zonal.DrtZone;
 import org.matsim.contrib.drt.optimizer.rebalancing.demandestimator.ZonalDemandEstimator;
@@ -46,10 +45,11 @@ public class DemandEstimatorAsTargetCalculator implements RebalancingTargetCalcu
 	}
 
 	@Override
-	public ToIntFunction<DrtZone> calculate(double time, Map<DrtZone, List<DvrpVehicle>> rebalancableVehiclesPerZone) {
+	public ToDoubleFunction<DrtZone> calculate(double time,
+			Map<DrtZone, List<DvrpVehicle>> rebalancableVehiclesPerZone) {
 		// TODO remove this hidden "+60"
 		// XXX this "time+60" (taken from old code) means probably "in the next time bin"
 		ToDoubleFunction<DrtZone> expectedDemandFunction = demandEstimator.getExpectedDemandForTimeBin(time + 60);
-		return zone -> (int)Math.round(alpha * expectedDemandFunction.applyAsDouble(zone) + beta);
+		return zone -> alpha * expectedDemandFunction.applyAsDouble(zone) + beta;
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/DemandEstimatorAsTargetCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/DemandEstimatorAsTargetCalculator.java
@@ -26,7 +26,6 @@ import java.util.function.ToDoubleFunction;
 
 import org.matsim.contrib.drt.analysis.zonal.DrtZone;
 import org.matsim.contrib.drt.optimizer.rebalancing.demandestimator.ZonalDemandEstimator;
-import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingStrategyParams;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 
 /**
@@ -34,14 +33,9 @@ import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
  */
 public class DemandEstimatorAsTargetCalculator implements RebalancingTargetCalculator {
 	private final ZonalDemandEstimator demandEstimator;
-	private final double alpha;
-	private final double beta;
 
-	public DemandEstimatorAsTargetCalculator(ZonalDemandEstimator demandEstimator,
-			MinCostFlowRebalancingStrategyParams params) {
+	public DemandEstimatorAsTargetCalculator(ZonalDemandEstimator demandEstimator) {
 		this.demandEstimator = demandEstimator;
-		alpha = params.getTargetAlpha();
-		beta = params.getTargetBeta();
 	}
 
 	@Override
@@ -49,7 +43,6 @@ public class DemandEstimatorAsTargetCalculator implements RebalancingTargetCalcu
 			Map<DrtZone, List<DvrpVehicle>> rebalancableVehiclesPerZone) {
 		// TODO remove this hidden "+60"
 		// XXX this "time+60" (taken from old code) means probably "in the next time bin"
-		ToDoubleFunction<DrtZone> expectedDemandFunction = demandEstimator.getExpectedDemandForTimeBin(time + 60);
-		return zone -> alpha * expectedDemandFunction.applyAsDouble(zone) + beta;
+		return demandEstimator.getExpectedDemandForTimeBin(time + 60);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualRebalancableVehicleDistributionTargetCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualRebalancableVehicleDistributionTargetCalculator.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.ToDoubleFunction;
-import java.util.function.ToIntFunction;
 
 import org.apache.log4j.Logger;
 import org.matsim.contrib.drt.analysis.zonal.DrtZonalSystem;
@@ -52,7 +51,8 @@ public class EqualRebalancableVehicleDistributionTargetCalculator implements Reb
 	}
 
 	@Override
-	public ToIntFunction<DrtZone> calculate(double time, Map<DrtZone, List<DvrpVehicle>> rebalancableVehiclesPerZone) {
+	public ToDoubleFunction<DrtZone> calculate(double time,
+			Map<DrtZone, List<DvrpVehicle>> rebalancableVehiclesPerZone) {
 		int numAvailableVehicles = rebalancableVehiclesPerZone.values().stream().mapToInt(List::size).sum();
 
 		ToDoubleFunction<DrtZone> currentDemandEstimator = demandEstimator.getExpectedDemandForTimeBin(time);
@@ -75,13 +75,7 @@ public class EqualRebalancableVehicleDistributionTargetCalculator implements Reb
 			return zone -> 0;
 		}
 
-		int targetValue = numAvailableVehicles / activeZones.size();
-		if (targetValue < 1) {
-			log.debug(
-					"There is too few idling vehicles to perform rebalance! No vehicles will be assigned to rebalance task at this period");
-			return zone -> 0;
-		} else {
-			return zone -> activeZones.contains(zone) ? targetValue : 0;
-		}
+		double targetValue = (double)numAvailableVehicles / activeZones.size();
+		return zone -> activeZones.contains(zone) ? targetValue : 0;
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehicleDensityTargetCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehicleDensityTargetCalculator.java
@@ -26,7 +26,7 @@ package org.matsim.contrib.drt.optimizer.rebalancing.targetcalculator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.ToIntFunction;
+import java.util.function.ToDoubleFunction;
 
 import javax.validation.constraints.NotNull;
 
@@ -56,11 +56,9 @@ public final class EqualVehicleDensityTargetCalculator implements RebalancingTar
 	}
 
 	@Override
-	public ToIntFunction<DrtZone> calculate(double time, Map<DrtZone, List<DvrpVehicle>> rebalancableVehiclesPerZone) {
-		return zone -> {
-			double areaShare = zoneAreaShares.getOrDefault(zone, 0.);
-			return (int)Math.floor(areaShare * this.fleetSpecification.getVehicleSpecifications().size());
-		};
+	public ToDoubleFunction<DrtZone> calculate(double time,
+			Map<DrtZone, List<DvrpVehicle>> rebalancableVehiclesPerZone) {
+		return zone -> zoneAreaShares.getOrDefault(zone, 0.) * fleetSpecification.getVehicleSpecifications().size();
 	}
 
 	private void initAreaShareMap(DrtZonalSystem zonalSystem) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehiclesToPopulationRatioTargetCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehiclesToPopulationRatioTargetCalculator.java
@@ -23,10 +23,14 @@
  */
 package org.matsim.contrib.drt.optimizer.rebalancing.targetcalculator;
 
-import java.util.HashMap;
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.counting;
+
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.ToIntFunction;
+import java.util.stream.Collectors;
 
 import javax.validation.constraints.NotNull;
 
@@ -51,39 +55,30 @@ public final class EqualVehiclesToPopulationRatioTargetCalculator implements Reb
 
 	private final DrtZonalSystem zonalSystem;
 	private final FleetSpecification fleetSpecification;
-	private final Map<DrtZone, Integer> activitiesPerZone = new HashMap<>();
-	private Integer totalNrActivities;
+	private final Map<DrtZone, Integer> activitiesPerZone;
+	private final int totalNrActivities;
 
 	public EqualVehiclesToPopulationRatioTargetCalculator(DrtZonalSystem zonalSystem, Population population,
 			@NotNull FleetSpecification fleetSpecification) {
 		this.zonalSystem = zonalSystem;
-		prepareZones();
-		countFirstActsPerZone(population);
 		this.fleetSpecification = fleetSpecification;
-	}
 
-	private void countFirstActsPerZone(Population population) {
-		log.info("start counting how many first activities each rebalancing zone has");
 		log.info("nr of zones: " + this.zonalSystem.getZones().size() + "\t nr of persons = " + population.getPersons()
 				.size());
+		activitiesPerZone = countFirstActsPerZone(population);
 
-		population.getPersons()
+		totalNrActivities = this.activitiesPerZone.values().stream().mapToInt(Integer::intValue).sum();
+		log.info("nr of persons that have their first activity inside the service area = " + this.totalNrActivities);
+	}
+
+	private Map<DrtZone, Integer> countFirstActsPerZone(Population population) {
+		return population.getPersons()
 				.values()
 				.stream()
-				.map(person -> person.getSelectedPlan().getPlanElements().get(0))
-				.forEach(element -> {
-					if (!(element instanceof Activity))
-						throw new RuntimeException("first plan element is not an activity");
-					Activity activity = (Activity)element;
-					DrtZone zone = zonalSystem.getZoneForLinkId(activity.getLinkId());
-					if (zone != null) {
-						Integer oldDemandValue = this.activitiesPerZone.get(zone);
-						this.activitiesPerZone.put(zone, oldDemandValue + 1);
-					}
-				});
-
-		this.totalNrActivities = this.activitiesPerZone.values().stream().mapToInt(Integer::intValue).sum();
-		log.info("nr of persons that have their first activity inside the service area = " + this.totalNrActivities);
+				.map(person -> (Activity)person.getSelectedPlan().getPlanElements().get(0))
+				.map(activity -> zonalSystem.getZoneForLinkId(activity.getLinkId()))
+				.filter(Objects::nonNull)
+				.collect(Collectors.groupingBy(zone -> zone, collectingAndThen(counting(), Long::intValue)));
 	}
 
 	@Override
@@ -92,11 +87,5 @@ public final class EqualVehiclesToPopulationRatioTargetCalculator implements Reb
 		int fleetSize = this.fleetSpecification.getVehicleSpecifications().size();
 		return zoneId -> (int)Math.floor(
 				(this.activitiesPerZone.getOrDefault(zoneId, 0).doubleValue() / totalNrActivities) * fleetSize);
-	}
-
-	private void prepareZones() {
-		for (DrtZone zone : zonalSystem.getZones().values()) {
-			activitiesPerZone.put(zone, 0);
-		}
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehiclesToPopulationRatioTargetCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehiclesToPopulationRatioTargetCalculator.java
@@ -80,6 +80,10 @@ public final class EqualVehiclesToPopulationRatioTargetCalculator implements Reb
 	@Override
 	public ToDoubleFunction<DrtZone> calculate(double time,
 			Map<DrtZone, List<DvrpVehicle>> rebalancableVehiclesPerZone) {
+		if (totalNrActivities == 0) {
+			return zoneId -> 0;
+		}
+
 		double factor = (double)fleetSize / totalNrActivities;
 		return zoneId -> this.activitiesPerZone.getOrDefault(zoneId, 0).doubleValue() * factor;
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/RebalancingTargetCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/RebalancingTargetCalculator.java
@@ -22,7 +22,7 @@ package org.matsim.contrib.drt.optimizer.rebalancing.targetcalculator;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.ToIntFunction;
+import java.util.function.ToDoubleFunction;
 
 import org.matsim.contrib.drt.analysis.zonal.DrtZone;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
@@ -31,5 +31,5 @@ import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
  * @author Michal Maciejewski (michalm)
  */
 public interface RebalancingTargetCalculator {
-	ToIntFunction<DrtZone> calculate(double time, Map<DrtZone, List<DvrpVehicle>> rebalancableVehiclesPerZone);
+	ToDoubleFunction<DrtZone> calculate(double time, Map<DrtZone, List<DvrpVehicle>> rebalancableVehiclesPerZone);
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehicleDensityTargetCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehicleDensityTargetCalculatorTest.java
@@ -23,7 +23,7 @@ package org.matsim.contrib.drt.optimizer.rebalancing.targetcalculator;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
-import java.util.function.ToIntFunction;
+import java.util.function.ToDoubleFunction;
 
 import org.junit.Test;
 import org.matsim.api.core.v01.Id;
@@ -58,23 +58,23 @@ public class EqualVehicleDensityTargetCalculatorTest {
 
 	@Test
 	public void calculate_oneVehiclePerZone() {
-		ToIntFunction<DrtZone> demandFunction = new EqualVehicleDensityTargetCalculator(zonalSystem,
+		var targetFunction = new EqualVehicleDensityTargetCalculator(zonalSystem,
 				createFleetSpecification(8)).calculate(0, Map.of());
-		zonalSystem.getZones().keySet().forEach(id -> assertTarget(demandFunction, zonalSystem, id, 1));
+		zonalSystem.getZones().keySet().forEach(id -> assertTarget(targetFunction, zonalSystem, id, 1));
 	}
 
 	@Test
 	public void calculate_lessVehiclesThanZones() {
-		ToIntFunction<DrtZone> demandFunction = new EqualVehicleDensityTargetCalculator(zonalSystem,
+		var targetFunction = new EqualVehicleDensityTargetCalculator(zonalSystem,
 				createFleetSpecification(7)).calculate(0, Map.of());
-		zonalSystem.getZones().keySet().forEach(id -> assertTarget(demandFunction, zonalSystem, id, 0));
+		zonalSystem.getZones().keySet().forEach(id -> assertTarget(targetFunction, zonalSystem, id, 7. / 8));
 	}
 
 	@Test
 	public void calculate_moreVehiclesThanZones() {
-		ToIntFunction<DrtZone> demandFunction = new EqualVehicleDensityTargetCalculator(zonalSystem,
+		var targetFunction = new EqualVehicleDensityTargetCalculator(zonalSystem,
 				createFleetSpecification(9)).calculate(0, Map.of());
-		zonalSystem.getZones().keySet().forEach(id -> assertTarget(demandFunction, zonalSystem, id, 1));
+		zonalSystem.getZones().keySet().forEach(id -> assertTarget(targetFunction, zonalSystem, id, 9. / 8));
 	}
 
 	private FleetSpecification createFleetSpecification(int count) {
@@ -91,8 +91,8 @@ public class EqualVehicleDensityTargetCalculatorTest {
 		return fleetSpecification;
 	}
 
-	private void assertTarget(ToIntFunction<DrtZone> targetFunction, DrtZonalSystem zonalSystem, String zoneId,
-			int expectedValue) {
-		assertThat(targetFunction.applyAsInt(zonalSystem.getZones().get(zoneId))).isEqualTo(expectedValue);
+	private void assertTarget(ToDoubleFunction<DrtZone> targetFunction, DrtZonalSystem zonalSystem, String zoneId,
+			double expectedValue) {
+		assertThat(targetFunction.applyAsDouble(zonalSystem.getZones().get(zoneId))).isEqualTo(expectedValue);
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehiclesToPopulationRatioTargetCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehiclesToPopulationRatioTargetCalculatorTest.java
@@ -23,7 +23,7 @@ package org.matsim.contrib.drt.optimizer.rebalancing.targetcalculator;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
-import java.util.function.ToIntFunction;
+import java.util.function.ToDoubleFunction;
 
 import org.junit.Test;
 import org.matsim.api.core.v01.Id;
@@ -66,32 +66,32 @@ public class EqualVehiclesToPopulationRatioTargetCalculatorTest {
 
 	@Test
 	public void testCalculate_oneVehiclePerZone() {
-		ToIntFunction<DrtZone> demandFunction = new EqualVehiclesToPopulationRatioTargetCalculator(zonalSystem,
-				createPopulation(), createFleetSpecification(8)).calculate(0, Map.of());
+		var targetFunction = new EqualVehiclesToPopulationRatioTargetCalculator(zonalSystem, createPopulation(),
+				createFleetSpecification(8)).calculate(0, Map.of());
 
-		assertTarget(demandFunction, zonalSystem, "1", 0);
-		assertTarget(demandFunction, zonalSystem, "2", 2);
-		assertTarget(demandFunction, zonalSystem, "3", 0);
-		assertTarget(demandFunction, zonalSystem, "4", 2);
-		assertTarget(demandFunction, zonalSystem, "5", 0);
-		assertTarget(demandFunction, zonalSystem, "6", 0);
-		assertTarget(demandFunction, zonalSystem, "7", 0);
-		assertTarget(demandFunction, zonalSystem, "8", 2);
+		assertTarget(targetFunction, zonalSystem, "1", 0);
+		assertTarget(targetFunction, zonalSystem, "2", 8. / 3);
+		assertTarget(targetFunction, zonalSystem, "3", 0);
+		assertTarget(targetFunction, zonalSystem, "4", 8. / 3);
+		assertTarget(targetFunction, zonalSystem, "5", 0);
+		assertTarget(targetFunction, zonalSystem, "6", 0);
+		assertTarget(targetFunction, zonalSystem, "7", 0);
+		assertTarget(targetFunction, zonalSystem, "8", 8. / 3);
 	}
 
 	@Test
 	public void testCalculate_twoVehiclesPerZone() {
-		ToIntFunction<DrtZone> demandFunction = new EqualVehiclesToPopulationRatioTargetCalculator(zonalSystem,
-				createPopulation(), createFleetSpecification(16)).calculate(0, Map.of());
+		var targetFunction = new EqualVehiclesToPopulationRatioTargetCalculator(zonalSystem, createPopulation(),
+				createFleetSpecification(16)).calculate(0, Map.of());
 
-		assertTarget(demandFunction, zonalSystem, "1", 0);
-		assertTarget(demandFunction, zonalSystem, "2", 5);
-		assertTarget(demandFunction, zonalSystem, "3", 0);
-		assertTarget(demandFunction, zonalSystem, "4", 5);
-		assertTarget(demandFunction, zonalSystem, "5", 0);
-		assertTarget(demandFunction, zonalSystem, "6", 0);
-		assertTarget(demandFunction, zonalSystem, "7", 0);
-		assertTarget(demandFunction, zonalSystem, "8", 5);
+		assertTarget(targetFunction, zonalSystem, "1", 0);
+		assertTarget(targetFunction, zonalSystem, "2", 16. / 3);
+		assertTarget(targetFunction, zonalSystem, "3", 0);
+		assertTarget(targetFunction, zonalSystem, "4", 16. / 3);
+		assertTarget(targetFunction, zonalSystem, "5", 0);
+		assertTarget(targetFunction, zonalSystem, "6", 0);
+		assertTarget(targetFunction, zonalSystem, "7", 0);
+		assertTarget(targetFunction, zonalSystem, "8", 16. / 3);
 	}
 
 	private FleetSpecification createFleetSpecification(int count) {
@@ -184,8 +184,8 @@ public class EqualVehiclesToPopulationRatioTargetCalculatorTest {
 		return population;
 	}
 
-	private void assertTarget(ToIntFunction<DrtZone> targetFunction, DrtZonalSystem zonalSystem, String zoneId,
-			int expectedValue) {
-		assertThat(targetFunction.applyAsInt(zonalSystem.getZones().get(zoneId))).isEqualTo(expectedValue);
+	private void assertTarget(ToDoubleFunction<DrtZone> targetFunction, DrtZonalSystem zonalSystem, String zoneId,
+			double expectedValue) {
+		assertThat(targetFunction.applyAsDouble(zonalSystem.getZones().get(zoneId))).isEqualTo(expectedValue);
 	}
 }


### PR DESCRIPTION
Main changes:
- change rebalancing target value type from int to double
- apply alpha-beta linear scaling to all target calculators (when called from `MinCostRebalancingStrategy`)
- cleanups and fixes in EqualVehiclesToPopulationRatioTargetCalculator