### PR TITLE
Speed factor for bikes not mandatory

### DIFF
--- a/contribs/bicycle/src/test/java/org/matsim/contrib/bicycle/BicycleLinkSpeedCalculatorTest.java
+++ b/contribs/bicycle/src/test/java/org/matsim/contrib/bicycle/BicycleLinkSpeedCalculatorTest.java
@@ -23,7 +23,7 @@ public class BicycleLinkSpeedCalculatorTest {
 
     private static final BicycleConfigGroup configGroup = new BicycleConfigGroup();
     private static final double maxBicycleSpeed = 15;
-    private static Network unusedNetwork = NetworkUtils.createNetwork();
+    private static final Network unusedNetwork = NetworkUtils.createNetwork();
 
     @BeforeClass
     public static void before() {
@@ -121,12 +121,24 @@ public class BicycleLinkSpeedCalculatorTest {
         Link linkWithReducedSpeed = createLink(0, "paved", "not-a-cycle-way", 0.5);
         Vehicle vehicle = createVehicle(linkForComparison.getFreespeed() * 0.5, 1);
 
-		BicycleLinkSpeedCalculatorDefaultImpl calculator = new BicycleLinkSpeedCalculatorDefaultImpl(configGroup);
+        BicycleLinkSpeedCalculatorDefaultImpl calculator = new BicycleLinkSpeedCalculatorDefaultImpl(configGroup);
 
         double comparisonSpeed = calculator.getMaximumVelocityForLink(linkForComparison, vehicle);
         double gradientSpeed = calculator.getMaximumVelocityForLink(linkWithReducedSpeed, vehicle);
 
         assertTrue(comparisonSpeed > gradientSpeed);
+    }
+
+    @Test
+    public void getMaximumVelocityForLink_noSpeedFactor() {
+
+        var link = createLinkWithNoGradientAndNoSpecialSurface();
+        var vehicle = createVehicle(link.getFreespeed() + 1, 1);
+        var calculator = new BicycleLinkSpeedCalculatorDefaultImpl(configGroup);
+
+        var speed = calculator.getMaximumVelocityForLink(link, vehicle);
+
+        assertEquals(link.getFreespeed(), speed, 0.001);
     }
 
     @Test
@@ -136,7 +148,7 @@ public class BicycleLinkSpeedCalculatorTest {
         Link linkWithCobbleStone = createLink(0, "cobblestone", "not-a-cycle-way", 1.0);
 
         Vehicle vehicle = createVehicle(linkForComparison.getFreespeed(), 1);
-		BicycleLinkSpeedCalculatorDefaultImpl calculator = new BicycleLinkSpeedCalculatorDefaultImpl(configGroup);
+        BicycleLinkSpeedCalculatorDefaultImpl calculator = new BicycleLinkSpeedCalculatorDefaultImpl(configGroup);
 
         double comparisonSpeed = calculator.getMaximumVelocityForLink(linkForComparison, vehicle);
         double gradientSpeed = calculator.getMaximumVelocityForLink(linkWithCobbleStone, vehicle);
@@ -151,10 +163,8 @@ public class BicycleLinkSpeedCalculatorTest {
         double length = 100;
         Node fromNode = NetworkUtils.createAndAddNode(unusedNetwork, Id.createNodeId(UUID.randomUUID().toString()), from);
         Node toNode = NetworkUtils.createAndAddNode(unusedNetwork, Id.createNodeId(UUID.randomUUID().toString()), to);
-        Link link = NetworkUtils.createAndAddLink(unusedNetwork, Id.createLinkId(UUID.randomUUID().toString()),
+        return NetworkUtils.createAndAddLink(unusedNetwork, Id.createLinkId(UUID.randomUUID().toString()),
                 fromNode, toNode, length, 1000, 1000, 1);
-        link.getAttributes().putAttribute(BicycleUtils.BICYCLE_INFRASTRUCTURE_SPEED_FACTOR, 1.0);
-        return link;
     }
 
     private Link createLink(double elevation, String surfaceType, String wayType, double speedFactor) {

--- a/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/OsmBicycleReader.java
+++ b/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/OsmBicycleReader.java
@@ -23,14 +23,13 @@ import java.util.function.Predicate;
  */
 public final class OsmBicycleReader extends SupersonicOsmNetworkReader {
 
-	public static final String BICYCLE_INFRASTRUCTURE_SPEED_FACTOR = "bicycleInfrastructureSpeedFactor";
 	private static final double BIKE_PCU = 0.25;
-	private static Set<String> bicycleNotAllowed = new HashSet<>(Arrays.asList(OsmTags.MOTORWAY, OsmTags.MOTORWAY_LINK,
+	private static final Set<String> bicycleNotAllowed = new HashSet<>(Arrays.asList(OsmTags.MOTORWAY, OsmTags.MOTORWAY_LINK,
 			OsmTags.TRUNK, OsmTags.TRUNK_LINK));
-	private static Set<String> onlyBicycleAllowed = new HashSet<>(Arrays.asList(OsmTags.TRACK, OsmTags.CYCLEWAY, OsmTags.SERVICE,
+	private static final Set<String> onlyBicycleAllowed = new HashSet<>(Arrays.asList(OsmTags.TRACK, OsmTags.CYCLEWAY, OsmTags.SERVICE,
 			OsmTags.FOOTWAY, OsmTags.PEDESTRIAN, OsmTags.PATH, OsmTags.STEPS));
 
-	private SupersonicOsmNetworkReader.AfterLinkCreated afterLinkCreated;
+	private final SupersonicOsmNetworkReader.AfterLinkCreated afterLinkCreated;
 
 	public OsmBicycleReader(OsmNetworkParser parser,
 							Predicate<Long> preserveNodeWithId,
@@ -49,9 +48,6 @@ public final class OsmBicycleReader extends SupersonicOsmNetworkReader {
 		setSmoothness(link, tags);
 		setCycleWay(link, tags);
 		setRestrictions(link, tags);
-
-		// do infrastructure factor
-		link.getAttributes().putAttribute(BICYCLE_INFRASTRUCTURE_SPEED_FACTOR, 0.5);
 
 		outfacingCallback.accept(link, tags, direction);
 	}


### PR DESCRIPTION
Having an infrastructure speed factor of 0.5 as a default seemed to be un intuitive. Make it optional for this reason. 