### PR TITLE
Integrate drt speedup into drt

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/PreviousIterationDRTDemandEstimator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/PreviousIterationDRTDemandEstimator.java
@@ -49,7 +49,6 @@ public final class PreviousIterationDRTDemandEstimator implements ZonalDemandEst
 
 	private final DrtZonalSystem zonalSystem;
 	private final String mode;
-	private final String drtSpeedUpMode;
 	private final int timeBinSize;
 	private Map<Integer, Map<DrtZone, MutableInt>> currentIterationDepartures = new HashMap<>();
 	private Map<Integer, Map<DrtZone, MutableInt>> previousIterationDepartures = new HashMap<>();
@@ -58,7 +57,6 @@ public final class PreviousIterationDRTDemandEstimator implements ZonalDemandEst
 			int demandEstimationPeriod) {
 		this.zonalSystem = zonalSystem;
 		mode = drtCfg.getMode();
-		drtSpeedUpMode = drtCfg.getDrtSpeedUpMode();
 		timeBinSize = demandEstimationPeriod;
 	}
 
@@ -70,7 +68,7 @@ public final class PreviousIterationDRTDemandEstimator implements ZonalDemandEst
 
 	@Override
 	public void handleEvent(PersonDepartureEvent event) {
-		if (event.getLegMode().equals(mode) || event.getLegMode().equals(drtSpeedUpMode)) {
+		if (event.getLegMode().equals(mode)) {
 			DrtZone zone = zonalSystem.getZoneForLinkId(event.getLinkId());
 			if (zone == null) {
 				//might be that somebody walks into the service area or that service area is larger/different than DrtZonalSystem...

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -42,6 +42,7 @@ import org.matsim.contrib.drt.optimizer.insertion.ExtensiveInsertionSearchParams
 import org.matsim.contrib.drt.optimizer.insertion.SelectiveInsertionSearchParams;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingParams;
 import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingStrategyParams;
+import org.matsim.contrib.drt.speedup.DrtSpeedUpParams;
 import org.matsim.contrib.dvrp.router.DvrpModeRoutingNetworkModule;
 import org.matsim.contrib.dvrp.run.Modal;
 import org.matsim.contrib.util.ReflectiveConfigGroupWithConfigurableParameterSets;
@@ -220,6 +221,9 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 	@Nullable
 	private DrtFareParams drtFareParams;
 
+	@Nullable
+	private DrtSpeedUpParams drtSpeedUpParams;
+
 	@NotNull
 	private String drtSpeedUpMode = "";
 
@@ -248,6 +252,10 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 		//drt fare
 		addDefinition(DrtFareParams.SET_NAME, DrtFareParams::new, () -> drtFareParams,
 				params -> drtFareParams = (DrtFareParams)params);
+
+		//drt speedup
+		addDefinition(DrtSpeedUpParams.SET_NAME, DrtSpeedUpParams::new, () -> drtSpeedUpParams,
+				params -> drtSpeedUpParams = (DrtSpeedUpParams)params);
 	}
 
 	@Override
@@ -685,5 +693,9 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 
 	public Optional<DrtFareParams> getDrtFareParams() {
 		return Optional.ofNullable(drtFareParams);
+	}
+
+	public Optional<DrtSpeedUpParams> getDrtSpeedUpParams() {
+		return Optional.ofNullable(drtSpeedUpParams);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -147,9 +147,6 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 					+ " Scales well up to 4, due to path data provision, the most computationally intensive part,"
 					+ " using up to 4 threads. Default value is 'min(4, no. of cores available to JVM)'";
 
-	public static final String DRT_SPEED_UP_MODE = "drtSpeedUpMode";
-	static final String DRT_SPEED_UP_MODE_EXP = "For PreviousIterationZonalDemandAggregator in rebalancing to work properly with the drt-speed-up module, also departures of the speed-up mode must be considered as drt mode departures. Set to the empty String \"\" if not using drt-speed-up (the default). Drt-speed-up module should set this automatically if used.";
-
 	@NotBlank
 	private String mode = TransportMode.drt; // travel mode (passengers'/customers' perspective)
 
@@ -223,9 +220,6 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 
 	@Nullable
 	private DrtSpeedUpParams drtSpeedUpParams;
-
-	@NotNull
-	private String drtSpeedUpMode = "";
 
 	public DrtConfigGroup() {
 		super(GROUP_NAME);
@@ -332,7 +326,6 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 		map.put(REJECT_REQUEST_IF_MAX_WAIT_OR_TRAVEL_TIME_VIOLATED,
 				REJECT_REQUEST_IF_MAX_WAIT_OR_TRAVEL_TIME_VIOLATED_EXP);
 		map.put(DRT_SERVICE_AREA_SHAPE_FILE, DRT_SERVICE_AREA_SHAPE_FILE_EXP);
-		map.put(DRT_SPEED_UP_MODE, DRT_SPEED_UP_MODE_EXP);
 		return map;
 	}
 
@@ -660,14 +653,6 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 	public DrtConfigGroup setNumberOfThreads(final int numberOfThreads) {
 		this.numberOfThreads = numberOfThreads;
 		return this;
-	}
-
-	public String getDrtSpeedUpMode() {
-		return drtSpeedUpMode;
-	}
-
-	public void setDrtSpeedUpMode(String drtSpeedUpMode) {
-		this.drtSpeedUpMode = drtSpeedUpMode;
 	}
 
 	public double getAdvanceRequestPlanningHorizon() {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -164,9 +164,9 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 
 		drtCfg.getDrtSpeedUpParams().ifPresent(drtSpeedUpParams -> {
 			bindModal(DrtSpeedUp.class).toProvider(modalProvider(
-					getter -> new DrtSpeedUp(getMode(), drtSpeedUpParams, getConfig(), getter.get(Network.class),
-							getter.getModal(FleetSpecification.class), getter.getModal(DrtRequestAnalyzer.class))))
-					.asEagerSingleton();
+					getter -> new DrtSpeedUp(getMode(), drtSpeedUpParams, getConfig().controler(),
+							getter.get(Network.class), getter.getModal(FleetSpecification.class),
+							getter.getModal(DrtRequestAnalyzer.class)))).asEagerSingleton();
 			addControlerListenerBinding().to(modalKey(DrtSpeedUp.class));
 		});
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -28,6 +28,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Population;
+import org.matsim.contrib.drt.analysis.DrtRequestAnalyzer;
 import org.matsim.contrib.drt.analysis.zonal.DrtModeZonalSystemModule;
 import org.matsim.contrib.drt.fare.DrtFareHandler;
 import org.matsim.contrib.drt.optimizer.rebalancing.Feedforward.DrtModeFeedforwardRebalanceModule;
@@ -45,7 +46,9 @@ import org.matsim.contrib.drt.routing.DrtRouteUpdater;
 import org.matsim.contrib.drt.routing.DrtStopFacility;
 import org.matsim.contrib.drt.routing.DrtStopFacilityImpl;
 import org.matsim.contrib.drt.routing.DrtStopNetwork;
+import org.matsim.contrib.drt.speedup.DrtSpeedUp;
 import org.matsim.contrib.dvrp.fleet.FleetModule;
+import org.matsim.contrib.dvrp.fleet.FleetSpecification;
 import org.matsim.contrib.dvrp.router.ClosestAccessEgressFacilityFinder;
 import org.matsim.contrib.dvrp.router.DecideOnLinkAccessEgressFacilityFinder;
 import org.matsim.contrib.dvrp.router.DefaultMainLegRouter;
@@ -158,6 +161,14 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 
 		drtCfg.getDrtFareParams()
 				.ifPresent(params -> addEventHandlerBinding().toInstance(new DrtFareHandler(getMode(), params)));
+
+		drtCfg.getDrtSpeedUpParams().ifPresent(drtSpeedUpParams -> {
+			bindModal(DrtSpeedUp.class).toProvider(modalProvider(
+					getter -> new DrtSpeedUp(getMode(), drtSpeedUpParams, getConfig(), getter.get(Network.class),
+							getter.getModal(FleetSpecification.class), getter.getModal(DrtRequestAnalyzer.class))))
+					.asEagerSingleton();
+			addControlerListenerBinding().to(modalKey(DrtSpeedUp.class));
+		});
 	}
 
 	private static class DrtRouteCreatorProvider extends ModalProviders.AbstractProvider<DrtRouteCreator> {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/speedup/DrtSpeedUp.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/speedup/DrtSpeedUp.java
@@ -90,6 +90,10 @@ public final class DrtSpeedUp implements IterationStartsListener, IterationEndsL
 		currentAvgInVehicleBeelineSpeed = drtSpeedUpParams.getInitialInVehicleBeelineSpeed();
 	}
 
+	public DrtTeleportedRouteCalculator createTeleportedRouteCalculator() {
+		return new DrtTeleportedRouteCalculator(currentAvgWaitingTime, currentAvgInVehicleBeelineSpeed);
+	}
+
 	@Override
 	public void notifyIterationStarts(IterationStartsEvent event) {
 		int iteration = event.getIteration();

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/speedup/DrtSpeedUp.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/speedup/DrtSpeedUp.java
@@ -189,9 +189,6 @@ public final class DrtSpeedUp implements IterationStartsListener, IterationEndsL
 			double waitTime = pickupTime - sequence.getSubmitted().getTime();
 			double rideTime = sequence.getDroppedOff().get().getTime() - pickupTime;
 
-			//TODO do we need these checks?
-			Preconditions.checkState(rideTime > 0);
-			Preconditions.checkState(beelineDistance > 0);
 			//TODO I would map unshared_ride_time to rideTime -- should be more precise
 			meanInVehicleBeelineSpeed.increment(beelineDistance / rideTime);
 			meanWaitTime.increment(waitTime);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/speedup/DrtSpeedUp.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/speedup/DrtSpeedUp.java
@@ -1,0 +1,236 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.speedup;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.math3.stat.descriptive.moment.Mean;
+import org.apache.commons.math3.stat.regression.SimpleRegression;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.drt.analysis.DrtRequestAnalyzer;
+import org.matsim.contrib.drt.passenger.events.DrtRequestSubmittedEvent;
+import org.matsim.contrib.dvrp.fleet.FleetSpecification;
+import org.matsim.contrib.util.distance.DistanceUtils;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.groups.ControlerConfigGroup;
+import org.matsim.core.controler.events.IterationEndsEvent;
+import org.matsim.core.controler.events.IterationStartsEvent;
+import org.matsim.core.controler.listener.IterationEndsListener;
+import org.matsim.core.controler.listener.IterationStartsListener;
+import org.matsim.core.utils.collections.Tuple;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * @author ikaddoura
+ * @author michalm (Michal Maciejewski)
+ */
+public final class DrtSpeedUp implements IterationStartsListener, IterationEndsListener {
+	private static final Logger log = LogManager.getLogger(DrtSpeedUp.class);
+
+	public static boolean isTeleportDrtUsers(DrtSpeedUpParams drtSpeedUpParams, ControlerConfigGroup controlerConfig,
+			int iteration) {
+		int lastIteration = controlerConfig.getLastIteration();
+		if (iteration < drtSpeedUpParams.getFractionOfIterationsSwitchOn() * lastIteration
+				|| iteration >= drtSpeedUpParams.getFractionOfIterationsSwitchOff() * lastIteration) {
+			return false; // full drt simulation
+		} else {
+			//full drt simulation only with a defined interval
+			return iteration % drtSpeedUpParams.getIntervalDetailedIteration() != 0;
+		}
+	}
+
+	private final String mode;
+	private final DrtSpeedUpParams drtSpeedUpParams;
+	private final Config config;
+	private final Network network;
+	private final FleetSpecification fleetSpecification;
+	private final DrtRequestAnalyzer drtRequestAnalyzer;
+
+	private final List<Tuple<Double, Double>> ridesPerVehicle2avgWaitingTime = new ArrayList<>();
+	private final List<Double> averageWaitingTimes = new ArrayList<>();
+	private final List<Double> averageInVehicleBeelineSpeeds = new ArrayList<>();
+
+	private double currentAvgWaitingTime;
+	private double currentAvgInVehicleBeelineSpeed;
+	private boolean teleportDrtUsers;
+
+	public DrtSpeedUp(String mode, DrtSpeedUpParams drtSpeedUpParams, Config config, Network network,
+			FleetSpecification fleetSpecification, DrtRequestAnalyzer drtRequestAnalyzer) {
+		this.mode = mode;
+		this.drtSpeedUpParams = drtSpeedUpParams;
+		this.config = config;
+		this.network = network;
+		this.fleetSpecification = fleetSpecification;
+		this.drtRequestAnalyzer = drtRequestAnalyzer;
+
+		currentAvgWaitingTime = drtSpeedUpParams.getInitialWaitingTime();
+		currentAvgInVehicleBeelineSpeed = drtSpeedUpParams.getInitialInVehicleBeelineSpeed();
+	}
+
+	@Override
+	public void notifyIterationStarts(IterationStartsEvent event) {
+		int iteration = event.getIteration();
+		teleportDrtUsers = isTeleportDrtUsers(drtSpeedUpParams, config.controler(), iteration);
+		if (teleportDrtUsers) {
+			log.info(
+					"Teleporting {} users in iteration {}. Current teleported mode speed: {}. Current waiting time: {}",
+					mode, iteration, currentAvgInVehicleBeelineSpeed, currentAvgWaitingTime);
+		} else {
+			log.info("Simulating {} in iteration {}", mode, iteration);
+		}
+	}
+
+	@Override
+	public void notifyIterationEnds(IterationEndsEvent event) {
+		int iteration = event.getIteration();
+		if (iteration < drtSpeedUpParams.getFirstSimulatedDrtIterationToReplaceInitialDrtPerformanceParams()) {
+			String type = teleportDrtUsers ? "teleported" : "simulated";
+			log.info("Number of {} {} trips: {}", type, mode, completedTripCount());
+		} else {
+			if (teleportDrtUsers) {
+				postprocessTeleportedDrtTrips();
+			} else {
+				postprocessSimulatedDrtTrips();
+			}
+		}
+	}
+
+	private int completedTripCount() {
+		return (int)drtRequestAnalyzer.getPerformedRequestSequences()
+				.values()
+				.stream()
+				.filter(DrtRequestAnalyzer.PerformedRequestEventSequence::isCompleted)
+				.count();
+	}
+
+	private void postprocessSimulatedDrtTrips() {
+		SimulatedTripStats tripStats = computeSimulatedTripStats();
+		log.info("Number of simulated " + mode + " trips: " + tripStats.count);
+
+		// store additional information
+		averageWaitingTimes.add(tripStats.averageWaitTime);
+		averageInVehicleBeelineSpeeds.add(tripStats.averageInVehicleBeelineSpeed);
+
+		double movingAverageWaitingTime = computeMovingAverage(drtSpeedUpParams.getMovingAverageSize(),
+				averageWaitingTimes);
+		log.info("Setting waiting time for {} to: {} (previous value: {})", mode, movingAverageWaitingTime,
+				currentAvgWaitingTime);
+		currentAvgWaitingTime = movingAverageWaitingTime;
+
+		double movingAverageInVehicleBeelineSpeed = computeMovingAverage(drtSpeedUpParams.getMovingAverageSize(),
+				averageInVehicleBeelineSpeeds);
+		log.info("Setting in-vehicle beeline speed for {} to: {} (previous value: {})", mode,
+				movingAverageInVehicleBeelineSpeed, currentAvgInVehicleBeelineSpeed);
+		currentAvgInVehicleBeelineSpeed = movingAverageInVehicleBeelineSpeed;
+
+		if (drtSpeedUpParams.getWaitingTimeUpdateDuringSpeedUp()
+				== DrtSpeedUpParams.WaitingTimeUpdateDuringSpeedUp.LinearRegression) {
+			// store some additional statistics
+			double fleetSize = fleetSpecification.getVehicleSpecifications().size();
+			Preconditions.checkState(fleetSize < 1, "No vehicles for drt mode %s. Aborting...", mode);
+			double ridesPerVehicle = tripStats.count / fleetSize;
+			ridesPerVehicle2avgWaitingTime.add(new Tuple<>(ridesPerVehicle, currentAvgWaitingTime));
+		}
+	}
+
+	private static class SimulatedTripStats {
+		private final int count;
+		private final double averageInVehicleBeelineSpeed;
+		private final double averageWaitTime;
+
+		private SimulatedTripStats(int count, double averageInVehicleBeelineSpeed, double averageWaitTime) {
+			this.count = count;
+			this.averageInVehicleBeelineSpeed = averageInVehicleBeelineSpeed;
+			this.averageWaitTime = averageWaitTime;
+		}
+	}
+
+	private SimulatedTripStats computeSimulatedTripStats() {
+		Mean meanInVehicleBeelineSpeed = new Mean();
+		Mean meanWaitTime = new Mean();
+
+		for (var sequence : drtRequestAnalyzer.getPerformedRequestSequences().values()) {
+			if (!sequence.isCompleted()) {
+				continue;//skip incomplete sequences
+			}
+			DrtRequestSubmittedEvent submittedEvent = sequence.getSubmitted();
+
+			Link depLink = network.getLinks().get(submittedEvent.getFromLinkId());
+			Link arrLink = network.getLinks().get(submittedEvent.getToLinkId());
+			double beelineDistance = DistanceUtils.calculateDistance(depLink, arrLink);
+
+			double pickupTime = sequence.getPickedUp().get().getTime();
+			double waitTime = pickupTime - sequence.getSubmitted().getTime();
+			double rideTime = sequence.getDroppedOff().get().getTime() - pickupTime;
+
+			//TODO do we need these checks?
+			Preconditions.checkState(rideTime > 0);
+			Preconditions.checkState(beelineDistance > 0);
+			//TODO I would map unshared_ride_time to rideTime -- should be more precise
+			meanInVehicleBeelineSpeed.increment(beelineDistance / rideTime);
+			meanWaitTime.increment(waitTime);
+		}
+
+		int count = (int)meanWaitTime.getN();
+		return new SimulatedTripStats(count,
+				count == 0 ? drtSpeedUpParams.getInitialInVehicleBeelineSpeed() : meanInVehicleBeelineSpeed.getResult(),
+				count == 0 ? drtSpeedUpParams.getInitialWaitingTime() : meanWaitTime.getResult());
+	}
+
+	static double computeMovingAverage(int movingAverageSize, List<Double> values) {
+		int startIndex = Math.max(0, values.size() - movingAverageSize);
+		return values.subList(startIndex, values.size()).stream().mapToDouble(v -> v).average().orElseThrow();
+	}
+
+	private void postprocessTeleportedDrtTrips() {
+		if (drtSpeedUpParams.getWaitingTimeUpdateDuringSpeedUp()
+				== DrtSpeedUpParams.WaitingTimeUpdateDuringSpeedUp.LinearRegression) {
+			int tripCount = completedTripCount();
+			SimpleRegression regression = new SimpleRegression();
+			for (Tuple<Double, Double> x2y : ridesPerVehicle2avgWaitingTime) {
+				regression.addData(x2y.getFirst(), x2y.getSecond());
+			}
+
+			log.info("Current data points for {}: {}", mode, ridesPerVehicle2avgWaitingTime.toString());
+			double fleetSize = fleetSpecification.getVehicleSpecifications().size();
+			Preconditions.checkState(fleetSize < 1, "No vehicles for drt mode %s. Aborting...", mode);
+			log.info("Current fleet size for {}: {}", mode, fleetSize);
+			double predictedWaitingTime = regression.predict(tripCount / fleetSize);
+			log.info("Predicted average waiting time for {}: {}", mode, predictedWaitingTime);
+
+			if (Double.isNaN(predictedWaitingTime)) {
+				log.info("Not enough data points for linear regression. Not updating the average waiting time!");
+			} else if (predictedWaitingTime <= 0.) {
+				log.info(
+						"Predicted average waiting from linear regression is negative. Not updating the average waiting time!");
+			} else {
+				log.info("Setting waiting time for {} to: {} (previous value: {})", mode, predictedWaitingTime,
+						currentAvgWaitingTime);
+				currentAvgWaitingTime = predictedWaitingTime;
+			}
+		}
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/speedup/DrtSpeedUpParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/speedup/DrtSpeedUpParams.java
@@ -1,0 +1,171 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.speedup;
+
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ReflectiveConfigGroup;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * @author ikaddoura
+ */
+public class DrtSpeedUpParams extends ReflectiveConfigGroup {
+	public static final String SET_NAME = "drtSpeedUp";
+
+	private static final String SWITCH_OFF_FRACTION_ITERATION = "fractionOfIterationsSwitchOff";
+	private static final String SWITCH_ON_FRACTION_ITERATION = "fractionOfIterationsSwitchOn";
+	private static final String DETAILED_ITERATION_INTERVAL = "intervalDetailedIteration";
+	private static final String INITIAL_WAITING_TIME = "initialWaitingTime";
+	private static final String INITIAL_IN_VEHICLE_BEELINE_SPEED = "initialInVehicleBeelineSpeed";
+	private static final String FIRST_SIMULATED_DRT_ITERATION_TO_REPLACE_INITIAL_DRT_PERFORMANCE_PARAMS = "firstSimulatedDrtIterationToReplaceInitialDrtPerformanceParams";
+	private static final String WAITING_TIME_UPDATE_DURING_SPEED_UP = "waitingTimeUpdateDuringSpeedUp";
+	private static final String MOVING_AVERAGE_SIZE = "movingAverageSize";
+
+	public DrtSpeedUpParams() {
+		super(SET_NAME);
+	}
+
+	@DecimalMin("0.0")
+	@DecimalMax("1.0")
+	private double fractionOfIterationsSwitchOff = 0.99;
+
+	@DecimalMin("0.0")
+	@DecimalMax("1.0")
+	private double fractionOfIterationsSwitchOn = 0.;
+
+	@Positive
+	private int intervalDetailedIteration = 10;
+
+	@PositiveOrZero
+	private double initialWaitingTime = 900.;
+	@Positive
+	private double initialInVehicleBeelineSpeed = 4.16667;
+	@PositiveOrZero
+	private int firstSimulatedDrtIterationToReplaceInitialDrtPerformanceParams = 0;
+
+	@NotNull
+	private WaitingTimeUpdateDuringSpeedUp waitingTimeUpdateDuringSpeedUp = WaitingTimeUpdateDuringSpeedUp.Disabled;
+
+	@Positive
+	private int movingAverageSize = 1;
+
+	public enum WaitingTimeUpdateDuringSpeedUp {
+		Disabled, LinearRegression
+	}
+
+	@Override
+	protected void checkConsistency(Config config) {
+		super.checkConsistency(config);
+
+		Preconditions.checkArgument(fractionOfIterationsSwitchOn <= fractionOfIterationsSwitchOff,
+				"fractionOfIterationsSwitchOn (%s) must be less than or equal to fractionOfIterationsSwitchOff (%s)",
+				fractionOfIterationsSwitchOn, fractionOfIterationsSwitchOff);
+	}
+
+	@StringGetter(SWITCH_OFF_FRACTION_ITERATION)
+	public double getFractionOfIterationsSwitchOff() {
+		return fractionOfIterationsSwitchOff;
+	}
+
+	@StringSetter(SWITCH_OFF_FRACTION_ITERATION)
+	public void setFractionOfIterationsSwitchOff(double fractionOfIterationsSwitchOff) {
+		this.fractionOfIterationsSwitchOff = fractionOfIterationsSwitchOff;
+	}
+
+	@StringGetter(SWITCH_ON_FRACTION_ITERATION)
+	public double getFractionOfIterationsSwitchOn() {
+		return fractionOfIterationsSwitchOn;
+	}
+
+	@StringSetter(SWITCH_ON_FRACTION_ITERATION)
+	public void setFractionOfIterationsSwitchOn(double fractionOfIterationsSwitchOn) {
+		this.fractionOfIterationsSwitchOn = fractionOfIterationsSwitchOn;
+	}
+
+	@StringGetter(DETAILED_ITERATION_INTERVAL)
+	public int getIntervalDetailedIteration() {
+		return intervalDetailedIteration;
+	}
+
+	@StringSetter(DETAILED_ITERATION_INTERVAL)
+	public void setIntervalDetailedIteration(int intervalDetailedIteration) {
+		this.intervalDetailedIteration = intervalDetailedIteration;
+	}
+
+	@StringGetter(INITIAL_WAITING_TIME)
+	public double getInitialWaitingTime() {
+		return initialWaitingTime;
+	}
+
+	@StringSetter(INITIAL_WAITING_TIME)
+	public void setInitialWaitingTime(double initialWaitingTime) {
+		this.initialWaitingTime = initialWaitingTime;
+	}
+
+	@StringGetter(INITIAL_IN_VEHICLE_BEELINE_SPEED)
+	public double getInitialInVehicleBeelineSpeed() {
+		return initialInVehicleBeelineSpeed;
+	}
+
+	@StringSetter(INITIAL_IN_VEHICLE_BEELINE_SPEED)
+	public void setInitialInVehicleBeelineSpeed(double initialInVehicleBeelineSpeed) {
+		this.initialInVehicleBeelineSpeed = initialInVehicleBeelineSpeed;
+	}
+
+	@StringGetter(FIRST_SIMULATED_DRT_ITERATION_TO_REPLACE_INITIAL_DRT_PERFORMANCE_PARAMS)
+	public int getFirstSimulatedDrtIterationToReplaceInitialDrtPerformanceParams() {
+		return firstSimulatedDrtIterationToReplaceInitialDrtPerformanceParams;
+	}
+
+	@StringSetter(FIRST_SIMULATED_DRT_ITERATION_TO_REPLACE_INITIAL_DRT_PERFORMANCE_PARAMS)
+	public void setFirstSimulatedDrtIterationToReplaceInitialDrtPerformanceParams(
+			int firstSimulatedDrtIterationToReplaceInitialDrtPerformanceParams) {
+		this.firstSimulatedDrtIterationToReplaceInitialDrtPerformanceParams = firstSimulatedDrtIterationToReplaceInitialDrtPerformanceParams;
+	}
+
+	@StringGetter(WAITING_TIME_UPDATE_DURING_SPEED_UP)
+	public WaitingTimeUpdateDuringSpeedUp getWaitingTimeUpdateDuringSpeedUp() {
+		return waitingTimeUpdateDuringSpeedUp;
+	}
+
+	@StringSetter(WAITING_TIME_UPDATE_DURING_SPEED_UP)
+	public void setWaitingTimeUpdateDuringSpeedUp(WaitingTimeUpdateDuringSpeedUp waitingTimeUpdateDuringSpeedUp) {
+		this.waitingTimeUpdateDuringSpeedUp = waitingTimeUpdateDuringSpeedUp;
+	}
+
+	@StringGetter(MOVING_AVERAGE_SIZE)
+	public int getMovingAverageSize() {
+		return movingAverageSize;
+	}
+
+	@StringSetter(MOVING_AVERAGE_SIZE)
+	public void setMovingAverageSize(int movingAverageSize) {
+		this.movingAverageSize = movingAverageSize;
+	}
+}
+

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/speedup/DrtTeleportedRouteCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/speedup/DrtTeleportedRouteCalculator.java
@@ -1,0 +1,59 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.speedup;
+
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.population.Route;
+import org.matsim.contrib.dvrp.passenger.PassengerRequest;
+import org.matsim.contrib.dvrp.passenger.TeleportingPassengerEngine.TeleportedRouteCalculator;
+import org.matsim.core.population.routes.GenericRouteImpl;
+import org.matsim.core.utils.geometry.CoordUtils;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class DrtTeleportedRouteCalculator implements TeleportedRouteCalculator {
+	private final double averageWaitingTime;
+	private final double averageInVehicleBeelineSpeed;
+
+	DrtTeleportedRouteCalculator(double averageWaitingTime, double averageInVehicleBeelineSpeed) {
+		this.averageWaitingTime = averageWaitingTime;
+		this.averageInVehicleBeelineSpeed = averageInVehicleBeelineSpeed;
+	}
+
+	@Override
+	public Route calculateRoute(PassengerRequest request) {
+		Link startLink = request.getFromLink();
+		Link endLink = request.getToLink();
+		final Coord fromActCoord = Preconditions.checkNotNull(startLink.getCoord());
+		final Coord toActCoord = Preconditions.checkNotNull(endLink.getCoord());
+		double dist = CoordUtils.calcEuclideanDistance(fromActCoord, toActCoord);
+		Route route = new GenericRouteImpl(startLink.getId(), endLink.getId());
+		//TODO move wait time outside the route (handle it explicitly by the TeleportingPassengerEngine)
+		int travTime = (int)(averageWaitingTime + (dist / averageInVehicleBeelineSpeed));
+		route.setTravelTime(travTime);
+		route.setDistance(dist);
+		return route;
+	}
+}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/PreviousIterationDRTDemandEstimatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/PreviousIterationDRTDemandEstimatorTest.java
@@ -41,7 +41,6 @@ import org.matsim.testcases.fakes.FakeLink;
  */
 public class PreviousIterationDRTDemandEstimatorTest {
 
-	private static final String DRT_SPEEDUP = "drt_speedup";
 	private static final int ESTIMATION_PERIOD = 1800;
 
 	private final Link link1 = new FakeLink(Id.createLinkId("link_1"));
@@ -72,16 +71,16 @@ public class PreviousIterationDRTDemandEstimatorTest {
 
 		//time bin 0-1800
 		estimator.handleEvent(departureEvent(100, link1, TransportMode.drt));
-		estimator.handleEvent(departureEvent(200, link1, DRT_SPEEDUP));
+		estimator.handleEvent(departureEvent(200, link1, TransportMode.drt));
 		estimator.handleEvent(departureEvent(500, link2, TransportMode.drt));
 		estimator.handleEvent(departureEvent(1500, link1, TransportMode.drt));
 		//time bin 1800-3600
-		estimator.handleEvent(departureEvent(2500, link1, DRT_SPEEDUP));
+		estimator.handleEvent(departureEvent(2500, link1, TransportMode.drt));
 		//time bin 3600-5400
 		estimator.handleEvent(departureEvent(4000, link2, TransportMode.drt));
 		//time bin 5400-7200
 		estimator.handleEvent(departureEvent(7000, link1, TransportMode.drt));
-		estimator.handleEvent(departureEvent(7100, link2, DRT_SPEEDUP));
+		estimator.handleEvent(departureEvent(7100, link2, TransportMode.drt));
 		estimator.reset(1);
 
 		//time bin 0-1800
@@ -117,7 +116,7 @@ public class PreviousIterationDRTDemandEstimatorTest {
 	public void currentCountsAreCopiedToPreviousAfterReset() {
 		PreviousIterationDRTDemandEstimator estimator = createEstimator();
 
-		estimator.handleEvent(departureEvent(100, link1, DRT_SPEEDUP));
+		estimator.handleEvent(departureEvent(100, link1, TransportMode.drt));
 		estimator.handleEvent(departureEvent(200, link2, TransportMode.drt));
 
 		assertDemand(estimator, 0, zone1, 0);
@@ -133,7 +132,7 @@ public class PreviousIterationDRTDemandEstimatorTest {
 	public void timeBinsAreRespected() {
 		PreviousIterationDRTDemandEstimator estimator = createEstimator();
 
-		estimator.handleEvent(departureEvent(100, link1, DRT_SPEEDUP));
+		estimator.handleEvent(departureEvent(100, link1, TransportMode.drt));
 		estimator.handleEvent(departureEvent(2200, link2, TransportMode.drt));
 		estimator.reset(1);
 
@@ -151,7 +150,7 @@ public class PreviousIterationDRTDemandEstimatorTest {
 	public void noTimeLimitIsImposed() {
 		PreviousIterationDRTDemandEstimator estimator = createEstimator();
 
-		estimator.handleEvent(departureEvent(10000000, link1, DRT_SPEEDUP));
+		estimator.handleEvent(departureEvent(10000000, link1, TransportMode.drt));
 		estimator.reset(1);
 
 		assertDemand(estimator, 10000000, zone1, 1);
@@ -162,7 +161,6 @@ public class PreviousIterationDRTDemandEstimatorTest {
 		rebalancingParams.setInterval(ESTIMATION_PERIOD);
 
 		DrtConfigGroup drtConfigGroup = new DrtConfigGroup();
-		drtConfigGroup.setDrtSpeedUpMode(DRT_SPEEDUP);
 		drtConfigGroup.addParameterSet(rebalancingParams);
 
 		return new PreviousIterationDRTDemandEstimator(zonalSystem, drtConfigGroup, ESTIMATION_PERIOD);

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/speedup/DrtSpeedUpTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/speedup/DrtSpeedUpTest.java
@@ -1,0 +1,71 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.speedup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.matsim.contrib.drt.speedup.DrtSpeedUp.computeMovingAverage;
+import static org.matsim.contrib.drt.speedup.DrtSpeedUp.isTeleportDrtUsers;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.matsim.core.config.groups.ControlerConfigGroup;
+
+/**
+ * @author ikaddoura
+ * @author michalm (Michal Maciejewski)
+ */
+public class DrtSpeedUpTest {
+	@Test
+	public final void test_computeMovingAverage() {
+		List<Double> list = List.of(2., 5., 22.);
+		assertThat(computeMovingAverage(2, list)).isEqualTo(27. / 2);
+		assertThat(computeMovingAverage(3, list)).isEqualTo(29. / 3);
+		assertThat(computeMovingAverage(4, list)).isEqualTo(29. / 3);
+	}
+
+	@Test
+	public void test_isTeleportDrtUsers() {
+		DrtSpeedUpParams drtSpeedUpParams = new DrtSpeedUpParams();
+		drtSpeedUpParams.setFractionOfIterationsSwitchOn(0.1);
+		drtSpeedUpParams.setFractionOfIterationsSwitchOff(0.9);
+		drtSpeedUpParams.setIntervalDetailedIteration(10);
+
+		ControlerConfigGroup controlerConfig = new ControlerConfigGroup();
+		controlerConfig.setLastIteration(100);
+
+		assertThat(isTeleportDrtUsers(drtSpeedUpParams, controlerConfig, 0)).isFalse();
+
+		assertThat(isTeleportDrtUsers(drtSpeedUpParams, controlerConfig, 9)).isFalse();
+		assertThat(isTeleportDrtUsers(drtSpeedUpParams, controlerConfig, 10)).isFalse();
+		assertThat(isTeleportDrtUsers(drtSpeedUpParams, controlerConfig, 11)).isTrue();
+
+		assertThat(isTeleportDrtUsers(drtSpeedUpParams, controlerConfig, 49)).isTrue();
+		assertThat(isTeleportDrtUsers(drtSpeedUpParams, controlerConfig, 50)).isFalse();
+		assertThat(isTeleportDrtUsers(drtSpeedUpParams, controlerConfig, 51)).isTrue();
+
+		assertThat(isTeleportDrtUsers(drtSpeedUpParams, controlerConfig, 89)).isTrue();
+		assertThat(isTeleportDrtUsers(drtSpeedUpParams, controlerConfig, 90)).isFalse();
+		assertThat(isTeleportDrtUsers(drtSpeedUpParams, controlerConfig, 91)).isFalse();
+
+		assertThat(isTeleportDrtUsers(drtSpeedUpParams, controlerConfig, 100)).isFalse();
+	}
+}


### PR DESCRIPTION
This is an integration of drt-speed-up (https://github.com/matsim-vsp/drt-speed-up) into DRT.

The main idea: the teleporting passenger engine will move passengers instead of calling the optimiser to send a vehicle. This allows a very straightforward re-implementation of drt-speed-up.

This is a draft PR until the new functionality gets covered by tests.