### PR TITLE
income-dependent marginal utility of money in PersonScoringParameters

### DIFF
--- a/contribs/vsp/src/main/java/playground/vsp/scoring/IncomeDependentUtilityOfMoneyPersonScoringParameters.java
+++ b/contribs/vsp/src/main/java/playground/vsp/scoring/IncomeDependentUtilityOfMoneyPersonScoringParameters.java
@@ -1,0 +1,123 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2013 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+package playground.vsp.scoring;
+
+import org.apache.log4j.Logger;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.core.config.groups.PlanCalcScoreConfigGroup;
+import org.matsim.core.config.groups.ScenarioConfigGroup;
+import org.matsim.core.population.PopulationUtils;
+import org.matsim.core.scoring.functions.ActivityUtilityParameters;
+import org.matsim.core.scoring.functions.ScoringParameters;
+import org.matsim.core.scoring.functions.ScoringParametersForPerson;
+import org.matsim.pt.PtConstants;
+import org.matsim.pt.config.TransitConfigGroup;
+
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author tschlenther
+ *
+ * This class is an adoption of {@link org.matsim.core.scoring.functions.SubpopulationScoringParameters}.
+ * It additionaly accounts for person-specific marginalUtilityOfMoney.
+ * In order to use this, you need to provide an attribute {@link #PERSONAL_INCOME_ATTRIBUTE_NAME} for persons that have
+ * a specific income. Persons in the population, that have no attribute {@link #PERSONAL_INCOME_ATTRIBUTE_NAME} will use the
+ * default marginal utility set in their subpopulation's scoring parameters.
+ *
+ * The person specific marginal utility is computed by AVERAGE_INCOME / PERSONAL_INCOME
+ *
+ * Note that AVERAGE_INCOME might be person-specific, if provided in the person attribute {@link #INCOME_AVG_RELEVANT_FOR_PERSON_ATTRIBUTE_NAME}.
+ * This is useful in scenarios where you want distinguish zonal average incomes.
+ * However, if the person-specific average income attribute is not provided, the overall global average income is taken into account.
+ * This is computed as the sum of all values of the attribute {@link #PERSONAL_INCOME_ATTRIBUTE_NAME} that are contained in the population.
+ */
+public class IncomeDependentUtilityOfMoneyPersonScoringParameters implements ScoringParametersForPerson {
+	Logger log = Logger.getLogger(IncomeDependentUtilityOfMoneyPersonScoringParameters.class);
+
+	public static final String PERSONAL_INCOME_ATTRIBUTE_NAME = "income";
+	public static final String INCOME_AVG_RELEVANT_FOR_PERSON_ATTRIBUTE_NAME = "relevantAvgIncome";
+
+	private final PlanCalcScoreConfigGroup config;
+	private final ScenarioConfigGroup scConfig;
+	private final TransitConfigGroup transitConfigGroup;
+	private final Map<Id<Person>, ScoringParameters> params = new HashMap<>();
+	private final double globalAvgIncome;
+
+	@Inject
+	IncomeDependentUtilityOfMoneyPersonScoringParameters(Population population, PlanCalcScoreConfigGroup planCalcScoreConfigGroup, ScenarioConfigGroup scenarioConfigGroup, TransitConfigGroup transitConfigGroup) {
+		this.config = planCalcScoreConfigGroup;
+		this.scConfig = scenarioConfigGroup;
+		this.transitConfigGroup = transitConfigGroup;
+		this.globalAvgIncome = computeAvgIncome(population);
+	}
+
+	private double computeAvgIncome(Population population) {
+		log.info("read income attribute '" + PERSONAL_INCOME_ATTRIBUTE_NAME + "' of all agents and compute global average.\n" +
+				"Make sure to set this attribute only to appropriate agents (i.e. true 'persons' and not freight agents)");
+		double averageIncome =  population.getPersons().values().stream()
+				.filter(person -> PopulationUtils.getSubpopulation(person).equals("person"))
+				.filter(person -> person.getAttributes().getAttribute(PERSONAL_INCOME_ATTRIBUTE_NAME) != null) //consider only agents that have a specific income provided
+				.mapToDouble(person ->	(double) person.getAttributes().getAttribute(PERSONAL_INCOME_ATTRIBUTE_NAME))
+				.average()
+				.getAsDouble();
+		log.info("global average income is " + averageIncome);
+		return averageIncome;
+	}
+
+	@Override
+	public ScoringParameters getScoringParameters(Person person) {
+
+		if (!this.params.containsKey(person.getId())) {
+			final String subpopulation = PopulationUtils.getSubpopulation( person );
+			/* lazy initialization of params. not strictly thread safe, as different threads could
+			 * end up with different params-object, although all objects will have the same
+			 * values in them due to using the same config. Still much better from a memory performance
+			 * point of view than giving each ScoringFunction its own copy of the params.
+			 */
+			ScoringParameters.Builder builder = new ScoringParameters.Builder(this.config, this.config.getScoringParameters(subpopulation), scConfig);
+			if (transitConfigGroup.isUseTransit()) {
+
+				PlanCalcScoreConfigGroup.ActivityParams transitActivityParams = new PlanCalcScoreConfigGroup.ActivityParams(PtConstants.TRANSIT_ACTIVITY_TYPE);
+				transitActivityParams.setTypicalDuration(120.0);
+				transitActivityParams.setOpeningTime(0.) ;
+				transitActivityParams.setClosingTime(0.) ;
+				ActivityUtilityParameters.Builder modeParamsBuilder = new ActivityUtilityParameters.Builder(transitActivityParams);
+				modeParamsBuilder.setScoreAtAll(false);
+				builder.setActivityParameters(PtConstants.TRANSIT_ACTIVITY_TYPE, modeParamsBuilder);
+			}
+
+			if (person.getAttributes().getAttribute(PERSONAL_INCOME_ATTRIBUTE_NAME) != null){
+				double averageIncome = person.getAttributes().getAttribute(INCOME_AVG_RELEVANT_FOR_PERSON_ATTRIBUTE_NAME) != null ?
+						(double) person.getAttributes().getAttribute(INCOME_AVG_RELEVANT_FOR_PERSON_ATTRIBUTE_NAME) : globalAvgIncome;
+				//this is where we put person-specific stuff
+				builder.setMarginalUtilityOfMoney( averageIncome / (double) person.getAttributes().getAttribute(PERSONAL_INCOME_ATTRIBUTE_NAME));
+			}
+
+			this.params.put(
+					person.getId(),
+					builder.build());
+		}
+
+		return this.params.get(person.getId());
+	}
+}

--- a/contribs/vsp/src/test/java/playground/vsp/scoring/IncomeDependentUtilityOfMoneyPersonScoringParametersTest.java
+++ b/contribs/vsp/src/test/java/playground/vsp/scoring/IncomeDependentUtilityOfMoneyPersonScoringParametersTest.java
@@ -1,0 +1,143 @@
+package playground.vsp.scoring;
+
+import org.junit.*;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.api.core.v01.population.PopulationFactory;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.config.groups.PlanCalcScoreConfigGroup;
+import org.matsim.core.config.groups.ScenarioConfigGroup;
+import org.matsim.core.population.PopulationUtils;
+import org.matsim.core.scoring.functions.CharyparNagelMoneyScoring;
+import org.matsim.core.scoring.functions.ScoringParameters;
+import org.matsim.pt.config.TransitConfigGroup;
+import org.matsim.testcases.MatsimTestUtils;
+
+import static playground.vsp.scoring.IncomeDependentUtilityOfMoneyPersonScoringParameters.*;
+
+/**
+ * this class tests {@link IncomeDependentUtilityOfMoneyPersonScoringParameters}
+ *
+ * It checks whether the person specific income is read from the person attributes.
+ * The marginalUtilityOfMoney should be calculated as averageIncome/personSpecificIncome and not taken from the subpopulation-specific scoring params.
+ * To check whether the remaining scoring params are subpopulation-specific, this class tests the the person's marginalUtilityOfWaitingPt_s accordingly.
+ *
+ */
+public class IncomeDependentUtilityOfMoneyPersonScoringParametersTest {
+
+	@Rule
+	public MatsimTestUtils utils;
+	private static TransitConfigGroup transitConfigGroup;
+	private static ScenarioConfigGroup scenarioConfigGroup;
+	private static PlanCalcScoreConfigGroup planCalcScoreConfigGroup;
+	private static IncomeDependentUtilityOfMoneyPersonScoringParameters personScoringParams;
+	private static Population population;
+
+	@BeforeClass
+	public static void setUp() throws Exception {
+		transitConfigGroup = new TransitConfigGroup();
+		scenarioConfigGroup = new ScenarioConfigGroup();
+		planCalcScoreConfigGroup = new PlanCalcScoreConfigGroup();
+
+		PlanCalcScoreConfigGroup.ScoringParameterSet personParams = planCalcScoreConfigGroup.getOrCreateScoringParameters("person");
+		personParams.setMarginalUtilityOfMoney(5000);
+		personParams.setMarginalUtlOfWaitingPt_utils_hr(0.5 * 3600);
+
+		PlanCalcScoreConfigGroup.ScoringParameterSet freightParams = planCalcScoreConfigGroup.getOrCreateScoringParameters("freight");
+		freightParams.setMarginalUtilityOfMoney(444);
+		freightParams.setMarginalUtlOfWaitingPt_utils_hr(1d * 3600);
+
+		population = PopulationUtils.createPopulation(ConfigUtils.createConfig());
+		PopulationFactory factory = population.getFactory();
+
+		{ //fill population
+			Person lowIncome = factory.createPerson(Id.createPersonId("lowIncome"));
+			PopulationUtils.putSubpopulation(lowIncome, "person");
+			PopulationUtils.putPersonAttribute(lowIncome, PERSONAL_INCOME_ATTRIBUTE_NAME, 0.5d);
+			population.addPerson(lowIncome);
+
+			Person mediumIncome = factory.createPerson(Id.createPersonId("mediumIncome"));
+			PopulationUtils.putSubpopulation(mediumIncome, "person");
+			PopulationUtils.putPersonAttribute(mediumIncome, PERSONAL_INCOME_ATTRIBUTE_NAME, 1d);
+			population.addPerson(mediumIncome);
+
+			Person highIncome = factory.createPerson(Id.createPersonId("highIncome"));
+			PopulationUtils.putSubpopulation(highIncome, "person");
+			PopulationUtils.putPersonAttribute(highIncome, PERSONAL_INCOME_ATTRIBUTE_NAME, 1.5d);
+			population.addPerson(highIncome);
+
+			Person freight = factory.createPerson(Id.createPersonId("freight"));
+			PopulationUtils.putSubpopulation(freight, "freight");
+			population.addPerson(freight);
+
+			//a person living in a specifically poor are - average income is provided in person's attribute and might differ from global average
+			Person mediumIncomeWithSpecificAverage = factory.createPerson(Id.createPersonId("mediumIncomeWithSpecificAverage"));
+			PopulationUtils.putSubpopulation(mediumIncomeWithSpecificAverage, "person");
+			PopulationUtils.putPersonAttribute(mediumIncomeWithSpecificAverage, PERSONAL_INCOME_ATTRIBUTE_NAME, 1d);
+			PopulationUtils.putPersonAttribute(mediumIncomeWithSpecificAverage, INCOME_AVG_RELEVANT_FOR_PERSON_ATTRIBUTE_NAME, 0.1d);
+			population.addPerson(mediumIncomeWithSpecificAverage);
+		}
+		personScoringParams = new IncomeDependentUtilityOfMoneyPersonScoringParameters(population, planCalcScoreConfigGroup, scenarioConfigGroup, transitConfigGroup);
+	}
+
+	@Test
+	public void testPersonWithLowIncome(){
+		Id<Person> id = Id.createPersonId("lowIncome");
+		ScoringParameters params = personScoringParams.getScoringParameters(population.getPersons().get(id));
+		makeAssert(params, 0.5d, 0.5d);
+	}
+
+	@Test
+	public void testPersonWithHighIncome(){
+		Id<Person> id = Id.createPersonId("highIncome");
+		ScoringParameters params = personScoringParams.getScoringParameters(population.getPersons().get(id));
+		makeAssert(params, 1.5d, 0.5d);
+	}
+
+	@Test
+	public void testPersonWithMediumIncome(){
+		Id<Person> id = Id.createPersonId("mediumIncome");
+		ScoringParameters params = personScoringParams.getScoringParameters(population.getPersons().get(id));
+		makeAssert(params, 1d, 0.5d);
+	}
+
+	@Test
+	public void testPersonFreight(){
+		Id<Person> id = Id.createPersonId("freight");
+		ScoringParameters params = personScoringParams.getScoringParameters(population.getPersons().get(id));
+		//freight agent has no income attribute set, so it should use the marginal utility of money that is set in it's subpopulation scoring parameters!
+		makeAssert(params, 1d/444d, 1d);
+	}
+
+	@Test
+	public void testPersonWithSpecificIncomeAverage(){
+		Id<Person> id = Id.createPersonId("mediumIncomeWithSpecificAverage");
+		ScoringParameters params = personScoringParams.getScoringParameters(population.getPersons().get(id));
+		//this agent actually has income attribute set to 1, but it's person-specific average income attribute is set to 0.1.
+		// the resulting marginal utility of money should thus be 1/10 which is the same as if it used the global average income (1) and had an income of 10.
+		makeAssert(params, 10d, 0.5d);
+	}
+
+	@Test
+	public void testMoneyScore(){
+		ScoringParameters paramsRich = personScoringParams.getScoringParameters(population.getPersons().get(Id.createPersonId("highIncome")));
+		CharyparNagelMoneyScoring moneyScoringRich = new CharyparNagelMoneyScoring(paramsRich);
+		moneyScoringRich.addMoney(100);
+		Assert.assertEquals("for the rich person, 100 money units should be equal to a score of 66.66", 1./1.5 * 100, moneyScoringRich.getScore(), utils.EPSILON);
+
+		ScoringParameters paramsPoor = personScoringParams.getScoringParameters(population.getPersons().get(Id.createPersonId("lowIncome")));
+		CharyparNagelMoneyScoring moneyScoringPoor = new CharyparNagelMoneyScoring(paramsPoor);
+		moneyScoringPoor.addMoney(100);
+		Assert.assertEquals("for the poor person, 100 money units should be equal to a score of 200.00", 1./0.5 * 100, moneyScoringPoor.getScore(), utils.EPSILON);
+
+		Assert.assertTrue("100 money units should worth more for a poor person than for a rich person", moneyScoringPoor.getScore() > moneyScoringRich.getScore());
+	}
+
+	private void makeAssert(ScoringParameters params, double income, double marginalUtilityOfWaitingPt_s){
+		Assert.assertEquals("marginalUtilityOfMoney is wrong", 1 / income , params.marginalUtilityOfMoney, 0.);
+		Assert.assertEquals("marginalUtilityOfWaitingPt_s is wrong", marginalUtilityOfWaitingPt_s , params.marginalUtilityOfWaitingPt_s, 0.);
+	}
+
+
+}


### PR DESCRIPTION
This PR introduces a new implementation of `ScoringParametersForPerson` which accounts for agent-specific values for marginalUtilityOfMoney.
This functionality relies on person attributes.

The resulting marginal utility of money is computed as:

mgnUtilityOfMoney = averageIncome / personalIncome

Note that the global average income is dynamically computed based on the population. However, e.g. in cases of heterogenous spatial distribution, it is possible to provide an agent-specific relevant income attribute. The value of this attribute then replaces global value for average income in the equation formulated above.

Be aware that all agents that have the personal income attribute is taken into account. If no such attribute is found for a person, the subpopulation's scoring parameters are taken (as usual).

