### PR TITLE
Convert empty collection and empty map object attributes

### DIFF
--- a/matsim/src/main/java/org/matsim/utils/objectattributes/ObjectAttributesConverter.java
+++ b/matsim/src/main/java/org/matsim/utils/objectattributes/ObjectAttributesConverter.java
@@ -100,11 +100,17 @@ public class ObjectAttributesConverter {
 		//we pass in a lot of maps here that we can and (maybe) do not want to write
 		{
 			if(converter instanceof StringStringMapConverter){
-				Map.Entry firstEntry = ((Map<Object, Object>) o).entrySet().iterator().next();
-				if(! (firstEntry.getKey() instanceof String && firstEntry.getValue() instanceof String) ) return null;
+				Map<Object, Object> map = ((Map<Object, Object>) o);
+				if (! map.isEmpty()){
+					Map.Entry firstEntry = map.entrySet().iterator().next();
+					if(! (firstEntry.getKey() instanceof String && firstEntry.getValue() instanceof String) ) return null;
+				}
 			}
 			if(converter instanceof StringCollectionConverter){
-				if(! ( ((Collection) o).iterator().next() instanceof String) ) return null;
+				Collection collection = ((Collection) o);
+				if(! collection.isEmpty()){
+					if(! ( collection.iterator().next() instanceof String) ) return null;
+				}
 			}
 		}
 

--- a/matsim/src/test/java/org/matsim/utils/objectattributes/ObjectAttributesConverterTest.java
+++ b/matsim/src/test/java/org/matsim/utils/objectattributes/ObjectAttributesConverterTest.java
@@ -85,7 +85,7 @@ public class ObjectAttributesConverterTest {
 		var expectedString = "[\"a\",\"b\"]";
 		final var converter = new ObjectAttributesConverter();
 
-		Collection<String> parsed = Arrays.asList("a", "b");
+		Collection<String> parsed = (Collection<String>) converter.convert("java.util.Collection", expectedString);
 		var serialized = converter.convertToString(parsed);
 
 		assertEquals(expectedString, serialized);

--- a/matsim/src/test/java/org/matsim/utils/objectattributes/ObjectAttributesConverterTest.java
+++ b/matsim/src/test/java/org/matsim/utils/objectattributes/ObjectAttributesConverterTest.java
@@ -25,6 +25,9 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.time.Month;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -59,6 +62,42 @@ public class ObjectAttributesConverterTest {
 		final var converter = new ObjectAttributesConverter();
 
 		Map<String, String> parsed = (Map<String, String>) converter.convert("java.util.Map", expectedString);
+		var serialized = converter.convertToString(parsed);
+
+		assertEquals(expectedString, serialized);
+	}
+
+	@Test
+	public void testEmptyHashMap() {
+
+		var expectedString = "{}";
+		final var converter = new ObjectAttributesConverter();
+
+		Map<String, String> parsed = new HashMap<>();
+		var serialized = converter.convertToString(parsed);
+
+		assertEquals(expectedString, serialized);
+	}
+
+	@Test
+	public void testCollection() {
+
+		var expectedString = "[\"a\",\"b\"]";
+		final var converter = new ObjectAttributesConverter();
+
+		Collection<String> parsed = Arrays.asList("a", "b");
+		var serialized = converter.convertToString(parsed);
+
+		assertEquals(expectedString, serialized);
+	}
+
+	@Test
+	public void testEmptyCollection() {
+
+		var expectedString = "[]";
+		final var converter = new ObjectAttributesConverter();
+
+		Collection<String> parsed = Arrays.asList();
 		var serialized = converter.convertToString(parsed);
 
 		assertEquals(expectedString, serialized);


### PR DESCRIPTION
Fixes #1348 

Object attributes of type Map and of type Collection can now be empty without provoking a crash in ObjectAttributesConverter.
I added tests.