### PR TITLE
add DRT request insertion retry functionality

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DrtRequestInsertionRetryParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DrtRequestInsertionRetryParams.java
@@ -1,0 +1,82 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.optimizer.insertion;
+
+import java.util.Map;
+
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+
+import org.matsim.core.config.ReflectiveConfigGroup;
+
+/**
+ * @author Steffen Axer
+ */
+public class DrtRequestInsertionRetryParams extends ReflectiveConfigGroup {
+	public static final String SET_NAME = "dvrpRequestRetry";
+
+	private static final String RETRY_INTERVAL = "retryInterval";
+	private static final String RETRY_INTERVAL_EXP = "The time interval at which rejected request are repeated."
+			+ " Default value is 120 s.";
+
+	private static final String MAX_REQUEST_AGE = "maxRequestAge";
+	private static final String MAX_REQUEST_AGE_EXP =
+			"The maximum age of a request until it gets finally rejected, if not already scheduled."
+					+ " The default value is 0 s (i.e. no retry).";
+
+	public DrtRequestInsertionRetryParams() {
+		super(SET_NAME);
+	}
+
+	@Positive
+	private int retryInterval = 120;
+
+	@PositiveOrZero
+	private double maxRequestAge = 0;// no retry by default
+
+	@StringGetter(RETRY_INTERVAL)
+	public int getRetryInterval() {
+		return retryInterval;
+	}
+
+	@StringSetter(RETRY_INTERVAL)
+	public void setRetryInterval(int retryInterval) {
+		this.retryInterval = retryInterval;
+	}
+
+	@StringGetter(MAX_REQUEST_AGE)
+	public double getMaxRequestAge() {
+		return maxRequestAge;
+	}
+
+	@StringSetter(MAX_REQUEST_AGE)
+	public void setMaxRequestAge(double maxRequestAge) {
+		this.maxRequestAge = maxRequestAge;
+	}
+
+	@Override
+	public Map<String, String> getComments() {
+		var map = super.getComments();
+		map.put(RETRY_INTERVAL, RETRY_INTERVAL_EXP);
+		map.put(MAX_REQUEST_AGE, MAX_REQUEST_AGE_EXP);
+		return map;
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DrtRequestInsertionRetryQueue.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DrtRequestInsertionRetryQueue.java
@@ -1,0 +1,79 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.optimizer.insertion;
+
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.matsim.contrib.drt.passenger.DrtRequest;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+class DrtRequestInsertionRetryQueue {
+	private final DrtRequestInsertionRetryParams params;
+
+	DrtRequestInsertionRetryQueue(DrtRequestInsertionRetryParams params) {
+		this.params = params;
+	}
+
+	//priority queue not needed - retry interval is equal for all requests
+	private final Deque<RequestRetryEntry> requestQueue = new LinkedList<>();
+
+	boolean tryAddFailedRequest(DrtRequest request, double now) {
+		if (request.getSubmissionTime() + params.getMaxRequestAge() < now + params.getRetryInterval()) {
+			return false;//request is too old, not eligible for retry
+		}
+		requestQueue.addLast(new RequestRetryEntry(request, now));
+		return true;
+	}
+
+	List<DrtRequest> getRequestsToRetryNow(double now) {
+		double maxAttemptTimeForRetry = now - params.getRetryInterval();
+		List<DrtRequest> requests = new ArrayList<>();
+		while (!requestQueue.isEmpty() && requestQueue.getFirst().lastAttemptTime <= maxAttemptTimeForRetry) {
+			var entry = requestQueue.removeFirst();
+			//no guarantee that this method is called every second, so we need to calculate time delta, instead of
+			//directly using the retry interval
+			double timeDelta = now - entry.lastAttemptTime;
+			var oldRequest = entry.request;
+			//XXX alternatively make both latest start/arrival times modifiable
+			var newRequest = DrtRequest.newBuilder(oldRequest)
+					.latestStartTime(oldRequest.getLatestStartTime() + timeDelta)
+					.latestArrivalTime(oldRequest.getLatestArrivalTime() + timeDelta)
+					.build();
+			requests.add(newRequest);
+		}
+		return requests;
+	}
+
+	private static class RequestRetryEntry {
+		private final DrtRequest request;
+		private final double lastAttemptTime;
+
+		private RequestRetryEntry(DrtRequest request, double lastAttemptTime) {
+			this.request = request;
+			this.lastAttemptTime = lastAttemptTime;
+		}
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -38,6 +38,7 @@ import org.matsim.api.core.v01.TransportMode;
 import org.matsim.contrib.drt.analysis.zonal.DrtZonalSystemParams;
 import org.matsim.contrib.drt.fare.DrtFareParams;
 import org.matsim.contrib.drt.optimizer.insertion.DrtInsertionSearchParams;
+import org.matsim.contrib.drt.optimizer.insertion.DrtRequestInsertionRetryParams;
 import org.matsim.contrib.drt.optimizer.insertion.ExtensiveInsertionSearchParams;
 import org.matsim.contrib.drt.optimizer.insertion.SelectiveInsertionSearchParams;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingParams;
@@ -207,6 +208,9 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 	@Nullable
 	private DrtSpeedUpParams drtSpeedUpParams;
 
+	@Nullable
+	private DrtRequestInsertionRetryParams drtRequestInsertionRetryParams;
+
 	public DrtConfigGroup() {
 		super(GROUP_NAME);
 		initSingletonParameterSets();
@@ -229,13 +233,18 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 				() -> drtInsertionSearchParams,
 				params -> drtInsertionSearchParams = (SelectiveInsertionSearchParams)params);
 
-		//drt fare
+		//drt fare (optional)
 		addDefinition(DrtFareParams.SET_NAME, DrtFareParams::new, () -> drtFareParams,
 				params -> drtFareParams = (DrtFareParams)params);
 
-		//drt speedup
+		//drt speedup (optional)
 		addDefinition(DrtSpeedUpParams.SET_NAME, DrtSpeedUpParams::new, () -> drtSpeedUpParams,
 				params -> drtSpeedUpParams = (DrtSpeedUpParams)params);
+
+		//request retry handling (optional)
+		addDefinition(DrtRequestInsertionRetryParams.SET_NAME, DrtRequestInsertionRetryParams::new,
+				() -> drtRequestInsertionRetryParams,
+				params -> drtRequestInsertionRetryParams = (DrtRequestInsertionRetryParams)params);
 	}
 
 	@Override
@@ -632,5 +641,9 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 
 	public Optional<DrtSpeedUpParams> getDrtSpeedUpParams() {
 		return Optional.ofNullable(drtSpeedUpParams);
+	}
+
+	public Optional<DrtRequestInsertionRetryParams> getDrtRequestInsertionRetryParams() {
+		return Optional.ofNullable(drtRequestInsertionRetryParams);
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DrtRequestInsertionRetryQueueTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DrtRequestInsertionRetryQueueTest.java
@@ -1,0 +1,122 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.optimizer.insertion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.matsim.api.core.v01.Id;
+import org.matsim.contrib.drt.passenger.DrtRequest;
+import org.matsim.contrib.dvrp.optimizer.Request;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class DrtRequestInsertionRetryQueueTest {
+	private static final double SUBMISSION_TIME = 100;
+	private static final double MAX_WAIT_TIME = 100;
+	private static final double MAX_TRAVEL_TIME = 200;
+	private final DrtRequest request = DrtRequest.newBuilder()
+			.id(Id.create("r", Request.class))
+			.submissionTime(SUBMISSION_TIME)
+			.earliestStartTime(SUBMISSION_TIME)
+			.latestStartTime(SUBMISSION_TIME + MAX_WAIT_TIME)
+			.latestArrivalTime(SUBMISSION_TIME + MAX_TRAVEL_TIME)
+			.build();
+
+	@Test
+	public void maxRequestAgeZero_noRetry() {
+		var queue = new DrtRequestInsertionRetryQueue(params(10, 0));
+		assertThat(queue.tryAddFailedRequest(request, SUBMISSION_TIME)).isFalse();
+		assertThat(queue.getRequestsToRetryNow(9999)).isEmpty();
+	}
+
+	@Test
+	public void requestMaxAgeExceeded_noRetry() {
+		var queue = new DrtRequestInsertionRetryQueue(params(2, 10));
+		assertThat(queue.tryAddFailedRequest(request, SUBMISSION_TIME + 10)).isFalse();
+		assertThat(queue.getRequestsToRetryNow(9999)).isEmpty();
+	}
+
+	@Test
+	public void requestMaxAgeNotExceeded_retry() {
+		var queue = new DrtRequestInsertionRetryQueue(params(2, 10));
+		assertThat(queue.tryAddFailedRequest(request, SUBMISSION_TIME)).isTrue();
+
+		//too early for retry
+		assertThat(queue.getRequestsToRetryNow(SUBMISSION_TIME + 1)).isEmpty();
+
+		//retry
+		double now = SUBMISSION_TIME + 2;
+		assertThat(queue.getRequestsToRetryNow(now)).usingFieldByFieldElementComparator()
+				.containsExactly(DrtRequest.newBuilder(request)
+						.latestStartTime(now + MAX_WAIT_TIME)
+						.latestArrivalTime(now + MAX_TRAVEL_TIME)
+						.build());
+
+		//empty queue
+		assertThat(queue.getRequestsToRetryNow(SUBMISSION_TIME + 3)).isEmpty();
+	}
+
+	@Test
+	public void requestMaxAgeNotExceeded_lateRetry() {
+		var queue = new DrtRequestInsertionRetryQueue(params(2, 10));
+		assertThat(queue.tryAddFailedRequest(request, SUBMISSION_TIME)).isTrue();
+
+		//retry
+		double now = 999999;// no guarantee the method is called every second, so let's make a very late call
+		assertThat(queue.getRequestsToRetryNow(now)).usingFieldByFieldElementComparator()
+				.containsExactly(DrtRequest.newBuilder(request)
+						.latestStartTime(now + MAX_WAIT_TIME)
+						.latestArrivalTime(now + MAX_TRAVEL_TIME)
+						.build());
+	}
+
+	@Test
+	public void queueOrderMaintained() {
+		var queue = new DrtRequestInsertionRetryQueue(params(2, 10));
+		assertThat(queue.tryAddFailedRequest(DrtRequest.newBuilder(request).id(Id.create("a", Request.class)).build(),
+				SUBMISSION_TIME)).isTrue();
+		assertThat(queue.tryAddFailedRequest(DrtRequest.newBuilder(request).id(Id.create("b", Request.class)).build(),
+				SUBMISSION_TIME)).isTrue();
+		assertThat(queue.tryAddFailedRequest(DrtRequest.newBuilder(request).id(Id.create("c", Request.class)).build(),
+				SUBMISSION_TIME)).isTrue();
+		assertThat(queue.tryAddFailedRequest(DrtRequest.newBuilder(request).id(Id.create("d", Request.class)).build(),
+				SUBMISSION_TIME)).isTrue();
+
+		//too early for retry
+		assertThat(queue.getRequestsToRetryNow(SUBMISSION_TIME + 1)).isEmpty();
+
+		//order is maintained
+		assertThat(queue.getRequestsToRetryNow(SUBMISSION_TIME + 2)).extracting(req -> req.getId().toString())
+				.containsExactly("a", "b", "c", "d");
+
+		//empty queue
+		assertThat(queue.getRequestsToRetryNow(SUBMISSION_TIME + 3)).isEmpty();
+	}
+
+	private DrtRequestInsertionRetryParams params(int interval, double maxAge) {
+		var params = new DrtRequestInsertionRetryParams();
+		params.setRetryInterval(interval);
+		params.setMaxRequestAge(maxAge);
+		return params;
+	}
+}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/run/examples/RunDrtExampleIT.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/run/examples/RunDrtExampleIT.java
@@ -26,6 +26,7 @@ import java.net.URL;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.matsim.contrib.drt.optimizer.insertion.DrtRequestInsertionRetryParams;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.core.config.Config;
@@ -45,10 +46,16 @@ public class RunDrtExampleIT {
 	public MatsimTestUtils utils = new MatsimTestUtils();
 
 	@Test
-	public void testRunDrtExample() {
+	public void testRunDrtExampleWithRequestRetry() {
 		URL configUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("mielec"), "mielec_drt_config.xml");
 		Config config = ConfigUtils.loadConfig(configUrl, new MultiModeDrtConfigGroup(), new DvrpConfigGroup(),
 				new OTFVisConfigGroup());
+
+		for (var drtCfg : MultiModeDrtConfigGroup.get(config).getModalElements()) {
+			var retryParams = new DrtRequestInsertionRetryParams();
+			retryParams.setMaxRequestAge(7200);//relatively high value to prevent rejections
+			drtCfg.addParameterSet(retryParams);
+		}
 
 		config.controler().setOverwriteFileSetting(OverwriteFileSetting.deleteDirectoryIfExists);
 		config.controler().setOutputDirectory(utils.getOutputDirectory());
@@ -57,7 +64,8 @@ public class RunDrtExampleIT {
 
 	@Test
 	public void testRunDrtStopbasedExample() {
-		URL configUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("mielec"), "mielec_stop_based_drt_config.xml");
+		URL configUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("mielec"),
+				"mielec_stop_based_drt_config.xml");
 		Config config = ConfigUtils.loadConfig(configUrl, new MultiModeDrtConfigGroup(), new DvrpConfigGroup(),
 				new OTFVisConfigGroup());
 
@@ -66,10 +74,10 @@ public class RunDrtExampleIT {
 		RunDrtExample.run(config, false);
 	}
 
-
 	@Test
 	public void testRunServiceAreabasedExampleWithSpeedUp() {
-		URL configUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("mielec"), "mielec_serviceArea_based_drt_config.xml");
+		URL configUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("mielec"),
+				"mielec_serviceArea_based_drt_config.xml");
 		Config config = ConfigUtils.loadConfig(configUrl, new MultiModeDrtConfigGroup(), new DvrpConfigGroup(),
 				new OTFVisConfigGroup());
 


### PR DESCRIPTION
Inspired by https://github.com/matsim-org/matsim-libs/pull/1247

Main differences:
- minimal in terms of required changes in the existing code: the request retry is handled within the `insertion` package (insertion procedure), and so it does not involve changes in the event processing or adding another passenger engine
- request rejection events are not triggered until the final attempt
- the next retry time is computed individually for each unsuccessful request and the requests are queued accordingly (instead of running every N seconds the retry procedure for all unsuccessful requests)