### PR TITLE
String collection attribute in joint demand package

### DIFF
--- a/contribs/commercialTrafficApplications/scenarios/grid/jointDemand_population.xml
+++ b/contribs/commercialTrafficApplications/scenarios/grid/jointDemand_population.xml
@@ -15,8 +15,8 @@
             <activity type="home" link="259" x="0.0" y="0.0" end_time="16:00:00">
                 <attributes>
                     <!-- the pattern is the following
-                    <attribute name="commercialJob[NUMBER]" class="java.lang.String">[TYPE];[OPERATOR];[CAPACITYDEMAND];[EARLIESTSTART];[LATESTSTART];[DURATION]</attribute> !-->
-                    <attribute name="commercialJob1" class="java.lang.String">salamiPizza;1;43200;46800;180</attribute>
+                    <attribute name="commercialJob[NUMBER]" class="java.util.Collection">["TYPE","OPERATOR","CAPACITYDEMAND","EARLIESTSTART","LATESTSTART","DURATION"]</attribute> !-->
+                    <attribute name="commercialJob1" class="java.util.Collection">["salamiPizza","1","43200","46800","180"]</attribute>
                 </attributes>
             </activity>
             <leg mode="car">
@@ -35,7 +35,7 @@
             </leg>
             <activity type="home" x="-200.0" y="800.0" end_time="16:00:00">
                 <attributes>
-                    <attribute name="commercialJob1" class="java.lang.String">salamiPizza;1;43200;46800;180</attribute>
+                    <attribute name="commercialJob1" class="java.util.Collection">["salamiPizza","1","43200","46800","180"]</attribute>
                 </attributes>
             </activity>
             <leg mode="car">
@@ -54,7 +54,9 @@
             </leg>
             <activity type="home" link="259" x="0.0" y="0.0" end_time="16:00:00">
                 <attributes>
-                    <attribute name="commercialJob1" class="java.lang.String">salamiPizza;1;50000;51000;180</attribute>
+                    <!-- the pattern is the following
+                    <attribute name="commercialJob[NUMBER]" class="java.util.Collection">["TYPE","OPERATOR","CAPACITYDEMAND","EARLIESTSTART","LATESTSTART","DURATION"]</attribute> !-->
+                    <attribute name="commercialJob1" class="java.util.Collection">["salamiPizza","1","50000","51000","180"]</attribute>
                 </attributes>
             </activity>
             <leg mode="car">

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/CommercialJobGenerator.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/CommercialJobGenerator.java
@@ -18,10 +18,7 @@
 
 package org.matsim.contrib.commercialTrafficApplications.jointDemand.commercialJob;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
@@ -61,6 +58,8 @@ import org.matsim.core.population.routes.RouteUtils;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleUtils;
+
+import static org.matsim.contrib.commercialTrafficApplications.jointDemand.commercialJob.JointDemandUtils.*;
 
 /**
  * Generates carriers and tours depending on next iteration's freight demand
@@ -143,17 +142,18 @@ class CommercialJobGenerator implements BeforeMobsimListener, AfterMobsimListene
             for (Activity activity : customer2ActsWithJobs.get(customer)) {
                 Map<String,Object> commercialJobAttributes = JointDemandUtils.getCommercialJobAttributes(activity);
                 for (String commercialJobAttributeKey : commercialJobAttributes.keySet()) {
-                    String[] commercialJobProperties = String.valueOf(commercialJobAttributes.get(commercialJobAttributeKey)).split(JointDemandUtils.COMMERCIALJOB_ATTRIBUTE_DELIMITER);
+                    List<String> commercialJobProperties = new ArrayList<>();
+                    commercialJobProperties.addAll((Collection<? extends String>) commercialJobAttributes.get(commercialJobAttributeKey));
 
                     int jobIdx = Integer.parseInt(commercialJobAttributeKey.substring(JointDemandUtils.COMMERCIALJOB_ATTRIBUTE_NAME.length()));
                     Id<CarrierService> serviceId = createCarrierServiceIdXForCustomer(customer,jobIdx);
 
-                    double earliestStart = Double.parseDouble(commercialJobProperties[JointDemandUtils.COMMERCIALJOB_ATTRIBUTE_START_IDX]);
-                    double latestStart = Double.parseDouble(commercialJobProperties[JointDemandUtils.COMMERCIALJOB_ATTRIBUTE_END_IDX]);
+                    double earliestStart = Double.parseDouble(commercialJobProperties.get(COMMERCIALJOB_ATTRIBUTE_START_IDX));
+                    double latestStart = Double.parseDouble(commercialJobProperties.get(COMMERCIALJOB_ATTRIBUTE_END_IDX));
 
                     CarrierService.Builder serviceBuilder = CarrierService.Builder.newInstance(serviceId, activity.getLinkId());
-                    serviceBuilder.setCapacityDemand(Integer.parseInt(commercialJobProperties[JointDemandUtils.COMMERCIALJOB_ATTRIBUTE_AMOUNT_IDX]));
-                    serviceBuilder.setServiceDuration(Double.parseDouble(commercialJobProperties[JointDemandUtils.COMMERCIALJOB_ATTRIBUTE_DURATION_IDX]));
+                    serviceBuilder.setCapacityDemand(Integer.parseInt(commercialJobProperties.get(COMMERCIALJOB_ATTRIBUTE_AMOUNT_IDX)));
+                    serviceBuilder.setServiceDuration(Double.parseDouble(commercialJobProperties.get(COMMERCIALJOB_ATTRIBUTE_DURATION_IDX)));
                     serviceBuilder.setServiceStartTimeWindow(TimeWindow.newInstance(earliestStart,latestStart));
 
                     Id<Carrier> carrierId = JointDemandUtils.getCurrentlySelectedCarrierForJob(activity, jobIdx);

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/CommercialTrafficChecker.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/CommercialTrafficChecker.java
@@ -29,6 +29,8 @@ import org.matsim.api.core.v01.population.Population;
 import org.matsim.contrib.freight.carrier.Carrier;
 import org.matsim.contrib.freight.carrier.Carriers;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 class CommercialTrafficChecker {
@@ -64,13 +66,13 @@ class CommercialTrafficChecker {
                 log.error("index 0 is not supported for commercial job attributes. please start with index 1. See activity " + activity + " of person " + pid);
                 fail = true;
             }
-            String[] jobProperties = ((String) (attributes.get(attribute))).split(JointDemandUtils.COMMERCIALJOB_ATTRIBUTE_DELIMITER);
-            if (jobProperties.length != 5) {
+            Collection<String> jobProperties = (Collection) attributes.get(attribute);
+            if (jobProperties.size() != 5) {
                 log.error("Activity " + activity + " of person " + pid + " defines commercialJob attribute " + attribute + " with a wrong number of properties. Length should be 6");
                 fail = true;
             }
-            Double timeWindowStart = Double.valueOf(jobProperties[JointDemandUtils.COMMERCIALJOB_ATTRIBUTE_START_IDX]);
-            Double timeWindowEnd = Double.valueOf(jobProperties[JointDemandUtils.COMMERCIALJOB_ATTRIBUTE_END_IDX]);
+            Double timeWindowStart = Double.valueOf((String) jobProperties.toArray()[JointDemandUtils.COMMERCIALJOB_ATTRIBUTE_START_IDX]);
+            Double timeWindowEnd = Double.valueOf((String) jobProperties.toArray()[JointDemandUtils.COMMERCIALJOB_ATTRIBUTE_END_IDX]);
             if (timeWindowEnd < timeWindowStart) {
                 log.error("Person " + pid + " has an error in properties of job attribute " + attribute + " in activity " + activity.getType() + ".TimeWindow: start=" + timeWindowStart + " end=" + timeWindowEnd);
                 fail = true;

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/JointDemandUtils.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/JointDemandUtils.java
@@ -26,10 +26,7 @@ import org.matsim.contrib.freight.carrier.Carrier;
 import org.matsim.contrib.freight.carrier.CarrierVehicle;
 import org.matsim.contrib.freight.carrier.Carriers;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class JointDemandUtils {
@@ -37,11 +34,10 @@ public class JointDemandUtils {
     //TODO use StringCollection object attribute type instead of custom convention (using semicolon)
     public static final String COMMERCIALJOB_ATTRIBUTE_NAME = "commercialJob";
     public static final String CARRIER_MARKET_ATTRIBUTE_NAME = "market";
-    static final String COMMERCIALJOB_ATTRIBUTE_DELIMITER = ";";
     static final String FREIGHT_DRIVER_PREFIX = "freight";
 
-    //the pattern for the activity attribute is the following:
-    //<attribute name="commercialJob[NUMBER]" class="java.lang.String">[OPERATOR];[CAPACITYDEMAND];[EARLIESTSTART];[LATESTSTART];[DURATION]</attribute>
+//    the pattern is the following
+//    attribute name="commercialJob[NUMBER]" class="java.util.Collection">["TYPE","OPERATOR","CAPACITYDEMAND","EARLIESTSTART","LATESTSTART","DURATION"]</attribute>
     static final int COMMERCIALJOB_ATTRIBUTE_CARRIER_IDX = 0;
     static final int COMMERCIALJOB_ATTRIBUTE_AMOUNT_IDX = 1;
     static final int COMMERCIALJOB_ATTRIBUTE_START_IDX = 2;
@@ -58,14 +54,16 @@ public class JointDemandUtils {
     }
 
     static Id<Carrier> getCurrentlySelectedCarrierForJob(Activity activity, int commercialJobIndex) {
-        String[] commercialJobProperties = ((String) getCommercialJob(activity, commercialJobIndex)).split(COMMERCIALJOB_ATTRIBUTE_DELIMITER);
-        return Id.create(commercialJobProperties[COMMERCIALJOB_ATTRIBUTE_CARRIER_IDX], Carrier.class);
+        Collection<String> commercialJobProperties = getCommercialJob(activity, commercialJobIndex);
+        return Id.create((String) commercialJobProperties.toArray()[COMMERCIALJOB_ATTRIBUTE_CARRIER_IDX], Carrier.class);
     }
 
     static void setJobCarrier(Activity activity, int commercialJobIndex, Id<Carrier> carrier) {
-        String[] commercialJobProperties = String.valueOf(getCommercialJob(activity, commercialJobIndex)).split(COMMERCIALJOB_ATTRIBUTE_DELIMITER);
-        commercialJobProperties[COMMERCIALJOB_ATTRIBUTE_CARRIER_IDX] = carrier.toString();
-        activity.getAttributes().putAttribute(COMMERCIALJOB_ATTRIBUTE_NAME + commercialJobIndex, convertPropertiesArrayToAttributeValue(commercialJobProperties));
+        Collection<String> commercialJobProperties = getCommercialJob(activity, commercialJobIndex);
+        List<String> copy = new ArrayList<>();
+        copy.addAll(commercialJobProperties);
+        copy.set(COMMERCIALJOB_ATTRIBUTE_CARRIER_IDX, carrier.toString());
+        activity.getAttributes().putAttribute(COMMERCIALJOB_ATTRIBUTE_NAME + commercialJobIndex, copy);
     }
 
     static Set<Id<Carrier>> getExistingOperatorsForMarket(Carriers carriers, String market) {
@@ -105,7 +103,7 @@ public class JointDemandUtils {
         Map<String,Object> commercialJobs = new HashMap<>();
         activity.getAttributes().getAsMap().forEach((key, value) -> {
             if (key.startsWith(COMMERCIALJOB_ATTRIBUTE_NAME)) {
-                if (((String) value).split(COMMERCIALJOB_ATTRIBUTE_DELIMITER).length != 5)
+                if (((Collection)value).size() != 5)
                     throw new IllegalArgumentException("wrong length of commercialJob attribute for activity=" + activity);
                 commercialJobs.put(key, value);
             }
@@ -132,8 +130,8 @@ public class JointDemandUtils {
         return carriersSplitByMarket;
     }
 
-    private static Object getCommercialJob(Activity activity, int jobIndex){
-        return activity.getAttributes().getAttribute(COMMERCIALJOB_ATTRIBUTE_NAME + jobIndex);
+    private static Collection<String> getCommercialJob(Activity activity, int jobIndex){
+        return (Collection<String>) activity.getAttributes().getAttribute(COMMERCIALJOB_ATTRIBUTE_NAME + jobIndex);
     }
 
     private static String convertPropertiesArrayToAttributeValue(String[] jobProperties){
@@ -148,8 +146,8 @@ public class JointDemandUtils {
     public static void addCustomerCommercialJobAttribute(Activity activity, Id<Carrier> carrier,
                                                          int amount, double earliestStart, double latestStart, double duration) {
         int commercialJobIndex = getNumberOfJobsForActivity(activity) + 1;
-        String jobProperties = carrier + ";" + amount + ";" + earliestStart + ";" + latestStart + ";" + duration;
-        if (activity.getAttributes().getAsMap().containsKey(COMMERCIALJOB_ATTRIBUTE_NAME + commercialJobIndex)) throw new RuntimeException("");
+        List<String> jobProperties = List.of(carrier.toString(), String.valueOf(amount), String.valueOf(earliestStart), String.valueOf(latestStart), String.valueOf(duration));
+        if (activity.getAttributes().getAsMap().containsKey(COMMERCIALJOB_ATTRIBUTE_NAME + commercialJobIndex)) throw new RuntimeException("job attribute nr " + commercialJobIndex + " already exists");
         activity.getAttributes().putAttribute(COMMERCIALJOB_ATTRIBUTE_NAME + commercialJobIndex, jobProperties);
     }
 

--- a/contribs/commercialTrafficApplications/src/test/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/TestScenarioGeneration.java
+++ b/contribs/commercialTrafficApplications/src/test/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/TestScenarioGeneration.java
@@ -36,6 +36,8 @@ import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehicleUtils;
 
+import java.util.List;
+
 import static org.matsim.core.config.ConfigUtils.loadConfig;
 import static org.matsim.core.scenario.ScenarioUtils.createScenario;
 
@@ -110,7 +112,7 @@ public class TestScenarioGeneration {
         work.setLinkId(Id.createLinkId(259));
         work.setEndTime(16 * 3600);
 
-        work.getAttributes().putAttribute(JointDemandUtils.COMMERCIALJOB_ATTRIBUTE_NAME + "1", "pizza_italian;1;" + 12 * 3600 + ";" + 13 * 3600 + ";180");
+        work.getAttributes().putAttribute(JointDemandUtils.COMMERCIALJOB_ATTRIBUTE_NAME + "1", List.of("pizza_italian","1",String.valueOf(12 * 3600), String.valueOf(13 * 3600),"180"));
         plan.addActivity(work);
         plan.addLeg(PopulationUtils.createLeg(TransportMode.car));
 


### PR DESCRIPTION
Rather than using a string represenation with a convention-based delimiter, use Collection<String> as attribute type within jointDemand package. This requires reformatting of input data but is more robust.