### PR TITLE
remove maven source plugin from freight

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/PreviousIterationDRTDemandEstimator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/PreviousIterationDRTDemandEstimator.java
@@ -35,6 +35,8 @@ import org.matsim.contrib.drt.analysis.zonal.DrtZonalSystem;
 import org.matsim.contrib.drt.analysis.zonal.DrtZone;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 
+import com.google.common.base.Preconditions;
+
 /**
  * Aggregates PersonDepartureEvents per iteration for the given mode and returns the numbers from the previous iteration
  * as expected demand for the current iteration.
@@ -56,7 +58,7 @@ public final class PreviousIterationDRTDemandEstimator implements ZonalDemandEst
 		this.zonalSystem = zonalSystem;
 		mode = drtCfg.getMode();
 		drtSpeedUpMode = drtCfg.getDrtSpeedUpMode();
-		timeBinSize = Math.max(drtCfg.getRebalancingParams().get().getInterval(), 1800);
+		timeBinSize = drtCfg.getRebalancingParams().get().getInterval();
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/PreviousIterationDRTDemandEstimator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/PreviousIterationDRTDemandEstimator.java
@@ -35,8 +35,6 @@ import org.matsim.contrib.drt.analysis.zonal.DrtZonalSystem;
 import org.matsim.contrib.drt.analysis.zonal.DrtZone;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 
-import com.google.common.base.Preconditions;
-
 /**
  * Aggregates PersonDepartureEvents per iteration for the given mode and returns the numbers from the previous iteration
  * as expected demand for the current iteration.
@@ -58,7 +56,7 @@ public final class PreviousIterationDRTDemandEstimator implements ZonalDemandEst
 		this.zonalSystem = zonalSystem;
 		mode = drtCfg.getMode();
 		drtSpeedUpMode = drtCfg.getDrtSpeedUpMode();
-		timeBinSize = drtCfg.getRebalancingParams().get().getInterval();
+		timeBinSize = Math.max(drtCfg.getRebalancingParams().get().getInterval(), 1800);
 	}
 
 	@Override

--- a/contribs/freight/pom.xml
+++ b/contribs/freight/pom.xml
@@ -32,7 +32,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>2.4</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>

--- a/contribs/freight/pom.xml
+++ b/contribs/freight/pom.xml
@@ -16,31 +16,6 @@
 
 	<build>
 		<plugins>
-			<!--<plugin>-->
-			<!--<groupId>org.apache.maven.plugins</groupId>-->
-			<!--<artifactId>maven-javadoc-plugin</artifactId>-->
-			<!--<version>2.7</version>-->
-			<!--<executions>-->
-			<!--<execution>-->
-			<!--<id>attach-javadoc</id>-->
-			<!--<goals>-->
-			<!--<goal>jar</goal>-->
-			<!--</goals>-->
-			<!--</execution>-->
-			<!--</executions>-->
-			<!--</plugin>-->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<goals>
-							<goal>jar-no-fork</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 			</plugin>


### PR DESCRIPTION
Hello Michal, 

I had a build error (see my previous email) with the matsim-lib (the freight module, which I have not touched before). I tried different methods to solve it. The build error was finally solved after I deleted one line in the pom file (see the commit). I guess that line is the reason for the build error, but I'm not sure. Could you have a look? Thanks!