### PR TITLE
Hermes fixes and improvements

### DIFF
--- a/matsim/src/main/java/org/matsim/api/core/v01/IdMap.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/IdMap.java
@@ -126,7 +126,7 @@ public class IdMap<T, V> implements Map<Id<T>, V>, Iterable<V> {
 		return null;
 	}
 
-	V get(int index) {
+	public V get(int index) {
 		if (index < this.data.length) {
 			return (V) this.data[index];
 		}

--- a/matsim/src/main/java/org/matsim/core/events/ParallelEventsManager.java
+++ b/matsim/src/main/java/org/matsim/core/events/ParallelEventsManager.java
@@ -79,7 +79,7 @@ public final class ParallelEventsManager implements EventsManager {
 		this.syncOnTimeSteps = syncOnTimeSteps;
 		this.oneThreadPerHandler = oneThreadPerHandler;
 		this.numOfThreads = numOfThreads;
-		this.eventsHandlers = new ArrayList<EventHandler>();
+		this.eventsHandlers = new ArrayList<>();
 		this.eventsArraySize = syncOnTimeSteps ? 512 : 32768;
 		this.eventsQueueSize = eventsQueueSize;
 		this.eventQueue = new ArrayBlockingQueue<>(eventsQueueSize);
@@ -138,7 +138,7 @@ public final class ParallelEventsManager implements EventsManager {
 			distributor.interrupt();
 			distributor.join();
 		} catch (InterruptedException e) {
-			throw new RuntimeException("Exception while waiting on join..." + e.getMessage());
+			throw new RuntimeException("Exception while waiting on join...", e);
 		}
 
 	}
@@ -147,11 +147,19 @@ public final class ParallelEventsManager implements EventsManager {
 	public void processEvent(final Event event) {
 		EventArray array = new EventArray(1);
 		array.add(event);
-		this.eventQueue.add(array);
+		try {
+			this.eventQueue.put(array);
+		} catch (InterruptedException e) {
+			throw new RuntimeException("Exception while adding event.", e);
+		}
 	}
 
 	public void processEvents(final EventArray events) {
-		this.eventQueue.add(events);
+		try {
+			this.eventQueue.put(events);
+		} catch (InterruptedException e) {
+			throw new RuntimeException("Exception while adding event.", e);
+		}
 	}
 
 	@Override

--- a/matsim/src/main/java/org/matsim/core/mobsim/hermes/Agent.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/hermes/Agent.java
@@ -104,16 +104,16 @@ public class Agent {
     // Timestamp of when the agent will be ready to exit link.
     protected int linkFinishTime;
 
-    // Number of passagers that this agent can take (zero for personal vehicles)
+    // Number of passengers that this agent can take (zero for personal vehicles)
     private int capacity;
 
-    // Number of passegers that are currently being transported.
+    // Number of passengers that are currently being transported.
     private int passengersInside;
 
     private float storageCapacityPCUE = -1;
     private float flowCapacityPCUE = -1;
 
-    // Array of passagers on this vehicle.
+    // Array of passengers on this vehicle.
     private ArrayList<ArrayList<Agent>> passengersByStop;
 
     public Agent(int id, int capacity, PlanArray plan, EventArray events) {
@@ -188,7 +188,7 @@ public class Agent {
     }
 
     /*
-     *Number of passagers that this agent can take (zero for personal vehicles)
+     * Number of passengers that this agent can take (zero for personal vehicles)
      */
     public int getCapacity() {
         return this.capacity;
@@ -225,11 +225,11 @@ public class Agent {
     public static int getPlanHeader         (long plan) { return (int)((plan >> 60) & 0x000000000000000FL); }
     public static int getPlanEvent          (long plan) { return (int)((plan >> 40) & 0x000000000000FFFFL); }
     public static int getDeparture          (long plan) { return (int)((plan >> 40) & 0x00000000000FFFFFL); }
-    public static int getLinkPlanEntry      (long plan) {return (int) ((plan >> 8) & 0x00000000FFFFFFFFL); }
+    public static int getLinkPlanEntry      (long plan) { return (int) ((plan >> 8) & 0x00000000FFFFFFFFL); }
     public static int getLinkPCEEntry       (long plan) {
         return (int) ((plan >> 56) & 0x000000000000000FL);
     }
-    public static int getVelocityPlanEntry  (long plan) {return (int) (plan & 0x00000000000000FFL); }
+    public static int getVelocityPlanEntry  (long plan) { return (int) (plan & 0x00000000000000FFL); }
     public static int getRoutePlanEntry     (long plan) { return (int)((plan >> 16) & 0x000000000000FFFFL); }
     public static int getStopPlanEntry      (long plan) { return (int)( plan        & 0x000000000000FFFFL); }
     public static int getStopIndexPlanEntry (long plan) { return (int)( plan >> 32  & 0x00000000000000FFL); }
@@ -373,7 +373,7 @@ public class Agent {
                 return String.format("type=wait; event=%d; route=%d stopid=%d stopidx=%d",
             		getPlanEvent(planEntry), getRoutePlanEntry(planEntry), getStopPlanEntry(planEntry), getStopIndexPlanEntry(planEntry));
             default:
-                return String.format("unknow plan type %d", type);
+                return String.format("unknown plan type %d", type);
         }
 
     }

--- a/matsim/src/main/java/org/matsim/core/mobsim/hermes/Hermes.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/hermes/Hermes.java
@@ -67,19 +67,19 @@ public final class Hermes implements Mobsim {
 		try {
 			time = System.currentTimeMillis();
 			importScenario();
-			log.info(String.format("ETHZ importing hermes scenario took %d ms", System.currentTimeMillis() - time));
+			log.info(String.format("Hermes importing scenario took %d ms", System.currentTimeMillis() - time));
 
 			eventsManager.initProcessing();
 
 			time = System.currentTimeMillis();
 			realm.run();
 			log.info(String.format(
-					"ETHZ hermes took %d ms", System.currentTimeMillis() - time));
+					"Hermes took %d ms", System.currentTimeMillis() - time));
 
 			time = System.currentTimeMillis();
 			processEvents();
 			eventsManager.finishProcessing();
-			log.info(String.format("ETHZ matsim event processing took %d ms", System.currentTimeMillis() - time));
+			log.info(String.format("Hermes MATSim event processing took %d ms", System.currentTimeMillis() - time));
 
 			// Launch scenario imported in background
 			si.reset();

--- a/matsim/src/main/java/org/matsim/core/mobsim/hermes/HermesConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/hermes/HermesConfigGroup.java
@@ -33,8 +33,6 @@ public class HermesConfigGroup extends ReflectiveConfigGroup {
 
     // Maximum number of links (limited to 24 bits in the plan)
     public static final int MAX_LINK_ID = 16777216;
-    // Maximum number of stops in a link (limited to 8 bits in the plan)
-    public static final int MAX_STOP_IDX = 255;
     // Maximum number of stops (limited to 20bits in the plan)
     public static final int MAX_STOP_ROUTE_ID = 65536;
     // Maximum vehicle velocity (limited to 8 bits in the plan)

--- a/matsim/src/main/java/org/matsim/core/mobsim/hermes/Realm.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/hermes/Realm.java
@@ -49,7 +49,7 @@ public class Realm {
     // nqsim_stops.get(curr station id).get(line id).get(dst station id) -> queue of agents
     private final ArrayList<ArrayList<Map<Integer, ArrayDeque<Agent>>>> agent_stops;
     // stop ids per route id
-    private final ArrayList<ArrayList<Integer>> stops_in_route;
+    private final ArrayList<int[]> stops_in_route;
     // line id of a particular route
     private final int[] line_of_route;
     // queue of sorted events by time
@@ -231,11 +231,11 @@ public class Realm {
         int lineid = line_of_route[routeid];
         Map<Integer, ArrayDeque<Agent>> agents_next_stops =
                 agent_stops.get(stopid).get(lineid);
-        ArrayList<Integer> next_stops = stops_in_route.get(routeid);
+        int[] next_stops = stops_in_route.get(routeid);
 
         // take agents
-        for (int idx = stopidx; idx < next_stops.size(); idx++) {
-            ArrayDeque<Agent> in_agents = agents_next_stops.get(next_stops.get(idx));
+        for (int idx = stopidx; idx < next_stops.length; idx++) {
+            ArrayDeque<Agent> in_agents = agents_next_stops.get(next_stops[idx]);
 
             if (in_agents == null) {
                 continue;

--- a/matsim/src/main/java/org/matsim/core/mobsim/hermes/Realm.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/hermes/Realm.java
@@ -198,14 +198,8 @@ public class Realm {
     }
 
     protected boolean processAgentStopDelay(Agent agent, long planentry) {
-        int routeid = Agent.getRoutePlanEntry(planentry);
-        int stopid = Agent.getStopPlanEntry(planentry);
         int stopidx = Agent.getStopIndexPlanEntry(planentry);
-        int lineid = line_of_route[routeid];
         int departure = Agent.getDeparture(planentry);
-        ArrayList<Integer> next_stops = stops_in_route.get(routeid);
-        Map<Integer, ArrayDeque<Agent>> agents_next_stops =
-            agent_stops.get(stopid).get(lineid);
 
         // consume stop delay
         add_delayed_agent(agent, Math.max(secs + 1, departure));

--- a/matsim/src/main/java/org/matsim/core/mobsim/hermes/Realm.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/hermes/Realm.java
@@ -81,7 +81,7 @@ public class Realm {
 
     public void log(int time, String s) {
         if (HermesConfigGroup.DEBUG_REALMS) {
-            log.debug(String.format("ETHZ [ time = %d ] %s", time, s));
+            log.debug(String.format("Hermes [ time = %d ] %s", time, s));
         }
     }
 
@@ -171,7 +171,7 @@ public class Realm {
         advanceAgentandSetEventTime(agent);
         int routeNo = Agent.getRoutePlanEntry(planentry);
         int accessStop = Agent.getStopPlanEntry(planentry);
-        // Note: getNextStop needs to be called after advanveAgent.
+        // Note: getNextStop needs to be called after advanceAgent.
         int egressStop = agent.getNextStopPlanEntry();
         int lineid = line_of_route[routeNo];
 
@@ -184,7 +184,7 @@ public class Realm {
             list3 = list2.get(egressStop);
             list3.add(agent);
         } catch (NullPointerException npe) {
-        	System.out.println(String.format("ETHZ NPE agent=%d routeNo=%d accessStop=%d lineid=%d egressStop=%d", agent.id, routeNo, accessStop, lineid, egressStop));
+        	log.error(String.format("Hermes NPE agent=%d routeNo=%d accessStop=%d lineid=%d egressStop=%d", agent.id, routeNo, accessStop, lineid, egressStop), npe);
         }
         return true;
     }

--- a/matsim/src/main/java/org/matsim/core/mobsim/hermes/ScenarioImporter.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/hermes/ScenarioImporter.java
@@ -19,15 +19,6 @@
 
 package org.matsim.core.mobsim.hermes;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
@@ -74,6 +65,14 @@ import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleCapacity;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehicleUtils;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ScenarioImporter {
 
@@ -252,41 +251,35 @@ public class ScenarioImporter {
 
 	private void generatePT() {
 		initRoutesStations();
-		Set<Integer> stopIds = new HashSet<>();
-		TransitSchedule ts = scenario.getTransitSchedule();
-		int transit_line_counter = 0;
+		TransitSchedule ts = this.scenario.getTransitSchedule();
 
 		for (TransitLine tl : ts.getTransitLines().values()) {
 			int tid = tl.getId().index();
-			transit_line_counter += 1;
 			for (TransitRoute tr : tl.getRoutes().values()) {
 				int rid = tr.getId().index();
 
 				// Initialize line of route
-				line_of_route[rid] = tid;
+				this.line_of_route[rid] = tid;
 				// Initialize stops in route
-				route_stops_by_index.set(rid, new ArrayList<>(tr.getStops().size()));
+				this.route_stops_by_index.set(rid, new ArrayList<>(tr.getStops().size()));
 				for (TransitRouteStop trs : tr.getStops()) {
 					int sid = trs.getStopFacility().getId().index();
-					if (stopIds.contains(sid)) {
-					} else {
-						stopIds.add(sid);
-					}
-
 					// Initialize stops in route
-					route_stops_by_index.get(rid).add(sid);
+					this.route_stops_by_index.get(rid).add(sid);
 				}
 			}
 		}
 
 		// Initialize agent_stops.
-		agent_stops = new ArrayList<>(stopIds.size());
-		for (int i = 0; i < stopIds.size(); i++) {
-			ArrayList<Map<Integer, ArrayDeque<Agent>>> agent_lines = new ArrayList<>(transit_line_counter);
-			for (int j = 0; j < transit_line_counter; j++) {
+		int stopIdCount = Id.getNumberOfIds(TransitStopFacility.class);
+		int lineIdCount = Id.getNumberOfIds(TransitLine.class);
+		this.agent_stops = new ArrayList<>(stopIdCount);
+		for (int i = 0; i < stopIdCount; i++) {
+			ArrayList<Map<Integer, ArrayDeque<Agent>>> agent_lines = new ArrayList<>(lineIdCount);
+			for (int j = 0; j < lineIdCount; j++) {
 				agent_lines.add(new HashMap<>());
 			}
-			agent_stops.add(agent_lines);
+			this.agent_stops.add(agent_lines);
 		}
 	}
 

--- a/matsim/src/main/java/org/matsim/core/mobsim/hermes/ScenarioImporter.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/hermes/ScenarioImporter.java
@@ -650,7 +650,15 @@ public class ScenarioImporter {
 					deterministicPtEvents.get(timerunning).add(new LinkEnterEvent(timerunning, v.getId(), link));
 				}
 				double length = scenario.getNetwork().getLinks().get(link).getLength();
-				timerunning += length / (atEndOfRoute ? averageSpeedBetweenStops.get(stopidx - 2) : averageSpeedBetweenStops.get(stopidx - 1));
+				double avgSpeed;
+				if (atEndOfRoute) {
+					avgSpeed = averageSpeedBetweenStops.get(stopidx - 2);
+				} else if (stopidx > 0) {
+					avgSpeed = averageSpeedBetweenStops.get(stopidx - 1);
+				} else {
+					avgSpeed = averageSpeedBetweenStops.get(stopidx);
+				}
+				timerunning += length / avgSpeed;
 				if (timerunning < deterministicPtEvents.size()) {
 					deterministicPtEvents.get(timerunning - 2).add(new LinkLeaveEvent(timerunning - 2, v.getId(), link));
 				}

--- a/matsim/src/main/java/org/matsim/core/mobsim/hermes/ScenarioImporter.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/hermes/ScenarioImporter.java
@@ -679,13 +679,13 @@ public class ScenarioImporter {
 				}
 
 				c.flatevents.add(new VehicleArrivesAtFacilityEvent(0, c.vehId, stopId, arrivalTime));
-				c.flatplan.add(Agent.prepareStopArrivalEntry(c.flatevents.size() - 1, c.routeNo, stopIdIndex, c.stopidx));
+				c.flatplan.add(Agent.prepareStopArrivalEntry(c.flatevents.size() - 1, c.routeNo, stopIdIndex));
 
 				// no event associated to stop delay
-				c.flatplan.add(Agent.prepareStopDelayEntry((int) departureTime, c.routeNo, stopIdIndex, c.stopidx));
+				c.flatplan.add(Agent.prepareStopDelayEntry((int) departureTime, c.routeNo, stopIdIndex));
 
 				c.flatevents.add(new VehicleDepartsAtFacilityEvent(0, c.vehId, stopId, departureTime));
-				c.flatplan.add(Agent.prepareStopDepartureEntry(c.flatevents.size() - 1, c.routeNo, stopIdIndex, c.stopidx));
+				c.flatplan.add(Agent.prepareStopDepartureEntry(c.flatevents.size() - 1, c.routeNo, stopIdIndex));
 
 				c.time = (int) departureTime;
 				c.stopidx++;
@@ -782,7 +782,7 @@ public class ScenarioImporter {
 		List<TransitRouteStop> trs = tr.getStops();
 		TransitRouteStop next = trs.get(0);
 		int stopidx = 0;
-		Vehicle v = scenario.getTransitVehicles().getVehicles().get(depart.getVehicleId());
+		Vehicle v = this.scenario.getTransitVehicles().getVehicles().get(depart.getVehicleId());
 		VehicleType vt = v.getType();
 		NetworkRoute nr = tr.getRoute();
 		int endid = nr.getEndLinkId().index();
@@ -810,11 +810,11 @@ public class ScenarioImporter {
 			while (checkForStop) {
 				if (next.getStopFacility().getLinkId().equals(nr.getStartLinkId())) {
 					flatevents.add(new VehicleArrivesAtFacilityEvent(0, v.getId(), next.getStopFacility().getId(), arrivalOffsetHelper(depart, next)));
-					flatplan.add(Agent.prepareStopArrivalEntry(flatevents.size() - 1, routeNo, stop_ids[stopidx], stopidx));
+					flatplan.add(Agent.prepareStopArrivalEntry(flatevents.size() - 1, routeNo, stop_ids[stopidx]));
 					// no event associated to stop delay
-					flatplan.add(Agent.prepareStopDelayEntry((int) departureOffsetHelper(depart, next), routeNo, stop_ids[stopidx], stopidx));
+					flatplan.add(Agent.prepareStopDelayEntry((int) departureOffsetHelper(depart, next), routeNo, stop_ids[stopidx]));
 					flatevents.add(new VehicleDepartsAtFacilityEvent(0, v.getId(), next.getStopFacility().getId(), departureOffsetHelper(depart, next)));
-					flatplan.add(Agent.prepareStopDepartureEntry(flatevents.size() - 1, routeNo, stop_ids[stopidx], stopidx));
+					flatplan.add(Agent.prepareStopDepartureEntry(flatevents.size() - 1, routeNo, stop_ids[stopidx]));
 
 					stopidx += 1;
 
@@ -841,11 +841,11 @@ public class ScenarioImporter {
 				TransitStopFacility nextStopFacility = next.getStopFacility();
 				if (nextStopFacility.getLinkId().equals(link)) {
 					flatevents.add(new VehicleArrivesAtFacilityEvent(0, v.getId(), nextStopFacility.getId(), arrivalOffsetHelper(depart, next)));
-					flatplan.add(Agent.prepareStopArrivalEntry(flatevents.size() - 1, routeNo, stopid, stopidx));
+					flatplan.add(Agent.prepareStopArrivalEntry(flatevents.size() - 1, routeNo, stopid));
 					// no event associated to stop delay
-					flatplan.add(Agent.prepareStopDelayEntry((int) departureOffsetHelper(depart, next), routeNo, stopid, stopidx));
+					flatplan.add(Agent.prepareStopDelayEntry((int) departureOffsetHelper(depart, next), routeNo, stopid));
 					flatevents.add(new VehicleDepartsAtFacilityEvent(0, v.getId(), nextStopFacility.getId(), departureOffsetHelper(depart, next)));
-					flatplan.add(Agent.prepareStopDepartureEntry(flatevents.size() - 1, routeNo, stopid, stopidx));
+					flatplan.add(Agent.prepareStopDepartureEntry(flatevents.size() - 1, routeNo, stopid));
 
 					stopidx += 1;
 					if (stopidx < trs.size()) {
@@ -870,11 +870,11 @@ public class ScenarioImporter {
 			if (nextStopFacility.getLinkId().equals(nr.getEndLinkId())) {
 				int stopid = stop_ids[stopidx];
 				flatevents.add(new VehicleArrivesAtFacilityEvent(0, v.getId(), nextStopFacility.getId(), arrivalOffsetHelper(depart, next)));
-				flatplan.add(Agent.prepareStopArrivalEntry(flatevents.size() - 1, routeNo, stopid, stopidx));
+				flatplan.add(Agent.prepareStopArrivalEntry(flatevents.size() - 1, routeNo, stopid));
 				// no event associated to stop delay
-				flatplan.add(Agent.prepareStopDelayEntry((int) departureOffsetHelper(depart, next), routeNo, stopid, stopidx));
+				flatplan.add(Agent.prepareStopDelayEntry((int) departureOffsetHelper(depart, next), routeNo, stopid));
 				flatevents.add(new VehicleDepartsAtFacilityEvent(0, v.getId(), nextStopFacility.getId(), departureOffsetHelper(depart, next)));
-				flatplan.add(Agent.prepareStopDepartureEntry(flatevents.size() - 1, routeNo, stopid, stopidx));
+				flatplan.add(Agent.prepareStopDepartureEntry(flatevents.size() - 1, routeNo, stopid));
 				stopidx += 1;
 				if (stopidx < trs.size()) {
 					next = trs.get(stopidx);

--- a/matsim/src/main/java/org/matsim/core/mobsim/hermes/ScenarioImporter.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/hermes/ScenarioImporter.java
@@ -87,7 +87,7 @@ public class ScenarioImporter {
 
 	protected int agent_persons;
 
-	// hermes stop ids per route id. Shold be used as follows:
+	// hermes stop ids per route id. Should be used as follows:
 	// bla.get(route id).get(station index) -> station id
 	protected ArrayList<ArrayList<Integer>> route_stops_by_index;
 
@@ -581,20 +581,22 @@ public class ScenarioImporter {
 			timerunning++;
 		}
 
-		// For each link (exclucing the first and the last)
+		// For each link (excluding the first and the last)
 		for (Id<org.matsim.api.core.v01.network.Link> link : nr.getLinkIds()) {
 			// Adding link and possibly a stop.
-			if (next.getStopFacility().getLinkId().equals(link)) {
+			TransitStopFacility nextStopFacility = next.getStopFacility();
+			if (nextStopFacility.getLinkId().equals(link)) {
 
 				int stopArrival = (int) arrivalOffsetHelper(depart, next);
+				int stopid = stop_ids.get(stopidx);
 				flatevents.add(new LinkEnterEvent(0, v.getId(), link));
-				flatevents.add(new VehicleArrivesAtFacilityEvent(0, v.getId(), next.getStopFacility().getId(), stopArrival));
-				flatplan.add(Agent.prepareStopArrivalEntry(flatevents.size() - 1, rid, stop_ids.get(stopidx), stopidx));
+				flatevents.add(new VehicleArrivesAtFacilityEvent(0, v.getId(), nextStopFacility.getId(), stopArrival));
+				flatplan.add(Agent.prepareStopArrivalEntry(flatevents.size() - 1, rid, stopid, stopidx));
 				// no event associated to stop delay
 				int stopDeparture = (int) departureOffsetHelper(depart, next);
-				flatplan.add(Agent.prepareStopDelayEntry(stopDeparture, rid, stop_ids.get(stopidx), stopidx));
-				flatevents.add(new VehicleDepartsAtFacilityEvent(0, v.getId(), next.getStopFacility().getId(), stopDeparture));
-				flatplan.add(Agent.prepareStopDepartureEntry(flatevents.size() - 1, rid, stop_ids.get(stopidx), stopidx));
+				flatplan.add(Agent.prepareStopDelayEntry(stopDeparture, rid, stopid, stopidx));
+				flatevents.add(new VehicleDepartsAtFacilityEvent(0, v.getId(), nextStopFacility.getId(), stopDeparture));
+				flatplan.add(Agent.prepareStopDepartureEntry(flatevents.size() - 1, rid, stopid, stopidx));
 				timerunning = stopDeparture;
 				stopidx += 1;
 				next = trs.get(stopidx);
@@ -612,14 +614,16 @@ public class ScenarioImporter {
 		}
 
 		// Adding last link and possibly the last stop.
-		if (next.getStopFacility().getLinkId().equals(nr.getEndLinkId())) {
+			TransitStopFacility nextStopFacility = next.getStopFacility();
+		if (nextStopFacility.getLinkId().equals(nr.getEndLinkId())) {
 			int stopArrival = (int) arrivalOffsetHelper(depart, next);
+			int stopid = stop_ids.get(stopidx);
 			flatevents.add(new LinkEnterEvent(0, v.getId(), nr.getEndLinkId()));
-			flatevents.add(new VehicleArrivesAtFacilityEvent(0, v.getId(), next.getStopFacility().getId(), stopArrival));
-			flatplan.add(Agent.prepareStopArrivalEntry(flatevents.size() - 1, rid, stop_ids.get(stopidx), stopidx));
-			flatplan.add(Agent.prepareStopDelayEntry((int) departureOffsetHelper(depart, next), rid, stop_ids.get(stopidx), stopidx));
-			flatevents.add(new VehicleDepartsAtFacilityEvent(0, v.getId(), next.getStopFacility().getId(), departureOffsetHelper(depart, next)));
-			flatplan.add(Agent.prepareStopDepartureEntry(flatevents.size() - 1, rid, stop_ids.get(stopidx), stopidx));
+			flatevents.add(new VehicleArrivesAtFacilityEvent(0, v.getId(), nextStopFacility.getId(), stopArrival));
+			flatplan.add(Agent.prepareStopArrivalEntry(flatevents.size() - 1, rid, stopid, stopidx));
+			flatplan.add(Agent.prepareStopDelayEntry((int) departureOffsetHelper(depart, next), rid, stopid, stopidx));
+			flatevents.add(new VehicleDepartsAtFacilityEvent(0, v.getId(), nextStopFacility.getId(), departureOffsetHelper(depart, next)));
+			flatplan.add(Agent.prepareStopDepartureEntry(flatevents.size() - 1, rid, stopid, stopidx));
 		}
 		flatevents.add(new VehicleLeavesTrafficEvent(0, driverid, nr.getEndLinkId(), v.getId(), legmode, 1));
 		flatevents.add(new PersonLeavesVehicleEvent(0, driverid, v.getId()));
@@ -675,19 +679,21 @@ public class ScenarioImporter {
 			next = trs.get(stopidx);
 		}
 
-		// For each link (exclucing the first and the last)
+		// For each link (excluding the first and the last)
 		for (Id<org.matsim.api.core.v01.network.Link> link : nr.getLinkIds()) {
 			int linkid = link.index();
+			int stopid = stop_ids.get(stopidx);
 			flatevents.add(new LinkEnterEvent(0, v.getId(), link));
 			flatplan.add(Agent.prepareLinkEntry(flatevents.size() - 1, linkid, velocity, pcuCategory));
 			// Adding link and possibly a stop.
-			if (next.getStopFacility().getLinkId().equals(link)) {
-				flatevents.add(new VehicleArrivesAtFacilityEvent(0, v.getId(), next.getStopFacility().getId(), arrivalOffsetHelper(depart, next)));
-				flatplan.add(Agent.prepareStopArrivalEntry(flatevents.size() - 1, rid, stop_ids.get(stopidx), stopidx));
+			TransitStopFacility nextStopFacility = next.getStopFacility();
+			if (nextStopFacility.getLinkId().equals(link)) {
+				flatevents.add(new VehicleArrivesAtFacilityEvent(0, v.getId(), nextStopFacility.getId(), arrivalOffsetHelper(depart, next)));
+				flatplan.add(Agent.prepareStopArrivalEntry(flatevents.size() - 1, rid, stopid, stopidx));
 				// no event associated to stop delay
-				flatplan.add(Agent.prepareStopDelayEntry((int) departureOffsetHelper(depart, next), rid, stop_ids.get(stopidx), stopidx));
-				flatevents.add(new VehicleDepartsAtFacilityEvent(0, v.getId(), next.getStopFacility().getId(), departureOffsetHelper(depart, next)));
-				flatplan.add(Agent.prepareStopDepartureEntry(flatevents.size() - 1, rid, stop_ids.get(stopidx), stopidx));
+				flatplan.add(Agent.prepareStopDelayEntry((int) departureOffsetHelper(depart, next), rid, stopid, stopidx));
+				flatevents.add(new VehicleDepartsAtFacilityEvent(0, v.getId(), nextStopFacility.getId(), departureOffsetHelper(depart, next)));
+				flatplan.add(Agent.prepareStopDepartureEntry(flatevents.size() - 1, rid, stopid, stopidx));
 
 				stopidx += 1;
 				next = trs.get(stopidx);
@@ -698,13 +704,15 @@ public class ScenarioImporter {
 		// Adding last link and possibly the last stop.
 		flatevents.add(new LinkEnterEvent(0, v.getId(), nr.getEndLinkId()));
 		flatplan.add(Agent.prepareLinkEntry(flatevents.size() - 1, endid, velocity, pcuCategory));
-		if (next.getStopFacility().getLinkId().equals(nr.getEndLinkId())) {
-			flatevents.add(new VehicleArrivesAtFacilityEvent(0, v.getId(), next.getStopFacility().getId(), arrivalOffsetHelper(depart, next)));
-			flatplan.add(Agent.prepareStopArrivalEntry(flatevents.size() - 1, rid, stop_ids.get(stopidx), stopidx));
+		TransitStopFacility nextStopFacility = next.getStopFacility();
+		if (nextStopFacility.getLinkId().equals(nr.getEndLinkId())) {
+			int stopid = stop_ids.get(stopidx);
+			flatevents.add(new VehicleArrivesAtFacilityEvent(0, v.getId(), nextStopFacility.getId(), arrivalOffsetHelper(depart, next)));
+			flatplan.add(Agent.prepareStopArrivalEntry(flatevents.size() - 1, rid, stopid, stopidx));
 			// no event associated to stop delay
-			flatplan.add(Agent.prepareStopDelayEntry((int) departureOffsetHelper(depart, next), rid, stop_ids.get(stopidx), stopidx));
-			flatevents.add(new VehicleDepartsAtFacilityEvent(0, v.getId(), next.getStopFacility().getId(), departureOffsetHelper(depart, next)));
-			flatplan.add(Agent.prepareStopDepartureEntry(flatevents.size() - 1, rid, stop_ids.get(stopidx), stopidx));
+			flatplan.add(Agent.prepareStopDelayEntry((int) departureOffsetHelper(depart, next), rid, stopid, stopidx));
+			flatevents.add(new VehicleDepartsAtFacilityEvent(0, v.getId(), nextStopFacility.getId(), departureOffsetHelper(depart, next)));
+			flatplan.add(Agent.prepareStopDepartureEntry(flatevents.size() - 1, rid, stopid, stopidx));
 			stopidx += 1;
 		}
 		flatevents.add(new VehicleLeavesTrafficEvent(0, driverid, nr.getEndLinkId(), v.getId(), legmode, 1));

--- a/matsim/src/main/java/org/matsim/core/mobsim/hermes/ScenarioImporter.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/hermes/ScenarioImporter.java
@@ -646,10 +646,14 @@ public class ScenarioImporter {
 			if (hasStop) {
 				flatevents.add(new LinkLeaveEvent(0, v.getId(), link));
 			} else {
-				deterministicPtEvents.get(timerunning).add(new LinkEnterEvent(timerunning, v.getId(), link));
+				if (timerunning < deterministicPtEvents.size()) {
+					deterministicPtEvents.get(timerunning).add(new LinkEnterEvent(timerunning, v.getId(), link));
+				}
 				double length = scenario.getNetwork().getLinks().get(link).getLength();
 				timerunning += length / (atEndOfRoute ? averageSpeedBetweenStops.get(stopidx - 2) : averageSpeedBetweenStops.get(stopidx - 1));
-				deterministicPtEvents.get(timerunning - 2).add(new LinkLeaveEvent(timerunning - 2, v.getId(), link));
+				if (timerunning < deterministicPtEvents.size()) {
+					deterministicPtEvents.get(timerunning - 2).add(new LinkLeaveEvent(timerunning - 2, v.getId(), link));
+				}
 			}
 			timerunning++;
 		}

--- a/matsim/src/main/java/org/matsim/core/mobsim/hermes/ScenarioImporter.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/hermes/ScenarioImporter.java
@@ -660,7 +660,9 @@ public class ScenarioImporter {
 				}
 				timerunning += length / avgSpeed;
 				if (timerunning < deterministicPtEvents.size()) {
-					deterministicPtEvents.get(timerunning - 2).add(new LinkLeaveEvent(timerunning - 2, v.getId(), link));
+					var linkLeaveTime = timerunning - 2;
+					if (linkLeaveTime < 0) linkLeaveTime = 0;
+					deterministicPtEvents.get(linkLeaveTime).add(new LinkLeaveEvent(linkLeaveTime, v.getId(), link));
 				}
 			}
 			timerunning++;

--- a/matsim/src/main/java/org/matsim/core/utils/collections/ArrayMap.java
+++ b/matsim/src/main/java/org/matsim/core/utils/collections/ArrayMap.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * Memory-optimized map, backed by two simple arrays, for storing a <b>small</b> number of entries.
+ * Memory-optimized map, backed by a simple array, for storing a <b>small</b> number of entries.
  * Many operations (like {@link #get(Object)}) have a runtime of <code>O(n)</code>, so this map implementation
  * should only be used to store a small number of elements in it. But for small number of elements,
  * this implementation performs very well, especially because of its very low memory overhead.

--- a/matsim/src/main/java/org/matsim/core/utils/collections/IntArrayMap.java
+++ b/matsim/src/main/java/org/matsim/core/utils/collections/IntArrayMap.java
@@ -1,0 +1,757 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.core.utils.collections;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Memory-optimized map, backed by two simple arrays, for storing a <b>small</b> number of entries with integer keys.
+ * Many operations (like {@link #get(Object)}) have a runtime of <code>O(n)</code>, so this map implementation
+ * should only be used to store a small number of elements in it. But for small number of elements,
+ * this implementation performs very well, especially because of its very low memory overhead.
+ *
+ * @author mrieser / Simunto GmbH
+ */
+public class IntArrayMap<V> implements Map<Integer, V> {
+
+	private int[] keys;
+	private Object[] values;
+	private int length = 0;
+
+	public IntArrayMap() {
+		this(8);
+	}
+
+	public IntArrayMap(int capacity) {
+		this.keys = new int[capacity];
+		this.values = new Object[capacity];
+	}
+
+	@Override
+	public int size() {
+		return this.length;
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return this.length == 0;
+	}
+
+	/**
+	 * @deprecated use {@link #containsKey(int)}
+	 */
+	@Deprecated
+	@Override
+	public boolean containsKey(Object key) {
+		if (key instanceof Integer) {
+			return containsKey(((Integer) key).intValue());
+		}
+		return false;
+	}
+
+	public boolean containsKey(int key) {
+		for (int i = 0, n = this.length; i < n; i++) {
+			if (this.keys[i] == key) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public boolean containsValue(Object value) {
+		for (int i = 0, n = this.length; i < n; i++) {
+			Object v = this.values[i];
+			if (Objects.equals(v, value)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * @deprecated use {@link #get(int)}
+	 */
+	@Deprecated
+	@Override
+	public V get(Object key) {
+		if (key instanceof Integer) {
+			return this.get(((Integer) key).intValue());
+		}
+		return null;
+	}
+
+	@SuppressWarnings("unchecked")
+	public V get(int key) {
+		for (int i = 0, n = this.length; i < n; i++) {
+			if (this.keys[i] == key) {
+				return (V) this.values[i];
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * @deprecated use {@link #put(int, V)}
+	 */
+	@Deprecated
+	@Override
+	public V put(Integer key, V value) {
+		return this.put(key.intValue(), value);
+	}
+
+	@SuppressWarnings("unchecked")
+	public V put(int key, V value) {
+		for (int i = 0, n = this.length; i < n; i++) {
+			if (this.keys[i] == key) {
+				V oldValue = (V) this.values[i];
+				this.values[i] = value;
+				return oldValue;
+			}
+		}
+		ensureCapacity(this.length + 1);
+
+		this.keys[this.length] = key;
+		this.values[this.length] = value;
+		this.length++;
+		return null;
+	}
+
+	private void ensureCapacity(int capacity) {
+		if (this.keys.length < capacity) {
+			int newLength = (this.keys.length + 1) * 2;
+			while (newLength < capacity) {
+				newLength = (newLength + 1) * 2;
+			}
+			this.keys = Arrays.copyOf(this.keys, newLength);
+			this.values = Arrays.copyOf(this.values, newLength);
+		}
+	}
+
+	/**
+	 * @deprecated use {@link #replace(int, Object)}
+	 */
+	@Deprecated
+	@Override
+	public V replace(Integer key, V value) {
+		return replace(key.intValue(), value);
+	}
+
+	@SuppressWarnings("unchecked")
+	public V replace(int key, V value) {
+		for (int i = 0, n = this.length; i < n; i++) {
+			if (this.keys[i] == key) {
+				V oldValue = (V) this.values[i];
+				this.values[i] = value;
+				return oldValue;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * @deprecated use {@link #remove(int)}
+	 */
+	@Deprecated
+	@Override
+	public V remove(final Object key) {
+		if (key instanceof Integer) {
+			return remove(((Integer) key).intValue());
+		}
+		return null;
+	}
+
+	@SuppressWarnings("unchecked")
+	public V remove(int key) {
+		for (int i = 0, n = this.length; i < n; i++) {
+			if (this.keys[i] == key) {
+				V oldValue = (V) this.values[i];
+				removeIndex(i);
+				return oldValue;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * @deprecated use {@link #remove(int, Object)}
+	 */
+	@Deprecated
+	@Override
+	public boolean remove(Object key, Object value) {
+		if (key instanceof Integer) {
+			return remove(((Integer) key).intValue(), value);
+		}
+		return false;
+	}
+
+	@SuppressWarnings("unchecked")
+	public boolean remove(int key, Object value) {
+		for (int i = 0, n = this.length; i < n; i++) {
+			if (this.keys[i] == key) {
+				V v = (V) this.values[i];
+				if (Objects.equals(v, value)) {
+					removeIndex(i);
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	public boolean removeKey(int key) {
+		for (int i = 0, n = this.length; i < n; i++) {
+			if (this.keys[i] == key) {
+				removeIndex(i);
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public boolean removeValue(final Object value) {
+		for (int i = 0, n = this.length; i < n; i++) {
+			Object v = this.values[i];
+			if (Objects.equals(v, value)) {
+				removeIndex(i);
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private void removeIndex(int i) {
+		int lastIndex = this.length - 1;
+		this.keys[i] = this.keys[lastIndex];
+		this.values[i] = this.values[lastIndex];
+		this.keys[lastIndex] = 0;
+		this.values[lastIndex] = null;
+		this.length--;
+	}
+
+	@Override
+	public void putAll(final Map<? extends Integer, ? extends V> m) {
+		m.forEach(this::put);
+	}
+
+	@Override
+	public void clear() {
+		Arrays.fill(this.keys, 0);
+		Arrays.fill(this.values, null);
+		this.length = 0;
+	}
+
+	@Override
+	public Set<Integer> keySet() {
+		return new KeySetView<>(this);
+	}
+
+	@Override
+	public Collection<V> values() {
+		return new ValuesView<>(this);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Set<Map.Entry<Integer, V>> entrySet() {
+		return new EntrySetView<>(this);
+	}
+
+	private static class Entry<V> implements Map.Entry<Integer, V> {
+
+		private final int k;
+		private final V v;
+
+		public Entry(int k, V v) {
+			this.k = k;
+			this.v = v;
+		}
+
+		@Override
+		public Integer getKey() {
+			return this.k;
+		}
+
+		@Override
+		public V getValue() {
+			return this.v;
+		}
+
+		@Override
+		public V setValue(final V value) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			Entry<?> entry = (Entry<?>) o;
+			return Objects.equals(this.k, entry.k) &&
+					Objects.equals(this.v, entry.v);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(this.k, this.v);
+		}
+	}
+
+	private static class KeySetView<V> implements Set<Integer> {
+
+		private final IntArrayMap<V> map;
+
+		KeySetView(IntArrayMap<V> map) {
+			this.map = map;
+		}
+
+		@Override
+		public int size() {
+			return this.map.size();
+		}
+
+		@Override
+		public boolean isEmpty() {
+			return this.map.isEmpty();
+		}
+
+		@Override
+		public boolean contains(Object o) {
+			if (o instanceof Integer) {
+				return this.map.containsKey(((Integer) o).intValue());
+			}
+			return false;
+		}
+
+		@Override
+		public Iterator<Integer> iterator() {
+			return new KeyIterator<>(this.map);
+		}
+
+		@Override
+		public Integer[] toArray() {
+			Integer[] array = new Integer[this.map.length];
+			for (int i = 0; i < this.map.length; i++) {
+				array[i] = this.map.keys[i];
+			}
+			return array;
+		}
+
+		@Override
+		public <T> T[] toArray(T[] a) {
+			int resultLength = this.map.length;
+			Object[] result = a;
+			if (result == null) {
+				result = new Object[resultLength];
+			} else if (result.length != resultLength) {
+				result = Arrays.copyOf(a, resultLength);
+			}
+			System.arraycopy(this.map.values, 0, result, 0, result.length);
+			return (T[]) result;
+		}
+
+		@Override
+		public boolean add(Integer k) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean remove(Object o) {
+			if (o instanceof Integer) {
+				return this.map.removeKey(((Integer)o).intValue());
+			}
+			return false;
+		}
+
+		@Override
+		public boolean containsAll(Collection<?> c) {
+			for (Object o : c) {
+				if (o instanceof Integer) {
+					if (!this.map.containsKey(((Integer) o).intValue())) {
+						return false;
+					}
+				} else {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		@Override
+		public boolean addAll(Collection<? extends Integer> c) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean retainAll(Collection<?> c) {
+			boolean modified = false;
+			for (int i = 0, n = this.map.length; i < n; i++) {
+				int key = this.map.keys[i];
+				if (!c.contains(key)) {
+					this.map.remove(key);
+					modified = true;
+				}
+			}
+			return modified;
+		}
+
+		@Override
+		public boolean removeAll(Collection<?> c) {
+			boolean modified = false;
+			for (Object o : c) {
+				if (o instanceof Integer) {
+					if (this.map.removeKey(((Integer) o).intValue())) {
+						modified = true;
+					}
+				}
+			}
+			return modified;
+		}
+
+		@Override
+		public void clear() {
+			this.map.clear();
+		}
+	}
+
+	private static class KeyIterator<V> implements Iterator<Integer> {
+		private final IntArrayMap<V> map;
+		private int nextIndex;
+
+		KeyIterator(IntArrayMap<V> map) {
+			this.map = map;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return this.map.length > this.nextIndex;
+		}
+
+		@Override
+		public Integer next() {
+			if (hasNext()) {
+				int key = this.map.keys[this.nextIndex];
+				this.nextIndex++;
+				return key;
+			}
+			throw new NoSuchElementException();
+		}
+
+		@Override
+		public void remove() {
+			this.nextIndex--;
+			this.map.removeIndex(this.nextIndex);
+		}
+	}
+
+	private static class ValuesView<V> implements Collection<V> {
+
+		private final IntArrayMap<V> map;
+
+		public ValuesView(IntArrayMap<V> map) {
+			this.map = map;
+		}
+
+		@Override
+		public int size() {
+			return this.map.size();
+		}
+
+		@Override
+		public boolean isEmpty() {
+			return this.map.isEmpty();
+		}
+
+		@Override
+		public boolean contains(Object o) {
+			return this.map.containsValue(o);
+		}
+
+		@Override
+		public Iterator<V> iterator() {
+			return new ValueIterator<>(this.map);
+		}
+
+		@Override
+		public Object[] toArray() {
+			Object[] data = this.map.values;
+			Object[] result = new Object[this.map.length];
+			if (result.length >= 0) {
+				System.arraycopy(data, 0, result, 0, result.length);
+			}
+			return result;
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public <T> T[] toArray(T[] a) {
+			Object[] data = this.map.values;
+			int resultLength = this.map.length;
+			Object[] result = a;
+			if (result == null) {
+				result = new Object[resultLength];
+			} else if (result.length != resultLength) {
+				result = Arrays.copyOf(a, resultLength);
+			}
+			System.arraycopy(data, 0, result, 0, result.length);
+			return (T[]) result;
+		}
+
+		@Override
+		public boolean add(V v) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean remove(Object o) {
+			return this.map.removeValue(o);
+		}
+
+		@Override
+		public boolean containsAll(Collection<?> c) {
+			for (Object o : c) {
+				if (!this.map.containsValue(o)) {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		@Override
+		public boolean addAll(Collection<? extends V> c) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean removeAll(Collection<?> c) {
+			boolean modified = false;
+			for (Object o : c) {
+				if (this.map.removeValue(o)) {
+					modified = true;
+				}
+			}
+			return modified;
+		}
+
+		@Override
+		public boolean retainAll(Collection<?> c) {
+			boolean modified = false;
+			Object[] data = this.map.values;
+			for (int i = 0, n = this.map.length; i < n; i++) {
+				Object value = data[i + 1];
+				if (!c.contains(value)) {
+					this.map.removeValue(value);
+					modified = true;
+				}
+			}
+			return modified;
+		}
+
+		@Override
+		public void clear() {
+			this.map.clear();
+		}
+	}
+
+	private static class ValueIterator<V> implements Iterator<V> {
+
+		private final IntArrayMap<V> map;
+		private int nextIndex;
+
+		ValueIterator(IntArrayMap<V> map) {
+			this.map = map;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return this.map.length > this.nextIndex;
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public V next() {
+			if (hasNext()) {
+				V value = (V) this.map.values[this.nextIndex];
+				this.nextIndex++;
+				return value;
+			}
+			throw new NoSuchElementException();
+		}
+
+		@Override
+		public void remove() {
+			this.nextIndex--;
+			this.map.removeIndex(this.nextIndex);
+		}
+	}
+
+	private static class EntrySetView<V> implements Set<Map.Entry<Integer, V>> {
+
+		private final IntArrayMap<V> map;
+
+		EntrySetView(IntArrayMap<V> map) {
+			this.map = map;
+		}
+
+		@Override
+		public int size() {
+			return this.map.size();
+		}
+
+		@Override
+		public boolean isEmpty() {
+			return this.map.isEmpty();
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public boolean contains(Object o) {
+			if (o instanceof Entry) {
+				Entry<V> e = (Entry<V>) o;
+				return Objects.equals(e.v, this.map.get(e.k));
+			}
+			return false;
+		}
+
+		@Override
+		public Iterator<Map.Entry<Integer, V>> iterator() {
+			return new EntryIterator<>(this.map);
+		}
+
+		@Override
+		public Object[] toArray() {
+			Object[] result = new Object[this.map.length];
+			for (int i = 0; i < result.length; i++) {
+				result[i] = new Entry<>(this.map.keys[i], this.map.values[i]);
+			}
+			return result;
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public <T> T[] toArray(T[] a) {
+			int resultLength = this.map.length;
+			Object[] result = a;
+			if (result == null) {
+				result = new Object[resultLength];
+			} else if (result.length != resultLength) {
+				result = Arrays.copyOf(a, resultLength);
+			}
+			for (int i = 0; i < result.length; i++) {
+				result[i] = new Entry<>(this.map.keys[i], this.map.values[i]);
+			}
+			return (T[]) result;
+		}
+
+		@Override
+		public boolean add(Map.Entry<Integer, V> kvEntry) {
+			throw new UnsupportedOperationException();
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public boolean remove(Object o) {
+			if (o instanceof Entry) {
+				Entry<V> e = (Entry<V>) o;
+				return this.map.remove(e.k, e.v);
+			}
+			return false;
+		}
+
+		@Override
+		public boolean containsAll(Collection<?> c) {
+			for (Object o : c) {
+				if (!this.contains(o)) {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		@Override
+		public boolean addAll(Collection<? extends Map.Entry<Integer, V>> c) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean retainAll(Collection<?> c) {
+			boolean modified = false;
+			for (int i = 0, n = this.map.length; i < n; i++) {
+				int key = this.map.keys[i];
+				Object value = this.map.values[i];
+				if (!c.contains(new Entry<>(key, value))) {
+					this.map.remove(key, value);
+					modified = true;
+				}
+			}
+			return modified;
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public boolean removeAll(Collection<?> c) {
+			boolean modified = false;
+			for (Object o : c) {
+				if (o instanceof Entry) {
+					Entry<V> e = (Entry<V>) o;
+					if (this.map.remove(e.k, e.v)) {
+						modified = true;
+					}
+				}
+			}
+			return modified;
+		}
+
+		@Override
+		public void clear() {
+			this.map.clear();
+		}
+	}
+
+	private static class EntryIterator<V> implements Iterator<Map.Entry<Integer, V>> {
+		private final IntArrayMap<V> map;
+		private int nextIndex;
+
+		EntryIterator(IntArrayMap<V> map) {
+			this.map = map;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return this.map.length > this.nextIndex;
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public Map.Entry<Integer, V> next() {
+			int key = this.map.keys[this.nextIndex];
+			V value = (V) this.map.values[this.nextIndex];
+			this.nextIndex++;
+			return new Entry<>(key, value);
+		}
+	}
+
+}

--- a/matsim/src/test/java/org/matsim/core/mobsim/hermes/HermesTransitTest.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/hermes/HermesTransitTest.java
@@ -457,6 +457,76 @@ public class HermesTransitTest {
 	}
 
 	/**
+	 * Makes sure Hermes does not produce exceptions when the configured end time is before the latest transit event
+	 */
+	@Test
+	public void testEarlyEnd() {
+		double baseTime = 30 * 3600 - 10; // HERMES has a default of 30:00:00 as end time, so let's start later
+		Fixture f = new Fixture();
+		f.config.transit().setUseTransit(true);
+		f.config.hermes().setDeterministicPt(true);
+
+		Vehicles ptVehicles = f.scenario.getTransitVehicles();
+
+		VehicleType ptVehType1 = ptVehicles.getFactory().createVehicleType(Id.create("bus", VehicleType.class));
+		ptVehicles.addVehicleType(ptVehType1);
+
+		Vehicle ptVeh1 = ptVehicles.getFactory().createVehicle(Id.create("veh1", Vehicle.class), ptVehType1);
+		ptVehicles.addVehicle(ptVeh1);
+
+		TransitSchedule schedule = f.scenario.getTransitSchedule();
+		TransitScheduleFactory sf = schedule.getFactory();
+
+		TransitStopFacility stop1 = sf.createTransitStopFacility(Id.create(1, TransitStopFacility.class), new Coord(1000, 10), false);
+		TransitStopFacility stop2 = sf.createTransitStopFacility(Id.create(2, TransitStopFacility.class), new Coord(2900, 29), false);
+		TransitStopFacility stop3 = sf.createTransitStopFacility(Id.create(3, TransitStopFacility.class), new Coord(3000, 30), false);
+
+		stop1.setLinkId(f.link1.getId());
+		stop2.setLinkId(f.link2.getId());
+		stop3.setLinkId(f.link3.getId());
+
+		schedule.addStopFacility(stop1);
+		schedule.addStopFacility(stop2);
+		schedule.addStopFacility(stop3);
+
+		TransitLine line1 = sf.createTransitLine(Id.create(1, TransitLine.class));
+		NetworkRoute netRoute = RouteUtils.createLinkNetworkRouteImpl(f.link1.getId(), List.of(f.link2.getId()), f.link3.getId());
+		List<TransitRouteStop> stops = List.of(
+				new TransitRouteStopImpl.Builder().stop(stop1).departureOffset(0).build(),
+				new TransitRouteStopImpl.Builder().stop(stop3).arrivalOffset(600).build()
+		);
+		TransitRoute route1 = sf.createTransitRoute(Id.create(0, TransitRoute.class), netRoute, stops, "bus");
+		Departure dep1 = sf.createDeparture(Id.create("dep1", Departure.class), baseTime);
+		dep1.setVehicleId(ptVeh1.getId());
+		route1.addDeparture(dep1);
+		line1.addRoute(route1);
+
+		schedule.addTransitLine(line1);
+
+		/* build events */
+		EventsManager events = EventsUtils.createEventsManager();
+		EventsCollector allEventsCollector = new EventsCollector();
+		events.addHandler(allEventsCollector);
+		LinkEnterEventCollector collector = new LinkEnterEventCollector();
+		events.addHandler(collector);
+
+		/* run sim */
+		Hermes sim = createHermes(f, events);
+		sim.run();
+
+		/* finish */
+
+		for (Event event : allEventsCollector.getEvents()) {
+			System.out.println(event.toString());
+		}
+
+		// Not having an Exception here is already good :-)
+		Assert.assertEquals("wrong number of link enter events.", 1, collector.events.size());
+		Assert.assertEquals("wrong link in first event.", f.link2.getId(), collector.events.get(0).getLinkId());
+		// there should be no more events after that, as at 30:00:00 the simulation should stop
+	}
+
+	/**
 	 * Initializes some commonly used data in the tests.
 	 *
 	 * @author mrieser

--- a/matsim/src/test/java/org/matsim/core/mobsim/hermes/HermesTransitTest.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/hermes/HermesTransitTest.java
@@ -19,6 +19,7 @@ import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Plan;
 import org.matsim.api.core.v01.population.Population;
 import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.api.experimental.events.VehicleArrivesAtFacilityEvent;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.PrepareForSimUtils;
@@ -47,6 +48,7 @@ import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.Vehicles;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -270,6 +272,191 @@ public class HermesTransitTest {
 	}
 
 	/**
+	 * Makes sure Hermes works with TransitRoutes where two successive stops are on the same link.
+	 * Originally, this resulted in wrong events because there was an exception that there is at most one stop per link.
+	 */
+	@Test
+	public void testConsecutiveStopsWithSameLink_1() {
+		Fixture f = new Fixture();
+		f.config.transit().setUseTransit(true);
+		f.config.hermes().setDeterministicPt(true);
+
+		Vehicles ptVehicles = f.scenario.getTransitVehicles();
+
+		VehicleType ptVehType1 = ptVehicles.getFactory().createVehicleType(Id.create("bus", VehicleType.class));
+		ptVehicles.addVehicleType(ptVehType1);
+
+		Vehicle ptVeh1 = ptVehicles.getFactory().createVehicle(Id.create("veh1", Vehicle.class), ptVehType1);
+		ptVehicles.addVehicle(ptVeh1);
+
+		TransitSchedule schedule = f.scenario.getTransitSchedule();
+		TransitScheduleFactory sf = schedule.getFactory();
+
+		TransitStopFacility stop1 = sf.createTransitStopFacility(Id.create(1, TransitStopFacility.class), new Coord(1000, 10), false);
+		TransitStopFacility stop2 = sf.createTransitStopFacility(Id.create(2, TransitStopFacility.class), new Coord(2900, 29), false);
+		TransitStopFacility stop3 = sf.createTransitStopFacility(Id.create(3, TransitStopFacility.class), new Coord(3000, 30), false);
+
+		stop1.setLinkId(f.link1.getId());
+		stop2.setLinkId(f.link3.getId());
+		stop3.setLinkId(f.link3.getId());
+
+		schedule.addStopFacility(stop1);
+		schedule.addStopFacility(stop2);
+		schedule.addStopFacility(stop3);
+
+		TransitLine line1 = sf.createTransitLine(Id.create(1, TransitLine.class));
+		NetworkRoute netRoute = RouteUtils.createLinkNetworkRouteImpl(f.link1.getId(), List.of(f.link2.getId()), f.link3.getId());
+		List<TransitRouteStop> stops = List.of(
+				new TransitRouteStopImpl.Builder().stop(stop1).departureOffset(0).build(),
+				new TransitRouteStopImpl.Builder().stop(stop2).departureOffset(300).build(),
+				new TransitRouteStopImpl.Builder().stop(stop3).arrivalOffset(600).build()
+		);
+		TransitRoute route1 = sf.createTransitRoute(Id.create(0, TransitRoute.class), netRoute, stops, "bus");
+		Departure dep1 = sf.createDeparture(Id.create("dep1", Departure.class), 7*3600);
+		dep1.setVehicleId(ptVeh1.getId());
+		route1.addDeparture(dep1);
+		line1.addRoute(route1);
+
+		schedule.addTransitLine(line1);
+
+		// add a single person with leg from link1 to link3
+		Person person = PopulationUtils.getFactory().createPerson(Id.create(0, Person.class));
+		Plan plan = PersonUtils.createAndAddPlan(person, true);
+		Activity a1 = PopulationUtils.createAndAddActivityFromLinkId(plan, "h", f.link1.getId());
+		a1.setEndTime(6*3600);
+		Leg leg = PopulationUtils.createAndAddLeg(plan, TransportMode.pt);
+		TripStructureUtils.setRoutingMode(leg, TransportMode.pt);
+		leg.setRoute(new DefaultTransitPassengerRoute(f.link1.getId(), f.link3.getId(), stop1.getId(), stop3.getId(), line1.getId(), route1.getId()));
+		PopulationUtils.createAndAddActivityFromLinkId(plan, "w", f.link3.getId());
+		f.plans.addPerson(person);
+
+		/* build events */
+		EventsManager events = EventsUtils.createEventsManager();
+		LinkEnterEventCollector collector = new LinkEnterEventCollector();
+		events.addHandler(collector);
+		EventsCollector allEventsCollector = new EventsCollector();
+		events.addHandler(allEventsCollector);
+
+		/* run sim */
+		Hermes sim = createHermes(f, events);
+		sim.run();
+
+		/* finish */
+
+		List<VehicleArrivesAtFacilityEvent> stopArrivalEvents = new ArrayList<>();
+		for (Event event : allEventsCollector.getEvents()) {
+			System.out.println(event.toString());
+			if (event instanceof VehicleArrivesAtFacilityEvent) {
+				stopArrivalEvents.add((VehicleArrivesAtFacilityEvent) event);
+			}
+		}
+
+		Assert.assertEquals("wrong number of link enter events.", 2, collector.events.size());
+		Assert.assertEquals("wrong link in first event.", f.link2.getId(), collector.events.get(0).getLinkId());
+		Assert.assertEquals("wrong link in second event.", f.link3.getId(), collector.events.get(1).getLinkId());
+
+		Assert.assertEquals("wrong number of stops served.", 3, stopArrivalEvents.size());
+		Assert.assertEquals("wrong stop id at first stop.", stop1.getId(), stopArrivalEvents.get(0).getFacilityId());
+		Assert.assertEquals("wrong stop id at 2nd stop.", stop2.getId(), stopArrivalEvents.get(1).getFacilityId());
+		Assert.assertEquals("wrong stop id at 3rd stop.", stop3.getId(), stopArrivalEvents.get(2).getFacilityId());
+
+	}
+
+	/**
+	 * Makes sure Hermes works with TransitRoutes where two successive stops are on the same link.
+	 * Originally, this resulted in problems as the distance between the stops was 0 meters, given they are on the same link,
+	 * and this 0 meters than resulted in infinite values somewhere later on.
+	 */
+	@Test
+	public void testConsecutiveStopsWithSameLink_2() {
+		Fixture f = new Fixture();
+		f.config.transit().setUseTransit(true);
+		f.config.hermes().setDeterministicPt(true);
+
+		Vehicles ptVehicles = f.scenario.getTransitVehicles();
+
+		VehicleType ptVehType1 = ptVehicles.getFactory().createVehicleType(Id.create("bus", VehicleType.class));
+		ptVehicles.addVehicleType(ptVehType1);
+
+		Vehicle ptVeh1 = ptVehicles.getFactory().createVehicle(Id.create("veh1", Vehicle.class), ptVehType1);
+		ptVehicles.addVehicle(ptVeh1);
+
+		TransitSchedule schedule = f.scenario.getTransitSchedule();
+		TransitScheduleFactory sf = schedule.getFactory();
+
+		TransitStopFacility stop1 = sf.createTransitStopFacility(Id.create(1, TransitStopFacility.class), new Coord(1000, 10), false);
+		TransitStopFacility stop2 = sf.createTransitStopFacility(Id.create(2, TransitStopFacility.class), new Coord(2900, 29), false);
+		TransitStopFacility stop3 = sf.createTransitStopFacility(Id.create(3, TransitStopFacility.class), new Coord(3000, 30), false);
+
+		stop1.setLinkId(f.link1.getId());
+		stop2.setLinkId(f.link3.getId());
+		stop3.setLinkId(f.link3.getId());
+
+		schedule.addStopFacility(stop1);
+		schedule.addStopFacility(stop2);
+		schedule.addStopFacility(stop3);
+
+		TransitLine line1 = sf.createTransitLine(Id.create(1, TransitLine.class));
+		NetworkRoute netRoute = RouteUtils.createLinkNetworkRouteImpl(f.link1.getId(), List.of(f.link2.getId(), f.link3.getId(), f.linkX.getId(), f.link1.getId(), f.link2.getId()), f.link3.getId()); // the vehicle must drive a loop to trigger the original error.
+		List<TransitRouteStop> stops = List.of(
+				new TransitRouteStopImpl.Builder().stop(stop1).departureOffset(0).build(),
+				new TransitRouteStopImpl.Builder().stop(stop2).departureOffset(300).build(),
+				new TransitRouteStopImpl.Builder().stop(stop3).arrivalOffset(600).build()
+		);
+		TransitRoute route1 = sf.createTransitRoute(Id.create(0, TransitRoute.class), netRoute, stops, "bus");
+		Departure dep1 = sf.createDeparture(Id.create("dep1", Departure.class), 7*3600);
+		dep1.setVehicleId(ptVeh1.getId());
+		route1.addDeparture(dep1);
+		line1.addRoute(route1);
+
+		schedule.addTransitLine(line1);
+
+		// add a single person with leg from link1 to link3
+		Person person = PopulationUtils.getFactory().createPerson(Id.create(0, Person.class));
+		Plan plan = PersonUtils.createAndAddPlan(person, true);
+		Activity a1 = PopulationUtils.createAndAddActivityFromLinkId(plan, "h", f.link1.getId());
+		a1.setEndTime(6*3600);
+		Leg leg = PopulationUtils.createAndAddLeg(plan, TransportMode.pt);
+		TripStructureUtils.setRoutingMode(leg, TransportMode.pt);
+		leg.setRoute(new DefaultTransitPassengerRoute(f.link1.getId(), f.link3.getId(), stop1.getId(), stop2.getId(), line1.getId(), route1.getId()));
+		PopulationUtils.createAndAddActivityFromLinkId(plan, "w", f.link3.getId());
+		f.plans.addPerson(person);
+
+		/* build events */
+		EventsManager events = EventsUtils.createEventsManager();
+		LinkEnterEventCollector collector = new LinkEnterEventCollector();
+		events.addHandler(collector);
+		EventsCollector allEventsCollector = new EventsCollector();
+		events.addHandler(allEventsCollector);
+
+		/* run sim */
+		Hermes sim = createHermes(f, events);
+		sim.run();
+
+		/* finish */
+
+		for (Event event : allEventsCollector.getEvents()) {
+			System.out.println(event.toString());
+		}
+
+		// Not having an Exception here is already good :-)
+//		collector.events.sort((o1, o2) -> Double.compare(o1.getTime(), o2.getTime()));
+//
+//		System.out.println("-----");
+//		for (Event event : collector.events) {
+//			System.out.println(event.toString());
+//		}
+
+		Assert.assertEquals("wrong number of link enter events.", 6, collector.events.size());
+		Assert.assertEquals("wrong link in first event.", f.link2.getId(), collector.events.get(0).getLinkId());
+		Assert.assertEquals("wrong link in second event.", f.link3.getId(), collector.events.get(1).getLinkId());
+//		Assert.assertEquals("wrong link in second event.", f.linkX.getId(), collector.events.get(2).getLinkId());
+//		Assert.assertEquals("wrong link in second event.", f.link1.getId(), collector.events.get(3).getLinkId());
+//		Assert.assertEquals("wrong link in second event.", f.link2.getId(), collector.events.get(4).getLinkId());
+//		Assert.assertEquals("wrong link in second event.", f.link3.getId(), collector.events.get(5).getLinkId());
+	}
+
+	/**
 	 * Initializes some commonly used data in the tests.
 	 *
 	 * @author mrieser
@@ -285,6 +472,7 @@ public class HermesTransitTest {
 		final Link link1;
 		final Link link2;
 		final Link link3;
+		final Link linkX;
 		final Population plans;
 		final List<Id<Link>> linkIdsNone;
 		final List<Id<Link>> linkIds2;
@@ -304,6 +492,7 @@ public class HermesTransitTest {
 			this.link1 = NetworkUtils.createAndAddLink(this.network, Id.create("1", Link.class), this.node1, this.node2, 100, 100, 60000, 9 );
 			this.link2 = NetworkUtils.createAndAddLink(this.network, Id.create("2", Link.class), this.node2, this.node3, 1000, 100, 6000, 2 );
 			this.link3 = NetworkUtils.createAndAddLink(this.network, Id.create("3", Link.class), this.node3, this.node4, 100, 100, 60000, 9 );
+			this.linkX = NetworkUtils.createAndAddLink(this.network, Id.create("X", Link.class), this.node4, this.node1, 2000, 100, 2000, 1 );
 
 			/* build plans */
 			this.plans = this.scenario.getPopulation();

--- a/matsim/src/test/java/org/matsim/core/mobsim/hermes/HermesTransitTest.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/hermes/HermesTransitTest.java
@@ -1,0 +1,208 @@
+package org.matsim.core.mobsim.hermes;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.api.core.v01.population.Activity;
+import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Plan;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.controler.PrepareForSimUtils;
+import org.matsim.core.events.EventsUtils;
+import org.matsim.core.mobsim.hermes.HermesTest.LinkEnterEventCollector;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.population.PersonUtils;
+import org.matsim.core.population.PopulationUtils;
+import org.matsim.core.population.routes.NetworkRoute;
+import org.matsim.core.population.routes.RouteUtils;
+import org.matsim.core.router.TripStructureUtils;
+import org.matsim.core.scenario.MutableScenario;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.core.utils.misc.Time;
+import org.matsim.pt.routes.DefaultTransitPassengerRoute;
+import org.matsim.pt.transitSchedule.TransitRouteStopImpl;
+import org.matsim.pt.transitSchedule.api.Departure;
+import org.matsim.pt.transitSchedule.api.TransitLine;
+import org.matsim.pt.transitSchedule.api.TransitRoute;
+import org.matsim.pt.transitSchedule.api.TransitRouteStop;
+import org.matsim.pt.transitSchedule.api.TransitSchedule;
+import org.matsim.pt.transitSchedule.api.TransitScheduleFactory;
+import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import org.matsim.vehicles.Vehicle;
+import org.matsim.vehicles.VehicleType;
+import org.matsim.vehicles.Vehicles;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Various unit tests checking various pt-related things in HERMES.
+ *
+ * @author mrieser / Simunto
+ */
+public class HermesTransitTest {
+
+	private final static Logger log = LogManager.getLogger(HermesTransitTest.class);
+
+	protected static Hermes createHermes(MutableScenario scenario, EventsManager events) {
+		PrepareForSimUtils.createDefaultPrepareForSim(scenario).run();
+		return new HermesBuilder().build(scenario, events);
+	}
+
+	protected static Hermes createHermes(Fixture f, EventsManager events) {
+		return createHermes(f.scenario, events);
+	}
+
+	protected static Hermes createHermes(Scenario scenario, EventsManager events) {
+		return createHermes(scenario, events, true);
+	}
+
+	protected static Hermes createHermes(Scenario scenario, EventsManager events, boolean prepareForSim) {
+		if (prepareForSim) {
+			PrepareForSimUtils.createDefaultPrepareForSim(scenario).run();
+		}
+		return new HermesBuilder().build(scenario, events);
+	}
+
+	@Before
+	public void prepareTest() {
+		Id.resetCaches();
+		ScenarioImporter.flush();
+		HermesConfigGroup.SIM_STEPS = 30 * 60 * 60;
+	}
+
+	/**
+	 * Makes sure Hermes works also when not all stop facilities are used by transit lines.
+	 */
+	@Test
+	public void testSuperflousStopFacilities() {
+		Fixture f = new Fixture();
+		f.config.transit().setUseTransit(true);
+
+		Vehicles ptVehicles = f.scenario.getTransitVehicles();
+
+		VehicleType ptVehType1 = ptVehicles.getFactory().createVehicleType(Id.create("bus", VehicleType.class));
+		ptVehicles.addVehicleType(ptVehType1);
+
+		Vehicle ptVeh1 = ptVehicles.getFactory().createVehicle(Id.create("veh1", Vehicle.class), ptVehType1);
+		ptVehicles.addVehicle(ptVeh1);
+
+		TransitSchedule schedule = f.scenario.getTransitSchedule();
+		TransitScheduleFactory sf = schedule.getFactory();
+
+		TransitStopFacility stop0 = sf.createTransitStopFacility(Id.create(0, TransitStopFacility.class), new Coord(0, 0), false); // create an unused Id<TransitStopFacility> first
+		TransitStopFacility stop1 = sf.createTransitStopFacility(Id.create(1, TransitStopFacility.class), new Coord(1000, 10), false);
+		TransitStopFacility stop2 = sf.createTransitStopFacility(Id.create(2, TransitStopFacility.class), new Coord(2000, 20), false);
+		TransitStopFacility stop3 = sf.createTransitStopFacility(Id.create(3, TransitStopFacility.class), new Coord(3000, 30), false);
+
+		stop0.setLinkId(f.link1.getId());
+		stop1.setLinkId(f.link1.getId());
+		stop2.setLinkId(f.link2.getId());
+		stop3.setLinkId(f.link3.getId());
+
+		schedule.addStopFacility(stop0);
+		schedule.addStopFacility(stop1);
+		schedule.addStopFacility(stop2);
+		schedule.addStopFacility(stop3);
+
+		TransitLine line1 = sf.createTransitLine(Id.create(1, TransitLine.class));
+		NetworkRoute netRoute = RouteUtils.createLinkNetworkRouteImpl(f.link1.getId(), List.of(f.link2.getId()), f.link3.getId());
+		List<TransitRouteStop> stops = List.of(
+				new TransitRouteStopImpl.Builder().stop(stop1).departureOffset(0).build(),
+				new TransitRouteStopImpl.Builder().stop(stop2).departureOffset(300).build(),
+				new TransitRouteStopImpl.Builder().stop(stop3).arrivalOffset(600).build()
+		);
+		TransitRoute route1 = sf.createTransitRoute(Id.create(0, TransitRoute.class), netRoute, stops, "bus");
+		Departure dep1 = sf.createDeparture(Id.create("dep1", Departure.class), 7*3600);
+		dep1.setVehicleId(ptVeh1.getId());
+		route1.addDeparture(dep1);
+		line1.addRoute(route1);
+
+		schedule.addTransitLine(line1);
+
+		// add a single person with leg from link1 to link3
+		Person person = PopulationUtils.getFactory().createPerson(Id.create(0, Person.class));
+		Plan plan = PersonUtils.createAndAddPlan(person, true);
+		Activity a1 = PopulationUtils.createAndAddActivityFromLinkId(plan, "h", f.link1.getId());
+		a1.setEndTime(6*3600);
+		Leg leg = PopulationUtils.createAndAddLeg(plan, TransportMode.pt);
+		TripStructureUtils.setRoutingMode(leg, TransportMode.pt);
+		leg.setRoute(new DefaultTransitPassengerRoute(f.link1.getId(), f.link3.getId(), stop1.getId(), stop2.getId(), line1.getId(), route1.getId()));
+		PopulationUtils.createAndAddActivityFromLinkId(plan, "w", f.link3.getId());
+		f.plans.addPerson(person);
+
+		/* build events */
+		EventsManager events = EventsUtils.createEventsManager();
+		LinkEnterEventCollector collector = new LinkEnterEventCollector();
+		events.addHandler(collector);
+
+		/* run sim */
+		Hermes sim = createHermes(f, events);
+		sim.run();
+
+		/* finish */
+		// Not having an Exception here is already good :-)
+		Assert.assertEquals("wrong number of link enter events.", 2, collector.events.size());
+		Assert.assertEquals("wrong link in first event.", f.link2.getId(), collector.events.get(0).getLinkId());
+		Assert.assertEquals("wrong link in second event.", f.link3.getId(), collector.events.get(1).getLinkId());
+	}
+
+	/**
+	 * Initializes some commonly used data in the tests.
+	 *
+	 * @author mrieser
+	 */
+	public static final class Fixture {
+		final Config config;
+		final Scenario scenario;
+		final Network network;
+		final Node node1;
+		final Node node2;
+		final Node node3;
+		final Node node4;
+		final Link link1;
+		final Link link2;
+		final Link link3;
+		final Population plans;
+		final List<Id<Link>> linkIdsNone;
+		final List<Id<Link>> linkIds2;
+
+		public Fixture() {
+			this.scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+			this.config = this.scenario.getConfig();
+
+
+			/* build network */
+			this.network = this.scenario.getNetwork();
+			this.network.setCapacityPeriod(Time.parseTime("1:00:00"));
+			this.node1 = NetworkUtils.createAndAddNode(this.network, Id.create("1", Node.class), new Coord(0, 0));
+			this.node2 = NetworkUtils.createAndAddNode(this.network, Id.create("2", Node.class), new Coord(100, 0));
+			this.node3 = NetworkUtils.createAndAddNode(this.network, Id.create("3", Node.class), new Coord(1100, 0));
+			this.node4 = NetworkUtils.createAndAddNode(this.network, Id.create("4", Node.class), new Coord(1200, 0));
+			this.link1 = NetworkUtils.createAndAddLink(this.network, Id.create("1", Link.class), this.node1, this.node2, 100, 100, 60000, 9 );
+			this.link2 = NetworkUtils.createAndAddLink(this.network, Id.create("2", Link.class), this.node2, this.node3, 1000, 100, 6000, 2 );
+			this.link3 = NetworkUtils.createAndAddLink(this.network, Id.create("3", Link.class), this.node3, this.node4, 100, 100, 60000, 9 );
+
+			/* build plans */
+			this.plans = this.scenario.getPopulation();
+
+			this.linkIdsNone = Collections.emptyList();
+
+			this.linkIds2 = List.of(this.link2.getId());
+		}
+	}
+
+}

--- a/matsim/src/test/java/org/matsim/core/mobsim/hermes/HermesTransitTest.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/hermes/HermesTransitTest.java
@@ -9,6 +9,7 @@ import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.events.Event;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
@@ -41,6 +42,7 @@ import org.matsim.pt.transitSchedule.api.TransitRouteStop;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitScheduleFactory;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import org.matsim.testcases.utils.EventsCollector;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.Vehicles;
@@ -91,6 +93,7 @@ public class HermesTransitTest {
 	public void testSuperflousStopFacilities() {
 		Fixture f = new Fixture();
 		f.config.transit().setUseTransit(true);
+		f.config.hermes().setDeterministicPt(true);
 
 		Vehicles ptVehicles = f.scenario.getTransitVehicles();
 
@@ -148,12 +151,19 @@ public class HermesTransitTest {
 		EventsManager events = EventsUtils.createEventsManager();
 		LinkEnterEventCollector collector = new LinkEnterEventCollector();
 		events.addHandler(collector);
+		EventsCollector allEventsCollector = new EventsCollector();
+		events.addHandler(allEventsCollector);
 
 		/* run sim */
 		Hermes sim = createHermes(f, events);
 		sim.run();
 
 		/* finish */
+
+		for (Event event : allEventsCollector.getEvents()) {
+			System.out.println(event.toString());
+		}
+
 		// Not having an Exception here is already good :-)
 		Assert.assertEquals("wrong number of link enter events.", 2, collector.events.size());
 		Assert.assertEquals("wrong link in first event.", f.link2.getId(), collector.events.get(0).getLinkId());

--- a/matsim/src/test/java/org/matsim/core/utils/collections/IntArrayMapTest.java
+++ b/matsim/src/test/java/org/matsim/core/utils/collections/IntArrayMapTest.java
@@ -1,0 +1,515 @@
+package org.matsim.core.utils.collections;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+/**
+ * @author mrieser / Simunto GmbH
+ */
+public class IntArrayMapTest {
+
+	@Test
+	public void testPutGetRemoveSize() {
+		IntArrayMap<String> map = new IntArrayMap<>();
+
+		Assert.assertEquals(0, map.size());
+		Assert.assertTrue(map.isEmpty());
+
+		Assert.assertNull(map.put(1, "one"));
+
+		Assert.assertEquals(1, map.size());
+		Assert.assertFalse(map.isEmpty());
+
+		Assert.assertNull(map.put(2, "two"));
+
+		Assert.assertEquals(2, map.size());
+		Assert.assertFalse(map.isEmpty());
+
+		Assert.assertEquals("one", map.put(1, "also-one"));
+		Assert.assertEquals(2, map.size());
+
+		Assert.assertNull(map.put(3, "three"));
+		Assert.assertEquals(3, map.size());
+
+		Assert.assertNull(map.put(4, null));
+		Assert.assertEquals(4, map.size());
+
+		Assert.assertEquals("also-one", map.get(1));
+		Assert.assertEquals("two", map.get(2));
+		Assert.assertEquals("three", map.get(3));
+		Assert.assertNull(map.get(4));
+
+		Assert.assertEquals("two", map.remove(2));
+		Assert.assertEquals(3, map.size());
+		Assert.assertNull(map.get(2));
+	}
+
+	@Test
+	public void testValuesIterable() {
+		IntArrayMap<String> map = new IntArrayMap<>();
+
+		map.put(1, "one");
+		map.put(2, "two");
+		map.put(4, "four");
+		map.put(5, "five");
+
+		int i = 0;
+		for (String data : map.values()) {
+			if (i == 0) {
+				Assert.assertEquals("one", data);
+			} else if (i == 1) {
+				Assert.assertEquals("two", data);
+			} else if (i == 2) {
+				Assert.assertEquals("four", data);
+			} else if (i == 3) {
+				Assert.assertEquals("five", data);
+			} else {
+				throw new RuntimeException("unexpected element: " + data);
+			}
+			i++;
+		}
+		Assert.assertEquals(4, i);
+	}
+
+	@Test
+	public void testForEach() {
+		IntArrayMap<String> map = new IntArrayMap<>();
+
+		map.put(1, "one");
+		map.put(2, "two");
+		map.put(4, "four");
+		map.put(5, "five");
+
+		List<Tuple<Integer, String>> data = new ArrayList<>();
+
+		map.forEach((k, v) -> data.add(new Tuple<>(k, v)));
+
+		Assert.assertEquals(1, data.get(0).getFirst().intValue());
+		Assert.assertEquals("one", data.get(0).getSecond());
+
+		Assert.assertEquals(2, data.get(1).getFirst().intValue());
+		Assert.assertEquals("two", data.get(1).getSecond());
+
+		Assert.assertEquals(4, data.get(2).getFirst().intValue());
+		Assert.assertEquals("four", data.get(2).getSecond());
+
+		Assert.assertEquals(5, data.get(3).getFirst().intValue());
+		Assert.assertEquals("five", data.get(3).getSecond());
+	}
+
+	@Test
+	public void testContainsKey() {
+		IntArrayMap<String> map = new IntArrayMap<>();
+
+		map.put(1, "one");
+		map.put(2, "two");
+		map.put(4, "four");
+		map.put(5, "five");
+
+		Assert.assertTrue(map.containsKey(1));
+		Assert.assertTrue(map.containsKey(2));
+		Assert.assertFalse(map.containsKey(3));
+		Assert.assertTrue(map.containsKey(4));
+		Assert.assertTrue(map.containsKey(5));
+		Assert.assertFalse(map.containsKey(6));
+
+		Assert.assertTrue(map.containsKey(1));
+		Assert.assertTrue(map.containsKey(2));
+		Assert.assertFalse(map.containsKey(3));
+		Assert.assertTrue(map.containsKey(4));
+		Assert.assertTrue(map.containsKey(5));
+		Assert.assertFalse(map.containsKey(6));
+	}
+
+	@Test
+	public void testContainsValue() {
+		IntArrayMap<String> map = new IntArrayMap<>();
+
+		map.put(1, "one");
+		map.put(2, "two");
+		map.put(4, "four");
+		map.put(5, "five");
+
+		Assert.assertTrue(map.containsValue("one"));
+		Assert.assertTrue(map.containsValue("two"));
+		Assert.assertFalse(map.containsValue("three"));
+		Assert.assertTrue(map.containsValue("four"));
+		Assert.assertTrue(map.containsValue("five"));
+		Assert.assertFalse(map.containsValue("six"));
+	}
+
+	@Test
+	public void testPutAll_ArrayMap() {
+		IntArrayMap<String> map = new IntArrayMap<>();
+
+		IntArrayMap<String> map2 = new IntArrayMap<>();
+		map2.put(1, "one");
+		map2.put(2, "two");
+		map2.put(4, "four");
+		map2.put(5, "five");
+
+		map.putAll(map2);
+
+		Assert.assertEquals(4, map.size());
+
+		Assert.assertEquals("one", map.get(1));
+		Assert.assertEquals("two", map.get(2));
+		Assert.assertNull(map.get(3));
+		Assert.assertEquals("four", map.get(4));
+		Assert.assertEquals("five", map.get(5));
+	}
+
+	@Test
+	public void testPutAll_GenericMap() {
+		IntArrayMap<String> map = new IntArrayMap<>();
+
+		Map<Integer, String> map2 = new HashMap<>();
+		map2.put(1, "one");
+		map2.put(2, "two");
+		map2.put(4, "four");
+		map2.put(5, "five");
+
+		map.putAll(map2);
+
+		Assert.assertEquals(4, map.size());
+
+		Assert.assertEquals("one", map.get(1));
+		Assert.assertEquals("two", map.get(2));
+		Assert.assertNull(map.get(3));
+		Assert.assertEquals("four", map.get(4));
+		Assert.assertEquals("five", map.get(5));
+	}
+
+	@Test
+	public void testClear() {
+		IntArrayMap<String> map = new IntArrayMap<>();
+
+		map.put(1, "one");
+		map.put(2, "two");
+		map.put(4, "four");
+		map.put(5, "five");
+
+		Assert.assertEquals(4, map.size());
+
+		map.clear();
+
+		Assert.assertEquals(0, map.size());
+
+		Assert.assertNull(map.get(1));
+		Assert.assertNull(map.get(2));
+		Assert.assertNull(map.get(3));
+
+		Assert.assertFalse(map.containsKey(1));
+	}
+
+	@Test
+	public void testValues() {
+		IntArrayMap<String> map = new IntArrayMap<>();
+
+		map.put(1, "one");
+		map.put(2, "two");
+		map.put(4, "four");
+		map.put(5, "five");
+
+		Collection<String> coll = map.values();
+		Assert.assertEquals(4, coll.size());
+
+		map.put(6, "six");
+		Assert.assertEquals(5, coll.size());
+
+		Assert.assertTrue(coll.remove("one"));
+		Assert.assertFalse(coll.remove("null"));
+
+		Assert.assertFalse(map.containsValue("one"));
+		Assert.assertTrue(map.containsValue("two"));
+
+		Assert.assertTrue(coll.contains("two"));
+		Assert.assertFalse(coll.contains("one"));
+
+		Set<String> values = new HashSet<>();
+		coll.forEach(v -> values.add(v));
+
+		Assert.assertEquals(4, values.size());
+		Assert.assertTrue(values.contains("two"));
+		Assert.assertTrue(values.contains("four"));
+		Assert.assertTrue(values.contains("five"));
+		Assert.assertTrue(values.contains("six"));
+	}
+
+	@Test
+	public void testKeySet() {
+		int key1 = 1;
+		int key2 = 2;
+		int key3 = 3;
+		int key4 = 4;
+		int key5 = 5;
+		int key6 = 6;
+
+		IntArrayMap<String> map = new IntArrayMap<>();
+
+		map.put(key1, "one");
+		map.put(key2, "two");
+		map.put(key4, "four");
+		map.put(key5, "five");
+
+		Set<Integer> set = map.keySet();
+		Assert.assertEquals(4, set.size());
+
+		map.put(key6, "six");
+		Assert.assertEquals(5, set.size());
+
+		Assert.assertTrue(set.remove(key1));
+		Assert.assertFalse(set.remove(key3));
+
+		Assert.assertFalse(map.containsKey(key1));
+		Assert.assertTrue(map.containsKey(key2));
+
+		Assert.assertTrue(set.contains(key2));
+		Assert.assertFalse(set.contains(key1));
+
+		Set<Integer> keys = new HashSet<>();
+		set.forEach(k -> keys.add(k));
+
+		Assert.assertEquals(4, keys.size());
+		Assert.assertTrue(keys.contains(key2));
+		Assert.assertTrue(keys.contains(key4));
+		Assert.assertTrue(keys.contains(key5));
+		Assert.assertTrue(keys.contains(key6));
+	}
+
+	@Test
+	public void testEntrySet() {
+		int key1 = 1;
+		int key2 = 2;
+		int key4 = 4;
+		int key5 = 5;
+		int key6 = 6;
+
+		IntArrayMap<String> map = new IntArrayMap<>();
+
+		map.put(key1, "one");
+		map.put(key2, "two");
+		map.put(key4, "four");
+		map.put(key5, "five");
+
+		Set<Map.Entry<Integer, String>> set = map.entrySet();
+		Assert.assertEquals(4, set.size());
+
+		map.put(key6, "six");
+		Assert.assertEquals(5, set.size());
+
+		Map<Integer, Map.Entry<Integer, String>> entries = new HashMap<>();
+
+		for (Map.Entry<Integer, String> e : set) {
+			entries.put(e.getKey(), e);
+		}
+
+		Assert.assertEquals(key1, entries.get(key1).getKey().intValue());
+		Assert.assertEquals("one", entries.get(key1).getValue());
+		Assert.assertEquals("two", entries.get(key2).getValue());
+		Assert.assertEquals("four", entries.get(key4).getValue());
+		Assert.assertEquals("five", entries.get(key5).getValue());
+
+		Assert.assertTrue(set.remove(entries.get(key1)));
+		//noinspection SuspiciousMethodCalls
+		Assert.assertFalse(set.remove(new Object()));
+
+		Assert.assertFalse(map.containsKey(key1));
+		Assert.assertTrue(map.containsKey(key2));
+
+		Assert.assertTrue(set.contains(entries.get(key2)));
+		Assert.assertFalse(set.contains(entries.get(key1)));
+
+		// test forEach
+		Set<Map.Entry<Integer, String>> es = new HashSet<>();
+		set.forEach(k -> es.add(k));
+
+		Assert.assertEquals(4, es.size());
+		Assert.assertTrue(es.contains(entries.get(key2)));
+		Assert.assertTrue(es.contains(entries.get(key4)));
+		Assert.assertTrue(es.contains(entries.get(key5)));
+		Assert.assertTrue(es.contains(entries.get(key6)));
+	}
+
+	@Test
+	public void testValuesIterator_iterate() {
+		int key1 = 1;
+		int key2 = 2;
+		int key4 = 4;
+		int key5 = 5;
+
+		IntArrayMap<String> map = new IntArrayMap<>();
+
+		map.put(key1, "one");
+		map.put(key2, "two");
+		map.put(key4, "four");
+		map.put(key5, "five");
+
+		Iterator<String> iter = map.values().iterator();
+		Assert.assertNotNull(iter);
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals("one", iter.next());
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals("two", iter.next());
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals("four", iter.next());
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals("five", iter.next());
+
+		Assert.assertFalse(iter.hasNext());
+		try {
+			iter.next();
+			Assert.fail("Expected exception, got none.");
+		} catch (NoSuchElementException ignore) {
+		}
+
+		Assert.assertFalse(iter.hasNext());
+	}
+
+	@Test
+	public void testValuesIterator_remove() {
+		int key1 = 1;
+		int key2 = 2;
+		int key4 = 4;
+		int key5 = 5;
+
+		IntArrayMap<String> map = new IntArrayMap<>();
+
+		map.put(key1, "one");
+		map.put(key2, "two");
+		map.put(key4, "four");
+		map.put(key5, "five");
+
+		Iterator<String> iter = map.values().iterator();
+		Assert.assertNotNull(iter);
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals("one", iter.next());
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals("two", iter.next());
+
+		iter.remove();
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals("five", iter.next());
+		Assert.assertEquals("four", iter.next());
+
+		Assert.assertEquals(3, map.size());
+		Assert.assertTrue(map.containsValue("one"));
+		Assert.assertFalse(map.containsValue("two"));
+		Assert.assertTrue(map.containsValue("four"));
+		Assert.assertTrue(map.containsValue("five"));
+	}
+
+	@Test
+	public void testKeySetIterator_iterate() {
+		int key1 = 1;
+		int key2 = 2;
+		int key4 = 4;
+		int key5 = 5;
+
+		IntArrayMap<String> map = new IntArrayMap<>();
+
+		map.put(key1, "one");
+		map.put(key2, "two");
+		map.put(key4, "four");
+		map.put(key5, "five");
+
+		Iterator<Integer> iter = map.keySet().iterator();
+		Assert.assertNotNull(iter);
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals(1, iter.next().intValue());
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals(2, iter.next().intValue());
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals(4, iter.next().intValue());
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals(5, iter.next().intValue());
+
+		Assert.assertFalse(iter.hasNext());
+		try {
+			iter.next();
+			Assert.fail("Expected exception, got none.");
+		} catch (NoSuchElementException ignore) {
+		}
+
+		Assert.assertFalse(iter.hasNext());
+	}
+
+	@Test
+	public void testKeySetIterator_remove() {
+		int key1 = 1;
+		int key2 = 2;
+		int key4 = 4;
+		int key5 = 5;
+
+		IntArrayMap<String> map = new IntArrayMap<>();
+
+		map.put(key1, "one");
+		map.put(key2, "two");
+		map.put(key4, "four");
+		map.put(key5, "five");
+
+		Iterator<Integer> iter = map.keySet().iterator();
+		Assert.assertNotNull(iter);
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals(1, iter.next().intValue());
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals(2, iter.next().intValue());
+
+		iter.remove();
+
+		Assert.assertTrue(iter.hasNext());
+		Assert.assertEquals(5, iter.next().intValue());
+		Assert.assertEquals(4, iter.next().intValue());
+
+		Assert.assertEquals(3, map.size());
+		Assert.assertTrue(map.containsKey(1));
+		Assert.assertFalse(map.containsKey(2));
+		Assert.assertTrue(map.containsKey(4));
+		Assert.assertTrue(map.containsKey(5));
+	}
+
+	@Test
+	public void testKeySetToArray() {
+		int key1 = 1;
+		int key2 = 2;
+		int key4 = 4;
+		int key5 = 5;
+
+		IntArrayMap<String> map = new IntArrayMap<>();
+
+		map.put(key1, "one");
+		map.put(key2, "two");
+		map.put(key4, "four");
+		map.put(key5, "five");
+
+		Object[] array = map.keySet().toArray();
+		Assert.assertEquals(key1, array[0]);
+		Assert.assertEquals(key2, array[1]);
+		Assert.assertEquals(key4, array[2]);
+		Assert.assertEquals(key5, array[3]);
+	}
+
+}


### PR DESCRIPTION
Various changes and fixes for Hermes, see #1248. Mostly related to correctly support rarely used features of the transit schedule, e.g. support multiple stops on the same link, support circular routes, support additional links before the first or after the last stop in a transit route. For this, I had to rewrite parts of the ScenarioImporter. But I've also added several unit tests, so I'm hopeful I didn't break anything.

With all this work, I've also cleaned up the code a bit and optimized it in some places, e.g. using `double[]` instead of `ArrayList<Double>` at some place, using `int[]` instead of `ArrayList<Integer>` in some other place, reducing the number of instantiated ArrayList and HashMaps in various places. In general, the memory consumption of Hermes should now be considerably lower than before.

I did some limited performance testing with a small scenario (20k agents, randomly distributed over the area of the city of Zurich, PT for the area of the city of Zurich). I did 3 runs each with the state of the current master branch, and the state of this branch, and measured the time required for hermes in the first 5 iterations. Then I averaged all the numbers (3 runs x 5 iterations), which resulted in the following:

| | master | hermes_fixes | change |
|---|---:|---:|---:|
| time hermes [s] | 16.38 | 14.11 | -15% |
| min. RAM [GB] | 4.2 | 1.9 | -50% |

Clearly, this is only a single measurement, running on a laptop. Larger scenarios running on different machines might behave differently. But the memory savings are real and performance should be at least as good, if not better, than before.