### PR TITLE
Major Bug fixing for Feedforward Rebalancing Strategy

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalWaitTimesAnalyzer.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalWaitTimesAnalyzer.java
@@ -24,7 +24,13 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 import org.apache.log4j.Logger;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/Feedforward/FeedforwardRebalancingStrategyParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/Feedforward/FeedforwardRebalancingStrategyParams.java
@@ -20,8 +20,8 @@ package org.matsim.contrib.drt.optimizer.rebalancing.Feedforward;
 
 import java.util.Map;
 
-import javax.annotation.Nonnegative;
 import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
 
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingParams;
 import org.matsim.core.config.ReflectiveConfigGroup;
@@ -47,25 +47,27 @@ public final class FeedforwardRebalancingStrategyParams extends ReflectiveConfig
 			+ "the time it takes the vehicles to travel can be compensated to some extent. Expect a non-negative integer value. Default value is 0";
 
 	public static final String FEEDBACK_SWITCH = "feedbackSwitch";
-	static final String FEEDBACK_SWITCH_EXP = "Turn on or off the feedback part in the strategy. Feedback part will mainain a minimum number of vehicles"
-			+ " in each zone. Default value is false";
+	static final String FEEDBACK_SWITCH_EXP =
+			"Turn on or off the feedback part in the strategy. Feedback part will mainain a minimum number of vehicles"
+					+ " in each zone. Default value is false";
 
 	public static final String MIN_NUM_VEHICLES_PER_ZONE = "minNumVehiclesPerZone";
-	static final String MIN_NUM_VEHICLES_PER_ZONE_EXP = "The minimum number of vehicles a zone should keep. This value will only be used when feed back "
-			+ " switch is true! Expect a non-negative value. Default value is 1";
+	static final String MIN_NUM_VEHICLES_PER_ZONE_EXP =
+			"The minimum number of vehicles a zone should keep. This value will only be used when feed back "
+					+ " switch is true! Expect a non-negative value. Default value is 1";
 
 	@Positive
 	private int timeBinSize = 900; // [s]
 
-	@Positive
+	@PositiveOrZero
 	private double feedforwardSignalStrength = 1;
 
-	@Nonnegative
+	@PositiveOrZero
 	private int feedforwardSignalLead = 0;
 
 	private boolean feedbackSwitch = false;
 
-	@Nonnegative
+	@PositiveOrZero
 	private int minNumVehiclesPerZone = 1;
 
 	public FeedforwardRebalancingStrategyParams() {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/Feedforward/FeedforwardSignalHandler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/Feedforward/FeedforwardSignalHandler.java
@@ -38,20 +38,19 @@ public class FeedforwardSignalHandler implements IterationStartsListener {
 	}
 
 	private void calculateFeedforwardSignal() {
+		netDepartureReplenishDemandEstimator.update(1);
 		feedforwardSignal.clear();
 		int progressCounter = 0;
 		int numOfTimeBin = simulationEndTime * 3600 / timeBinSize;
 		log.info("Start calculating rebalnace plan now");
 		for (int i = 0; i < numOfTimeBin; i++) {
 			double timeBin = i;
-
 			ToDoubleFunction<DrtZone> netDepartureInputFunction = netDepartureReplenishDemandEstimator.getExpectedDemandForTimeBin(
 					timeBin);
-
 			List<DrtZoneVehicleSurplus> vehicleSurpluses = zonalSystem.getZones()
 					.values()
 					.stream()
-					.map(z -> new DrtZoneVehicleSurplus(z, (int)netDepartureInputFunction.applyAsDouble(z)))
+					.map(z -> new DrtZoneVehicleSurplus(z, (int)netDepartureInputFunction.applyAsDouble(z) * -1))
 					.collect(toList());
 
 			feedforwardSignal.put(timeBin, TransportProblem.solveForVehicleSurplus(vehicleSurpluses));

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/NetDepartureReplenishDemandEstimator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/NetDepartureReplenishDemandEstimator.java
@@ -20,9 +20,8 @@ import org.matsim.contrib.dvrp.passenger.PassengerRequestRejectedEventHandler;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestScheduledEvent;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestScheduledEventHandler;
 
-public class NetDepartureReplenishDemandEstimator
-		implements PassengerRequestScheduledEventHandler, DrtRequestSubmittedEventHandler,
-		PassengerRequestRejectedEventHandler {
+public class NetDepartureReplenishDemandEstimator implements PassengerRequestScheduledEventHandler,
+		DrtRequestSubmittedEventHandler, PassengerRequestRejectedEventHandler {
 
 	private final DrtZonalSystem zonalSystem;
 	private final String mode;
@@ -31,8 +30,6 @@ public class NetDepartureReplenishDemandEstimator
 	private final Map<Double, Map<DrtZone, MutableInt>> previousZoneNetDepartureMap = new HashMap<>();
 	private final Map<Id<Request>, Triple<Double, DrtZone, DrtZone>> potentialDrtTripsMap = new HashMap<>();
 	private static final MutableInt ZERO = new MutableInt(0);
-	private final int simulationEndTime = 36; // simulation ending time in hour (greater than or equal to actual end
-	// time)
 
 	public NetDepartureReplenishDemandEstimator(DrtZonalSystem zonalSystem, DrtConfigGroup drtCfg,
 			FeedforwardRebalancingStrategyParams strategySpecificParams) {
@@ -79,14 +76,13 @@ public class NetDepartureReplenishDemandEstimator
 		}
 	}
 
-	@Override
-	public void reset(int iteration) {
+	public void update(int iteration) {
 		previousZoneNetDepartureMap.clear();
 		previousZoneNetDepartureMap.putAll(currentZoneNetDepartureMap);
+		currentZoneNetDepartureMap.clear();
 	}
 
-	public ToDoubleFunction<DrtZone> getExpectedDemandForTimeBin(double time) {
-		double timeBin = Math.floor(time / timeBinSize);
+	public ToDoubleFunction<DrtZone> getExpectedDemandForTimeBin(double timeBin) {
 		Map<DrtZone, MutableInt> expectedDemandForTimeBin = previousZoneNetDepartureMap.getOrDefault(timeBin,
 				Collections.emptyMap());
 		return zone -> expectedDemandForTimeBin.getOrDefault(zone, ZERO).intValue();


### PR DESCRIPTION
**Major Bug fixing** for Feedforward Rebalancing Strategy:
1. No rebalance in the second iteration
Preoblem: The reset function in the demand estimator (which update the demand database based on previous iteration) is called after the calculation of feedforward signal. Therefore, the feedforward signal for 2nd iteration (i.e. Iteration #1) is always emtpy.
Fix: Add an update function in the demand estimator and it is called before the calculation of the feedforward signal.
2. Wrong surplus calculation
Problem: In the feedforward signal handler, the surplus calculation is wrong. It should be -1 * net departure. 
Fix: List<DrtZoneVehicleSurplus> vehicleSurpluses = zonalSystem.getZones().values().stream()
					.map(z -> new DrtZoneVehicleSurplus(z, **(int) netDepartureInputFunction.applyAsDouble(z) * -1))**
					.collect(toList());
3. Change the requirement of the feedforward signal strength from @positive to @non-negative. This enables the possbility to totally turn off the feedforward part.

Due to the different auto formattor used, some of the other files are also shown as "changed". But in fact there is no changes.