### PR TITLE
quick fix for #1226: emissions: introduce a switch for level of consitency check

### DIFF
--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/ColdEmissionAnalysisModule.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/ColdEmissionAnalysisModule.java
@@ -85,11 +85,15 @@ final class ColdEmissionAnalysisModule {
 	/*package-private*/ ColdEmissionAnalysisModule( Map<HbefaColdEmissionFactorKey, HbefaColdEmissionFactor> avgHbefaColdTable,
 													Map<HbefaColdEmissionFactorKey, HbefaColdEmissionFactor> detailedHbefaColdTable, EmissionsConfigGroup ecg,
 													Set<Pollutant> coldPollutants, EventsManager eventsManager ){
+
+		Gbl.assertIf( avgHbefaColdTable!=null || detailedHbefaColdTable!=null );
 		this.avgHbefaColdTable = avgHbefaColdTable;
 		this.detailedHbefaColdTable = detailedHbefaColdTable;
-		this.eventsManager = eventsManager;
 		this.ecg = ecg;
 		this.coldPollutants = coldPollutants;
+
+		Gbl.assertNotNull( eventsManager );
+		this.eventsManager = eventsManager;
 	}
 
 	/*package-private*/ Map<Pollutant, Double> checkVehicleInfoAndCalculateWColdEmissions(

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/WarmEmissionAnalysisModule.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/WarmEmissionAnalysisModule.java
@@ -101,6 +101,8 @@ public final class WarmEmissionAnalysisModule implements LinkEmissionsCalculator
 					// The following tests if the detailed table is consistent, i.e. if there exist all combinations of entries.  There used to be some test
 					// cases where this was deliberately not the case, implying that this was assumed as plausible also for studies.  This is now forbidding it.
 					// If this causes too many problems, we could insert a switch (or attach it to the fallback behavior switch).  kai, feb'20
+					// Eventually vehicle category and vehicle attribute should be alligned in order to make the allCombinations setting useful
+					// see discussion in  https://github.com/matsim-org/matsim-libs/issues/1226 kturner, nov'20
 					if (detailedHbefaWarmTable != null) {
 						Set<String> roadCategories = new HashSet<>();
 						Set<HbefaTrafficSituation> trafficSituations = EnumSet.noneOf(HbefaTrafficSituation.class);

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/WarmEmissionAnalysisModule.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/WarmEmissionAnalysisModule.java
@@ -95,78 +95,90 @@ public final class WarmEmissionAnalysisModule implements LinkEmissionsCalculator
 		Gbl.assertNotNull( eventsManager );
 		this.eventsManager = eventsManager;
 
-		if ( detailedHbefaWarmTable!=null ){
-			// The following tests if the detailed table is consistent, i.e. if there exist all combinations of entries.  There used to be some test
-			// cases where this was deliberately not the case, implying that this was assumed as plausible also for studies.  This is now forbidding it.
-			// If this causes too many problems, we could insert a switch (or attach it to the fallback behavior switch).  kai, feb'20
-			Set<String> roadCategories = new HashSet<>();
-			Set<HbefaTrafficSituation> trafficSituations = EnumSet.noneOf( HbefaTrafficSituation.class );
-			Set<HbefaVehicleCategory> vehicleCategories = EnumSet.noneOf( HbefaVehicleCategory.class );
-			Set<HbefaVehicleAttributes> vehicleAttributes = new HashSet<>();
-			Set<Pollutant> pollutantsInTable = EnumSet.noneOf( Pollutant.class );
-			for( HbefaWarmEmissionFactorKey emissionFactorKey : detailedHbefaWarmTable.keySet() ){
-				roadCategories.add( emissionFactorKey.getHbefaRoadCategory() );
-				trafficSituations.add( emissionFactorKey.getHbefaTrafficSituation() );
-				vehicleCategories.add( emissionFactorKey.getHbefaVehicleCategory() );
-				vehicleAttributes.add( emissionFactorKey.getHbefaVehicleAttributes() );
-				pollutantsInTable.add( emissionFactorKey.getHbefaComponent() );
-			}
-			for( String roadCategory : roadCategories ){
-				for( HbefaTrafficSituation trafficSituation : trafficSituations ){
-					for( HbefaVehicleCategory vehicleCategory : vehicleCategories ){
-						for( HbefaVehicleAttributes vehicleAttribute : vehicleAttributes ){
-							for( Pollutant pollutant : pollutantsInTable ){
-								HbefaWarmEmissionFactorKey key = new HbefaWarmEmissionFactorKey();
-								key.setHbefaRoadCategory( roadCategory );
-								key.setHbefaTrafficSituation( trafficSituation );
-								key.setHbefaVehicleCategory( vehicleCategory );
-								key.setHbefaVehicleAttributes( vehicleAttribute );
-								key.setHbefaComponent( pollutant );
-								HbefaWarmEmissionFactor result = detailedHbefaWarmTable.get( key );
-								if( result == null ){
-									throw new RuntimeException( "emissions factor for key=" + key + " is missing." +
-														    "  There used to be some " +
-														    "fallback, but it was " +
-														    "inconsistent and confusing, so " +
-														    "we are now just aborting." );
+		if ( detailedHbefaWarmTable!=null ) {
+			switch (ecg.gethbefaTableConsistencyCheckingLevel()) {
+				case allCombinations:
+					// The following tests if the detailed table is consistent, i.e. if there exist all combinations of entries.  There used to be some test
+					// cases where this was deliberately not the case, implying that this was assumed as plausible also for studies.  This is now forbidding it.
+					// If this causes too many problems, we could insert a switch (or attach it to the fallback behavior switch).  kai, feb'20
+					if (detailedHbefaWarmTable != null) {
+						Set<String> roadCategories = new HashSet<>();
+						Set<HbefaTrafficSituation> trafficSituations = EnumSet.noneOf(HbefaTrafficSituation.class);
+						Set<HbefaVehicleCategory> vehicleCategories = EnumSet.noneOf(HbefaVehicleCategory.class);
+						Set<HbefaVehicleAttributes> vehicleAttributes = new HashSet<>();
+						Set<Pollutant> pollutantsInTable = EnumSet.noneOf(Pollutant.class);
+						for (HbefaWarmEmissionFactorKey emissionFactorKey : detailedHbefaWarmTable.keySet()) {
+							roadCategories.add(emissionFactorKey.getHbefaRoadCategory());
+							trafficSituations.add(emissionFactorKey.getHbefaTrafficSituation());
+							vehicleCategories.add(emissionFactorKey.getHbefaVehicleCategory());
+							vehicleAttributes.add(emissionFactorKey.getHbefaVehicleAttributes());
+							pollutantsInTable.add(emissionFactorKey.getHbefaComponent());
+						}
+						for (String roadCategory : roadCategories) {
+							for (HbefaTrafficSituation trafficSituation : trafficSituations) {
+								for (HbefaVehicleCategory vehicleCategory : vehicleCategories) {
+									for (HbefaVehicleAttributes vehicleAttribute : vehicleAttributes) {
+										for (Pollutant pollutant : pollutantsInTable) {
+											HbefaWarmEmissionFactorKey key = new HbefaWarmEmissionFactorKey();
+											key.setHbefaRoadCategory(roadCategory);
+											key.setHbefaTrafficSituation(trafficSituation);
+											key.setHbefaVehicleCategory(vehicleCategory);
+											key.setHbefaVehicleAttributes(vehicleAttribute);
+											key.setHbefaComponent(pollutant);
+											HbefaWarmEmissionFactor result = detailedHbefaWarmTable.get(key);
+											if (result == null) {
+												throw new RuntimeException("emissions factor for key=" + key + " is missing." +
+														"  There used to be some " +
+														"fallback, but it was " +
+														"inconsistent and confusing, so " +
+														"we are now just aborting.");
+											}
+										}
+									}
 								}
 							}
 						}
 					}
-				}
-			}
-			// yy The above consistency check might actually be too restrictive.  The code only needs that both freeflow and stopgo traffic
-			// conditions exist for a certain lookup.  So we could still have some road categories, vehicle categories or vehicle attributes
-			// where some detailed values exist and others don't.  So the thing to check would be if for each existing
-			//   roadCategory x vehicleCategory x vehicleAttribute x pollutant
-			// there is a freeflow and a stopgo entry.  Maybe something like this here:
-			Set<String> freeflowSet = new HashSet<>();
-			Set<String> stopgoSet = new HashSet<>();
-			for( HbefaWarmEmissionFactorKey key : detailedHbefaWarmTable.keySet() ){
-				String syntheticKey = key.getHbefaRoadCategory() + "--" + key.getHbefaVehicleCategory() + "--" + key.getHbefaVehicleAttributes() + "--" + key.getHbefaComponent() ;
-				switch(key.getHbefaTrafficSituation()){
-					case FREEFLOW:
-						freeflowSet.add( syntheticKey );
-						break;
-					case STOPANDGO:
-						stopgoSet.add( syntheticKey );
-						break;
-					default:
-						// do nothing
-				}
-			}
-			for( String syntheticKey : freeflowSet ){
-				if ( !stopgoSet.contains( syntheticKey ) ) {
-					throw new RuntimeException( "inconsistent" );
-				}
-			}
-			for( String syntheticKey : stopgoSet ){
-				if ( !freeflowSet.contains( syntheticKey ) ) {
-					throw new RuntimeException( "inconsistent" );
-				}
+					break;
+
+				case consistent:
+					// yy The above consistency check might actually be too restrictive.  The code only needs that both freeflow and stopgo traffic
+					// conditions exist for a certain lookup.  So we could still have some road categories, vehicle categories or vehicle attributes
+					// where some detailed values exist and others don't.  So the thing to check would be if for each existing
+					//   roadCategory x vehicleCategory x vehicleAttribute x pollutant
+					// there is a freeflow and a stopgo entry.  Maybe something like this here:
+					Set<String> freeflowSet = new HashSet<>();
+					Set<String> stopgoSet = new HashSet<>();
+					for (HbefaWarmEmissionFactorKey key : detailedHbefaWarmTable.keySet()) {
+						String syntheticKey = key.getHbefaRoadCategory() + "--" + key.getHbefaVehicleCategory() + "--" + key.getHbefaVehicleAttributes() + "--" + key.getHbefaComponent();
+						switch (key.getHbefaTrafficSituation()) {
+							case FREEFLOW:
+								freeflowSet.add(syntheticKey);
+								break;
+							case STOPANDGO:
+								stopgoSet.add(syntheticKey);
+								break;
+							default:
+								// do nothing
+						}
+					}
+					for (String syntheticKey : freeflowSet) {
+						if (!stopgoSet.contains(syntheticKey)) {
+							throw new RuntimeException("inconsistent");
+						}
+					}
+					for (String syntheticKey : stopgoSet) {
+						if (!freeflowSet.contains(syntheticKey)) {
+							throw new RuntimeException("inconsistent");
+						}
+					}
+					break;
+				case none:
+					break;
+				default:
+					throw new IllegalStateException("Unexpected value: " + ecg.gethbefaTableConsistencyCheckingLevel());
 			}
 		}
-
 	}
 
 	void reset() {

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/utils/EmissionsConfigGroup.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/utils/EmissionsConfigGroup.java
@@ -100,6 +100,12 @@ public final class EmissionsConfigGroup extends ReflectiveConfigGroup {
 	private static final String DETAILED_VS_AVERAGE_LOOKUP_BEHAVIOR = "detailedVsAverageLookupBehavior";
 	private DetailedVsAverageLookupBehavior detailedVsAverageLookupBehavior = DetailedVsAverageLookupBehavior.onlyTryDetailedElseAbort;
 
+	//This is the first quick fix for the issue https://github.com/matsim-org/matsim-libs/issues/1226.
+	// Maybe other (smarter) strategies will be added later. kturner nov'20
+	public enum HbefaTableConsistencyCheckingLevel { allCombinations, consistent, none}
+	private static final String HBEFA_TABLE_CONSISTENCY_CHECKING_LEVEL = "hbefaTableConsistencyCheckingLevel";
+	private HbefaTableConsistencyCheckingLevel hbefaTableConsistencyCheckingLevel = HbefaTableConsistencyCheckingLevel.allCombinations;
+
 	@Deprecated // should be phased out.  kai, oct'18
 	private static final String EMISSION_ROADTYPE_MAPPING_FILE_CMT = "REQUIRED if source of the HBEFA road type is set to "+HbefaRoadTypeSource.fromFile +". It maps from input road types to HBEFA 3.1 road type strings";
 	private static final String EMISSION_FACTORS_WARM_FILE_AVERAGE_CMT = "file with HBEFA vehicle type specific fleet average warm emission factors";
@@ -128,6 +134,13 @@ public final class EmissionsConfigGroup extends ReflectiveConfigGroup {
 															   "FALSE (DO NOT USE except for backwards compability): vehicle description is used for the emission specifications. The emission specifications of a vehicle " +
 															   "type should be surrounded by emission specification markers.\n\t\t" +
 															   "do not actively set (or set to null) (default): hbefa vehicle type description comes from attribute in vehicle type." ;
+
+	private static final String HBEFA_TABLE_CONSISTENCY_CHECKING_LEVEL_CMT = "Define on which level the entries in the provided hbefa tables are checked for consistency" + "\n\t\t" +
+			HbefaTableConsistencyCheckingLevel.allCombinations.name() + " : check if entries for all combinations of HbefaTrafficSituation, HbefaVehicleCategory, HbefaVehicleAttributes, HbefaComponent. " +
+																"are available in the table. It only checks for paramters that are available in the table (e.g. if there is no HGV in the table, it can also pass. \n\t\t" +
+			HbefaTableConsistencyCheckingLevel.consistent.name() + " : check if the entries for the two HbefaTrafficSituations 'StopAndGo' and 'FreeFlow' (nov 2020, maybe subject to change) are consistently available in the table. \n\t\t" + //TODO
+			HbefaTableConsistencyCheckingLevel.none.name() + " : There is no consistency check. This option is NOT recommended and only for backward capability to inputs from before spring 2020 . \n\t\t" +
+			"Default is " + HbefaTableConsistencyCheckingLevel.allCombinations.name();
 
 	// yyyy the EmissionsSpecificationMarker thing should be replaced by link attributes.  Did not exist when this functionality was written.  kai, oct'18
 
@@ -176,6 +189,8 @@ public final class EmissionsConfigGroup extends ReflectiveConfigGroup {
 
 //		map.put(USING_DETAILED_EMISSION_CALCULATION, USING_DETAILED_EMISSION_CALCULATION_CMT);	//is deprecated now. This functionality is integrated in DETAILED_VS_AVERAGE_LOOKUP_BEHAVIOR.
 		map.put(DETAILED_VS_AVERAGE_LOOKUP_BEHAVIOR, DETAILED_VS_AVERAGE_LOOKUP_BEHAVIOR_CMT);
+
+		map.put(HBEFA_TABLE_CONSISTENCY_CHECKING_LEVEL, HBEFA_TABLE_CONSISTENCY_CHECKING_LEVEL_CMT);
 
 		map.put(EMISSION_FACTORS_WARM_FILE_DETAILED, EMISSION_FACTORS_WARM_FILE_DETAILED_CMT) ;
 
@@ -295,6 +310,7 @@ public final class EmissionsConfigGroup extends ReflectiveConfigGroup {
 	public boolean setUsingDetailedEmissionCalculation( boolean val ) {
 		throw new RuntimeException( message );
 	}
+
 	// ---
 	/**
 	 * @param detailedVsAverageLookupBehavior -- {@value #DETAILED_VS_AVERAGE_LOOKUP_BEHAVIOR_CMT}
@@ -309,6 +325,22 @@ public final class EmissionsConfigGroup extends ReflectiveConfigGroup {
 	public DetailedVsAverageLookupBehavior getDetailedVsAverageLookupBehavior() {
 		return this.detailedVsAverageLookupBehavior;
 	}
+
+	// ---
+	/**
+	 * @param hbefaTableConsistencyCheckingLevel -- {@value #HBEFA_TABLE_CONSISTENCY_CHECKING_LEVEL}
+	 * @noinspection JavadocReference
+	 */
+	@StringSetter(HBEFA_TABLE_CONSISTENCY_CHECKING_LEVEL)
+	public void setDetailedVsAverageLookupBehavior(HbefaTableConsistencyCheckingLevel hbefaTableConsistencyCheckingLevel) {
+		this.hbefaTableConsistencyCheckingLevel = hbefaTableConsistencyCheckingLevel;
+	}
+
+	@StringGetter(HBEFA_TABLE_CONSISTENCY_CHECKING_LEVEL)
+	public HbefaTableConsistencyCheckingLevel gethbefaTableConsistencyCheckingLevel() {
+		return this.hbefaTableConsistencyCheckingLevel;
+	}
+
 	// ===============
 	/**
 	 * @param detailedWarmEmissionFactorsFile -- {@value #EMISSION_FACTORS_WARM_FILE_DETAILED_CMT}


### PR DESCRIPTION
this is a quick fix for #1226 allowing to choose a (lower) level for the consistency check of the hbefa values.
Additionally I added some NotNull checks inside the ColdEmissionsAnalysisModule (on the way)

Notes: 
- There is still no check for consistency of the coldEmissions table
- One times ion the future, one should / may  add another (smarter) consistency check --> see discussion in #1226   