### PR TITLE
Write seconds in DrtRoute description 

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRoute.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRoute.java
@@ -69,7 +69,7 @@ public class DrtRoute extends AbstractRoute {
 
 	@Override
 	public String getRouteDescription() {
-		return maxWaitTime + " " + directRideTime;
+		return maxWaitTime.seconds() + " " + directRideTime.seconds();
 	}
 
 	@Override


### PR DESCRIPTION
Currently, the maxWaitTime and directRideTime are dumped out in the format OptionalTime[%s]. This can not be parsed (with FloatingDecimal.parseDouble), which means, we can currently not read plans with drt routes.

This PR proposes to dump out only the numeric values of maxWaitTime and directRideTime (this is how it used to be) and throw an Exception is one of those is undefined. As legs are either routed or they aren't, it should be okay to throw an exception, shouldn't it?

