### PR TITLE
dump out dvrp fleet at shutdown

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/FleetControlerListener.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/FleetControlerListener.java
@@ -1,0 +1,45 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * Controler.java
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2007 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.dvrp.fleet;
+
+import org.matsim.core.controler.OutputDirectoryHierarchy;
+import org.matsim.core.controler.events.ShutdownEvent;
+import org.matsim.core.controler.listener.ShutdownListener;
+
+class FleetControlerListener implements ShutdownListener {
+
+	private static final String OUTPUT_FILE_NAME = "_vehicles.xml.gz";
+	private final OutputDirectoryHierarchy controlerIO;
+	private FleetSpecification fleetSpecification;
+	private final String mode;
+
+	FleetControlerListener(String mode, OutputDirectoryHierarchy controlerIO, FleetSpecification fleetSpecification) {
+		this.mode = mode;
+		this.controlerIO = controlerIO;
+		this.fleetSpecification = fleetSpecification;
+	}
+
+	@Override
+	public void notifyShutdown(ShutdownEvent event) {
+		FleetWriter writer = new FleetWriter(fleetSpecification.getVehicleSpecifications().values().stream());
+		writer.write(controlerIO.getOutputFilename(mode + "_" +  OUTPUT_FILE_NAME));
+	}
+}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/FleetModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/FleetModule.java
@@ -22,11 +22,13 @@ package org.matsim.contrib.dvrp.fleet;
 
 import java.net.URL;
 
+import com.google.inject.Singleton;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.ModalProviders;
 import org.matsim.contrib.dvrp.run.QSimScopeObjectListenerModule;
+import org.matsim.core.controler.OutputDirectoryHierarchy;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -70,5 +72,11 @@ public class FleetModule extends AbstractDvrpModeModule {
 							getter -> new VehicleStartLinkToLastLinkUpdater(getter.getModal(FleetSpecification.class)))
 					.build());
 		}
+
+		bindModal(FleetControlerListener.class).toProvider(modalProvider(getter ->
+				new FleetControlerListener(getMode(),
+						getter.get(OutputDirectoryHierarchy.class),
+						getter.getModal(FleetSpecification.class)))).in(Singleton.class);
+		addControlerListenerBinding().to(modalKey(FleetControlerListener.class));
 	}
 }


### PR DESCRIPTION
Dump out resulting dvrp fleet (which is possibly subject to change over iterations) at the end of the simulation.
See also https://github.com/matsim-vsp/opt-drt/issues/3

