### PR TITLE
Make EmissionToolOfflineExamples writing output again

### DIFF
--- a/contribs/emissions/scenarios/sampleScenario/testv2_Vehv1/config_average.xml
+++ b/contribs/emissions/scenarios/sampleScenario/testv2_Vehv1/config_average.xml
@@ -39,6 +39,13 @@
 		<!-- following should eventually become default but currently is not: -->
 		<param name="hbefaRoadTypeSource" value="fromLinkAttributes" />
 
+		<!-- Each vehicle in matsim points to a VehicleType.  For the emissions package to work,
+			each VehicleType needs to contain corresponding information.  This switch
+			determines _where_ in VehicleType that information is contained.
+			default: HbefaVehicleDescriptionSource.asEngineInformationAttributes -->
+		<param name="hbefaVehicleDescriptionSource" value="fromVehicleTypeDescription"/>
+
+
 	</module>
 
 <!-- ====================================================================== -->

--- a/contribs/emissions/scenarios/sampleScenario/testv2_Vehv1/config_detailed.xml
+++ b/contribs/emissions/scenarios/sampleScenario/testv2_Vehv1/config_detailed.xml
@@ -45,6 +45,12 @@
 
 		<!-- if true then detailed emission factor files must be provided! -->
 		<param name="usingDetailedEmissionCalculation" value="true" />
+
+		<!-- Each vehicle in matsim points to a VehicleType.  For the emissions package to work,
+			each VehicleType needs to contain corresponding information.  This switch
+			determines _where_ in VehicleType that information is contained.
+			default: HbefaVehicleDescriptionSource.asEngineInformationAttributes -->
+		<param name="hbefaVehicleDescriptionSource" value="fromVehicleTypeDescription"/>
 	</module>
 
 <!-- ====================================================================== -->


### PR DESCRIPTION
by adding `eventsManager.initProcessing()` and `eventsManager.finishProcessing(), see #1342 

Also done: 
- Align the code of both offlineExamples;
- add a note for usage of old EventsManager (if using larger scenarios with more events) see: #1091   
- add config parameter to the testv2_Vehv1 configs, to ensure that the hbefaVehicleDescription is read correctly
