### PR TITLE
Refine demand estimator interface

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/PreviousIterationDRTDemandEstimator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/PreviousIterationDRTDemandEstimator.java
@@ -51,14 +51,15 @@ public final class PreviousIterationDRTDemandEstimator implements ZonalDemandEst
 	private final String mode;
 	private final String drtSpeedUpMode;
 	private final int timeBinSize;
-	private Map<Double, Map<DrtZone, MutableInt>> currentIterationDepartures = new HashMap<>();
-	private Map<Double, Map<DrtZone, MutableInt>> previousIterationDepartures = new HashMap<>();
+	private Map<Integer, Map<DrtZone, MutableInt>> currentIterationDepartures = new HashMap<>();
+	private Map<Integer, Map<DrtZone, MutableInt>> previousIterationDepartures = new HashMap<>();
 
-	public PreviousIterationDRTDemandEstimator(DrtZonalSystem zonalSystem, DrtConfigGroup drtCfg) {
+	public PreviousIterationDRTDemandEstimator(DrtZonalSystem zonalSystem, DrtConfigGroup drtCfg,
+			int demandEstimationPeriod) {
 		this.zonalSystem = zonalSystem;
 		mode = drtCfg.getMode();
 		drtSpeedUpMode = drtCfg.getDrtSpeedUpMode();
-		timeBinSize = drtCfg.getRebalancingParams().get().getInterval();
+		timeBinSize = demandEstimationPeriod;
 	}
 
 	@Override
@@ -70,8 +71,6 @@ public final class PreviousIterationDRTDemandEstimator implements ZonalDemandEst
 	@Override
 	public void handleEvent(PersonDepartureEvent event) {
 		if (event.getLegMode().equals(mode) || event.getLegMode().equals(drtSpeedUpMode)) {
-			Double bin = getBinForTime(event.getTime());
-
 			DrtZone zone = zonalSystem.getZoneForLinkId(event.getLinkId());
 			if (zone == null) {
 				//might be that somebody walks into the service area or that service area is larger/different than DrtZonalSystem...
@@ -79,7 +78,8 @@ public final class PreviousIterationDRTDemandEstimator implements ZonalDemandEst
 				return;
 			}
 
-			currentIterationDepartures.computeIfAbsent(bin, v -> new HashMap<>())
+			int timeBin = getBinForTime(event.getTime());
+			currentIterationDepartures.computeIfAbsent(timeBin, v -> new HashMap<>())
 					.computeIfAbsent(zone, z -> new MutableInt())
 					.increment();
 		}
@@ -87,13 +87,15 @@ public final class PreviousIterationDRTDemandEstimator implements ZonalDemandEst
 
 	private static final MutableInt ZERO = new MutableInt(0);
 
-	public ToDoubleFunction<DrtZone> getExpectedDemandForTimeBin(double time) {
-		Double bin = getBinForTime(time);
-		Map<DrtZone, MutableInt> expectedDemandForTimeBin = previousIterationDepartures.getOrDefault(bin, Map.of());
+	@Override
+	public ToDoubleFunction<DrtZone> getExpectedDemand(double fromTime, double estimationPeriod) {
+		Preconditions.checkArgument(estimationPeriod == timeBinSize);//TODO add more flexibility later
+		int timeBin = getBinForTime(fromTime);
+		Map<DrtZone, MutableInt> expectedDemandForTimeBin = previousIterationDepartures.getOrDefault(timeBin, Map.of());
 		return zone -> expectedDemandForTimeBin.getOrDefault(zone, ZERO).intValue();
 	}
 
-	private Double getBinForTime(double time) {
-		return Math.floor(time / timeBinSize);
+	private int getBinForTime(double time) {
+		return (int)(time / timeBinSize);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/ZonalDemandEstimator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/ZonalDemandEstimator.java
@@ -29,7 +29,8 @@ import org.matsim.contrib.drt.analysis.zonal.DrtZone;
 
 /**
  * @author jbischoff
+ * @author Michal Maciejewski (michalm)
  */
 public interface ZonalDemandEstimator {
-	ToDoubleFunction<DrtZone> getExpectedDemandForTimeBin(double time);
+	ToDoubleFunction<DrtZone> getExpectedDemand(double fromTime, double estimationPeriod);
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
@@ -54,9 +54,6 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 		RebalancingParams params = drtCfg.getRebalancingParams().orElseThrow();
 		MinCostFlowRebalancingStrategyParams strategyParams = (MinCostFlowRebalancingStrategyParams)params.getRebalancingStrategyParams();
 
-		//TODO make demandEstimationPeriod independent of the rebalancing interval
-		int demandEstimationPeriod = params.getInterval();
-
 		installQSimModule(new AbstractDvrpModeQSimModule(getMode()) {
 			@Override
 			protected void configureQSim() {
@@ -69,16 +66,16 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 					case EstimatedDemand:
 						bindModal(RebalancingTargetCalculator.class).toProvider(modalProvider(
 								getter -> new DemandEstimatorAsTargetCalculator(
-										getter.getModal(ZonalDemandEstimator.class), demandEstimationPeriod)))
-								.asEagerSingleton();
+										getter.getModal(ZonalDemandEstimator.class),
+										strategyParams.getDemandEstimationPeriod()))).asEagerSingleton();
 						break;
 
 					case EqualRebalancableVehicleDistribution:
 						bindModal(RebalancingTargetCalculator.class).toProvider(modalProvider(
 								getter -> new EqualRebalancableVehicleDistributionTargetCalculator(
 										getter.getModal(ZonalDemandEstimator.class),
-										getter.getModal(DrtZonalSystem.class), demandEstimationPeriod)))
-								.asEagerSingleton();
+										getter.getModal(DrtZonalSystem.class),
+										strategyParams.getDemandEstimationPeriod()))).asEagerSingleton();
 						break;
 
 					case EqualVehicleDensity:
@@ -109,7 +106,7 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 			case PreviousIterationDemand:
 				bindModal(PreviousIterationDRTDemandEstimator.class).toProvider(modalProvider(
 						getter -> new PreviousIterationDRTDemandEstimator(getter.getModal(DrtZonalSystem.class), drtCfg,
-								demandEstimationPeriod))).asEagerSingleton();
+								strategyParams.getDemandEstimationPeriod()))).asEagerSingleton();
 				bindModal(ZonalDemandEstimator.class).to(modalKey(PreviousIterationDRTDemandEstimator.class));
 				addEventHandlerBinding().to(modalKey(PreviousIterationDRTDemandEstimator.class));
 				break;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategyParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategyParams.java
@@ -61,6 +61,11 @@ public final class MinCostFlowRebalancingStrategyParams extends ReflectiveConfig
 	static final String ZONAL_DEMAND_ESTIMATOR_TYPE_EXP = "Defines the methodology for demand estimation."
 			+ " Can be one of [PreviousIterationDemand, None]. Current default is PreviousIterationDemand";
 
+	public static final String DEMAND_ESTIMATION_PERIOD = "demandEstimationPeriod";
+	static final String DEMAND_ESTIMATION_PERIOD_EXP = "Defines the time horizon for predicting the demand."
+			+ " Used when 'zonalDemandEstimatorType' is not set to 'None'."
+			+ " Default value is 1800 s.";
+
 	@NotNull
 	private RebalancingTargetCalculatorType rebalancingTargetCalculatorType = RebalancingTargetCalculatorType.EstimatedDemand;
 
@@ -69,6 +74,9 @@ public final class MinCostFlowRebalancingStrategyParams extends ReflectiveConfig
 
 	@PositiveOrZero
 	private double targetBeta = Double.NaN;
+
+	@PositiveOrZero
+	private int demandEstimationPeriod = 1800;
 
 	@NotNull
 	private ZonalDemandEstimatorType zonalDemandEstimatorType = ZonalDemandEstimatorType.PreviousIterationDemand;
@@ -83,6 +91,7 @@ public final class MinCostFlowRebalancingStrategyParams extends ReflectiveConfig
 		map.put(TARGET_ALPHA, TARGET_ALPHA_EXP);
 		map.put(TARGET_BETA, TARGET_BETA_EXP);
 		map.put(ZONAL_DEMAND_ESTIMATOR_TYPE, ZONAL_DEMAND_ESTIMATOR_TYPE_EXP);
+		map.put(DEMAND_ESTIMATION_PERIOD, DEMAND_ESTIMATION_PERIOD_EXP);
 		return map;
 	}
 
@@ -116,6 +125,22 @@ public final class MinCostFlowRebalancingStrategyParams extends ReflectiveConfig
 	@StringSetter(TARGET_BETA)
 	public void setTargetBeta(double targetBeta) {
 		this.targetBeta = targetBeta;
+	}
+
+	/**
+	 * @return -- {@value #DEMAND_ESTIMATION_PERIOD_EXP}
+	 */
+	@StringGetter(DEMAND_ESTIMATION_PERIOD)
+	public int getDemandEstimationPeriod() {
+		return demandEstimationPeriod;
+	}
+
+	/**
+	 * @param demandEstimationPeriod -- {@value #DEMAND_ESTIMATION_PERIOD_EXP}
+	 */
+	@StringSetter(DEMAND_ESTIMATION_PERIOD)
+	public void setDemandEstimationPeriod(int demandEstimationPeriod) {
+		this.demandEstimationPeriod = demandEstimationPeriod;
 	}
 
 	/**

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/DemandEstimatorAsTargetCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/DemandEstimatorAsTargetCalculator.java
@@ -33,16 +33,16 @@ import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
  */
 public class DemandEstimatorAsTargetCalculator implements RebalancingTargetCalculator {
 	private final ZonalDemandEstimator demandEstimator;
+	private final double demandEstimationPeriod;
 
-	public DemandEstimatorAsTargetCalculator(ZonalDemandEstimator demandEstimator) {
+	public DemandEstimatorAsTargetCalculator(ZonalDemandEstimator demandEstimator, double demandEstimationPeriod) {
 		this.demandEstimator = demandEstimator;
+		this.demandEstimationPeriod = demandEstimationPeriod;
 	}
 
 	@Override
 	public ToDoubleFunction<DrtZone> calculate(double time,
 			Map<DrtZone, List<DvrpVehicle>> rebalancableVehiclesPerZone) {
-		// TODO remove this hidden "+60"
-		// XXX this "time+60" (taken from old code) means probably "in the next time bin"
-		return demandEstimator.getExpectedDemandForTimeBin(time + 60);
+		return demandEstimator.getExpectedDemand(time, demandEstimationPeriod);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualRebalancableVehicleDistributionTargetCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualRebalancableVehicleDistributionTargetCalculator.java
@@ -43,11 +43,13 @@ public class EqualRebalancableVehicleDistributionTargetCalculator implements Reb
 
 	private final ZonalDemandEstimator demandEstimator;
 	private final DrtZonalSystem zonalSystem;
+	private final double demandEstimationPeriod;
 
 	public EqualRebalancableVehicleDistributionTargetCalculator(ZonalDemandEstimator demandEstimator,
-			DrtZonalSystem zonalSystem) {
+			DrtZonalSystem zonalSystem, double demandEstimationPeriod) {
 		this.demandEstimator = demandEstimator;
 		this.zonalSystem = zonalSystem;
+		this.demandEstimationPeriod = demandEstimationPeriod;
 	}
 
 	@Override
@@ -55,7 +57,8 @@ public class EqualRebalancableVehicleDistributionTargetCalculator implements Reb
 			Map<DrtZone, List<DvrpVehicle>> rebalancableVehiclesPerZone) {
 		int numAvailableVehicles = rebalancableVehiclesPerZone.values().stream().mapToInt(List::size).sum();
 
-		ToDoubleFunction<DrtZone> currentDemandEstimator = demandEstimator.getExpectedDemandForTimeBin(time);
+		ToDoubleFunction<DrtZone> currentDemandEstimator = demandEstimator.getExpectedDemand(time,
+				demandEstimationPeriod);
 		Set<DrtZone> activeZones = zonalSystem.getZones()
 				.values()
 				.stream()

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/PreviousIterationDRTDemandEstimatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/PreviousIterationDRTDemandEstimatorTest.java
@@ -42,6 +42,7 @@ import org.matsim.testcases.fakes.FakeLink;
 public class PreviousIterationDRTDemandEstimatorTest {
 
 	private static final String DRT_SPEEDUP = "drt_speedup";
+	private static final int ESTIMATION_PERIOD = 1800;
 
 	private final Link link1 = new FakeLink(Id.createLinkId("link_1"));
 	private final Link link2 = new FakeLink(Id.createLinkId("link_2"));
@@ -52,7 +53,7 @@ public class PreviousIterationDRTDemandEstimatorTest {
 
 	@Test
 	public void noDepartures() {
-		PreviousIterationDRTDemandEstimator estimator = createEstimator(1800);
+		PreviousIterationDRTDemandEstimator estimator = createEstimator();
 
 		//no events in previous iterations
 		estimator.reset(1);
@@ -67,7 +68,7 @@ public class PreviousIterationDRTDemandEstimatorTest {
 
 	@Test
 	public void drtDepartures() {
-		PreviousIterationDRTDemandEstimator estimator = createEstimator(1800);
+		PreviousIterationDRTDemandEstimator estimator = createEstimator();
 
 		//time bin 0-1800
 		estimator.handleEvent(departureEvent(100, link1, TransportMode.drt));
@@ -102,7 +103,7 @@ public class PreviousIterationDRTDemandEstimatorTest {
 
 	@Test
 	public void nonDrtDepartures() {
-		PreviousIterationDRTDemandEstimator estimator = createEstimator(1800);
+		PreviousIterationDRTDemandEstimator estimator = createEstimator();
 
 		estimator.handleEvent(departureEvent(100, link1, "mode X"));
 		estimator.handleEvent(departureEvent(200, link2, TransportMode.car));
@@ -114,7 +115,7 @@ public class PreviousIterationDRTDemandEstimatorTest {
 
 	@Test
 	public void currentCountsAreCopiedToPreviousAfterReset() {
-		PreviousIterationDRTDemandEstimator estimator = createEstimator(1800);
+		PreviousIterationDRTDemandEstimator estimator = createEstimator();
 
 		estimator.handleEvent(departureEvent(100, link1, DRT_SPEEDUP));
 		estimator.handleEvent(departureEvent(200, link2, TransportMode.drt));
@@ -130,7 +131,7 @@ public class PreviousIterationDRTDemandEstimatorTest {
 
 	@Test
 	public void timeBinsAreRespected() {
-		PreviousIterationDRTDemandEstimator estimator = createEstimator(1800);
+		PreviousIterationDRTDemandEstimator estimator = createEstimator();
 
 		estimator.handleEvent(departureEvent(100, link1, DRT_SPEEDUP));
 		estimator.handleEvent(departureEvent(2200, link2, TransportMode.drt));
@@ -148,7 +149,7 @@ public class PreviousIterationDRTDemandEstimatorTest {
 
 	@Test
 	public void noTimeLimitIsImposed() {
-		PreviousIterationDRTDemandEstimator estimator = createEstimator(1800);
+		PreviousIterationDRTDemandEstimator estimator = createEstimator();
 
 		estimator.handleEvent(departureEvent(10000000, link1, DRT_SPEEDUP));
 		estimator.reset(1);
@@ -156,23 +157,24 @@ public class PreviousIterationDRTDemandEstimatorTest {
 		assertDemand(estimator, 10000000, zone1, 1);
 	}
 
-	private PreviousIterationDRTDemandEstimator createEstimator(int timeBinSize) {
+	private PreviousIterationDRTDemandEstimator createEstimator() {
 		RebalancingParams rebalancingParams = new RebalancingParams();
-		rebalancingParams.setInterval(timeBinSize);
+		rebalancingParams.setInterval(ESTIMATION_PERIOD);
 
 		DrtConfigGroup drtConfigGroup = new DrtConfigGroup();
 		drtConfigGroup.setDrtSpeedUpMode(DRT_SPEEDUP);
 		drtConfigGroup.addParameterSet(rebalancingParams);
 
-		return new PreviousIterationDRTDemandEstimator(zonalSystem, drtConfigGroup);
+		return new PreviousIterationDRTDemandEstimator(zonalSystem, drtConfigGroup, ESTIMATION_PERIOD);
 	}
 
 	private PersonDepartureEvent departureEvent(double time, Link link, String mode) {
 		return new PersonDepartureEvent(time, null, link.getId(), mode);
 	}
 
-	private void assertDemand(PreviousIterationDRTDemandEstimator estimator, double time, DrtZone zone,
+	private void assertDemand(PreviousIterationDRTDemandEstimator estimator, double fromTime, DrtZone zone,
 			double expectedDemand) {
-		assertThat(estimator.getExpectedDemandForTimeBin(time).applyAsDouble(zone)).isEqualTo(expectedDemand);
+		assertThat(estimator.getExpectedDemand(fromTime, ESTIMATION_PERIOD).applyAsDouble(zone)).isEqualTo(
+				expectedDemand);
 	}
 }


### PR DESCRIPTION
Replace `ToDoubleFunction<DrtZone> getExpectedDemandForTimeBin(double time)` with `ToDoubleFunction<DrtZone> getExpectedDemand(double fromTime, double estimationPeriod)`

`demandEstimationPeriod` parameter was added to `MinCostFlowRebalancingParams`. Not all rebalancing strategies need to know that. Some actually do not use any demand estimation. So I decided to not have it one level above - i.e. in `RebalancingParams`.