### PR TITLE
Add dvrp global TT matrix

### DIFF
--- a/contribs/dvrp/pom.xml
+++ b/contribs/dvrp/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>contrib</artifactId>
@@ -10,6 +10,14 @@
 	<groupId>org.matsim.contrib</groupId>
 	<artifactId>dvrp</artifactId>
 	<name>dvrp</name>
+
+	<repositories>
+		<repository>
+			<id>SBB</id>
+			<url>https://schweizerischebundesbahnen.bintray.com/simba.mvn</url>
+		</repository>
+	</repositories>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -53,6 +61,11 @@
 			<groupId>one.util</groupId>
 			<artifactId>streamex</artifactId>
 			<version>0.7.2</version>
+		</dependency>
+		<dependency>
+			<groupId>ch.sbb</groupId>
+			<artifactId>matsim-sbb-extensions</artifactId>
+			<version>12.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpGlobalRoutingNetworkProvider.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpGlobalRoutingNetworkProvider.java
@@ -43,6 +43,7 @@ public class DvrpGlobalRoutingNetworkProvider implements Provider<Network> {
 
 	@Override
 	public Network get() {
+		//TODO add shape filtering (network area should contain the service area and possibly some buffer)
 		if (dvrpCfg.getNetworkModes().isEmpty()) { // no mode filtering
 			return network;
 		} else {

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigGroup.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigGroup.java
@@ -20,7 +20,9 @@
 package org.matsim.contrib.dvrp.run;
 
 import java.util.Map;
+import java.util.Optional;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.DecimalMax;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -30,13 +32,14 @@ import javax.validation.constraints.PositiveOrZero;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.contrib.dynagent.run.DynQSimConfigConsistencyChecker;
+import org.matsim.contrib.util.ReflectiveConfigGroupWithConfigurableParameterSets;
+import org.matsim.contrib.zone.skims.DvrpTravelTimeMatrixParams;
 import org.matsim.core.config.Config;
-import org.matsim.core.config.ReflectiveConfigGroup;
 import org.matsim.core.utils.misc.StringUtils;
 
 import com.google.common.collect.ImmutableSet;
 
-public final class DvrpConfigGroup extends ReflectiveConfigGroup {
+public final class DvrpConfigGroup extends ReflectiveConfigGroupWithConfigurableParameterSets {
 	private static final Logger log = Logger.getLogger(DvrpConfigGroup.class);
 
 	public static final String GROUP_NAME = "dvrp";
@@ -47,7 +50,8 @@ public final class DvrpConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	private static final String NETWORK_MODES = "networkModes";
-	private static final String NETWORK_MODES_EXP = "Set of modes of which the network will be used for DVRP travel time "
+	private static final String NETWORK_MODES_EXP = ""
+			+ "Set of modes of which the network will be used for DVRP travel time "
 			+ "estimation and routing DVRP vehicles. "
 			+ "Each specific DVRP mode may use a subnetwork of this network for routing vehicles (e.g. DRT buses "
 			+ "travelling only along a specified links or serving a limited area). "
@@ -70,7 +74,8 @@ public final class DvrpConfigGroup extends ReflectiveConfigGroup {
 					+ " the free-speed TTs is used as the initial estimates";
 
 	private static final String TRAVEL_TIME_ESTIMATION_BETA = "travelTimeEstimationBeta";
-	private static final String TRAVEL_TIME_ESTIMATION_BETA_EXP = "Used for ONLINE estimation of travel times for VrpOptimizer"
+	private static final String TRAVEL_TIME_ESTIMATION_BETA_EXP = ""
+			+ "Used for ONLINE estimation of travel times for VrpOptimizer"
 			+ " by combining WithinDayTravelTime and DvrpOfflineTravelTimeEstimator."
 			+ " The beta coefficient is provided in seconds and should be either 0 (no online estimation)"
 			+ " or positive (mixed online-offline estimation)."
@@ -107,8 +112,18 @@ public final class DvrpConfigGroup extends ReflectiveConfigGroup {
 	@PositiveOrZero
 	private double travelTimeEstimationBeta = 0; // [s], 0 ==> only offline TT estimation
 
+	@Nullable
+	private DvrpTravelTimeMatrixParams travelTimeMatrixParams;
+
 	public DvrpConfigGroup() {
 		super(GROUP_NAME);
+		initSingletonParameterSets();
+	}
+
+	private void initSingletonParameterSets() {
+		//travel time matrix (optional)
+		addDefinition(DvrpTravelTimeMatrixParams.SET_NAME, DvrpTravelTimeMatrixParams::new,
+				() -> travelTimeMatrixParams, params -> travelTimeMatrixParams = (DvrpTravelTimeMatrixParams)params);
 	}
 
 	@Override
@@ -219,5 +234,9 @@ public final class DvrpConfigGroup extends ReflectiveConfigGroup {
 	public DvrpConfigGroup setTravelTimeEstimationBeta(double travelTimeEstimationBeta) {
 		this.travelTimeEstimationBeta = travelTimeEstimationBeta;
 		return this;
+	}
+
+	public Optional<DvrpTravelTimeMatrixParams> getTravelTimeMatrixParams() {
+		return Optional.ofNullable(travelTimeMatrixParams);
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpModule.java
@@ -27,6 +27,7 @@ import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentQueryHelper;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentSourceQSimModule;
 import org.matsim.contrib.dynagent.run.DynActivityEngine;
+import org.matsim.contrib.zone.skims.DvrpTravelTimesMatrixModule;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
@@ -34,6 +35,7 @@ import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehicleUtils;
 import org.matsim.vis.otfvis.OnTheFlyServer.NonPlanAgentQueryHelper;
 
+import com.google.inject.Inject;
 import com.google.inject.name.Names;
 
 /**
@@ -45,6 +47,9 @@ import com.google.inject.name.Names;
  * @author michalm
  */
 public final class DvrpModule extends AbstractModule {
+	@Inject
+	private DvrpConfigGroup dvrpConfigGroup;
+
 	@Override
 	public void install() {
 		// Visualisation of schedules for DVRP DynAgents
@@ -54,6 +59,9 @@ public final class DvrpModule extends AbstractModule {
 				.toInstance(VehicleUtils.getDefaultVehicleType());
 
 		install(new DvrpTravelTimeModule());
+
+		dvrpConfigGroup.getTravelTimeMatrixParams()
+				.ifPresent(params -> install(new DvrpTravelTimesMatrixModule(getConfig().global(), params)));
 
 		bind(Network.class).annotatedWith(Names.named(DvrpGlobalRoutingNetworkProvider.DVRP_ROUTING))
 				.toProvider(DvrpGlobalRoutingNetworkProvider.class)

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/ZonalSystems.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/ZonalSystems.java
@@ -19,19 +19,49 @@
 
 package org.matsim.contrib.zone;
 
+import static java.util.stream.Collectors.*;
+
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.BinaryOperator;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.tuple.Pair;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.prep.PreparedGeometry;
 import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Node;
 import org.matsim.contrib.util.distance.DistanceUtils;
+import org.matsim.core.utils.geometry.geotools.MGC;
 
 import com.google.common.collect.Maps;
 
+//TODO add zone indexing?
 public class ZonalSystems {
-	public interface ZonalDistanceCalculator {
-		double calcDistance(Zone z1, Zone z2);
+	public static Set<Zone> filterZonesWithNodes(Collection<? extends Node> nodes, ZonalSystem zonalSystem) {
+		return nodes.stream().map(zonalSystem::getZone).collect(toSet());
+	}
+
+	public static List<Node> selectNodesWithinServiceArea(Collection<? extends Node> nodes,
+			List<PreparedGeometry> serviceAreaGeoms) {
+		return nodes.stream().filter(node -> {
+			Point point = MGC.coord2Point(node.getCoord());
+			return serviceAreaGeoms.stream().anyMatch(serviceArea -> serviceArea.intersects(point));
+		}).collect(toList());
+	}
+
+	public static Map<Zone, Node> computeMostCentralNodes(Collection<? extends Node> nodes, ZonalSystem zonalSystem) {
+		BinaryOperator<Node> chooseMoreCentralNode = (n1, n2) -> {
+			Zone zone = zonalSystem.getZone(n1);
+			return DistanceUtils.calculateSquaredDistance(n1, zone) <= DistanceUtils.calculateSquaredDistance(n2,
+					zone) ? n1 : n2;
+		};
+		return nodes.stream()
+				.map(n -> Pair.of(n, zonalSystem.getZone(n)))
+				.collect(toMap(Pair::getValue, Pair::getKey, chooseMoreCentralNode));
 	}
 
 	public static Map<Id<Zone>, List<Zone>> initZonesByDistance(Map<Id<Zone>, Zone> zones) {

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrix.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrix.java
@@ -20,15 +20,12 @@
 
 package org.matsim.contrib.zone.skims;
 
-import java.util.Map;
-
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.contrib.dvrp.router.TimeAsTravelDisutility;
 import org.matsim.contrib.zone.SquareGridSystem;
 import org.matsim.contrib.zone.ZonalSystems;
 import org.matsim.contrib.zone.Zone;
-import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
 
 import ch.sbb.matsim.analysis.skims.FloatMatrix;
@@ -37,18 +34,18 @@ import ch.sbb.matsim.analysis.skims.FloatMatrix;
  * @author Michal Maciejewski (michalm)
  */
 public class DvrpTravelTimeMatrix {
+	private final SquareGridSystem gridSystem;
 	private final FloatMatrix<Zone> freeSpeedTravelTimeMatrix;
 
 	public DvrpTravelTimeMatrix(Network dvrpNetwork, DvrpTravelTimeMatrixParams params, int numberOfThreads) {
-		SquareGridSystem gridSystem = new SquareGridSystem(dvrpNetwork.getNodes().values(), params.getCellSize());
-		Map<Zone, Node> centralNodes = ZonalSystems.computeMostCentralNodes(dvrpNetwork.getNodes().values(),
-				gridSystem);
-		TravelTime travelTime = new FreeSpeedTravelTime();
+		gridSystem = new SquareGridSystem(dvrpNetwork.getNodes().values(), params.getCellSize());
+		var centralNodes = ZonalSystems.computeMostCentralNodes(dvrpNetwork.getNodes().values(), gridSystem);
+		var travelTime = new FreeSpeedTravelTime();
 		freeSpeedTravelTimeMatrix = TravelTimeMatrices.calculateTravelTimeMatrix(dvrpNetwork, centralNodes, 0,
 				travelTime, new TimeAsTravelDisutility(travelTime), numberOfThreads);
 	}
 
-	public float getFreeSpeedTravelTime(Zone fromZone, Zone toZone) {
-		return freeSpeedTravelTimeMatrix.get(fromZone, toZone);
+	public float getFreeSpeedTravelTime(Node fromNode, Node toNode) {
+		return freeSpeedTravelTimeMatrix.get(gridSystem.getZone(fromNode), gridSystem.getZone(toNode));
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrix.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrix.java
@@ -1,0 +1,54 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.zone.skims;
+
+import java.util.Map;
+
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.contrib.dvrp.router.TimeAsTravelDisutility;
+import org.matsim.contrib.zone.SquareGridSystem;
+import org.matsim.contrib.zone.ZonalSystems;
+import org.matsim.contrib.zone.Zone;
+import org.matsim.core.router.util.TravelTime;
+import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
+
+import ch.sbb.matsim.analysis.skims.FloatMatrix;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class DvrpTravelTimeMatrix {
+	private final FloatMatrix<Zone> freeSpeedTravelTimeMatrix;
+
+	public DvrpTravelTimeMatrix(Network dvrpNetwork, DvrpTravelTimeMatrixParams params, int numberOfThreads) {
+		SquareGridSystem gridSystem = new SquareGridSystem(dvrpNetwork.getNodes().values(), params.getCellSize());
+		Map<Zone, Node> centralNodes = ZonalSystems.computeMostCentralNodes(dvrpNetwork.getNodes().values(),
+				gridSystem);
+		TravelTime travelTime = new FreeSpeedTravelTime();
+		freeSpeedTravelTimeMatrix = TravelTimeMatrices.calculateTravelTimeMatrix(dvrpNetwork, centralNodes, 0,
+				travelTime, new TimeAsTravelDisutility(travelTime), numberOfThreads);
+	}
+
+	public float getFreeSpeedTravelTime(Zone fromZone, Zone toZone) {
+		return freeSpeedTravelTimeMatrix.get(fromZone, toZone);
+	}
+}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrixParams.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrixParams.java
@@ -1,0 +1,68 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.zone.skims;
+
+import java.util.Map;
+
+import javax.validation.constraints.Positive;
+
+import org.matsim.core.config.ReflectiveConfigGroup;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class DvrpTravelTimeMatrixParams extends ReflectiveConfigGroup {
+	public static final String SET_NAME = "travelTimeMatrix";
+
+	public static final String CELL_SIZE = "cellSize";
+	private static final String CELL_SIZE_EXP = "size of square cells (meters) used for computing travel time matrix."
+			+ " Default value is 200 m";
+
+	@Positive
+	private int cellSize = 200; //[m]
+
+	public DvrpTravelTimeMatrixParams() {
+		super(SET_NAME);
+	}
+
+	@Override
+	public Map<String, String> getComments() {
+		var map = super.getComments();
+		map.put(CELL_SIZE, CELL_SIZE_EXP);
+		return map;
+	}
+
+	/**
+	 * @return {@value #CELL_SIZE_EXP}
+	 */
+	@StringGetter(CELL_SIZE)
+	public int getCellSize() {
+		return cellSize;
+	}
+
+	/**
+	 * @param cellSize {@value #CELL_SIZE_EXP}
+	 */
+	@StringSetter(CELL_SIZE)
+	public void setCellSize(int cellSize) {
+		this.cellSize = cellSize;
+	}
+}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpTravelTimesMatrixModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpTravelTimesMatrixModule.java
@@ -1,0 +1,58 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.zone.skims;
+
+import javax.inject.Provider;
+
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.dvrp.router.DvrpGlobalRoutingNetworkProvider;
+import org.matsim.core.config.groups.GlobalConfigGroup;
+import org.matsim.core.controler.AbstractModule;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class DvrpTravelTimesMatrixModule extends AbstractModule {
+	private final DvrpTravelTimeMatrixParams params;
+	private final int numberOfThreads;
+
+	public DvrpTravelTimesMatrixModule(GlobalConfigGroup globalConfig, DvrpTravelTimeMatrixParams params) {
+		this.params = params;
+		this.numberOfThreads = globalConfig.getNumberOfThreads();
+	}
+
+	@Override
+	public void install() {
+		bind(DvrpTravelTimeMatrix.class).toProvider(new Provider<>() {
+			@Inject
+			@Named(DvrpGlobalRoutingNetworkProvider.DVRP_ROUTING)
+			private Network network;
+
+			@Override
+			public DvrpTravelTimeMatrix get() {
+				return new DvrpTravelTimeMatrix(network, params, numberOfThreads);
+			}
+		}).asEagerSingleton();
+	}
+}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/TravelTimeMatrices.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/TravelTimeMatrices.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) Schweizerische Bundesbahnen SBB, 2018.
+ */
+
+package org.matsim.contrib.zone.skims;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.contrib.util.ExecutorServiceWithResource;
+import org.matsim.core.router.util.TravelDisutility;
+import org.matsim.core.router.util.TravelTime;
+import org.matsim.core.utils.misc.Counter;
+import org.matsim.core.utils.misc.OptionalTime;
+
+import ch.sbb.matsim.analysis.skims.FloatMatrix;
+import ch.sbb.matsim.routing.graph.Graph;
+import ch.sbb.matsim.routing.graph.LeastCostPathTree;
+
+/**
+ * Based on NetworkSkimMatrices from sbb-matsim-extensions
+ *
+ * @author Michal Maciejewski (michalm)
+ */
+public final class TravelTimeMatrices {
+
+	public static <T> FloatMatrix<T> calculateTravelTimeMatrix(Network routingNetwork, Map<T, Node> centralNodes,
+			double departureTime, TravelTime travelTime, TravelDisutility travelDisutility, int numberOfThreads) {
+		Graph graph = new Graph(routingNetwork);
+		ExecutorServiceWithResource<LeastCostPathTree> executorService = new ExecutorServiceWithResource<>(
+				IntStream.range(0, numberOfThreads)
+						.mapToObj(i -> new LeastCostPathTree(graph, travelTime, travelDisutility))
+						.collect(toList()));
+
+		FloatMatrix<T> travelTimeMatrix = new FloatMatrix<>(centralNodes.keySet(), Float.NaN);
+		Counter counter = new Counter("DVRP free-speed TT matrix: zone ", " / " + centralNodes.size());
+		executorService.submitRunnablesAndWait(centralNodes.keySet()
+				.stream()
+				.map(z -> (lcpTree -> computeForDepartureZone(z, centralNodes, departureTime, travelTimeMatrix, lcpTree,
+						counter))));
+
+		executorService.shutdown();
+		return travelTimeMatrix;
+	}
+
+	private static <T> void computeForDepartureZone(T fromZoneId, Map<T, Node> centralNodes, double departureTime,
+			FloatMatrix<T> travelTimeMatrix, LeastCostPathTree lcpTree, Counter counter) {
+		counter.incCounter();
+		Node fromNode = centralNodes.get(fromZoneId);
+		lcpTree.calculate(fromNode.getId().index(), departureTime, null, null);
+
+		for (T toZoneId : centralNodes.keySet()) {
+			Node toNode = centralNodes.get(toZoneId);
+			int nodeIndex = toNode.getId().index();
+			OptionalTime currOptionalTime = lcpTree.getTime(nodeIndex);
+			double currTime = currOptionalTime.orElseThrow(() -> new RuntimeException("Undefined Time"));
+			double tt = currTime - departureTime;
+			travelTimeMatrix.set(fromZoneId, toZoneId, (float)tt);
+		}
+	}
+}

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrixTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrixTest.java
@@ -1,0 +1,68 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.zone.skims;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.core.network.NetworkUtils;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class DvrpTravelTimeMatrixTest {
+
+	private final Network network = NetworkUtils.createNetwork();
+	private final Node nodeA = NetworkUtils.createAndAddNode(network, Id.createNodeId("A"), new Coord(0, 0));
+	private final Node nodeB = NetworkUtils.createAndAddNode(network, Id.createNodeId("B"), new Coord(150, 150));
+	private final DvrpTravelTimeMatrix matrix;
+
+	public DvrpTravelTimeMatrixTest() {
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("AB"), nodeA, nodeB, 150, 15, 20, 1);
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("BA"), nodeB, nodeA, 300, 15, 40, 1);
+		DvrpTravelTimeMatrixParams params = new DvrpTravelTimeMatrixParams();
+		params.setCellSize(100);
+		matrix = new DvrpTravelTimeMatrix(network, params, 1);
+	}
+
+	@Test
+	public void test_centralNodes() {
+		assertThat(matrix.getFreeSpeedTravelTime(nodeA, nodeA)).isEqualTo(0);
+		assertThat(matrix.getFreeSpeedTravelTime(nodeA, nodeB)).isEqualTo(10);
+		assertThat(matrix.getFreeSpeedTravelTime(nodeB, nodeA)).isEqualTo(20);
+		assertThat(matrix.getFreeSpeedTravelTime(nodeB, nodeB)).isEqualTo(0);
+	}
+
+	@Test
+	public void test_nonCentralNodes() {
+		Node nodeC = NetworkUtils.createAndAddNode(network, Id.createNodeId("C"), new Coord(10, 10));
+		Node nodeD = NetworkUtils.createAndAddNode(network, Id.createNodeId("D"), new Coord(140, 140));
+
+		assertThat(matrix.getFreeSpeedTravelTime(nodeC, nodeC)).isEqualTo(0);
+		assertThat(matrix.getFreeSpeedTravelTime(nodeC, nodeD)).isEqualTo(10);
+		assertThat(matrix.getFreeSpeedTravelTime(nodeD, nodeC)).isEqualTo(20);
+		assertThat(matrix.getFreeSpeedTravelTime(nodeD, nodeD)).isEqualTo(0);
+	}
+}

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/zone/skims/TravelTimeMatricesTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/zone/skims/TravelTimeMatricesTest.java
@@ -1,0 +1,59 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.zone.skims;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.contrib.dvrp.router.TimeAsTravelDisutility;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class TravelTimeMatricesTest {
+	@Test
+	public void test() {
+		Network network = NetworkUtils.createNetwork();
+		Node nodeA = NetworkUtils.createAndAddNode(network, Id.createNodeId("A"), new Coord(0, 0));
+		Node nodeB = NetworkUtils.createAndAddNode(network, Id.createNodeId("B"), new Coord(150, 150));
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("AB"), nodeA, nodeB, 150, 15, 20, 1);
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("BA"), nodeB, nodeA, 300, 15, 40, 1);
+		String zoneA = "Zone_A";
+		String zoneB = "Zone_B";
+
+		var centralNodes = Map.of(zoneA, nodeA, zoneB, nodeB);
+		var matrix = TravelTimeMatrices.calculateTravelTimeMatrix(network, centralNodes, 0, new FreeSpeedTravelTime(),
+				new TimeAsTravelDisutility(new FreeSpeedTravelTime()), 1);
+
+		assertThat(matrix.get(zoneA, zoneA)).isEqualTo(0);
+		assertThat(matrix.get(zoneA, zoneB)).isEqualTo(10);
+		assertThat(matrix.get(zoneB, zoneA)).isEqualTo(20);
+		assertThat(matrix.get(zoneB, zoneB)).isEqualTo(0);
+	}
+}


### PR DESCRIPTION
- currently only free-speed car TTs
- calculated only if `DvrpTravelTimeMatrixParams` are present inside `DvrpConfigGroup`
- square-grid zones are created automatically (cell size: `DvrpConfigGroup.getTravelTimeMatrixParams().get().getCellSize()`)
- global because of computation time and memory usage (but can be "guice-configured" per mode)

The TT matrix will replace the use of beeline TTs in `DrtInsertionSearch`es (both extensive and selective)
