### PR TITLE
Take carriers out of carrier module constructor

### DIFF
--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/Freight.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/Freight.java
@@ -1,16 +1,11 @@
 package org.matsim.contrib.freight;
 
-import org.matsim.contrib.freight.carrier.Carriers;
 import org.matsim.contrib.freight.controler.CarrierModule;
 import org.matsim.contrib.freight.controler.CarrierPlanStrategyManagerFactory;
 import org.matsim.contrib.freight.controler.CarrierScoringFunctionFactory;
 import org.matsim.contrib.freight.usecases.chessboard.CarrierScoringFunctionFactoryImpl;
-import org.matsim.contrib.freight.utils.FreightUtils;
-import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.AllowsConfiguration;
-import org.matsim.core.controler.Controler;
-import org.matsim.core.gbl.Gbl;
 
 public class Freight{
 	// yyyy todo:
@@ -19,27 +14,27 @@ public class Freight{
 	// * repair execution path where config instead of scenario is given to controler
 
 	public static void configure( AllowsConfiguration ao ) {
-		Gbl.assertIf( ao instanceof Controler);  // we need the scenario; otherwise find other way
-		Controler controler = (Controler) ao;
-		Carriers carriers = FreightUtils.getCarriers( controler.getScenario() );
-		FreightConfigGroup freightConfig = ConfigUtils.addOrGetModule( controler.getConfig(), FreightConfigGroup.class );;
-		if ( true ){
-			freightConfig.setTimeWindowHandling( FreightConfigGroup.TimeWindowHandling.enforceBeginnings );
-		} else{
-			freightConfig.setTimeWindowHandling( FreightConfigGroup.TimeWindowHandling.ignore );
-		}
-		final CarrierModule carrierModule = new CarrierModule( );
-		ao.addOverridingModule( carrierModule ) ;
+//		Gbl.assertIf( ao instanceof Controler);  // we need the scenario; otherwise find other way
+//		Controler controler = (Controler) ao;
+//		FreightConfigGroup freightConfig = ConfigUtils.addOrGetModule( controler.getConfig(), FreightConfigGroup.class );;
+//		if ( true ){
+//			freightConfig.setTimeWindowHandling( FreightConfigGroup.TimeWindowHandling.enforceBeginnings );
+//		} else{
+//			freightConfig.setTimeWindowHandling( FreightConfigGroup.TimeWindowHandling.ignore );
+//		}
+		ao.addOverridingModule( new CarrierModule( ) ) ;
 
 		ao.addOverridingModule( new AbstractModule(){
 			@Override
 			public void install(){
-				// yyyy these two are just quick fixes in order to get the material up and running without having it all in the run script.
-				bind( CarrierPlanStrategyManagerFactory.class ).toInstance( () -> null );
 				bind( CarrierScoringFunctionFactory.class ).to( CarrierScoringFunctionFactoryImpl.class  ) ;
+
+				// yyyy in the long run, needs to be done differently (establish strategy manager as fixed infrastructure; have user code register strategies there).
+				// kai/kai, jan'21
+				bind( CarrierPlanStrategyManagerFactory.class ).toInstance( () -> null );
 			}
 		} ) ;
-
+		
 	}
 
 }

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/Freight.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/Freight.java
@@ -28,7 +28,7 @@ public class Freight{
 		} else{
 			freightConfig.setTimeWindowHandling( FreightConfigGroup.TimeWindowHandling.ignore );
 		}
-		final CarrierModule carrierModule = new CarrierModule( carriers );
+		final CarrierModule carrierModule = new CarrierModule( );
 		ao.addOverridingModule( carrierModule ) ;
 
 		ao.addOverridingModule( new AbstractModule(){

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/CarrierModule.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/CarrierModule.java
@@ -46,34 +46,29 @@ import java.util.List;
 
 public class CarrierModule extends AbstractModule {
 
-	private FreightConfigGroup freightConfig;
-
-	private Carriers carriers;
 	private CarrierPlanStrategyManagerFactory strategyManagerFactory;
 	private CarrierScoringFunctionFactory scoringFunctionFactory;
 
-
 	public CarrierModule() {
-
 	}
 
+//	/**
+//	 * CarrierPlanStrategyManagerFactory and CarrierScoringFunctionFactory must be bound separately
+//	 * when this constructor is used.
+//	 *
+//	 * @deprecated please use FreightUtils.getCarriers(Scenario scenario) to load carriers into scenario and use CarrierModule()
+//	 */
+//	@Deprecated
+//	public CarrierModule(Carriers carriers) {
+//		this.carriers = carriers;
+//	}
+
 	/**
-	 * CarrierPlanStrategyManagerFactory and CarrierScoringFunctionFactory must be bound separately
-	 * when this constructor is used.
-	 *
 	 * @deprecated please use FreightUtils.getCarriers(Scenario scenario) to load carriers into scenario and use CarrierModule()
 	 */
 	@Deprecated
-	public CarrierModule(Carriers carriers) {
-		this.carriers = carriers;
-	}
-
-	/**
-	 * @deprecated please use FreightUtils.getCarriers(Scenario scenario) to load carriers into scenario and use CarrierModule()
-	 */
-	@Deprecated
-	public CarrierModule(Carriers carriers, CarrierPlanStrategyManagerFactory strategyManagerFactory, CarrierScoringFunctionFactory scoringFunctionFactory) {
-		this.carriers = carriers;
+	public CarrierModule(CarrierPlanStrategyManagerFactory strategyManagerFactory, CarrierScoringFunctionFactory scoringFunctionFactory) {
+//		this.carriers = carriers;
 		this.strategyManagerFactory = strategyManagerFactory;
 		this.scoringFunctionFactory = scoringFunctionFactory;
 	}
@@ -81,7 +76,7 @@ public class CarrierModule extends AbstractModule {
 	@Override public void install() {
 		FreightConfigGroup freightConfig = ConfigUtils.addOrGetModule( getConfig(), FreightConfigGroup.class ) ;
 
-		bind(Carriers.class).toProvider(new CarrierProvider()).asEagerSingleton(); // needs to be eager since it is still scenario construction. kai, oct'19
+		bind(Carriers.class).toProvider( new CarrierProvider() ).asEagerSingleton(); // needs to be eager since it is still scenario construction. kai, oct'19
 		// this is probably ok
 
 		if (strategyManagerFactory != null) {
@@ -156,17 +151,17 @@ public class CarrierModule extends AbstractModule {
 	}
 
 
-	private class CarrierProvider implements Provider<Carriers> {
+	private static class CarrierProvider implements Provider<Carriers> {
 		@Inject Scenario scenario;
 		@Override public Carriers get() {
-			if ( carriers!=null ){
-				if ( scenario.getScenarioElement( FreightUtils.CARRIERS ) != null ) {
-					throw new RuntimeException("carriers are provided as scenario element AND per the CarrierModule constructor.  I could check if " +
-										     "they are the same, but in general the second way to do this is deprecated so please put " +
-										     "null into your constructor (and expect more cleanup here).") ;
-				}
-				scenario.addScenarioElement( FreightUtils.CARRIERS, carriers );
-			}
+//			if ( carriers!=null ){
+//				if ( scenario.getScenarioElement( FreightUtils.CARRIERS ) != null ) {
+//					throw new RuntimeException("carriers are provided as scenario element AND per the CarrierModule constructor.  I could check if " +
+//										     "they are the same, but in general the second way to do this is deprecated so please put " +
+//										     "null into your constructor (and expect more cleanup here).") ;
+//				}
+//				scenario.addScenarioElement( FreightUtils.CARRIERS, carriers );
+//			}
 			return FreightUtils.getCarriers(scenario);
 		}
 	}

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/usecases/chessboard/RunPassengerAlongWithCarriers.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/usecases/chessboard/RunPassengerAlongWithCarriers.java
@@ -68,7 +68,7 @@ final class RunPassengerAlongWithCarriers {
 		CarrierPlanStrategyManagerFactory strategyManagerFactory = new MyCarrierPlanStrategyManagerFactory(types);
 		CarrierScoringFunctionFactory scoringFunctionFactory = createScoringFunctionFactory(scenario.getNetwork());
 
-		CarrierModule carrierController = new CarrierModule(carriers, strategyManagerFactory, scoringFunctionFactory);
+		CarrierModule carrierController = new CarrierModule( strategyManagerFactory, scoringFunctionFactory);
 
 		controler.addOverridingModule(carrierController);
 		prepareFreightOutputDataAndStats(scenario, controler.getEvents(), controler, carriers);

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/usecases/chessboard/RunPassengerAlongWithCarriers.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/usecases/chessboard/RunPassengerAlongWithCarriers.java
@@ -10,6 +10,7 @@ import org.matsim.contrib.freight.usecases.analysis.LegHistogram;
 import org.matsim.contrib.freight.usecases.chessboard.CarrierScoringFunctionFactoryImpl.DriversActivityScoring;
 import org.matsim.contrib.freight.usecases.chessboard.CarrierScoringFunctionFactoryImpl.DriversLegScoring;
 import org.matsim.contrib.freight.usecases.chessboard.CarrierScoringFunctionFactoryImpl.VehicleEmploymentScoring;
+import org.matsim.contrib.freight.utils.FreightUtils;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
@@ -90,6 +91,7 @@ final class RunPassengerAlongWithCarriers {
 			prepareConfig() ;
 		}
 		scenario = ScenarioUtils.loadScenario( config ) ;
+		FreightUtils.getOrCreateCarriers( scenario );
 		return scenario ;
 	}
 

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/utils/FreightUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/utils/FreightUtils.java
@@ -208,8 +208,7 @@ public class FreightUtils {
 	 * @param scenario
 	 */
 	public static void loadCarriersAccordingToFreightConfig(Scenario scenario) {
-		FreightConfigGroup freightConfigGroup = ConfigUtils.addOrGetModule(scenario.getConfig(),
-				FreightConfigGroup.class);
+		FreightConfigGroup freightConfigGroup = ConfigUtils.addOrGetModule(scenario.getConfig(), FreightConfigGroup.class);
 
 		Carriers carriers = getOrCreateCarriers( scenario ); // also registers with scenario
 		new CarrierPlanXmlReader( carriers ).readURL( IOUtils.extendUrl(scenario.getConfig().getContext(), freightConfigGroup.getCarriersFile()) );

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/utils/FreightUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/utils/FreightUtils.java
@@ -58,8 +58,7 @@ public class FreightUtils {
 	 * From the outside, rather use {@link FreightUtils#getCarriers(Scenario)} .
 	 * This string constant will eventually become private.
 	 */
-	@Deprecated
-	public static final String CARRIERS = "carriers";
+	private static final String CARRIERS = "carriers";
 	private static final String CARRIERVEHICLETYPES = "carrierVehicleTypes";
 	private static final Logger log = Logger.getLogger(FreightUtils.class);
 
@@ -190,6 +189,10 @@ public class FreightUtils {
 		// I have separated getOrCreateCarriers and getCarriers, since when the
 		// controler is started, it is better to fail if the carriers are not found.
 		// kai, oct'19
+		if ( scenario.getScenarioElement( CARRIERS ) == null ) {
+			throw new RuntimeException( "\n\ncannot retrieve carriers from scenario; typical ways to resolve that problem are to call " +
+								    "FreightUtils.getOrCreateCarriers(...) or FreightUtils.loadCarriersAccordingToFreightConfig(...) early enough\n") ;
+		}
 		return (Carriers) scenario.getScenarioElement(CARRIERS);
 	}
 

--- a/contribs/freight/src/test/java/org/matsim/contrib/freight/carrier/CarrierModuleTest.java
+++ b/contribs/freight/src/test/java/org/matsim/contrib/freight/carrier/CarrierModuleTest.java
@@ -96,7 +96,7 @@ public class CarrierModuleTest {
     @Test
     public void test_ConstructorWithOneParameter(){
 	    // note setUp method!
-        controler.addOverridingModule(new CarrierModule(null));
+        controler.addOverridingModule(new CarrierModule());
         controler.addOverridingModule(new AbstractModule() {
             @Override
             public void install() {
@@ -110,7 +110,7 @@ public class CarrierModuleTest {
     @Test
     public void test_ConstructorWithThreeParameters(){
 	    // note setUp method!
-        controler.addOverridingModule(new CarrierModule(null, new StrategyManagerFactoryForTests(),
+        controler.addOverridingModule(new CarrierModule(new StrategyManagerFactoryForTests(),
 		    new DistanceScoringFunctionFactoryForTests()));
         controler.run();
     }


### PR DESCRIPTION
and clean up things afterwards.
---
This avoids that carriers can be registered on twice ways and it is unclear what do do.