### PR TITLE
DRT: avoid systematic (under)estimation errors of detour time loss

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearch.java
@@ -55,14 +55,15 @@ public class ExtensiveInsertionSearch implements DrtInsertionSearch<PathData> {
 		this.forkJoinPool = forkJoinPool;
 
 		insertionParams = (ExtensiveInsertionSearchParams)drtCfg.getDrtInsertionSearchParams();
-		admissibleCostCalculator = new InsertionCostCalculator<>(drtCfg, timer, penaltyCalculator, Double::doubleValue);
+		var detourTimeEstimator = DetourTimeEstimator.createFreeSpeedZonalTimeEstimator(
+				insertionParams.getAdmissibleBeelineSpeedFactor(), dvrpTravelTimeMatrix);
+		admissibleCostCalculator = new InsertionCostCalculator<>(drtCfg, timer, penaltyCalculator, Double::doubleValue,
+				detourTimeEstimator);
 
-		admissibleDetourTimesProvider = new DetourTimesProvider(
-				DetourTimeEstimator.createFreeSpeedZonalTimeEstimator(insertionParams.getAdmissibleBeelineSpeedFactor(),
-						dvrpTravelTimeMatrix));
+		admissibleDetourTimesProvider = new DetourTimesProvider(detourTimeEstimator);
 
 		bestInsertionFinder = new BestInsertionFinder<>(
-				new InsertionCostCalculator<>(drtCfg, timer, penaltyCalculator, PathData::getTravelTime));
+				new InsertionCostCalculator<>(drtCfg, timer, penaltyCalculator, PathData::getTravelTime, null));
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearch.java
@@ -53,16 +53,16 @@ public class SelectiveInsertionSearch implements DrtInsertionSearch<PathData> {
 		this.forkJoinPool = forkJoinPool;
 
 		double restrictiveBeelineSpeedFactor = ((SelectiveInsertionSearchParams)drtCfg.getDrtInsertionSearchParams()).getRestrictiveBeelineSpeedFactor();
-
-		restrictiveDetourTimesProvider = new DetourTimesProvider(
-				DetourTimeEstimator.createFreeSpeedZonalTimeEstimator(restrictiveBeelineSpeedFactor,
-						dvrpTravelTimeMatrix));
+		var detourTimeEstimator = DetourTimeEstimator.createFreeSpeedZonalTimeEstimator(restrictiveBeelineSpeedFactor,
+				dvrpTravelTimeMatrix);
+		restrictiveDetourTimesProvider = new DetourTimesProvider(detourTimeEstimator);
 
 		initialInsertionFinder = new BestInsertionFinder<>(
-				new InsertionCostCalculator<>(drtCfg, timer, penaltyCalculator, Double::doubleValue));
+				new InsertionCostCalculator<>(drtCfg, timer, penaltyCalculator, Double::doubleValue,
+						detourTimeEstimator));
 
 		bestInsertionFinder = new BestInsertionFinder<>(
-				new InsertionCostCalculator<>(drtCfg, timer, penaltyCalculator, PathData::getTravelTime));
+				new InsertionCostCalculator<>(drtCfg, timer, penaltyCalculator, PathData::getTravelTime, null));
 	}
 
 	@Override


### PR DESCRIPTION
It's mostly underestimation, because the detour TTs are computed using the dvrp free-flow TT matrix while the replaced drive TTs are path-based.

This issue had an impact on the insertion pre-filtering step. The final insertion selection is executing using precise TTs (taken from computed paths).