### PR TITLE
fix: remove time-based termination criteria from multi insertion path calculator

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/MultiInsertionDetourPathCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/MultiInsertionDetourPathCalculator.java
@@ -97,9 +97,7 @@ public class MultiInsertionDetourPathCalculator implements DetourPathCalculator,
 		double earliestPickupTime = drtRequest.getEarliestStartTime(); // optimistic
 		Collection<Link> toLinks = getDetourLinks(filteredInsertions.stream(),
 				insertion -> insertion.pickup.previousWaypoint.getLink());
-		double maxTravelTime = drtRequest.getLatestStartTime() - earliestPickupTime;
-		return toPickupPathSearch.calcPathDataMap(drtRequest.getFromLink(), toLinks, earliestPickupTime, false,
-				maxTravelTime);
+		return toPickupPathSearch.calcPathDataMap(drtRequest.getFromLink(), toLinks, earliestPickupTime, false);
 	}
 
 	private Map<Link, PathData> calcPathsFromPickup(DrtRequest drtRequest, List<Insertion> filteredInsertions) {
@@ -107,8 +105,7 @@ public class MultiInsertionDetourPathCalculator implements DetourPathCalculator,
 		double earliestPickupTime = drtRequest.getEarliestStartTime(); // optimistic
 		Collection<Link> toLinks = getDetourLinks(filteredInsertions.stream(),
 				insertion -> insertion.pickup.nextWaypoint.getLink());
-		return fromPickupPathSearch.calcPathDataMap(drtRequest.getFromLink(), toLinks, earliestPickupTime, true,
-				maxTravelTime(drtRequest));
+		return fromPickupPathSearch.calcPathDataMap(drtRequest.getFromLink(), toLinks, earliestPickupTime, true);
 	}
 
 	private Map<Link, PathData> calcPathsToDropoff(DrtRequest drtRequest, List<Insertion> filteredInsertions) {
@@ -117,8 +114,7 @@ public class MultiInsertionDetourPathCalculator implements DetourPathCalculator,
 		Collection<Link> toLinks = getDetourLinks(filteredInsertions.stream()
 						.filter(insertion -> !(insertion.dropoff.previousWaypoint instanceof Waypoint.Pickup)),
 				insertion -> insertion.dropoff.previousWaypoint.getLink());
-		return toDropoffPathSearch.calcPathDataMap(drtRequest.getToLink(), toLinks, latestDropoffTime, false,
-				maxTravelTime(drtRequest));
+		return toDropoffPathSearch.calcPathDataMap(drtRequest.getToLink(), toLinks, latestDropoffTime, false);
 	}
 
 	private Map<Link, PathData> calcPathsFromDropoff(DrtRequest drtRequest, List<Insertion> filteredInsertions) {
@@ -127,12 +123,7 @@ public class MultiInsertionDetourPathCalculator implements DetourPathCalculator,
 		Collection<Link> toLinks = getDetourLinks(filteredInsertions.stream()
 						.filter(insertion -> !(insertion.dropoff.nextWaypoint instanceof Waypoint.End)),
 				insertion -> insertion.dropoff.nextWaypoint.getLink());
-		return fromDropoffPathSearch.calcPathDataMap(drtRequest.getToLink(), toLinks, latestDropoffTime, true,
-				maxTravelTime(drtRequest));
-	}
-
-	private double maxTravelTime(DrtRequest request) {
-		return request.getLatestArrivalTime() - request.getEarliestStartTime();
+		return fromDropoffPathSearch.calcPathDataMap(drtRequest.getToLink(), toLinks, latestDropoffTime, true);
 	}
 
 	private Collection<Link> getDetourLinks(Stream<Insertion> filteredInsertions,


### PR DESCRIPTION
It does not work properly with relaxed max wait/travel time rejections.

After this fix the one-to-many path search reaches further, so some slight increase in computation time may be observed.