### PR TITLE
limit appveyor builds to master; increase clone_depth

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,13 @@
 #for reference see: https://www.appveyor.com/docs/appveyor-yml/
 
 version: '{build}'
+
+branches:
+  only:
+    - master
 skip_tags: true
-clone_depth: 1
+clone_depth: 5
+
 environment:
   matrix:
     - JAVA_HOME: C:\Program Files\Java\jdk11


### PR DESCRIPTION
The new GH Actions CI is too fast for appveyor (esp. when combined with auto-merge):

https://ci.appveyor.com/project/michalmac/matsim-libs/history

Two problems:
- PR branches are already gone (-> therefore: build only master, which should be fine as the main goal is to detect some win-linux incompatibilities that pop up from time to time)
- even when processing only pushes to master, the appveyor is too slow ( -> therefore `clone_depth` is set to 5, which should be enough for short peaks)