### PR TITLE
use 13.0-SNAPSHOT instead of matsim.version var as version in POMs

### DIFF
--- a/contribs/freight/pom.xml
+++ b/contribs/freight/pom.xml
@@ -10,7 +10,6 @@
 	<name>freight</name>
 
 	<properties>
-		<matsim.version>13.0-SNAPSHOT</matsim.version>
 		<jsprit.version>1.8</jsprit.version>
 	</properties>
 
@@ -81,13 +80,13 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>roadpricing</artifactId>
-			<version>${matsim.version}</version>
+			<version>13.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>otfvis</artifactId>
-			<version>${matsim.version}</version>
+			<version>13.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
@@ -111,7 +110,7 @@
 		<dependency>
 			<groupId>org.matsim</groupId>
 			<artifactId>matsim-examples</artifactId>
-			<version>${matsim.version}</version>
+			<version>13.0-SNAPSHOT</version>
 		</dependency>
 
 	</dependencies>

--- a/contribs/integration/pom.xml
+++ b/contribs/integration/pom.xml
@@ -12,17 +12,6 @@
 		<version>13.0-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<!--release:-->
-		<!--		<matsim.version>11.0</matsim.version>-->
-
-		<!--weekly "release" (recommended):-->
-		<!--<matsim.version>0.11.0-2019w01-SNAPSHOT</matsim.version>-->
-
-		<!--development head:-->
-		<matsim.version>13.0-SNAPSHOT</matsim.version>
-	</properties>
-
 	<build>
 		<plugins>
 			<plugin>
@@ -91,7 +80,7 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>accessibility</artifactId>
-			<version>${matsim.version}</version>
+			<version>13.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.geotools.jdbc</groupId>
@@ -100,18 +89,18 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>analysis</artifactId>
-			<version>${matsim.version}</version>
+			<version>13.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>dvrp</artifactId>
-			<version>${matsim.version}</version>
+			<version>13.0-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>drt</artifactId>
-			<version>${matsim.version}</version>
+			<version>13.0-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/contribs/vsp/pom.xml
+++ b/contribs/vsp/pom.xml
@@ -11,57 +11,53 @@
 	<artifactId>vsp</artifactId>
 	<name>vsp</name>
 
-	<properties>
-		<matsim.version>13.0-SNAPSHOT</matsim.version>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>multimodal</artifactId>
-			<version>${matsim.version}</version>
+			<version>13.0-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>taxi</artifactId>
-			<version>${matsim.version}</version>
+			<version>13.0-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>dvrp</artifactId>
-			<version>${matsim.version}</version>
+			<version>13.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>parking</artifactId>
-			<version>${matsim.version}</version>
+			<version>13.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>accessibility</artifactId>
-			<version>${matsim.version}</version>
+			<version>13.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>emissions</artifactId>
-			<version>${matsim.version}</version>
+			<version>13.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>minibus</artifactId>
-			<version>${matsim.version}</version>
+			<version>13.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>common</artifactId>
-			<version>${matsim.version}</version>
+			<version>13.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>analysis</artifactId>
-			<version>${matsim.version}</version>
+			<version>13.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.processing</groupId>
@@ -81,7 +77,7 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>otfvis</artifactId>
-			<version>${matsim.version}</version>
+			<version>13.0-SNAPSHOT</version>
 		</dependency>
 <!--		<dependency>-->
 <!--			<groupId>org.apache.commons</groupId>-->
@@ -91,12 +87,12 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>noise</artifactId>
-			<version>${matsim.version}</version>
+			<version>13.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>signals</artifactId>
-			<version>${matsim.version}</version>
+			<version>13.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.openstreetmap.osmosis</groupId>
@@ -141,7 +137,7 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>cadytsIntegration</artifactId>
-			<version>${matsim.version}</version>
+			<version>13.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
@@ -170,12 +166,12 @@
 		<dependency>
 			<groupId>org.matsim</groupId>
 			<artifactId>matsim-examples</artifactId>
-			<version>${matsim.version}</version>
+			<version>13.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>drt</artifactId>
-			<version>${matsim.version}</version>
+			<version>13.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.openjfx</groupId>


### PR DESCRIPTION
a potential fix for https://github.com/matsim-org/matsim-libs/issues/1343#issuecomment-760895531