### PR TITLE
DRT: simplify input data creation for insertion cost calculation; compute pickup/dropoff times for evaluated insertions

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculator.java
@@ -107,7 +107,7 @@ public class InsertionCostCalculator<D> {
 	public double calculate(DrtRequest drtRequest, InsertionWithDetourData<D> insertion) {
 		//TODO precompute time slacks for each stop to filter out even more infeasible insertions ???????????
 
-		var detourTimeInfo = insertionDetourTimeCalculator.calculateDetourTimeLoss(insertion);
+		var detourTimeInfo = insertionDetourTimeCalculator.calculateDetourTimeInfo(insertion);
 		// the pickupTimeLoss is needed for stops that suffer only that one, while the sum of both will be suffered by
 		// the stops after the dropoff stop. kai, nov'18
 		// The computation is complicated; presumably, it takes care of this.  kai, nov'18

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculator.java
@@ -107,19 +107,18 @@ public class InsertionCostCalculator<D> {
 	public double calculate(DrtRequest drtRequest, InsertionWithDetourData<D> insertion) {
 		//TODO precompute time slacks for each stop to filter out even more infeasible insertions ???????????
 
-		double pickupDetourTimeLoss = insertionDetourTimeCalculator.calculatePickupDetourTimeLoss(insertion);
-		double dropoffDetourTimeLoss = insertionDetourTimeCalculator.calculateDropoffDetourTimeLoss(insertion);
+		var detourTimeInfo = insertionDetourTimeCalculator.calculateDetourTimeLoss(insertion);
 		// the pickupTimeLoss is needed for stops that suffer only that one, while the sum of both will be suffered by
 		// the stops after the dropoff stop. kai, nov'18
 		// The computation is complicated; presumably, it takes care of this.  kai, nov'18
 
 		// this is what we want to minimise
-		double totalTimeLoss = pickupDetourTimeLoss + dropoffDetourTimeLoss;
-		if (!checkHardConstraints(insertion, pickupDetourTimeLoss, totalTimeLoss)) {
+		double totalTimeLoss = detourTimeInfo.pickupTimeLoss + detourTimeInfo.dropoffTimeLoss;
+		if (!checkHardConstraints(insertion, detourTimeInfo.pickupTimeLoss, totalTimeLoss)) {
 			return INFEASIBLE_SOLUTION_COST;
 		}
 
-		return totalTimeLoss + calcSoftConstraintPenalty(drtRequest, insertion, pickupDetourTimeLoss);
+		return totalTimeLoss + calcSoftConstraintPenalty(drtRequest, insertion, detourTimeInfo.pickupTimeLoss);
 	}
 
 	private boolean checkHardConstraints(InsertionWithDetourData<?> insertion, double pickupDetourTimeLoss,

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
@@ -35,6 +35,7 @@ import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.testcases.fakes.FakeLink;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableTable;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -48,97 +49,116 @@ public class InsertionDetourTimeCalculatorTest {
 
 	@Test
 	public void detourTimeLoss_start_pickup_dropoff() {
-		Waypoint.Start start = start(null, 0, link("start"));
+		Waypoint.Start start = start(null, 10, link("start"));
 		Entry entry = entry(start);
 		var detour = new Detour(100., 15., null, 0.);
 		var insertion = insertion(entry, 0, 0, detour);
 
+		double departureTime = start.getDepartureTime() + detour.toPickup + STOP_DURATION;
 		double pickupTimeLoss = detour.toPickup + STOP_DURATION + detour.fromPickup;
+		double arrivalTime = departureTime + detour.fromPickup;
 		double dropoffTimeLoss = STOP_DURATION;
-		assertDetourTimeInfo(insertion, new DetourTimeInfo(pickupTimeLoss,  dropoffTimeLoss));
+		assertDetourTimeInfo(insertion,
+				new DetourTimeInfo(departureTime, arrivalTime, pickupTimeLoss, dropoffTimeLoss));
 	}
 
 	@Test
 	public void detourTimeLoss_ongoingStopAsStart_pickup_dropoff() {
 		//similar to detourTmeLoss_start_pickup_dropoff(), but the pickup is appended to the ongoing STOP task
-		Waypoint.Start start = start(new DrtStopTask(0, STOP_DURATION, fromLink), STOP_DURATION, fromLink);
+		Waypoint.Start start = start(new DrtStopTask(20, 20 + STOP_DURATION, fromLink), STOP_DURATION, fromLink);
 		Entry entry = entry(start);
 		var detour = new Detour(null, 15., null, 0.);//toPickup/Dropoff unused
 		var insertion = insertion(entry, 0, 0, detour);
 
+		double departureTime = start.getDepartureTime();
 		double pickupTimeLoss = detour.fromPickup;
+		double arrivalTime = departureTime + detour.fromPickup;
 		double dropoffTimeLoss = STOP_DURATION;
-		assertDetourTimeInfo(insertion, new DetourTimeInfo(pickupTimeLoss,  dropoffTimeLoss));
+		assertDetourTimeInfo(insertion,
+				new DetourTimeInfo(departureTime, arrivalTime, pickupTimeLoss, dropoffTimeLoss));
 	}
 
 	@Test
 	public void detourTimeLoss_start_pickup_dropoff_stop() {
-		Waypoint.Start start = start(null, 0, link("start"));
+		Waypoint.Start start = start(null, 5, link("start"));
 		Waypoint.Stop stop0 = stop(10, link("stop0"));
 		Entry entry = entry(start, stop0);
 		var detour = new Detour(10., 30., null, 300.);//toDropoff unused
 		var insertion = insertion(entry, 0, 0, detour);
 
-		double pickupTimeLoss =
-				detour.toPickup + STOP_DURATION + detour.fromPickup - timeBetween(start, stop0);
+		double departureTime = start.getDepartureTime() + detour.toPickup + STOP_DURATION;
+		double pickupTimeLoss = detour.toPickup + STOP_DURATION + detour.fromPickup - timeBetween(start, stop0);
+		double arrivalTime = departureTime + detour.fromPickup;
 		double dropoffTimeLoss = STOP_DURATION + detour.fromDropoff;
-		assertDetourTimeInfo(insertion, new DetourTimeInfo(pickupTimeLoss,  dropoffTimeLoss));
+		assertDetourTimeInfo(insertion,
+				new DetourTimeInfo(departureTime, arrivalTime, pickupTimeLoss, dropoffTimeLoss));
 	}
 
 	@Test
 	public void calculatePickupDetourTimeLoss_start_pickup_stop_dropoff() {
-		Waypoint.Start start = start(null, 0, link("start"));
+		Waypoint.Start start = start(null, 5, link("start"));
 		Waypoint.Stop stop0 = stop(10, link("stop0"));
 		Entry entry = entry(start, stop0);
 		var detour = new Detour(10., 30., 100., 0.);
 		var insertion = insertion(entry, 0, 1, detour);
 
-		double pickupTimeLoss =
-				detour.toPickup + STOP_DURATION + detour.fromPickup - timeBetween(start, stop0);
+		double departureTime = start.getDepartureTime() + detour.toPickup + STOP_DURATION;
+		double pickupTimeLoss = detour.toPickup + STOP_DURATION + detour.fromPickup - timeBetween(start, stop0);
+		double arrivalTime = stop0.getDepartureTime() + pickupTimeLoss + detour.toDropoff;
 		double dropoffTimeLoss = detour.toDropoff + STOP_DURATION;
-		assertDetourTimeInfo(insertion, new DetourTimeInfo(pickupTimeLoss,  dropoffTimeLoss));
+		assertDetourTimeInfo(insertion,
+				new DetourTimeInfo(departureTime, arrivalTime, pickupTimeLoss, dropoffTimeLoss));
 	}
 
 	@Test
 	public void calculatePickupDetourTimeLoss_start_pickup_stop_dropoff_stop() {
-		Waypoint.Start start = start(null, 0, link("start"));
+		Waypoint.Start start = start(null, 5, link("start"));
 		Waypoint.Stop stop0 = stop(10, link("stop0"));
 		Waypoint.Stop stop1 = stop(200, link("stop1"));
 		Entry entry = entry(start, stop0, stop1);
 		var detour = new Detour(10., 30., 100., 150.);
 		var insertion = insertion(entry, 0, 1, detour);
 
+		double departureTime = start.getDepartureTime() + detour.toPickup + STOP_DURATION;
 		double pickupTimeLoss = detour.toPickup + STOP_DURATION + detour.fromPickup - timeBetween(start, stop0);
+		double arrivalTime = stop0.getDepartureTime() + pickupTimeLoss + detour.toDropoff;
 		double dropoffTimeLoss = detour.toDropoff + STOP_DURATION + detour.fromDropoff - timeBetween(stop0, stop1);
-		assertDetourTimeInfo(insertion, new DetourTimeInfo(pickupTimeLoss,  dropoffTimeLoss));
+		assertDetourTimeInfo(insertion,
+				new DetourTimeInfo(departureTime, arrivalTime, pickupTimeLoss, dropoffTimeLoss));
 	}
 
 	@Test
 	public void calculatePickupDetourTimeLoss_start_pickupNotAppended_stop_dropoffAppended_stop() {
-		Waypoint.Start start = start(null, 0, fromLink);//not a STOP -> pickup cannot be appended
+		Waypoint.Start start = start(null, 5, fromLink);//not a STOP -> pickup cannot be appended
 		Waypoint.Stop stop0 = stop(10, toLink);
 		Waypoint.Stop stop1 = stop(200, link("stop1"));
 		Entry entry = entry(start, stop0, stop1);
 		var detour = new Detour(null, null, null, null);//all unused
 		var insertion = insertion(entry, 0, 1, detour);
 
+		double departureTime = start.getDepartureTime() + STOP_DURATION;
 		double pickupTimeLoss = STOP_DURATION;
+		double arrivalTime = stop0.getArrivalTime() + pickupTimeLoss;
 		double dropoffTimeLoss = 0;
-		assertDetourTimeInfo(insertion, new DetourTimeInfo(pickupTimeLoss,  dropoffTimeLoss));
+		assertDetourTimeInfo(insertion,
+				new DetourTimeInfo(departureTime, arrivalTime, pickupTimeLoss, dropoffTimeLoss));
 	}
 
 	@Test
 	public void calculatePickupDetourTimeLoss_start_stop_pickupAppended_stop_dropoffAppended() {
-		Waypoint.Start start = start(null, 0, link("start"));
+		Waypoint.Start start = start(null, 5, link("start"));
 		Waypoint.Stop stop0 = stop(10, fromLink);
 		Waypoint.Stop stop1 = stop(200, toLink);
 		Entry entry = entry(start, stop0, stop1);
 		var detour = new Detour(null, null, null, null);//all unused
 		var insertion = insertion(entry, 1, 2, detour);
 
+		double departureTime = stop0.getDepartureTime();
 		double pickupTimeLoss = 0;
+		double arrivalTime = stop1.getArrivalTime();
 		double dropoffTimeLoss = 0;
-		assertDetourTimeInfo(insertion, new DetourTimeInfo(pickupTimeLoss,  dropoffTimeLoss));
+		assertDetourTimeInfo(insertion,
+				new DetourTimeInfo(departureTime, arrivalTime, pickupTimeLoss, dropoffTimeLoss));
 	}
 
 	@Test
@@ -150,22 +170,29 @@ public class InsertionDetourTimeCalculatorTest {
 		var detour = new Detour(10., 30., 100., 150.);
 		var insertion = insertion(entry, 0, 1, detour);
 
-		double replacedDriveTimePickup = 33;
-		var detourTimeCalculatorPickup = new InsertionDetourTimeCalculator<>(STOP_DURATION, Double::doubleValue,
-				(from, to) -> replacedDriveTimePickup);
-		assertThat(detourTimeCalculatorPickup.calculateDetourTimeLoss(insertion).pickupTimeLoss).isEqualTo(
-				detour.toPickup + STOP_DURATION + detour.fromPickup - replacedDriveTimePickup);
+		double pickupDetourReplacedDriveEstimate = 33;
+		double dropoffDetourReplacedDriveEstimate = 111;
+		var replacedDriveTimeEstimates = ImmutableTable.<Link, Link, Double>builder()//
+				.put(start.getLink(), stop0.getLink(), pickupDetourReplacedDriveEstimate)
+				.put(stop0.getLink(), stop1.getLink(), dropoffDetourReplacedDriveEstimate)
+				.build();
 
-		double replacedDriveTimeDropoff = 111;
-		var detourTimeCalculatorDropoff = new InsertionDetourTimeCalculator<>(STOP_DURATION, Double::doubleValue,
-				(from, to) -> replacedDriveTimeDropoff);
-		assertThat(detourTimeCalculatorDropoff.calculateDetourTimeLoss(insertion).dropoffTimeLoss).isEqualTo(
-				detour.toDropoff + STOP_DURATION + detour.fromDropoff - replacedDriveTimeDropoff);
+		var detourTimeCalculator = new InsertionDetourTimeCalculator<>(STOP_DURATION, Double::doubleValue,
+				replacedDriveTimeEstimates::get);
+		var actualDetourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion);
+
+		double departureTime = start.getDepartureTime() + detour.toPickup + STOP_DURATION;
+		double pickupTimeLoss = detour.toPickup + STOP_DURATION + detour.fromPickup - pickupDetourReplacedDriveEstimate;
+		double arrivalTime = stop0.getDepartureTime() + pickupTimeLoss + detour.toDropoff;
+		double dropoffTimeLoss = detour.toDropoff + STOP_DURATION + detour.fromDropoff
+				- dropoffDetourReplacedDriveEstimate;
+		assertThat(actualDetourTimeInfo).isEqualToComparingFieldByField(
+				new DetourTimeInfo(departureTime, arrivalTime, pickupTimeLoss, dropoffTimeLoss));
 	}
 
 	private void assertDetourTimeInfo(InsertionWithDetourData<Double> insertion, DetourTimeInfo expected) {
 		var detourTimeCalculator = new InsertionDetourTimeCalculator<>(STOP_DURATION, Double::doubleValue, null);
-		var detourTimeInfo = detourTimeCalculator.calculateDetourTimeLoss(insertion);
+		var detourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion);
 		assertThat(detourTimeInfo).isEqualToComparingFieldByField(expected);
 	}
 


### PR DESCRIPTION
- Some code simplification, where the direct pickup->dropoff detour is handled separately. Despite ending up with a few more LOCs, the new version simplifies computating additional time information.
- Based on the above: compute expected pickup/dropoff times (in addition to the existing ones: pickup/dropoff time losses). They will be used in 