### PR TITLE
Update the error message of the zone systems (when there are too many zones)

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/Matrix.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/Matrix.java
@@ -49,7 +49,8 @@ public final class Matrix {
 
 	Matrix(Set<Zone> zones) {
 		size = zones.size();
-		checkArgument(size <= MAX_ZONE_COUNT, "Too many zones. Try using bigger cell sizes (when using grid zones)");
+		checkArgument(size <= MAX_ZONE_COUNT, "Too many zones for computing the DVRP travel time matrix."
+				+ " Try using bigger cell sizes (when using grid zones)");
 
 		//to make sure we do not refer to zones added later
 		Arrays.fill(zoneIndex2localIndex, -1);


### PR DESCRIPTION
Hello Michal, 

I have a suggestion on changing the descrption of the Error message. The original error message may cause some confusion between the DRT zonal system and the DVRP travel time matrix zones. This happened to me these days and I have spent quite some time "debugging" a non-exsiting bug in DRT zonal system generation...

Perhaps it is a good idea to seperate it into two different error information (i.e. one for DRT zonal system and one for the DVRP travel time zones)?

Or perhaps shall we also make the DVRP travel time matrix also depends on shapefile? For example, for the Vulkaneifel scenario, the network of the whole northwestern Germany is used. The default cell size of 200 for the DVRP travel time matrix will yield more than 60,000 zones, which is above limit.

Thanks!

