### PR TITLE
handle TransitQVehicles in SituationalFlowEfficiencyImpact examples

### DIFF
--- a/contribs/vsp/src/main/java/playground/vsp/flowEfficiency/AVFlowEfficiencyImpact.java
+++ b/contribs/vsp/src/main/java/playground/vsp/flowEfficiency/AVFlowEfficiencyImpact.java
@@ -23,6 +23,7 @@ package playground.vsp.flowEfficiency;
 import com.google.common.base.Preconditions;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
+import org.matsim.core.mobsim.qsim.pt.TransitQVehicle;
 import org.matsim.core.mobsim.qsim.qnetsimengine.QVehicle;
 import org.matsim.lanes.Lane;
 import org.matsim.vehicles.VehicleType;
@@ -46,6 +47,10 @@ public class AVFlowEfficiencyImpact implements SituationalFlowEfficiencyImpact {
 
 	@Override
 	public double calculateFlowEfficiency(QVehicle qVehicle, @Nullable QVehicle previousQVehicle, @Nullable Double timeGapToPreviousVeh, Link link, Id<Lane> laneId) {
+
+		// currently, we can not call chooseNextLinkId for TransitQVehicles because no link Id caching is performed!
+		if(qVehicle instanceof TransitQVehicle) { return 1;}
+
 		Id<Link> nextLinkId = qVehicle.getDriver().chooseNextLinkId();
 		if(nextLinkId != null && //vehicle is not arriving
 				this.autonomousVehicleTypes.contains(qVehicle.getVehicle().getType())){

--- a/contribs/vsp/src/main/java/playground/vsp/flowEfficiency/BunchingFlowEfficencyImpact.java
+++ b/contribs/vsp/src/main/java/playground/vsp/flowEfficiency/BunchingFlowEfficencyImpact.java
@@ -23,6 +23,7 @@ package playground.vsp.flowEfficiency;
 import com.google.common.base.Preconditions;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
+import org.matsim.core.mobsim.qsim.pt.TransitQVehicle;
 import org.matsim.core.mobsim.qsim.qnetsimengine.QVehicle;
 import org.matsim.lanes.Lane;
 import org.matsim.vehicles.VehicleType;
@@ -56,6 +57,9 @@ public class BunchingFlowEfficencyImpact implements SituationalFlowEfficiencyImp
 	@Override
 	public double calculateFlowEfficiency(QVehicle qVehicle, @Nullable QVehicle previousQVehicle, @Nullable Double timeGapToPreviousVeh, Link link, Id<Lane> laneId) {
 
+		// currently, we can not call chooseNextLinkId for TransitQVehicles because no link Id caching is performed!
+		if(qVehicle instanceof TransitQVehicle) { return 1;}
+
 		//querying the next link id forces the driver to take it (diversion can only take place after next link)
 		//this might change drt performance
 		Id<Link> nextLinkId = qVehicle.getDriver().chooseNextLinkId();
@@ -65,9 +69,10 @@ public class BunchingFlowEfficencyImpact implements SituationalFlowEfficiencyImp
 		double flowCapPerSecond = link.getFlowCapacityPerSec();
 		double standardMinTimeGap = 1 / flowCapPerSecond;
 
-		if(timeGapToPreviousVeh < standardMinTimeGap * toleratedTimeGapDeviationFactor &&
-				this.bunchableVehicleTypes.contains(qVehicle.getVehicle().getType()) &&
-				this.bunchableVehicleTypes.contains(previousQVehicle.getVehicle().getType())){
+		if(timeGapToPreviousVeh < standardMinTimeGap * toleratedTimeGapDeviationFactor && //is the time gap between the two vehicles small enough?
+				this.bunchableVehicleTypes.contains(qVehicle.getVehicle().getType()) && //are the two vehicles able to bunch? (i.e. can they communicate or whatever..)
+				this.bunchableVehicleTypes.contains(previousQVehicle.getVehicle().getType()) &&
+				previousQVehicle.getCurrentLink().getId().equals(nextLinkId)){ // do they drive in the same direction?
 
 			if(link.getAttributes().getAttribute("turns") != null){
 				Map<String, String> turns = (Map<String, String>) link.getAttributes().getAttribute("turns");
@@ -75,11 +80,6 @@ public class BunchingFlowEfficencyImpact implements SituationalFlowEfficiencyImp
 				Preconditions.checkNotNull(direction, "could not find toLinkId=" + nextLinkId + " in turns map of link " + link);
 
 				if(direction.equals(TurnDirection.STRAIGHT.toString())){ //bunching only in straight direction
-					/*careful: if you attend to allow bunching factors for turns, be aware that you only know about the direction of the currently investigated qVehicle
-					* and not about the direction of the previous vehicle!
-					* you would have to make assumptions about timeGapToPreviousVeh being small (what actually is already incorporated above) and call previousQVehicle.getCurrentLink()
-					* to query turns map and find out in which direction the previous vehicle drove.
-					*/
 					return impact;
 				}
 			} else {


### PR DESCRIPTION
Currently, TransitQVehicle.getDriver().chooseNextLinkId() must not be called several times (in a row). So we need to handle transit vehicles explicitly and can not model impacts of the direction on flow efficiency. See also #1338 for a discussion point.