### PR TITLE
Improve usage of TerminationCriterion

### DIFF
--- a/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/AccessibilityFromEvents.java
+++ b/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/AccessibilityFromEvents.java
@@ -95,7 +95,7 @@ public final class AccessibilityFromEvents{
 			if ( controlerListener instanceof ShutdownListener ) {
 				MatsimServices controler = null ;
 				boolean unexpected = false ;
-				ShutdownEvent shutdownEvent = new ShutdownEvent( controler, unexpected ) ;
+				ShutdownEvent shutdownEvent = new ShutdownEvent( controler, unexpected, 0 ) ;
 				((ShutdownListener) controlerListener).notifyShutdown( shutdownEvent );
 			}
 		}

--- a/contribs/commercialTrafficApplications/src/test/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/CommercialJobGeneratorTest.java
+++ b/contribs/commercialTrafficApplications/src/test/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/CommercialJobGeneratorTest.java
@@ -41,7 +41,7 @@ public class CommercialJobGeneratorTest {
         File file = new File(utils.getOutputDirectory() +  "/ITERS/it." + iteration + "/");
         file.mkdirs();
         Controler controler = new Controler(scenario);
-        generator.notifyBeforeMobsim(new BeforeMobsimEvent(controler, iteration));
+        generator.notifyBeforeMobsim(new BeforeMobsimEvent(controler, iteration, false));
     }
 
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/speedup/DrtSpeedUpTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/speedup/DrtSpeedUpTest.java
@@ -255,7 +255,7 @@ public class DrtSpeedUpTest {
 	}
 
 	private void iterationEnds(DrtSpeedUp drtSpeedUp, int iteration) {
-		drtSpeedUp.notifyIterationEnds(new IterationEndsEvent(null, iteration));
+		drtSpeedUp.notifyIterationEnds(new IterationEndsEvent(null, iteration, false));
 	}
 
 	//mock request analyser instead of running simulations

--- a/contribs/roadpricing/src/test/java/org/matsim/contrib/roadpricing/CalcPaidTollTest.java
+++ b/contribs/roadpricing/src/test/java/org/matsim/contrib/roadpricing/CalcPaidTollTest.java
@@ -219,7 +219,7 @@ public class CalcPaidTollTest {
 		@SuppressWarnings("unused")
 		RoadPricingTollCalculator paidToll = new RoadPricingTollCalculator(scenario.getNetwork(), toll, eventsManager);
 		EventsToScore scoring = EventsToScore.createWithScoreUpdating(scenario, new CharyparNagelScoringFunctionFactory(scenario), eventsManager);
-		scoring.beginIteration(0);
+		scoring.beginIteration(0, false);
 
 		PrepareForSimUtils.createDefaultPrepareForSim(scenario).run();
 		new QSimBuilder(scenario.getConfig()) //

--- a/contribs/roadpricing/src/test/java/org/matsim/contrib/roadpricing/RoadPricingTestUtils.java
+++ b/contribs/roadpricing/src/test/java/org/matsim/contrib/roadpricing/RoadPricingTestUtils.java
@@ -266,7 +266,7 @@ import junit.framework.TestCase;
 		Mobsim sim = new QSimBuilder(scenario.getConfig()) //
 				.useDefaults() //
 				.build(scenario, events);
-		scoring.beginIteration(0);
+		scoring.beginIteration(0, false);
 		sim.run();
 		scoring.finish();
 

--- a/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/framework/scoring/InternalizingPlansScoring.java
+++ b/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/framework/scoring/InternalizingPlansScoring.java
@@ -147,7 +147,7 @@ public class InternalizingPlansScoring implements PlansScoring, ScoringListener,
 
 	@Override
 	public void notifyIterationStarts( final IterationStartsEvent event ) {
-		this.eventsToScore.beginIteration( event.getIteration() );
+		this.eventsToScore.beginIteration( event.getIteration(), event.isLastIteration() );
 	}
 
 	public interface InternalizationSettings {

--- a/contribs/socnetsim/src/test/java/org/matsim/contrib/socnetsim/framework/scoring/GroupCompositionPenalizerTest.java
+++ b/contribs/socnetsim/src/test/java/org/matsim/contrib/socnetsim/framework/scoring/GroupCompositionPenalizerTest.java
@@ -136,7 +136,7 @@ public class GroupCompositionPenalizerTest {
 				},
 				events );
 
-		eventsToScore.beginIteration( 1 );
+		eventsToScore.beginIteration( 1, false );
 
 		new QSimBuilder(sc.getConfig()) //
 				.useDefaults()

--- a/matsim/src/main/java/org/matsim/analysis/IterationTravelStatsControlerListener.java
+++ b/matsim/src/main/java/org/matsim/analysis/IterationTravelStatsControlerListener.java
@@ -82,7 +82,7 @@ class IterationTravelStatsControlerListener implements IterationEndsListener, Sh
         pHbyModeCalculator.writeOutput();
         pkMbyModeCalculator.writeOutput();
         final boolean writingTripsAtAll = config.controler().getWriteTripsInterval() > 0;
-        final boolean regularWriteEvents = writingTripsAtAll && (event.getIteration() > 0 && event.getIteration() % config.controler().getWriteTripsInterval() == 0);
+        final boolean regularWriteEvents = writingTripsAtAll && ((event.getIteration() > 0 && event.getIteration() % config.controler().getWriteTripsInterval() == 0) || event.isLastIteration());
         if (regularWriteEvents || (writingTripsAtAll && event.getIteration() == 0)) {
             new TripsAndLegsCSVWriter(scenario, customTripsWriterExtension, customLegsWriterExtension, mainModeIdentifier).write(experiencedPlansService.getExperiencedPlans()
                     , outputDirectoryHierarchy.getIterationFilename(event.getIteration(), Controler.DefaultFiles.tripscsv)

--- a/matsim/src/main/java/org/matsim/core/controler/AbstractController.java
+++ b/matsim/src/main/java/org/matsim/core/controler/AbstractController.java
@@ -83,7 +83,7 @@ import org.matsim.utils.MemoryObserver;
 
             @Override
             public void shutdown(boolean unexpected) {
-                controlerListenerManagerImpl.fireControlerShutdownEvent(unexpected, thisIteration);
+                controlerListenerManagerImpl.fireControlerShutdownEvent(unexpected, thisIteration == null ? -1 : thisIteration);
             }
         };
         MatsimRuntimeModifications.run(runnable);
@@ -112,7 +112,9 @@ import org.matsim.utils.MemoryObserver;
 
     private void doIterations(Config config) throws MatsimRuntimeModifications.UnexpectedShutdownException {
     	int iteration = config.controler().getFirstIteration();
-    	boolean doTerminate = false;
+    	
+    	// Special case if lastIteration == -1 -> Do not run any Mobsim
+    	boolean doTerminate = config.controler().getLastIteration() < 0;
     	
     	while (!doTerminate) {
     		boolean isLastIteration = mayTerminateAfterIteration(iteration);

--- a/matsim/src/main/java/org/matsim/core/controler/AbstractController.java
+++ b/matsim/src/main/java/org/matsim/core/controler/AbstractController.java
@@ -114,7 +114,7 @@ import org.matsim.utils.MemoryObserver;
     	int iteration = config.controler().getFirstIteration();
     	
     	// Special case if lastIteration == -1 -> Do not run any Mobsim
-    	boolean doTerminate = config.controler().getLastIteration() < 0;
+    	boolean doTerminate = config.controler().getLastIteration() < iteration;
     	
     	while (!doTerminate) {
     		boolean isLastIteration = mayTerminateAfterIteration(iteration);

--- a/matsim/src/main/java/org/matsim/core/controler/AbstractController.java
+++ b/matsim/src/main/java/org/matsim/core/controler/AbstractController.java
@@ -83,7 +83,7 @@ import org.matsim.utils.MemoryObserver;
 
             @Override
             public void shutdown(boolean unexpected) {
-                controlerListenerManagerImpl.fireControlerShutdownEvent(unexpected);
+                controlerListenerManagerImpl.fireControlerShutdownEvent(unexpected, thisIteration);
             }
         };
         MatsimRuntimeModifications.run(runnable);
@@ -107,18 +107,24 @@ import org.matsim.utils.MemoryObserver;
      * method in the SimplifiedControllerUtils class ... as with all other abstract methods.
      * </ul>
      */
-    protected abstract boolean continueIterations(int iteration);
+	protected abstract boolean mayTerminateAfterIteration(int iteration);
+	protected abstract boolean shouldTerminate(int iteration);
 
     private void doIterations(Config config) throws MatsimRuntimeModifications.UnexpectedShutdownException {
-        for (int iteration = config.controler().getFirstIteration(); continueIterations(iteration); iteration++) {
-            iteration(config, iteration);
-        }
+    	int iteration = config.controler().getFirstIteration();
+    	boolean doTerminate = false;
+    	
+    	while (!doTerminate) {
+    		boolean isLastIteration = mayTerminateAfterIteration(iteration);
+    		iteration(config, iteration, isLastIteration);
+    		doTerminate = isLastIteration && shouldTerminate(iteration);
+    		iteration++;
+    	}
     }
-    
     
     final String MARKER = "### ";
 
-    private void iteration(final Config config, final int iteration) throws MatsimRuntimeModifications.UnexpectedShutdownException {
+    private void iteration(final Config config, final int iteration, boolean isLastIteration) throws MatsimRuntimeModifications.UnexpectedShutdownException {
         this.thisIteration = iteration;
         this.getStopwatch().beginIteration(iteration);
 
@@ -130,7 +136,7 @@ import org.matsim.utils.MemoryObserver;
         iterationStep("iterationStartsListeners", new Runnable() {
             @Override
             public void run() {
-                controlerListenerManagerImpl.fireControlerIterationStartsEvent(iteration);
+                controlerListenerManagerImpl.fireControlerIterationStartsEvent(iteration, isLastIteration);
             }
         });
 
@@ -138,18 +144,18 @@ import org.matsim.utils.MemoryObserver;
             iterationStep("replanning", new Runnable() {
                 @Override
                 public void run() {
-                    controlerListenerManagerImpl.fireControlerReplanningEvent(iteration);
+                    controlerListenerManagerImpl.fireControlerReplanningEvent(iteration, isLastIteration);
                 }
             });
         }
 
-        mobsim(config, iteration);
+        mobsim(config, iteration, isLastIteration);
 
         iterationStep("scoring", new Runnable() {
             @Override
             public void run() {
                 log.info(MARKER + "ITERATION " + iteration + " fires scoring event");
-                controlerListenerManagerImpl.fireControlerScoringEvent(iteration);
+                controlerListenerManagerImpl.fireControlerScoringEvent(iteration, isLastIteration);
             }
         });
 
@@ -157,7 +163,7 @@ import org.matsim.utils.MemoryObserver;
             @Override
             public void run() {
                 log.info(MARKER + "ITERATION " + iteration + " fires iteration end event");
-                controlerListenerManagerImpl.fireControlerIterationEndsEvent(iteration);
+                controlerListenerManagerImpl.fireControlerIterationEndsEvent(iteration, isLastIteration);
             }
         });
 
@@ -174,7 +180,7 @@ import org.matsim.utils.MemoryObserver;
         log.info(Controler.DIVIDER);
     }
 
-    private void mobsim(final Config config, final int iteration) throws MatsimRuntimeModifications.UnexpectedShutdownException {
+    private void mobsim(final Config config, final int iteration, boolean isLastIteration) throws MatsimRuntimeModifications.UnexpectedShutdownException {
         // ControlerListeners may create managed resources in
         // beforeMobsim which need to be cleaned up in afterMobsim.
         // Hence the finally block.
@@ -184,7 +190,7 @@ import org.matsim.utils.MemoryObserver;
             iterationStep("beforeMobsimListeners", new Runnable() {
                 @Override
                 public void run() {
-                    controlerListenerManagerImpl.fireControlerBeforeMobsimEvent(iteration);
+                    controlerListenerManagerImpl.fireControlerBeforeMobsimEvent(iteration, isLastIteration);
                 }
             });
             
@@ -224,7 +230,7 @@ import org.matsim.utils.MemoryObserver;
                 @Override
                 public void run() {
                     log.info(MARKER + "ITERATION " + iteration + " fires after mobsim event");
-                    controlerListenerManagerImpl.fireControlerAfterMobsimEvent(iteration);
+                    controlerListenerManagerImpl.fireControlerAfterMobsimEvent(iteration, isLastIteration);
                 }
             });
         }

--- a/matsim/src/main/java/org/matsim/core/controler/ControlerListenerManagerImpl.java
+++ b/matsim/src/main/java/org/matsim/core/controler/ControlerListenerManagerImpl.java
@@ -114,8 +114,8 @@ public final class ControlerListenerManagerImpl implements ControlerListenerMana
 	 * Notifies all ControlerListeners
 	 * @param unexpected Whether the shutdown is unexpected or not.
 	 */
-	public void fireControlerShutdownEvent(final boolean unexpected) {
-		ShutdownEvent event = new ShutdownEvent(this.controler, unexpected);
+	public void fireControlerShutdownEvent(final boolean unexpected, int iteration) {
+		ShutdownEvent event = new ShutdownEvent(this.controler, unexpected, iteration);
         ShutdownListener[] listener = this.coreListenerList.getListeners(ShutdownListener.class);
         for (ShutdownListener aListener : listener) {
             log.info("calling notifyShutdown on " + aListener.getClass().getName());
@@ -133,8 +133,8 @@ public final class ControlerListenerManagerImpl implements ControlerListenerMana
 	 * Notifies all ControlerSetupIterationStartsListeners
      *
 	 */
-	public void fireControlerIterationStartsEvent(final int iteration) {
-		IterationStartsEvent event = new IterationStartsEvent(this.controler, iteration);
+	public void fireControlerIterationStartsEvent(final int iteration, boolean isLastIteration) {
+		IterationStartsEvent event = new IterationStartsEvent(this.controler, iteration, isLastIteration);
 		IterationStartsListener[] listener = this.coreListenerList.getListeners(IterationStartsListener.class);
         for (IterationStartsListener aListener : listener) {
             log.info("calling notifyIterationStarts on " + aListener.getClass().getName());
@@ -152,8 +152,8 @@ public final class ControlerListenerManagerImpl implements ControlerListenerMana
 	 * Notifies all ControlerIterationEndsListeners
 	 *
 	 */
-	public void fireControlerIterationEndsEvent(final int iteration) {
-		IterationEndsEvent event = new IterationEndsEvent(this.controler, iteration);
+	public void fireControlerIterationEndsEvent(final int iteration, boolean isLastIteration) {
+		IterationEndsEvent event = new IterationEndsEvent(this.controler, iteration, isLastIteration);
 		{
 			IterationEndsListener[] listener = this.coreListenerList.getListeners(IterationEndsListener.class);
             for (IterationEndsListener aListener : listener) {
@@ -175,8 +175,8 @@ public final class ControlerListenerManagerImpl implements ControlerListenerMana
 	 * Notifies all ControlerScoringListeners
 	 *
 	 */
-	public void fireControlerScoringEvent(final int iteration) {
-		ScoringEvent event = new ScoringEvent(this.controler, iteration);
+	public void fireControlerScoringEvent(final int iteration, boolean isLastIteration) {
+		ScoringEvent event = new ScoringEvent(this.controler, iteration, isLastIteration);
 		{
 			ScoringListener[] listener = this.coreListenerList.getListeners(ScoringListener.class);
             for (ScoringListener aListener : listener) {
@@ -198,8 +198,8 @@ public final class ControlerListenerManagerImpl implements ControlerListenerMana
 	 * Notifies all ControlerReplanningListeners
 	 *
 	 */
-	public void fireControlerReplanningEvent(final int iteration) {
-		ReplanningEvent event = new ReplanningEvent(this.controler, iteration);
+	public void fireControlerReplanningEvent(final int iteration, boolean isLastIteration) {
+		ReplanningEvent event = new ReplanningEvent(this.controler, iteration, isLastIteration);
 		ReplanningListener[] listener = this.coreListenerList.getListeners(ReplanningListener.class);
         for (ReplanningListener aListener : listener) {
             log.info("calling notifyReplanning on " + aListener.getClass().getName());
@@ -217,8 +217,8 @@ public final class ControlerListenerManagerImpl implements ControlerListenerMana
 	 * Notifies all ControlerBeforeMobsimListeners
 	 *
 	 */
-	public void fireControlerBeforeMobsimEvent(final int iteration) {
-		BeforeMobsimEvent event = new BeforeMobsimEvent(this.controler, iteration);
+	public void fireControlerBeforeMobsimEvent(final int iteration, boolean isLastIteration) {
+		BeforeMobsimEvent event = new BeforeMobsimEvent(this.controler, iteration, isLastIteration);
 		BeforeMobsimListener[] listener = this.coreListenerList.getListeners(BeforeMobsimListener.class);
         for (BeforeMobsimListener aListener : listener) {
             log.info("calling notifyBeforeMobsim on " + aListener.getClass().getName());
@@ -236,8 +236,8 @@ public final class ControlerListenerManagerImpl implements ControlerListenerMana
 	 * Notifies all ControlerAfterMobsimListeners
 	 *
 	 */
-	public void fireControlerAfterMobsimEvent(final int iteration) {
-		AfterMobsimEvent event = new AfterMobsimEvent(this.controler, iteration);
+	public void fireControlerAfterMobsimEvent(final int iteration, boolean isLastIteration) {
+		AfterMobsimEvent event = new AfterMobsimEvent(this.controler, iteration, isLastIteration);
 		AfterMobsimListener[] listener = this.coreListenerList.getListeners(AfterMobsimListener.class);
         for (AfterMobsimListener aListener : listener) {
             log.info("calling notifyAfterMobsim on " + aListener.getClass().getName());

--- a/matsim/src/main/java/org/matsim/core/controler/NewControler.java
+++ b/matsim/src/main/java/org/matsim/core/controler/NewControler.java
@@ -125,8 +125,12 @@ class NewControler extends AbstractController implements ControlerI {
 	}
 
 	@Override
-	protected final boolean continueIterations(int it) {
-		return terminationCriterion.continueIterations(it);
+	protected final boolean mayTerminateAfterIteration(int iteration) {
+		return terminationCriterion.mayTerminateAfterIteration(iteration);
 	}
 
+	@Override
+	protected final boolean shouldTerminate(int iteration) {
+		return terminationCriterion.doTerminate(iteration);
+	}
 }

--- a/matsim/src/main/java/org/matsim/core/controler/ReplayEvents.java
+++ b/matsim/src/main/java/org/matsim/core/controler/ReplayEvents.java
@@ -66,7 +66,7 @@ public final class ReplayEvents {
                     }
                 });
         ReplayEvents instance = injector.getInstance(ReplayEvents.class);
-        instance.playEventsFile(eventsFilename, 1);
+        instance.playEventsFile(eventsFilename, 1, false);
 
         return new Results() {
             @Override
@@ -76,42 +76,42 @@ public final class ReplayEvents {
         };
     }
 
-    public void playEventsFile(String eventsFilename, int iterationNumber) {
+    public void playEventsFile(String eventsFilename, int iterationNumber, boolean isLastIteration) {
         ((ControlerListenerManagerImpl) controlerListenerManager).fireControlerStartupEvent();
         for (ControlerListener controlerListener : controlerListenersDeclaredByModules) {
             if (controlerListener instanceof StartupListener) {
                 ((StartupListener) controlerListener).notifyStartup(new StartupEvent(null));
             }
         }
-        ((ControlerListenerManagerImpl) controlerListenerManager).fireControlerIterationStartsEvent(iterationNumber);
+        ((ControlerListenerManagerImpl) controlerListenerManager).fireControlerIterationStartsEvent(iterationNumber, isLastIteration);
         for (ControlerListener controlerListener : controlerListenersDeclaredByModules) {
             if (controlerListener instanceof IterationStartsListener) {
-                ((IterationStartsListener) controlerListener).notifyIterationStarts(new IterationStartsEvent(null, iterationNumber));
+                ((IterationStartsListener) controlerListener).notifyIterationStarts(new IterationStartsEvent(null, iterationNumber, isLastIteration));
             }
         }
-        ((ControlerListenerManagerImpl) controlerListenerManager).fireControlerBeforeMobsimEvent(iterationNumber);
+        ((ControlerListenerManagerImpl) controlerListenerManager).fireControlerBeforeMobsimEvent(iterationNumber, isLastIteration);
         for (ControlerListener controlerListener : controlerListenersDeclaredByModules) {
             if (controlerListener instanceof BeforeMobsimListener) {
-                ((BeforeMobsimListener) controlerListener).notifyBeforeMobsim(new BeforeMobsimEvent(null, iterationNumber));
+                ((BeforeMobsimListener) controlerListener).notifyBeforeMobsim(new BeforeMobsimEvent(null, iterationNumber, isLastIteration));
             }
         }
         new MatsimEventsReader(eventsManager).readFile(eventsFilename);
-        ((ControlerListenerManagerImpl) controlerListenerManager).fireControlerAfterMobsimEvent(iterationNumber);
+        ((ControlerListenerManagerImpl) controlerListenerManager).fireControlerAfterMobsimEvent(iterationNumber, isLastIteration);
         for (ControlerListener controlerListener : controlerListenersDeclaredByModules) {
             if (controlerListener instanceof AfterMobsimListener) {
-                ((AfterMobsimListener) controlerListener).notifyAfterMobsim(new AfterMobsimEvent(null, iterationNumber));
+                ((AfterMobsimListener) controlerListener).notifyAfterMobsim(new AfterMobsimEvent(null, iterationNumber, isLastIteration));
             }
         }
-        ((ControlerListenerManagerImpl) controlerListenerManager).fireControlerIterationEndsEvent(iterationNumber);
+        ((ControlerListenerManagerImpl) controlerListenerManager).fireControlerIterationEndsEvent(iterationNumber, isLastIteration);
         for (ControlerListener controlerListener : controlerListenersDeclaredByModules) {
             if (controlerListener instanceof IterationEndsListener) {
-                ((IterationEndsListener) controlerListener).notifyIterationEnds(new IterationEndsEvent(null, iterationNumber));
+                ((IterationEndsListener) controlerListener).notifyIterationEnds(new IterationEndsEvent(null, iterationNumber, isLastIteration));
             }
         }
-        ((ControlerListenerManagerImpl) controlerListenerManager).fireControlerShutdownEvent(false);
+        ((ControlerListenerManagerImpl) controlerListenerManager).fireControlerShutdownEvent(false, iterationNumber);
         for (ControlerListener controlerListener : controlerListenersDeclaredByModules) {
             if (controlerListener instanceof ShutdownListener) {
-                ((ShutdownListener) controlerListener).notifyShutdown(new ShutdownEvent(null, false));
+                ((ShutdownListener) controlerListener).notifyShutdown(new ShutdownEvent(null, false, iterationNumber));
             }
         }
     }

--- a/matsim/src/main/java/org/matsim/core/controler/TerminateAtFixedIterationNumber.java
+++ b/matsim/src/main/java/org/matsim/core/controler/TerminateAtFixedIterationNumber.java
@@ -19,14 +19,13 @@
  *                                                                         *
  * *********************************************************************** */
 
- package org.matsim.core.controler;
-
-import org.matsim.core.config.groups.ControlerConfigGroup;
+package org.matsim.core.controler;
 
 import javax.inject.Inject;
 
-class TerminateAtFixedIterationNumber implements TerminationCriterion {
+import org.matsim.core.config.groups.ControlerConfigGroup;
 
+class TerminateAtFixedIterationNumber implements TerminationCriterion {
 	private final int lastIteration;
 
 	@Inject
@@ -35,8 +34,13 @@ class TerminateAtFixedIterationNumber implements TerminationCriterion {
 	}
 
 	@Override
-	public boolean continueIterations(int iteration) {
-		return (iteration <= lastIteration);
+	public boolean mayTerminateAfterIteration(int iteration) {
+		return iteration >= lastIteration;
+	}
+
+	@Override
+	public boolean doTerminate(int iteration) {
+		return iteration >= lastIteration;
 	}
 
 }

--- a/matsim/src/main/java/org/matsim/core/controler/TerminationCriterion.java
+++ b/matsim/src/main/java/org/matsim/core/controler/TerminationCriterion.java
@@ -19,9 +19,36 @@
  *                                                                         *
  * *********************************************************************** */
 
- package org.matsim.core.controler;
+package org.matsim.core.controler;
 
-
+/**
+ * This termination criterion defines whether a MATSim simulation run should
+ * stop. A tricky aspect of this is that the criterion may decide whether to
+ * stop the simulation based on information gather from the previous
+ * iteration(s). However, if we decide that the iteration is "done" with this
+ * criterion, it is already to late to write out, for instance, events for this
+ * iteration, unless there were written out in any case. It is therefore
+ * necessary to decode *before* an iteration if the iteration *may* be the last
+ * iteration. In case criteria, e.g. for convergence, change, this interface
+ * can, however, still decide that the iteration that was though to be the last
+ * is in fact not the one. For that reason, there are two methods implemented.
+ * 
+ * @author Sebastian Hörl
+ */
 public interface TerminationCriterion {
-	boolean continueIterations(int iteration);
+	/**
+	 * This method called by the controller to decide a priori whether the coming
+	 * iteration may be the last. This will trigger writing of events, statistics,
+	 * etc. if configured this way.
+	 */
+	boolean mayTerminateAfterIteration(int iteration);
+
+	/**
+	 * This method is called by the controller to decide whether an iteration that
+	 * was a priori decided to be the last, will, in fact, be the last. In case some
+	 * large deviation from previous iteration is detected in this iteration that
+	 * had printed all the output, we may decide to still continue simuilation to
+	 * find a better output state.
+	 */
+	boolean doTerminate(int iteration);
 }

--- a/matsim/src/main/java/org/matsim/core/controler/corelisteners/DumpDataAtEndImpl.java
+++ b/matsim/src/main/java/org/matsim/core/controler/corelisteners/DumpDataAtEndImpl.java
@@ -133,15 +133,15 @@ final class DumpDataAtEndImpl implements DumpDataAtEnd, ShutdownListener {
 		dumpCounts();
 
 		if (!event.isUnexpected() && this.vspConfig.isWritingOutputEvents() && (this.controlerConfigGroup.getWriteEventsInterval()!=0)) {
-			dumpOutputEvents();
+			dumpOutputEvents(event.getIteration());
 		}
-		dumpOutputTrips();
-        dumpOutputLegs();
-		dumpExperiencedPlans() ;
+		dumpOutputTrips(event.getIteration());
+        dumpOutputLegs(event.getIteration());
+		dumpExperiencedPlans(event.getIteration()) ;
 
 	}
 
-	private void dumpOutputEvents() {
+	private void dumpOutputEvents(int iteration) {
 		for (ControlerConfigGroup.EventsFileFormat format : this.controlerConfigGroup.getEventsFileFormats()) {
 			try {
 				Controler.DefaultFiles file;
@@ -160,7 +160,7 @@ final class DumpDataAtEndImpl implements DumpDataAtEnd, ShutdownListener {
 				}
 
 				File toFile = new File(this.controlerIO.getOutputFilename(file));
-				File fromFile = new File(this.controlerIO.getIterationFilename(this.controlerConfigGroup.getLastIteration(), file));
+				File fromFile = new File(this.controlerIO.getIterationFilename(iteration, file));
 				try {
 					Files.copy(fromFile.toPath(), toFile.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
 				} catch (IOException e) {
@@ -174,10 +174,10 @@ final class DumpDataAtEndImpl implements DumpDataAtEnd, ShutdownListener {
 		}
 	}
 
-	private void dumpOutputTrips() {
+	private void dumpOutputTrips(int iteration) {
 		try {
 			File toFile = new File(this.controlerIO.getOutputFilename(Controler.DefaultFiles.tripscsv));
-			File fromFile = new File(this.controlerIO.getIterationFilename(this.controlerConfigGroup.getLastIteration(), Controler.DefaultFiles.tripscsv));
+			File fromFile = new File(this.controlerIO.getIterationFilename(iteration, Controler.DefaultFiles.tripscsv));
 			try {
 				Files.copy(fromFile.toPath(), toFile.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
 			} catch (IOException e) {
@@ -189,10 +189,10 @@ final class DumpDataAtEndImpl implements DumpDataAtEnd, ShutdownListener {
 		}
 	}
 
-    private void dumpOutputLegs() {
+    private void dumpOutputLegs(int iteration) {
         try {
             File toFile = new File(this.controlerIO.getOutputFilename(Controler.DefaultFiles.legscsv));
-            File fromFile = new File(this.controlerIO.getIterationFilename(this.controlerConfigGroup.getLastIteration(), Controler.DefaultFiles.legscsv));
+            File fromFile = new File(this.controlerIO.getIterationFilename(iteration, Controler.DefaultFiles.legscsv));
             try {
                 Files.copy(fromFile.toPath(), toFile.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
             } catch (IOException e) {
@@ -204,11 +204,11 @@ final class DumpDataAtEndImpl implements DumpDataAtEnd, ShutdownListener {
         }
     }
 
-	private void dumpExperiencedPlans() {
+	private void dumpExperiencedPlans(int iteration) {
 		if (this.config.planCalcScore().isWriteExperiencedPlans() ) {
 			try {
 				File toFile = new File(this.controlerIO.getOutputFilename(Controler.DefaultFiles.experiencedPlans));
-				File fromFile = new File(this.controlerIO.getIterationFilename(this.controlerConfigGroup.getLastIteration(), Controler.DefaultFiles.experiencedPlans));
+				File fromFile = new File(this.controlerIO.getIterationFilename(iteration, Controler.DefaultFiles.experiencedPlans));
 				try {
 					Files.copy(fromFile.toPath(), toFile.toPath(),StandardCopyOption.REPLACE_EXISTING,StandardCopyOption.COPY_ATTRIBUTES);
 				} catch (IOException e) {

--- a/matsim/src/main/java/org/matsim/core/controler/corelisteners/EventsHandlingImpl.java
+++ b/matsim/src/main/java/org/matsim/core/controler/corelisteners/EventsHandlingImpl.java
@@ -55,7 +55,6 @@ final class EventsHandlingImpl implements EventsHandling, BeforeMobsimListener,
 	final static private Logger log = Logger.getLogger(EventsHandlingImpl.class);
 	
 	private final EventsManager eventsManager;
-	private final int lastIteration;
 	private List<EventWriter> eventWriters = new LinkedList<>();
 
 	private int writeEventsInterval;
@@ -73,7 +72,6 @@ final class EventsHandlingImpl implements EventsHandling, BeforeMobsimListener,
 			final OutputDirectoryHierarchy controlerIO) {
 		this.eventsManager = eventsManager;
 		this.writeEventsInterval = config.getWriteEventsInterval();
-		this.lastIteration = config.getLastIteration() ;
 		this.eventsFileFormats = config.getEventsFileFormats();
 		this.controlerIO = controlerIO;
 		this.writeMoreUntilIteration = config.getWriteEventsUntilIteration() ;
@@ -86,7 +84,7 @@ final class EventsHandlingImpl implements EventsHandling, BeforeMobsimListener,
 		final boolean regularWriteEvents = writingEventsAtAll && ( event.getIteration()>0 && event.getIteration() % writeEventsInterval == 0 ) ;
 		// (w/o the "writingEventsAtAll && ..." this is a division by zero when writeEventsInterval=0. kai, apr'18)
 		final boolean earlyIteration = event.getIteration() <= writeMoreUntilIteration ;
-		final boolean lastIteration = event.getIteration()==this.lastIteration ;
+		final boolean lastIteration = event.isLastIteration();
 		if (writingEventsAtAll && (regularWriteEvents||earlyIteration || lastIteration ) ) {
 			for (EventsFileFormat format : eventsFileFormats) {
 				switch (format) {

--- a/matsim/src/main/java/org/matsim/core/controler/events/AbstractIterationEvent.java
+++ b/matsim/src/main/java/org/matsim/core/controler/events/AbstractIterationEvent.java
@@ -1,0 +1,23 @@
+package org.matsim.core.controler.events;
+
+import org.matsim.core.controler.MatsimServices;
+
+public class AbstractIterationEvent extends ControlerEvent {
+	private final int iteration;
+	private final boolean isLastIteration;
+
+	public AbstractIterationEvent(MatsimServices services, int iteration, boolean isLastIteration) {
+		super(services);
+
+		this.iteration = iteration;
+		this.isLastIteration = isLastIteration;
+	}
+
+	public int getIteration() {
+		return iteration;
+	}
+
+	public boolean isLastIteration() {
+		return isLastIteration;
+	}
+}

--- a/matsim/src/main/java/org/matsim/core/controler/events/AfterMobsimEvent.java
+++ b/matsim/src/main/java/org/matsim/core/controler/events/AfterMobsimEvent.java
@@ -27,21 +27,8 @@ import org.matsim.core.controler.MatsimServices;
  *
  * @author mrieser
  */
-public final class AfterMobsimEvent extends ControlerEvent {
-
-	/** The iteration number */
-	private final int iteration;
-
-	public AfterMobsimEvent(final MatsimServices controler, final int iteration) {
-		super(controler);
-		this.iteration = iteration;
+public final class AfterMobsimEvent extends AbstractIterationEvent {
+	public AfterMobsimEvent(MatsimServices services, int iteration, boolean isLastIteration) {
+		super(services, iteration, isLastIteration);
 	}
-
-	/**
-	 * @return the number of the current iteration
-	 */
-	public int getIteration() {
-		return this.iteration;
-	}
-
 }

--- a/matsim/src/main/java/org/matsim/core/controler/events/BeforeMobsimEvent.java
+++ b/matsim/src/main/java/org/matsim/core/controler/events/BeforeMobsimEvent.java
@@ -27,21 +27,8 @@ import org.matsim.core.controler.MatsimServices;
  *
  * @author mrieser
  */
-public final class BeforeMobsimEvent extends ControlerEvent {
-
-	/** The iteration number */
-	private final int iteration;
-
-	public BeforeMobsimEvent(final MatsimServices controler, final int iteration) {
-		super(controler);
-		this.iteration = iteration;
+public final class BeforeMobsimEvent extends AbstractIterationEvent {
+	public BeforeMobsimEvent(MatsimServices services, int iteration, boolean isLastIteration) {
+		super(services, iteration, isLastIteration);
 	}
-
-	/**
-	 * @return the number of the current iteration
-	 */
-	public int getIteration() {
-		return this.iteration;
-	}
-
 }

--- a/matsim/src/main/java/org/matsim/core/controler/events/IterationEndsEvent.java
+++ b/matsim/src/main/java/org/matsim/core/controler/events/IterationEndsEvent.java
@@ -27,21 +27,8 @@ import org.matsim.core.controler.MatsimServices;
  *
  * @author dgrether
  */
-public final class IterationEndsEvent extends ControlerEvent {
-
-	/**
-	 * The iteration number
-	 */
-	private final int iteration;
-
-	public IterationEndsEvent(final MatsimServices controler, final int iteration) {
-		super(controler);
-		this.iteration = iteration;
-	}
-	/**
-	 * @return the number of the finished iteration
-	 */
-	public int getIteration() {
-		return this.iteration;
+public final class IterationEndsEvent extends AbstractIterationEvent {
+	public IterationEndsEvent(MatsimServices services, int iteration, boolean isLastIteration) {
+		super(services, iteration, isLastIteration);
 	}
 }

--- a/matsim/src/main/java/org/matsim/core/controler/events/IterationStartsEvent.java
+++ b/matsim/src/main/java/org/matsim/core/controler/events/IterationStartsEvent.java
@@ -22,30 +22,14 @@ package org.matsim.core.controler.events;
 
 import org.matsim.core.controler.MatsimServices;
 
-
 /**
- * ControlerEvent class to notify all observers interested in the preparation of an iteration
+ * ControlerEvent class to notify all observers interested in the preparation of
+ * an iteration
  *
  * @author dgrether
  */
-public final class IterationStartsEvent extends ControlerEvent {
-
-	/**
-	 * the number of the iteration
-	 */
-	private final int iteration;
-
-	public IterationStartsEvent(final MatsimServices controler, final int iteration) {
-		super(controler);
-		this.iteration = iteration;
+public final class IterationStartsEvent extends AbstractIterationEvent {
+	public IterationStartsEvent(MatsimServices services, int iteration, boolean isLastIteration) {
+		super(services, iteration, isLastIteration);
 	}
-
-	/**
-	 *
-	 * @return the number of the iteration to setup
-	 */
-	public int getIteration() {
-		return this.iteration;
-	}
-
 }

--- a/matsim/src/main/java/org/matsim/core/controler/events/ReplanningEvent.java
+++ b/matsim/src/main/java/org/matsim/core/controler/events/ReplanningEvent.java
@@ -28,27 +28,13 @@ import org.matsim.core.replanning.ReplanningContext;
  *
  * @author mrieser
  */
-public final class ReplanningEvent extends ControlerEvent {
-
-	/**
-	 * The iteration number
-	 */
-	private final int iteration;
-
-	public ReplanningEvent(final MatsimServices controler, final int iteration) {
-		super(controler);
-		this.iteration = iteration;
-	}
-
-	/**
-	 * @return the number of the current iteration
-	 */
-	public int getIteration() {
-		return this.iteration;
+public final class ReplanningEvent extends AbstractIterationEvent {
+	public ReplanningEvent(MatsimServices services, int iteration, boolean isLastIteration) {
+		super(services, iteration, isLastIteration);
 	}
 
 	public ReplanningContext getReplanningContext() {
-        return services.getInjector().getInstance(ReplanningContext.class);
-    }
+		return services.getInjector().getInstance(ReplanningContext.class);
+	}
 
 }

--- a/matsim/src/main/java/org/matsim/core/controler/events/ScoringEvent.java
+++ b/matsim/src/main/java/org/matsim/core/controler/events/ScoringEvent.java
@@ -27,23 +27,8 @@ import org.matsim.core.controler.MatsimServices;
  *
  * @author mrieser
  */
-public final class ScoringEvent extends ControlerEvent {
-
-	/**
-	 * The iteration number
-	 */
-	private final int iteration;
-
-	public ScoringEvent(final MatsimServices controler, final int iteration) {
-		super(controler);
-		this.iteration = iteration;
+public final class ScoringEvent extends AbstractIterationEvent {
+	public ScoringEvent(MatsimServices services, int iteration, boolean isLastIteration) {
+		super(services, iteration, isLastIteration);
 	}
-
-	/**
-	 * @return the number of the current iteration
-	 */
-	public int getIteration() {
-		return this.iteration;
-	}
-
 }

--- a/matsim/src/main/java/org/matsim/core/controler/events/ShutdownEvent.java
+++ b/matsim/src/main/java/org/matsim/core/controler/events/ShutdownEvent.java
@@ -33,10 +33,12 @@ public final class ShutdownEvent extends ControlerEvent {
 	 * Flag to indicate if the controler was shutdown unexpected
 	 */
 	private final boolean unexpected;
-
-	public ShutdownEvent(final MatsimServices controler, final boolean unexpected) {
+	private final int iteration;
+	
+	public ShutdownEvent(final MatsimServices controler, final boolean unexpected, int iteration) {
 		super(controler);
 		this.unexpected = unexpected;
+		this.iteration = iteration;
 	}
 
 	/**
@@ -45,5 +47,8 @@ public final class ShutdownEvent extends ControlerEvent {
 	public boolean isUnexpected() {
 		return this.unexpected;
 	}
-
+	
+	public int getIteration() {
+		return iteration;
+	}
 }

--- a/matsim/src/main/java/org/matsim/core/scoring/EventsToScore.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/EventsToScore.java
@@ -57,6 +57,7 @@ public final class EventsToScore {
 	private boolean finished = false;
 
 	private int iteration = -1 ;
+	private boolean isLastIteration = false;
 
 	@Inject
 	private EventsToScore(ControlerListenerManagerImpl controlerListenerManager, ScoringFunctionsForPopulation scoringFunctionsForPopulation, final Scenario scenario, NewScoreAssigner newScoreAssigner) {
@@ -106,9 +107,10 @@ public final class EventsToScore {
 		return injector.getInstance(EventsToScore.class);
 	}
 
-	public void beginIteration(int iteration) {
+	public void beginIteration(int iteration, boolean isLastIteration) {
 		this.iteration = iteration;
-		this.controlerListenerManager.fireControlerIterationStartsEvent(iteration);
+		this.isLastIteration = isLastIteration;
+		this.controlerListenerManager.fireControlerIterationStartsEvent(iteration, isLastIteration);
 	}
 
 	/**
@@ -119,7 +121,7 @@ public final class EventsToScore {
 		if (iteration == -1) {
 			throw new RuntimeException("Please initialize me before the iteration starts.");
 		}
-		controlerListenerManager.fireControlerAfterMobsimEvent(iteration);
+		controlerListenerManager.fireControlerAfterMobsimEvent(iteration, isLastIteration);
 		scoringFunctionsForPopulation.finishScoringFunctions();
 		newScoreAssigner.assignNewScores(this.iteration, scoringFunctionsForPopulation, population);
 		finished = true;

--- a/matsim/src/main/java/org/matsim/core/scoring/PlansScoringImpl.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/PlansScoringImpl.java
@@ -67,7 +67,7 @@ final class PlansScoringImpl implements PlansScoring, ScoringListener, Iteration
 		
 		if(planCalcScoreConfigGroup.isWriteExperiencedPlans()) {
 			final int writePlansInterval = controlerConfigGroup.getWritePlansInterval();
-			if (writePlansInterval > 0 && event.getIteration() % writePlansInterval == 0) {
+			if (writePlansInterval > 0 && (event.getIteration() % writePlansInterval == 0 || event.isLastIteration())) {
 				this.experiencedPlansService.writeExperiencedPlans(controlerIO.getIterationFilename(event.getIteration(), "experienced_plans.xml.gz"));
 				this.scoringFunctionsForPopulation.writePartialScores(controlerIO.getIterationFilename(event.getIteration(), "experienced_plans_scores.txt.gz"));
 			}

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/CapacityDependentScoringTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/CapacityDependentScoringTest.java
@@ -105,7 +105,7 @@ public class CapacityDependentScoringTest {
 		population.addPerson(person);
 
 		EventsToScore events2Score = EventsToScore.createWithoutScoreUpdating(f.scenario, testSFF, events);
-		events2Score.beginIteration(0);
+		events2Score.beginIteration(0, false);
 		events.addHandler(occTracker);
 
 		events.addHandler((BasicEventHandler) event -> {

--- a/matsim/src/test/java/org/matsim/analysis/IterationTravelStatsControlerListenerTest.java
+++ b/matsim/src/test/java/org/matsim/analysis/IterationTravelStatsControlerListenerTest.java
@@ -100,7 +100,7 @@ public class IterationTravelStatsControlerListenerTest {
 	private void performTest(Scenario scenario, String outputDirectory) {
 		
 		config.controler().setOutputDirectory(utils.getOutputDirectory());
-		ShutdownEvent shutdownEvent = new ShutdownEvent(null, false);
+		ShutdownEvent shutdownEvent = new ShutdownEvent(null, false, 0);
 		com.google.inject.Injector injector = Injector.createInjector(config, new AbstractModule() {
 			@Override
 			public void install() {

--- a/matsim/src/test/java/org/matsim/analysis/ModeStatsControlerListenerTest.java
+++ b/matsim/src/test/java/org/matsim/analysis/ModeStatsControlerListenerTest.java
@@ -364,7 +364,7 @@ public class ModeStatsControlerListenerTest {
 
 		HashMap<String, Integer> modesIter0 = new HashMap<String, Integer>();
 
-		IterationEndsEvent event0 = new IterationEndsEvent(null, 0);
+		IterationEndsEvent event0 = new IterationEndsEvent(null, 0, false);
 		modStatListner.notifyIterationEnds(event0);
 
 		//Merging 3 maps (modes of 3 persons) to a new single map and adding together the count of each mode of all 3 persons
@@ -385,7 +385,7 @@ public class ModeStatsControlerListenerTest {
 		leg.setMode(TransportMode.ride);
 		person3modes.put(leg.getMode(), person3modes.get(leg.getMode()) + 1);
 
-		IterationEndsEvent event1 = new IterationEndsEvent(null, 1);
+		IterationEndsEvent event1 = new IterationEndsEvent(null, 1, false);
 		modStatListner.notifyIterationEnds(event1);
 
 		HashMap<String, Integer> modesIter1 = new HashMap<String, Integer>();
@@ -399,7 +399,7 @@ public class ModeStatsControlerListenerTest {
 		//Remove one more person
 		population.getPersons().remove(Id.create("3", Person.class));
 
-		IterationEndsEvent event2 = new IterationEndsEvent(null, 2);
+		IterationEndsEvent event2 = new IterationEndsEvent(null, 2, false);
 		modStatListner.notifyIterationEnds(event2);
 
 		// in the last iteration check whether all iterations can still be found

--- a/matsim/src/test/java/org/matsim/analysis/ScoreStatsControlerListenerTest.java
+++ b/matsim/src/test/java/org/matsim/analysis/ScoreStatsControlerListenerTest.java
@@ -485,33 +485,33 @@ public class ScoreStatsControlerListenerTest {
 		StartupEvent eventStart = new StartupEvent(null);
 		scoreStatsControlerListener.notifyStartup(eventStart);
 		
-		IterationEndsEvent event0 = new IterationEndsEvent(null, 0);
+		IterationEndsEvent event0 = new IterationEndsEvent(null, 0, false);
 		scoreStatsControlerListener.notifyIterationEnds(event0);
 		
 		readAndValidateValues(0, population);
 		
 		population.getPersons().remove(Id.create("2", Person.class));
 		
-		IterationEndsEvent event1 = new IterationEndsEvent(null, 1);
+		IterationEndsEvent event1 = new IterationEndsEvent(null, 1, false);
 		scoreStatsControlerListener.notifyIterationEnds(event1);
 		
 		readAndValidateValues(1, population);
 		
 		population.getPersons().remove(Id.create("3", Person.class));
 		
-		IterationEndsEvent event2 = new IterationEndsEvent(null, 2);
+		IterationEndsEvent event2 = new IterationEndsEvent(null, 2, false);
 		scoreStatsControlerListener.notifyIterationEnds(event2);
 		
 		readAndValidateValues(2, population);
 		
 		population.getPersons().remove(Id.create("4", Person.class));
 		
-		IterationEndsEvent event3 = new IterationEndsEvent(null, 3);
+		IterationEndsEvent event3 = new IterationEndsEvent(null, 3, true);
 		scoreStatsControlerListener.notifyIterationEnds(event3);
 		
 		readAndValidateValues(3, population);
 		
-		ShutdownEvent eventShutdown = new ShutdownEvent(null, false);
+		ShutdownEvent eventShutdown = new ShutdownEvent(null, false, 3);
 		scoreStatsControlerListener.notifyShutdown(eventShutdown);
 
 	}

--- a/matsim/src/test/java/org/matsim/core/controler/ControlerEventsTest.java
+++ b/matsim/src/test/java/org/matsim/core/controler/ControlerEventsTest.java
@@ -121,10 +121,15 @@ public class ControlerEventsTest extends MatsimTestCase {
 		@Override
 		protected void prepareForMobsim() {
 		}
-		
+
 		@Override
-		protected boolean continueIterations(int iteration) {
-			return iteration <= config.controler().getLastIteration();
+		protected boolean mayTerminateAfterIteration(int iteration) {
+			return iteration >= config.controler().getLastIteration();
+		}
+
+		@Override
+		protected boolean shouldTerminate(int iteration) {
+			return iteration >= config.controler().getLastIteration();
 		}
 	}
 

--- a/matsim/src/test/java/org/matsim/core/controler/ControlerIT.java
+++ b/matsim/src/test/java/org/matsim/core/controler/ControlerIT.java
@@ -116,8 +116,13 @@ public class ControlerIT {
 		Controler controler = new Controler(config);
 		controler.setTerminationCriterion(new TerminationCriterion() {
 			@Override
-			public boolean continueIterations(int iteration) {
-				return false;
+			public boolean mayTerminateAfterIteration(int iteration) {
+				return true;
+			}
+
+			@Override
+			public boolean doTerminate(int iteration) {
+				return true;
 			}
 		});
 		controler.run();

--- a/matsim/src/test/java/org/matsim/core/controler/ControlerListenerManagerImplTest.java
+++ b/matsim/src/test/java/org/matsim/core/controler/ControlerListenerManagerImplTest.java
@@ -50,21 +50,21 @@ public class ControlerListenerManagerImplTest {
 		Assert.assertEquals(0, ecl.nOfIterStarts);
 		Assert.assertEquals(0, ecl.nOfShutdowns);
 		
-		m.fireControlerIterationStartsEvent(0);
+		m.fireControlerIterationStartsEvent(0, false);
 		Assert.assertEquals(1, ccl.nOfStartups);
 		Assert.assertEquals(1, ccl.nOfIterStarts);
 		Assert.assertEquals(1, ecl.nOfStartups);
 		Assert.assertEquals(1, ecl.nOfIterStarts);
 		Assert.assertEquals(0, ecl.nOfShutdowns);
 		
-		m.fireControlerIterationStartsEvent(1);
+		m.fireControlerIterationStartsEvent(1, false);
 		Assert.assertEquals(1, ccl.nOfStartups);
 		Assert.assertEquals(2, ccl.nOfIterStarts);
 		Assert.assertEquals(1, ecl.nOfStartups);
 		Assert.assertEquals(2, ecl.nOfIterStarts);
 		Assert.assertEquals(0, ecl.nOfShutdowns);
 		
-		m.fireControlerShutdownEvent(false);
+		m.fireControlerShutdownEvent(false, 1);
 		Assert.assertEquals(1, ccl.nOfStartups);
 		Assert.assertEquals(2, ccl.nOfIterStarts);
 		Assert.assertEquals(1, ecl.nOfStartups);
@@ -87,21 +87,21 @@ public class ControlerListenerManagerImplTest {
 		Assert.assertEquals(0, ecl.nOfIterStarts);
 		Assert.assertEquals(0, ecl.nOfShutdowns);
 
-		m.fireControlerIterationStartsEvent(0);
+		m.fireControlerIterationStartsEvent(0, false);
 		Assert.assertEquals(1, ccl.nOfStartups);
 		Assert.assertEquals(1, ccl.nOfIterStarts);
 		Assert.assertEquals(1, ecl.nOfStartups);
 		Assert.assertEquals(1, ecl.nOfIterStarts);
 		Assert.assertEquals(0, ecl.nOfShutdowns);
 
-		m.fireControlerIterationStartsEvent(1);
+		m.fireControlerIterationStartsEvent(1, false);
 		Assert.assertEquals(1, ccl.nOfStartups);
 		Assert.assertEquals(2, ccl.nOfIterStarts);
 		Assert.assertEquals(1, ecl.nOfStartups);
 		Assert.assertEquals(2, ecl.nOfIterStarts);
 		Assert.assertEquals(0, ecl.nOfShutdowns);
 		
-		m.fireControlerShutdownEvent(false);
+		m.fireControlerShutdownEvent(false, 1);
 		Assert.assertEquals(1, ccl.nOfStartups);
 		Assert.assertEquals(2, ccl.nOfIterStarts);
 		Assert.assertEquals(1, ecl.nOfStartups);

--- a/matsim/src/test/java/org/matsim/core/controler/TerminationTest.java
+++ b/matsim/src/test/java/org/matsim/core/controler/TerminationTest.java
@@ -1,0 +1,205 @@
+package org.matsim.core.controler;
+
+import java.io.File;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.events.PersonDepartureEvent;
+import org.matsim.api.core.v01.events.handler.PersonDepartureEventHandler;
+import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.groups.StrategyConfigGroup.StrategySettings;
+import org.matsim.core.controler.events.IterationStartsEvent;
+import org.matsim.core.controler.listener.IterationStartsListener;
+import org.matsim.core.replanning.strategies.DefaultPlanStrategiesModule.DefaultStrategy;
+import org.matsim.core.router.TripStructureUtils;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.core.utils.io.IOUtils;
+import org.matsim.core.utils.misc.CRCChecksum;
+import org.matsim.examples.ExamplesUtils;
+import org.matsim.testcases.MatsimTestUtils;
+
+import com.google.inject.Singleton;
+
+/**
+ * This test makes sure that events are written based on the
+ * TerminationCriterion.
+ */
+public class TerminationTest {
+	@Rule
+	public MatsimTestUtils utils = new MatsimTestUtils();
+
+	@Test
+	public void testSimulationEndsOnInterval() {
+		prepareExperiment(2, 4).run();
+
+		Assert.assertTrue(new File(utils.getOutputDirectory(), "/ITERS/it.4/4.events.xml.gz").exists());
+		Assert.assertTrue(new File(utils.getOutputDirectory(), "/output_events.xml.gz").exists());
+
+		long iterationOutput = CRCChecksum.getCRCFromFile(utils.getOutputDirectory() + "/ITERS/it.4/4.events.xml.gz");
+		long mainOutput = CRCChecksum.getCRCFromFile(utils.getOutputDirectory() + "/output_events.xml.gz");
+		Assert.assertEquals(iterationOutput, mainOutput);
+	}
+
+	@Test
+	public void testOnlyRunIterationZero() {
+		prepareExperiment(2, 0).run();
+
+		Assert.assertTrue(new File(utils.getOutputDirectory(), "/ITERS/it.0/0.events.xml.gz").exists());
+		Assert.assertTrue(new File(utils.getOutputDirectory(), "/output_events.xml.gz").exists());
+
+		long iterationOutput = CRCChecksum.getCRCFromFile(utils.getOutputDirectory() + "/ITERS/it.0/0.events.xml.gz");
+		long mainOutput = CRCChecksum.getCRCFromFile(utils.getOutputDirectory() + "/output_events.xml.gz");
+		Assert.assertEquals(iterationOutput, mainOutput);
+	}
+
+	@Test
+	public void testSimulationEndsOffInterval() {
+		// This is the case when the TerminationCriterion decides that the simulation is
+		// done, but it does not fall at the same time as the output interval.
+
+		prepareExperiment(2, 3).run();
+
+		Assert.assertTrue(new File(utils.getOutputDirectory(), "/ITERS/it.2/2.events.xml.gz").exists());
+		Assert.assertTrue(new File(utils.getOutputDirectory(), "/ITERS/it.3/3.events.xml.gz").exists());
+		Assert.assertTrue(new File(utils.getOutputDirectory(), "/output_events.xml.gz").exists());
+
+		long iterationOutput = CRCChecksum.getCRCFromFile(utils.getOutputDirectory() + "/ITERS/it.3/3.events.xml.gz");
+		long mainOutput = CRCChecksum.getCRCFromFile(utils.getOutputDirectory() + "/output_events.xml.gz");
+		Assert.assertEquals(iterationOutput, mainOutput);
+	}
+
+	private Controler prepareExperiment(int interval, int criterion) {
+		Config config = utils.loadConfig(IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("equil"), "config.xml"));
+		config.controler().setOutputDirectory(utils.getOutputDirectory());
+
+		config.controler().setWriteEventsInterval(interval);
+		config.controler().setLastIteration(criterion);
+
+		return new Controler(config);
+	}
+
+	@Test
+	public void testMultipleLastIterations() {
+		/**
+		 * This test covers the case where the termination criterion decides that the
+		 * coming iteration may be the last, but then, after analysis and after the data
+		 * is written, decides that more iterations need to be run.
+		 */
+
+		Controler controller = prepareExperiment(2, 1000);
+
+		controller.setTerminationCriterion(new TerminationCriterion() {
+			@Override
+			public boolean mayTerminateAfterIteration(int iteration) {
+				return iteration >= 2; // After it 2 we decide that we need to write events
+			}
+
+			@Override
+			public boolean doTerminate(int iteration) {
+				return iteration >= 4; // But only iteration 4 is actually the last one
+			}
+		});
+
+		controller.run();
+
+		Assert.assertTrue(new File(utils.getOutputDirectory(), "/ITERS/it.2/2.events.xml.gz").exists());
+		Assert.assertTrue(new File(utils.getOutputDirectory(), "/ITERS/it.3/3.events.xml.gz").exists());
+		Assert.assertTrue(new File(utils.getOutputDirectory(), "/ITERS/it.4/4.events.xml.gz").exists());
+		Assert.assertTrue(new File(utils.getOutputDirectory(), "/output_events.xml.gz").exists());
+
+		long iterationOutput = CRCChecksum.getCRCFromFile(utils.getOutputDirectory() + "/ITERS/it.4/4.events.xml.gz");
+		long mainOutput = CRCChecksum.getCRCFromFile(utils.getOutputDirectory() + "/output_events.xml.gz");
+		Assert.assertEquals(iterationOutput, mainOutput);
+	}
+
+	@Test
+	public void testCustomConverenceCriterion() {
+		/**
+		 * In this test, we set all legs to walk and let agents change them to car. We
+		 * stop the simulation once there are more car legs than walk legs.
+		 */
+
+		Config config = utils.loadConfig(IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("equil"), "config.xml"));
+		config.controler().setOutputDirectory(utils.getOutputDirectory());
+
+		{ // Set up mode choice
+			config.changeMode().setModes(new String[] { "car", "walk" });
+
+			StrategySettings modeStrategy = new StrategySettings();
+			modeStrategy.setStrategyName(DefaultStrategy.ChangeTripMode);
+			modeStrategy.setWeight(0.1);
+			config.strategy().addStrategySettings(modeStrategy);
+		}
+
+		Scenario scenario = ScenarioUtils.loadScenario(config);
+
+		{ // Change initial mode to walk
+			for (Person person : scenario.getPopulation().getPersons().values()) {
+				for (Leg leg : TripStructureUtils.getLegs(person.getSelectedPlan())) {
+					leg.setMode("walk");
+					leg.setRoute(null);
+				}
+			}
+		}
+
+		Controler controler = new Controler(scenario);
+
+		{ // Set convergence criterion
+			controler.addOverridingModule(new AbstractModule() {
+				@Override
+				public void install() {
+					addControlerListenerBinding().to(CustomConvergenceCriterion.class);
+					bind(TerminationCriterion.class).to(CustomConvergenceCriterion.class);
+					addEventHandlerBinding().to(CustomConvergenceCriterion.class);
+				}
+			});
+		}
+
+		controler.run();
+
+		Assert.assertEquals(12, (int) controler.getIterationNumber());
+
+		Assert.assertTrue(new File(utils.getOutputDirectory(), "/ITERS/it.12/12.events.xml.gz").exists());
+		Assert.assertTrue(new File(utils.getOutputDirectory(), "/output_events.xml.gz").exists());
+
+		long iterationOutput = CRCChecksum.getCRCFromFile(utils.getOutputDirectory() + "/ITERS/it.12/12.events.xml.gz");
+		long mainOutput = CRCChecksum.getCRCFromFile(utils.getOutputDirectory() + "/output_events.xml.gz");
+		Assert.assertEquals(iterationOutput, mainOutput);
+	}
+
+	@Singleton
+	static private class CustomConvergenceCriterion
+			implements TerminationCriterion, PersonDepartureEventHandler, IterationStartsListener {
+		private int countCar = 0;
+		private int countWalk = 0;
+
+		@Override
+		public void notifyIterationStarts(IterationStartsEvent event) {
+			countCar = 0;
+			countWalk = 0;
+		}
+
+		@Override
+		public void handleEvent(PersonDepartureEvent event) {
+			if (event.getLegMode().equals("car")) {
+				countCar++;
+			} else {
+				countWalk++;
+			}
+		}
+
+		@Override
+		public boolean mayTerminateAfterIteration(int iteration) {
+			return countCar > countWalk; // Check before the iteration!
+		}
+
+		@Override
+		public boolean doTerminate(int iteration) {
+			return countCar > countWalk; // Verify after the iteration!
+		}
+	}
+}

--- a/matsim/src/test/java/org/matsim/core/events/MobsimScopeEventHandlingTest.java
+++ b/matsim/src/test/java/org/matsim/core/events/MobsimScopeEventHandlingTest.java
@@ -44,7 +44,7 @@ public class MobsimScopeEventHandlingTest {
 	@Test
 	public void test_notifyAfterMobsim_oneHandler() {
 		eventHandling.addMobsimScopeHandler(handler);
-		eventHandling.notifyAfterMobsim(new AfterMobsimEvent(null, 99));
+		eventHandling.notifyAfterMobsim(new AfterMobsimEvent(null, 99, false));
 
 		verify(eventsManager, times(1)).removeHandler(argThat(arg -> arg == handler));
 		verify(handler, times(1)).cleanupAfterMobsim(intThat(arg -> arg == 99));
@@ -53,13 +53,13 @@ public class MobsimScopeEventHandlingTest {
 	@Test
 	public void test_notifyAfterMobsim_noHandlersAfterRemoval() {
 		eventHandling.addMobsimScopeHandler(handler);
-		eventHandling.notifyAfterMobsim(new AfterMobsimEvent(null, 99));
+		eventHandling.notifyAfterMobsim(new AfterMobsimEvent(null, 99, false));
 
 		verify(eventsManager, times(1)).removeHandler(any());
 		verify(handler, times(1)).cleanupAfterMobsim(anyInt());
 
 		//no handlers in this iteration, so no new calls to removeHandler() and cleanupAfterMobsim()
-		eventHandling.notifyAfterMobsim(new AfterMobsimEvent(null, 100));
+		eventHandling.notifyAfterMobsim(new AfterMobsimEvent(null, 100, false));
 
 		verify(eventsManager, times(1)).removeHandler(any());
 		verify(handler, times(1)).cleanupAfterMobsim(anyInt());

--- a/matsim/src/test/java/org/matsim/core/scoring/EventsToScoreTest.java
+++ b/matsim/src/test/java/org/matsim/core/scoring/EventsToScoreTest.java
@@ -52,7 +52,7 @@ public class EventsToScoreTest extends MatsimTestCase {
 		MockScoringFunctionFactory sfFactory = new MockScoringFunctionFactory();
 		EventsManager events = EventsUtils.createEventsManager();
 		EventsToScore e2s = EventsToScore.createWithoutScoreUpdating(scenario, sfFactory, events);
-		e2s.beginIteration(0);
+		e2s.beginIteration(0, false);
 		events.initProcessing();
 		events.processEvent(new PersonMoneyEvent(3600.0, person.getId(), 3.4, "tollRefund", "motorwayOperator"));
 		events.finishProcessing();
@@ -83,7 +83,7 @@ public class EventsToScoreTest extends MatsimTestCase {
 
 		for ( int mockIteration = config.controler().getFirstIteration() ; mockIteration <= config.controler().getLastIteration() ; mockIteration++ ) {
 
-			e2s.beginIteration(mockIteration); ;
+			e2s.beginIteration(mockIteration, false); ;
 			events.initProcessing();
 
 			// generating a money event with amount mockIteration-98 (i.e. 1, 2, 3, 4):

--- a/matsim/src/test/java/org/matsim/core/scoring/ExperiencedPlanElementsModuleTest.java
+++ b/matsim/src/test/java/org/matsim/core/scoring/ExperiencedPlanElementsModuleTest.java
@@ -50,7 +50,7 @@ public class ExperiencedPlanElementsModuleTest {
 		Subscriber subscriber = new Subscriber();
 		injector.getInstance(EventsToActivities.class).addActivityHandler(subscriber);
 		ReplayEvents replayEvents = injector.getInstance(ReplayEvents.class);
-		replayEvents.playEventsFile(matsimTestUtils.getClassInputDirectory() + "events.xml", 0);
+		replayEvents.playEventsFile(matsimTestUtils.getClassInputDirectory() + "events.xml", 0, false);
 		Assert.assertEquals("There are two activities.", 2, subscriber.activityCount);
 	}
 

--- a/matsim/src/test/java/org/matsim/core/scoring/ScoringFunctionsForPopulationStressIT.java
+++ b/matsim/src/test/java/org/matsim/core/scoring/ScoringFunctionsForPopulationStressIT.java
@@ -72,7 +72,7 @@ public class ScoringFunctionsForPopulationStressIT {
 				scenario.getPopulation(),
 				throwingScoringFunctionFactory
 		);
-		controlerListenerManager.fireControlerIterationStartsEvent(0);
+		controlerListenerManager.fireControlerIterationStartsEvent(0, false);
 		events.processEvent(new PersonMoneyEvent(3600.0, personId, 3.4, "tollRefund", "motorwayOperator"));
 		scoringFunctionsForPopulation.finishScoringFunctions();
 	}
@@ -223,7 +223,7 @@ public class ScoringFunctionsForPopulationStressIT {
 				scenario.getPopulation(),
 				scoringFunctionFactory
 		);
-		controlerListenerManager.fireControlerIterationStartsEvent(0);
+		controlerListenerManager.fireControlerIterationStartsEvent(0, false);
 		events.initProcessing();
 		for (int i=0; i<MAX; i++) {
 			events.processEvent(new PersonMoneyEvent(i*200, personId, 1.0, "tollRefund", "motorwayOperator"));
@@ -371,7 +371,7 @@ public class ScoringFunctionsForPopulationStressIT {
 				scenario.getPopulation(),
 				scoringFunctionFactory
 		);
-		controlerListenerManager.fireControlerIterationStartsEvent(0);
+		controlerListenerManager.fireControlerIterationStartsEvent(0, false);
 		int MAX = 10;
 		events.initProcessing();
 		for (int i=0; i<MAX; i++) {

--- a/matsim/src/test/java/org/matsim/core/scoring/ScoringFunctionsForPopulationTest.java
+++ b/matsim/src/test/java/org/matsim/core/scoring/ScoringFunctionsForPopulationTest.java
@@ -65,7 +65,7 @@ public class ScoringFunctionsForPopulationTest {
 		ScoringFunctionFactory scoringFunctionFactory = agentId -> new RecordingScoringFunction();
 
 		ScoringFunctionsForPopulation sf = new ScoringFunctionsForPopulation(controlerListenerManager, eventsManager, eventsToActivities, eventsToLegs, population, scoringFunctionFactory);
-		controlerListenerManager.fireControlerIterationStartsEvent(0);
+		controlerListenerManager.fireControlerIterationStartsEvent(0, false);
 		ScoringFunction s = sf.getScoringFunctionForAgent(personId);
 		Assert.assertEquals(RecordingScoringFunction.class, s.getClass());
 		RecordingScoringFunction rs = (RecordingScoringFunction) s;
@@ -111,7 +111,7 @@ public class ScoringFunctionsForPopulationTest {
 		ScoringFunctionFactory scoringFunctionFactory = agentId -> new RecordingScoringFunction();
 
 		ScoringFunctionsForPopulation sf = new ScoringFunctionsForPopulation(controlerListenerManager, eventsManager, eventsToActivities, eventsToLegs, population, scoringFunctionFactory);
-		controlerListenerManager.fireControlerIterationStartsEvent(0);
+		controlerListenerManager.fireControlerIterationStartsEvent(0, false);
 		ScoringFunction s = sf.getScoringFunctionForAgent(personId);
 
 		eventsManager.initProcessing();

--- a/matsim/src/test/java/org/matsim/integration/SimulateAndScoreTest.java
+++ b/matsim/src/test/java/org/matsim/integration/SimulateAndScoreTest.java
@@ -216,7 +216,7 @@ public class SimulateAndScoreTest extends MatsimTestCase {
 		EventsCollector handler = new EventsCollector();
 		events.addHandler(handler);
 
-		scorer.beginIteration(0);
+		scorer.beginIteration(0, false);
 		sim.run();
 		scorer.finish();
 
@@ -283,7 +283,7 @@ public class SimulateAndScoreTest extends MatsimTestCase {
 		EventsCollector handler = new EventsCollector();
 		events.addHandler(handler);
 
-		scorer.beginIteration(0);
+		scorer.beginIteration(0, false);
 		sim.run();
 		scorer.finish();
 


### PR DESCRIPTION
For a current paper I was implementing convergence criteria (stabilizing of mode use, stabilizing of routed vs. observed travel times), and I noticed a couple of flaws with the `TerminationCriterion` interface, which was, up to now, not as useful as it could be. I noticed that it is easy to implement the interface and stop the simulation with it, yet many of the expected outputs are not generated (e.g. output events), which are usually generated by default in the last iteration, if they are configured to be written at all. The first objective of this PR is therefore to enable this functionality: By letting downstream `ControlerListener`s know that the current iteration is the last, they can set up all the necessary components (events writing, ...) to prepare for generating the output.

There is a second goal of this PR. Convergence criteria are usually based on the last iteration outcome, or the outcome of previous iterations. A convergence criterion would, therefore, decide after the outcome of the last iteration whether the simulation should stop. Unfortunately, at this point, we may not have tracked all the output (e.g. events), because this would have needed to be configured at the beginning of the iteration. Hence, we would need to run one more iteration to produce events output. Yet, in that iteration things may change (or even go terribly wrong) so the convergence criterion is not fulfilled any more. In this case, we may not want to make use of this output and actually run a couple more iterations to avoid stopping at some "outlier state". Therefore, I extended the convergence criterion to make two decisions:

- *Before* the iteration, `TerminationCriterion.mayTerminateAfterIteration` decides whether this *could* be the last iteration. This notifies all the downstream components to write the output, etc.
- *After* the iteration and *if* it was decided that the iteration may be the last, `TerminationCriterion.doTerminate` decides whether the simulation should actually be stopped. In case that out of stochasticity the last written state is an "outlier", here we can decide to continue the simulation.

Sumarry of major changes:
- Changes `TerminationCriterion` interface
- Changed iteration logic in `AbstractController`
- Added `AbstractIterationEvent` deriving from `ControlerEvent` to unify inclusion of `iteration` and `isLastIteration` in a couple of `ControlerEvent`s (e.g. `IterationStartsEvent`). This is useful for letting, e.g. `EventsHandling` know that it should prepare events writing for the current iteration. `ShutdownEvent` now includes the `iteration` to inform `DumpDataAtEnd` where to search for the last output files