### PR TITLE
Switch to patched JOGL version

### DIFF
--- a/contribs/otfvis/pom.xml
+++ b/contribs/otfvis/pom.xml
@@ -38,13 +38,49 @@
 		</dependency>
 		<dependency>
 			<groupId>org.jogamp.gluegen</groupId>
-			<artifactId>gluegen-rt-main</artifactId>
-			<version>2.3.2</version>
+			<artifactId>gluegen-rt</artifactId>
+			<version>2.4.0-matsim-1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jogamp.gluegen</groupId>
+			<artifactId>gluegen-rt</artifactId>
+			<version>2.4.0-matsim-1</version>
+			<classifier>natives-macosx-universal</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.jogamp.gluegen</groupId>
+			<artifactId>gluegen-rt</artifactId>
+			<version>2.4.0-matsim-1</version>
+			<classifier>natives-linux-i586</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.jogamp.gluegen</groupId>
+			<artifactId>gluegen-rt</artifactId>
+			<version>2.4.0-matsim-1</version>
+			<classifier>natives-windows-i586</classifier>
 		</dependency>
 		<dependency>
 			<groupId>org.jogamp.jogl</groupId>
-			<artifactId>jogl-all-main</artifactId>
-			<version>2.3.2</version>
+			<artifactId>jogl-all</artifactId>
+			<version>2.4.0-matsim-1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jogamp.jogl</groupId>
+			<artifactId>jogl-all</artifactId>
+			<version>2.4.0-matsim-1</version>
+			<classifier>natives-macosx-universal</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.jogamp.jogl</groupId>
+			<artifactId>jogl-all</artifactId>
+			<version>2.4.0-matsim-1</version>
+			<classifier>natives-linux-i586</classifier>
+		</dependency>
+		<dependency>
+			<groupId>org.jogamp.jogl</groupId>
+			<artifactId>jogl-all</artifactId>
+			<version>2.4.0-matsim-1</version>
+			<classifier>natives-windows-i586</classifier>
 		</dependency>
 		<dependency>
 			<groupId>org.jxmapviewer</groupId>


### PR DESCRIPTION
Fixes #972. I uploaded the patched JOGL version, as discussed in #972, to our Bintray, and switched OTFVis to that version.

As it's a bit messy to do this since it uses the Maven classifier feature for the different platform versions, here is the command line for the native binary JARs (starting from the cloned web site as suggested in #972). Use this if we want to repeat this for another version, or add more platform JARs such as AMD (since I don't know how to build the JAR that holds all of the platform JARs):

```
mvn deploy:deploy-file -Durl="https://api.bintray.com/maven/matsim/matsim/JOGL/;publish=1" \
                       -DrepositoryId=matsim \
                       -Dfile=jogamp.org/deployment/archive/master/gluegen_937-joal_660-jogl_1506-jocl_1147/jar/jogl-all-natives-windows-i586.jar \
                       -DgroupId=org.jogamp.jogl \   
                       -DartifactId=jogl-all \      
                       -Dversion=2.4.0-matsim-1 \
                       -Dpackaging=jar \                                    
                       -DgeneratePom=false -Dclassifier=natives-windows-i586

mvn deploy:deploy-file -Durl="https://api.bintray.com/maven/matsim/matsim/JOGL/;publish=1" \
                       -DrepositoryId=matsim \
                       -Dfile=jogamp.org/deployment/archive/master/gluegen_937-joal_660-jogl_1506-jocl_1147/jar/gluegen-rt-natives-windows-i586.jar \
                       -DgroupId=org.jogamp.gluegen \
                       -DartifactId=gluegen-rt \
                       -Dversion=2.4.0-matsim-1 \
                       -Dpackaging=jar \
                       -DgeneratePom=false -Dclassifier=natives-windows-i586
```

Change the platform identifier in two places: Filename and classifier.

When uploading the main JARs (e.g. for a new version), remove the last line (POM should be generated, and no classifier, since it's the main JAR).