### PR TITLE
Include vehicles outside zonal system in rebalancing

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/RebalancingUtils.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/RebalancingUtils.java
@@ -46,10 +46,10 @@ public class RebalancingUtils {
 		rebalancableVehicles.filter(v -> v.getServiceEndTime() > time + params.getMinServiceTime()).forEach(v -> {
 			Link link = ((StayTask)v.getSchedule().getCurrentTask()).getLink();
 			DrtZone zone = zonalSystem.getZoneForLinkId(link.getId());
-			if (zone != null) {
-				// zonePerVehicle.put(v.getId(), zone);
-				rebalancableVehiclesPerZone.computeIfAbsent(zone, z -> new ArrayList<>()).add(v);
+			if (zone == null) {
+				zone = DrtZone.createDummyZone("single-vehicle-zone-" + v.getId(), List.of(link), link.getCoord());
 			}
+			rebalancableVehiclesPerZone.computeIfAbsent(zone, z -> new ArrayList<>()).add(v);
 		});
 		return rebalancableVehiclesPerZone;
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
@@ -109,6 +109,9 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 				addEventHandlerBinding().to(modalKey(PreviousIterationDRTDemandEstimator.class));
 				break;
 
+			case None:
+				break;
+
 			default:
 				throw new IllegalArgumentException(
 						"Unsupported zonalDemandEstimatorType=" + strategyParams.getZonalDemandEstimatorType());

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategy.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategy.java
@@ -20,7 +20,6 @@ package org.matsim.contrib.drt.optimizer.rebalancing.mincostflow;
 
 import static java.util.stream.Collectors.toList;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.ToDoubleFunction;
@@ -62,7 +61,7 @@ public class MinCostFlowRebalancingStrategy implements RebalancingStrategy {
 		Map<DrtZone, List<DvrpVehicle>> rebalancableVehiclesPerZone = RebalancingUtils.groupRebalancableVehicles(
 				zonalSystem, params, rebalancableVehicles, time);
 		if (rebalancableVehiclesPerZone.isEmpty()) {
-			return Collections.emptyList();
+			return List.of();
 		}
 		Map<DrtZone, List<DvrpVehicle>> soonIdleVehiclesPerZone = RebalancingUtils.groupSoonIdleVehicles(zonalSystem,
 				params, fleet, time);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategyParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategyParams.java
@@ -18,16 +18,12 @@
 
 package org.matsim.contrib.drt.optimizer.rebalancing.mincostflow;
 
-import static com.google.common.base.Preconditions.checkState;
-
 import java.util.Map;
 
-import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.PositiveOrZero;
 
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingParams;
-import org.matsim.core.config.Config;
 import org.matsim.core.config.ReflectiveConfigGroup;
 
 /**
@@ -42,7 +38,7 @@ public final class MinCostFlowRebalancingStrategyParams extends ReflectiveConfig
 	}
 
 	public enum ZonalDemandEstimatorType {
-		PreviousIterationDemand
+		PreviousIterationDemand, None
 	}
 
 	public static final String TARGET_ALPHA = "targetAlpha";
@@ -65,7 +61,7 @@ public final class MinCostFlowRebalancingStrategyParams extends ReflectiveConfig
 
 	public static final String ZONAL_DEMAND_ESTIMATOR_TYPE = "zonalDemandEstimatorType";
 	static final String ZONAL_DEMAND_ESTIMATOR_TYPE_EXP = "Defines the methodology for demand estimation."
-			+ " Can be one of [PreviousIterationDemand]. Current default is PreviousIterationDemand";
+			+ " Can be one of [PreviousIterationDemand, None]. Current default is PreviousIterationDemand";
 
 	@NotNull
 	private RebalancingTargetCalculatorType rebalancingTargetCalculatorType = RebalancingTargetCalculatorType.EstimatedDemand;
@@ -76,26 +72,11 @@ public final class MinCostFlowRebalancingStrategyParams extends ReflectiveConfig
 	@PositiveOrZero
 	private double targetBeta = Double.NaN;
 
-	@Nullable //required only if rebalancingTargetCalculatorType == EstimatedDemand
+	@NotNull
 	private ZonalDemandEstimatorType zonalDemandEstimatorType = ZonalDemandEstimatorType.PreviousIterationDemand;
 
 	public MinCostFlowRebalancingStrategyParams() {
 		super(SET_NAME);
-	}
-
-	@Override
-	protected void checkConsistency(Config config) {
-		super.checkConsistency(config);
-
-		if (rebalancingTargetCalculatorType == RebalancingTargetCalculatorType.EstimatedDemand) {
-			checkState(zonalDemandEstimatorType != null,
-					"zonalDemandEstimatorType is required if EstimatedDemand is used as rebalancing target");
-		}
-//		not possible to set zonalDemandEstimatorType because the the switch in DrtModeMinCostFlowRebalancingModule will lead to a NullPointer
-//		else {
-//			checkState(zonalDemandEstimatorType == null,
-//					"zonalDemandEstimatorType should be null if the rebalancing target is not set to EstimatedDemand");
-//		}
 	}
 
 	@Override


### PR DESCRIPTION
A dummy (single-vehicle) zone is created for each such vehicle. These dummy zones provide a supply of rebalancable vehicles, but the demand is 0. So vehicles will either stay where they are or will be relocated to areas with a negative vehicle surplus.

By doing this, the service area can be bigger than the zonal system used for rebalancing.