### PR TITLE
Delay LastEventOfSimStep

### DIFF
--- a/matsim/src/main/java/org/matsim/core/events/SimStepParallelEventsManagerImpl.java
+++ b/matsim/src/main/java/org/matsim/core/events/SimStepParallelEventsManagerImpl.java
@@ -35,7 +35,6 @@ import java.util.Queue;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -128,15 +127,15 @@ class SimStepParallelEventsManagerImpl implements EventsManager {
 		for (EventsManager eventsManager : this.eventsManagers) eventsManager.initProcessing();
 
 		Queue<Event>[] eventsQueuesArray = new Queue[this.numOfThreads];
-		List<Queue<Event>> eventsQueues = new ArrayList<Queue<Event>>();
+		List<Queue<Event>> eventsQueues = new ArrayList<>();
 		for (int i = 0; i < numOfThreads; i++) {
 			Queue<Event> eventsQueue = new LinkedBlockingQueue<>();
 			eventsQueues.add(eventsQueue);
 			eventsQueuesArray[i] = eventsQueue;
 		}
-				
+
 		/*
-		 * Add a null entry to the list which will be set as nextEventsQueue in the last ProcessEventsThread. 
+		 * Add a null entry to the list which will be set as nextEventsQueue in the last ProcessEventsThread.
 		 */
 		eventsQueues.add(null);
 		
@@ -226,9 +225,8 @@ class SimStepParallelEventsManagerImpl implements EventsManager {
 		}
 		
 		try {
-			Gbl.assertNotNull( this.processedEventsChecker );
+			Gbl.assertNotNull(this.processedEventsChecker);
 			this.processedEventsChecker.setTime(time);
-			this.processEvent(new LastEventOfSimStep(time));
 			simStepEndBarrier.await();
 		} catch (InterruptedException | BrokenBarrierException e) {
 			throw new RuntimeException(e);

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSim.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSim.java
@@ -20,20 +20,7 @@
 
 package org.matsim.core.mobsim.qsim;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
-
-import javax.inject.Inject;
-
+import com.google.inject.Injector;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.IdMap;
@@ -47,6 +34,7 @@ import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.groups.QSimConfigGroup;
 import org.matsim.core.config.groups.QSimConfigGroup.EndtimeInterpretation;
 import org.matsim.core.events.EventsUtils;
+import org.matsim.core.events.LastEventOfSimStep;
 import org.matsim.core.gbl.Gbl;
 import org.matsim.core.mobsim.framework.AgentSource;
 import org.matsim.core.mobsim.framework.HasPerson;
@@ -54,13 +42,8 @@ import org.matsim.core.mobsim.framework.MobsimAgent;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.mobsim.framework.listeners.MobsimListener;
 import org.matsim.core.mobsim.qsim.changeeventsengine.NetworkChangeEventsEngineI;
-import org.matsim.core.mobsim.qsim.interfaces.ActivityHandler;
 import org.matsim.core.mobsim.qsim.interfaces.AgentCounter;
-import org.matsim.core.mobsim.qsim.interfaces.DepartureHandler;
-import org.matsim.core.mobsim.qsim.interfaces.MobsimEngine;
-import org.matsim.core.mobsim.qsim.interfaces.MobsimVehicle;
-import org.matsim.core.mobsim.qsim.interfaces.Netsim;
-import org.matsim.core.mobsim.qsim.interfaces.NetsimNetwork;
+import org.matsim.core.mobsim.qsim.interfaces.*;
 import org.matsim.core.mobsim.qsim.qnetsimengine.NetsimEngine;
 import org.matsim.core.mobsim.qsim.qnetsimengine.QNetsimEngineI;
 import org.matsim.core.network.NetworkChangeEvent;
@@ -76,7 +59,10 @@ import org.matsim.vis.snapshotwriters.VisMobsim;
 import org.matsim.vis.snapshotwriters.VisNetwork;
 import org.matsim.withinday.mobsim.WithinDayEngine;
 
-import com.google.inject.Injector;
+import javax.inject.Inject;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * This has developed over the last couple of months/years towards an increasingly pluggable module.  The current (dec'2011)
@@ -401,32 +387,41 @@ public final class QSim extends Thread implements VisMobsim, Netsim, ActivityEnd
 		// "added" engines
 		for (MobsimEngine mobsimEngine : this.mobsimEngines) {
 			if (analyzeRunTimes) this.startClockTime = System.nanoTime();
-			
+
 			// withindayEngine.doSimStep(time) has already been called
 			if (mobsimEngine == this.withindayEngine) continue;
 
 			mobsimEngine.doSimStep(now);
-			
-			if (analyzeRunTimes) this.mobsimEngineRunTimes.get(mobsimEngine).addAndGet(System.nanoTime() - this.startClockTime);
+
+			if (analyzeRunTimes)
+				this.mobsimEngineRunTimes.get(mobsimEngine).addAndGet(System.nanoTime() - this.startClockTime);
 		}
 
 		if (analyzeRunTimes) this.startClockTime = System.nanoTime();
-		
+
 		// console printout:
 		this.printSimLog(now);
-		boolean doContinue =  (this.agentCounter.isLiving() && (this.stopTime > now));
-		this.events.afterSimStep(now);
+
+		// trigger the after sim step listeners before finishing the events processing of this sim step.
+		// this gives after sim step listeners like snapshot generator the opportunity to generate events
+		// for the current time step.
 		this.listenerManager.fireQueueSimulationAfterSimStepEvent(now);
+		// this triggers finishing of parallel events processing
+		this.events.processEvent(new LastEventOfSimStep(now));
+		// this awaits finishing of parallel events processing
+		this.events.afterSimStep(now);
+
 
 		final QSimConfigGroup qsimConfigGroup = this.scenario.getConfig().qsim();
-		if ( qsimConfigGroup.getSimEndtimeInterpretation()==EndtimeInterpretation.onlyUseEndtime ) {
+		boolean doContinue = (this.agentCounter.isLiving() && (this.stopTime > now));
+		if (qsimConfigGroup.getSimEndtimeInterpretation() == EndtimeInterpretation.onlyUseEndtime) {
 			doContinue = now <= qsimConfigGroup.getEndTime().seconds();
 		}
 
 		if (doContinue) {
 			this.simTimer.incrementTime();
 		}
-		
+
 		if (analyzeRunTimes) this.qSimInternalTime += System.nanoTime() - this.startClockTime;
 
 		return doContinue;

--- a/matsim/src/test/java/org/matsim/core/events/SimStepParallelEventsManagerImplTest.java
+++ b/matsim/src/test/java/org/matsim/core/events/SimStepParallelEventsManagerImplTest.java
@@ -49,27 +49,30 @@ public class SimStepParallelEventsManagerImplTest {
 			}
 
 			@Override
-			public void reset(int iteration) {}
+			public void reset(int iteration) {
+			}
 		});
 		EventsCollector collector = new EventsCollector();
 		events.addHandler(collector);
 		events.initProcessing();
 		events.processEvent(new LinkEnterEvent(0.0, Id.createVehicleId(0), Id.createLinkId(0)));
 		events.processEvent(new LinkLeaveEvent(0.0, Id.createVehicleId(0), Id.createLinkId(0)));
+		events.processEvent(new LastEventOfSimStep(0));
 		events.afterSimStep(0.0);
 		events.processEvent(new LinkEnterEvent(1.0, Id.createVehicleId(0), Id.createLinkId(0)));
 		events.processEvent(new LinkLeaveEvent(1.0, Id.createVehicleId(0), Id.createLinkId(0)));
+		events.processEvent(new LastEventOfSimStep(1));
 		events.afterSimStep(1.0);
 		events.finishProcessing();
 
 		assertThat(collector.getEvents(),
-			contains(
-					new LinkEnterEvent(0.0, Id.createVehicleId(0), Id.createLinkId(0)),
-					new LinkLeaveEvent(0.0, Id.createVehicleId(0), Id.createLinkId(0)),
-					new PersonStuckEvent(0.0, Id.createPersonId(0), Id.createLinkId(0), "car"),
-					new LinkEnterEvent(1.0, Id.createVehicleId(0), Id.createLinkId(0)),
-					new LinkLeaveEvent(1.0, Id.createVehicleId(0), Id.createLinkId(0)),
-					new PersonStuckEvent(1.0, Id.createPersonId(0), Id.createLinkId(0), "car")));
+				contains(
+						new LinkEnterEvent(0.0, Id.createVehicleId(0), Id.createLinkId(0)),
+						new LinkLeaveEvent(0.0, Id.createVehicleId(0), Id.createLinkId(0)),
+						new PersonStuckEvent(0.0, Id.createPersonId(0), Id.createLinkId(0), "car"),
+						new LinkEnterEvent(1.0, Id.createVehicleId(0), Id.createLinkId(0)),
+						new LinkLeaveEvent(1.0, Id.createVehicleId(0), Id.createLinkId(0)),
+						new PersonStuckEvent(1.0, Id.createPersonId(0), Id.createLinkId(0), "car")));
 	}
 
 }


### PR DESCRIPTION
Delay the LastEventOfSimStep to after calling MobsimAfterSimStepListeners, so that such listeners may issue events themselves.

Before, the events manager had marked the sim step as finished and didn't accept events with the time stamp of the last sim step from those listeners. This became relevant while generating emission events for each sim step

@kainagel I think it is okay, to reverse the order of 
```
this.events.afterSimStep(now);
this.listenerManager.fireQueueSimulationAfterSimStepEvent(now);
```
to 
```
this.listenerManager.fireQueueSimulationAfterSimStepEvent(now);
this.events.processEvent(new LastEventOfSimStep(now));
this.events.afterSimStep(now);
```
The AfterSimStepListeners shouldn't care about the EventsManager finishing up the current sim step. But it gives us the opportunity to issue events from the AfterSimStepListeners.