### PR TITLE
Finalise switch to link to node coord

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtTripsAnalyser.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtTripsAnalyser.java
@@ -106,7 +106,7 @@ public class DrtTripsAnalyser {
 			}
 			for (Entry<Id<Link>, int[]> e : boardings.entrySet()) {
 				bw.newLine();
-				Coord coord = network.getLinks().get(e.getKey()).getCoord();
+				Coord coord = network.getLinks().get(e.getKey()).getToNode().getCoord();
 				bw.write(e.getKey().toString() + delimiter + coord.getX() + delimiter + coord.getY());
 				for (int i = 0; i < e.getValue().length; i++) {
 					bw.write(delimiter + e.getValue()[i]);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtTripsAnalyser.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtTripsAnalyser.java
@@ -9,6 +9,7 @@ import java.text.DecimalFormatSymbols;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -144,17 +145,15 @@ public class DrtTripsAnalyser {
 			directDistanceStats.addValue(trip.unsharedDistanceEstimate_m);
 			traveltimes.addValue(trip.arrivalTime - trip.departureTime);
 		}
-		double percentageWaitTimeBelow600 = getPercentageWaitTimeBelow(600, waitStats);
-		double percentageWaitTimeBelow900 = getPercentageWaitTimeBelow(900, waitStats);
-		
+
 		return String.join(delimiter, format.format(waitStats.getValues().length) + "",//
 				format.format(waitStats.getMean()) + "",//
 				format.format(waitStats.getMax()) + "",//
 				format.format(waitStats.getPercentile(95)) + "",//
 				format.format(waitStats.getPercentile(75)) + "",//
 				format.format(waitStats.getPercentile(50)) + "",//
-				format.format(percentageWaitTimeBelow600) + "",//
-				format.format(percentageWaitTimeBelow900) + "",//
+				format.format(getPercentageWaitTimeBelow(600, waitStats)) + "",//
+				format.format(getPercentageWaitTimeBelow(900, waitStats)) + "",//
 				format.format(rideStats.getMean()) + "",//
 				format.format(distanceStats.getMean()) + "",//
 				format.format(directDistanceStats.getMean()) + "",//
@@ -477,22 +476,15 @@ public class DrtTripsAnalyser {
 
 		return result.toString();
 	}
-	
+
 	public static double getPercentageWaitTimeBelow(int timeCriteria, DescriptiveStatistics stats) {
 		double[] waitingTimes = stats.getValues();
-		
+
 		if (waitingTimes.length == 0) {
-			return 1; // When there is no request in zone, we assume "everyone" is satisfied
+			return Double.NaN; // to be consistent with DescriptiveStatistics
 		}
-		
-		double count = 0;
-		for (int i = 0; i < waitingTimes.length; i++) {
-			if (waitingTimes[i] - timeCriteria < 0) {
-				count += 1;
-			}
-		}
-		
+
+		double count = (double)Arrays.stream(waitingTimes).filter(t -> t < timeCriteria).count();
 		return count / waitingTimes.length;
 	}
-	
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystem.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystem.java
@@ -73,8 +73,6 @@ public class DrtZonalSystem {
 	 */
 	@Nullable
 	private static String getGeometryIdForLink(Link link, Map<String, PreparedGeometry> geometries) {
-		//TODO use endNode.getCoord() ?
-//		Point linkCoord = MGC.coord2Point(link.getCoord());
 		Point linkCoord = MGC.coord2Point(link.getToNode().getCoord());
 		return geometries.entrySet()
 				.stream()

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/depot/Depots.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/depot/Depots.java
@@ -62,7 +62,8 @@ public class Depots {
 				null /* already at a depot*/ :
 				links.stream()
 						.min(Comparator.comparing(
-								l -> DistanceUtils.calculateSquaredDistance(currentLink.getCoord(), l.getCoord())))
+								l -> DistanceUtils.calculateSquaredDistance(currentLink.getToNode().getCoord(),
+										l.getFromNode().getCoord())))
 						.get();
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/RebalancingUtils.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/RebalancingUtils.java
@@ -47,7 +47,8 @@ public class RebalancingUtils {
 			Link link = ((StayTask)v.getSchedule().getCurrentTask()).getLink();
 			DrtZone zone = zonalSystem.getZoneForLinkId(link.getId());
 			if (zone == null) {
-				zone = DrtZone.createDummyZone("single-vehicle-zone-" + v.getId(), List.of(link), link.getCoord());
+				zone = DrtZone.createDummyZone("single-vehicle-zone-" + v.getId(), List.of(link),
+						link.getToNode().getCoord());
 			}
 			rebalancableVehiclesPerZone.computeIfAbsent(zone, z -> new ArrayList<>()).add(v);
 		});

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/speedup/DrtTeleportedRouteCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/speedup/DrtTeleportedRouteCalculator.java
@@ -28,8 +28,6 @@ import org.matsim.contrib.dvrp.passenger.TeleportingPassengerEngine.TeleportedRo
 import org.matsim.core.population.routes.GenericRouteImpl;
 import org.matsim.core.utils.geometry.CoordUtils;
 
-import com.google.common.base.Preconditions;
-
 /**
  * @author Michal Maciejewski (michalm)
  */
@@ -46,8 +44,8 @@ public class DrtTeleportedRouteCalculator implements TeleportedRouteCalculator {
 	public Route calculateRoute(PassengerRequest request) {
 		Link startLink = request.getFromLink();
 		Link endLink = request.getToLink();
-		final Coord fromActCoord = Preconditions.checkNotNull(startLink.getCoord());
-		final Coord toActCoord = Preconditions.checkNotNull(endLink.getCoord());
+		final Coord fromActCoord = startLink.getToNode().getCoord();
+		final Coord toActCoord = endLink.getToNode().getCoord();
 		double dist = CoordUtils.calcEuclideanDistance(fromActCoord, toActCoord);
 		Route route = new GenericRouteImpl(startLink.getId(), endLink.getId());
 		//TODO move wait time outside the route (handle it explicitly by the TeleportingPassengerEngine)


### PR DESCRIPTION
A few remaining `link.coord` cases that were not part of https://github.com/matsim-org/matsim-libs/pull/1287

Additionally, I also changed the handling of empty arrays in `getPercentageWaitTimeBelow()`. Now it returns `NaN` to be consistent with all other stats (this is a contract behind all stats computations in `DescriptiveStatistics`).