### PR TITLE
DRT: Remove pickup dropoff from drt request

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
@@ -109,13 +109,12 @@ public class DefaultUnplannedRequestInserter implements UnplannedRequestInserter
 			}
 		} else {
 			InsertionWithDetourData<PathData> insertion = best.get();
-			insertionScheduler.scheduleRequest(req, insertion);
+			var pickupDropoffTaskPair = insertionScheduler.scheduleRequest(req, insertion);
 			vData.updateEntry(insertion.getVehicleEntry().vehicle);
 			eventsManager.processEvent(
 					new PassengerRequestScheduledEvent(now, drtCfg.getMode(), req.getId(), req.getPassengerId(),
-							insertion.getVehicleEntry().vehicle.getId(), req.getPickupTask().getEndTime(),
-							req.getDropoffTask().getBeginTime()));
+							insertion.getVehicleEntry().vehicle.getId(), pickupDropoffTaskPair.pickupTask.getEndTime(),
+							pickupDropoffTaskPair.dropoffTask.getBeginTime()));
 		}
-
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DrtRequest.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DrtRequest.java
@@ -23,7 +23,6 @@ package org.matsim.contrib.drt.passenger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
-import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.dvrp.optimizer.Request;
 import org.matsim.contrib.dvrp.passenger.PassengerRequest;
 
@@ -45,9 +44,6 @@ public class DrtRequest implements PassengerRequest {
 	private final Link fromLink;
 	private final Link toLink;
 
-	private DrtStopTask pickupTask = null;
-	private DrtStopTask dropoffTask = null;
-
 	private DrtRequest(Builder builder) {
 		id = builder.id;
 		submissionTime = builder.submissionTime;
@@ -58,8 +54,6 @@ public class DrtRequest implements PassengerRequest {
 		mode = builder.mode;
 		fromLink = builder.fromLink;
 		toLink = builder.toLink;
-		setPickupTask(builder.pickupTask);
-		setDropoffTask(builder.dropoffTask);
 	}
 
 	public static Builder newBuilder() {
@@ -77,8 +71,6 @@ public class DrtRequest implements PassengerRequest {
 		builder.mode = copy.getMode();
 		builder.fromLink = copy.getFromLink();
 		builder.toLink = copy.getToLink();
-		builder.pickupTask = copy.getPickupTask();
-		builder.dropoffTask = copy.getDropoffTask();
 		return builder;
 	}
 
@@ -126,22 +118,6 @@ public class DrtRequest implements PassengerRequest {
 		return mode;
 	}
 
-	public DrtStopTask getPickupTask() {
-		return pickupTask;
-	}
-
-	public void setPickupTask(DrtStopTask pickupTask) {
-		this.pickupTask = pickupTask;
-	}
-
-	public DrtStopTask getDropoffTask() {
-		return dropoffTask;
-	}
-
-	public void setDropoffTask(DrtStopTask dropoffTask) {
-		this.dropoffTask = dropoffTask;
-	}
-
 	@Override
 	public String toString() {
 		return MoreObjects.toStringHelper(this)
@@ -154,8 +130,6 @@ public class DrtRequest implements PassengerRequest {
 				.add("mode", mode)
 				.add("fromLink", fromLink)
 				.add("toLink", toLink)
-				.add("pickupTask", pickupTask)
-				.add("dropoffTask", dropoffTask)
 				.toString();
 	}
 
@@ -169,8 +143,6 @@ public class DrtRequest implements PassengerRequest {
 		private String mode;
 		private Link fromLink;
 		private Link toLink;
-		private DrtStopTask pickupTask;
-		private DrtStopTask dropoffTask;
 
 		private Builder() {
 		}
@@ -217,16 +189,6 @@ public class DrtRequest implements PassengerRequest {
 
 		public Builder toLink(Link val) {
 			toLink = val;
-			return this;
-		}
-
-		public Builder pickupTask(DrtStopTask val) {
-			pickupTask = val;
-			return this;
-		}
-
-		public Builder dropoffTask(DrtStopTask val) {
-			dropoffTask = val;
 			return this;
 		}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/util/DrtRequestTimeConstraintViolations.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/util/DrtRequestTimeConstraintViolations.java
@@ -37,24 +37,10 @@ public class DrtRequestTimeConstraintViolations {
 	}
 
 	/**
-	 * @return expected/actual wait time constraint violation of a planned/performed pickup
-	 */
-	public static double getCurrentWaitTimeViolation(DrtRequest request) {
-		return getTimeConstraintViolation(request.getPickupTask().getEndTime(), request.getLatestStartTime());
-	}
-
-	/**
 	 * @return travel time constraint violation at the moment of request insertion
 	 */
 	public static double getInitialTravelTimeViolation(DrtRequest request, PassengerRequestScheduledEvent event) {
 		return getTimeConstraintViolation(event.getDropoffTime(), request.getLatestArrivalTime());
-	}
-
-	/**
-	 * @return expected/actual travel time constraint violation of a planned/performed pickup
-	 */
-	public static double getCurrentTravelTimeViolation(DrtRequest request) {
-		return getTimeConstraintViolation(request.getDropoffTask().getEndTime(), request.getLatestArrivalTime());
 	}
 
 	private static double getTimeConstraintViolation(double time, double maxTime) {

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/passenger/TaxiRequest.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/passenger/TaxiRequest.java
@@ -54,6 +54,7 @@ public class TaxiRequest implements PassengerRequest {
 	private final Link fromLink;
 	private final Link toLink;
 
+	//TODO remove (request should be unmodifiable)
 	private TaxiPickupTask pickupTask;
 	private TaxiDropoffTask dropoffTask;
 
@@ -103,22 +104,15 @@ public class TaxiRequest implements PassengerRequest {
 		return mode;
 	}
 
-	public TaxiPickupTask getPickupTask() {
-		return pickupTask;
-	}
-
 	public void setPickupTask(TaxiPickupTask pickupTask) {
 		this.pickupTask = pickupTask;
-	}
-
-	public TaxiDropoffTask getDropoffTask() {
-		return dropoffTask;
 	}
 
 	public void setDropoffTask(TaxiDropoffTask dropoffTask) {
 		this.dropoffTask = dropoffTask;
 	}
 
+	//TODO remove, replace with events analysis (request should be unmodifiable)
 	public TaxiRequestStatus getStatus() {
 		if (pickupTask == null) {
 			return TaxiRequestStatus.UNPLANNED;
@@ -158,8 +152,6 @@ public class TaxiRequest implements PassengerRequest {
 				.add("mode", mode)
 				.add("fromLink", fromLink)
 				.add("toLink", toLink)
-				.add("pickupTask", pickupTask)
-				.add("dropoffTask", dropoffTask)
 				.toString();
 	}
 }


### PR DESCRIPTION
Reason: Requests should be unmodifiable input (so this is not a place for storing planning/execution details)

Additionally: hide pickup/dropoff tasks from `TaxiRequest` to prepare for removal. We cannot remove them completely yet, as the taxi request also contains status (which depends on these tasks).