### PR TITLE
add constructor which allows for marginal utility of money

### DIFF
--- a/matsim/src/main/java/org/matsim/core/scoring/functions/CharyparNagelLegScoring.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/functions/CharyparNagelLegScoring.java
@@ -60,11 +60,25 @@ public class CharyparNagelLegScoring implements org.matsim.core.scoring.SumScori
 	
 	private Set<String> modesAlreadyConsideredForDailyConstants;
 	
+	private final double marginalUtilityOfMoney;
+	
 	public CharyparNagelLegScoring(final ScoringParameters params, Network network, Set<String> ptModes) {
 		this.params = params;
 		this.network = network;
 		this.ptModes = ptModes;
 		modesAlreadyConsideredForDailyConstants = new HashSet<>();
+		this.marginalUtilityOfMoney = this.params.marginalUtilityOfMoney;
+	}
+	
+	/**
+	 * Scoring with person-specific marginal utility of money
+	 */
+	public CharyparNagelLegScoring(final ScoringParameters params, double marginalUtilityOfMoney, Network network, Set<String> ptModes) {
+		this.params = params;
+		this.network = network;
+		this.ptModes = ptModes;
+		modesAlreadyConsideredForDailyConstants = new HashSet<>();
+		this.marginalUtilityOfMoney = marginalUtilityOfMoney;
 	}
 
 	/**
@@ -116,7 +130,7 @@ public class CharyparNagelLegScoring implements org.matsim.core.scoring.SumScori
 				}
 			}
 			tmpScore += modeParams.marginalUtilityOfDistance_m * dist;
-			tmpScore += modeParams.monetaryDistanceCostRate * this.params.marginalUtilityOfMoney * dist;
+			tmpScore += modeParams.monetaryDistanceCostRate * this.marginalUtilityOfMoney * dist;
 		}
 		tmpScore += modeParams.constant;
 		// (yyyy once we have multiple legs without "real" activities in between, this will produce wrong results.  kai, dec'12)
@@ -124,7 +138,7 @@ public class CharyparNagelLegScoring implements org.matsim.core.scoring.SumScori
 		
 		// account for the daily constants
 		if (!modesAlreadyConsideredForDailyConstants.contains(leg.getMode())) {
-			tmpScore += modeParams.dailyUtilityConstant + modeParams.dailyMoneyConstant * this.params.marginalUtilityOfMoney;
+			tmpScore += modeParams.dailyUtilityConstant + modeParams.dailyMoneyConstant * this.marginalUtilityOfMoney;
 			modesAlreadyConsideredForDailyConstants.add(leg.getMode());
 		}
 		// yyyy the above will cause problems if we ever decide to differentiate pt mode into bus, tram, train, ...


### PR DESCRIPTION
Logic similar to the money scoring function; allow to plug together a scoring context in which the person specific marginal utility of money is used. mainly meant as a fall back in case the person specific scoring parameters approach uses up too much memory...
