### PR TITLE
provide AbstractMobsimModule with iteration number

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtModeOptimizerQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtModeOptimizerQSimModule.java
@@ -1,0 +1,160 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2018 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.optimizer;
+
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.drt.optimizer.depot.DepotFinder;
+import org.matsim.contrib.drt.optimizer.depot.NearestStartLinkAsDepot;
+import org.matsim.contrib.drt.optimizer.insertion.DefaultUnplannedRequestInserter;
+import org.matsim.contrib.drt.optimizer.insertion.DrtInsertionSearch;
+import org.matsim.contrib.drt.optimizer.insertion.ExtensiveInsertionSearchParams;
+import org.matsim.contrib.drt.optimizer.insertion.ExtensiveInsertionSearchQSimModule;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator;
+import org.matsim.contrib.drt.optimizer.insertion.SelectiveInsertionSearchParams;
+import org.matsim.contrib.drt.optimizer.insertion.SelectiveInsertionSearchQSimModule;
+import org.matsim.contrib.drt.optimizer.insertion.UnplannedRequestInserter;
+import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.drt.schedule.DrtStayTaskEndTimeCalculator;
+import org.matsim.contrib.drt.schedule.DrtTaskFactory;
+import org.matsim.contrib.drt.schedule.DrtTaskFactoryImpl;
+import org.matsim.contrib.drt.scheduler.DrtScheduleInquiry;
+import org.matsim.contrib.drt.scheduler.EmptyVehicleRelocator;
+import org.matsim.contrib.drt.scheduler.RequestInsertionScheduler;
+import org.matsim.contrib.drt.vrpagent.DrtActionCreator;
+import org.matsim.contrib.dvrp.fleet.Fleet;
+import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
+import org.matsim.contrib.dvrp.passenger.PassengerHandler;
+import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
+import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
+import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.contrib.dvrp.run.ModalProviders;
+import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
+import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
+import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.mobsim.framework.MobsimTimer;
+import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
+import org.matsim.core.router.util.TravelDisutility;
+import org.matsim.core.router.util.TravelTime;
+
+import com.google.inject.Inject;
+import com.google.inject.TypeLiteral;
+import com.google.inject.name.Named;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class DrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
+	private final DrtConfigGroup drtCfg;
+
+	public DrtModeOptimizerQSimModule(DrtConfigGroup drtCfg) {
+		super(drtCfg.getMode());
+		this.drtCfg = drtCfg;
+	}
+
+	@Override
+	protected void configureQSim() {
+		addModalComponent(DrtOptimizer.class, modalProvider(
+				getter -> new DefaultDrtOptimizer(drtCfg, getter.getModal(Fleet.class), getter.get(MobsimTimer.class),
+						getter.getModal(DepotFinder.class), getter.getModal(RebalancingStrategy.class),
+						getter.getModal(DrtScheduleInquiry.class), getter.getModal(ScheduleTimingUpdater.class),
+						getter.getModal(EmptyVehicleRelocator.class),
+						getter.getModal(UnplannedRequestInserter.class))));
+
+		bindModal(DepotFinder.class).toProvider(
+				modalProvider(getter -> new NearestStartLinkAsDepot(getter.getModal(Fleet.class)))).asEagerSingleton();
+
+		addModalComponent(QSimScopeForkJoinPoolHolder.class,
+				() -> new QSimScopeForkJoinPoolHolder(drtCfg.getNumberOfThreads()));
+
+		bindModal(UnplannedRequestInserter.class).toProvider(modalProvider(
+				getter -> new DefaultUnplannedRequestInserter(drtCfg, getter.getModal(Fleet.class),
+						getter.get(MobsimTimer.class), getter.get(EventsManager.class),
+						getter.getModal(RequestInsertionScheduler.class),
+						getter.getModal(VehicleData.EntryFactory.class),
+						getter.getModal(new TypeLiteral<DrtInsertionSearch<PathData>>() {
+						}), getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool()))).asEagerSingleton();
+
+		install(getInsertionSearchQSimModule(drtCfg));
+
+		bindModal(VehicleData.EntryFactory.class).toInstance(new VehicleDataEntryFactoryImpl(drtCfg));
+
+		bindModal(InsertionCostCalculator.PenaltyCalculator.class).to(
+				drtCfg.isRejectRequestIfMaxWaitOrTravelTimeViolated() ?
+						InsertionCostCalculator.RejectSoftConstraintViolations.class :
+						InsertionCostCalculator.DiscourageSoftConstraintViolations.class).asEagerSingleton();
+
+		bindModal(DrtTaskFactory.class).toInstance(new DrtTaskFactoryImpl());
+
+		bindModal(EmptyVehicleRelocator.class).toProvider(new ModalProviders.AbstractProvider<>(drtCfg.getMode()) {
+			@Inject
+			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
+			private TravelTime travelTime;
+
+			@Inject
+			private MobsimTimer timer;
+
+			@Override
+			public EmptyVehicleRelocator get() {
+				Network network = getModalInstance(Network.class);
+				DrtTaskFactory taskFactory = getModalInstance(DrtTaskFactory.class);
+				TravelDisutility travelDisutility = getModalInstance(
+						TravelDisutilityFactory.class).createTravelDisutility(travelTime);
+				return new EmptyVehicleRelocator(network, travelTime, travelDisutility, timer, taskFactory);
+			}
+		}).asEagerSingleton();
+
+		bindModal(DrtScheduleInquiry.class).to(DrtScheduleInquiry.class).asEagerSingleton();
+
+		bindModal(RequestInsertionScheduler.class).toProvider(modalProvider(
+				getter -> new RequestInsertionScheduler(drtCfg, getter.getModal(Fleet.class),
+						getter.get(MobsimTimer.class),
+						getter.getNamed(TravelTime.class, DvrpTravelTimeModule.DVRP_ESTIMATED),
+						getter.getModal(ScheduleTimingUpdater.class), getter.getModal(DrtTaskFactory.class))))
+				.asEagerSingleton();
+
+		bindModal(ScheduleTimingUpdater.class).toProvider(modalProvider(
+				getter -> new ScheduleTimingUpdater(getter.get(MobsimTimer.class),
+						new DrtStayTaskEndTimeCalculator(drtCfg)))).asEagerSingleton();
+
+		bindModal(VrpAgentLogic.DynActionCreator.class).
+				toProvider(modalProvider(getter -> new DrtActionCreator(getter.getModal(PassengerHandler.class),
+						getter.get(MobsimTimer.class), getter.get(DvrpConfigGroup.class)))).
+				asEagerSingleton();
+
+		bindModal(VrpOptimizer.class).to(modalKey(DrtOptimizer.class));
+	}
+
+	public static AbstractDvrpModeQSimModule getInsertionSearchQSimModule(DrtConfigGroup drtCfg) {
+		switch (drtCfg.getDrtInsertionSearchParams().getName()) {
+			case ExtensiveInsertionSearchParams.SET_NAME:
+				return new ExtensiveInsertionSearchQSimModule(drtCfg);
+
+			case SelectiveInsertionSearchParams.SET_NAME:
+				return new SelectiveInsertionSearchQSimModule(drtCfg);
+
+			default:
+				throw new RuntimeException(
+						"Unsupported DRT insertion search type: " + drtCfg.getDrtInsertionSearchParams().getName());
+		}
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeQSimModule.java
@@ -20,56 +20,23 @@
 
 package org.matsim.contrib.drt.run;
 
-import org.matsim.api.core.v01.network.Network;
-import org.matsim.contrib.drt.optimizer.DefaultDrtOptimizer;
-import org.matsim.contrib.drt.optimizer.DrtOptimizer;
-import org.matsim.contrib.drt.optimizer.QSimScopeForkJoinPoolHolder;
-import org.matsim.contrib.drt.optimizer.VehicleData;
-import org.matsim.contrib.drt.optimizer.VehicleDataEntryFactoryImpl;
-import org.matsim.contrib.drt.optimizer.depot.DepotFinder;
-import org.matsim.contrib.drt.optimizer.depot.NearestStartLinkAsDepot;
-import org.matsim.contrib.drt.optimizer.insertion.DefaultUnplannedRequestInserter;
-import org.matsim.contrib.drt.optimizer.insertion.DrtInsertionSearch;
+import org.matsim.contrib.drt.optimizer.DrtModeOptimizerQSimModule;
 import org.matsim.contrib.drt.optimizer.insertion.ExtensiveInsertionSearchParams;
 import org.matsim.contrib.drt.optimizer.insertion.ExtensiveInsertionSearchQSimModule;
-import org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator;
 import org.matsim.contrib.drt.optimizer.insertion.SelectiveInsertionSearchParams;
 import org.matsim.contrib.drt.optimizer.insertion.SelectiveInsertionSearchQSimModule;
-import org.matsim.contrib.drt.optimizer.insertion.UnplannedRequestInserter;
-import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.drt.passenger.DrtRequestCreator;
-import org.matsim.contrib.drt.schedule.DrtStayTaskEndTimeCalculator;
-import org.matsim.contrib.drt.schedule.DrtTaskFactory;
-import org.matsim.contrib.drt.schedule.DrtTaskFactoryImpl;
-import org.matsim.contrib.drt.scheduler.DrtScheduleInquiry;
-import org.matsim.contrib.drt.scheduler.EmptyVehicleRelocator;
-import org.matsim.contrib.drt.scheduler.RequestInsertionScheduler;
-import org.matsim.contrib.drt.vrpagent.DrtActionCreator;
-import org.matsim.contrib.dvrp.fleet.Fleet;
-import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
 import org.matsim.contrib.dvrp.passenger.DefaultPassengerRequestValidator;
 import org.matsim.contrib.dvrp.passenger.PassengerEngineQSimModule;
-import org.matsim.contrib.dvrp.passenger.PassengerHandler;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestCreator;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestValidator;
-import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
-import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
-import org.matsim.contrib.dvrp.run.ModalProviders;
-import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
-import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
-import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentSourceQSimModule;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.framework.MobsimTimer;
-import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
-import org.matsim.core.router.util.TravelDisutility;
-import org.matsim.core.router.util.TravelTime;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
-import com.google.inject.TypeLiteral;
-import com.google.inject.name.Named;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -86,76 +53,7 @@ public class DrtModeQSimModule extends AbstractDvrpModeQSimModule {
 	protected void configureQSim() {
 		install(new VrpAgentSourceQSimModule(getMode()));
 		install(new PassengerEngineQSimModule(getMode()));
-
-		addModalComponent(DrtOptimizer.class, modalProvider(
-				getter -> new DefaultDrtOptimizer(drtCfg, getter.getModal(Fleet.class), getter.get(MobsimTimer.class),
-						getter.getModal(DepotFinder.class), getter.getModal(RebalancingStrategy.class),
-						getter.getModal(DrtScheduleInquiry.class), getter.getModal(ScheduleTimingUpdater.class),
-						getter.getModal(EmptyVehicleRelocator.class),
-						getter.getModal(UnplannedRequestInserter.class))));
-
-		bindModal(DepotFinder.class).toProvider(
-				modalProvider(getter -> new NearestStartLinkAsDepot(getter.getModal(Fleet.class))));
-
 		bindModal(PassengerRequestValidator.class).to(DefaultPassengerRequestValidator.class).asEagerSingleton();
-
-		addModalComponent(QSimScopeForkJoinPoolHolder.class,
-				() -> new QSimScopeForkJoinPoolHolder(drtCfg.getNumberOfThreads()));
-
-		bindModal(UnplannedRequestInserter.class).toProvider(modalProvider(
-				getter -> new DefaultUnplannedRequestInserter(drtCfg, getter.getModal(Fleet.class),
-						getter.get(MobsimTimer.class), getter.get(EventsManager.class),
-						getter.getModal(RequestInsertionScheduler.class),
-						getter.getModal(VehicleData.EntryFactory.class),
-						getter.getModal(new TypeLiteral<DrtInsertionSearch<PathData>>() {
-						}), getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool()))).asEagerSingleton();
-
-		install(getInsertionSearchQSimModule(drtCfg));
-
-		bindModal(VehicleData.EntryFactory.class).toInstance(new VehicleDataEntryFactoryImpl(drtCfg));
-
-		bindModal(InsertionCostCalculator.PenaltyCalculator.class).to(
-				drtCfg.isRejectRequestIfMaxWaitOrTravelTimeViolated() ?
-						InsertionCostCalculator.RejectSoftConstraintViolations.class :
-						InsertionCostCalculator.DiscourageSoftConstraintViolations.class).asEagerSingleton();
-
-		bindModal(DrtTaskFactory.class).toInstance(new DrtTaskFactoryImpl());
-
-		bindModal(EmptyVehicleRelocator.class).toProvider(new ModalProviders.AbstractProvider<>(drtCfg.getMode()) {
-			@Inject
-			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
-			private TravelTime travelTime;
-
-			@Inject
-			private MobsimTimer timer;
-
-			@Override
-			public EmptyVehicleRelocator get() {
-				Network network = getModalInstance(Network.class);
-				DrtTaskFactory taskFactory = getModalInstance(DrtTaskFactory.class);
-				TravelDisutility travelDisutility = getModalInstance(
-						TravelDisutilityFactory.class).createTravelDisutility(travelTime);
-				return new EmptyVehicleRelocator(network, travelTime, travelDisutility, timer, taskFactory);
-			}
-		}).asEagerSingleton();
-
-		bindModal(DrtScheduleInquiry.class).to(DrtScheduleInquiry.class).asEagerSingleton();
-
-		bindModal(RequestInsertionScheduler.class).toProvider(modalProvider(
-				getter -> new RequestInsertionScheduler(drtCfg, getter.getModal(Fleet.class),
-						getter.get(MobsimTimer.class),
-						getter.getNamed(TravelTime.class, DvrpTravelTimeModule.DVRP_ESTIMATED),
-						getter.getModal(ScheduleTimingUpdater.class), getter.getModal(DrtTaskFactory.class))))
-				.asEagerSingleton();
-
-		bindModal(ScheduleTimingUpdater.class).toProvider(modalProvider(
-				getter -> new ScheduleTimingUpdater(getter.get(MobsimTimer.class),
-						new DrtStayTaskEndTimeCalculator(drtCfg)))).asEagerSingleton();
-
-		bindModal(VrpAgentLogic.DynActionCreator.class).
-				toProvider(modalProvider(getter -> new DrtActionCreator(getter.getModal(PassengerHandler.class),
-						getter.get(MobsimTimer.class), getter.get(DvrpConfigGroup.class)))).
-				asEagerSingleton();
 
 		bindModal(PassengerRequestCreator.class).toProvider(new Provider<DrtRequestCreator>() {
 			@Inject
@@ -169,7 +67,7 @@ public class DrtModeQSimModule extends AbstractDvrpModeQSimModule {
 			}
 		}).asEagerSingleton();
 
-		bindModal(VrpOptimizer.class).to(modalKey(DrtOptimizer.class));
+		install(new DrtModeOptimizerQSimModule(drtCfg));
 	}
 
 	public static AbstractDvrpModeQSimModule getInsertionSearchQSimModule(DrtConfigGroup drtCfg) {

--- a/matsim/src/main/java/org/matsim/core/mobsim/framework/AbstractMobsimModule.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/framework/AbstractMobsimModule.java
@@ -23,7 +23,7 @@
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
+import java.util.Objects;
 
 import org.matsim.core.config.Config;
 
@@ -32,28 +32,46 @@ import com.google.inject.Module;
 import com.google.inject.util.Modules;
 
 public abstract class AbstractMobsimModule extends AbstractModule {
-	private Optional<Config> config = Optional.empty();
-	private Optional<AbstractMobsimModule> parent = Optional.empty();
+	private Config config = null;
+	private Integer iterationNumber = null;
+	private AbstractMobsimModule parent = null;
 
 	public final void setConfig(Config config) {
-		this.config = Optional.of(config);
+		this.config = Objects.requireNonNull(config);
+	}
+
+	public final void setIterationNumber(int iterationNumber) {
+		this.iterationNumber = iterationNumber;
 	}
 
 	public final void setParent(AbstractMobsimModule parent) {
-		this.parent = Optional.of(parent);
+		this.parent = Objects.requireNonNull(parent);
 	}
 
 	protected final Config getConfig() {
-		if (config.isPresent()) {
-			return config.get();
+		if (config != null) {
+			return config;
 		}
 
-		if (parent.isPresent()) {
-			return parent.get().getConfig();
+		if (parent != null) {
+			return parent.getConfig();
 		}
 
 		throw new IllegalStateException(
 				"No config set. Did you try to use the module outside of the QSim initialization process?");
+	}
+
+	protected final int getIterationNumber() {
+		if (iterationNumber != null) {
+			return iterationNumber;
+		}
+
+		if (parent != null) {
+			return parent.getIterationNumber();
+		}
+
+		throw new IllegalStateException(
+				"No iteration number set. Did you try to use the module outside of the QSim initialization process?");
 	}
 
 	protected final void configure() {

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSimBuilder.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSimBuilder.java
@@ -32,6 +32,7 @@ import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.AllowsConfiguration;
+import org.matsim.core.controler.IterationCounter;
 import org.matsim.core.mobsim.framework.Mobsim;
 import org.matsim.core.mobsim.qsim.components.QSimComponentsConfig;
 import org.matsim.core.mobsim.qsim.components.QSimComponentsConfigurator;
@@ -185,8 +186,12 @@ public class QSimBuilder implements AllowsConfiguration{
 	 * components.
 	 */
 	public QSim build(Scenario scenario, EventsManager eventsManager) {
+		return build(scenario, eventsManager, 0);
+	}
+
+	public QSim build(Scenario scenario, EventsManager eventsManager, int iterationNumber) {
 		// First, load standard QSim module
-		AbstractModule controllerModule = new StandaloneQSimModule(scenario, eventsManager);
+		AbstractModule controllerModule = new StandaloneQSimModule(scenario, eventsManager, () -> iterationNumber);
 
 		// Add all overrides
 		for (AbstractModule override : overridingControllerModules) {
@@ -212,16 +217,19 @@ public class QSimBuilder implements AllowsConfiguration{
 	private static class StandaloneQSimModule extends AbstractModule {
 		private final Scenario scenario;
 		private final EventsManager eventsManager;
+		private final IterationCounter iterationCounter;
 
-		public StandaloneQSimModule(Scenario scenario, EventsManager eventsManager) {
+		public StandaloneQSimModule(Scenario scenario, EventsManager eventsManager, IterationCounter iterationCounter) {
 			this.scenario = scenario;
 			this.eventsManager = eventsManager;
+			this.iterationCounter = iterationCounter;
 		}
 
 		@Override
 		public void install() {
 			install(new ScenarioByInstanceModule(scenario));
 			bind(EventsManager.class).toInstance(eventsManager);
+			bind(IterationCounter.class).toInstance(iterationCounter);
 			install(new QSimModule(false));
 		}
 	}

--- a/matsim/src/test/java/org/matsim/core/controler/corelisteners/ListenersInjectionTest.java
+++ b/matsim/src/test/java/org/matsim/core/controler/corelisteners/ListenersInjectionTest.java
@@ -25,9 +25,13 @@ import org.junit.Test;
 import org.matsim.analysis.IterationStopWatch;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
-import org.matsim.core.controler.*;
 import org.matsim.core.controler.AbstractModule;
+import org.matsim.core.controler.ControlerDefaultsModule;
+import org.matsim.core.controler.ControlerListenerManager;
+import org.matsim.core.controler.ControlerListenerManagerImpl;
 import org.matsim.core.controler.Injector;
+import org.matsim.core.controler.IterationCounter;
+import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.core.controler.listener.ControlerListener;
 import org.matsim.core.scenario.ScenarioByInstanceModule;
 import org.matsim.core.scenario.ScenarioUtils;
@@ -78,12 +82,15 @@ public class ListenersInjectionTest {
                 new AbstractModule() {
                     @Override
                     public void install() {
-                        // put dummy dependencies to get the listenners happy
+						// put dummy dependencies to get the listenners happy
 						bind(ControlerListenerManager.class).to(ControlerListenerManagerImpl.class);
-						bind(OutputDirectoryHierarchy.class).toInstance( new OutputDirectoryHierarchy( outputDir , OutputDirectoryHierarchy.OverwriteFileSetting.deleteDirectoryIfExists, config.controler().getCompressionType() ) );
-						bind(IterationStopWatch.class).toInstance( new IterationStopWatch() );
+						bind(OutputDirectoryHierarchy.class).toInstance(new OutputDirectoryHierarchy(outputDir,
+								OutputDirectoryHierarchy.OverwriteFileSetting.deleteDirectoryIfExists,
+								config.controler().getCompressionType()));
+						bind(IterationStopWatch.class).toInstance(new IterationStopWatch());
+						bind(IterationCounter.class).toInstance(() -> 0);
 						install(new ScenarioByInstanceModule(ScenarioUtils.createScenario(config)));
-                    }
+					}
                 },
 				new ControlerDefaultCoreListenersModule());
 


### PR DESCRIPTION
Background:
- Some parameters in configs define iteration-specific behaviour of MATSim (e.g. do something only in certain iterations)
- mobsim (guice) modules are installed anew while instantiating a mobsim in each iteration, the scope of injection is one mobsim simulation

Providing the current iteration number to mobsim modules will add a context for interpreting the config (which is already available to mobsim modules) and simplify implementing a conditional behaviour, like switching on/off certain mobsim components/features depending on the iteration number.

Possible first application: switching off the vrp optimiser to speedup the mobsim (passengers are teleported instead). Currently this behaviour is hacked by replacing drt legs in plans before mobsim starts (https://github.com/matsim-vsp/drt-speed-up)
