### PR TITLE
Get zone for link ID: use to node of the link

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
@@ -106,8 +106,8 @@ public class DrtAnalysisControlerListener implements IterationEndsListener {
 				filename(event, "drt_rejections", ".csv"),
 				String.join(";", "time", "personId", "fromLinkId", "toLinkId", "fromX", "fromY", "toX", "toY"), seq -> {
 					DrtRequestSubmittedEvent submission = seq.getSubmitted();
-					Coord fromCoord = network.getLinks().get(submission.getFromLinkId()).getCoord();
-					Coord toCoord = network.getLinks().get(submission.getToLinkId()).getCoord();
+					Coord fromCoord = network.getLinks().get(submission.getFromLinkId()).getToNode().getCoord();
+					Coord toCoord = network.getLinks().get(submission.getToLinkId()).getToNode().getCoord();
 					return String.join(";", submission.getTime() + "",//
 							submission.getPersonId() + "",//
 							submission.getFromLinkId() + "",//

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtTrip.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtTrip.java
@@ -57,9 +57,9 @@ final class DrtTrip {
 		this.person = submittedEvent.getPersonId();
 		this.vehicle = pickedUpEvent.getVehicleId();
 		this.fromLinkId = submittedEvent.getFromLinkId();
-		this.fromCoord = linkProvider.apply(fromLinkId).getCoord();
+		this.fromCoord = linkProvider.apply(fromLinkId).getToNode().getCoord();
 		this.toLink = submittedEvent.getToLinkId();
-		this.toCoord = linkProvider.apply(toLink).getCoord();
+		this.toCoord = linkProvider.apply(toLink).getToNode().getCoord();
 		this.waitTime = pickedUpEvent.getTime() - submittedEvent.getTime();
 		this.unsharedDistanceEstimate_m = submittedEvent.getUnsharedRideDistance();
 		this.unsharedTimeEstimate_m = submittedEvent.getUnsharedRideTime();

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystem.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystem.java
@@ -74,7 +74,8 @@ public class DrtZonalSystem {
 	@Nullable
 	private static String getGeometryIdForLink(Link link, Map<String, PreparedGeometry> geometries) {
 		//TODO use endNode.getCoord() ?
-		Point linkCoord = MGC.coord2Point(link.getCoord());
+//		Point linkCoord = MGC.coord2Point(link.getCoord());
+		Point linkCoord = MGC.coord2Point(link.getToNode().getCoord());
 		return geometries.entrySet()
 				.stream()
 				.filter(e -> e.getValue().intersects(linkCoord))

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtStopFacilityImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtStopFacilityImpl.java
@@ -38,7 +38,7 @@ public class DrtStopFacilityImpl implements DrtStopFacility {
 	}
 
 	public static DrtStopFacility createFromLink(Link link) {
-		return new DrtStopFacilityImpl(Id.create(link.getId(), DrtStopFacility.class), link.getId(), link.getCoord());
+		return new DrtStopFacilityImpl(Id.create(link.getId(), DrtStopFacility.class), link.getId(), link.getToNode().getCoord());
 	}
 
 	private final Id<DrtStopFacility> id;

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystemTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystemTest.java
@@ -66,7 +66,7 @@ public class DrtZonalSystemTest {
 		DrtZonalSystem zonalSystem = createFromPreparedGeometries(createNetwork(),
 				grid);
 
-		assertEquals(3, zonalSystem.getZones().size());
+		assertEquals(2, zonalSystem.getZones().size());
 
 		//link 'da' is outside of the service area
 		Id<Link> id = Id.createLinkId("da");

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystemTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystemTest.java
@@ -47,14 +47,14 @@ public class DrtZonalSystemTest {
 	public void test_cellSize100() {
 		DrtZonalSystem drtZonalSystem = createFromPreparedGeometries(createNetwork(),
 				DrtGridUtils.createGridFromNetwork(createNetwork(), 100));
-		assertThat(drtZonalSystem.getZoneForLinkId(Id.createLinkId("ab")).getId()).isEqualTo("5");
+		assertThat(drtZonalSystem.getZoneForLinkId(Id.createLinkId("ab")).getId()).isEqualTo("10");
 	}
 
 	@Test
 	public void test_cellSize700() {
 		DrtZonalSystem drtZonalSystem = createFromPreparedGeometries(createNetwork(),
 				DrtGridUtils.createGridFromNetwork(createNetwork(), 700));
-		assertThat(drtZonalSystem.getZoneForLinkId(Id.createLinkId("ab")).getId()).isEqualTo("1");
+		assertThat(drtZonalSystem.getZoneForLinkId(Id.createLinkId("ab")).getId()).isEqualTo("2");
 	}
 
 	@Test


### PR DESCRIPTION
**This Pull request is open for discussion**

When we determine wheter a link (i.e. DRT stops)  is within the service area, the coordinate of the "toNode" of the link is used (see DrtModeModule, line 229), Therefore, I think it is better to also use "toNode" of the link when determine the zone a link belongs to. If we use the link's coordinate, there are likely to be some requests within the service area but outside any of the zone. This will add some unwanted effect to the analysis. 

Alternatively, we can also change the way we determine whether a link is within the service area (i.e. change the code DrtModeModule).

Attention: the test will fail because this change will change the zone belonging of some links, which will make the test fail. If we want to implment this pull request, we need to update the test as well.