### PR TITLE
Added request retry handling

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtRequestAnalyzer.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtRequestAnalyzer.java
@@ -155,6 +155,11 @@ public class DrtRequestAnalyzer implements PassengerRequestRejectedEventHandler,
 		if (event.getMode().equals(mode)) {
 			performedRequestSequences.put(event.getRequestId(),
 					new PerformedRequestEventSequence(requestSubmissions.get(event.getRequestId()), event));
+			
+			// Remove rejections that could be handled due to PassengerEngineWithRetryLogic
+			if (rejectedRequestSequences.containsKey(event.getRequestId())) {
+				rejectedRequestSequences.remove(event.getRequestId());
+			}
 		}
 	}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -111,6 +111,11 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 	public static final String IDLE_VEHICLES_RETURN_TO_DEPOTS = "idleVehiclesReturnToDepots";
 	static final String IDLE_VEHICLES_RETURN_TO_DEPOTS_EXP = "Idle vehicles return to the nearest of all start links. See: DvrpVehicle.getStartLink()";
 
+	
+	public static final String RETRY_REQUEST_HANDLING = "retryRequestHandling";
+	static final String RETRY_REQUEST_HANDLING_EXP = "Enable request repetition for rejected request. See: DvrpRequestRetryParams for available parameters";
+
+	
 	public static final String OPERATIONAL_SCHEME = "operationalScheme";
 	static final String OPERATIONAL_SCHEME_EXP = "Operational Scheme, either of door2door, stopbased or serviceAreaBased. door2door by default";
 
@@ -164,6 +169,8 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 	private boolean changeStartLinkToLastLinkInSchedule = false;
 
 	private boolean idleVehiclesReturnToDepots = false;
+	
+	private boolean retryRequestHandling = false;
 
 	@NotNull
 	private OperationalScheme operationalScheme = OperationalScheme.door2door;
@@ -206,6 +213,7 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 
 	@Nullable
 	private DrtSpeedUpParams drtSpeedUpParams;
+	
 
 	public DrtConfigGroup() {
 		super(GROUP_NAME);
@@ -236,6 +244,8 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 		//drt speedup
 		addDefinition(DrtSpeedUpParams.SET_NAME, DrtSpeedUpParams::new, () -> drtSpeedUpParams,
 				params -> drtSpeedUpParams = (DrtSpeedUpParams)params);
+		
+
 	}
 
 	@Override
@@ -310,6 +320,7 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 		map.put(REJECT_REQUEST_IF_MAX_WAIT_OR_TRAVEL_TIME_VIOLATED,
 				REJECT_REQUEST_IF_MAX_WAIT_OR_TRAVEL_TIME_VIOLATED_EXP);
 		map.put(DRT_SERVICE_AREA_SHAPE_FILE, DRT_SERVICE_AREA_SHAPE_FILE_EXP);
+		map.put(RETRY_REQUEST_HANDLING,RETRY_REQUEST_HANDLING_EXP);
 		return map;
 	}
 
@@ -497,6 +508,23 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 	}
 
 	/**
+	 * @return -- {@value #RETRY_REQUEST_HANDLING_EXP}}
+	 */
+	@StringGetter(RETRY_REQUEST_HANDLING)
+	public boolean getRetryRequestHandling() {
+		return retryRequestHandling;
+	}
+
+	/**
+	 * @param retryRequestHandling -- {@value #RETRY_REQUEST_HANDLING_EXP}
+	 */
+	@StringSetter(RETRY_REQUEST_HANDLING)
+	public DrtConfigGroup setRetryRequestHandling(boolean retryRequestHandling) {
+		this.retryRequestHandling = retryRequestHandling;
+		return this;
+	}
+	
+	/**
 	 * @return -- {@value #IDLE_VEHICLES_RETURN_TO_DEPOTS_EXP}}
 	 */
 	@StringGetter(IDLE_VEHICLES_RETURN_TO_DEPOTS)
@@ -512,6 +540,8 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 		this.idleVehiclesReturnToDepots = idleVehiclesReturnToDepots;
 		return this;
 	}
+	
+	
 
 	/**
 	 * @return -- {@value #OPERATIONAL_SCHEME_EXP}
@@ -633,4 +663,5 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 	public Optional<DrtSpeedUpParams> getDrtSpeedUpParams() {
 		return Optional.ofNullable(drtSpeedUpParams);
 	}
+	
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/run/examples/RunDrtExampleWithRetryIT.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/run/examples/RunDrtExampleWithRetryIT.java
@@ -1,0 +1,90 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2017 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+/**
+ *
+ */
+package org.matsim.contrib.drt.run.examples;
+
+import java.net.URL;
+import java.util.Optional;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
+import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.contrib.dvrp.run.DvrpRequestRetryParams;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
+import org.matsim.core.utils.io.IOUtils;
+import org.matsim.examples.ExamplesUtils;
+import org.matsim.testcases.MatsimTestUtils;
+import org.matsim.vis.otfvis.OTFVisConfigGroup;
+
+/**
+ * @author Steffen Axer based on jbischoff
+ */
+public class RunDrtExampleWithRetryIT {
+
+	@Rule
+	public MatsimTestUtils utils = new MatsimTestUtils();
+
+	@Test
+	public void testRunDrtExample() {
+		URL configUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("mielec"), "mielec_drt_config.xml");
+		Config config = ConfigUtils.loadConfig(configUrl, new MultiModeDrtConfigGroup(), new DvrpConfigGroup(),
+				new OTFVisConfigGroup());
+
+		MultiModeDrtConfigGroup multiModeDrtConfigGroup = MultiModeDrtConfigGroup.get(config);
+
+		for (DrtConfigGroup drtConfig : multiModeDrtConfigGroup.getModalElements()) {
+			drtConfig.setRetryRequestHandling(true);
+		}
+		
+		DvrpConfigGroup dvrpConfigGroup = DvrpConfigGroup.get(config);
+		Optional<DvrpRequestRetryParams> params = dvrpConfigGroup.getDvrpRequestRetryParams();
+		params.get().setMaxRequestAge(600);
+		params.get().setRetryInterval(200);
+
+		config.controler().setOverwriteFileSetting(OverwriteFileSetting.deleteDirectoryIfExists);
+		config.controler().setOutputDirectory(utils.getOutputDirectory());
+		RunDrtExample.run(config, false);
+	}
+
+	@Test
+	public void testRunDrtStopbasedExample() {
+		URL configUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("mielec"),
+				"mielec_stop_based_drt_config.xml");
+		Config config = ConfigUtils.loadConfig(configUrl, new MultiModeDrtConfigGroup(), new DvrpConfigGroup(),
+				new OTFVisConfigGroup());
+
+		MultiModeDrtConfigGroup multiModeDrtConfigGroup = MultiModeDrtConfigGroup.get(config);
+
+		for (DrtConfigGroup drtConfig : multiModeDrtConfigGroup.getModalElements()) {
+			drtConfig.setRetryRequestHandling(true);
+		}
+		
+		config.controler().setOverwriteFileSetting(OverwriteFileSetting.deleteDirectoryIfExists);
+		config.controler().setOutputDirectory(utils.getOutputDirectory());
+		RunDrtExample.run(config, false);
+	}
+
+}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/PassengerEngineQSimModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/PassengerEngineQSimModule.java
@@ -4,9 +4,11 @@ import static org.matsim.contrib.dvrp.passenger.PassengerEngineQSimModule.Passen
 
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 
+
 public class PassengerEngineQSimModule extends AbstractDvrpModeQSimModule {
+		
 	public enum PassengerEngineType {
-		DEFAULT, WITH_PREBOOKING, TELEPORTING
+		DEFAULT, WITH_PREBOOKING, TELEPORTING, WITH_RETRY
 	}
 
 	private final PassengerEngineType type;
@@ -22,6 +24,8 @@ public class PassengerEngineQSimModule extends AbstractDvrpModeQSimModule {
 
 	@Override
 	protected void configureQSim() {
+		
+		
 		bindModal(PassengerHandler.class).to(modalKey(PassengerEngine.class));
 		addMobsimScopeEventHandlerBinding().to(modalKey(PassengerEngine.class));
 		switch (type) {
@@ -33,6 +37,9 @@ public class PassengerEngineQSimModule extends AbstractDvrpModeQSimModule {
 				return;
 			case TELEPORTING:
 				addModalComponent(PassengerEngine.class, TeleportingPassengerEngine.createProvider(getMode()));
+				return;
+			case WITH_RETRY:
+				addModalComponent(PassengerEngine.class, PassengerEngineWithRetryLogic.createProvider(getMode()));
 				return;
 			default:
 				throw new IllegalStateException("Type: " + type + " is not supported");

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/PassengerEngineWithRetryLogic.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/PassengerEngineWithRetryLogic.java
@@ -1,0 +1,256 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2014 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.dvrp.passenger;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import org.apache.log4j.Logger;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Route;
+import org.matsim.contrib.dvrp.optimizer.Request;
+import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
+import org.matsim.contrib.dvrp.passenger.PassengerEngine;
+import org.matsim.contrib.dvrp.passenger.PassengerRequestRejectedEventHandler;
+import org.matsim.contrib.dvrp.run.ModalProviders;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.mobsim.framework.MobsimAgent;
+import org.matsim.core.mobsim.framework.MobsimDriverAgent;
+import org.matsim.core.mobsim.framework.MobsimPassengerAgent;
+import org.matsim.core.mobsim.framework.MobsimTimer;
+import org.matsim.core.mobsim.framework.PlanAgent;
+import org.matsim.core.mobsim.qsim.InternalInterface;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
+
+/**
+ * A PassengerEngine that allows to retry requests.
+ * retryInterval controls how often the retry method is called within qsim
+ * maxRequestAge controls how long a request may exists till it gets expired
+ * 
+ * @author Steffen Axer
+ *
+ */
+
+public final class PassengerEngineWithRetryLogic
+		implements PassengerEngine, PassengerRequestRejectedEventHandler {
+	private Logger log = Logger.getLogger(PassengerEngineWithRetryLogic.class);
+	private final String mode;
+	private final MobsimTimer mobsimTimer;
+	private final PassengerRequestCreator requestCreator;
+	private final VrpOptimizer optimizer;
+	private final Network network;
+	private final PassengerRequestValidator requestValidator;
+	private final InternalPassengerHandling internalPassengerHandling;
+	private InternalInterface internalInterface;
+
+	// TODO: Control these parameters by DvrpConfigGroup
+	private double retryInterval = 100.0;
+	private double maxRequestAge = 600.0;
+
+	// accessed in doSimStep() and handleDeparture() (no need to sync)
+	private final Map<Id<Request>, MobsimPassengerAgent> activePassengers = new ConcurrentHashMap<>();
+	private final Map<Id<Request>, RequestData> historicalPassengersRequestData = new ConcurrentHashMap<>();
+
+	// accessed in doSimStep() and handleEvent() (potential data races)
+	private final Queue<Id<Request>> rejectedRequestsEvents = new ConcurrentLinkedQueue<>();
+
+	PassengerEngineWithRetryLogic(String mode, EventsManager eventsManager, MobsimTimer mobsimTimer,
+			PassengerRequestCreator requestCreator, VrpOptimizer optimizer, Network network,
+			PassengerRequestValidator requestValidator) {
+		this.mode = mode;
+		this.mobsimTimer = mobsimTimer;
+		this.requestCreator = requestCreator;
+		this.optimizer = optimizer;
+		this.network = network;
+		this.requestValidator = requestValidator;
+
+		internalPassengerHandling = new InternalPassengerHandling(mode, eventsManager);
+	}
+
+	@Override
+	public void setInternalInterface(InternalInterface internalInterface) {
+		this.internalInterface = internalInterface;
+		internalPassengerHandling.setInternalInterface(internalInterface);
+	}
+
+	@Override
+	public void onPrepareSim() {
+	}
+
+	double getRequestAge(Id<Request> requestId, double now) {
+		RequestData requestData = this.historicalPassengersRequestData.get(requestId);
+		double age = now - requestData.getDesiredDepartureTime();
+
+		return age;
+	}
+
+	@Override
+	public void doSimStep(double time) {
+
+		retryRejectedRequests(time);
+
+	}
+
+	void retryRejectedRequests(double time) {
+		// Step width in which retryRejectedRequests method gets executed
+		if (time % retryInterval == 0) {
+
+			ArrayList<Id<Request>> appendToQueue = new ArrayList<Id<Request>>();
+			
+			while (!rejectedRequestsEvents.isEmpty()) {
+
+				// Loop over rejectedRequestsEvents and get head element from queue
+				Id<Request> rejectedRequestId = rejectedRequestsEvents.poll();
+
+				if (historicalPassengersRequestData.containsKey(rejectedRequestId)) {
+
+					// Get the age of this request
+					double requestAge = getRequestAge(rejectedRequestId, time);
+
+					// Check if request is already expired
+					if (requestAge >= maxRequestAge) {
+						MobsimPassengerAgent passenger = activePassengers.remove(rejectedRequestId);
+						passenger.setStateToAbort(mobsimTimer.getTimeOfDay());
+						internalInterface.arrangeNextAgentState(passenger);
+						historicalPassengersRequestData.remove(rejectedRequestId);
+
+					// Only insert within retry interval step width to avoid to early retries
+					} else if ( requestAge % retryInterval ==0 ) {
+						// Retry to schedule this request with the same requestId
+						MobsimPassengerAgent passenger = activePassengers.remove(rejectedRequestId);
+						RequestData initalRequestData = historicalPassengersRequestData.get(rejectedRequestId);
+						PassengerRequest newRequest = requestCreator.createRequest(initalRequestData.getRequestId(),
+								initalRequestData.getPassenger().getId(), initalRequestData.getRoute(),
+								getLink(initalRequestData.getFromLink()), getLink(initalRequestData.getToLink()), time,
+								time);
+						validateAndSubmitRequest(passenger, newRequest, time);
+
+					// If retried request is to early, append it again to the queue 
+					} else {
+						appendToQueue.add(rejectedRequestId);
+					}
+				}
+			}
+			
+			rejectedRequestsEvents.addAll(appendToQueue);
+
+		}
+	}
+
+	@Override
+	public void afterSim() {
+		activePassengers.clear();
+		historicalPassengersRequestData.clear();
+	}
+
+	@Override
+	public boolean handleDeparture(double now, MobsimAgent agent, Id<Link> fromLinkId) {
+		if (!agent.getMode().equals(mode)) {
+			return false;
+		}
+
+		MobsimPassengerAgent passenger = (MobsimPassengerAgent) agent;
+		internalInterface.registerAdditionalAgentOnLink(passenger);
+
+		Id<Link> toLinkId = passenger.getDestinationLinkId();
+
+		Route route = ((Leg) ((PlanAgent) passenger).getCurrentPlanElement()).getRoute();
+		Id<Request> requestId = internalPassengerHandling.createRequestId();
+		PassengerRequest request = requestCreator.createRequest(requestId, passenger.getId(), route,
+				getLink(fromLinkId), getLink(toLinkId), now, now);
+		validateAndSubmitRequest(passenger, request, now);
+
+		historicalPassengersRequestData.put(requestId,
+				new RequestData(requestId, passenger, route, fromLinkId, toLinkId, now));
+
+		return true;
+	}
+
+	private void validateAndSubmitRequest(MobsimPassengerAgent passenger, PassengerRequest request, double now) {
+		activePassengers.put(request.getId(), passenger);
+		if (internalPassengerHandling.validateRequest(request, requestValidator, now)) {
+			// need to synchronise to address cases where requestSubmitted() may:
+			// - be called from outside DepartureHandlers
+			// - interfere with VrpOptimizer.nextTask()
+			// - impact VrpAgentLogic.computeNextAction()
+			synchronized (optimizer) {
+				// optimizer can also reject request if cannot handle it
+				// (async operation, notification comes via the events channel)
+				optimizer.requestSubmitted(request);
+			}
+		}
+	}
+
+	private Link getLink(Id<Link> linkId) {
+		return Preconditions.checkNotNull(network.getLinks().get(linkId),
+				"Link id=%s does not exist in network for mode %s. Agent departs from a link that does not belong to that network?",
+				linkId, mode);
+	}
+
+	@Override
+	public boolean tryPickUpPassenger(PassengerPickupActivity pickupActivity, MobsimDriverAgent driver,
+			PassengerRequest request, double now) {
+		boolean pickedUp = internalPassengerHandling.tryPickUpPassenger(driver, activePassengers.get(request.getId()),
+				request.getId(), now);
+		Verify.verify(pickedUp, "Not possible without prebooking");
+		return pickedUp;
+	}
+
+	@Override
+	public void dropOffPassenger(MobsimDriverAgent driver, PassengerRequest request, double now) {
+		internalPassengerHandling.dropOffPassenger(driver, activePassengers.remove(request.getId()), request.getId(),
+				now);
+	}
+
+	@Override
+	public void handleEvent(PassengerRequestRejectedEvent event) {
+		if (event.getMode().equals(mode)) {
+			rejectedRequestsEvents.add(event.getRequestId());
+		}
+	}
+
+	public static Provider<PassengerEngine> createProvider(String mode) {
+		return new ModalProviders.AbstractProvider<>(mode) {
+			
+			@Inject
+			private EventsManager eventsManager;
+
+			@Inject
+			private MobsimTimer mobsimTimer;
+
+			@Override
+			public PassengerEngineWithRetryLogic get() {
+				return new PassengerEngineWithRetryLogic(getMode(), eventsManager, mobsimTimer,
+						getModalInstance(PassengerRequestCreator.class), getModalInstance(VrpOptimizer.class),
+						getModalInstance(Network.class), getModalInstance(PassengerRequestValidator.class));
+			}
+		};
+	}
+
+}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/RequestData.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/RequestData.java
@@ -1,0 +1,84 @@
+package org.matsim.contrib.dvrp.passenger;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.population.Route;
+import org.matsim.contrib.dvrp.optimizer.Request;
+import org.matsim.core.mobsim.framework.MobsimPassengerAgent;
+
+/**
+ * A data container that stores initially provided request information, required
+ * for a request retry.
+ * 
+ * @author Steffen Axer
+ *
+ */
+
+public class RequestData {
+
+	MobsimPassengerAgent passenger;
+	Route route;
+	Id<Request> requestId;
+	Id<Link> fromLink;
+	Id<Link> toLink;
+	Double desiredDepartureTime;
+
+	public RequestData(Id<Request> requestId, MobsimPassengerAgent passenger, Route route, Id<Link> fromLink,
+			Id<Link> toLink, Double desiredDepartureTime) {
+		this.requestId = requestId;
+		this.passenger = passenger;
+		this.route = route;
+		this.fromLink = fromLink;
+		this.toLink = toLink;
+		this.desiredDepartureTime = desiredDepartureTime;
+	}
+
+	public Id<Request> getRequestId() {
+		return requestId;
+	}
+
+	public void setRequestId(Id<Request> requestId) {
+		this.requestId = requestId;
+	}
+
+	public MobsimPassengerAgent getPassenger() {
+		return passenger;
+	}
+
+	public void setPassenger(MobsimPassengerAgent passenger) {
+		this.passenger = passenger;
+	}
+
+	public Route getRoute() {
+		return route;
+	}
+
+	public void setRoute(Route route) {
+		this.route = route;
+	}
+
+	public Id<Link> getFromLink() {
+		return fromLink;
+	}
+
+	public void setFromLink(Id<Link> fromLink) {
+		this.fromLink = fromLink;
+	}
+
+	public Id<Link> getToLink() {
+		return toLink;
+	}
+
+	public void setToLink(Id<Link> toLink) {
+		this.toLink = toLink;
+	}
+
+	public Double getDesiredDepartureTime() {
+		return desiredDepartureTime;
+	}
+
+	public void setDesiredDepartureTime(Double desiredDepartureTime) {
+		this.desiredDepartureTime = desiredDepartureTime;
+	}
+
+}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigGroup.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigGroup.java
@@ -20,6 +20,7 @@
 package org.matsim.contrib.dvrp.run;
 
 import java.util.Map;
+import java.util.Optional;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.DecimalMax;
@@ -113,6 +114,9 @@ public final class DvrpConfigGroup extends ReflectiveConfigGroupWithConfigurable
 
 	@Nullable
 	private DvrpTravelTimeMatrixParams travelTimeMatrixParams;
+	
+	@Nullable 
+	private DvrpRequestRetryParams dvrpRequestRetryParams;
 
 	public DvrpConfigGroup() {
 		super(GROUP_NAME);
@@ -123,6 +127,10 @@ public final class DvrpConfigGroup extends ReflectiveConfigGroupWithConfigurable
 		//travel time matrix (optional)
 		addDefinition(DvrpTravelTimeMatrixParams.SET_NAME, DvrpTravelTimeMatrixParams::new,
 				() -> travelTimeMatrixParams, params -> travelTimeMatrixParams = (DvrpTravelTimeMatrixParams)params);
+		
+		//dvrp request retry handling (optional)
+		addDefinition(DvrpRequestRetryParams.SET_NAME, DvrpRequestRetryParams::new, () -> dvrpRequestRetryParams,
+				params -> dvrpRequestRetryParams = (DvrpRequestRetryParams)params);
 	}
 
 	@Override
@@ -233,6 +241,16 @@ public final class DvrpConfigGroup extends ReflectiveConfigGroupWithConfigurable
 	public DvrpConfigGroup setTravelTimeEstimationBeta(double travelTimeEstimationBeta) {
 		this.travelTimeEstimationBeta = travelTimeEstimationBeta;
 		return this;
+	}
+	
+	
+	public Optional<DvrpRequestRetryParams> getDvrpRequestRetryParams() {
+		
+		if (dvrpRequestRetryParams == null) {
+			addParameterSet(new DvrpRequestRetryParams());
+		}
+		
+		return Optional.ofNullable(dvrpRequestRetryParams);
 	}
 
 	public DvrpTravelTimeMatrixParams getTravelTimeMatrixParams() {

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpRequestRetryParams.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpRequestRetryParams.java
@@ -1,0 +1,93 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.dvrp.run;
+
+import java.util.Map;
+
+import javax.validation.constraints.Positive;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigGroup;
+import org.matsim.core.config.ReflectiveConfigGroup;
+
+/**
+ * 
+ * @author Steffen Axer
+ *
+ */
+public class DvrpRequestRetryParams extends ReflectiveConfigGroup {
+	public static final String SET_NAME = "dvrpRequestRetry";
+	private static final String RETRY_INTERVAL = "retryInterval";
+	private static final String RETRY_INTERVAL_EXP = "The time interval at which rejected request are repeated";
+	private static final String MAX_REQUEST_AGE = "maxRequestAge";
+	private static final String MAX_REQUEST_AGE_EXP = "The maximum age of a request till it gets finally rejected, if not already scheduled"
+			+ "Used with serviceArea Operational Scheme";
+
+	public DvrpRequestRetryParams() {
+		super(SET_NAME);
+	}
+	
+	@Positive
+	private double retryInterval = 100.0;
+	
+	@Positive
+	private double maxRequestAge = 600.0;
+
+	@Override
+	protected void checkConsistency(Config config) {
+		super.checkConsistency(config);
+
+	}
+
+	@StringGetter(RETRY_INTERVAL)
+	public double getRetryInterval() {
+		return retryInterval;
+	}
+
+	@StringSetter(RETRY_INTERVAL)
+	public void setRetryInterval(double retryInterval) {
+		this.retryInterval = retryInterval;
+	}
+
+	@StringGetter(MAX_REQUEST_AGE)
+	public double getMaxRequestAge() {
+		return maxRequestAge;
+	}
+
+	@StringSetter(MAX_REQUEST_AGE)
+	public void setMaxRequestAge(double maxRequestAge) {
+		this.maxRequestAge = maxRequestAge;
+	}
+	
+	@Override
+	public ConfigGroup createParameterSet(String type) {
+		return super.createParameterSet(type);
+	}
+	
+	
+	@Override
+	public Map<String, String> getComments() {
+		var map = super.getComments();
+		map.put(RETRY_INTERVAL, RETRY_INTERVAL_EXP);
+		map.put(MAX_REQUEST_AGE,MAX_REQUEST_AGE_EXP );
+		return map;
+	}
+
+}


### PR DESCRIPTION
A rejected request leads normally directly to a stuckAndAbort event. This pull request allows to collect rejected requests and reinsert them into the passenger engine after waiting for a certain time interval (retryInveral). If the maximum age of a request is exceeded (maxRequestAge), the request is thrown away and causes a  stuckAndAbort event. Functionality is controlled by the help of DvrpRequestRetryParams

