### PR TITLE
DRT: fix soft constraint calculation

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtModeOptimizerQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtModeOptimizerQSimModule.java
@@ -98,7 +98,7 @@ public class DrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 
 		bindModal(VehicleData.EntryFactory.class).toInstance(new VehicleDataEntryFactoryImpl(drtCfg));
 
-		bindModal(InsertionCostCalculator.PenaltyCalculator.class).to(
+		bindModal(InsertionCostCalculator.CostCalculationStrategy.class).to(
 				drtCfg.isRejectRequestIfMaxWaitOrTravelTimeViolated() ?
 						InsertionCostCalculator.RejectSoftConstraintViolations.class :
 						InsertionCostCalculator.DiscourageSoftConstraintViolations.class).asEagerSingleton();

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearch.java
@@ -49,7 +49,7 @@ public class ExtensiveInsertionSearch implements DrtInsertionSearch<PathData> {
 	private final BestInsertionFinder<PathData> bestInsertionFinder;
 
 	public ExtensiveInsertionSearch(DetourPathCalculator detourPathCalculator, DrtConfigGroup drtCfg, MobsimTimer timer,
-			ForkJoinPool forkJoinPool, InsertionCostCalculator.PenaltyCalculator penaltyCalculator,
+			ForkJoinPool forkJoinPool, InsertionCostCalculator.CostCalculationStrategy costCalculationStrategy,
 			DvrpTravelTimeMatrix dvrpTravelTimeMatrix) {
 		this.detourPathCalculator = detourPathCalculator;
 		this.forkJoinPool = forkJoinPool;
@@ -57,13 +57,13 @@ public class ExtensiveInsertionSearch implements DrtInsertionSearch<PathData> {
 		insertionParams = (ExtensiveInsertionSearchParams)drtCfg.getDrtInsertionSearchParams();
 		var detourTimeEstimator = DetourTimeEstimator.createFreeSpeedZonalTimeEstimator(
 				insertionParams.getAdmissibleBeelineSpeedFactor(), dvrpTravelTimeMatrix);
-		admissibleCostCalculator = new InsertionCostCalculator<>(drtCfg, timer, penaltyCalculator, Double::doubleValue,
-				detourTimeEstimator);
+		admissibleCostCalculator = new InsertionCostCalculator<>(drtCfg, timer, costCalculationStrategy,
+				Double::doubleValue, detourTimeEstimator);
 
 		admissibleDetourTimesProvider = new DetourTimesProvider(detourTimeEstimator);
 
 		bestInsertionFinder = new BestInsertionFinder<>(
-				new InsertionCostCalculator<>(drtCfg, timer, penaltyCalculator, PathData::getTravelTime, null));
+				new InsertionCostCalculator<>(drtCfg, timer, costCalculationStrategy, PathData::getTravelTime, null));
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchQSimModule.java
@@ -54,7 +54,7 @@ public class ExtensiveInsertionSearchQSimModule extends AbstractDvrpModeQSimModu
 		}).toProvider(modalProvider(
 				getter -> new ExtensiveInsertionSearch(getter.getModal(DetourPathCalculator.class), drtCfg,
 						getter.get(MobsimTimer.class), getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool(),
-						getter.getModal(InsertionCostCalculator.PenaltyCalculator.class),
+						getter.getModal(InsertionCostCalculator.CostCalculationStrategy.class),
 						getter.getModal(DvrpTravelTimeMatrix.class))));
 
 		addModalComponent(MultiInsertionDetourPathCalculator.class, new ModalProviders.AbstractProvider<>(getMode()) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculator.java
@@ -77,8 +77,8 @@ public class InsertionCostCalculator<D> {
 	public static class DiscourageSoftConstraintViolations implements CostCalculationStrategy {
 		//XXX try to keep penalties reasonably high to prevent people waiting or travelling for hours
 		//XXX however, at the same time prefer max-wait-time to max-travel-time violations
-		private static final double MAX_WAIT_TIME_VIOLATION_PENALTY = 1;// 1 second of penalty per 1 second of late departure
-		private static final double MAX_TRAVEL_TIME_VIOLATION_PENALTY = 10;// 10 seconds of penalty per 1 second of late arrival
+		static final double MAX_WAIT_TIME_VIOLATION_PENALTY = 1;// 1 second of penalty per 1 second of late departure
+		static final double MAX_TRAVEL_TIME_VIOLATION_PENALTY = 10;// 10 seconds of penalty per 1 second of late arrival
 
 		@Override
 		public double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion, double vehicleSlackTime,

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculator.java
@@ -27,9 +27,6 @@ import javax.annotation.Nullable;
 import org.matsim.contrib.drt.optimizer.VehicleData;
 import org.matsim.contrib.drt.optimizer.Waypoint;
 import org.matsim.contrib.drt.passenger.DrtRequest;
-import org.matsim.contrib.drt.passenger.DrtRequestCreator;
-import org.matsim.contrib.drt.routing.DefaultDrtRouteUpdater;
-import org.matsim.contrib.drt.routing.DrtRouteCreator;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
 import org.matsim.contrib.dvrp.schedule.Schedules;
@@ -39,52 +36,86 @@ import org.matsim.core.mobsim.framework.MobsimTimer;
  * @author michalm
  */
 public class InsertionCostCalculator<D> {
-	public interface PenaltyCalculator {
-		double calcPenalty(double maxWaitTimeViolation, double maxTravelTimeViolation);
-	}
+	public static class DetourTimeInfo {
+		public final double departureTime;
+		public final double arrivalTime;
+		public final double pickupTimeLoss;
+		public final double dropoffTimeLoss;
 
-	public static class RejectSoftConstraintViolations implements PenaltyCalculator {
-		@Override
-		public double calcPenalty(double maxWaitTimeViolation, double maxTravelTimeViolation) {
-			return maxWaitTimeViolation > 0 || maxTravelTimeViolation > 0 ? INFEASIBLE_SOLUTION_COST : 0;
+		public DetourTimeInfo(double departureTime, double arrivalTime, double pickupTimeLoss, double dropoffTimeLoss) {
+			this.departureTime = departureTime;
+			this.arrivalTime = arrivalTime;
+			this.pickupTimeLoss = pickupTimeLoss;
+			this.dropoffTimeLoss = dropoffTimeLoss;
+		}
+
+		public double getTotalTimeLoss() {
+			return pickupTimeLoss + dropoffTimeLoss;
 		}
 	}
 
-	public static class DiscourageSoftConstraintViolations implements PenaltyCalculator {
+	public interface CostCalculationStrategy {
+		double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion, double vehicleSlackTime,
+				DetourTimeInfo detourTimeInfo);
+	}
+
+	public static class RejectSoftConstraintViolations implements CostCalculationStrategy {
+		@Override
+		public double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion, double vehicleSlackTime,
+				DetourTimeInfo detourTimeInfo) {
+			double totalTimeLoss = detourTimeInfo.getTotalTimeLoss();
+			if (totalTimeLoss - vehicleSlackTime > 0
+					|| detourTimeInfo.departureTime - request.getLatestStartTime() > 0
+					|| detourTimeInfo.arrivalTime - request.getLatestArrivalTime() > 0) {
+				return INFEASIBLE_SOLUTION_COST;
+			}
+
+			return totalTimeLoss;
+		}
+	}
+
+	public static class DiscourageSoftConstraintViolations implements CostCalculationStrategy {
 		//XXX try to keep penalties reasonably high to prevent people waiting or travelling for hours
 		//XXX however, at the same time prefer max-wait-time to max-travel-time violations
 		private static final double MAX_WAIT_TIME_VIOLATION_PENALTY = 1;// 1 second of penalty per 1 second of late departure
 		private static final double MAX_TRAVEL_TIME_VIOLATION_PENALTY = 10;// 10 seconds of penalty per 1 second of late arrival
 
 		@Override
-		public double calcPenalty(double maxWaitTimeViolation, double maxTravelTimeViolation) {
-			return MAX_WAIT_TIME_VIOLATION_PENALTY * maxWaitTimeViolation
-					+ MAX_TRAVEL_TIME_VIOLATION_PENALTY * maxTravelTimeViolation;
+		public double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion, double vehicleSlackTime,
+				DetourTimeInfo detourTimeInfo) {
+			double totalTimeLoss = detourTimeInfo.getTotalTimeLoss();
+			if (totalTimeLoss - vehicleSlackTime > 0) {
+				return INFEASIBLE_SOLUTION_COST;
+			}
+
+			double waitTimeViolation = Math.max(0, detourTimeInfo.departureTime - request.getLatestStartTime());
+			double travelTimeViolation = Math.max(0, detourTimeInfo.arrivalTime - request.getLatestArrivalTime());
+			return MAX_WAIT_TIME_VIOLATION_PENALTY * waitTimeViolation
+					+ MAX_TRAVEL_TIME_VIOLATION_PENALTY * travelTimeViolation
+					+ totalTimeLoss;
 		}
 	}
 
-	public static final double INFEASIBLE_SOLUTION_COST = Double.MAX_VALUE / 2;
+	public static final double INFEASIBLE_SOLUTION_COST = Double.POSITIVE_INFINITY;
 
-	private final double stopDuration;
 	private final DoubleSupplier timeOfDay;
-	private final PenaltyCalculator penaltyCalculator;
-	private final ToDoubleFunction<D> detourTime;
-	private final InsertionDetourTimeCalculator<D> insertionDetourTimeCalculator;
+	private final CostCalculationStrategy costCalculationStrategy;
+	private final InsertionDetourTimeCalculator<D> detourTimeCalculator;
 
-	public InsertionCostCalculator(DrtConfigGroup drtConfig, MobsimTimer timer, PenaltyCalculator penaltyCalculator,
-			ToDoubleFunction<D> detourTime, @Nullable DetourTimeEstimator replacedDriveTimeEstimator) {
-		this(drtConfig.getStopDuration(), timer::getTimeOfDay, penaltyCalculator, detourTime,
+	public InsertionCostCalculator(DrtConfigGroup drtConfig, MobsimTimer timer,
+			CostCalculationStrategy costCalculationStrategy, ToDoubleFunction<D> detourTime,
+			@Nullable DetourTimeEstimator replacedDriveTimeEstimator) {
+		this(drtConfig.getStopDuration(), timer::getTimeOfDay, costCalculationStrategy, detourTime,
 				replacedDriveTimeEstimator);
 	}
 
-	public InsertionCostCalculator(double stopDuration, DoubleSupplier timeOfDay, PenaltyCalculator penaltyCalculator,
-			ToDoubleFunction<D> detourTime, @Nullable DetourTimeEstimator replacedDriveTimeEstimator) {
-		this.stopDuration = stopDuration;
+	public InsertionCostCalculator(double stopDuration, DoubleSupplier timeOfDay,
+			CostCalculationStrategy costCalculationStrategy, ToDoubleFunction<D> detourTime,
+			@Nullable DetourTimeEstimator replacedDriveTimeEstimator) {
 		this.timeOfDay = timeOfDay;
-		this.penaltyCalculator = penaltyCalculator;
-		this.detourTime = detourTime;
+		this.costCalculationStrategy = costCalculationStrategy;
 
-		insertionDetourTimeCalculator = new InsertionDetourTimeCalculator<>(stopDuration, detourTime,
+		detourTimeCalculator = new InsertionDetourTimeCalculator<>(stopDuration, detourTime,
 				replacedDriveTimeEstimator);
 	}
 
@@ -107,24 +138,19 @@ public class InsertionCostCalculator<D> {
 	public double calculate(DrtRequest drtRequest, InsertionWithDetourData<D> insertion) {
 		//TODO precompute time slacks for each stop to filter out even more infeasible insertions ???????????
 
-		var detourTimeInfo = insertionDetourTimeCalculator.calculateDetourTimeInfo(insertion);
+		var detourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion);
 		// the pickupTimeLoss is needed for stops that suffer only that one, while the sum of both will be suffered by
 		// the stops after the dropoff stop. kai, nov'18
 		// The computation is complicated; presumably, it takes care of this.  kai, nov'18
 
 		// this is what we want to minimise
-		double totalTimeLoss = detourTimeInfo.pickupTimeLoss + detourTimeInfo.dropoffTimeLoss;
-		if (!checkHardConstraints(insertion, detourTimeInfo.pickupTimeLoss, totalTimeLoss)) {
+		if (!checkTimeConstraintsForScheduledRequests(insertion.getInsertion(), detourTimeInfo.pickupTimeLoss,
+				detourTimeInfo.getTotalTimeLoss())) {
 			return INFEASIBLE_SOLUTION_COST;
 		}
 
-		return totalTimeLoss + calcSoftConstraintPenalty(drtRequest, insertion, detourTimeInfo.pickupTimeLoss);
-	}
-
-	private boolean checkHardConstraints(InsertionWithDetourData<?> insertion, double pickupDetourTimeLoss,
-			double totalTimeLoss) {
-		return checkTimeConstraintsForScheduledRequests(insertion.getInsertion(), pickupDetourTimeLoss, totalTimeLoss)
-				&& checkTimeConstraintsForVehicle(insertion.getVehicleEntry(), totalTimeLoss, timeOfDay.getAsDouble());
+		double vehicleSlackTime = calcVehicleSlackTime(insertion.getVehicleEntry(), timeOfDay.getAsDouble());
+		return costCalculationStrategy.calcCost(drtRequest, insertion.getInsertion(), vehicleSlackTime, detourTimeInfo);
 	}
 
 	static boolean checkTimeConstraintsForScheduledRequests(InsertionGenerator.Insertion insertion,
@@ -159,52 +185,8 @@ public class InsertionCostCalculator<D> {
 		return true; //all time constraints of all stops are satisfied
 	}
 
-	static boolean checkTimeConstraintsForVehicle(VehicleData.Entry vEntry, double totalTimeLoss, double now) {
-		// check if the vehicle operations end time is satisfied
+	static double calcVehicleSlackTime(VehicleData.Entry vEntry, double now) {
 		DrtStayTask lastTask = (DrtStayTask)Schedules.getLastTask(vEntry.vehicle.getSchedule());
-		double timeSlack = vEntry.vehicle.getServiceEndTime() - Math.max(lastTask.getBeginTime(), now);
-		return timeSlack >= totalTimeLoss;
-	}
-
-	public static class SoftConstraintViolation {
-		public final double maxWaitTimeViolation;
-		public final double maxTravelTimeViolation;
-
-		public SoftConstraintViolation(double maxWaitTimeViolation, double maxTravelTimeViolation) {
-			this.maxWaitTimeViolation = maxWaitTimeViolation;
-			this.maxTravelTimeViolation = maxTravelTimeViolation;
-		}
-	}
-
-	/**
-	 * The request constraints are set in {@link DrtRequest}, which is used by {@link DrtRequestCreator},
-	 * which is used by {@link DrtRouteCreator} and {@link DefaultDrtRouteUpdater}.  kai, nov'18
-	 */
-	private double calcSoftConstraintPenalty(DrtRequest drtRequest, InsertionWithDetourData<D> insertion,
-			double pickupDetourTimeLoss) {
-		VehicleData.Entry vEntry = insertion.getVehicleEntry();
-		final int pickupIdx = insertion.getPickup().index;
-		final int dropoffIdx = insertion.getDropoff().index;
-
-		double driveToPickupStartTime = vEntry.getWaypoint(pickupIdx).getDepartureTime();
-		// (normally the end time of the previous task)
-		double pickupEndTime = driveToPickupStartTime
-				+ detourTime.applyAsDouble(insertion.getDetourToPickup())
-				+ stopDuration;
-		double dropoffStartTime = pickupIdx == dropoffIdx ?
-				pickupEndTime + detourTime.applyAsDouble(insertion.getDetourFromPickup()) :
-				// (special case if inserted dropoff is directly after inserted pickup)
-				vEntry.stops.get(dropoffIdx - 1).task.getEndTime() + pickupDetourTimeLoss + detourTime.applyAsDouble(
-						insertion.getDetourToDropoff());
-
-		double maxWaitTimeViolation = Math.max(0, pickupEndTime - drtRequest.getLatestStartTime());
-		// how much we are beyond the latest start time = request time + max wait time.
-		// max wait time currently comes from config
-
-		double maxTravelTimeViolation = Math.max(0, dropoffStartTime - drtRequest.getLatestArrivalTime());
-		// how much we are beyond the latest dropoff time = request time + max travel time.
-		// max travel time currently calculated with DrtRouteModule.getMaxTravelTime(unsharedRideTime)
-
-		return penaltyCalculator.calcPenalty(maxWaitTimeViolation, maxTravelTimeViolation);
+		return vEntry.vehicle.getServiceEndTime() - Math.max(lastTask.getBeginTime(), now);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculator.java
@@ -7,6 +7,7 @@ import java.util.function.ToDoubleFunction;
 import javax.annotation.Nullable;
 
 import org.matsim.contrib.drt.optimizer.VehicleData;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.DetourTimeInfo;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -26,20 +27,6 @@ class InsertionDetourTimeCalculator<D> {
 		this.stopDuration = stopDuration;
 		this.detourTime = detourTime;
 		this.replacedDriveTimeEstimator = replacedDriveTimeEstimator;
-	}
-
-	static class DetourTimeInfo {
-		final double departureTime;
-		final double arrivalTime;
-		final double pickupTimeLoss;
-		final double dropoffTimeLoss;
-
-		DetourTimeInfo(double departureTime, double arrivalTime, double pickupTimeLoss, double dropoffTimeLoss) {
-			this.departureTime = departureTime;
-			this.arrivalTime = arrivalTime;
-			this.pickupTimeLoss = pickupTimeLoss;
-			this.dropoffTimeLoss = dropoffTimeLoss;
-		}
 	}
 
 	DetourTimeInfo calculateDetourTimeInfo(InsertionWithDetourData<D> insertion) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearch.java
@@ -47,7 +47,7 @@ public class SelectiveInsertionSearch implements DrtInsertionSearch<PathData> {
 	private final BestInsertionFinder<PathData> bestInsertionFinder;
 
 	public SelectiveInsertionSearch(DetourPathCalculator detourPathCalculator, DrtConfigGroup drtCfg, MobsimTimer timer,
-			ForkJoinPool forkJoinPool, InsertionCostCalculator.PenaltyCalculator penaltyCalculator,
+			ForkJoinPool forkJoinPool, InsertionCostCalculator.CostCalculationStrategy costCalculationStrategy,
 			DvrpTravelTimeMatrix dvrpTravelTimeMatrix) {
 		this.detourPathCalculator = detourPathCalculator;
 		this.forkJoinPool = forkJoinPool;
@@ -58,11 +58,11 @@ public class SelectiveInsertionSearch implements DrtInsertionSearch<PathData> {
 		restrictiveDetourTimesProvider = new DetourTimesProvider(detourTimeEstimator);
 
 		initialInsertionFinder = new BestInsertionFinder<>(
-				new InsertionCostCalculator<>(drtCfg, timer, penaltyCalculator, Double::doubleValue,
+				new InsertionCostCalculator<>(drtCfg, timer, costCalculationStrategy, Double::doubleValue,
 						detourTimeEstimator));
 
 		bestInsertionFinder = new BestInsertionFinder<>(
-				new InsertionCostCalculator<>(drtCfg, timer, penaltyCalculator, PathData::getTravelTime, null));
+				new InsertionCostCalculator<>(drtCfg, timer, costCalculationStrategy, PathData::getTravelTime, null));
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchQSimModule.java
@@ -54,7 +54,7 @@ public class SelectiveInsertionSearchQSimModule extends AbstractDvrpModeQSimModu
 		}).toProvider(modalProvider(
 				getter -> new SelectiveInsertionSearch(getter.getModal(DetourPathCalculator.class), drtCfg,
 						getter.get(MobsimTimer.class), getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool(),
-						getter.getModal(InsertionCostCalculator.PenaltyCalculator.class),
+						getter.getModal(InsertionCostCalculator.CostCalculationStrategy.class),
 						getter.getModal(DvrpTravelTimeMatrix.class))));
 
 		addModalComponent(SingleInsertionDetourPathCalculator.class, new ModalProviders.AbstractProvider<>(getMode()) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/EDrtModeOptimizerQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/EDrtModeOptimizerQSimModule.java
@@ -129,7 +129,7 @@ public class EDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 		bindModal(VehicleData.EntryFactory.class).toProvider(
 				EDrtVehicleDataEntryFactory.EDrtVehicleDataEntryFactoryProvider.class).asEagerSingleton();
 
-		bindModal(InsertionCostCalculator.PenaltyCalculator.class).to(
+		bindModal(InsertionCostCalculator.CostCalculationStrategy.class).to(
 				drtCfg.isRejectRequestIfMaxWaitOrTravelTimeViolated() ?
 						InsertionCostCalculator.RejectSoftConstraintViolations.class :
 						InsertionCostCalculator.DiscourageSoftConstraintViolations.class).asEagerSingleton();

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
@@ -21,8 +21,8 @@
 package org.matsim.contrib.drt.optimizer.insertion;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.calcVehicleSlackTime;
 import static org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.checkTimeConstraintsForScheduledRequests;
-import static org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.checkTimeConstraintsForVehicle;
 
 import org.junit.Test;
 import org.matsim.api.core.v01.Id;
@@ -96,15 +96,19 @@ public class InsertionCostCalculatorTest {
 	}
 
 	@Test
-	public void checkTimeConstraintsForVehicle_all_cases() {
-		//just enough of slack time
-		assertThat(checkTimeConstraintsForVehicle(entry(1000, 600), 400, 0)).isTrue();
+	public void calcVehicleSlackTime_all_cases() {
+		//we are ahead of time
+		assertThat(calcVehicleSlackTime(entry(1000, 600), 0)).isEqualTo(400);
 
-		//not enough of slack time - due to predicted last stay begin time
-		assertThat(checkTimeConstraintsForVehicle(entry(1000, 600), 401, 0)).isFalse();
+		//at least 150 s of delay, optimistically 250 s of slack
+		assertThat(calcVehicleSlackTime(entry(1000, 600), 750)).isEqualTo(250);
 
-		//note enough of slack time - due to current time
-		assertThat(checkTimeConstraintsForVehicle(entry(1000, 600), 400, 601)).isFalse();
+		//behind the vehicle end time - due to current time
+		assertThat(calcVehicleSlackTime(entry(1000, 990), 1111)).isEqualTo(-111);
+
+		//behind the vehicle end time - due to predicted last task end time
+		assertThat(calcVehicleSlackTime(entry(1000, 1234), 888)).isEqualTo(-234);
+
 	}
 
 	private VehicleData.Entry entry(double vehicleEndTime, double lastStayTaskBeginTime) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
@@ -21,14 +21,16 @@
 package org.matsim.contrib.drt.optimizer.insertion;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.calcVehicleSlackTime;
-import static org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.checkTimeConstraintsForScheduledRequests;
+import static org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.DiscourageSoftConstraintViolations.MAX_TRAVEL_TIME_VIOLATION_PENALTY;
+import static org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.DiscourageSoftConstraintViolations.MAX_WAIT_TIME_VIOLATION_PENALTY;
+import static org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.*;
 
 import org.junit.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.optimizer.VehicleData;
 import org.matsim.contrib.drt.optimizer.Waypoint;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.*;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
 import org.matsim.contrib.drt.schedule.DrtStopTask;
@@ -144,4 +146,70 @@ public class InsertionCostCalculatorTest {
 	private InsertionGenerator.Insertion insertion(VehicleData.Entry entry, int pickupIdx, int dropoffIdx) {
 		return new InsertionGenerator.Insertion(drtRequest, entry, pickupIdx, dropoffIdx);
 	}
+
+	@Test
+	public void RejectSoftConstraintViolations_tooLittleSlackTime() {
+		assertRejectSoftConstraintViolations(9999, 9999, 10, new DetourTimeInfo(0, 0, 5, 5.01),
+				INFEASIBLE_SOLUTION_COST);
+	}
+
+	@Test
+	public void RejectSoftConstraintViolations_tooLongWaitTime() {
+		assertRejectSoftConstraintViolations(10, 9999, 9999, new DetourTimeInfo(11, 22, 0, 0),
+				INFEASIBLE_SOLUTION_COST);
+	}
+
+	@Test
+	public void RejectSoftConstraintViolations_tooLongTravelTime() {
+		assertRejectSoftConstraintViolations(9999, 10, 9999, new DetourTimeInfo(0, 11, 0, 0), INFEASIBLE_SOLUTION_COST);
+	}
+
+	@Test
+	public void RejectSoftConstraintViolations_allConstraintSatisfied() {
+		assertRejectSoftConstraintViolations(9999, 9999, 9999, new DetourTimeInfo(11, 22, 33, 44), 33 + 44);
+	}
+
+	private void assertRejectSoftConstraintViolations(double latestStartTime, double latestArrivalTime,
+			double vehicleSlackTime, DetourTimeInfo detourTimeInfo, double expectedCost) {
+		var drtRequest = DrtRequest.newBuilder()
+				.latestStartTime(latestStartTime)
+				.latestArrivalTime(latestArrivalTime)
+				.build();
+		assertThat(new InsertionCostCalculator.RejectSoftConstraintViolations().calcCost(drtRequest, null,
+				vehicleSlackTime, detourTimeInfo)).isEqualTo(expectedCost);
+	}
+
+	@Test
+	public void DiscourageSoftConstraintViolations_tooLittleSlackTime() {
+		assertDiscourageSoftConstraintViolations(9999, 9999, 10, new DetourTimeInfo(0, 0, 5, 5.01),
+				INFEASIBLE_SOLUTION_COST);
+	}
+
+	@Test
+	public void DiscourageSoftConstraintViolations_tooLongWaitTime() {
+		assertDiscourageSoftConstraintViolations(10, 9999, 9999, new DetourTimeInfo(11, 22, 0, 0),
+				MAX_WAIT_TIME_VIOLATION_PENALTY);
+	}
+
+	@Test
+	public void DiscourageSoftConstraintViolations_tooLongTravelTime() {
+		assertDiscourageSoftConstraintViolations(9999, 10, 9999, new DetourTimeInfo(0, 11, 0, 0),
+				MAX_TRAVEL_TIME_VIOLATION_PENALTY);
+	}
+
+	@Test
+	public void DiscourageSoftConstraintViolations_allConstraintSatisfied() {
+		assertDiscourageSoftConstraintViolations(9999, 9999, 9999, new DetourTimeInfo(11, 22, 33, 44), 33 + 44);
+	}
+
+	private void assertDiscourageSoftConstraintViolations(double latestStartTime, double latestArrivalTime,
+			double vehicleSlackTime, DetourTimeInfo detourTimeInfo, double expectedCost) {
+		var drtRequest = DrtRequest.newBuilder()
+				.latestStartTime(latestStartTime)
+				.latestArrivalTime(latestArrivalTime)
+				.build();
+		assertThat(new InsertionCostCalculator.DiscourageSoftConstraintViolations().calcCost(drtRequest, null,
+				vehicleSlackTime, detourTimeInfo)).isEqualTo(expectedCost);
+	}
+
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
@@ -27,7 +27,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.optimizer.VehicleData.Entry;
 import org.matsim.contrib.drt.optimizer.Waypoint;
-import org.matsim.contrib.drt.optimizer.insertion.InsertionDetourTimeCalculator.DetourTimeInfo;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.DetourTimeInfo;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.schedule.DrtStopTask;


### PR DESCRIPTION
The existing soft constraint calculation did not capture all possible special cases (e.g. pickup is included into ongoing/planned stop task -> no additional time loss wrt stop task) when computing the expected departure/arrival times for an incoming request (given insertion points).

The new approach to insertion cost computation uses `DetourTimeInfo`, where most of the critical data is already pre-computed (by `InsertionDetourTimeCalculator`, see #1357 ).

This PR may lead to slightly different results obtained by DRT (e.g. fewer rejections if they are enabled).