### PR TITLE
Cleanup and unit-test insertion detour calculation

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculator.java
@@ -135,12 +135,14 @@ public class InsertionCostCalculator<D> {
 		boolean driveToPickup = true;
 		boolean appendPickupToExistingStop = false;
 		if (pickup.newWaypoint.getLink() == pickup.previousWaypoint.getLink()) {
-			if (appendPickupToExistingStopIfSameLinkAsPrevious(vEntry, pickupIdx)) {
-				if (pickupIdx != insertion.getDropoff().index) {
-					return 0;// no detour, no additional stop duration, no existing drive task replaced
-				}
-				appendPickupToExistingStop = true;//no additional stop duration
+			//check if possible to append -> no additional stop duration
+			appendPickupToExistingStop = appendPickupToExistingStopIfSameLinkAsPrevious(vEntry, pickupIdx);
+
+			if (pickupIdx != insertion.getDropoff().index) {
+				// no detour, no existing drive task replaced
+				return appendPickupToExistingStop ? 0 : stopDuration;
 			}
+
 			driveToPickup = false;
 		}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculator.java
@@ -1,0 +1,98 @@
+package org.matsim.contrib.drt.optimizer.insertion;
+
+import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.STOP;
+
+import java.util.function.ToDoubleFunction;
+
+import javax.annotation.Nullable;
+
+import org.matsim.contrib.drt.optimizer.VehicleData;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+class InsertionDetourTimeCalculator<D> {
+	private final double stopDuration;
+	private final ToDoubleFunction<D> detourTime;
+
+	// If the detour data uses approximated detour times (e.g. beeline or matrix-based), provide the same estimator for
+	// replaced drives to avoid systematic errors
+	// When null, the replaced drive duration is derived from the schedule
+	@Nullable
+	private final DetourTimeEstimator replacedDriveTimeEstimator;
+
+	InsertionDetourTimeCalculator(double stopDuration, ToDoubleFunction<D> detourTime,
+			@Nullable DetourTimeEstimator replacedDriveTimeEstimator) {
+		this.stopDuration = stopDuration;
+		this.detourTime = detourTime;
+		this.replacedDriveTimeEstimator = replacedDriveTimeEstimator;
+	}
+
+	double calculatePickupDetourTimeLoss(InsertionWithDetourData<D> insertion) {
+		VehicleData.Entry vEntry = insertion.getVehicleEntry();
+		InsertionGenerator.InsertionPoint pickup = insertion.getPickup();
+		int pickupIdx = pickup.index;
+
+		boolean driveToPickup = true;
+		boolean appendPickupToExistingStop = false;
+		if (pickup.newWaypoint.getLink() == pickup.previousWaypoint.getLink()) {
+			//check if possible to append -> no additional stop duration
+			appendPickupToExistingStop = appendPickupToExistingStopIfSameLinkAsPrevious(vEntry, pickupIdx);
+
+			if (pickupIdx != insertion.getDropoff().index) {
+				// no detour, no existing drive task replaced
+				return appendPickupToExistingStop ? 0 : stopDuration;
+			}
+
+			driveToPickup = false;
+		}
+
+		double toPickupTT = driveToPickup ? detourTime.applyAsDouble(insertion.getDetourToPickup()) : 0;
+		double additionalStopDuration = appendPickupToExistingStop ? 0 : stopDuration;
+		double fromPickupTT = detourTime.applyAsDouble(insertion.getDetourFromPickup());
+		double replacedDriveTT = calculateReplacedDriveDuration(vEntry, pickupIdx);
+		return toPickupTT + additionalStopDuration + fromPickupTT - replacedDriveTT;
+	}
+
+	private boolean appendPickupToExistingStopIfSameLinkAsPrevious(VehicleData.Entry vEntry, int pickupIdx) {
+		if (pickupIdx > 0) {
+			return true;
+		}
+		var startTask = vEntry.start.task;
+		return startTask.isPresent() && STOP.isBaseTypeOf(startTask.get());
+	}
+
+	double calculateDropoffDetourTimeLoss(InsertionWithDetourData<D> insertion) {
+		InsertionGenerator.InsertionPoint dropoff = insertion.getDropoff();
+
+		if (dropoff.index == insertion.getPickup().index) {
+			//toDropoffTT and replacedDriveTT taken into account in pickupDetourTimeLoss
+			return stopDuration + detourTime.applyAsDouble(insertion.getDetourFromDropoff());
+		}
+
+		if (dropoff.newWaypoint.getLink() == dropoff.previousWaypoint.getLink()) {
+			return 0; // no detour, no additional stop duration
+		}
+
+		double toDropoffTT = detourTime.applyAsDouble(insertion.getDetourToDropoff());
+		double fromDropoffTT = detourTime.applyAsDouble(insertion.getDetourFromDropoff());
+		double replacedDriveTT = calculateReplacedDriveDuration(insertion.getVehicleEntry(), dropoff.index);
+		return toDropoffTT + stopDuration + fromDropoffTT - replacedDriveTT;
+	}
+
+	private double calculateReplacedDriveDuration(VehicleData.Entry vEntry, int insertionIdx) {
+		if (insertionIdx == vEntry.stops.size()) {
+			return 0;// end of route - bus would wait there
+		}
+
+		if (replacedDriveTimeEstimator != null) {
+			//use the approximated drive times instead of deriving (presumably more accurate) times from the schedule
+			return replacedDriveTimeEstimator.estimateTime(vEntry.getWaypoint(insertionIdx).getLink(),
+					vEntry.getWaypoint(insertionIdx + 1).getLink());
+		}
+
+		double replacedDriveStartTime = vEntry.getWaypoint(insertionIdx).getDepartureTime();
+		double replacedDriveEndTime = vEntry.stops.get(insertionIdx).task.getBeginTime();
+		return replacedDriveEndTime - replacedDriveStartTime;
+	}
+}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
@@ -1,0 +1,186 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.optimizer.insertion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.contrib.drt.optimizer.VehicleData.Entry;
+import org.matsim.contrib.drt.optimizer.Waypoint;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
+import org.matsim.contrib.drt.passenger.DrtRequest;
+import org.matsim.contrib.drt.schedule.DrtStopTask;
+import org.matsim.contrib.dvrp.schedule.Task;
+import org.matsim.testcases.fakes.FakeLink;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class InsertionDetourTimeCalculatorTest {
+	private static final int STOP_DURATION = 10;
+
+	private final Link fromLink = link("from");
+	private final Link toLink = link("to");
+	private final DrtRequest drtRequest = DrtRequest.newBuilder().fromLink(fromLink).toLink(toLink).build();
+
+	@Test
+	public void detourTmeLoss_start_pickup_dropoff() {
+		Waypoint.Start start = start(null, 0, link("start"));
+		Entry entry = entry(start);
+		var detour = new Detour(100., 15., null, 0.);
+		var insertion = insertion(entry, 0, 0, detour);
+
+		assertPickupDetourTimeLoss(insertion, detour.toPickup + STOP_DURATION + detour.fromPickup);
+		assertDropoffDetourTimeLoss(insertion, STOP_DURATION);
+	}
+
+	@Test
+	public void detourTmeLoss_ongoingStopAsStart_pickup_dropoff() {
+		//similar to detourTmeLoss_start_pickup_dropoff(), but the pickup is appended to the ongoing STOP task
+		Waypoint.Start start = start(new DrtStopTask(0, STOP_DURATION, fromLink), STOP_DURATION, fromLink);
+		Entry entry = entry(start);
+		var detour = new Detour(null, 15., null, 0.);//toPickup/Dropoff unused
+		var insertion = insertion(entry, 0, 0, detour);
+
+		assertPickupDetourTimeLoss(insertion, detour.fromPickup);
+		assertDropoffDetourTimeLoss(insertion, STOP_DURATION);
+	}
+
+	@Test
+	public void detourTimeLoss_start_pickup_dropoff_stop() {
+		Waypoint.Start start = start(null, 0, link("start"));
+		Waypoint.Stop stop0 = stop(10, link("stop0"));
+		Entry entry = entry(start, stop0);
+		var detour = new Detour(10., 30., null, 300.);//toDropoff unused
+		var insertion = insertion(entry, 0, 0, detour);
+
+		assertPickupDetourTimeLoss(insertion,
+				detour.toPickup + STOP_DURATION + detour.fromPickup - timeBetween(start, stop0));
+		assertDropoffDetourTimeLoss(insertion, STOP_DURATION + detour.fromDropoff);
+	}
+
+	@Test
+	public void calculatePickupDetourTimeLoss_start_pickup_stop_dropoff() {
+		Waypoint.Start start = start(null, 0, link("start"));
+		Waypoint.Stop stop0 = stop(10, link("stop0"));
+		Entry entry = entry(start, stop0);
+		var detour = new Detour(10., 30., 100., 0.);
+		var insertion = insertion(entry, 0, 1, detour);
+
+		assertPickupDetourTimeLoss(insertion,
+				detour.toPickup + STOP_DURATION + detour.fromPickup - timeBetween(start, stop0));
+		assertDropoffDetourTimeLoss(insertion, detour.toDropoff + STOP_DURATION);
+	}
+
+	@Test
+	public void calculatePickupDetourTimeLoss_start_pickup_stop_dropoff_stop() {
+		Waypoint.Start start = start(null, 0, link("start"));
+		Waypoint.Stop stop0 = stop(10, link("stop0"));
+		Waypoint.Stop stop1 = stop(200, link("stop1"));
+		Entry entry = entry(start, stop0, stop1);
+		var detour = new Detour(10., 30., 100., 150.);
+		var insertion = insertion(entry, 0, 1, detour);
+
+		assertPickupDetourTimeLoss(insertion,
+				detour.toPickup + STOP_DURATION + detour.fromPickup - timeBetween(start, stop0));
+		assertDropoffDetourTimeLoss(insertion,
+				detour.toDropoff + STOP_DURATION + detour.fromDropoff - timeBetween(stop0, stop1));
+	}
+
+	@Test
+	public void calculatePickupDetourTimeLoss_start_pickupNotAppended_stop_dropoffAppended_stop() {
+		Waypoint.Start start = start(null, 0, fromLink);//not a STOP -> pickup cannot be appended
+		Waypoint.Stop stop0 = stop(10, toLink);
+		Waypoint.Stop stop1 = stop(200, link("stop1"));
+		Entry entry = entry(start, stop0, stop1);
+		var detour = new Detour(null, null, null, null);//all unused
+		var insertion = insertion(entry, 0, 1, detour);
+
+		assertPickupDetourTimeLoss(insertion, STOP_DURATION);
+		assertDropoffDetourTimeLoss(insertion, 0);
+	}
+
+	@Test
+	public void calculatePickupDetourTimeLoss_start_stop_pickupAppended_stop_dropoffAppended() {
+		Waypoint.Start start = start(null, 0, link("start"));
+		Waypoint.Stop stop0 = stop(10, fromLink);
+		Waypoint.Stop stop1 = stop(200, toLink);
+		Entry entry = entry(start, stop0, stop1);
+		var detour = new Detour(null, null, null, null);//all unused
+		var insertion = insertion(entry, 1, 2, detour);
+
+		assertPickupDetourTimeLoss(insertion, 0);
+		assertDropoffDetourTimeLoss(insertion, 0);
+	}
+
+	private void assertPickupDetourTimeLoss(InsertionWithDetourData<Double> insertion, double expected) {
+		var detourTimeCalculator = new InsertionDetourTimeCalculator<>(STOP_DURATION, Double::doubleValue, null);
+		assertThat(detourTimeCalculator.calculatePickupDetourTimeLoss(insertion)).isEqualTo(expected);
+	}
+
+	private void assertDropoffDetourTimeLoss(InsertionWithDetourData<Double> insertion, double expected) {
+		var detourTimeCalculator = new InsertionDetourTimeCalculator<>(STOP_DURATION, Double::doubleValue, null);
+		assertThat(detourTimeCalculator.calculateDropoffDetourTimeLoss(insertion)).isEqualTo(expected);
+	}
+
+	private Link link(String id) {
+		return new FakeLink(Id.createLinkId(id));
+	}
+
+	private Waypoint.Start start(Task task, double time, Link link) {
+		return new Waypoint.Start(task, link, time, 0);
+	}
+
+	private Waypoint.Stop stop(double beginTime, Link link) {
+		return new Waypoint.Stop(new DrtStopTask(beginTime, beginTime + STOP_DURATION, link), 0);
+	}
+
+	private Entry entry(Waypoint.Start start, Waypoint.Stop... stops) {
+		return new Entry(null, start, ImmutableList.copyOf(stops));
+	}
+
+	private InsertionWithDetourData<Double> insertion(Entry entry, int pickupIdx, int dropoffIdx, Detour detour) {
+		return new InsertionWithDetourData<>(new Insertion(drtRequest, entry, pickupIdx, dropoffIdx), detour.toPickup,
+				detour.fromPickup, detour.toDropoff, detour.fromDropoff);
+	}
+
+	private static class Detour {
+		private final Double toPickup;
+		private final Double fromPickup;
+		private final Double toDropoff;
+		private final Double fromDropoff;
+
+		private Detour(Double toPickup, Double fromPickup, Double toDropoff, Double fromDropoff) {
+			this.toPickup = toPickup;
+			this.fromPickup = fromPickup;
+			this.toDropoff = toDropoff;
+			this.fromDropoff = fromDropoff;
+		}
+	}
+
+	private double timeBetween(Waypoint from, Waypoint to) {
+		return to.getArrivalTime() - from.getDepartureTime();
+	}
+}


### PR DESCRIPTION
- extract `InsertionDetourTimeCalculator` from `InsertionCostCalculator` so that the latter can be easily replaced with some other definitions (giving more flexibility wrt. the optimisation objective function)
- add unit tests for `InsertionDetourTimeCalculator`