### PR TITLE
DRT: move CostCalculationStrategy outside InsertionCostCalculator

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtModeOptimizerQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtModeOptimizerQSimModule.java
@@ -23,11 +23,11 @@ package org.matsim.contrib.drt.optimizer;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.optimizer.depot.DepotFinder;
 import org.matsim.contrib.drt.optimizer.depot.NearestStartLinkAsDepot;
+import org.matsim.contrib.drt.optimizer.insertion.CostCalculationStrategy;
 import org.matsim.contrib.drt.optimizer.insertion.DefaultUnplannedRequestInserter;
 import org.matsim.contrib.drt.optimizer.insertion.DrtInsertionSearch;
 import org.matsim.contrib.drt.optimizer.insertion.ExtensiveInsertionSearchParams;
 import org.matsim.contrib.drt.optimizer.insertion.ExtensiveInsertionSearchQSimModule;
-import org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator;
 import org.matsim.contrib.drt.optimizer.insertion.SelectiveInsertionSearchParams;
 import org.matsim.contrib.drt.optimizer.insertion.SelectiveInsertionSearchQSimModule;
 import org.matsim.contrib.drt.optimizer.insertion.UnplannedRequestInserter;
@@ -98,10 +98,10 @@ public class DrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 
 		bindModal(VehicleData.EntryFactory.class).toInstance(new VehicleDataEntryFactoryImpl(drtCfg));
 
-		bindModal(InsertionCostCalculator.CostCalculationStrategy.class).to(
+		bindModal(CostCalculationStrategy.class).to(
 				drtCfg.isRejectRequestIfMaxWaitOrTravelTimeViolated() ?
-						InsertionCostCalculator.RejectSoftConstraintViolations.class :
-						InsertionCostCalculator.DiscourageSoftConstraintViolations.class).asEagerSingleton();
+						CostCalculationStrategy.RejectSoftConstraintViolations.class :
+						CostCalculationStrategy.DiscourageSoftConstraintViolations.class).asEagerSingleton();
 
 		bindModal(DrtTaskFactory.class).toInstance(new DrtTaskFactoryImpl());
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategy.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategy.java
@@ -26,6 +26,13 @@ import org.matsim.contrib.drt.passenger.DrtRequest;
  * @author Michal Maciejewski (michalm)
  */
 public interface CostCalculationStrategy {
+	/**
+	 * @param request
+	 * @param insertion
+	 * @param vehicleSlackTime
+	 * @param detourTimeInfo
+	 * @return the cost of insertion, INFEASIBLE_SOLUTION_COST if insertion is not feasible
+	 */
 	double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion, double vehicleSlackTime,
 			InsertionCostCalculator.DetourTimeInfo detourTimeInfo);
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategy.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategy.java
@@ -1,0 +1,68 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2021 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.optimizer.insertion;
+
+import org.matsim.contrib.drt.passenger.DrtRequest;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public interface CostCalculationStrategy {
+	double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion, double vehicleSlackTime,
+			InsertionCostCalculator.DetourTimeInfo detourTimeInfo);
+
+	class RejectSoftConstraintViolations implements CostCalculationStrategy {
+		@Override
+		public double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion, double vehicleSlackTime,
+				InsertionCostCalculator.DetourTimeInfo detourTimeInfo) {
+			double totalTimeLoss = detourTimeInfo.getTotalTimeLoss();
+			if (totalTimeLoss - vehicleSlackTime > 0
+					|| detourTimeInfo.departureTime - request.getLatestStartTime() > 0
+					|| detourTimeInfo.arrivalTime - request.getLatestArrivalTime() > 0) {
+				return InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
+			}
+
+			return totalTimeLoss;
+		}
+	}
+
+	class DiscourageSoftConstraintViolations implements CostCalculationStrategy {
+		//XXX try to keep penalties reasonably high to prevent people waiting or travelling for hours
+		//XXX however, at the same time prefer max-wait-time to max-travel-time violations
+		static final double MAX_WAIT_TIME_VIOLATION_PENALTY = 1;// 1 second of penalty per 1 second of late departure
+		static final double MAX_TRAVEL_TIME_VIOLATION_PENALTY = 10;// 10 seconds of penalty per 1 second of late arrival
+
+		@Override
+		public double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion, double vehicleSlackTime,
+				InsertionCostCalculator.DetourTimeInfo detourTimeInfo) {
+			double totalTimeLoss = detourTimeInfo.getTotalTimeLoss();
+			if (totalTimeLoss - vehicleSlackTime > 0) {
+				return InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
+			}
+
+			double waitTimeViolation = Math.max(0, detourTimeInfo.departureTime - request.getLatestStartTime());
+			double travelTimeViolation = Math.max(0, detourTimeInfo.arrivalTime - request.getLatestArrivalTime());
+			return MAX_WAIT_TIME_VIOLATION_PENALTY * waitTimeViolation
+					+ MAX_TRAVEL_TIME_VIOLATION_PENALTY * travelTimeViolation
+					+ totalTimeLoss;
+		}
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearch.java
@@ -49,7 +49,7 @@ public class ExtensiveInsertionSearch implements DrtInsertionSearch<PathData> {
 	private final BestInsertionFinder<PathData> bestInsertionFinder;
 
 	public ExtensiveInsertionSearch(DetourPathCalculator detourPathCalculator, DrtConfigGroup drtCfg, MobsimTimer timer,
-			ForkJoinPool forkJoinPool, InsertionCostCalculator.CostCalculationStrategy costCalculationStrategy,
+			ForkJoinPool forkJoinPool, CostCalculationStrategy costCalculationStrategy,
 			DvrpTravelTimeMatrix dvrpTravelTimeMatrix) {
 		this.detourPathCalculator = detourPathCalculator;
 		this.forkJoinPool = forkJoinPool;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchQSimModule.java
@@ -54,7 +54,7 @@ public class ExtensiveInsertionSearchQSimModule extends AbstractDvrpModeQSimModu
 		}).toProvider(modalProvider(
 				getter -> new ExtensiveInsertionSearch(getter.getModal(DetourPathCalculator.class), drtCfg,
 						getter.get(MobsimTimer.class), getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool(),
-						getter.getModal(InsertionCostCalculator.CostCalculationStrategy.class),
+						getter.getModal(CostCalculationStrategy.class),
 						getter.getModal(DvrpTravelTimeMatrix.class))));
 
 		addModalComponent(MultiInsertionDetourPathCalculator.class, new ModalProviders.AbstractProvider<>(getMode()) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculator.java
@@ -54,48 +54,6 @@ public class InsertionCostCalculator<D> {
 		}
 	}
 
-	public interface CostCalculationStrategy {
-		double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion, double vehicleSlackTime,
-				DetourTimeInfo detourTimeInfo);
-	}
-
-	public static class RejectSoftConstraintViolations implements CostCalculationStrategy {
-		@Override
-		public double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion, double vehicleSlackTime,
-				DetourTimeInfo detourTimeInfo) {
-			double totalTimeLoss = detourTimeInfo.getTotalTimeLoss();
-			if (totalTimeLoss - vehicleSlackTime > 0
-					|| detourTimeInfo.departureTime - request.getLatestStartTime() > 0
-					|| detourTimeInfo.arrivalTime - request.getLatestArrivalTime() > 0) {
-				return INFEASIBLE_SOLUTION_COST;
-			}
-
-			return totalTimeLoss;
-		}
-	}
-
-	public static class DiscourageSoftConstraintViolations implements CostCalculationStrategy {
-		//XXX try to keep penalties reasonably high to prevent people waiting or travelling for hours
-		//XXX however, at the same time prefer max-wait-time to max-travel-time violations
-		static final double MAX_WAIT_TIME_VIOLATION_PENALTY = 1;// 1 second of penalty per 1 second of late departure
-		static final double MAX_TRAVEL_TIME_VIOLATION_PENALTY = 10;// 10 seconds of penalty per 1 second of late arrival
-
-		@Override
-		public double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion, double vehicleSlackTime,
-				DetourTimeInfo detourTimeInfo) {
-			double totalTimeLoss = detourTimeInfo.getTotalTimeLoss();
-			if (totalTimeLoss - vehicleSlackTime > 0) {
-				return INFEASIBLE_SOLUTION_COST;
-			}
-
-			double waitTimeViolation = Math.max(0, detourTimeInfo.departureTime - request.getLatestStartTime());
-			double travelTimeViolation = Math.max(0, detourTimeInfo.arrivalTime - request.getLatestArrivalTime());
-			return MAX_WAIT_TIME_VIOLATION_PENALTY * waitTimeViolation
-					+ MAX_TRAVEL_TIME_VIOLATION_PENALTY * travelTimeViolation
-					+ totalTimeLoss;
-		}
-	}
-
 	public static final double INFEASIBLE_SOLUTION_COST = Double.POSITIVE_INFINITY;
 
 	private final DoubleSupplier timeOfDay;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearch.java
@@ -47,7 +47,7 @@ public class SelectiveInsertionSearch implements DrtInsertionSearch<PathData> {
 	private final BestInsertionFinder<PathData> bestInsertionFinder;
 
 	public SelectiveInsertionSearch(DetourPathCalculator detourPathCalculator, DrtConfigGroup drtCfg, MobsimTimer timer,
-			ForkJoinPool forkJoinPool, InsertionCostCalculator.CostCalculationStrategy costCalculationStrategy,
+			ForkJoinPool forkJoinPool, CostCalculationStrategy costCalculationStrategy,
 			DvrpTravelTimeMatrix dvrpTravelTimeMatrix) {
 		this.detourPathCalculator = detourPathCalculator;
 		this.forkJoinPool = forkJoinPool;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchQSimModule.java
@@ -54,7 +54,7 @@ public class SelectiveInsertionSearchQSimModule extends AbstractDvrpModeQSimModu
 		}).toProvider(modalProvider(
 				getter -> new SelectiveInsertionSearch(getter.getModal(DetourPathCalculator.class), drtCfg,
 						getter.get(MobsimTimer.class), getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool(),
-						getter.getModal(InsertionCostCalculator.CostCalculationStrategy.class),
+						getter.getModal(CostCalculationStrategy.class),
 						getter.getModal(DvrpTravelTimeMatrix.class))));
 
 		addModalComponent(SingleInsertionDetourPathCalculator.class, new ModalProviders.AbstractProvider<>(getMode()) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/EDrtModeOptimizerQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/edrt/run/EDrtModeOptimizerQSimModule.java
@@ -27,9 +27,9 @@ import org.matsim.contrib.drt.optimizer.DrtOptimizer;
 import org.matsim.contrib.drt.optimizer.QSimScopeForkJoinPoolHolder;
 import org.matsim.contrib.drt.optimizer.VehicleData;
 import org.matsim.contrib.drt.optimizer.depot.DepotFinder;
+import org.matsim.contrib.drt.optimizer.insertion.CostCalculationStrategy;
 import org.matsim.contrib.drt.optimizer.insertion.DefaultUnplannedRequestInserter;
 import org.matsim.contrib.drt.optimizer.insertion.DrtInsertionSearch;
-import org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator;
 import org.matsim.contrib.drt.optimizer.insertion.UnplannedRequestInserter;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
@@ -129,10 +129,10 @@ public class EDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 		bindModal(VehicleData.EntryFactory.class).toProvider(
 				EDrtVehicleDataEntryFactory.EDrtVehicleDataEntryFactoryProvider.class).asEagerSingleton();
 
-		bindModal(InsertionCostCalculator.CostCalculationStrategy.class).to(
+		bindModal(CostCalculationStrategy.class).to(
 				drtCfg.isRejectRequestIfMaxWaitOrTravelTimeViolated() ?
-						InsertionCostCalculator.RejectSoftConstraintViolations.class :
-						InsertionCostCalculator.DiscourageSoftConstraintViolations.class).asEagerSingleton();
+						CostCalculationStrategy.RejectSoftConstraintViolations.class :
+						CostCalculationStrategy.DiscourageSoftConstraintViolations.class).asEagerSingleton();
 
 		bindModal(DrtTaskFactory.class).toInstance(new EDrtTaskFactoryImpl());
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategyTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategyTest.java
@@ -1,0 +1,102 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2021 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.optimizer.insertion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.matsim.contrib.drt.optimizer.insertion.CostCalculationStrategy.DiscourageSoftConstraintViolations.MAX_TRAVEL_TIME_VIOLATION_PENALTY;
+import static org.matsim.contrib.drt.optimizer.insertion.CostCalculationStrategy.DiscourageSoftConstraintViolations.MAX_WAIT_TIME_VIOLATION_PENALTY;
+import static org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
+
+import org.junit.Test;
+import org.matsim.contrib.drt.passenger.DrtRequest;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class CostCalculationStrategyTest {
+	@Test
+	public void RejectSoftConstraintViolations_tooLittleSlackTime() {
+		assertRejectSoftConstraintViolations(9999, 9999, 10, new InsertionCostCalculator.DetourTimeInfo(0, 0, 5, 5.01),
+				INFEASIBLE_SOLUTION_COST);
+	}
+
+	@Test
+	public void RejectSoftConstraintViolations_tooLongWaitTime() {
+		assertRejectSoftConstraintViolations(10, 9999, 9999, new InsertionCostCalculator.DetourTimeInfo(11, 22, 0, 0),
+				INFEASIBLE_SOLUTION_COST);
+	}
+
+	@Test
+	public void RejectSoftConstraintViolations_tooLongTravelTime() {
+		assertRejectSoftConstraintViolations(9999, 10, 9999, new InsertionCostCalculator.DetourTimeInfo(0, 11, 0, 0),
+				INFEASIBLE_SOLUTION_COST);
+	}
+
+	@Test
+	public void RejectSoftConstraintViolations_allConstraintSatisfied() {
+		assertRejectSoftConstraintViolations(9999, 9999, 9999,
+				new InsertionCostCalculator.DetourTimeInfo(11, 22, 33, 44), 33 + 44);
+	}
+
+	private void assertRejectSoftConstraintViolations(double latestStartTime, double latestArrivalTime,
+			double vehicleSlackTime, InsertionCostCalculator.DetourTimeInfo detourTimeInfo, double expectedCost) {
+		var drtRequest = DrtRequest.newBuilder()
+				.latestStartTime(latestStartTime)
+				.latestArrivalTime(latestArrivalTime)
+				.build();
+		assertThat(new CostCalculationStrategy.RejectSoftConstraintViolations().calcCost(drtRequest, null,
+				vehicleSlackTime, detourTimeInfo)).isEqualTo(expectedCost);
+	}
+
+	@Test
+	public void DiscourageSoftConstraintViolations_tooLittleSlackTime() {
+		assertDiscourageSoftConstraintViolations(9999, 9999, 10,
+				new InsertionCostCalculator.DetourTimeInfo(0, 0, 5, 5.01), INFEASIBLE_SOLUTION_COST);
+	}
+
+	@Test
+	public void DiscourageSoftConstraintViolations_tooLongWaitTime() {
+		assertDiscourageSoftConstraintViolations(10, 9999, 9999,
+				new InsertionCostCalculator.DetourTimeInfo(11, 22, 0, 0), MAX_WAIT_TIME_VIOLATION_PENALTY);
+	}
+
+	@Test
+	public void DiscourageSoftConstraintViolations_tooLongTravelTime() {
+		assertDiscourageSoftConstraintViolations(9999, 10, 9999,
+				new InsertionCostCalculator.DetourTimeInfo(0, 11, 0, 0), MAX_TRAVEL_TIME_VIOLATION_PENALTY);
+	}
+
+	@Test
+	public void DiscourageSoftConstraintViolations_allConstraintSatisfied() {
+		assertDiscourageSoftConstraintViolations(9999, 9999, 9999,
+				new InsertionCostCalculator.DetourTimeInfo(11, 22, 33, 44), 33 + 44);
+	}
+
+	private void assertDiscourageSoftConstraintViolations(double latestStartTime, double latestArrivalTime,
+			double vehicleSlackTime, InsertionCostCalculator.DetourTimeInfo detourTimeInfo, double expectedCost) {
+		var drtRequest = DrtRequest.newBuilder()
+				.latestStartTime(latestStartTime)
+				.latestArrivalTime(latestArrivalTime)
+				.build();
+		assertThat(new CostCalculationStrategy.DiscourageSoftConstraintViolations().calcCost(drtRequest, null,
+				vehicleSlackTime, detourTimeInfo)).isEqualTo(expectedCost);
+	}
+}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
@@ -21,16 +21,14 @@
 package org.matsim.contrib.drt.optimizer.insertion;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.DiscourageSoftConstraintViolations.MAX_TRAVEL_TIME_VIOLATION_PENALTY;
-import static org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.DiscourageSoftConstraintViolations.MAX_WAIT_TIME_VIOLATION_PENALTY;
-import static org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.*;
+import static org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.calcVehicleSlackTime;
+import static org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.checkTimeConstraintsForScheduledRequests;
 
 import org.junit.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.optimizer.VehicleData;
 import org.matsim.contrib.drt.optimizer.Waypoint;
-import org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.*;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
 import org.matsim.contrib.drt.schedule.DrtStopTask;
@@ -146,70 +144,4 @@ public class InsertionCostCalculatorTest {
 	private InsertionGenerator.Insertion insertion(VehicleData.Entry entry, int pickupIdx, int dropoffIdx) {
 		return new InsertionGenerator.Insertion(drtRequest, entry, pickupIdx, dropoffIdx);
 	}
-
-	@Test
-	public void RejectSoftConstraintViolations_tooLittleSlackTime() {
-		assertRejectSoftConstraintViolations(9999, 9999, 10, new DetourTimeInfo(0, 0, 5, 5.01),
-				INFEASIBLE_SOLUTION_COST);
-	}
-
-	@Test
-	public void RejectSoftConstraintViolations_tooLongWaitTime() {
-		assertRejectSoftConstraintViolations(10, 9999, 9999, new DetourTimeInfo(11, 22, 0, 0),
-				INFEASIBLE_SOLUTION_COST);
-	}
-
-	@Test
-	public void RejectSoftConstraintViolations_tooLongTravelTime() {
-		assertRejectSoftConstraintViolations(9999, 10, 9999, new DetourTimeInfo(0, 11, 0, 0), INFEASIBLE_SOLUTION_COST);
-	}
-
-	@Test
-	public void RejectSoftConstraintViolations_allConstraintSatisfied() {
-		assertRejectSoftConstraintViolations(9999, 9999, 9999, new DetourTimeInfo(11, 22, 33, 44), 33 + 44);
-	}
-
-	private void assertRejectSoftConstraintViolations(double latestStartTime, double latestArrivalTime,
-			double vehicleSlackTime, DetourTimeInfo detourTimeInfo, double expectedCost) {
-		var drtRequest = DrtRequest.newBuilder()
-				.latestStartTime(latestStartTime)
-				.latestArrivalTime(latestArrivalTime)
-				.build();
-		assertThat(new InsertionCostCalculator.RejectSoftConstraintViolations().calcCost(drtRequest, null,
-				vehicleSlackTime, detourTimeInfo)).isEqualTo(expectedCost);
-	}
-
-	@Test
-	public void DiscourageSoftConstraintViolations_tooLittleSlackTime() {
-		assertDiscourageSoftConstraintViolations(9999, 9999, 10, new DetourTimeInfo(0, 0, 5, 5.01),
-				INFEASIBLE_SOLUTION_COST);
-	}
-
-	@Test
-	public void DiscourageSoftConstraintViolations_tooLongWaitTime() {
-		assertDiscourageSoftConstraintViolations(10, 9999, 9999, new DetourTimeInfo(11, 22, 0, 0),
-				MAX_WAIT_TIME_VIOLATION_PENALTY);
-	}
-
-	@Test
-	public void DiscourageSoftConstraintViolations_tooLongTravelTime() {
-		assertDiscourageSoftConstraintViolations(9999, 10, 9999, new DetourTimeInfo(0, 11, 0, 0),
-				MAX_TRAVEL_TIME_VIOLATION_PENALTY);
-	}
-
-	@Test
-	public void DiscourageSoftConstraintViolations_allConstraintSatisfied() {
-		assertDiscourageSoftConstraintViolations(9999, 9999, 9999, new DetourTimeInfo(11, 22, 33, 44), 33 + 44);
-	}
-
-	private void assertDiscourageSoftConstraintViolations(double latestStartTime, double latestArrivalTime,
-			double vehicleSlackTime, DetourTimeInfo detourTimeInfo, double expectedCost) {
-		var drtRequest = DrtRequest.newBuilder()
-				.latestStartTime(latestStartTime)
-				.latestArrivalTime(latestArrivalTime)
-				.build();
-		assertThat(new InsertionCostCalculator.DiscourageSoftConstraintViolations().calcCost(drtRequest, null,
-				vehicleSlackTime, detourTimeInfo)).isEqualTo(expectedCost);
-	}
-
 }


### PR DESCRIPTION
Main change: `CostCalculationStrategy` becomes a standalone interface, putting some more spotlight on it as a way of making DRT more flexible.

BTW. The recent changes in `CostCalculationStrategy.calcCost()` open up modelling the following use cases:
- allow exceeding the vehicle operation time (i.e. scheduling tasks beyond the vehicle's `serviceEndTime`)
- shifting focus from minimising the fleet workload to maximising the service quality (i.e. calculating impact on all scheduled requests and the new one).