### PR TITLE
Add teleporting passenger engine

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
@@ -105,8 +105,10 @@ public class DrtAnalysisControlerListener implements IterationEndsListener {
 		DrtTripsAnalyser.analyseDetours(network, trips, drtCfg, filename(event, "drt_detours"), createGraphs);
 		DrtTripsAnalyser.analyseWaitTimes(filename(event, "waitStats"), trips, 1800, createGraphs);
 
-		double endTime = qSimCfg.getEndTime().orElseGet(()->
-			 trips.isEmpty() ? qSimCfg.getStartTime().seconds() : trips.get(trips.size() - 1).getDepartureTime());
+		double endTime = qSimCfg.getEndTime()
+				.orElseGet(() -> trips.isEmpty() ?
+						qSimCfg.getStartTime().orElse(0) :
+						trips.get(trips.size() - 1).getDepartureTime());
 
 		DrtTripsAnalyser.analyzeBoardingsAndDeboardings(trips, ";", qSimCfg.getStartTime().orElse(0), endTime, 3600,
 				filename(event, "drt_boardings", ".csv"), filename(event, "drt_alightments", ".csv"), network);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/AggregatedMinCostRelocationCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/AggregatedMinCostRelocationCalculator.java
@@ -37,7 +37,7 @@ import org.matsim.contrib.util.distance.DistanceUtils;
  *
  * @author michalm
  */
-public class AggregatedMinCostRelocationCalculator implements RelocationCalculator {
+public class AggregatedMinCostRelocationCalculator implements ZonalRelocationCalculator {
 	public static class DrtZoneVehicleSurplus {
 		public final DrtZone zone;
 		public final int surplus;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
@@ -60,7 +60,7 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 				bindModal(RebalancingStrategy.class).toProvider(modalProvider(
 						getter -> new MinCostFlowRebalancingStrategy(getter.getModal(RebalancingTargetCalculator.class),
 								getter.getModal(DrtZonalSystem.class), getter.getModal(Fleet.class),
-								getter.getModal(RelocationCalculator.class), params))).asEagerSingleton();
+								getter.getModal(ZonalRelocationCalculator.class), params))).asEagerSingleton();
 
 				switch (strategyParams.getRebalancingTargetCalculatorType()) {
 					case EstimatedDemand:
@@ -94,7 +94,7 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 								+ strategyParams.getZonalDemandEstimatorType());
 				}
 
-				bindModal(RelocationCalculator.class).toProvider(modalProvider(
+				bindModal(ZonalRelocationCalculator.class).toProvider(modalProvider(
 						getter -> new AggregatedMinCostRelocationCalculator(
 								getter.getModal(DrtZoneTargetLinkSelector.class)))).asEagerSingleton();
 			}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategy.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategy.java
@@ -43,11 +43,11 @@ public class MinCostFlowRebalancingStrategy implements RebalancingStrategy {
 	private final RebalancingTargetCalculator rebalancingTargetCalculator;
 	private final DrtZonalSystem zonalSystem;
 	private final Fleet fleet;
-	private final RelocationCalculator relocationCalculator;
+	private final ZonalRelocationCalculator relocationCalculator;
 	private final RebalancingParams params;
 
 	public MinCostFlowRebalancingStrategy(RebalancingTargetCalculator rebalancingTargetCalculator,
-			DrtZonalSystem zonalSystem, Fleet fleet, RelocationCalculator relocationCalculator,
+			DrtZonalSystem zonalSystem, Fleet fleet, ZonalRelocationCalculator relocationCalculator,
 			RebalancingParams params) {
 		this.rebalancingTargetCalculator = rebalancingTargetCalculator;
 		this.zonalSystem = zonalSystem;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/ZonalRelocationCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/ZonalRelocationCalculator.java
@@ -29,7 +29,7 @@ import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 /**
  * @author michalm
  */
-public interface RelocationCalculator {
+public interface ZonalRelocationCalculator {
 	/**
 	 * @param vehicleSurplus              could be negative (supply - demand), typically contains only non-zero values (zones with zero surplus are skipped)
 	 * @param rebalancableVehiclesPerZone list of rebalancable vehicles per each zone (zones without rebalancable vehicles are usually skipped)

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/DefaultPassengerEngine.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/DefaultPassengerEngine.java
@@ -80,10 +80,6 @@ public final class DefaultPassengerEngine implements PassengerEngine {
 		passengerHandler.setInternalInterface(internalInterface);
 	}
 
-	public String getMode() {
-		return mode;
-	}
-
 	@Override
 	public void onPrepareSim() {
 	}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/PassengerEngineQSimModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/PassengerEngineQSimModule.java
@@ -6,7 +6,7 @@ import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 
 public class PassengerEngineQSimModule extends AbstractDvrpModeQSimModule {
 	public enum PassengerEngineType {
-		DEFAULT, WITH_PREBOOKING
+		DEFAULT, WITH_PREBOOKING, TELEPORTING
 	}
 
 	private final PassengerEngineType type;
@@ -28,6 +28,9 @@ public class PassengerEngineQSimModule extends AbstractDvrpModeQSimModule {
 				return;
 			case WITH_PREBOOKING:
 				addModalComponent(PassengerEngine.class, PassengerEngineWithPrebooking.createProvider(getMode()));
+				return;
+			case TELEPORTING:
+				addModalComponent(PassengerEngine.class, TeleportingPassengerEngine.class);
 				return;
 			default:
 				throw new IllegalStateException("Type: " + type + " is not supported");

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/TeleportingPassengerEngine.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/TeleportingPassengerEngine.java
@@ -1,0 +1,75 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.dvrp.passenger;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.core.mobsim.framework.MobsimAgent;
+import org.matsim.core.mobsim.framework.MobsimDriverAgent;
+import org.matsim.core.mobsim.qsim.InternalInterface;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class TeleportingPassengerEngine implements PassengerEngine {
+	@Override
+	public void setInternalInterface(InternalInterface internalInterface) {
+	}
+
+	@Override
+	public void onPrepareSim() {
+	}
+
+	@Override
+	public void doSimStep(double time) {
+	}
+
+	@Override
+	public void afterSim() {
+	}
+
+	@Override
+	public boolean handleDeparture(double now, MobsimAgent agent, Id<Link> linkId) {
+		// departures of the corresponding dvrp mode are not handled --> agents will be teleported
+		return false;
+	}
+
+	@Override
+	public boolean pickUpPassenger(PassengerPickupActivity pickupActivity, MobsimDriverAgent driver,
+			PassengerRequest request, double now) {
+		throw new UnsupportedOperationException("No picking-up when teleporting");
+	}
+
+	@Override
+	public void dropOffPassenger(MobsimDriverAgent driver, PassengerRequest request, double now) {
+		throw new UnsupportedOperationException("No dropping-off when teleporting");
+	}
+
+	@Override
+	public void notifyPassengerRequestRejected(PassengerRequestRejectedEvent event) {
+		throw new UnsupportedOperationException("No request-vehicle scheduling when teleporting");
+	}
+
+	@Override
+	public void notifyPassengerRequestScheduled(PassengerRequestScheduledEvent event) {
+		throw new UnsupportedOperationException("No request-vehicle scheduling when teleporting");
+	}
+}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/AbstractDvrpModeQSimModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/AbstractDvrpModeQSimModule.java
@@ -95,19 +95,24 @@ public abstract class AbstractDvrpModeQSimModule extends AbstractQSimModule {
 	}
 
 	protected final <T extends QSimComponent> void addModalComponent(Class<T> componentClass, Key<? extends T> key) {
-		bind(componentClass).annotatedWith(getDvrpMode()).to(key).asEagerSingleton();
-		addQSimComponentBinding(getDvrpMode()).to(Key.get(componentClass, getDvrpMode()));
+		bindModal(componentClass).to(key).asEagerSingleton();
+		addModalQSimComponentBinding().to(modalKey(componentClass));
 	}
 
 	protected final <T extends QSimComponent> void addModalComponent(Class<T> componentClass,
-			Provider<T> componentProvider) {
-		bind(componentClass).annotatedWith(getDvrpMode()).toProvider(componentProvider).asEagerSingleton();
-		addQSimComponentBinding(getDvrpMode()).to(Key.get(componentClass, getDvrpMode()));
+			Provider<? extends T> componentProvider) {
+		bindModal(componentClass).toProvider(componentProvider).asEagerSingleton();
+		addModalQSimComponentBinding().to(modalKey(componentClass));
+	}
+
+	protected final <T extends QSimComponent> void addModalComponent(Class<T> componentClass,
+			Class<? extends T> implementation) {
+		bindModal(componentClass).to(implementation).asEagerSingleton();
+		addModalQSimComponentBinding().to(modalKey(componentClass));
 	}
 
 	protected final <T extends QSimComponent> void addModalComponent(Class<T> componentClass) {
-		bind(componentClass).annotatedWith(getDvrpMode()).to(componentClass).asEagerSingleton();
-		addQSimComponentBinding(getDvrpMode()).to(Key.get(componentClass, getDvrpMode()));
+		addModalComponent(componentClass, componentClass);
 	}
 
 	protected final <T> Provider<T> modalProvider(Function<ModalProviders.InstanceGetter, T> delegate) {


### PR DESCRIPTION
This enables simulating DVRP without actually calling the optimiser 

A potential application: speeding up DRT, see some discussion here: https://github.com/matsim-org/matsim-libs/pull/1057#issuecomment-653741087