### PR TITLE
DRT: check slack time iff insertion ends in time loss

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategy.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategy.java
@@ -41,9 +41,10 @@ public interface CostCalculationStrategy {
 		public double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion, double vehicleSlackTime,
 				InsertionCostCalculator.DetourTimeInfo detourTimeInfo) {
 			double totalTimeLoss = detourTimeInfo.getTotalTimeLoss();
-			if (totalTimeLoss - vehicleSlackTime > 0
-					|| detourTimeInfo.departureTime - request.getLatestStartTime() > 0
-					|| detourTimeInfo.arrivalTime - request.getLatestArrivalTime() > 0) {
+			if ((totalTimeLoss > 0 && totalTimeLoss > vehicleSlackTime)
+					|| detourTimeInfo.departureTime > request.getLatestStartTime()
+					|| detourTimeInfo.arrivalTime > request.getLatestArrivalTime()) {
+				//no extra time is lost => do not check if the current slack time is long enough (can be even negative)
 				return InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
 			}
 
@@ -61,7 +62,8 @@ public interface CostCalculationStrategy {
 		public double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion, double vehicleSlackTime,
 				InsertionCostCalculator.DetourTimeInfo detourTimeInfo) {
 			double totalTimeLoss = detourTimeInfo.getTotalTimeLoss();
-			if (totalTimeLoss - vehicleSlackTime > 0) {
+			if (totalTimeLoss > 0 && totalTimeLoss > vehicleSlackTime) {
+				//no extra time is lost => do not check if the current slack time is long enough (can be even negative)
 				return InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
 			}
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategyTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategyTest.java
@@ -39,6 +39,12 @@ public class CostCalculationStrategyTest {
 	}
 
 	@Test
+	public void RejectSoftConstraintViolations_negativeSlackTime_butNoTimeLoss() {
+		assertRejectSoftConstraintViolations(9999, 9999, -10, new InsertionCostCalculator.DetourTimeInfo(0, 0, 0, 0),
+				0);
+	}
+
+	@Test
 	public void RejectSoftConstraintViolations_tooLongWaitTime() {
 		assertRejectSoftConstraintViolations(10, 9999, 9999, new InsertionCostCalculator.DetourTimeInfo(11, 22, 0, 0),
 				INFEASIBLE_SOLUTION_COST);
@@ -70,6 +76,12 @@ public class CostCalculationStrategyTest {
 	public void DiscourageSoftConstraintViolations_tooLittleSlackTime() {
 		assertDiscourageSoftConstraintViolations(9999, 9999, 10,
 				new InsertionCostCalculator.DetourTimeInfo(0, 0, 5, 5.01), INFEASIBLE_SOLUTION_COST);
+	}
+
+	@Test
+	public void DiscourageSoftConstraintViolations_negativeSlackTime_butNoTimeLoss() {
+		assertDiscourageSoftConstraintViolations(9999, 9999, -10,
+				new InsertionCostCalculator.DetourTimeInfo(0, 0, 0, 0), 0);
 	}
 
 	@Test


### PR DESCRIPTION
Otherwise, do not check if the current slack time is long enough (can be even negative)

In other words: if vehicle is behind its schedule and will stop operations after the desired `serviceEndTime`, we can still add more requests if they are picked up and dropped off at the already planned stops (so it does not incur additional delays).

This change is applied to both default cost strategies: `RejectSoftConstraintViolations` and `DiscourageSoftConstraintViolations`.