### PR TITLE
Remove fixed travel time estimate from detour calculation

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/MultiInsertionDetourPathCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/MultiInsertionDetourPathCalculator.java
@@ -20,13 +20,13 @@ package org.matsim.contrib.drt.optimizer.insertion;
 
 import static org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
 
-import java.util.HashMap;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
+import java.util.function.Function;
 
 import javax.inject.Named;
 
@@ -45,48 +45,20 @@ import org.matsim.core.mobsim.framework.listeners.MobsimBeforeCleanupListener;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
 
+import com.google.common.collect.Maps;
+
 import ch.sbb.matsim.routing.graph.Graph;
 
 /**
  * @author michalm
  */
 public class MultiInsertionDetourPathCalculator implements DetourPathCalculator, MobsimBeforeCleanupListener {
-
-	private static class DetourLinksSet {
-		final Map<Id<Link>, Link> pickupDetourStartLinks;
-		final Map<Id<Link>, Link> pickupDetourEndLinks;
-		final Map<Id<Link>, Link> dropoffDetourStartLinks;
-		final Map<Id<Link>, Link> dropoffDetourEndLinks;
-
-		public DetourLinksSet(List<Insertion> filteredInsertions) {
-			pickupDetourStartLinks = new HashMap<>();
-			pickupDetourEndLinks = new HashMap<>();
-			dropoffDetourStartLinks = new HashMap<>();
-			dropoffDetourEndLinks = new HashMap<>();
-
-			filteredInsertions.forEach(insertion -> {
-				addLink(pickupDetourStartLinks, insertion.pickup.previousLink);
-				addLink(pickupDetourEndLinks, insertion.pickup.nextLink);
-				addLink(dropoffDetourStartLinks, insertion.dropoff.previousLink);
-				addLink(dropoffDetourEndLinks, insertion.dropoff.nextLink);
-			});
-		}
-
-		private void addLink(Map<Id<Link>, Link> map, Link link) {
-			if (link != null) {
-				map.put(link.getId(), link);
-			}
-		}
-	}
-
 	public static final int MAX_THREADS = 4;
 
 	private final OneToManyPathSearch toPickupPathSearch;
 	private final OneToManyPathSearch fromPickupPathSearch;
 	private final OneToManyPathSearch toDropoffPathSearch;
 	private final OneToManyPathSearch fromDropoffPathSearch;
-
-	private final double stopDuration;
 
 	private final ExecutorService executorService;
 
@@ -101,47 +73,17 @@ public class MultiInsertionDetourPathCalculator implements DetourPathCalculator,
 		fromPickupPathSearch = OneToManyPathSearch.createSearch(graph, nodeMap, travelTime, travelDisutility, true);
 		toDropoffPathSearch = OneToManyPathSearch.createSearch(graph, nodeMap, travelTime, travelDisutility, true);
 		fromDropoffPathSearch = OneToManyPathSearch.createSearch(graph, nodeMap, travelTime, travelDisutility, true);
-		stopDuration = drtCfg.getStopDuration();
 		executorService = Executors.newFixedThreadPool(Math.min(drtCfg.getNumberOfThreads(), MAX_THREADS));
 	}
 
 	@Override
 	public DetourData<PathData> calculatePaths(DrtRequest drtRequest, List<Insertion> filteredInsertions) {
-		Link pickup = drtRequest.getFromLink();
-		Link dropoff = drtRequest.getToLink();
-
-		double earliestPickupTime = drtRequest.getEarliestStartTime(); // optimistic
-		double latestDropoffTime = drtRequest.getLatestArrivalTime(); // pessimistic
-
 		// with vehicle insertion filtering -- pathsToPickup is the most computationally demanding task, while
 		// pathsFromDropoff is the least demanding one
-
-		//TODO move extraction of links from filteredInsertions to each Callable task
-		DetourLinksSet detourLinksSet = new DetourLinksSet(filteredInsertions);
-
-		// calc backward dijkstra from pickup to ends of selected stops + starts
-		// highest computation time (approx. 45% total CPU time)
-		Future<Map<Link, PathData>> pathsToPickupFuture = executorService.submit(
-				() -> toPickupPathSearch.calcPathDataMap(pickup, detourLinksSet.pickupDetourStartLinks.values(),
-						earliestPickupTime, false, drtRequest.getLatestStartTime() - earliestPickupTime));
-
-		// calc forward dijkstra from pickup to beginnings of selected stops + dropoff
-		// medium computation time (approx. 25% total CPU time)
-		Future<Map<Link, PathData>> pathsFromPickupFuture = executorService.submit(
-				() -> fromPickupPathSearch.calcPathDataMap(pickup, detourLinksSet.pickupDetourEndLinks.values(),
-						earliestPickupTime, true));
-
-		// calc backward dijkstra from dropoff to ends of selected stops
-		// medium computation time (approx. 25% total CPU time)
-		Future<Map<Link, PathData>> pathsToDropoffFuture = executorService.submit(
-				() -> toDropoffPathSearch.calcPathDataMap(dropoff, detourLinksSet.dropoffDetourStartLinks.values(),
-						latestDropoffTime, false));
-
-		// calc forward dijkstra from dropoff to beginnings of selected stops
-		// lowest computation time (approx. 5% total CPU time)
-		Future<Map<Link, PathData>> pathsFromDropoffFuture = executorService.submit(
-				() -> fromDropoffPathSearch.calcPathDataMap(dropoff, detourLinksSet.dropoffDetourEndLinks.values(),
-						latestDropoffTime, true));
+		var pathsToPickupFuture = executorService.submit(() -> calcPathsToPickup(drtRequest, filteredInsertions));
+		var pathsFromPickupFuture = executorService.submit(() -> calcPathsFromPickup(drtRequest, filteredInsertions));
+		var pathsToDropoffFuture = executorService.submit(() -> calcPathsToDropoff(drtRequest, filteredInsertions));
+		var pathsFromDropoffFuture = executorService.submit(() -> calcPathsFromDropoff(drtRequest, filteredInsertions));
 
 		try {
 			return new DetourData<>(pathsToPickupFuture.get(), pathsFromPickupFuture.get(), pathsToDropoffFuture.get(),
@@ -149,6 +91,48 @@ public class MultiInsertionDetourPathCalculator implements DetourPathCalculator,
 		} catch (InterruptedException | ExecutionException e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	private Map<Link, PathData> calcPathsToPickup(DrtRequest drtRequest, List<Insertion> filteredInsertions) {
+		// calc backward dijkstra from pickup to ends of selected stops + starts
+		double earliestPickupTime = drtRequest.getEarliestStartTime(); // optimistic
+		Collection<Link> toLinks = getDetourLinks(filteredInsertions, insertion -> insertion.pickup.previousLink);
+		double maxTravelTime = drtRequest.getLatestStartTime() - earliestPickupTime;
+		return toPickupPathSearch.calcPathDataMap(drtRequest.getFromLink(), toLinks, earliestPickupTime, false,
+				maxTravelTime);
+	}
+
+	private Map<Link, PathData> calcPathsFromPickup(DrtRequest drtRequest, List<Insertion> filteredInsertions) {
+		// calc forward dijkstra from pickup to beginnings of selected stops + dropoff
+		double earliestPickupTime = drtRequest.getEarliestStartTime(); // optimistic
+		Collection<Link> toLinks = getDetourLinks(filteredInsertions, insertion -> insertion.pickup.nextLink);
+		return fromPickupPathSearch.calcPathDataMap(drtRequest.getFromLink(), toLinks, earliestPickupTime, true);
+	}
+
+	private Map<Link, PathData> calcPathsToDropoff(DrtRequest drtRequest, List<Insertion> filteredInsertions) {
+		// calc backward dijkstra from dropoff to ends of selected stops
+		double latestDropoffTime = drtRequest.getLatestArrivalTime(); // pessimistic
+		Collection<Link> toLinks = getDetourLinks(filteredInsertions, insertion -> insertion.dropoff.previousLink);
+		return toDropoffPathSearch.calcPathDataMap(drtRequest.getToLink(), toLinks, latestDropoffTime, false);
+	}
+
+	private Map<Link, PathData> calcPathsFromDropoff(DrtRequest drtRequest, List<Insertion> filteredInsertions) {
+		// calc forward dijkstra from dropoff to beginnings of selected stops
+		double latestDropoffTime = drtRequest.getLatestArrivalTime(); // pessimistic
+		Collection<Link> toLinks = getDetourLinks(filteredInsertions, insertion -> insertion.dropoff.nextLink);
+		return fromDropoffPathSearch.calcPathDataMap(drtRequest.getToLink(), toLinks, latestDropoffTime, true);
+	}
+
+	private Collection<Link> getDetourLinks(List<Insertion> filteredInsertions,
+			Function<Insertion, Link> detourLinkExtractor) {
+		Map<Id<Link>, Link> pickupDetourStartLinks = Maps.newHashMapWithExpectedSize(filteredInsertions.size());
+		for (Insertion insertion : filteredInsertions) {
+			Link link = detourLinkExtractor.apply(insertion);
+			if (link != null) {
+				pickupDetourStartLinks.putIfAbsent(link.getId(), link);
+			}
+		}
+		return pickupDetourStartLinks.values();
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/MultiInsertionDetourPathCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/MultiInsertionDetourPathCalculator.java
@@ -111,8 +111,7 @@ public class MultiInsertionDetourPathCalculator implements DetourPathCalculator,
 		Link dropoff = drtRequest.getToLink();
 
 		double earliestPickupTime = drtRequest.getEarliestStartTime(); // optimistic
-		double minTravelTime = 15 * 60; // FIXME inaccurate temp solution: fixed 15 min
-		double earliestDropoffTime = earliestPickupTime + minTravelTime + stopDuration;
+		double latestDropoffTime = drtRequest.getLatestArrivalTime(); // pessimistic
 
 		// with vehicle insertion filtering -- pathsToPickup is the most computationally demanding task, while
 		// pathsFromDropoff is the least demanding one
@@ -136,13 +135,13 @@ public class MultiInsertionDetourPathCalculator implements DetourPathCalculator,
 		// medium computation time (approx. 25% total CPU time)
 		Future<Map<Link, PathData>> pathsToDropoffFuture = executorService.submit(
 				() -> toDropoffPathSearch.calcPathDataMap(dropoff, detourLinksSet.dropoffDetourStartLinks.values(),
-						earliestDropoffTime, false));
+						latestDropoffTime, false));
 
 		// calc forward dijkstra from dropoff to beginnings of selected stops
 		// lowest computation time (approx. 5% total CPU time)
 		Future<Map<Link, PathData>> pathsFromDropoffFuture = executorService.submit(
 				() -> fromDropoffPathSearch.calcPathDataMap(dropoff, detourLinksSet.dropoffDetourEndLinks.values(),
-						earliestDropoffTime, true));
+						latestDropoffTime, true));
 
 		try {
 			return new DetourData<>(pathsToPickupFuture.get(), pathsFromPickupFuture.get(), pathsToDropoffFuture.get(),

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRoute.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRoute.java
@@ -17,10 +17,13 @@
  * *********************************************************************** */
 package org.matsim.contrib.drt.routing;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.core.population.routes.AbstractRoute;
+import org.matsim.core.utils.misc.OptionalTime;
 
 import com.google.common.base.MoreObjects;
 
@@ -37,27 +40,31 @@ import com.google.common.base.MoreObjects;
 public class DrtRoute extends AbstractRoute {
 	public final static String ROUTE_TYPE = TransportMode.drt;
 
-	private double maxWaitTime;
-	private double directRideTime;
+	private OptionalTime maxWaitTime = OptionalTime.undefined();
+	private OptionalTime directRideTime = OptionalTime.undefined();
 
 	public DrtRoute(Id<Link> startLinkId, Id<Link> endLinkId) {
 		super(startLinkId, endLinkId);
 	}
 
 	public double getDirectRideTime() {
-		return directRideTime;
+		return directRideTime.seconds();
 	}
 
 	public double getMaxWaitTime() {
-		return maxWaitTime;
+		return maxWaitTime.seconds();
 	}
 
-	public void setUnsharedRideTime(double directRideTime) {
-		this.directRideTime = directRideTime;
+	public void setDirectRideTime(double directRideTime) {
+		this.directRideTime = OptionalTime.defined(directRideTime);
 	}
 
 	public void setMaxWaitTime(double maxWaitTime) {
-		this.maxWaitTime = maxWaitTime;
+		this.maxWaitTime = OptionalTime.defined(maxWaitTime);
+	}
+
+	public double getMaxTravelTime() {
+		return getTravelTime().seconds(); // currently DrtRoute.travelTime is set to the max allowed travel time
 	}
 
 	@Override
@@ -68,8 +75,8 @@ public class DrtRoute extends AbstractRoute {
 	@Override
 	public void setRouteDescription(String routeDescription) {
 		String[] values = routeDescription.split(" ");
-		maxWaitTime = requiresZeroOrPositive(Double.parseDouble(values[0]));
-		directRideTime = requiresZeroOrPositive(Double.parseDouble(values[1]));
+		maxWaitTime = OptionalTime.defined(requiresZeroOrPositive(Double.parseDouble(values[0])));
+		directRideTime = OptionalTime.defined(requiresZeroOrPositive(Double.parseDouble(values[1])));
 	}
 
 	@Override
@@ -83,10 +90,8 @@ public class DrtRoute extends AbstractRoute {
 	}
 
 	private double requiresZeroOrPositive(double value) {
-		if (value >= 0 || value <= Double.MAX_VALUE) {
-			return value;
-		}
-		throw new IllegalArgumentException("Value: " + value + " must be zero or positive");
+		checkArgument(value >= 0 || value <= Double.MAX_VALUE, "Value: (%s) must be zero or positive", value);
+		return value;
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRouteCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRouteCreator.java
@@ -77,7 +77,7 @@ public class DrtRouteCreator implements DefaultMainLegRouter.RouteCreator {
 		DrtRoute route = routeFactories.createRoute(DrtRoute.class, accessActLink.getId(), egressActLink.getId());
 		route.setDistance(unsharedDistance);
 		route.setTravelTime(maxTravelTime);
-		route.setUnsharedRideTime(unsharedRideTime);
+		route.setDirectRideTime(unsharedRideTime);
 		route.setMaxWaitTime(drtCfg.getMaxWaitTime());
 		return route;
 	}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/DrtRoutingModuleTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/DrtRoutingModuleTest.java
@@ -79,6 +79,7 @@ public class DrtRoutingModuleTest {
 		drtCfg.setMode(drtMode);
 		drtCfg.setMaxTravelTimeAlpha(1.5);
 		drtCfg.setMaxTravelTimeBeta(5 * 60);
+		drtCfg.setMaxWaitTime(5 * 60);
 
 		ImmutableMap<Id<DrtStopFacility>, DrtStopFacility> drtStops = scenario.getTransitSchedule()
 				.getFacilities()


### PR DESCRIPTION
Also:
- refactor `DrtRoute` methods
- use `OptionalTime` for times stored inside `DrtRoute`