### PR TITLE
verify pushes to branches with GH Actions

### DIFF
--- a/.github/workflows/verify-push.yaml
+++ b/.github/workflows/verify-push.yaml
@@ -1,0 +1,92 @@
+name: verify-push
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          - matsim
+          # sorted from longest to shortest (to minimise the overall test stage duration)
+          # (used in travis; not respected in GitHub Action workflows)
+          - contribs/vsp
+          - contribs/common
+          - contribs/taxi
+          - contribs/minibus
+          - contribs/signals
+          - contribs/bicycle
+          - contribs/cadytsIntegration
+          - contribs/drt
+          - contribs/discrete_mode_choice
+          - contribs/carsharing
+          - contribs/commercialTrafficApplications
+          - contribs/av
+          - contribs/locationchoice
+          - contribs/ev
+          - contribs/dvrp
+          - contribs/emissions
+          - contribs/decongestion
+          - contribs/noise
+          - contribs/accidents
+          - contribs/freight
+          - contribs/parking
+          - contribs/matrixbasedptrouter
+          - contribs/accessibility
+          - contribs/integration
+          - contribs/multimodal
+          - contribs/protobuf
+          - contribs/socnetsim
+          - contribs/sumo
+          - contribs/pseudosimulation
+          - contribs/roadpricing
+          - contribs/analysis
+          - contribs/eventsBasedPTRouter
+          - contribs/hybridsim
+          - contribs/otfvis
+          - contribs/osm
+
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v2
+
+      - name: Detect changes against master
+        # we only want to build matsim (module) if changes are not limited to contribs
+        id: detect-changes
+        uses: dorny/paths-filter@v2
+        if: ${{matrix.module == 'matsim'}}
+        with:
+          filters: |
+            outside-contribs:
+              - '!contribs/**'
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        if: ${{matrix.module != 'matsim' || steps.detect-changes.outputs.outside-contribs == 'true'}}
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Setup Java
+        if: ${{matrix.module != 'matsim' || steps.detect-changes.outputs.outside-contribs == 'true'}}
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Build module (with dependencies)
+        if: ${{matrix.module != 'matsim' || steps.detect-changes.outputs.outside-contribs == 'true'}}
+        run: mvn install --batch-mode --also-make --projects ${{matrix.module}} -DskipTests -Dmaven.javadoc.skip -Dsource.skip -Dassembly.skipAssembly=true
+
+      - name: Test module
+        if: ${{matrix.module != 'matsim' || steps.detect-changes.outputs.outside-contribs == 'true'}}
+        run: mvn verify --batch-mode -Dmaven.test.redirectTestOutputToFile -Dmatsim.preferLocalDtds=true --fail-at-end -Dmaven.javadoc.skip -Dsource.skip -Dassembly.skipAssembly=true
+        working-directory: ${{matrix.module}}
+
+    env:
+      MAVEN_OPTS: -Xmx2g
+

--- a/matsim/src/test/java/org/matsim/core/network/algorithms/NetworkSimplifierTest.java
+++ b/matsim/src/test/java/org/matsim/core/network/algorithms/NetworkSimplifierTest.java
@@ -20,7 +20,13 @@
 
 package org.matsim.core.network.algorithms;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Map;
+
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
@@ -30,21 +36,20 @@ import org.matsim.api.core.v01.network.Node;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.utils.geometry.CoordUtils;
 
-import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 public class NetworkSimplifierTest {
 
-	@Test
-	public void testBuildNetwork(){
-		Network network = buildNetwork();
-		assertEquals("Wrong number of nodes.",  6, network.getNodes().size());
-		assertEquals("Wrong number of links.",  5, network.getLinks().size());
+	@Before
+	public void setUp() {
+		Id.resetCaches();
 	}
-	
-	
+
+	@Test
+	public void testBuildNetwork() {
+		Network network = buildNetwork();
+		assertEquals("Wrong number of nodes.", 6, network.getNodes().size());
+		assertEquals("Wrong number of links.", 5, network.getLinks().size());
+	}
+
 	@Test
 	public void testRun() {
 		Network network = buildNetwork();


### PR DESCRIPTION
Enable a GitHub Actions workflow for pushes to branches.

If the diff between the pushed commit and the master branch`(*)` is limited to contribs, only they are built (less than 15 min. built time). Otherwise also matsim is built (less than 30 min).
`(*)` For pushes to master the diff is done against the most recent commit before that push.

I will reconfigure the checks and make the new workflow required (instead of the travis one) for merging to master.

Sorry for not putting this into a discussion. The ongoing development is stalled, so it needs to be fixed asap. We can later revise some decisions.

==

In the next step I would like to configure the workflow for merging to master. Verifying such pushes is not time critical, so I was thinking about running them using a (very) limited number of parallel jobs, so it does not stall other builds. Something to discuss...

==

During the test period, we could continue using travis for testing PRs coming from external forks (instead of scraping it out completely). Again, something to discuss...


