### PR TITLE
Rollback event manager changes

### DIFF
--- a/contribs/emissions/src/test/java/org/matsim/contrib/emissions/TestPositionEmissionModule.java
+++ b/contribs/emissions/src/test/java/org/matsim/contrib/emissions/TestPositionEmissionModule.java
@@ -23,7 +23,7 @@ import org.matsim.core.config.groups.StrategyConfigGroup;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
-import org.matsim.core.events.SimStepParallelEventsManagerImpl;
+import org.matsim.core.events.EventsManagerImpl;
 import org.matsim.core.events.handler.BasicEventHandler;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.population.PopulationUtils;
@@ -132,7 +132,7 @@ public class TestPositionEmissionModule {
                 addEventHandlerBinding().toInstance(handler);
                 addEventHandlerBinding().toInstance(mainLinkWarmHandler);
                 addEventHandlerBinding().toInstance(coldHandler);
-                bind(EventsManager.class).to(SimStepParallelEventsManagerImpl.class).in(Singleton.class);
+                bind(EventsManager.class).to(EventsManagerImpl.class).in(Singleton.class);
             }
         });
 

--- a/matsim/src/main/java/org/matsim/core/api/experimental/events/EventsManager.java
+++ b/matsim/src/main/java/org/matsim/core/api/experimental/events/EventsManager.java
@@ -20,6 +20,7 @@
 package org.matsim.core.api.experimental.events;
 
 import org.matsim.api.core.v01.events.Event;
+import org.matsim.core.events.EventArray;
 import org.matsim.core.events.handler.EventHandler;
 import org.matsim.core.mobsim.framework.Steppable;
 
@@ -30,6 +31,15 @@ import org.matsim.core.mobsim.framework.Steppable;
 public interface EventsManager {
 
 	public void processEvent(final Event event);
+
+	/**
+	 * Submit multiple events for processing at once.
+	 */
+	default void processEvents(final EventArray events) {
+		for (int i = 0; i < events.size(); i++) {
+			processEvent(events.get(i));
+		}
+	}
 
 	public void addHandler(final EventHandler handler);
 	

--- a/matsim/src/main/java/org/matsim/core/events/EventsUtils.java
+++ b/matsim/src/main/java/org/matsim/core/events/EventsUtils.java
@@ -28,9 +28,19 @@ import org.matsim.utils.eventsfilecomparison.EventsFileComparator;
 
 public final class EventsUtils {
 
+	/**
+	 * Create a events manager instance that guarantees causality of processed events across all handlers.
+	 */
     public static EventsManager createEventsManager() {
-		return new ParallelEventsManager(false);
+		return new EventsManagerImpl();
     }
+
+	/**
+	 * Creates a parallel events manager, with no guarantees for the order of processed events between multiple handlers.
+	 */
+	public static EventsManager createParallelEventsManager() {
+		return new ParallelEventsManager(false);
+	}
 
 	public static EventsManager createEventsManager(Config config) {
 		final EventsManager events = Injector.createInjector( config, new EventsManagerModule() ).getInstance( EventsManager.class );

--- a/matsim/src/main/java/org/matsim/core/events/ParallelEventsManager.java
+++ b/matsim/src/main/java/org/matsim/core/events/ParallelEventsManager.java
@@ -158,6 +158,7 @@ public final class ParallelEventsManager implements EventsManager {
 		}
 	}
 
+	@Override
 	public void processEvents(final EventArray events) {
 		if (!init) throw new IllegalStateException(".initProcessing() has to be called before processing events!");
 

--- a/matsim/src/main/java/org/matsim/core/events/ParallelEventsManager.java
+++ b/matsim/src/main/java/org/matsim/core/events/ParallelEventsManager.java
@@ -50,6 +50,7 @@ public final class ParallelEventsManager implements EventsManager {
 	private final int numOfThreads;
 	private final ExceptionHandler uncaughtExceptionHandler;
 	private int iteration = 0;
+	private boolean init = false;
 	private final BlockingQueue<EventArray> eventQueue;
 
 	private final int eventsQueueSize;
@@ -127,6 +128,7 @@ public final class ParallelEventsManager implements EventsManager {
 		this.distributor.setUncaughtExceptionHandler(this.uncaughtExceptionHandler);
 		this.distributor.setName("EventsDistributor");
 		this.distributor.start();
+		this.init = true;
 	}
 
 	private void teardown() {
@@ -145,6 +147,8 @@ public final class ParallelEventsManager implements EventsManager {
 
 	@Override
 	public void processEvent(final Event event) {
+		if (!init) throw new IllegalStateException(".initProcessing() has to be called before processing events!");
+
 		EventArray array = new EventArray(1);
 		array.add(event);
 		try {
@@ -155,6 +159,8 @@ public final class ParallelEventsManager implements EventsManager {
 	}
 
 	public void processEvents(final EventArray events) {
+		if (!init) throw new IllegalStateException(".initProcessing() has to be called before processing events!");
+
 		try {
 			this.eventQueue.put(events);
 		} catch (InterruptedException e) {
@@ -164,6 +170,9 @@ public final class ParallelEventsManager implements EventsManager {
 
 	@Override
 	public void addHandler(final EventHandler handler) {
+		if (init)
+			throw new IllegalStateException("Handlers can not be added after .initProcessing() was called!");
+
 		// this will be used the next time we start an iteration
 		this.eventsHandlers.add(handler);
 	}

--- a/matsim/src/main/java/org/matsim/core/mobsim/hermes/Hermes.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/hermes/Hermes.java
@@ -34,11 +34,11 @@ final class Hermes implements Mobsim {
 	private Agent[] agents;
 	private ScenarioImporter si;
 	private final Scenario scenario;
-	private final ParallelEventsManager eventsManager;
+	private final EventsManager eventsManager;
 
 	public Hermes(Scenario scenario, EventsManager eventsManager) {
 		this.scenario = scenario;
-		this.eventsManager = (ParallelEventsManager) eventsManager;
+		this.eventsManager = eventsManager;
 	}
 
 	private void importScenario() throws Exception {

--- a/matsim/src/main/java/org/matsim/core/mobsim/hermes/Realm.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/hermes/Realm.java
@@ -58,7 +58,7 @@ class Realm {
     // queue of sorted events by time
     private EventArray sorted_events;
     // MATSim event manager.
-    private final ParallelEventsManager eventsManager;
+    private final EventsManager eventsManager;
     // Current timestamp
     private int secs;
     Logger log = Logger.getLogger(Realm.class);
@@ -73,7 +73,7 @@ class Realm {
         this.route_stops_by_route_no = scenario.route_stops_by_route_no;
         this.line_of_route = scenario.line_of_route;
         this.sorted_events = new EventArray();
-        this.eventsManager = (ParallelEventsManager)eventsManager;
+        this.eventsManager = eventsManager;
 
 	// the last position is to store events that will not happen...
         for (int i = 0; i <= HermesConfigGroup.SIM_STEPS + 1; i++) {

--- a/matsim/src/test/java/org/matsim/core/events/EventsHandlerHierarchyTest.java
+++ b/matsim/src/test/java/org/matsim/core/events/EventsHandlerHierarchyTest.java
@@ -92,7 +92,7 @@ public class EventsHandlerHierarchyTest extends MatsimTestCase {
 		assertEquals(this.eventHandled, 1);
 		//then test the reset
 		events.resetHandlers(0);
-		assertEquals(2, this.resetCalled);
+		assertEquals(1, this.resetCalled);
 	}
 
 }

--- a/matsim/src/test/java/org/matsim/core/events/EventsManagerImplTest.java
+++ b/matsim/src/test/java/org/matsim/core/events/EventsManagerImplTest.java
@@ -64,7 +64,7 @@ public class EventsManagerImplTest {
 			log.info("Catched expected exception.", e);
 
 			Assert.assertEquals(1, handler.counter);
-			Assert.assertTrue(e.getCause().getCause() instanceof ArithmeticException);
+			Assert.assertTrue(e.getCause() instanceof ArithmeticException);
 		}
 	}
 

--- a/matsim/src/test/java/org/matsim/core/events/ParallelEventsManagerTest.java
+++ b/matsim/src/test/java/org/matsim/core/events/ParallelEventsManagerTest.java
@@ -1,0 +1,52 @@
+package org.matsim.core.events;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.matsim.api.core.v01.events.Event;
+import org.matsim.core.api.experimental.events.EventsManager;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class ParallelEventsManagerTest {
+
+    private final Event e = new EventsManagerImplTest.MyEvent(5);
+
+    private EventsManagerImplTest.CountingMyEventHandler handler;
+
+    @Before
+    public void setUp() throws Exception {
+        handler = new EventsManagerImplTest.CountingMyEventHandler();
+    }
+
+    @Test
+    public void forgetInit() {
+
+        EventsManager m = EventsUtils.createParallelEventsManager();
+
+        m.addHandler(handler);
+
+        assertThrows(IllegalStateException.class, () -> m.processEvent(e));
+
+        m.initProcessing();
+        m.processEvent(e);
+
+        m.finishProcessing();
+
+        assertEquals(1, handler.counter);
+    }
+
+    @Test
+    public void lateHandler() {
+
+        EventsManager m = EventsUtils.createParallelEventsManager();
+        m.initProcessing();
+
+        assertThrows(IllegalStateException.class, () -> m.addHandler(handler));
+
+        m.processEvent(e);
+
+        assertEquals(0, handler.counter);
+
+    }
+}

--- a/matsim/src/test/java/org/matsim/core/events/SimStepParallelEventsManagerImplTest.java
+++ b/matsim/src/test/java/org/matsim/core/events/SimStepParallelEventsManagerImplTest.java
@@ -23,21 +23,14 @@
 
 import org.junit.Test;
 import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.events.Event;
 import org.matsim.api.core.v01.events.LinkEnterEvent;
 import org.matsim.api.core.v01.events.LinkLeaveEvent;
 import org.matsim.api.core.v01.events.PersonStuckEvent;
 import org.matsim.api.core.v01.events.handler.LinkEnterEventHandler;
-import org.matsim.core.api.experimental.events.EventsManager;
-import org.matsim.core.events.handler.BasicEventHandler;
-import org.matsim.core.events.handler.EventHandler;
 import org.matsim.testcases.utils.EventsCollector;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.junit.Assert.assertThat;
 
 public class SimStepParallelEventsManagerImplTest {
 
@@ -56,8 +49,7 @@ public class SimStepParallelEventsManagerImplTest {
 			}
 
 			@Override
-			public void reset(int iteration) {
-			}
+			public void reset(int iteration) {}
 		});
 		EventsCollector collector = new EventsCollector();
 		events.addHandler(collector);
@@ -70,223 +62,14 @@ public class SimStepParallelEventsManagerImplTest {
 		events.afterSimStep(1.0);
 		events.finishProcessing();
 
-		collector.getEvents().containsAll(Set.of(new LinkEnterEvent(0.0, Id.createVehicleId(0), Id.createLinkId(0)),
-				new LinkLeaveEvent(0.0, Id.createVehicleId(0), Id.createLinkId(0)),
-				new PersonStuckEvent(0.0, Id.createPersonId(0), Id.createLinkId(0), "car"),
-				new LinkEnterEvent(1.0, Id.createVehicleId(0), Id.createLinkId(0)),
-				new LinkLeaveEvent(1.0, Id.createVehicleId(0), Id.createLinkId(0)),
-				new PersonStuckEvent(1.0, Id.createPersonId(0), Id.createLinkId(0), "car")));
+		assertThat(collector.getEvents(),
+			contains(
+					new LinkEnterEvent(0.0, Id.createVehicleId(0), Id.createLinkId(0)),
+					new LinkLeaveEvent(0.0, Id.createVehicleId(0), Id.createLinkId(0)),
+					new PersonStuckEvent(0.0, Id.createPersonId(0), Id.createLinkId(0), "car"),
+					new LinkEnterEvent(1.0, Id.createVehicleId(0), Id.createLinkId(0)),
+					new LinkLeaveEvent(1.0, Id.createVehicleId(0), Id.createLinkId(0)),
+					new PersonStuckEvent(1.0, Id.createPersonId(0), Id.createLinkId(0), "car")));
 	}
 
-	@Test(expected = RuntimeException.class)
-	public void ensureOrder() {
-
-		var manager = new SimStepParallelEventsManagerImpl(1);
-		manager.addHandler((BasicEventHandler) event -> { // nothing
-		});
-
-		manager.initProcessing();
-		manager.processEvent(new GenericEvent(2, "some"));
-		manager.processEvent(new GenericEvent(1, "some"));
-		manager.afterSimStep(2);
-		manager.finishProcessing();
-	}
-
-	@Test(expected = RuntimeException.class)
-	public void testExceptionsInHandler() {
-
-		var manager = new SimStepParallelEventsManagerImpl(1);
-		manager.addHandler((BasicEventHandler) event -> {
-			throw new RuntimeException("Test");
-		});
-
-		manager.initProcessing();
-		manager.processEvent(new GenericEvent(2,  "some"));
-		manager.afterSimStep(2);
-		manager.finishProcessing();
-	}
-
-	@Test
-	public void testWaitingWhenTimestepIsIncreased() {
-
-		var manager = new SimStepParallelEventsManagerImpl(1);
-		manager.addHandler(new SlowHandler(manager, "afterSimStep"));
-		var assertionHandler = new CounterHandler(SlowHandler.EVENT_TYPE_THROWN);
-		manager.addHandler(assertionHandler);
-
-		manager.initProcessing();
-		manager.processEvent(new GenericEvent(2, "afterSimStep"));
-		manager.processEvent(new GenericEvent(3, "some"));
-		assertEquals(1, assertionHandler.counter);
-		manager.finishProcessing();
-	}
-
-	@Test
-	public void testWaitingWhenTimestepIsIncreasedAsync() {
-
-		var manager = new SimStepParallelEventsManagerImpl(1);
-		manager.addHandler(new SlowHandler(manager, "afterSimStep"));
-		EventHandler handler = (BasicEventHandler) event -> {
-			if (event.getEventType().equals(SlowHandler.EVENT_TYPE_THROWN)) {
-				// trigger update of manager's timestep while main thread is awaiting this thread to finish
-				manager.processEvent(new GenericEvent(event.getTime() + 1, "some"));
-			}
-		};
-		manager.addHandler(handler);
-
-		manager.initProcessing();
-		manager.processEvent(new GenericEvent(2, "afterSimStep"));
-
-		// increase timestep from main thread
-		manager.processEvent(new GenericEvent(3, "some"));
-		manager.finishProcessing();
-	}
-
-	@Test
-	public void testWaitingWhenFinishProcessing() {
-
-		var manager = new SimStepParallelEventsManagerImpl(1);
-		manager.addHandler(new SlowHandler(manager, "some-event"));
-		var handlerOfSlowHandlersEvents = new CounterHandler(SlowHandler.EVENT_TYPE_THROWN);
-		var handlerOfSyncEvents = new CounterHandler("synchronous-event");
-		manager.addHandler(handlerOfSlowHandlersEvents);
-		manager.addHandler(handlerOfSyncEvents);
-
-		manager.initProcessing();
-		manager.processEvent(new GenericEvent(1, "some-event"));
-
-		// the slow handler will issue an event to 'processEvent' while finishing
-		// is awaited. The finish method should also wait for this event
-		manager.finishProcessing();
-
-		// after finish processing events are directed to a synchronous manager therefore
-		// the following event should be caught without awaiting
-		manager.processEvent(new GenericEvent(1,"synchronous-event"));
-
-		assertEquals(1, handlerOfSlowHandlersEvents.counter);
-		assertEquals(1, handlerOfSyncEvents.counter);
-	}
-
-	@Test
-	public void testWaitingWhenTimeIsIncreased() {
-
-		var manager = new SimStepParallelEventsManagerImpl(1);
-		manager.addHandler(new SlowHandler(manager, "some-event"));
-		var counterHandler = new CounterHandler(SlowHandler.EVENT_TYPE_THROWN);
-		manager.addHandler(counterHandler);
-
-		manager.initProcessing();
-		manager.processEvent(new GenericEvent(1, "some-event"));
-		manager.processEvent(new GenericEvent(2, "event-from-next-timestep"));
-
-		assertEquals(1, counterHandler.counter);
-	}
-
-	@Test
-	public void testWaitingWhenAfterSimStep() {
-
-		var manager = new SimStepParallelEventsManagerImpl(1);
-		manager.addHandler(new SlowHandler(manager, "some-event"));
-		var counterHandler = new CounterHandler(SlowHandler.EVENT_TYPE_THROWN);
-		manager.addHandler(counterHandler);
-
-		manager.initProcessing();
-		manager.processEvent(new GenericEvent(1, "some-event"));
-		manager.afterSimStep(1);
-
-		assertEquals(1, counterHandler.counter);
-	}
-
-	@Test
-	public void testOrderOfEventsIsKept() {
-
-		var manager = new SimStepParallelEventsManagerImpl(3);
-		var events = List.of(
-				new GenericEvent(1,"first"),
-				new GenericEvent(1, "second"),
-				new GenericEvent(1, "third"));
-
-		var handler = new BasicEventHandler() {
-
-			private final List<GenericEvent> caughtEvents = new ArrayList<>();
-			@Override
-			public void handleEvent(Event event) {
-				if (event instanceof GenericEvent) {
-					caughtEvents.add((GenericEvent) event);
-				}
-			}
-		};
-		manager.addHandler(handler);
-
-		manager.initProcessing();
-		for (var event : events) {
-			manager.processEvent(event);
-		}
-		manager.finishProcessing();
-
-		assertEquals(events.size(), handler.caughtEvents.size());
-		for (var i = 0; i < events.size(); i++) {
-			var expected = events.get(i);
-			var actual = handler.caughtEvents.get(i);
-			assertEquals(expected.type, actual.type);
-		}
-	}
-
-	private static class SlowHandler implements BasicEventHandler {
-
-		static final String EVENT_TYPE_THROWN = "fromSlowHandler";
-
-		final EventsManager manager;
-		final String eventType;
-
-		private SlowHandler(EventsManager manager, String eventType) {
-			this.manager = manager;
-			this.eventType = eventType;
-		}
-
-		@Override
-		public void handleEvent(Event event) {
-
-			if (event.getEventType().equals(eventType)) {
-				try {
-					Thread.sleep(1000); // long computation
-				} catch (InterruptedException e) {
-					throw new RuntimeException(e);
-				}
-				manager.processEvent(new GenericEvent(event.getTime(), EVENT_TYPE_THROWN));
-			}
-		}
-	}
-
-	private static class CounterHandler implements BasicEventHandler {
-
-		private final String eventType;
-
-		private int counter;
-
-		private CounterHandler(String eventType) {
-			this.eventType = eventType;
-		}
-
-		@Override
-		public void handleEvent(Event event) {
-			if (event.getEventType().equals(eventType))
-				counter++;
-		}
-	}
-
-	private static class GenericEvent extends Event {
-
-		private final String type;
-
-		private GenericEvent(double time, String type) {
-			super(time);
-			this.type = type;
-		}
-
-		@Override
-		public String getEventType() {
-			return type;
-		}
-	}
 }


### PR DESCRIPTION
Rollback some changes to the EventManagers that have been introduced recently and during the integration of hermes.

* `createEventsManager()` returns the single threaded variant again
* Added `createParallelEventsManager()` for users who want to create the parallel variant
* Reverted `SimStepParallelEventsManagerImpl` to the old implementation again. (cf. #1341). @tschlenther already reported some problems in the berlin scenario
* The parallel events manager checks for correct usage of `.initProcessing()`. 

This PR closes #1342, #1347, #1091 