### PR TITLE
In one LSP...EVentHandler the "extends EventHandler" was missing.

### DIFF
--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/events/eventhandler/LSPVehicleLeavesTrafficEventHandler.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/events/eventhandler/LSPVehicleLeavesTrafficEventHandler.java
@@ -1,8 +1,9 @@
 package org.matsim.contrib.freight.events.eventhandler;
 
 import org.matsim.contrib.freight.events.LSPFreightVehicleLeavesTrafficEvent;
+import org.matsim.core.events.handler.EventHandler;
 
-public interface LSPVehicleLeavesTrafficEventHandler{
+public interface LSPVehicleLeavesTrafficEventHandler extends EventHandler {
 	
 	public void handleEvent( LSPFreightVehicleLeavesTrafficEvent event );
 }


### PR DESCRIPTION
This lead to failures in the dfg-project since PR #1180