### PR TITLE
rename (misleading) performance indicator from revenue distance to pa…

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
@@ -217,8 +217,8 @@ public class DrtAnalysisControlerListener implements IterationEndsListener {
 		try (var bw = getAppendingBufferedWriter("drt_vehicle_stats", ".csv")) {
 			if (!vheaderWritten) {
 				bw.write(line("runId", "iteration", "vehicles", "totalDistance", "totalEmptyDistance", "emptyRatio",
-						"totalPassengerDistance", "averageDrivenDistance", "averageEmptyDistance",
-						"averagePassengerDistance", "d_p/d_t", "l_det"));
+						"totalPassengerDistanceTraveled", "averageDrivenDistance", "averageEmptyDistance",
+						"averagePassengerDistanceTraveled", "d_p/d_t", "l_det"));
 			}
 			bw.write(line(runId, it, summarizeVehicles));
 		} catch (IOException e) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
@@ -199,7 +199,7 @@ public class DrtAnalysisControlerListener implements IterationEndsListener {
 			if (!headerWritten) {
 				headerWritten = true;
 				bw.write(line("runId", "iteration", "rides", "wait_average", "wait_max", "wait_p95", "wait_p75",
-						"wait_median", "percentage_WT_below_10", "percentage_WT_below_15", "inVehicleTravelTime_mean", 
+						"wait_median", "percentage_WT_below_10", "percentage_WT_below_15", "inVehicleTravelTime_mean",
 						"distance_m_mean", "directDistance_m_mean", "totalTravelTime_mean", "rejections", "rejectionRate"));
 			}
 			bw.write(runId + ";" + it + ";" + summarizeTrips);
@@ -217,8 +217,8 @@ public class DrtAnalysisControlerListener implements IterationEndsListener {
 		try (var bw = getAppendingBufferedWriter("drt_vehicle_stats", ".csv")) {
 			if (!vheaderWritten) {
 				bw.write(line("runId", "iteration", "vehicles", "totalDistance", "totalEmptyDistance", "emptyRatio",
-						"totalRevenueDistance", "averageDrivenDistance", "averageEmptyDistance",
-						"averageRevenueDistance", "d_r/d_t", "l_det"));
+						"totalPassengerDistance", "averageDrivenDistance", "averageEmptyDistance",
+						"averagePassengerDistance", "d_p/d_t", "l_det"));
 			}
 			bw.write(line(runId, it, summarizeVehicles));
 		} catch (IOException e) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtTripsAnalyser.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtTripsAnalyser.java
@@ -368,7 +368,7 @@ public class DrtTripsAnalyser {
 	 */
 	public static void writeVehicleDistances(Map<Id<Vehicle>, DrtVehicleDistanceStats.VehicleState> vehicleDistances,
 			String iterationFilename) {
-		String header = "vehicleId;drivenDistance_m;occupiedDistance_m;emptyDistance_m;passengerDistance_pm";
+		String header = "vehicleId;drivenDistance_m;occupiedDistance_m;emptyDistance_m;passengerDistanceTraveled_pm";
 		BufferedWriter bw = IOUtils.getBufferedWriter(iterationFilename);
 		DecimalFormat format = new DecimalFormat();
 		format.setDecimalFormatSymbols(new DecimalFormatSymbols(Locale.US));
@@ -385,7 +385,7 @@ public class DrtTripsAnalyser {
 						+ format.format(vehicleState.totalDistance) + ";"//
 						+ format.format(vehicleState.totalOccupiedDistance) + ";"//
 						+ format.format(vehicleState.totalDistanceByOccupancy[0]) + ";"//
-						+ format.format(vehicleState.totalPassengerMeter));
+						+ format.format(vehicleState.totalPassengerTraveledDistance));
 				bw.newLine();
 			}
 			bw.flush();
@@ -410,25 +410,25 @@ public class DrtTripsAnalyser {
 		format.setGroupingUsed(false);
 
 		DescriptiveStatistics driven = new DescriptiveStatistics();
-		DescriptiveStatistics passengerMeter = new DescriptiveStatistics();
+		DescriptiveStatistics passengerTraveledDistance = new DescriptiveStatistics();
 		DescriptiveStatistics occupied = new DescriptiveStatistics();
 		DescriptiveStatistics empty = new DescriptiveStatistics();
 
 		for (DrtVehicleDistanceStats.VehicleState state : vehicleDistances.values()) {
 			driven.addValue(state.totalDistance);
-			passengerMeter.addValue(state.totalPassengerMeter);
+			passengerTraveledDistance.addValue(state.totalPassengerTraveledDistance);
 			occupied.addValue(state.totalOccupiedDistance);
 			empty.addValue(state.totalDistanceByOccupancy[0]);
 		}
-		double d_p_d_t = passengerMeter.getSum() / driven.getSum();
+		double d_p_d_t = passengerTraveledDistance.getSum() / driven.getSum();
 		return String.join(del, vehicleDistances.size() + "",//
 				format.format(driven.getSum()) + "",//
 				format.format(empty.getSum()) + "",//
 				format.format(empty.getSum() / driven.getSum()) + "",//
-				format.format(passengerMeter.getSum()) + "",//
+				format.format(passengerTraveledDistance.getSum()) + "",//
 				format.format(driven.getMean()) + "",//
 				format.format(empty.getMean()) + "",//
-				format.format(passengerMeter.getMean()) + "",//
+				format.format(passengerTraveledDistance.getMean()) + "",//
 				format.format(d_p_d_t) + "");
 	}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtTripsAnalyser.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtTripsAnalyser.java
@@ -368,7 +368,7 @@ public class DrtTripsAnalyser {
 	 */
 	public static void writeVehicleDistances(Map<Id<Vehicle>, DrtVehicleDistanceStats.VehicleState> vehicleDistances,
 			String iterationFilename) {
-		String header = "vehicleId;drivenDistance_m;occupiedDistance_m;emptyDistance_m;revenueDistance_pm";
+		String header = "vehicleId;drivenDistance_m;occupiedDistance_m;emptyDistance_m;passengerDistance_pm";
 		BufferedWriter bw = IOUtils.getBufferedWriter(iterationFilename);
 		DecimalFormat format = new DecimalFormat();
 		format.setDecimalFormatSymbols(new DecimalFormatSymbols(Locale.US));
@@ -385,7 +385,7 @@ public class DrtTripsAnalyser {
 						+ format.format(vehicleState.totalDistance) + ";"//
 						+ format.format(vehicleState.totalOccupiedDistance) + ";"//
 						+ format.format(vehicleState.totalDistanceByOccupancy[0]) + ";"//
-						+ format.format(vehicleState.totalRevenueDistance));
+						+ format.format(vehicleState.totalPassengerMeter));
 				bw.newLine();
 			}
 			bw.flush();
@@ -410,27 +410,26 @@ public class DrtTripsAnalyser {
 		format.setGroupingUsed(false);
 
 		DescriptiveStatistics driven = new DescriptiveStatistics();
-		DescriptiveStatistics revenue = new DescriptiveStatistics();
+		DescriptiveStatistics passengerMeter = new DescriptiveStatistics();
 		DescriptiveStatistics occupied = new DescriptiveStatistics();
 		DescriptiveStatistics empty = new DescriptiveStatistics();
 
 		for (DrtVehicleDistanceStats.VehicleState state : vehicleDistances.values()) {
 			driven.addValue(state.totalDistance);
-			revenue.addValue(state.totalRevenueDistance);
+			passengerMeter.addValue(state.totalPassengerMeter);
 			occupied.addValue(state.totalOccupiedDistance);
 			empty.addValue(state.totalDistanceByOccupancy[0]);
 		}
-		double d_r_d_t = revenue.getSum() / driven.getSum();
-		// bw.write("iteration;vehicles;totalDistance;totalEmptyDistance;emptyRatio;totalRevenueDistance;averageDrivenDistance;averageEmptyDistance;averageRevenueDistance");
+		double d_p_d_t = passengerMeter.getSum() / driven.getSum();
 		return String.join(del, vehicleDistances.size() + "",//
 				format.format(driven.getSum()) + "",//
 				format.format(empty.getSum()) + "",//
 				format.format(empty.getSum() / driven.getSum()) + "",//
-				format.format(revenue.getSum()) + "",//
+				format.format(passengerMeter.getSum()) + "",//
 				format.format(driven.getMean()) + "",//
 				format.format(empty.getMean()) + "",//
-				format.format(revenue.getMean()) + "",//
-				format.format(d_r_d_t) + "");
+				format.format(passengerMeter.getMean()) + "",//
+				format.format(d_p_d_t) + "");
 	}
 
 	public static double getTotalDistance(Map<Id<Vehicle>, DrtVehicleDistanceStats.VehicleState> vehicleDistances) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtVehicleDistanceStats.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtVehicleDistanceStats.java
@@ -58,7 +58,7 @@ public class DrtVehicleDistanceStats
 		final Map<Id<Person>, MutableDouble> distanceByPersonId = new HashMap<>();
 		double totalDistance = 0;
 		double totalOccupiedDistance = 0;
-		double totalPassengerMeter = 0; //in (passenger x meters)
+		double totalPassengerTraveledDistance = 0; //in (passenger x meters)
 		final double[] totalDistanceByOccupancy;
 
 		private VehicleState(int maxCapacity) {
@@ -72,7 +72,7 @@ public class DrtVehicleDistanceStats
 			int occupancy = distanceByPersonId.size();
 			if (occupancy > 0) {
 				totalOccupiedDistance += linkLength;
-				totalPassengerMeter += linkLength * occupancy;
+				totalPassengerTraveledDistance += linkLength * occupancy;
 			}
 			totalDistanceByOccupancy[occupancy] += linkLength;
 		}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtVehicleDistanceStats.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtVehicleDistanceStats.java
@@ -58,7 +58,7 @@ public class DrtVehicleDistanceStats
 		final Map<Id<Person>, MutableDouble> distanceByPersonId = new HashMap<>();
 		double totalDistance = 0;
 		double totalOccupiedDistance = 0;
-		double totalRevenueDistance = 0; //in (passenger x meters)
+		double totalPassengerMeter = 0; //in (passenger x meters)
 		final double[] totalDistanceByOccupancy;
 
 		private VehicleState(int maxCapacity) {
@@ -72,7 +72,7 @@ public class DrtVehicleDistanceStats
 			int occupancy = distanceByPersonId.size();
 			if (occupancy > 0) {
 				totalOccupiedDistance += linkLength;
-				totalRevenueDistance += linkLength * occupancy;
+				totalPassengerMeter += linkLength * occupancy;
 			}
 			totalDistanceByOccupancy[occupancy] += linkLength;
 		}


### PR DESCRIPTION
…ssenger distance.

The term revenue distance indicates that it can be multiplied with the distance fee in order to obtain the distance-dependent-component of the total operator income. That is not correct, as the indicator also is increased for detours with passengers on board and passengers only pay for direct distances.

Please let me know if i missed places where to adjust the naming or if i misunderstood the code. Thank you :)

