### PR TITLE
DVRP: use custom comparator in PartialSort to allow for deterministic tie-breaking

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/BestInsertionFinder.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/BestInsertionFinder.java
@@ -34,11 +34,11 @@ import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
  * @author michalm
  */
 public class BestInsertionFinder<D> {
-	private static class InsertionWithCost<D> {
-		private final InsertionWithDetourData<D> insertionWithDetourData;
-		private final double cost;
+	static class InsertionWithCost<D> {
+		final InsertionWithDetourData<D> insertionWithDetourData;
+		final double cost;
 
-		private InsertionWithCost(InsertionWithDetourData<D> insertionWithDetourData, double cost) {
+		InsertionWithCost(InsertionWithDetourData<D> insertionWithDetourData, double cost) {
 			this.insertionWithDetourData = insertionWithDetourData;
 			this.cost = cost;
 		}
@@ -48,10 +48,13 @@ public class BestInsertionFinder<D> {
 			insertion -> insertion.vehicleEntry.vehicle.getId()).thenComparingInt(insertion -> insertion.pickup.index)
 			.thenComparingInt(insertion -> insertion.dropoff.index);
 
-	private final Comparator<InsertionWithCost<D>> comparator = Comparator.<InsertionWithCost<D>>comparingDouble(
-			insertionWithCost -> insertionWithCost.cost).thenComparing(
-			insertion -> insertion.insertionWithDetourData.getInsertion(), INSERTION_COMPARATOR);
+	static <D> Comparator<InsertionWithCost<D>> createInsertionWithCostComparator() {
+		return Comparator.<InsertionWithCost<D>>comparingDouble(
+				insertionWithCost -> insertionWithCost.cost).thenComparing(
+				insertion -> insertion.insertionWithDetourData.getInsertion(), INSERTION_COMPARATOR);
+	}
 
+	private final Comparator<InsertionWithCost<D>> comparator = createInsertionWithCostComparator();
 	private final InsertionCostCalculator<D> costCalculator;
 
 	BestInsertionFinder(InsertionCostCalculator<D> costCalculator) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/KNearestInsertionsAtEndFilter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/KNearestInsertionsAtEndFilter.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
+import org.matsim.contrib.drt.optimizer.insertion.BestInsertionFinder.InsertionWithCost;
 import org.matsim.contrib.util.PartialSort;
 
 /**
@@ -34,7 +35,8 @@ import org.matsim.contrib.util.PartialSort;
 class KNearestInsertionsAtEndFilter {
 	static List<InsertionGenerator.Insertion> filterInsertionsAtEnd(int k, double admissibleBeelineSpeedFactor,
 			List<InsertionWithDetourData<Double>> insertions) {
-		var nearestInsertionsAtEnd = new PartialSort<InsertionGenerator.Insertion>(k);
+		var nearestInsertionsAtEnd = new PartialSort<InsertionWithCost<Double>>(k,
+				BestInsertionFinder.createInsertionWithCostComparator());
 		var filteredInsertions = new ArrayList<InsertionGenerator.Insertion>(insertions.size());
 
 		for (var insertion : insertions) {
@@ -48,11 +50,13 @@ class KNearestInsertionsAtEndFilter {
 				// x ADMISSIBLE_BEELINE_SPEED_FACTOR to remove bias towards near but still busy vehicles
 				// (timeToPickup is underestimated by this factor)
 				double timeDistance = departureTime + admissibleBeelineSpeedFactor * insertion.getDetourToPickup();
-				nearestInsertionsAtEnd.add(insertion.getInsertion(), timeDistance);
+				nearestInsertionsAtEnd.add(new InsertionWithCost<>(insertion, timeDistance));
 			}
 		}
 
-		filteredInsertions.addAll(nearestInsertionsAtEnd.kSmallestElements());
+		nearestInsertionsAtEnd.kSmallestElements()
+				.forEach(i -> filteredInsertions.add(i.insertionWithDetourData.getInsertion()));
+
 		return filteredInsertions;
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/util/PartialSort.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/util/PartialSort.java
@@ -19,11 +19,12 @@
 
 package org.matsim.contrib.util;
 
-import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
-import java.util.function.ToDoubleFunction;
 import java.util.stream.Stream;
+
+import com.google.common.base.Preconditions;
 
 /**
  * Sorts from smallest to largest. If the opposite should be the case then add elements with their values negated:
@@ -35,50 +36,36 @@ import java.util.stream.Stream;
  * @param <T>
  */
 public class PartialSort<T> {
-	public static <T> List<T> kSmallestElements(int k, Stream<T> elements, ToDoubleFunction<T> evaluator) {
-		PartialSort<T> nearestRequestSort = new PartialSort<>(k);
-		nearestRequestSort.addAll(elements, evaluator);
+	public static <T> List<T> kSmallestElements(int k, Stream<T> elements, Comparator<T> comparator) {
+		PartialSort<T> nearestRequestSort = new PartialSort<>(k, comparator);
+		elements.forEach(nearestRequestSort::add);
 		return nearestRequestSort.kSmallestElements();
 	}
 
-	private static class ElementValuePair<T> implements Comparable<ElementValuePair<T>> {
-		private final T element;
-		private final double value;
-
-		public ElementValuePair(T element, double value) {
-			this.element = element;
-			this.value = value;
-		}
-
-		@Override
-		public int compareTo(ElementValuePair<T> o) {
-			return -Double.compare(value, o.value);// reversed comparison (the smallest is the last in the queue)
-		}
-	}
-
 	private final int k;
-	private final PriorityQueue<ElementValuePair<T>> kSmallestElements;// descending order: from k-th to 1-st
+	private final Comparator<T> comparator;
+	private final PriorityQueue<T> kSmallestElements;// descending order: from k-th to 1-st
 
-	public PartialSort(int k) {
+	public PartialSort(int k, Comparator<T> comparator) {
+		Preconditions.checkArgument(k > 0, "k must be positive.");
 		this.k = k;
-		kSmallestElements = new PriorityQueue<>(k);
+		this.comparator = comparator;
+		kSmallestElements = new PriorityQueue<>(k, comparator.reversed());
 	}
 
-	public void add(T element, double value) {
+	public void add(T element) {
 		if (kSmallestElements.size() < k) {
-			kSmallestElements.add(new ElementValuePair<>(element, value));
-		} else if (Double.compare(value, kSmallestElements.peek().value) < 0) {
+			kSmallestElements.add(element);
+		} else if (comparator.compare(element, kSmallestElements.peek()) < 0) {
 			kSmallestElements.poll();
-			kSmallestElements.add(new ElementValuePair<>(element, value));
+			kSmallestElements.add(element);
 		}
-	}
-
-	public void addAll(Stream<T> elements, ToDoubleFunction<T> evaluator) {
-		elements.forEach(e -> this.add(e, evaluator.applyAsDouble(e)));
 	}
 
 	/**
-	 * Gets k smallest elements (side effect: they are removed from the queue -- the queue gets empty).
+	 * Gets k smallest elements.
+	 *
+	 * SIDE EFFECT: elements are removed from the queue.
 	 *
 	 * @return list containing k smallest elements sorted ascending: from the smallest to the k-th smallest
 	 */
@@ -86,8 +73,8 @@ public class PartialSort<T> {
 		@SuppressWarnings("unchecked")
 		T[] array = (T[])new Object[kSmallestElements.size()];
 		for (int i = array.length - 1; i >= 0; i--) {
-			array[i] = kSmallestElements.poll().element;
+			array[i] = kSmallestElements.poll();
 		}
-		return Arrays.asList(array);
+		return List.of(array);
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/util/StraightLineKnnFinder.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/util/StraightLineKnnFinder.java
@@ -19,6 +19,7 @@
 
 package org.matsim.contrib.util;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -42,7 +43,7 @@ public class StraightLineKnnFinder<T, N> {
 
 	public List<N> findNearest(T obj, Stream<N> neighbours) {
 		Coord objectCoord = objectToLink.apply(obj);
-		return PartialSort.kSmallestElements(k, neighbours,
-				n -> DistanceUtils.calculateSquaredDistance(objectCoord, neighbourToLink.apply(n)));
+		return PartialSort.kSmallestElements(k, neighbours, Comparator.comparingDouble(
+				n -> DistanceUtils.calculateSquaredDistance(objectCoord, neighbourToLink.apply(n))));
 	}
 }

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/util/PartialSortTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/util/PartialSortTest.java
@@ -1,0 +1,66 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2021 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.matsim.contrib.util.PartialSort.kSmallestElements;
+
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class PartialSortTest {
+	private final Comparator<Integer> comparator = Integer::compareTo;
+
+	@Test
+	public void reversedComparator_largestElementsSelected() {
+		assertThat(kSmallestElements(1, Stream.of(7, 1, 4, 9, 8), comparator.reversed())).containsExactly(9);
+		assertThat(kSmallestElements(3, Stream.of(7, 1, 4, 9, 8), comparator.reversed())).containsExactly(9, 8, 7);
+	}
+
+	@Test
+	public void allElementsPairwiseNonEqual_inputOrderNotImportant() {
+		assertThat(kSmallestElements(3, Stream.of(1, 7, 9, 8), comparator)).containsExactly(1, 7, 8);
+		assertThat(kSmallestElements(3, Stream.of(9, 8, 7, 1), comparator)).containsExactly(1, 7, 8);
+	}
+
+	@Test
+	public void exactlyKElementsProvided() {
+		assertThat(kSmallestElements(3, Stream.of(7, 1, 4), comparator)).containsExactly(1, 4, 7);
+	}
+
+	@Test
+	public void moreThenKElementsProvided() {
+		assertThat(kSmallestElements(3, Stream.of(7, 1, 4, 9, 8), comparator)).containsExactly(1, 4, 7);
+		assertThat(kSmallestElements(3, Stream.of(13, 7, 1, 55, 4, 9, 8, 11), comparator)).containsExactly(1, 4, 7);
+	}
+
+	@Test
+	public void lessThenKElementsProvided() {
+		assertThat(kSmallestElements(3, Stream.of(7, 1), comparator)).containsExactly(1, 7);
+		assertThat(kSmallestElements(3, Stream.of(13), comparator)).containsExactly(13);
+		assertThat(kSmallestElements(3, Stream.of(), comparator)).isEmpty();
+	}
+}

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/assignment/AssignmentETaxiOptimizer.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/assignment/AssignmentETaxiOptimizer.java
@@ -19,6 +19,7 @@
 
 package org.matsim.contrib.etaxi.optimizer.assignment;
 
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -190,7 +191,8 @@ public class AssignmentETaxiOptimizer extends DefaultTaxiOptimizer {
 		// filter least charged vehicles
 		// assumption: all b.capacities are equal
 		List<DvrpVehicle> leastChargedVehicles = PartialSort.kSmallestElements(pData.getSize(),
-				vehiclesBelowMinSocLevel, v -> ((EvDvrpVehicle)v).getElectricVehicle().getBattery().getSoc());
+				vehiclesBelowMinSocLevel,
+				Comparator.comparingDouble(v -> ((EvDvrpVehicle)v).getElectricVehicle().getBattery().getSoc()));
 
 		return new VehicleData(timer.getTimeOfDay(), eScheduler.getScheduleInquiry(), leastChargedVehicles.stream());
 	}


### PR DESCRIPTION
@luchengqi7 I adapted `KNearestInsertionsAtEndFilter` so that it uses `vehicleId` as a tiebreaker if two or more vehicles are equally distant so that we can hopefully be able to reproduce DRT runs.