### PR TITLE
Update freight example scenario

### DIFF
--- a/contribs/freight/src/test/java/org/matsim/contrib/freight/utils/FreightUtilsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/contrib/freight/utils/FreightUtilsTest.java
@@ -436,8 +436,6 @@ public class FreightUtilsTest {
 		FreightUtils.loadCarriersAccordingToFreightConfig(scenario);
 		Controler controler = new Controler(scenario);
 
-		setJspritIterationsForCarriers(scenario);
-
 		try {
 			FreightUtils.runJsprit(scenario, freightConfig);
 		} catch (Exception e) {
@@ -452,13 +450,20 @@ public class FreightUtilsTest {
 	 * This test should lead to an exception, because the NumberOfJspritIterations is not set for carriers.
 	 */
 	@Test(expected = java.util.concurrent.ExecutionException.class)
-	public void testRunJsprit_NoOfJsprtiIterationsMissing() throws ExecutionException, InterruptedException {
+	public void testRunJsprit_NoOfJspritIterationsMissing() throws ExecutionException, InterruptedException {
 		Config config = prepareConfig();
 		config.controler().setOutputDirectory(utils.getOutputDirectory());
 		Scenario scenario = ScenarioUtils.loadScenario(config);
-		FreightUtils.loadCarriersAccordingToFreightConfig(scenario);
 
 		FreightConfigGroup freightConfig = ConfigUtils.addOrGetModule( config, FreightConfigGroup.class ) ;
+
+		FreightUtils.loadCarriersAccordingToFreightConfig(scenario);
+
+		//remove all attributes --> remove the NumberOfJspritIterations attribute to trigger exception
+		Carriers carriers = FreightUtils.getCarriers(scenario);
+		for (Carrier carrier : carriers.getCarriers().values()) {
+			carrier.getAttributes().clear();
+		}
 
 		FreightUtils.runJsprit(scenario, freightConfig);
 	}
@@ -472,8 +477,6 @@ public class FreightUtilsTest {
 		config.controler().setOutputDirectory(utils.getOutputDirectory());
 		Scenario scenario = ScenarioUtils.loadScenario(config);
 		FreightUtils.loadCarriersAccordingToFreightConfig(scenario);
-
-		setJspritIterationsForCarriers(scenario);
 
 		FreightConfigGroup freightConfig = ConfigUtils.addOrGetModule( config, FreightConfigGroup.class ) ;
 		try {
@@ -498,10 +501,5 @@ public class FreightUtilsTest {
 		return config;
 	}
 
-	private void setJspritIterationsForCarriers(Scenario scenario) {
-		for (Carrier carrier : FreightUtils.getCarriers(scenario).getCarriers().values()) {
-			CarrierUtils.setJspritIterations(carrier, 1);
-		}
-	}
 
 }

--- a/examples/scenarios/freight-chessboard-9x9/carrierPlans.xml
+++ b/examples/scenarios/freight-chessboard-9x9/carrierPlans.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 	<carriers>
 		<carrier id="19">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_19_heavyVehicle" depotLinkId="j(0,1)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -303,6 +306,9 @@
 		</carrier>
 
 		<carrier id="17">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_17_heavyVehicle" depotLinkId="i(9,9)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -605,6 +611,9 @@
 		</carrier>
 
 		<carrier id="35">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_35_heavyVehicle" depotLinkId="j(0,9)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -907,6 +916,9 @@
 		</carrier>
 
 		<carrier id="18">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_18_heavyVehicle" depotLinkId="i(9,0)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1209,6 +1221,9 @@
 		</carrier>
 
 		<carrier id="36">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_36_heavyVehicle" depotLinkId="j(9,9)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1511,6 +1526,9 @@
 		</carrier>
 
 		<carrier id="15">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_15_heavyVehicle" depotLinkId="i(8,9)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1813,6 +1831,9 @@
 		</carrier>
 
 		<carrier id="33">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_33_heavyVehicle" depotLinkId="j(0,8)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -2115,6 +2136,9 @@
 		</carrier>
 
 		<carrier id="16">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_16_heavyVehicle" depotLinkId="i(8,0)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -2417,6 +2441,9 @@
 		</carrier>
 
 		<carrier id="34">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_34_heavyVehicle" depotLinkId="j(9,8)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -2719,6 +2746,9 @@
 		</carrier>
 
 		<carrier id="13">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_13_heavyVehicle" depotLinkId="i(7,9)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -3021,6 +3051,9 @@
 		</carrier>
 
 		<carrier id="14">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_14_heavyVehicle" depotLinkId="i(7,0)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -3323,6 +3356,9 @@
 		</carrier>
 
 		<carrier id="11">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_11_heavyVehicle" depotLinkId="i(6,9)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -3625,6 +3661,9 @@
 		</carrier>
 
 		<carrier id="12">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_12_heavyVehicle" depotLinkId="i(6,0)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -3927,6 +3966,9 @@
 		</carrier>
 
 		<carrier id="21">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_21_heavyVehicle" depotLinkId="j(0,2)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -4229,6 +4271,9 @@
 		</carrier>
 
 		<carrier id="20">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_20_heavyVehicle" depotLinkId="j(9,1)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -4531,6 +4576,9 @@
 		</carrier>
 
 		<carrier id="22">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_22_heavyVehicle" depotLinkId="j(9,2)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -4833,6 +4881,9 @@
 		</carrier>
 
 		<carrier id="23">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_23_heavyVehicle" depotLinkId="j(0,3)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -5135,6 +5186,9 @@
 		</carrier>
 
 		<carrier id="24">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_24_heavyVehicle" depotLinkId="j(9,3)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -5437,6 +5491,9 @@
 		</carrier>
 
 		<carrier id="25">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_25_heavyVehicle" depotLinkId="j(0,4)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -5739,6 +5796,9 @@
 		</carrier>
 
 		<carrier id="26">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_26_heavyVehicle" depotLinkId="j(9,4)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -6041,6 +6101,9 @@
 		</carrier>
 
 		<carrier id="27">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_27_heavyVehicle" depotLinkId="j(0,5)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -6343,6 +6406,9 @@
 		</carrier>
 
 		<carrier id="28">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_28_heavyVehicle" depotLinkId="j(9,5)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -6645,6 +6711,9 @@
 		</carrier>
 
 		<carrier id="29">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_29_heavyVehicle" depotLinkId="j(0,6)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -6947,6 +7016,9 @@
 		</carrier>
 
 		<carrier id="3">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_3_heavyVehicle" depotLinkId="i(2,9)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -7249,6 +7321,9 @@
 		</carrier>
 
 		<carrier id="2">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_2_heavyVehicle" depotLinkId="i(1,0)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -7551,6 +7626,9 @@
 		</carrier>
 
 		<carrier id="1">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_1_heavyVehicle" depotLinkId="i(1,9)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -7853,6 +7931,9 @@
 		</carrier>
 
 		<carrier id="10">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_10_heavyVehicle" depotLinkId="i(5,0)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -8155,6 +8236,9 @@
 		</carrier>
 
 		<carrier id="7">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_7_heavyVehicle" depotLinkId="i(4,9)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -8457,6 +8541,9 @@
 		</carrier>
 
 		<carrier id="30">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_30_heavyVehicle" depotLinkId="j(9,6)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -8759,6 +8846,9 @@
 		</carrier>
 
 		<carrier id="6">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_6_heavyVehicle" depotLinkId="i(3,0)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -9061,6 +9151,9 @@
 		</carrier>
 
 		<carrier id="5">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_5_heavyVehicle" depotLinkId="i(3,9)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -9363,6 +9456,9 @@
 		</carrier>
 
 		<carrier id="32">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_32_heavyVehicle" depotLinkId="j(9,7)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -9665,6 +9761,9 @@
 		</carrier>
 
 		<carrier id="4">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_4_heavyVehicle" depotLinkId="i(2,0)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -9967,6 +10066,9 @@
 		</carrier>
 
 		<carrier id="31">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_31_heavyVehicle" depotLinkId="j(0,7)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -10269,6 +10371,9 @@
 		</carrier>
 
 		<carrier id="9">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_9_heavyVehicle" depotLinkId="i(5,9)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -10571,6 +10676,9 @@
 		</carrier>
 
 		<carrier id="8">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_8_heavyVehicle" depotLinkId="i(4,0)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>

--- a/examples/scenarios/freight-chessboard-9x9/carrierPlansWithoutRoutes.xml
+++ b/examples/scenarios/freight-chessboard-9x9/carrierPlansWithoutRoutes.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 	<carriers>
 		<carrier id="19">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_19_heavyVehicle" depotLinkId="j(0,1)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -65,6 +68,9 @@
 		</carrier>
 
 		<carrier id="35">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_35_heavyVehicle" depotLinkId="j(0,9)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -129,6 +135,9 @@
 		</carrier>
 
 		<carrier id="17">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_17_heavyVehicle" depotLinkId="i(9,9)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -193,6 +202,9 @@
 		</carrier>
 
 		<carrier id="36">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_36_heavyVehicle" depotLinkId="j(9,9)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -257,6 +269,9 @@
 		</carrier>
 
 		<carrier id="18">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_18_heavyVehicle" depotLinkId="i(9,0)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -321,6 +336,9 @@
 		</carrier>
 
 		<carrier id="33">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_33_heavyVehicle" depotLinkId="j(0,8)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -385,6 +403,9 @@
 		</carrier>
 
 		<carrier id="15">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_15_heavyVehicle" depotLinkId="i(8,9)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -449,6 +470,9 @@
 		</carrier>
 
 		<carrier id="34">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_34_heavyVehicle" depotLinkId="j(9,8)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -513,6 +537,9 @@
 		</carrier>
 
 		<carrier id="16">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_16_heavyVehicle" depotLinkId="i(8,0)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -577,6 +604,9 @@
 		</carrier>
 
 		<carrier id="13">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_13_heavyVehicle" depotLinkId="i(7,9)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -641,6 +671,9 @@
 		</carrier>
 
 		<carrier id="14">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_14_heavyVehicle" depotLinkId="i(7,0)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -705,6 +738,9 @@
 		</carrier>
 
 		<carrier id="11">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_11_heavyVehicle" depotLinkId="i(6,9)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -769,6 +805,9 @@
 		</carrier>
 
 		<carrier id="12">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_12_heavyVehicle" depotLinkId="i(6,0)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -833,6 +872,9 @@
 		</carrier>
 
 		<carrier id="21">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_21_heavyVehicle" depotLinkId="j(0,2)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -897,6 +939,9 @@
 		</carrier>
 
 		<carrier id="20">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_20_heavyVehicle" depotLinkId="j(9,1)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -961,6 +1006,9 @@
 		</carrier>
 
 		<carrier id="22">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_22_heavyVehicle" depotLinkId="j(9,2)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1025,6 +1073,9 @@
 		</carrier>
 
 		<carrier id="23">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_23_heavyVehicle" depotLinkId="j(0,3)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1089,6 +1140,9 @@
 		</carrier>
 
 		<carrier id="24">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_24_heavyVehicle" depotLinkId="j(9,3)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1153,6 +1207,9 @@
 		</carrier>
 
 		<carrier id="25">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_25_heavyVehicle" depotLinkId="j(0,4)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1217,6 +1274,9 @@
 		</carrier>
 
 		<carrier id="26">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_26_heavyVehicle" depotLinkId="j(9,4)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1281,6 +1341,9 @@
 		</carrier>
 
 		<carrier id="27">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_27_heavyVehicle" depotLinkId="j(0,5)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1345,6 +1408,9 @@
 		</carrier>
 
 		<carrier id="28">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_28_heavyVehicle" depotLinkId="j(9,5)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1409,6 +1475,9 @@
 		</carrier>
 
 		<carrier id="29">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_29_heavyVehicle" depotLinkId="j(0,6)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1473,6 +1542,9 @@
 		</carrier>
 
 		<carrier id="3">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_3_heavyVehicle" depotLinkId="i(2,9)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1537,6 +1609,9 @@
 		</carrier>
 
 		<carrier id="2">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_2_heavyVehicle" depotLinkId="i(1,0)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1601,6 +1676,9 @@
 		</carrier>
 
 		<carrier id="10">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_10_heavyVehicle" depotLinkId="i(5,0)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1665,6 +1743,9 @@
 		</carrier>
 
 		<carrier id="1">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_1_heavyVehicle" depotLinkId="i(1,9)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1729,6 +1810,9 @@
 		</carrier>
 
 		<carrier id="30">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_30_heavyVehicle" depotLinkId="j(9,6)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1793,6 +1877,9 @@
 		</carrier>
 
 		<carrier id="7">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_7_heavyVehicle" depotLinkId="i(4,9)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1857,6 +1944,9 @@
 		</carrier>
 
 		<carrier id="6">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_6_heavyVehicle" depotLinkId="i(3,0)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1921,6 +2011,9 @@
 		</carrier>
 
 		<carrier id="32">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_32_heavyVehicle" depotLinkId="j(9,7)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1985,6 +2078,9 @@
 		</carrier>
 
 		<carrier id="5">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_5_heavyVehicle" depotLinkId="i(3,9)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -2049,6 +2145,9 @@
 		</carrier>
 
 		<carrier id="31">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_31_heavyVehicle" depotLinkId="j(0,7)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -2113,6 +2212,9 @@
 		</carrier>
 
 		<carrier id="4">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_4_heavyVehicle" depotLinkId="i(2,0)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -2177,6 +2279,9 @@
 		</carrier>
 
 		<carrier id="9">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_9_heavyVehicle" depotLinkId="i(5,9)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -2241,6 +2346,9 @@
 		</carrier>
 
 		<carrier id="8">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_8_heavyVehicle" depotLinkId="i(4,0)" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>

--- a/examples/scenarios/freight-chessboard-9x9/carrierPlansWithoutRoutesAndBigVehicles.xml
+++ b/examples/scenarios/freight-chessboard-9x9/carrierPlansWithoutRoutesAndBigVehicles.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 	<carriers>
 		<carrier id="carrier1">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_19_heavyVehicle" depotLinkId="j(0,1)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>

--- a/examples/scenarios/freight-chessboard-9x9/multipleCarriers_withoutTW_withDepots_withoutPlan.xml
+++ b/examples/scenarios/freight-chessboard-9x9/multipleCarriers_withoutTW_withDepots_withoutPlan.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 	<carriers>
 		<carrier id="22">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_22_lightVehicle_a" depotLinkId="j(9,2)" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -37,6 +40,9 @@
 		</carrier>
 
 		<carrier id="23">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_23_lightVehicle_a" depotLinkId="j(0,3)R" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -73,6 +79,9 @@
 		</carrier>
 
 		<carrier id="24">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_24_lightVehicle_a" depotLinkId="j(9,3)" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -109,6 +118,9 @@
 		</carrier>
 
 		<carrier id="25">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_25_lightVehicle_a" depotLinkId="j(0,4)R" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -145,6 +157,9 @@
 		</carrier>
 
 		<carrier id="26">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_26_lightVehicle_a" depotLinkId="j(9,4)" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -181,6 +196,9 @@
 		</carrier>
 
 		<carrier id="27">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_27_lightVehicle_a" depotLinkId="j(0,5)R" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -217,6 +235,9 @@
 		</carrier>
 
 		<carrier id="28">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_28_lightVehicle_a" depotLinkId="j(9,5)" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -253,6 +274,9 @@
 		</carrier>
 
 		<carrier id="29">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_29_lightVehicle_a" depotLinkId="j(0,6)R" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -289,6 +313,9 @@
 		</carrier>
 
 		<carrier id="30">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_30_lightVehicle_a" depotLinkId="j(9,6)" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -325,6 +352,9 @@
 		</carrier>
 
 		<carrier id="31">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_31_lightVehicle_a" depotLinkId="j(0,7)R" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -361,6 +391,9 @@
 		</carrier>
 
 		<carrier id="10">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_10_lightVehicle_a" depotLinkId="i(5,0)" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -397,6 +430,9 @@
 		</carrier>
 
 		<carrier id="32">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_32_lightVehicle_a" depotLinkId="j(9,7)" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -433,6 +469,9 @@
 		</carrier>
 
 		<carrier id="11">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_11_lightVehicle_a" depotLinkId="i(6,9)R" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -469,6 +508,9 @@
 		</carrier>
 
 		<carrier id="33">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_33_lightVehicle_a" depotLinkId="j(0,8)R" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -505,6 +547,9 @@
 		</carrier>
 
 		<carrier id="12">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_12_lightVehicle_a" depotLinkId="i(6,0)" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -541,6 +586,9 @@
 		</carrier>
 
 		<carrier id="34">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_34_lightVehicle_a" depotLinkId="j(9,8)" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -577,6 +625,9 @@
 		</carrier>
 
 		<carrier id="13">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_13_lightVehicle_a" depotLinkId="i(7,9)R" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -613,6 +664,9 @@
 		</carrier>
 
 		<carrier id="35">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_35_lightVehicle_a" depotLinkId="j(0,9)R" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -649,6 +703,9 @@
 		</carrier>
 
 		<carrier id="14">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_14_lightVehicle_a" depotLinkId="i(7,0)" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -685,6 +742,9 @@
 		</carrier>
 
 		<carrier id="36">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_36_lightVehicle_a" depotLinkId="j(9,9)" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -721,6 +781,9 @@
 		</carrier>
 
 		<carrier id="15">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_15_lightVehicle_a" depotLinkId="i(8,9)R" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -757,6 +820,9 @@
 		</carrier>
 
 		<carrier id="16">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_16_lightVehicle_a" depotLinkId="i(8,0)" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -793,6 +859,9 @@
 		</carrier>
 
 		<carrier id="17">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_17_lightVehicle_a" depotLinkId="i(9,9)R" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -829,6 +898,9 @@
 		</carrier>
 
 		<carrier id="18">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_18_lightVehicle_a" depotLinkId="i(9,0)" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -865,6 +937,9 @@
 		</carrier>
 
 		<carrier id="19">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_19_lightVehicle_a" depotLinkId="j(0,1)R" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -901,6 +976,9 @@
 		</carrier>
 
 		<carrier id="1">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_1_lightVehicle_a" depotLinkId="i(1,9)R" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -937,6 +1015,9 @@
 		</carrier>
 
 		<carrier id="2">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_2_lightVehicle_a" depotLinkId="i(1,0)" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -973,6 +1054,9 @@
 		</carrier>
 
 		<carrier id="3">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_3_lightVehicle_a" depotLinkId="i(2,9)R" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1009,6 +1093,9 @@
 		</carrier>
 
 		<carrier id="4">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_4_lightVehicle_a" depotLinkId="i(2,0)" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1045,6 +1132,9 @@
 		</carrier>
 
 		<carrier id="5">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_5_lightVehicle_a" depotLinkId="i(3,9)R" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1081,6 +1171,9 @@
 		</carrier>
 
 		<carrier id="6">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_6_lightVehicle_a" depotLinkId="i(3,0)" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1117,6 +1210,9 @@
 		</carrier>
 
 		<carrier id="7">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_7_lightVehicle_a" depotLinkId="i(4,9)R" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1153,6 +1249,9 @@
 		</carrier>
 
 		<carrier id="8">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_8_lightVehicle_a" depotLinkId="i(4,0)" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1189,6 +1288,9 @@
 		</carrier>
 
 		<carrier id="9">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_9_lightVehicle_a" depotLinkId="i(5,9)R" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1225,6 +1327,9 @@
 		</carrier>
 
 		<carrier id="20">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_20_lightVehicle_a" depotLinkId="j(9,1)" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>
@@ -1261,6 +1366,9 @@
 		</carrier>
 
 		<carrier id="21">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_21_lightVehicle_a" depotLinkId="j(0,2)R" typeId="small" earliestStart="06:00:00" latestEnd="16:00:00"/>

--- a/examples/scenarios/freight-chessboard-9x9/singleCarrierFiveActivities.xml
+++ b/examples/scenarios/freight-chessboard-9x9/singleCarrierFiveActivities.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 	<carriers>
 		<carrier id="carrier1">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_19_heavyVehicle" depotLinkId="j(0,1)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>

--- a/examples/scenarios/freight-chessboard-9x9/singleCarrierFiveActivitiesWithoutRoutes.xml
+++ b/examples/scenarios/freight-chessboard-9x9/singleCarrierFiveActivitiesWithoutRoutes.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 	<carriers>
 		<carrier id="carrier1">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<!--<vehicle id="carrier_19_heavyVehicle" depotLinkId="j(0,1)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>-->

--- a/examples/scenarios/freight-chessboard-9x9/singleCarrierOneActivity.xml
+++ b/examples/scenarios/freight-chessboard-9x9/singleCarrierOneActivity.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 	<carriers>
 		<carrier id="carrier1">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">10</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_19_heavyVehicle" depotLinkId="j(0,1)R" typeId="heavy" earliestStart="08:00:00" latestEnd="16:00:00"/>

--- a/examples/scenarios/freight-chessboard-9x9/singleCarrierOneActivityWithoutRoutes.xml
+++ b/examples/scenarios/freight-chessboard-9x9/singleCarrierOneActivityWithoutRoutes.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 	<carriers>
 		<carrier id="carrier1">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_19_heavyVehicle" depotLinkId="j(0,1)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>

--- a/examples/scenarios/freight-chessboard-9x9/singleCarrierPlanBigVehicles.xml
+++ b/examples/scenarios/freight-chessboard-9x9/singleCarrierPlanBigVehicles.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 	<carriers>
 		<carrier id="carrier1">
+			<attributes>
+				<attribute name="jspritIterations" class="java.lang.Integer">100</attribute>
+			</attributes>
 			<capabilities fleetSize="INFINITE">
 				<vehicles>
 					<vehicle id="carrier_19_heavyVehicle" depotLinkId="j(0,1)R" typeId="heavy" earliestStart="06:00:00" latestEnd="16:00:00"/>

--- a/examples/scenarios/freight-chessboard-9x9/vehicleTypes.xml
+++ b/examples/scenarios/freight-chessboard-9x9/vehicleTypes.xml
@@ -1,14 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-	<vehicleTypes>
-		<vehicleType id="heavy">
-			<description>null</description>
-			<capacity>50</capacity>
-			<costInformation fix="130.0" perMeter="7.7E-4" perSecond="0.0080"/>
-		</vehicleType>
-		<vehicleType id="light">
-			<description>null</description>
-			<capacity>5</capacity>
-			<costInformation fix="84.0" perMeter="4.7E-4" perSecond="0.0080"/>
-		</vehicleType>
-	</vehicleTypes>
 
+<vehicleDefinitions xmlns="http://www.matsim.org/files/dtd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+					xsi:schemaLocation="http://www.matsim.org/files/dtd http://www.matsim.org/files/dtd/vehicleDefinitions_v2.0.xsd">
+
+	<!-- Small example according to the vehicleDefinitions_v2.0 scheme. The freight contrib now uses the regular MATSim vehicleType format
+	For more information please have a look to http://matsim.org/files/dtd/vehicleDefinitions_v2.0.xsd -->
+
+	<vehicleType id="heavy">
+		<description>A heavy truck</description>
+		<capacity seats="1" standingRoomInPersons="0" other="50.0"/>
+		<costInformation  fixedCostsPerDay="130.0" costsPerMeter="7.7E-4" costsPerSecond="0.0080"/>
+	</vehicleType>
+	<vehicleType id="light">
+		<description>A light truck</description>
+		<capacity seats="1" standingRoomInPersons="0" other="5.0"/>
+		<costInformation  fixedCostsPerDay="84.0" costsPerMeter="4.7E-4" costsPerSecond="0.0080"/>
+	</vehicleType>
+
+</vehicleDefinitions>


### PR DESCRIPTION
... to the current code:
- add the (new) NumberOfJspritIterations as Attribute to the carriers
- adapt one test to that: e.g. remove the manually setting of this (previously missing) attributes
- Update the vehicleTypes.xml from the old freight specific format to the regular MATSim vehicleDefinitions_v2.0 scheme

This PR is also done as preparation for updating the RunFreightExample in [matsim-code-examples](https://github.com/matsim-org/matsim-code-examples).