### PR TITLE
Replace beeline TT with TT matrix in DRT

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourTimeEstimator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourTimeEstimator.java
@@ -20,6 +20,7 @@ package org.matsim.contrib.drt.optimizer.insertion;
 
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.util.distance.DistanceUtils;
+import org.matsim.contrib.zone.skims.DvrpTravelTimeMatrix;
 
 /**
  * @author michalm
@@ -27,6 +28,10 @@ import org.matsim.contrib.util.distance.DistanceUtils;
 public interface DetourTimeEstimator {
 	static DetourTimeEstimator createNodeToNodeBeelineTimeEstimator(double beelineSpeed) {
 		return (from, to) -> DistanceUtils.calculateDistance(from.getToNode(), to.getToNode()) / beelineSpeed;
+	}
+
+	static DetourTimeEstimator createFreeSpeedZonalTimeEstimator(double factor, DvrpTravelTimeMatrix matrix) {
+		return (from, to) -> factor * matrix.getFreeSpeedTravelTime(from.getToNode(), to.getToNode());
 	}
 
 	double estimateTime(Link from, Link to);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearch.java
@@ -30,6 +30,7 @@ import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
+import org.matsim.contrib.zone.skims.DvrpTravelTimeMatrix;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 
 /**
@@ -48,19 +49,17 @@ public class ExtensiveInsertionSearch implements DrtInsertionSearch<PathData> {
 	private final BestInsertionFinder<PathData> bestInsertionFinder;
 
 	public ExtensiveInsertionSearch(DetourPathCalculator detourPathCalculator, DrtConfigGroup drtCfg, MobsimTimer timer,
-			ForkJoinPool forkJoinPool, InsertionCostCalculator.PenaltyCalculator penaltyCalculator) {
+			ForkJoinPool forkJoinPool, InsertionCostCalculator.PenaltyCalculator penaltyCalculator,
+			DvrpTravelTimeMatrix dvrpTravelTimeMatrix) {
 		this.detourPathCalculator = detourPathCalculator;
 		this.forkJoinPool = forkJoinPool;
 
 		insertionParams = (ExtensiveInsertionSearchParams)drtCfg.getDrtInsertionSearchParams();
 		admissibleCostCalculator = new InsertionCostCalculator<>(drtCfg, timer, penaltyCalculator, Double::doubleValue);
 
-		// TODO use more sophisticated DetourTimeEstimator
-		double admissibleBeelineSpeed = insertionParams.getAdmissibleBeelineSpeedFactor()
-				* drtCfg.getEstimatedDrtSpeed() / drtCfg.getEstimatedBeelineDistanceFactor();
-
 		admissibleDetourTimesProvider = new DetourTimesProvider(
-				DetourTimeEstimator.createNodeToNodeBeelineTimeEstimator(admissibleBeelineSpeed));
+				DetourTimeEstimator.createFreeSpeedZonalTimeEstimator(insertionParams.getAdmissibleBeelineSpeedFactor(),
+						dvrpTravelTimeMatrix));
 
 		bestInsertionFinder = new BestInsertionFinder<>(
 				new InsertionCostCalculator<>(drtCfg, timer, penaltyCalculator, PathData::getTravelTime));

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchParams.java
@@ -35,7 +35,7 @@ public class ExtensiveInsertionSearchParams extends DrtInsertionSearchParams {
 
 	public static final String ADMISSIBLE_BEELINE_SPEED_FACTOR = "admissibleBeelineSpeedFactor";
 	@DecimalMin("1.0")
-	private double admissibleBeelineSpeedFactor = 1.5;
+	private double admissibleBeelineSpeedFactor = 1.0;
 
 	public ExtensiveInsertionSearchParams() {
 		super(SET_NAME);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchQSimModule.java
@@ -55,7 +55,7 @@ public class ExtensiveInsertionSearchQSimModule extends AbstractDvrpModeQSimModu
 				getter -> new ExtensiveInsertionSearch(getter.getModal(DetourPathCalculator.class), drtCfg,
 						getter.get(MobsimTimer.class), getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool(),
 						getter.getModal(InsertionCostCalculator.PenaltyCalculator.class),
-						getter.get(DvrpTravelTimeMatrix.class))));
+						getter.getModal(DvrpTravelTimeMatrix.class))));
 
 		addModalComponent(MultiInsertionDetourPathCalculator.class, new ModalProviders.AbstractProvider<>(getMode()) {
 			@Inject

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchQSimModule.java
@@ -27,6 +27,7 @@ import org.matsim.contrib.dvrp.path.OneToManyPathSearch;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.ModalProviders;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
+import org.matsim.contrib.zone.skims.DvrpTravelTimeMatrix;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
 import org.matsim.core.router.util.TravelDisutility;
@@ -53,7 +54,8 @@ public class ExtensiveInsertionSearchQSimModule extends AbstractDvrpModeQSimModu
 		}).toProvider(modalProvider(
 				getter -> new ExtensiveInsertionSearch(getter.getModal(DetourPathCalculator.class), drtCfg,
 						getter.get(MobsimTimer.class), getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool(),
-						getter.getModal(InsertionCostCalculator.PenaltyCalculator.class))));
+						getter.getModal(InsertionCostCalculator.PenaltyCalculator.class),
+						getter.get(DvrpTravelTimeMatrix.class))));
 
 		addModalComponent(MultiInsertionDetourPathCalculator.class, new ModalProviders.AbstractProvider<>(getMode()) {
 			@Inject

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearch.java
@@ -29,6 +29,7 @@ import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
+import org.matsim.contrib.zone.skims.DvrpTravelTimeMatrix;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 
 /**
@@ -46,16 +47,16 @@ public class SelectiveInsertionSearch implements DrtInsertionSearch<PathData> {
 	private final BestInsertionFinder<PathData> bestInsertionFinder;
 
 	public SelectiveInsertionSearch(DetourPathCalculator detourPathCalculator, DrtConfigGroup drtCfg, MobsimTimer timer,
-			ForkJoinPool forkJoinPool, InsertionCostCalculator.PenaltyCalculator penaltyCalculator) {
+			ForkJoinPool forkJoinPool, InsertionCostCalculator.PenaltyCalculator penaltyCalculator,
+			DvrpTravelTimeMatrix dvrpTravelTimeMatrix) {
 		this.detourPathCalculator = detourPathCalculator;
 		this.forkJoinPool = forkJoinPool;
 
-		// TODO use more sophisticated DetourTimeEstimator
-		double restrictiveBeelineSpeed = ((SelectiveInsertionSearchParams)drtCfg.getDrtInsertionSearchParams()).getRestrictiveBeelineSpeedFactor()
-				* drtCfg.getEstimatedDrtSpeed() / drtCfg.getEstimatedBeelineDistanceFactor();
+		double restrictiveBeelineSpeedFactor = ((SelectiveInsertionSearchParams)drtCfg.getDrtInsertionSearchParams()).getRestrictiveBeelineSpeedFactor();
 
 		restrictiveDetourTimesProvider = new DetourTimesProvider(
-				DetourTimeEstimator.createNodeToNodeBeelineTimeEstimator(restrictiveBeelineSpeed));
+				DetourTimeEstimator.createFreeSpeedZonalTimeEstimator(restrictiveBeelineSpeedFactor,
+						dvrpTravelTimeMatrix));
 
 		initialInsertionFinder = new BestInsertionFinder<>(
 				new InsertionCostCalculator<>(drtCfg, timer, penaltyCalculator, Double::doubleValue));

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchQSimModule.java
@@ -55,7 +55,7 @@ public class SelectiveInsertionSearchQSimModule extends AbstractDvrpModeQSimModu
 				getter -> new SelectiveInsertionSearch(getter.getModal(DetourPathCalculator.class), drtCfg,
 						getter.get(MobsimTimer.class), getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool(),
 						getter.getModal(InsertionCostCalculator.PenaltyCalculator.class),
-						getter.get(DvrpTravelTimeMatrix.class))));
+						getter.getModal(DvrpTravelTimeMatrix.class))));
 
 		addModalComponent(SingleInsertionDetourPathCalculator.class, new ModalProviders.AbstractProvider<>(getMode()) {
 			@Inject

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchQSimModule.java
@@ -27,6 +27,7 @@ import org.matsim.contrib.dvrp.path.OneToManyPathSearch;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.ModalProviders;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
+import org.matsim.contrib.zone.skims.DvrpTravelTimeMatrix;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
 import org.matsim.core.router.util.TravelDisutility;
@@ -53,7 +54,8 @@ public class SelectiveInsertionSearchQSimModule extends AbstractDvrpModeQSimModu
 		}).toProvider(modalProvider(
 				getter -> new SelectiveInsertionSearch(getter.getModal(DetourPathCalculator.class), drtCfg,
 						getter.get(MobsimTimer.class), getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool(),
-						getter.getModal(InsertionCostCalculator.PenaltyCalculator.class))));
+						getter.getModal(InsertionCostCalculator.PenaltyCalculator.class),
+						getter.get(DvrpTravelTimeMatrix.class))));
 
 		addModalComponent(SingleInsertionDetourPathCalculator.class, new ModalProviders.AbstractProvider<>(getMode()) {
 			@Inject

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -118,14 +118,6 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 	public static final String MAX_WALK_DISTANCE = "maxWalkDistance";
 	static final String MAX_WALK_DISTANCE_EXP = "Maximum beeline distance (in meters) to next stop location in stopbased system for access/egress walk leg to/from drt. If no stop can be found within this maximum distance will return null (in most cases caught by fallback routing module).";
 
-	public static final String ESTIMATED_DRT_SPEED = "estimatedDrtSpeed";
-	static final String ESTIMATED_DRT_SPEED_EXP =
-			"Beeline-speed estimate for DRT. Used in analysis, optimisation constraints "
-					+ "and in plans file, [m/s]. The default value is 25 km/h";
-
-	public static final String ESTIMATED_BEELINE_DISTANCE_FACTOR = "estimatedBeelineDistanceFactor";
-	static final String ESTIMATED_BEELINE_DISTANCE_FACTOR_EXP = "Beeline distance factor for DRT. Used in analyis and in plans file. The default value is 1.3.";
-
 	public static final String VEHICLES_FILE = "vehiclesFile";
 	static final String VEHICLES_FILE_EXP = "An XML file specifying the vehicle fleet. The file format according to dvrp_vehicles_v1.dtd";
 
@@ -178,12 +170,6 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 
 	@PositiveOrZero // used only for stopbased DRT scheme
 	private double maxWalkDistance = Double.MAX_VALUE;// [m];
-
-	@PositiveOrZero
-	private double estimatedDrtSpeed = 25. / 3.6;// [m/s]
-
-	@DecimalMin("1.0")
-	private double estimatedBeelineDistanceFactor = 1.3;// [-]
 
 	@Nullable//it is possible to generate a FleetSpecification (instead of reading it from a file)
 	private String vehiclesFile = null;
@@ -320,8 +306,6 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 		map.put(OPERATIONAL_SCHEME, OPERATIONAL_SCHEME_EXP);
 		map.put(MAX_WALK_DISTANCE, MAX_WALK_DISTANCE_EXP);
 		map.put(TRANSIT_STOP_FILE, TRANSIT_STOP_FILE_EXP);
-		map.put(ESTIMATED_DRT_SPEED, ESTIMATED_DRT_SPEED_EXP);
-		map.put(ESTIMATED_BEELINE_DISTANCE_FACTOR, ESTIMATED_BEELINE_DISTANCE_FACTOR_EXP);
 		map.put(NUMBER_OF_THREADS, NUMBER_OF_THREADS_EXP);
 		map.put(REJECT_REQUEST_IF_MAX_WAIT_OR_TRAVEL_TIME_VIOLATED,
 				REJECT_REQUEST_IF_MAX_WAIT_OR_TRAVEL_TIME_VIOLATED_EXP);
@@ -584,40 +568,6 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 	@StringSetter(MAX_WALK_DISTANCE)
 	public DrtConfigGroup setMaxWalkDistance(double maximumWalkDistance) {
 		this.maxWalkDistance = maximumWalkDistance;
-		return this;
-	}
-
-	/**
-	 * @return -- {@value #ESTIMATED_DRT_SPEED_EXP}
-	 */
-	@StringGetter(ESTIMATED_DRT_SPEED)
-	public double getEstimatedDrtSpeed() {
-		return estimatedDrtSpeed;
-	}
-
-	/**
-	 * @param-- {@value #ESTIMATED_DRT_SPEED_EXP}
-	 */
-	@StringSetter(ESTIMATED_DRT_SPEED)
-	public DrtConfigGroup setEstimatedDrtSpeed(double estimatedSpeed) {
-		this.estimatedDrtSpeed = estimatedSpeed;
-		return this;
-	}
-
-	/**
-	 * @return -- {@value #ESTIMATED_BEELINE_DISTANCE_FACTOR_EXP}
-	 */
-	@StringGetter(ESTIMATED_BEELINE_DISTANCE_FACTOR)
-	public double getEstimatedBeelineDistanceFactor() {
-		return estimatedBeelineDistanceFactor;
-	}
-
-	/**
-	 * @param-- {@value #ESTIMATED_BEELINE_DISTANCE_FACTOR_EXP}
-	 */
-	@StringSetter(ESTIMATED_BEELINE_DISTANCE_FACTOR)
-	public DrtConfigGroup setEstimatedBeelineDistanceFactor(double estimatedBeelineDistanceFactor) {
-		this.estimatedBeelineDistanceFactor = estimatedBeelineDistanceFactor;
 		return this;
 	}
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/benchmark/DvrpBenchmarkModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/benchmark/DvrpBenchmarkModule.java
@@ -22,27 +22,41 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicleLookup;
 import org.matsim.contrib.dvrp.passenger.PassengerModule;
 import org.matsim.contrib.dvrp.router.DvrpGlobalRoutingNetworkProvider;
+import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.MobsimTimerProvider;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentSourceQSimModule;
 import org.matsim.contrib.dynagent.run.DynActivityEngine;
+import org.matsim.contrib.zone.skims.DvrpGlobalTravelTimesMatrixProvider;
+import org.matsim.contrib.zone.skims.DvrpTravelTimeMatrix;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehicleUtils;
 
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import com.google.inject.name.Names;
 
 /**
  * @author michalm
  */
 public class DvrpBenchmarkModule extends AbstractModule {
+	@Inject
+	private DvrpConfigGroup dvrpConfigGroup;
+
 	@Override
 	public void install() {
 		bind(VehicleType.class).annotatedWith(Names.named(VrpAgentSourceQSimModule.DVRP_VEHICLE_TYPE))
 				.toInstance(VehicleUtils.getDefaultVehicleType());
 
 		install(new DvrpBenchmarkTravelTimeModule());// fixed travel times
+
+		//lazily initialised:
+		// 1. we have only mode-filtered subnetworks
+		// 2. optimisers may do not use it
+		bind(DvrpTravelTimeMatrix.class).toProvider(new DvrpGlobalTravelTimesMatrixProvider(getConfig().global(),
+				dvrpConfigGroup.getTravelTimeMatrixParams())).in(Singleton.class);
 
 		bind(Network.class).annotatedWith(Names.named(DvrpGlobalRoutingNetworkProvider.DVRP_ROUTING))
 				.toProvider(DvrpGlobalRoutingNetworkProvider.class)

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpModeRoutingNetworkModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpModeRoutingNetworkModule.java
@@ -38,6 +38,7 @@ import org.matsim.core.network.algorithms.TransportModeNetworkFilter;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import com.google.inject.Key;
+import com.google.inject.Singleton;
 import com.google.inject.name.Names;
 
 /**
@@ -73,8 +74,8 @@ public class DvrpModeRoutingNetworkModule extends AbstractDvrpModeModule {
 			dvrpConfigGroup.getTravelTimeMatrixParams().ifPresent(travelTimeMatrixParams ->//
 					bindModal(DvrpTravelTimeMatrix.class).toProvider(createProvider(getMode(),
 							getter -> new DvrpTravelTimeMatrix(getter.getModal(Network.class), travelTimeMatrixParams,
-									globalConfigGroup.getNumberOfThreads()))).asEagerSingleton());
-
+									globalConfigGroup.getNumberOfThreads())))//
+							.in(Singleton.class));//lazily initialised - in case this specific mode does not need it
 		} else {
 			bindModal(Network.class).to(
 					Key.get(Network.class, Names.named(DvrpGlobalRoutingNetworkProvider.DVRP_ROUTING)));

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpModeRoutingNetworkModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpModeRoutingNetworkModule.java
@@ -71,17 +71,15 @@ public class DvrpModeRoutingNetworkModule extends AbstractDvrpModeModule {
 				return subnetwork;
 			})).asEagerSingleton();
 
-			dvrpConfigGroup.getTravelTimeMatrixParams().ifPresent(travelTimeMatrixParams ->//
-					bindModal(DvrpTravelTimeMatrix.class).toProvider(createProvider(getMode(),
-							getter -> new DvrpTravelTimeMatrix(getter.getModal(Network.class), travelTimeMatrixParams,
-									globalConfigGroup.getNumberOfThreads())))//
-							.in(Singleton.class));//lazily initialised - in case this specific mode does not need it
+			//lazily initialised: optimisers may do not need it
+			bindModal(DvrpTravelTimeMatrix.class).toProvider(createProvider(getMode(),
+					getter -> new DvrpTravelTimeMatrix(getter.getModal(Network.class),
+							dvrpConfigGroup.getTravelTimeMatrixParams(), globalConfigGroup.getNumberOfThreads())))
+					.in(Singleton.class);
 		} else {
 			bindModal(Network.class).to(
 					Key.get(Network.class, Names.named(DvrpGlobalRoutingNetworkProvider.DVRP_ROUTING)));
-			if (dvrpConfigGroup.getTravelTimeMatrixParams().isPresent()) {
-				bindModal(DvrpTravelTimeMatrix.class).to(DvrpTravelTimeMatrix.class);
-			}
+			bindModal(DvrpTravelTimeMatrix.class).to(DvrpTravelTimeMatrix.class);
 		}
 	}
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigGroup.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigGroup.java
@@ -20,7 +20,6 @@
 package org.matsim.contrib.dvrp.run;
 
 import java.util.Map;
-import java.util.Optional;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.DecimalMax;
@@ -236,7 +235,10 @@ public final class DvrpConfigGroup extends ReflectiveConfigGroupWithConfigurable
 		return this;
 	}
 
-	public Optional<DvrpTravelTimeMatrixParams> getTravelTimeMatrixParams() {
-		return Optional.ofNullable(travelTimeMatrixParams);
+	public DvrpTravelTimeMatrixParams getTravelTimeMatrixParams() {
+		if (travelTimeMatrixParams == null) {
+			addParameterSet(new DvrpTravelTimeMatrixParams());
+		}
+		return travelTimeMatrixParams;
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpModule.java
@@ -27,7 +27,8 @@ import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentQueryHelper;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentSourceQSimModule;
 import org.matsim.contrib.dynagent.run.DynActivityEngine;
-import org.matsim.contrib.zone.skims.DvrpTravelTimesMatrixModule;
+import org.matsim.contrib.zone.skims.DvrpGlobalTravelTimesMatrixProvider;
+import org.matsim.contrib.zone.skims.DvrpTravelTimeMatrix;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
@@ -36,6 +37,7 @@ import org.matsim.vehicles.VehicleUtils;
 import org.matsim.vis.otfvis.OnTheFlyServer.NonPlanAgentQueryHelper;
 
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import com.google.inject.name.Names;
 
 /**
@@ -60,8 +62,10 @@ public final class DvrpModule extends AbstractModule {
 
 		install(new DvrpTravelTimeModule());
 
-		dvrpConfigGroup.getTravelTimeMatrixParams()
-				.ifPresent(params -> install(new DvrpTravelTimesMatrixModule(getConfig().global(), params)));
+		dvrpConfigGroup.getTravelTimeMatrixParams().ifPresent(travelTimeMatrixParams ->//
+				bind(DvrpTravelTimeMatrix.class).toProvider(
+						new DvrpGlobalTravelTimesMatrixProvider(getConfig().global(), travelTimeMatrixParams))
+						.in(Singleton.class));//lazily initialised - in case we have only mode-filtered subnetworks!
 
 		bind(Network.class).annotatedWith(Names.named(DvrpGlobalRoutingNetworkProvider.DVRP_ROUTING))
 				.toProvider(DvrpGlobalRoutingNetworkProvider.class)

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpModule.java
@@ -62,10 +62,11 @@ public final class DvrpModule extends AbstractModule {
 
 		install(new DvrpTravelTimeModule());
 
-		dvrpConfigGroup.getTravelTimeMatrixParams().ifPresent(travelTimeMatrixParams ->//
-				bind(DvrpTravelTimeMatrix.class).toProvider(
-						new DvrpGlobalTravelTimesMatrixProvider(getConfig().global(), travelTimeMatrixParams))
-						.in(Singleton.class));//lazily initialised - in case we have only mode-filtered subnetworks!
+		//lazily initialised:
+		// 1. we have only mode-filtered subnetworks
+		// 2. optimisers may do not use it
+		bind(DvrpTravelTimeMatrix.class).toProvider(new DvrpGlobalTravelTimesMatrixProvider(getConfig().global(),
+				dvrpConfigGroup.getTravelTimeMatrixParams())).in(Singleton.class);
 
 		bind(Network.class).annotatedWith(Names.named(DvrpGlobalRoutingNetworkProvider.DVRP_ROUTING))
 				.toProvider(DvrpGlobalRoutingNetworkProvider.class)

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/util/NetworkAreaFiltering.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/util/NetworkAreaFiltering.java
@@ -1,0 +1,53 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.util;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.locationtech.jts.geom.prep.PreparedGeometry;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.contrib.zone.ZonalSystems;
+import org.matsim.core.network.algorithms.NetworkCleaner;
+import org.matsim.core.network.filter.NetworkFilterManager;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class NetworkAreaFiltering {
+	public static Network filterNetworkUsingShapefile(Network network, List<PreparedGeometry> areaGeometries,
+			boolean runNetworkCleaner) {
+		Set<Node> nodesWithinArea = new HashSet<>(
+				ZonalSystems.selectNodesWithinArea(network.getNodes().values(), areaGeometries));
+
+		NetworkFilterManager networkFilterManager = new NetworkFilterManager(network);
+		networkFilterManager.addLinkFilter(
+				l -> nodesWithinArea.contains(l.getFromNode()) || nodesWithinArea.contains(l.getToNode()));
+		Network filteredNetwork = networkFilterManager.applyFilters();
+
+		if (runNetworkCleaner) {
+			new NetworkCleaner().run(filteredNetwork);
+		}
+		return filteredNetwork;
+	}
+}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/ZonalSystems.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/ZonalSystems.java
@@ -45,11 +45,10 @@ public class ZonalSystems {
 		return nodes.stream().map(zonalSystem::getZone).collect(toSet());
 	}
 
-	public static List<Node> selectNodesWithinServiceArea(Collection<? extends Node> nodes,
-			List<PreparedGeometry> serviceAreaGeoms) {
+	public static List<Node> selectNodesWithinArea(Collection<? extends Node> nodes, List<PreparedGeometry> areaGeoms) {
 		return nodes.stream().filter(node -> {
 			Point point = MGC.coord2Point(node.getCoord());
-			return serviceAreaGeoms.stream().anyMatch(serviceArea -> serviceArea.intersects(point));
+			return areaGeoms.stream().anyMatch(serviceArea -> serviceArea.intersects(point));
 		}).collect(toList());
 	}
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpGlobalTravelTimesMatrixProvider.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpGlobalTravelTimesMatrixProvider.java
@@ -25,7 +25,6 @@ import javax.inject.Provider;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.router.DvrpGlobalRoutingNetworkProvider;
 import org.matsim.core.config.groups.GlobalConfigGroup;
-import org.matsim.core.controler.AbstractModule;
 
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -33,26 +32,21 @@ import com.google.inject.name.Named;
 /**
  * @author Michal Maciejewski (michalm)
  */
-public class DvrpTravelTimesMatrixModule extends AbstractModule {
+public class DvrpGlobalTravelTimesMatrixProvider implements Provider<DvrpTravelTimeMatrix> {
 	private final DvrpTravelTimeMatrixParams params;
 	private final int numberOfThreads;
 
-	public DvrpTravelTimesMatrixModule(GlobalConfigGroup globalConfig, DvrpTravelTimeMatrixParams params) {
+	@Inject
+	@Named(DvrpGlobalRoutingNetworkProvider.DVRP_ROUTING)
+	private Network network;
+
+	public DvrpGlobalTravelTimesMatrixProvider(GlobalConfigGroup globalConfig, DvrpTravelTimeMatrixParams params) {
 		this.params = params;
 		this.numberOfThreads = globalConfig.getNumberOfThreads();
 	}
 
 	@Override
-	public void install() {
-		bind(DvrpTravelTimeMatrix.class).toProvider(new Provider<>() {
-			@Inject
-			@Named(DvrpGlobalRoutingNetworkProvider.DVRP_ROUTING)
-			private Network network;
-
-			@Override
-			public DvrpTravelTimeMatrix get() {
-				return new DvrpTravelTimeMatrix(network, params, numberOfThreads);
-			}
-		}).asEagerSingleton();
+	public DvrpTravelTimeMatrix get() {
+		return new DvrpTravelTimeMatrix(network, params, numberOfThreads);
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrixParams.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrixParams.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import javax.validation.constraints.Positive;
 
+import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ReflectiveConfigGroup;
 
 /**
@@ -64,5 +65,10 @@ public class DvrpTravelTimeMatrixParams extends ReflectiveConfigGroup {
 	@StringSetter(CELL_SIZE)
 	public void setCellSize(int cellSize) {
 		this.cellSize = cellSize;
+	}
+
+	@Override
+	public ConfigGroup createParameterSet(String type) {
+		return super.createParameterSet(type);
 	}
 }

--- a/contribs/vsp/src/test/java/org/matsim/integration/drtAndPt/PtAlongALine2Test.java
+++ b/contribs/vsp/src/test/java/org/matsim/integration/drtAndPt/PtAlongALine2Test.java
@@ -210,8 +210,6 @@ public class PtAlongALine2Test{
 						.setMaxWaitTime(Double.MAX_VALUE)
 						.setRejectRequestIfMaxWaitOrTravelTimeViolated(false)
 						.setUseModeFilteredSubnetwork(true)
-						.setEstimatedBeelineDistanceFactor(1.0)
-						.setEstimatedDrtSpeed(15)
 						.setAdvanceRequestPlanningHorizon(99999);
 				drtConfigGroup.addParameterSet(new ExtensiveInsertionSearchParams());
 				mm.addParameterSet(drtConfigGroup);

--- a/examples/scenarios/dvrp-grid/multi_mode_one_shared_taxi_config.xml
+++ b/examples/scenarios/dvrp-grid/multi_mode_one_shared_taxi_config.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" ?>
 <!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
 <config>
+	<module name="dvrp">
+		<parameterset type="travelTimeMatrix">
+			<param name="cellSize" value="10"/>
+		</parameterset>
+	</module>
+
 	<module name="multiModeDrt">
 		<parameterset type="drt">
 			<parameterset type="ExtensiveInsertionSearch"/>

--- a/examples/scenarios/dvrp-grid/one_shared_taxi_config.xml
+++ b/examples/scenarios/dvrp-grid/one_shared_taxi_config.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" ?>
 <!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
 <config>
+	<module name="dvrp">
+		<parameterset type="travelTimeMatrix">
+			<param name="cellSize" value="10"/>
+		</parameterset>
+	</module>
+
 	<module name="multiModeDrt">
 		<parameterset type="drt">
 			<parameterset type="ExtensiveInsertionSearch"/>

--- a/examples/scenarios/mielec/mielec_drt_config.xml
+++ b/examples/scenarios/mielec/mielec_drt_config.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" ?>
 <!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
 <config>
+	<module name="dvrp">
+		<parameterset type="travelTimeMatrix">
+			<param name="cellSize" value="10000"/>
+		</parameterset>
+	</module>
+
 	<module name="multiModeDrt">
 		<parameterset type="drt">
 			<parameterset type="ExtensiveInsertionSearch"/>

--- a/examples/scenarios/mielec/mielec_edrt_config.xml
+++ b/examples/scenarios/mielec/mielec_edrt_config.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" ?>
 <!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
 <config>
+	<module name="dvrp">
+		<parameterset type="travelTimeMatrix">
+			<param name="cellSize" value="100"/>
+		</parameterset>
+	</module>
+
 	<module name="multiModeDrt">
 		<parameterset type="drt">
 			<parameterset type="ExtensiveInsertionSearch"/>

--- a/examples/scenarios/mielec/mielec_serviceArea_based_drt_config.xml
+++ b/examples/scenarios/mielec/mielec_serviceArea_based_drt_config.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" ?>
 <!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
 <config>
+	<module name="dvrp">
+		<parameterset type="travelTimeMatrix">
+			<param name="cellSize" value="100"/>
+		</parameterset>
+	</module>
+
 	<module name="multiModeDrt">
 		<parameterset type="drt">
 			<parameterset type="ExtensiveInsertionSearch"/>

--- a/examples/scenarios/mielec/mielec_stop_based_drt_config.xml
+++ b/examples/scenarios/mielec/mielec_stop_based_drt_config.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" ?>
 <!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
 <config>
+	<module name="dvrp">
+		<parameterset type="travelTimeMatrix">
+			<param name="cellSize" value="100"/>
+		</parameterset>
+	</module>
+
 	<module name="multiModeDrt">
 		<parameterset type="drt">
 			<parameterset type="ExtensiveInsertionSearch"/>

--- a/matsim/src/main/java/org/matsim/core/network/filter/NetworkFilterManager.java
+++ b/matsim/src/main/java/org/matsim/core/network/filter/NetworkFilterManager.java
@@ -115,28 +115,14 @@ public final class NetworkFilterManager {
 		Network net = NetworkUtils.createNetwork();
 		if (!this.nodeFilters.isEmpty()) {
 			for (Node n : this.network.getNodes().values()) {
-				boolean add = true;
-				for (NetworkNodeFilter f : nodeFilters) {
-					if (!f.judgeNode(n)) {
-						add = false;
-						break;
-					}
-				}
-				if (add) {
+				if (nodeFilters.stream().allMatch(f -> f.judgeNode(n))) {
 					this.addNode(net, n);
 				}
 			}
 		}
 		if (!this.linkFilters.isEmpty()) {
 			for (Link l : this.network.getLinks().values()) {
-				boolean add = true;
-				for (NetworkLinkFilter f : linkFilters) {
-					if (!f.judgeLink(l)) {
-						add = false;
-						break;
-					}
-				}
-				if (add) {
+				if (linkFilters.stream().allMatch(f -> f.judgeLink(l))) {
 					this.addLink(net, l);
 				}
 			}


### PR DESCRIPTION
Compute travel time matrices (using auto-generated grid zones) in order to:
1. stop using beeline distances and TTs in DRT and taxi (insertion, relocation etc.)
2. get more accurate results for `SelectiveInsertionSearch` to minimise rejections.

**Changes in configs**
1. `DvrpTravelTimeMatrixParams` is added to the DVRP config. If not provided this is assumed as default (200 m as the cell size):
```
        <parameterset type="travelTimeMatrix">
            <param name="cellSize" value="200"/>
        </parameterset>
```
Currently there is only 1 global free-speed TT matrix with one exception: if drt/taxi uses a mode-filtered network, a separate matrix is created for such a mode.

2. `estimatedDrtSpeed` and `estimatedBeelineDistanceFactor` are removed from the DRT config.

**Performance**
Since currently only the free-speed TT matrix is available, its computation is done once per matsim run. Usually computing travel time matrices should not take a lot of time (compared to the DRT optimisation) or memory. If the RAM or CPU usage is too high, there are 3 options:
- reduce DVRP routing network to the operation area (also beneficial for the DRT optimiser)
- increase the cell size
- provide a custom matrix (overriding the default guice bindings).
