### PR TITLE
LZ4 Improvements

### DIFF
--- a/matsim/src/main/java/org/matsim/core/events/MatsimEventsReader.java
+++ b/matsim/src/main/java/org/matsim/core/events/MatsimEventsReader.java
@@ -75,7 +75,7 @@ public final class MatsimEventsReader implements MatsimReader {
 	@Override
 	public void readFile(final String filename) {
 		String lcFilename = filename.toLowerCase(Locale.ROOT);
-		if (lcFilename.endsWith(".xml") || lcFilename.endsWith(".xml.gz") || lcFilename.endsWith(".xml.zst")) {
+		if (lcFilename.endsWith(".xml") || lcFilename.endsWith(".xml.gz") || lcFilename.endsWith(".xml.zst") || lcFilename.endsWith(".xml.lz4")) {
 			new XmlEventsReader(this.events, this.customEventMappers).readFile(filename );
 		} else if (lcFilename.endsWith(".ndjson") || lcFilename.endsWith(".ndjson.gz") || lcFilename.endsWith(".ndjson.zst")) {
 			EventsReaderJson reader = new EventsReaderJson(this.events);

--- a/matsim/src/main/java/org/matsim/core/utils/io/IOUtils.java
+++ b/matsim/src/main/java/org/matsim/core/utils/io/IOUtils.java
@@ -22,8 +22,8 @@ package org.matsim.core.utils.io;
 
 import com.github.luben.zstd.ZstdInputStream;
 import com.github.luben.zstd.ZstdOutputStream;
-import net.jpountz.lz4.LZ4BlockInputStream;
-import net.jpountz.lz4.LZ4BlockOutputStream;
+import net.jpountz.lz4.LZ4FrameInputStream;
+import net.jpountz.lz4.LZ4FrameOutputStream;
 import org.apache.commons.compress.compressors.CompressorException;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.apache.log4j.Logger;
@@ -252,7 +252,7 @@ final public class IOUtils {
 						inputStream = new GZIPInputStream(inputStream);
 						break;
 					case LZ4:
-						inputStream = new LZ4BlockInputStream(inputStream);
+						inputStream = new LZ4FrameInputStream(inputStream);
 						break;
 					case BZIP2:
 						inputStream = new CompressorStreamFactory().createCompressorInputStream(CompressorStreamFactory.BZIP2, inputStream);
@@ -321,7 +321,7 @@ final public class IOUtils {
 						outputStream = new GZIPOutputStream(outputStream);
 						break;
 					case LZ4:
-						outputStream = new LZ4BlockOutputStream(outputStream);
+						outputStream = new LZ4FrameOutputStream(outputStream);
 						break;
 					case BZIP2:
 						outputStream = new CompressorStreamFactory().createCompressorOutputStream(CompressorStreamFactory.BZIP2, outputStream);

--- a/matsim/src/test/java/org/matsim/core/utils/io/IOUtilsTest.java
+++ b/matsim/src/test/java/org/matsim/core/utils/io/IOUtilsTest.java
@@ -231,7 +231,10 @@ public class IOUtilsTest {
 		writer.write("12345678901234567890123456789012345678901234567890");
 		writer.close();
 		File file = new File(filename);
-		Assert.assertEquals("compressed file should be equal 62 bytes, but is " + file.length(), 62, file.length());
+		Assert.assertEquals("compressed file should be equal 35 bytes, but is " + file.length(), 35, file.length());
+
+		String content = IOUtils.getBufferedReader(filename).readLine();
+		Assert.assertEquals("12345678901234567890123456789012345678901234567890", content);
 	}
 
 	@Test(expected = UncheckedIOException.class)


### PR DESCRIPTION
Short PR to allow the EventReader to read "xml.lz4" files.

Also, this changes the lz4 format from block to frame format:
As described in this [thread](https://groups.google.com/forum/#!topic/lz4c/1g4cK5Yz_uU), the frame format can be used with the lz4 command line tools and has better interoperability.

I also did some benchmarks and noticed a quite significant regression in reading performance in MATSm 13.

Code snipped run on file with roughly 10 mio events
```java
EventsManager manager = EventsUtils.createEventsManager();
manager.initProcessing();
EventsUtils.readEvents(manager, XML_INPUT + compression);
```


|Benchmark|Mode|Samples|Score|Score Error (99,9%)|Unit|Param: compression|
|-----------|------|---------|-----|-------------------|-----|---------------------|
|MATSIm 12.0|avgt|5|18851,167160|900,754755|ms/op|
|MATSIm 12.0|avgt|5|21035,960020|2579,980226|ms/op|.gz
|MATSIm 12.0|avgt|5|19887,665060|2013,520721|ms/op|.zst


|Benchmark|Mode|Samples|Score|Score Error (99,9%)|Unit|Param: compression|
|-----------|------|---------|-----|-------------------|-----|---------------------|
|MATSIm 13 Snapshot|avgt|5|26010,928020|1946,984640|ms/op|
|MATSIm 13 Snapshot|avgt|5|30828,416980|1151,445063|ms/op|.gz
|MATSIm 13 Snapshot|avgt|5|28895,901280|2273,936140|ms/op|.lz4
|MATSIm 13 Snapshot|avgt|5|29983,215680|1537,772526|ms/op|.zst


I suspect this might be due to the parallel EventHandler causing additional overhead, but could not check in detail yet.
