### PR TITLE
Adding satisfaction rate to the drt analysis

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
@@ -199,8 +199,8 @@ public class DrtAnalysisControlerListener implements IterationEndsListener {
 			if (!headerWritten) {
 				headerWritten = true;
 				bw.write(line("runId", "iteration", "rides", "wait_average", "wait_max", "wait_p95", "wait_p75",
-						"wait_median", "inVehicleTravelTime_mean", "distance_m_mean", "directDistance_m_mean",
-						"totalTravelTime_mean", "rejections", "rejectionRate"));
+						"wait_median", "satisfaction_rate_10", "satisfaction_rate_15", "inVehicleTravelTime_mean", 
+						"distance_m_mean", "directDistance_m_mean", "totalTravelTime_mean", "rejections", "rejectionRate"));
 			}
 			bw.write(runId + ";" + it + ";" + summarizeTrips);
 			bw.newLine();

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
@@ -199,7 +199,7 @@ public class DrtAnalysisControlerListener implements IterationEndsListener {
 			if (!headerWritten) {
 				headerWritten = true;
 				bw.write(line("runId", "iteration", "rides", "wait_average", "wait_max", "wait_p95", "wait_p75",
-						"wait_median", "satisfaction_rate_10", "satisfaction_rate_15", "inVehicleTravelTime_mean", 
+						"wait_median", "percentage_WT_below_10", "percentage_WT_below_15", "inVehicleTravelTime_mean", 
 						"distance_m_mean", "directDistance_m_mean", "totalTravelTime_mean", "rejections", "rejectionRate"));
 			}
 			bw.write(runId + ";" + it + ";" + summarizeTrips);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtTripsAnalyser.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtTripsAnalyser.java
@@ -144,8 +144,8 @@ public class DrtTripsAnalyser {
 			directDistanceStats.addValue(trip.unsharedDistanceEstimate_m);
 			traveltimes.addValue(trip.arrivalTime - trip.departureTime);
 		}
-		double satisfactionRate600 = getSatisfactionRate(waitStats, 600);
-		double satisfactionRate900 = getSatisfactionRate(waitStats, 900);
+		double percentageWaitTimeBelow600 = getPercentageWaitTimeBelow(600, waitStats);
+		double percentageWaitTimeBelow900 = getPercentageWaitTimeBelow(900, waitStats);
 		
 		return String.join(delimiter, format.format(waitStats.getValues().length) + "",//
 				format.format(waitStats.getMean()) + "",//
@@ -153,8 +153,8 @@ public class DrtTripsAnalyser {
 				format.format(waitStats.getPercentile(95)) + "",//
 				format.format(waitStats.getPercentile(75)) + "",//
 				format.format(waitStats.getPercentile(50)) + "",//
-				format.format(satisfactionRate600) + "",//
-				format.format(satisfactionRate900) + "",//
+				format.format(percentageWaitTimeBelow600) + "",//
+				format.format(percentageWaitTimeBelow900) + "",//
 				format.format(rideStats.getMean()) + "",//
 				format.format(distanceStats.getMean()) + "",//
 				format.format(directDistanceStats.getMean()) + "",//
@@ -478,7 +478,7 @@ public class DrtTripsAnalyser {
 		return result.toString();
 	}
 	
-	public static double getSatisfactionRate(DescriptiveStatistics stats, int timeCriteria) {
+	public static double getPercentageWaitTimeBelow(int timeCriteria, DescriptiveStatistics stats) {
 		double[] waitingTimes = stats.getValues();
 		
 		if (waitingTimes.length == 0) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtTripsAnalyser.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtTripsAnalyser.java
@@ -485,7 +485,7 @@ public class DrtTripsAnalyser {
 			return 1; // When there is no request in zone, we assume "everyone" is satisfied
 		}
 		
-		int count = 0;
+		double count = 0;
 		for (int i = 0; i < waitingTimes.length; i++) {
 			if (waitingTimes[i] - timeCriteria < 0) {
 				count += 1;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtTripsAnalyser.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtTripsAnalyser.java
@@ -479,15 +479,20 @@ public class DrtTripsAnalyser {
 	}
 	
 	public static double getSatisfactionRate(DescriptiveStatistics stats, int timeCriteria) {
-		double[] sortedWaitingTime = stats.getSortedValues();
-		for (int i = 0; i < sortedWaitingTime.length; i++) {
-			if (sortedWaitingTime[i] > timeCriteria) {
-				double numOfRequestsInZone = sortedWaitingTime.length;
-				double output = i / numOfRequestsInZone;
-				return output;
+		double[] waitingTimes = stats.getValues();
+		
+		if (waitingTimes.length == 0) {
+			return 1; // When there is no request in zone, we assume "everyone" is satisfied
+		}
+		
+		int count = 0;
+		for (int i = 0; i < waitingTimes.length; i++) {
+			if (waitingTimes[i] - timeCriteria < 0) {
+				count += 1;
 			}
 		}
-		return 1;
+		
+		return count / waitingTimes.length;
 	}
 	
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtTripsAnalyser.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtTripsAnalyser.java
@@ -144,12 +144,17 @@ public class DrtTripsAnalyser {
 			directDistanceStats.addValue(trip.unsharedDistanceEstimate_m);
 			traveltimes.addValue(trip.arrivalTime - trip.departureTime);
 		}
+		double satisfactionRate600 = getSatisfactionRate(waitStats, 600);
+		double satisfactionRate900 = getSatisfactionRate(waitStats, 900);
+		
 		return String.join(delimiter, format.format(waitStats.getValues().length) + "",//
 				format.format(waitStats.getMean()) + "",//
 				format.format(waitStats.getMax()) + "",//
 				format.format(waitStats.getPercentile(95)) + "",//
 				format.format(waitStats.getPercentile(75)) + "",//
 				format.format(waitStats.getPercentile(50)) + "",//
+				format.format(satisfactionRate600) + "",//
+				format.format(satisfactionRate900) + "",//
 				format.format(rideStats.getMean()) + "",//
 				format.format(distanceStats.getMean()) + "",//
 				format.format(directDistanceStats.getMean()) + "",//
@@ -472,4 +477,17 @@ public class DrtTripsAnalyser {
 
 		return result.toString();
 	}
+	
+	public static double getSatisfactionRate(DescriptiveStatistics stats, int timeCriteria) {
+		double[] sortedWaitingTime = stats.getSortedValues();
+		for (int i = 0; i < sortedWaitingTime.length; i++) {
+			if (sortedWaitingTime[i] > timeCriteria) {
+				double numOfRequestsInZone = sortedWaitingTime.length;
+				double output = i / numOfRequestsInZone;
+				return output;
+			}
+		}
+		return 1;
+	}
+	
 }


### PR DESCRIPTION
As we have discussed before, it may be a good idea to add in this satisfaction rate into our analysis (See attached picture). 

Definition of satisfaction rate:
SR(x) = N(request with waiting time below x minutes)/N(total requests)

Here we have included SR(10) and SR(15), which are commonly used in different studies.

![SatisfactionRate](https://user-images.githubusercontent.com/43133404/102329170-58a14c00-3f88-11eb-8a72-d7215d16d7f2.png)


