### PR TITLE
Pass preceding activity attributes as trip attributes to routing

### DIFF
--- a/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/SwissRailRaptorAccessibilityContributionCalculator.java
+++ b/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/SwissRailRaptorAccessibilityContributionCalculator.java
@@ -31,6 +31,7 @@ import org.matsim.facilities.*;
 import org.matsim.pt.transitSchedule.TransitStopFacilityImpl;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -139,7 +140,7 @@ class SwissRailRaptorAccessibilityContributionCalculator implements Accessibilit
             Map<Id<? extends BasicLocation>, AggregationObject> aggregatedOpportunities, Double departureTime) {
         double expSum = 0.;
 
-        final Map<Id<TransitStopFacility>, SwissRailRaptorCore.TravelInfo> idTravelInfoMap = raptor.calcTree(origin, departureTime, null);
+        final Map<Id<TransitStopFacility>, SwissRailRaptorCore.TravelInfo> idTravelInfoMap = raptor.calcTree(origin, departureTime, null, new Attributes());
 
         for (final AggregationObject destination : aggregatedOpportunities.values()) {
             //compute direct walk costs

--- a/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/TripRouterAccessibilityContributionCalculator.java
+++ b/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/TripRouterAccessibilityContributionCalculator.java
@@ -49,6 +49,7 @@ import org.matsim.facilities.ActivityFacilitiesFactory;
 import org.matsim.facilities.ActivityFacilitiesFactoryImpl;
 import org.matsim.facilities.ActivityFacility;
 import org.matsim.facilities.ActivityFacilityImpl;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * @author nagel, dziemke
@@ -132,7 +133,7 @@ class TripRouterAccessibilityContributionCalculator implements AccessibilityCont
 			ActivityFacility destinationFacility = activityFacilitiesFactory.createActivityFacility(null, destination.getNearestBasicLocation().getCoord());
 
 			Gbl.assertNotNull(tripRouter);
-			List<? extends PlanElement> plan = tripRouter.calcRoute(mode, origin, destinationFacility, departureTime, null);
+			List<? extends PlanElement> plan = tripRouter.calcRoute(mode, origin, destinationFacility, departureTime, null, new Attributes());
 
 			double utility = 0.;
 			List<Leg> legs = TripStructureUtils.getLegs(plan);

--- a/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/relocation/qsim/Guidance.java
+++ b/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/relocation/qsim/Guidance.java
@@ -15,6 +15,7 @@ import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.LeastCostPathCalculator.Path;
 import org.matsim.core.utils.misc.OptionalTime;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * Mostly copied from tutorial.programming.ownMobsimAgentUsingRouter.MyGuidance
@@ -37,7 +38,7 @@ public class Guidance {
         String mainMode = TransportMode.car;
         Facility startFacility = new LinkWrapperFacility(startLink);
         Facility destinationFacility = new LinkWrapperFacility(destinationLink);
-        List<? extends PlanElement> trip = router.calcRoute(mainMode, startFacility, destinationFacility, departureTime, person);
+        List<? extends PlanElement> trip = router.calcRoute(mainMode, startFacility, destinationFacility, departureTime, person, new Attributes());
         Path path = lcpc.calcLeastCostPath(startLink.getToNode(), destinationLink.getFromNode(), now, person, null);
         if (path.links.size() == 0)
         	return destinationLink.getId();
@@ -49,7 +50,7 @@ public class Guidance {
     public synchronized OptionalTime getExpectedTravelTime(Link startLink, Link destinationLink, double departureTime, String mode, Person person) {
         Facility startFacility = new LinkWrapperFacility(startLink);
         Facility destinationFacility = new LinkWrapperFacility(destinationLink);
-        List<? extends PlanElement> trip = router.calcRoute(mode, startFacility, destinationFacility, departureTime, person);
+        List<? extends PlanElement> trip = router.calcRoute(mode, startFacility, destinationFacility, departureTime, person, new Attributes());
 		Route route = ((Leg) trip.get(0)).getRoute();
 
 		return route != null ? route.getTravelTime() : OptionalTime.undefined();
@@ -58,7 +59,7 @@ public class Guidance {
     public synchronized double getExpectedTravelDistance(Link startLink, Link destinationLink, double departureTime, String mode, Person person) {
         Facility startFacility = new LinkWrapperFacility(startLink);
         Facility destinationFacility = new LinkWrapperFacility(destinationLink);
-        List<? extends PlanElement> trip = router.calcRoute(mode, startFacility, destinationFacility, departureTime, person);
+        List<? extends PlanElement> trip = router.calcRoute(mode, startFacility, destinationFacility, departureTime, person, new Attributes());
 		Route route = ((Leg) trip.get(0)).getRoute();
 
 		double distance = route != null ? route.getDistance() : null;

--- a/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/router/FreeFloatingRoutingModule.java
+++ b/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/router/FreeFloatingRoutingModule.java
@@ -9,6 +9,7 @@ import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.router.RoutingModule;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 public class FreeFloatingRoutingModule implements RoutingModule {
 	
@@ -17,7 +18,7 @@ public class FreeFloatingRoutingModule implements RoutingModule {
 	}
 	@Override
 	public List<? extends PlanElement> calcRoute(Facility fromFacility,
-			Facility toFacility, double departureTime, Person person) {
+			Facility toFacility, double departureTime, Person person, Attributes tripAttributes) {
 		
 		final List<PlanElement> trip = new ArrayList<>();
 						

--- a/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/router/OneWayCarsharingRoutingModule.java
+++ b/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/router/OneWayCarsharingRoutingModule.java
@@ -16,6 +16,7 @@ import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.router.RoutingModule;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 public class OneWayCarsharingRoutingModule implements RoutingModule{
 	public OneWayCarsharingRoutingModule() {		
@@ -23,7 +24,7 @@ public class OneWayCarsharingRoutingModule implements RoutingModule{
 	}
 	@Override
 	public List<? extends PlanElement> calcRoute(Facility fromFacility,
-			Facility toFacility, double departureTime, Person person) {
+			Facility toFacility, double departureTime, Person person, Attributes tripAttributes) {
 		
 		final List<PlanElement> trip = new ArrayList<PlanElement>();		
 		

--- a/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/router/TwoWayCarsharingRoutingModule.java
+++ b/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/router/TwoWayCarsharingRoutingModule.java
@@ -9,13 +9,14 @@ import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.router.RoutingModule;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 public class TwoWayCarsharingRoutingModule implements RoutingModule {
 	
 	
 	@Override
 	public List<? extends PlanElement> calcRoute(Facility fromFacility,
-			Facility toFacility, double departureTime, Person person) {
+			Facility toFacility, double departureTime, Person person, Attributes tripAttributes) {
 		final List<PlanElement> trip = new ArrayList<>();
 		
 		final Leg leg1 = PopulationUtils.createLeg("twoway");

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/estimators/AbstractTripRouterEstimator.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/estimators/AbstractTripRouterEstimator.java
@@ -15,6 +15,7 @@ import org.matsim.core.router.TripRouter;
 import org.matsim.facilities.ActivityFacilities;
 import org.matsim.facilities.FacilitiesUtils;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * This is an abstract estimator class that makes it easy to rely on MATSim's
@@ -64,7 +65,7 @@ public abstract class AbstractTripRouterEstimator implements TripEstimator {
 		if (!isPrerouted(mode, trip)) {
 			// II) Perform the routing
 			List<? extends PlanElement> elements = tripRouter.calcRoute(mode, originFacility, destinationFacility,
-					trip.getDepartureTime(), person);
+					trip.getDepartureTime(), person, trip.getOriginActivity().getAttributes());
 
 			// III) Perform utility estimation
 			return estimateTripCandidate(person, mode, trip, previousTrips, elements);

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/estimators/UniformTripEstimator.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/estimators/UniformTripEstimator.java
@@ -8,6 +8,7 @@ import org.matsim.contribs.discrete_mode_choice.model.trip_based.TripEstimator;
 import org.matsim.contribs.discrete_mode_choice.model.trip_based.candidates.DefaultTripCandidate;
 import org.matsim.contribs.discrete_mode_choice.model.trip_based.candidates.TripCandidate;
 import org.matsim.contribs.discrete_mode_choice.replanning.time_interpreter.TimeInterpreter;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * This estimator simply return a zero utility for every trip candidate that it

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/trip_based/TripEstimator.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/trip_based/TripEstimator.java
@@ -13,5 +13,6 @@ import org.matsim.contribs.discrete_mode_choice.model.trip_based.candidates.Trip
  * @author sebhoerl
  */
 public interface TripEstimator {
-	TripCandidate estimateTrip(Person person, String mode, DiscreteModeChoiceTrip trip, List<TripCandidate> previousTrips);
+	TripCandidate estimateTrip(Person person, String mode, DiscreteModeChoiceTrip trip,
+			List<TripCandidate> previousTrips);
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/DrtRoutingModuleTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/DrtRoutingModuleTest.java
@@ -56,6 +56,7 @@ import org.matsim.facilities.FacilitiesUtils;
 import org.matsim.facilities.Facility;
 import org.matsim.pt.transitSchedule.api.TransitScheduleReader;
 import org.matsim.testcases.MatsimTestUtils;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -105,7 +106,7 @@ public class DrtRoutingModuleTest {
 		Activity w = (Activity)p1.getSelectedPlan().getPlanElements().get(2);
 		Facility wf = FacilitiesUtils.toFacility(w, facilities);
 
-		List<? extends PlanElement> routedList = dvrpRoutingModule.calcRoute(hf, wf, 8 * 3600, p1);
+		List<? extends PlanElement> routedList = dvrpRoutingModule.calcRoute(hf, wf, 8 * 3600, p1, new Attributes());
 
 		Assert.assertEquals(5, routedList.size());
 
@@ -160,7 +161,7 @@ public class DrtRoutingModuleTest {
 		Activity w2 = (Activity)p2.getSelectedPlan().getPlanElements().get(2);
 		Facility wf2 = FacilitiesUtils.toFacility(w2, facilities);
 
-		List<? extends PlanElement> routedList2 = dvrpRoutingModule.calcRoute(hf2, wf2, 8 * 3600, p2);
+		List<? extends PlanElement> routedList2 = dvrpRoutingModule.calcRoute(hf2, wf2, 8 * 3600, p2, new Attributes());
 
 		Assert.assertNull(routedList2);
 
@@ -172,7 +173,7 @@ public class DrtRoutingModuleTest {
 		Activity w3 = (Activity)p3.getSelectedPlan().getPlanElements().get(2);
 		Facility wf3 = FacilitiesUtils.toFacility(w3, facilities);
 
-		List<? extends PlanElement> routedList3 = dvrpRoutingModule.calcRoute(hf3, wf3, 8 * 3600, p3);
+		List<? extends PlanElement> routedList3 = dvrpRoutingModule.calcRoute(hf3, wf3, 8 * 3600, p3, new Attributes());
 
 		Assert.assertNull(routedList3);
 
@@ -184,7 +185,7 @@ public class DrtRoutingModuleTest {
 		Activity w4 = (Activity)p4.getSelectedPlan().getPlanElements().get(2);
 		Facility wf4 = FacilitiesUtils.toFacility(w4, facilities);
 
-		List<? extends PlanElement> routedList4 = dvrpRoutingModule.calcRoute(hf4, wf4, 8 * 3600, p4);
+		List<? extends PlanElement> routedList4 = dvrpRoutingModule.calcRoute(hf4, wf4, 8 * 3600, p4, new Attributes());
 
 		Assert.assertNull(routedList4);
 
@@ -196,7 +197,7 @@ public class DrtRoutingModuleTest {
 		Activity w5 = (Activity)p5.getSelectedPlan().getPlanElements().get(2);
 		Facility wf5 = FacilitiesUtils.toFacility(w5, facilities);
 
-		List<? extends PlanElement> routedList5 = dvrpRoutingModule.calcRoute(hf5, wf5, 8 * 3600, p5);
+		List<? extends PlanElement> routedList5 = dvrpRoutingModule.calcRoute(hf5, wf5, 8 * 3600, p5, new Attributes());
 
 		// TODO: Asserts are prepared for interpreting maxWalkingDistance as a real maximum, but routing still works wrongly
 		Assert.assertNull(routedList5);
@@ -209,7 +210,7 @@ public class DrtRoutingModuleTest {
 		Activity w6 = (Activity)p6.getSelectedPlan().getPlanElements().get(2);
 		Facility wf6 = FacilitiesUtils.toFacility(w6, facilities);
 
-		List<? extends PlanElement> routedList6 = dvrpRoutingModule.calcRoute(hf6, wf6, 8 * 3600, p6);
+		List<? extends PlanElement> routedList6 = dvrpRoutingModule.calcRoute(hf6, wf6, 8 * 3600, p6, new Attributes());
 
 		// TODO: Asserts are prepared for interpreting maxWalkingDistance as a real maximum, but routing still works wrongly
 		Assert.assertNull(routedList6);

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DefaultMainLegRouter.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DefaultMainLegRouter.java
@@ -31,6 +31,7 @@ import org.matsim.api.core.v01.population.Route;
 import org.matsim.core.population.routes.RouteFactories;
 import org.matsim.core.router.RoutingModule;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -58,7 +59,7 @@ public class DefaultMainLegRouter implements RoutingModule {
 
 	@Override
 	public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double departureTime,
-			Person person) {
+			Person person, Attributes tripAttributes) {
 		Link accessActLink = Preconditions.checkNotNull(modalNetwork.getLinks().get(fromFacility.getLinkId()),
 				"link: %s does not exist in the network of mode: %s", fromFacility.getLinkId(), mode);
 		Link egressActLink = Preconditions.checkNotNull(modalNetwork.getLinks().get(toFacility.getLinkId()),

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpRoutingModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpRoutingModule.java
@@ -36,6 +36,7 @@ import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.router.RoutingModule;
 import org.matsim.core.router.TripRouter;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * @author jbischoff
@@ -67,7 +68,7 @@ public class DvrpRoutingModule implements RoutingModule {
 
 	@Override
 	public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double departureTime,
-			Person person) {
+			Person person, Attributes tripAttributes) {
 		Optional<Pair<Facility, Facility>> stops = stopFinder.findFacilities(
 				Objects.requireNonNull(fromFacility, "fromFacility is null"),
 				Objects.requireNonNull(toFacility, "toFacility is null"));
@@ -98,7 +99,7 @@ public class DvrpRoutingModule implements RoutingModule {
 		double now = departureTime;
 
 		// access (sub-)trip:
-		List<? extends PlanElement> accessTrip = accessRouter.calcRoute(fromFacility, accessFacility, now, person);
+		List<? extends PlanElement> accessTrip = accessRouter.calcRoute(fromFacility, accessFacility, now, person, tripAttributes);
 		if (!accessTrip.isEmpty()) {
 			trip.addAll(accessTrip);
 			for (PlanElement planElement : accessTrip) {
@@ -111,14 +112,14 @@ public class DvrpRoutingModule implements RoutingModule {
 		}
 
 		// dvrp proper leg:
-		List<? extends PlanElement> drtLeg = mainRouter.calcRoute(accessFacility, egressFacility, now, person);
+		List<? extends PlanElement> drtLeg = mainRouter.calcRoute(accessFacility, egressFacility, now, person, tripAttributes);
 		trip.addAll(drtLeg);
 		for (PlanElement planElement : drtLeg) {
 			now = TripRouter.calcEndOfPlanElement(now, planElement, scenario.getConfig());
 		}
 
 		now++;
-		List<? extends PlanElement> egressTrip = egressRouter.calcRoute(egressFacility, toFacility, now, person);
+		List<? extends PlanElement> egressTrip = egressRouter.calcRoute(egressFacility, toFacility, now, person, tripAttributes);
 		if (!egressTrip.isEmpty()) {
 			// interaction activity:
 			trip.add(createDrtStageActivity(egressFacility, now));

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/routing/EvNetworkRoutingModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/routing/EvNetworkRoutingModule.java
@@ -53,6 +53,7 @@ import org.matsim.core.router.RoutingModule;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * This network Routing module adds stages for re-charging into the Route.
@@ -99,9 +100,9 @@ public final class EvNetworkRoutingModule implements RoutingModule {
 
 	@Override
 	public List<? extends PlanElement> calcRoute(final Facility fromFacility, final Facility toFacility,
-			final double departureTime, final Person person) {
+			final double departureTime, final Person person, final Attributes tripAttributes) {
 
-		List<? extends PlanElement> basicRoute = delegate.calcRoute(fromFacility, toFacility, departureTime, person);
+		List<? extends PlanElement> basicRoute = delegate.calcRoute(fromFacility, toFacility, departureTime, person, tripAttributes);
 		Id<ElectricVehicle> evId = Id.create(person.getId() + vehicleSuffix, ElectricVehicle.class);
 		if (!electricFleet.getVehicleSpecifications().containsKey(evId)) {
 			return basicRoute;
@@ -147,7 +148,7 @@ public final class EvNetworkRoutingModule implements RoutingModule {
 						continue;
 					}
 					List<? extends PlanElement> routeSegment = delegate.calcRoute(lastFrom, nexttoFacility,
-							lastArrivaltime, person);
+							lastArrivaltime, person, tripAttributes);
 					Leg lastLeg = (Leg)routeSegment.get(0);
 					lastArrivaltime = lastLeg.getDepartureTime().seconds() + lastLeg.getTravelTime().seconds();
 					stagedRoute.add(lastLeg);
@@ -160,7 +161,7 @@ public final class EvNetworkRoutingModule implements RoutingModule {
 					stagedRoute.add(chargeAct);
 					lastFrom = nexttoFacility;
 				}
-				stagedRoute.addAll(delegate.calcRoute(lastFrom, toFacility, lastArrivaltime, person));
+				stagedRoute.addAll(delegate.calcRoute(lastFrom, toFacility, lastArrivaltime, person, tripAttributes));
 
 				return stagedRoute;
 

--- a/contribs/eventsBasedPTRouter/src/main/java/org/matsim/contrib/eventsBasedPTRouter/TransitRouterVariableImpl.java
+++ b/contribs/eventsBasedPTRouter/src/main/java/org/matsim/contrib/eventsBasedPTRouter/TransitRouterVariableImpl.java
@@ -52,6 +52,7 @@ import org.matsim.pt.router.TransitRouterNetworkTravelTimeAndDisutility;
 import org.matsim.pt.routes.DefaultTransitPassengerRoute;
 import org.matsim.pt.routes.TransitPassengerRoute;
 import org.matsim.pt.transitSchedule.api.TransitRouteStop;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 public class TransitRouterVariableImpl implements TransitRouter {
 
@@ -110,7 +111,7 @@ public class TransitRouterVariableImpl implements TransitRouter {
 			return new HashMap<>();
 	}
 	    @Override
-	public List<Leg> calcRoute(final Facility fromFacility, final Facility toFacility, final double departureTime, final Person person) {
+	public List<Leg> calcRoute(final Facility fromFacility, final Facility toFacility, final double departureTime, final Person person, final Attributes attributes) {
 		// find possible start stops
 		Map<Node, InitialNode> wrappedFromNodes = this.locateWrappedNearestTransitNodes(person, fromFacility.getCoord(), departureTime);
 		// find possible end stops

--- a/contribs/locationchoice/src/main/java/org/matsim/contrib/locationchoice/timegeography/RecursiveLocationMutator.java
+++ b/contribs/locationchoice/src/main/java/org/matsim/contrib/locationchoice/timegeography/RecursiveLocationMutator.java
@@ -185,7 +185,7 @@ class RecursiveLocationMutator extends AbstractLocationMutator{
 			  FacilitiesUtils.toFacility( fromAct, null ),
 			  FacilitiesUtils.toFacility( toAct, null ),
 				fromAct.getEndTime().seconds(),
-				person );
+				person, fromAct.getAttributes() );
 
 		if ( trip.size() != 1 ) {
 			throw new IllegalStateException( "This method can only be used with "+

--- a/contribs/matrixbasedptrouter/src/main/java/org/matsim/contrib/matrixbasedptrouter/MatrixBasedPtRoutingModule.java
+++ b/contribs/matrixbasedptrouter/src/main/java/org/matsim/contrib/matrixbasedptrouter/MatrixBasedPtRoutingModule.java
@@ -33,6 +33,7 @@ import org.matsim.api.core.v01.population.Route;
 import org.matsim.core.population.routes.GenericRouteFactory;
 import org.matsim.core.router.RoutingModule;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import javax.inject.Inject;
 import java.util.Arrays;
@@ -69,7 +70,7 @@ public final class MatrixBasedPtRoutingModule implements RoutingModule {
 	}
 	
 	@Override
-	public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double departureTime, Person person) {
+	public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double departureTime, Person person, Attributes tripAttributes) {
 		Leg newLeg = scenario.getPopulation().getFactory().createLeg( TransportMode.pt );
 		Id<Link> startLinkId = fromFacility.getLinkId();
 		Id<Link> endLinkId = toFacility.getLinkId();

--- a/contribs/minibus/src/main/java/org/matsim/contrib/minibus/performance/PPlanRouter.java
+++ b/contribs/minibus/src/main/java/org/matsim/contrib/minibus/performance/PPlanRouter.java
@@ -98,7 +98,7 @@ final class PPlanRouter implements PlanAlgorithm, PersonAlgorithm {
 								toFacility( trip.getOriginActivity() ),
 								toFacility( trip.getDestinationActivity() ),
 								calcEndOfActivity( trip.getOriginActivity() , plan ),
-								plan.getPerson() );
+								plan.getPerson(), trip.getOriginActivity().getAttributes() );
 
 					TripRouter.insertTrip(
 							plan, 

--- a/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingsearch/DynAgent/agentLogic/ParkingAgentLogic.java
+++ b/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingsearch/DynAgent/agentLogic/ParkingAgentLogic.java
@@ -53,7 +53,9 @@ import org.matsim.core.router.RoutingModule;
 import org.matsim.core.utils.misc.Time;
 import org.matsim.facilities.Facility;
 import org.matsim.pt.routes.TransitPassengerRoute;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.vehicles.Vehicle;
+import org.matsim.withinday.utils.EditTrips;
 
 
 /**
@@ -201,7 +203,7 @@ public class ParkingAgentLogic implements DynAgentLogic {
 		Leg currentPlannedLeg = (Leg) currentPlanElement;
 		Facility fromFacility = new LinkWrapperFacility (network.getLinks().get(agent.getCurrentLinkId()));
 		Facility toFacility = new LinkWrapperFacility (network.getLinks().get(currentPlannedLeg.getRoute().getEndLinkId()));
-		List<? extends PlanElement> walkTrip = walkRouter.calcRoute(fromFacility, toFacility, now, plan.getPerson());
+		List<? extends PlanElement> walkTrip = walkRouter.calcRoute(fromFacility, toFacility, now, plan.getPerson(), new Attributes());
 		if (walkTrip.size() != 1 || ! (walkTrip.get(0) instanceof Leg)) {
 			String message = "walkRouter returned something else than a single Leg, e.g. it routes walk on the network with non_network_walk to access the network. Not implemented in parking yet!";
 			log.error(message);
@@ -261,7 +263,7 @@ public class ParkingAgentLogic implements DynAgentLogic {
     		Facility fromFacility = new LinkWrapperFacility (network.getLinks().get(agent.getCurrentLinkId()));
             Id<Link> teleportedParkLink = this.teleportationLogic.getVehicleLocation(agent.getCurrentLinkId(), vehicleId, parkLink, now, currentLeg.getMode());
     		Facility toFacility = new LinkWrapperFacility (network.getLinks().get(teleportedParkLink));
-    		List<? extends PlanElement> walkTrip = walkRouter.calcRoute(fromFacility, toFacility, now, plan.getPerson());
+    		List<? extends PlanElement> walkTrip = walkRouter.calcRoute(fromFacility, toFacility, now, plan.getPerson(), new Attributes());
     		if (walkTrip.size() != 1 || ! (walkTrip.get(0) instanceof Leg)) {
     			String message = "walkRouter returned something else than a single Leg, e.g. it routes walk on the network with non_network_walk to access the network. Not implemented in parking yet!";
     			log.error(message);

--- a/contribs/pseudosimulation/src/main/java/org/matsim/contrib/pseudosimulation/trafficinfo/deterministic/DeterministicStopStopTimeCalculator.java
+++ b/contribs/pseudosimulation/src/main/java/org/matsim/contrib/pseudosimulation/trafficinfo/deterministic/DeterministicStopStopTimeCalculator.java
@@ -34,7 +34,7 @@ public class DeterministicStopStopTimeCalculator implements StopStopTimeCalculat
 		TransitStopFacility originFacility = schedule.getFacilities().get(stopOId);
 		TransitStopFacility destinationFacility = schedule.getFacilities().get(stopDId);
 
-		List<Leg> legs = transitRouter.calcRoute(originFacility, destinationFacility, time, null);
+		List<Leg> legs = transitRouter.calcRoute(originFacility, destinationFacility, time, null, null);
 		return legs.stream().mapToDouble(l -> l.getTravelTime().seconds()).sum();
 	}
 

--- a/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/jointtrips/ImportedJointRoutesChecker.java
+++ b/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/jointtrips/ImportedJointRoutesChecker.java
@@ -31,6 +31,7 @@ import org.matsim.contrib.socnetsim.jointtrips.population.DriverRoute;
 import org.matsim.core.population.algorithms.PersonAlgorithm;
 import org.matsim.core.population.algorithms.PlanAlgorithm;
 import org.matsim.core.router.TripRouter;
+import org.matsim.core.router.TripStructureUtils;
 import org.matsim.core.utils.misc.OptionalTime;
 import org.matsim.facilities.FacilitiesUtils;
 
@@ -57,6 +58,8 @@ public class ImportedJointRoutesChecker implements PlanAlgorithm, PersonAlgorith
 		Iterator<PlanElement> pes = plan.getPlanElements().iterator();
 
 		Activity origin = (Activity) pes.next();
+		Activity nonInteractionOrigin = origin;
+		
 		double now = 0;
 		while (pes.hasNext()) {
 			// FIXME: relies on the assumption of strict alternance leg/act
@@ -71,7 +74,7 @@ public class ImportedJointRoutesChecker implements PlanAlgorithm, PersonAlgorith
 						  FacilitiesUtils.toFacility( origin, null ),
 						  FacilitiesUtils.toFacility( dest, null ),
 							now,
-							plan.getPerson());
+							plan.getPerson(), nonInteractionOrigin.getAttributes());
 
 				if (trip.size() != 1) {
 					throw new RuntimeException( "unexpected trip length "+trip.size()+" for "+trip+" for mode "+l.getMode());
@@ -84,6 +87,10 @@ public class ImportedJointRoutesChecker implements PlanAlgorithm, PersonAlgorith
 
 			now = updateTime( now , l );
 			origin = dest;
+			
+			if (!TripStructureUtils.isStageActivityType(origin.getType())) {
+				nonInteractionOrigin = origin;
+			}
 		}
 	}
 

--- a/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/jointtrips/router/DriverRoutingModule.java
+++ b/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/jointtrips/router/DriverRoutingModule.java
@@ -31,6 +31,7 @@ import org.matsim.contrib.socnetsim.jointtrips.population.DriverRoute;
 import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.router.RoutingModule;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * @author thibautd
@@ -54,13 +55,15 @@ public class DriverRoutingModule implements RoutingModule {
 			final Facility fromFacility,
 			final Facility toFacility, 
 			final double departureTime,
-			final Person person) {
+			final Person person,
+			final Attributes tripAttributes) {
 		List<? extends PlanElement> trip =
 			carRoutingModule.calcRoute(
 					fromFacility,
 					toFacility, 
 					departureTime,
-					person);
+					person,
+					tripAttributes);
 
 		if (trip.size() != 1) {
 			throw new RuntimeException( "unexpected trip size for trip "+trip+" for mode "+mode );

--- a/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/jointtrips/router/PassengerRoutingModule.java
+++ b/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/jointtrips/router/PassengerRoutingModule.java
@@ -29,7 +29,7 @@ import org.matsim.api.core.v01.population.PopulationFactory;
 import org.matsim.api.core.v01.population.Route;
 import org.matsim.core.router.RoutingModule;
 import org.matsim.facilities.Facility;
-
+import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.contrib.socnetsim.jointtrips.population.PassengerRoute;
 
 /**
@@ -51,7 +51,8 @@ public class PassengerRoutingModule implements RoutingModule {
 			final Facility fromFacility,
 			final Facility toFacility,
 			final double departureTime,
-			final Person person) {
+			final Person person,
+			final Attributes tripAttributes) {
 		Leg l = popFactory.createLeg( modeName );
 		l.setDepartureTime( departureTime );
 		Route r = new PassengerRoute( fromFacility.getLinkId() , toFacility.getLinkId() );

--- a/contribs/socnetsim/src/test/java/org/matsim/contrib/socnetsim/jointtrips/router/JointPlanRouterTest.java
+++ b/contribs/socnetsim/src/test/java/org/matsim/contrib/socnetsim/jointtrips/router/JointPlanRouterTest.java
@@ -48,6 +48,7 @@ import org.matsim.core.router.TripRouter;
 import org.matsim.core.router.TripStructureUtils;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * @author thibautd
@@ -182,7 +183,8 @@ public class JointPlanRouterTest {
 								final Facility fromFacility,
 								final Facility toFacility,
 								final double departureTime,
-								final Person person) {
+								final Person person,
+								final Attributes tripAttributes) {
 							NetworkRoute route = RouteUtils.createNetworkRoute(List.of(fromFacility.getLinkId(), toFacility.getLinkId()), null);
 							route.setTravelTime(10);
 							Leg leg =  PopulationUtils.createLeg(TransportMode.car);

--- a/contribs/socnetsim/src/test/java/org/matsim/contrib/socnetsim/sharedvehicles/PlanRouterWithVehicleRessourcesTest.java
+++ b/contribs/socnetsim/src/test/java/org/matsim/contrib/socnetsim/sharedvehicles/PlanRouterWithVehicleRessourcesTest.java
@@ -46,6 +46,7 @@ import org.matsim.core.router.TripStructureUtils;
 import org.matsim.core.router.TripStructureUtils.Trip;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.vehicles.Vehicle;
 
 /**
@@ -109,7 +110,8 @@ public class PlanRouterWithVehicleRessourcesTest {
 							final Facility fromFacility,
 							final Facility toFacility,
 							final double departureTime,
-							final Person p) {
+							final Person p,
+							final Attributes tripAttributes) {
 						final List<PlanElement> legs = new ArrayList<PlanElement>();
 
 						for (int i=0; i < 5; i++) {

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/RaptorStopFinder.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/RaptorStopFinder.java
@@ -2,6 +2,7 @@ package ch.sbb.matsim.routing.pt.raptor;
 
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import java.util.List;
 
@@ -15,6 +16,6 @@ public interface RaptorStopFinder {
 
 	public enum Direction { ACCESS, EGRESS }
 
-	List<InitialStop> findStops(Facility facility, Person person, double departureTime, RaptorParameters parameters, SwissRailRaptorData data, Direction type);
+	List<InitialStop> findStops(Facility facility, Person person, double departureTime, RaptorParameters parameters, SwissRailRaptorData data, Direction type, Attributes tripAttributes);
 
 }

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorRoutingModule.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorRoutingModule.java
@@ -22,6 +22,7 @@ import org.matsim.facilities.Facility;
 import org.matsim.pt.routes.TransitPassengerRoute;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * This replicates the functionality of {@link org.matsim.core.router.TransitRouterWrapper},
@@ -52,11 +53,11 @@ public class SwissRailRaptorRoutingModule implements RoutingModule {
     }
 
     @Override
-    public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double departureTime, Person person) {
-        List<Leg> legs = this.raptor.calcRoute(fromFacility, toFacility, departureTime, person);
+    public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double departureTime, Person person, Attributes tripAttributes) {
+        List<Leg> legs = this.raptor.calcRoute(fromFacility, toFacility, departureTime, person, tripAttributes);
         return legs != null ?
                 fillWithActivities(legs) :
-                walkRouter.calcRoute(fromFacility, toFacility, departureTime, person);
+                walkRouter.calcRoute(fromFacility, toFacility, departureTime, person, tripAttributes);
     }
 
     private List<? extends PlanElement> fillWithActivities(List<Leg> legs) {

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/PreplanningEngine.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/PreplanningEngine.java
@@ -346,7 +346,7 @@ public final class PreplanningEngine implements MobsimEngine {
 			Facility toFacility = tripInfo.getPickupLocation();
 			double departureTime = tripInfo.getExpectedBoardingTime() - 900.; // always depart 15min before pickup
 			List<? extends PlanElement> planElements = tripRouter.calcRoute(TransportMode.walk, fromFacility,
-					toFacility, departureTime, null);
+					toFacility, departureTime, null, inputTrip.getOriginActivity().getAttributes());
 			;
 			// not sure if this works for walk, but it should ...
 
@@ -384,7 +384,7 @@ public final class PreplanningEngine implements MobsimEngine {
 			}
 			double departureTime = tripInfo.getExpectedBoardingTime() + expectedTravelTime;
 			List<? extends PlanElement> planElements = tripRouter.calcRoute(TransportMode.walk, fromFacility,
-					toFacility, departureTime, null);
+					toFacility, departureTime, null, inputTrip.getOriginActivity().getAttributes());
 
 			result.addAll(planElements);
 		}

--- a/matsim/src/main/java/org/matsim/core/router/FallbackRoutingModuleDefaultImpl.java
+++ b/matsim/src/main/java/org/matsim/core/router/FallbackRoutingModuleDefaultImpl.java
@@ -15,6 +15,7 @@ import org.matsim.core.config.groups.GlobalConfigGroup;
 import org.matsim.core.config.groups.PlansCalcRouteConfigGroup;
 import org.matsim.facilities.FacilitiesUtils;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import java.util.Collections;
 import java.util.List;
@@ -29,7 +30,7 @@ class FallbackRoutingModuleDefaultImpl implements  FallbackRoutingModule {
 	@Inject private Population population ;
 	@Inject private Network network ;
 
-	@Override public List<? extends PlanElement> calcRoute( Facility fromFacility, Facility toFacility, double departureTime, Person person ){
+	@Override public List<? extends PlanElement> calcRoute( Facility fromFacility, Facility toFacility, double departureTime, Person person, Attributes tripAttributes ){
 		Leg leg = population.getFactory().createLeg( TransportMode.walk ) ;
 		Coord fromCoord = FacilitiesUtils.decideOnCoord( fromFacility, network, config );
 		Coord toCoord = FacilitiesUtils.decideOnCoord( toFacility, network, config ) ;

--- a/matsim/src/main/java/org/matsim/core/router/FreespeedFactorRoutingModule.java
+++ b/matsim/src/main/java/org/matsim/core/router/FreespeedFactorRoutingModule.java
@@ -29,6 +29,7 @@ import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.LeastCostPathCalculator.Path;
 import org.matsim.core.utils.geometry.CoordUtils;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import java.util.Arrays;
 import java.util.List;
@@ -60,7 +61,8 @@ public final class FreespeedFactorRoutingModule implements RoutingModule {
 			final Facility fromFacility,
 			final Facility toFacility,
 			final double departureTime,
-			final Person person) {
+			final Person person,
+			final Attributes tripAttributes) {
 		Leg newLeg = this.populationFactory.createLeg( this.mode );
 		newLeg.setDepartureTime( departureTime );
 

--- a/matsim/src/main/java/org/matsim/core/router/LinkToLinkRoutingModule.java
+++ b/matsim/src/main/java/org/matsim/core/router/LinkToLinkRoutingModule.java
@@ -33,6 +33,7 @@ import org.matsim.core.population.routes.RouteUtils;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.LeastCostPathCalculator.Path;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import java.util.Arrays;
 import java.util.List;
@@ -66,7 +67,7 @@ class LinkToLinkRoutingModule implements RoutingModule {
 
     @Override
     public List<? extends PlanElement> calcRoute( final Facility fromFacility,
-								  final Facility toFacility, final double departureTime, final Person person) {
+								  final Facility toFacility, final double departureTime, final Person person, final Attributes tripAttributes) {
         Leg newLeg = this.populationFactory.createLeg( this.mode );
 		
 		Gbl.assertNotNull(fromFacility);

--- a/matsim/src/main/java/org/matsim/core/router/NetworkRoutingModule.java
+++ b/matsim/src/main/java/org/matsim/core/router/NetworkRoutingModule.java
@@ -35,6 +35,7 @@ import org.matsim.core.population.routes.RouteUtils;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.LeastCostPathCalculator.Path;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * This wraps a "computer science" {@link LeastCostPathCalculator}, which routes from a node to another node, into something that
@@ -69,7 +70,7 @@ public final class NetworkRoutingModule implements RoutingModule {
 
 	@Override
 	public List<? extends PlanElement> calcRoute(final Facility fromFacility, final Facility toFacility, final double departureTime,
-			final Person person) {		
+			final Person person, final Attributes tripAttributes) {		
 		Leg newLeg = this.populationFactory.createLeg( this.mode );
 
 		Gbl.assertNotNull(fromFacility);

--- a/matsim/src/main/java/org/matsim/core/router/PlanRouter.java
+++ b/matsim/src/main/java/org/matsim/core/router/PlanRouter.java
@@ -33,6 +33,7 @@ import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.router.TripStructureUtils.Trip;
 import org.matsim.facilities.ActivityFacilities;
 import org.matsim.facilities.FacilitiesUtils;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.vehicles.Vehicle;
 
 import java.util.List;
@@ -89,6 +90,8 @@ public class PlanRouter implements PlanAlgorithm, PersonAlgorithm {
 
 		for (Trip oldTrip : trips) {
 			final String routingMode = TripStructureUtils.identifyMainMode( oldTrip.getTripElements() );
+			final Attributes tripAttributes = oldTrip.getOriginActivity().getAttributes();
+			
 			if (log.isDebugEnabled()) log.debug("about to call TripRouter with routingMode=" + routingMode);
 			final List<? extends PlanElement> newTrip =
 					tripRouter.calcRoute(
@@ -96,7 +99,7 @@ public class PlanRouter implements PlanAlgorithm, PersonAlgorithm {
 						  FacilitiesUtils.toFacility( oldTrip.getOriginActivity(), facilities ),
 						  FacilitiesUtils.toFacility( oldTrip.getDestinationActivity(), facilities ),
 							calcEndOfActivity( oldTrip.getOriginActivity() , plan, tripRouter.getConfig() ),
-							plan.getPerson() );
+							plan.getPerson(), tripAttributes );
 			putVehicleFromOldTripIntoNewTripIfMeaningful(oldTrip, newTrip);
 			TripRouter.insertTrip(
 					plan, 

--- a/matsim/src/main/java/org/matsim/core/router/RoutingModule.java
+++ b/matsim/src/main/java/org/matsim/core/router/RoutingModule.java
@@ -26,6 +26,7 @@ import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * Defines classes responsible for routing for a given
@@ -56,7 +57,8 @@ public interface RoutingModule {
 			Facility fromFacility,
 			Facility toFacility,
 			double departureTime,
-			Person person);
+			Person person,
+			Attributes tripAttributes);
 	// NOTE: It makes some sense to _not_ have the vehicle as an argument here ... since that only makes sense for vehicular modes. kai, feb'19
 
 }

--- a/matsim/src/main/java/org/matsim/core/router/TeleportationRoutingModule.java
+++ b/matsim/src/main/java/org/matsim/core/router/TeleportationRoutingModule.java
@@ -33,6 +33,7 @@ import org.matsim.core.gbl.Gbl;
 import org.matsim.core.utils.geometry.CoordUtils;
 import org.matsim.facilities.FacilitiesUtils;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 
 
@@ -63,7 +64,8 @@ public class TeleportationRoutingModule implements RoutingModule {
 			final Facility fromFacility,
 			final Facility toFacility,
 			final double departureTime,
-			final Person person) {
+			final Person person,
+			final Attributes tripAttributes) {
 		Leg newLeg = this.scenario.getPopulation().getFactory().createLeg( this.mode );
 		newLeg.setDepartureTime( departureTime );
 

--- a/matsim/src/main/java/org/matsim/core/router/TripRouter.java
+++ b/matsim/src/main/java/org/matsim/core/router/TripRouter.java
@@ -41,6 +41,7 @@ import org.matsim.core.config.Config;
 import org.matsim.core.gbl.Gbl;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import com.google.common.base.Preconditions;
 
@@ -160,7 +161,8 @@ public final class TripRouter implements MatsimExtensionPoint {
 			final Facility fromFacility,
 			final Facility toFacility,
 			final double departureTime,
-			final Person person) {
+			final Person person,
+			final Attributes tripAttributes) {
 		// I need this "synchronized" since I want mobsim agents to be able to call this during the mobsim.  So when the
 		// mobsim is multi-threaded, multiple agents might call this here at the same time.  kai, nov'17
 
@@ -175,10 +177,11 @@ public final class TripRouter implements MatsimExtensionPoint {
 						fromFacility,
 						toFacility,
 						departureTime,
-						person);
+						person,
+						tripAttributes);
 
 			if ( trip == null ) {
-				trip = fallbackRoutingModule.calcRoute( fromFacility, toFacility, departureTime, person ) ;
+				trip = fallbackRoutingModule.calcRoute( fromFacility, toFacility, departureTime, person, tripAttributes ) ;
 			}
 			for (Leg leg: TripStructureUtils.getLegs(trip)) {
 				TripStructureUtils.setRoutingMode(leg, mainMode);

--- a/matsim/src/main/java/org/matsim/pt/router/TransitRouter.java
+++ b/matsim/src/main/java/org/matsim/pt/router/TransitRouter.java
@@ -24,12 +24,13 @@ import java.util.List;
 import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * @author mrieser
  */
 public interface TransitRouter {
 
-	public abstract List<Leg> calcRoute(final Facility fromFacility, final Facility toFacility, final double departureTime, final Person person);
+	public abstract List<Leg> calcRoute(final Facility fromFacility, final Facility toFacility, final double departureTime, final Person person, Attributes tripAttributes);
 
 }

--- a/matsim/src/main/java/org/matsim/pt/router/TransitRouterImpl.java
+++ b/matsim/src/main/java/org/matsim/pt/router/TransitRouterImpl.java
@@ -29,6 +29,7 @@ import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.utils.geometry.CoordUtils;
 import org.matsim.facilities.Facility;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -110,7 +111,7 @@ public class TransitRouterImpl extends AbstractTransitRouter implements TransitR
     }
 
     @Override
-    public List<Leg> calcRoute( final Facility fromFacility, final Facility toFacility, final double departureTime, final Person person) {
+    public List<Leg> calcRoute( final Facility fromFacility, final Facility toFacility, final double departureTime, final Person person, final Attributes tripAttributes) {
         // find possible start stops
         Map<Node, InitialNode> wrappedFromNodes = this.locateWrappedNearestTransitNodes(person,
                 fromFacility.getCoord(),

--- a/matsim/src/main/java/org/matsim/withinday/utils/EditPlans.java
+++ b/matsim/src/main/java/org/matsim/withinday/utils/EditPlans.java
@@ -39,6 +39,7 @@ import org.matsim.core.router.StageActivityTypeIdentifier;
 import org.matsim.core.router.TripRouter;
 import org.matsim.core.router.TripStructureUtils;
 import org.matsim.core.router.TripStructureUtils.Trip;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 public final class EditPlans {
 	private static final Logger log = Logger.getLogger( EditPlans.class ) ;
@@ -63,7 +64,7 @@ public final class EditPlans {
 		Gbl.assertNotNull( this.editTrips = editTrips ) ;
 		Gbl.assertNotNull( this.pf = mobsim.getScenario().getPopulation().getFactory() ) ;
 	}
-	public boolean addActivityAtEnd(MobsimAgent agent, Activity activity, String routingMode) {
+	public boolean addActivityAtEnd(MobsimAgent agent, Activity activity, String routingMode, Attributes tripAttributes) {
 		log.debug("entering addActivityAtEnd with routingMode=" + routingMode) ;
 
 		Plan plan = WithinDayAgentUtils.getModifiablePlan(agent);
@@ -79,7 +80,7 @@ public final class EditPlans {
 		// (need the terminating activity in order to find the current trip. kai, nov'17)
 		
 		if (!isAtRealActivity(agent)) {
-			retVal1 = editTrips.replanCurrentTrip(agent,mobsim.getSimTimer().getTimeOfDay(),routingMode);
+			retVal1 = editTrips.replanCurrentTrip(agent,mobsim.getSimTimer().getTimeOfDay(), routingMode);
 		}
 		
 		
@@ -228,7 +229,8 @@ public final class EditPlans {
 	 * Convenience method, clarifying that this can be called without giving the mode.
 	 */
 	public void insertActivity(MobsimAgent agent, int index, Activity activity ) {
-		String mode = TripStructureUtils.identifyMainMode( EditTrips.findCurrentTrip(agent ).getTripElements() ) ;
+		Trip currentTrip = EditTrips.findCurrentTrip(agent);
+		String mode = TripStructureUtils.identifyMainMode( currentTrip.getTripElements() ) ;
 		insertActivity( agent, index, activity, mode, mode ) ;
 	}
 

--- a/matsim/src/main/java/org/matsim/withinday/utils/EditRoutes.java
+++ b/matsim/src/main/java/org/matsim/withinday/utils/EditRoutes.java
@@ -46,6 +46,7 @@ import org.matsim.core.router.TripRouter;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.LeastCostPathCalculator.Path;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.vehicles.Vehicle;
 
 /**
@@ -149,7 +150,7 @@ public final class EditRoutes {
 	 */
 	@Deprecated // not consistent with access/egress approach; can only be used if you know exactly what you are doing.  
 	// Maybe replanXxx is already sufficient?  Otherwise use EditTrips or EditPlans.  kai, nov'17
-	public static boolean relocateFutureLegRoute(Leg leg, Id<Link> fromLinkId, Id<Link> toLinkId, Person person, Network network, TripRouter tripRouter) {
+	public static boolean relocateFutureLegRoute(Leg leg, Id<Link> fromLinkId, Id<Link> toLinkId, Person person, Network network, TripRouter tripRouter, Attributes tripAttributes) {
 		// TripRouter variant; everything else uses the PathCalculator
 		
 		Link fromLink = network.getLinks().get(fromLinkId);
@@ -159,7 +160,7 @@ public final class EditRoutes {
 		Facility toFacility = new LinkWrapperFacility(toLink);
 
 		List<? extends PlanElement> planElements = tripRouter.calcRoute(leg.getMode(), fromFacility, toFacility,
-				leg.getDepartureTime().seconds(), person);
+				leg.getDepartureTime().seconds(), person, tripAttributes);
 
 		if (planElements.size() != 1) {
 			throw new RuntimeException("Expected a list of PlanElements containing exactly one element, " +

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/RaptorStopFinderTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/RaptorStopFinderTest.java
@@ -29,6 +29,7 @@ import org.matsim.pt.transitSchedule.api.TransitRouteStop;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitScheduleFactory;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -83,7 +84,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
 
             Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
             
@@ -111,7 +112,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -155,7 +156,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f1.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -212,7 +213,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
             
             Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
             
@@ -246,7 +247,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -297,7 +298,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -352,7 +353,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -400,7 +401,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
 
             Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
             
@@ -429,7 +430,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -473,7 +474,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f1.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -530,7 +531,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
 
             Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
             
@@ -565,7 +566,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -617,7 +618,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -673,7 +674,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -734,7 +735,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f1.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -779,7 +780,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f1.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -824,7 +825,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f1.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -878,7 +879,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -930,7 +931,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -978,7 +979,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f1.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -1024,7 +1025,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f1.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -1070,7 +1071,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f1.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -1125,7 +1126,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -1178,7 +1179,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -1241,7 +1242,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -1288,7 +1289,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f1.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -1346,7 +1347,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -1401,7 +1402,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -1453,7 +1454,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -1501,7 +1502,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f1.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -1560,7 +1561,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -1616,7 +1617,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -1689,7 +1690,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -1755,7 +1756,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -1817,7 +1818,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorCapacitiesTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorCapacitiesTest.java
@@ -36,6 +36,7 @@ import org.matsim.pt.transitSchedule.api.TransitRouteStop;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitScheduleFactory;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.vehicles.Vehicle;
 
 import java.util.ArrayList;
@@ -67,7 +68,7 @@ public class SwissRailRaptorCapacitiesTest {
 		Facility fromFacility = new FakeFacility(new Coord(900, 900), Id.create("aa", Link.class));
 		Facility toFacility = new FakeFacility(new Coord(7100, 1100), Id.create("cd", Link.class));
 
-		List<Leg> route1 = raptor.calcRoute(fromFacility, toFacility, Time.parseTime("07:00:00"), null);
+		List<Leg> route1 = raptor.calcRoute(fromFacility, toFacility, Time.parseTime("07:00:00"), null, new Attributes());
 		Assert.assertNotNull(route1);
 		System.out.println("uncongested route:");
 		for (Leg leg : route1) {
@@ -170,7 +171,7 @@ public class SwissRailRaptorCapacitiesTest {
 		tracker.handleEvent(new PersonEntersVehicleEvent(Time.parseTime("07:20:25"), person9, vehicle3));
 		tracker.handleEvent(new VehicleDepartsAtFacilityEvent(Time.parseTime("07:20:30"), vehicle3, f.stopAId, 0));
 
-		List<Leg> route2 = raptor.calcRoute(fromFacility, toFacility, Time.parseTime("07:00:00"), null);
+		List<Leg> route2 = raptor.calcRoute(fromFacility, toFacility, Time.parseTime("07:00:00"), null, new Attributes());
 		Assert.assertNotNull(route2);
 		System.out.println("congested route:");
 		for (Leg leg : route2) {

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorInVehicleCostTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorInVehicleCostTest.java
@@ -36,6 +36,7 @@ import org.matsim.pt.transitSchedule.api.TransitRouteStop;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitScheduleFactory;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.Vehicles;
@@ -120,7 +121,7 @@ public class SwissRailRaptorInVehicleCostTest {
 		Facility fromFacility = new FakeFacility(new Coord(900, 900), Id.create("aa", Link.class));
 		Facility toFacility = new FakeFacility(new Coord(7100, 1100), Id.create("cd", Link.class));
 
-		List<Leg> route1 = raptor.calcRoute(fromFacility, toFacility, Time.parseTime("07:00:00"), null);
+		List<Leg> route1 = raptor.calcRoute(fromFacility, toFacility, Time.parseTime("07:00:00"), null, new Attributes());
 		Assert.assertNotNull(route1);
 
 		System.out.println("calculated route:");

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorIntermodalTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorIntermodalTest.java
@@ -38,6 +38,7 @@ import org.matsim.pt.transitSchedule.api.TransitRouteStop;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitScheduleFactory;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -85,7 +86,7 @@ public class SwissRailRaptorIntermodalTest {
         Facility fromFac = new FakeFacility(new Coord(10000, 10500), Id.create("from", Link.class));
         Facility toFac = new FakeFacility(new Coord(50000, 10500), Id.create("to", Link.class));
 
-        List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson);
+        List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson, new Attributes());
         for (Leg leg : legs) {
             System.out.println(leg);
         }
@@ -160,7 +161,7 @@ public class SwissRailRaptorIntermodalTest {
         Facility fromFac = new FakeFacility(new Coord(10000, 10500), Id.create("from", Link.class));
         Facility toFac = new FakeFacility(new Coord(50000, 10500), Id.create("to", Link.class));
 
-        List<? extends PlanElement> planElements = tripRouter.calcRoute(TransportMode.pt, fromFac, toFac, 7*3600, f.dummyPerson);
+        List<? extends PlanElement> planElements = tripRouter.calcRoute(TransportMode.pt, fromFac, toFac, 7*3600, f.dummyPerson, new Attributes());
 
         for (PlanElement pe : planElements) {
             System.out.println(pe);
@@ -222,7 +223,7 @@ public class SwissRailRaptorIntermodalTest {
         Facility fromFac = new FakeFacility(new Coord(10000, 10500), Id.create("from", Link.class));
         Facility toFac = new FakeFacility(new Coord(50000, 10500), Id.create("to", Link.class));
 
-        List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson);
+        List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson, new Attributes());
         for (Leg leg : legs) {
             System.out.println(leg);
         }
@@ -277,7 +278,7 @@ public class SwissRailRaptorIntermodalTest {
         Facility fromFac = new FakeFacility(new Coord(10000, 9000), Id.create("from", Link.class));
         Facility toFac = new FakeFacility(new Coord(11000, 11000), Id.create("to", Link.class));
 
-        List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson);
+        List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson, new Attributes());
 
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
     }
@@ -328,7 +329,7 @@ public class SwissRailRaptorIntermodalTest {
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
         SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f.scenario.getConfig()).with(stopFinder).build();
 
-        List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson);
+        List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson, new Attributes());
         for (Leg leg : legs) {
             System.out.println(leg);
         }
@@ -345,7 +346,7 @@ public class SwissRailRaptorIntermodalTest {
         stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
         raptor = new SwissRailRaptor.Builder(data, f.scenario.getConfig()).with(stopFinder).build();
 
-        legs = raptor.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson);
+        legs = raptor.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson, new Attributes());
         for (Leg leg1 : legs) {
             System.out.println(leg1);
         }
@@ -415,7 +416,7 @@ public class SwissRailRaptorIntermodalTest {
         Facility fromFac = new FakeFacility(new Coord(10000, 10500), Id.create("from", Link.class));
         Facility toFac = new FakeFacility(new Coord(10500, 10500), Id.create("to", Link.class));
 
-        List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson);
+        List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson, new Attributes());
         
         /* 
          * Going by access/egress mode bike from "fromFac" to stop 3 (which is bikeAccessible) and from there by bike
@@ -468,7 +469,7 @@ public class SwissRailRaptorIntermodalTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -498,7 +499,7 @@ public class SwissRailRaptorIntermodalTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f.scenario.getConfig()).with(stopFinder).build();
 
-            List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f.dummyPerson);
+            List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f.dummyPerson, new Attributes());
             for (Leg leg : legs) {
                 System.out.println(leg);
             }
@@ -574,7 +575,7 @@ public class SwissRailRaptorIntermodalTest {
             for (int i = 0; i < 1000; i++) {
                 SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f.scenario.getConfig()).with(stopFinder).build();
 
-                List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f.dummyPerson);
+                List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f.dummyPerson, new Attributes());
 
                 { // Test 1: Checks whether the amount of legs is correct, whether the legs have the correct modes,
                   // and whether the legs start and end on the correct links
@@ -637,7 +638,7 @@ public class SwissRailRaptorIntermodalTest {
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), f.routingModules);
         SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f.scenario.getConfig()).with(stopFinder).build();
 
-        List<Leg> legs = raptor.calcRoute(fromFac, toFac, 8 * 3600 - 900, f.dummyPerson);
+        List<Leg> legs = raptor.calcRoute(fromFac, toFac, 8 * 3600 - 900, f.dummyPerson, new Attributes());
         for (Leg leg : legs) {
             System.out.println(leg);
         }
@@ -692,7 +693,7 @@ public class SwissRailRaptorIntermodalTest {
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), f.routingModules);
         SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f.scenario.getConfig()).with(stopFinder).build();
 
-        List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7.5 * 3600 + 900, f.dummyPerson);
+        List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7.5 * 3600 + 900, f.dummyPerson, new Attributes());
         for (Leg leg : legs) {
             System.out.println(leg);
         }
@@ -727,7 +728,7 @@ public class SwissRailRaptorIntermodalTest {
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), f.routingModules);
         SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f.scenario.getConfig()).with(stopFinder).build();
 
-        List<Leg> legs = raptor.calcRoute(fromFac, toFac, 8 * 3600 - 900, f.dummyPerson);
+        List<Leg> legs = raptor.calcRoute(fromFac, toFac, 8 * 3600 - 900, f.dummyPerson, new Attributes());
         for (Leg leg : legs) {
             System.out.println(leg);
         }
@@ -777,7 +778,7 @@ public class SwissRailRaptorIntermodalTest {
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), f.routingModules);
         SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f.scenario.getConfig()).with(stopFinder).build();
 
-        List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7.5 * 3600, f.dummyPerson);
+        List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7.5 * 3600, f.dummyPerson, new Attributes());
 
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
     }
@@ -810,7 +811,7 @@ public class SwissRailRaptorIntermodalTest {
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), f.routingModules);
         SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f.scenario.getConfig()).with(stopFinder).build();
 
-        List<Leg> legs = raptor.calcRoute(fromFac, toFac, 8 * 3600 - 900, f.dummyPerson);
+        List<Leg> legs = raptor.calcRoute(fromFac, toFac, 8 * 3600 - 900, f.dummyPerson, new Attributes());
         for (Leg leg : legs) {
             System.out.println(leg);
         }
@@ -845,7 +846,7 @@ public class SwissRailRaptorIntermodalTest {
 
 					@Override
 					public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility,
-							double departureTime, Person person) {
+							double departureTime, Person person, Attributes attributes) {
 						return null;
 					}
         	
@@ -855,7 +856,7 @@ public class SwissRailRaptorIntermodalTest {
         DefaultRaptorStopFinder stopFinder2 = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), f.routingModules);
         SwissRailRaptor raptor2 = new SwissRailRaptor.Builder(data2, f.scenario.getConfig()).with(stopFinder2).build();
 
-        List<Leg> legs2 = raptor2.calcRoute(fromFac, toFac, 8 * 3600 - 900, f.dummyPerson);
+        List<Leg> legs2 = raptor2.calcRoute(fromFac, toFac, 8 * 3600 - 900, f.dummyPerson, new Attributes());
         
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs2);        
     }

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorTest.java
@@ -45,6 +45,7 @@ import org.matsim.pt.transitSchedule.api.TransitScheduleFactory;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 import org.matsim.testcases.MatsimTestCase;
 import org.matsim.testcases.MatsimTestUtils;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -76,7 +77,7 @@ public class SwissRailRaptorTest {
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
         Coord fromCoord = new Coord(3800, 5100);
         Coord toCoord = new Coord(16100, 5050);
-        List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null);
+        List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null, new Attributes());
         assertEquals(3, legs.size());
         assertEquals(TransportMode.walk, legs.get(0).getMode());
         assertEquals(TransportMode.pt, legs.get(1).getMode());
@@ -110,7 +111,7 @@ public class SwissRailRaptorTest {
         Coord toCoord = new Coord(16100, 5050);
         Id<Link> fromLinkId = Id.create("ffrroomm", Link.class);
         Id<Link> toLinkId = Id.create("ttoo", Link.class);
-        List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord, fromLinkId), new FakeFacility(toCoord, toLinkId), 5.0*3600, null);
+        List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord, fromLinkId), new FakeFacility(toCoord, toLinkId), 5.0*3600, null, new Attributes());
         assertEquals(3, legs.size());
         assertEquals(TransportMode.walk, legs.get(0).getMode());
         assertEquals(fromLinkId, legs.get(0).getRoute().getStartLinkId());
@@ -140,7 +141,7 @@ public class SwissRailRaptorTest {
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
         Coord fromCoord = new Coord(3800, 5100);
         Coord toCoord = new Coord(16100, 5050);
-        List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null);
+        List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null, new Attributes());
         assertEquals(3, legs.size());
         assertEquals(TransportMode.walk, legs.get(0).getMode());
         assertEquals(TransportMode.pt, legs.get(1).getMode());
@@ -161,7 +162,7 @@ public class SwissRailRaptorTest {
         Coord fromCoord = new Coord(3800, 5100);
         Coord toCoord = new Coord(16100, 5050);
         double depTime = 5.0 * 3600;
-        List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 300, depTime, depTime + 300, null);
+        List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 300, depTime, depTime + 300, null, new Attributes());
         assertEquals(3, legs.size());
         assertEquals(TransportMode.walk, legs.get(0).getMode());
         assertEquals(TransportMode.pt, legs.get(1).getMode());
@@ -188,7 +189,7 @@ public class SwissRailRaptorTest {
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
         Coord fromCoord = new Coord(3800, 5100);
         Coord toCoord = new Coord(4100, 5050);
-        List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null);
+        List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null, new Attributes());
         
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
     }
@@ -205,7 +206,7 @@ public class SwissRailRaptorTest {
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
         Coord fromCoord = new Coord(4000, 3000);
         Coord toCoord = new Coord(8000, 3000);
-        List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null);
+        List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null, new Attributes());
         
         assertEquals(1, legs.size());
         assertEquals(TransportMode.walk, legs.get(0).getMode());
@@ -224,7 +225,7 @@ public class SwissRailRaptorTest {
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
         Coord fromCoord = new Coord(4000, 3000);
         Coord toCoord = new Coord(8000, 3000);
-        List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null);
+        List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null, new Attributes());
         
         assertEquals(3, legs.size());
         assertEquals(TransportMode.walk, legs.get(0).getMode());
@@ -255,7 +256,7 @@ public class SwissRailRaptorTest {
 
         double inVehicleTime = 7.0*60; // travel time from A to B
         for (int min = 0; min < 30; min += 3) {
-            List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600 + min*60, null);
+            List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600 + min*60, null, new Attributes());
             assertEquals(3, legs.size()); // walk-pt-walk
             double actualTravelTime = 0.0;
             for (Leg leg : legs) {
@@ -274,7 +275,7 @@ public class SwissRailRaptorTest {
         RaptorParameters raptorParams = RaptorUtils.createParameters(f.config);
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
         Coord toCoord = new Coord(16100, 10050);
-        List<Leg> legs = router.calcRoute(new FakeFacility(new Coord(3800, 5100)), new FakeFacility(toCoord), 6.0*3600, null);
+        List<Leg> legs = router.calcRoute(new FakeFacility(new Coord(3800, 5100)), new FakeFacility(toCoord), 6.0*3600, null, new Attributes());
         assertEquals(5, legs.size());
         assertEquals(TransportMode.walk, legs.get(0).getMode());
         assertEquals(TransportMode.pt, legs.get(1).getMode());
@@ -316,7 +317,7 @@ public class SwissRailRaptorTest {
         RaptorParameters raptorParams = RaptorUtils.createParameters(f.config);
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
         Coord toCoord = new Coord(28100, 4950);
-        List<Leg> legs = router.calcRoute(new FakeFacility( new Coord(3800, 5100)), new FakeFacility(toCoord), 5.0*3600 + 40.0*60, null);
+        List<Leg> legs = router.calcRoute(new FakeFacility( new Coord(3800, 5100)), new FakeFacility(toCoord), 5.0*3600 + 40.0*60, null, new Attributes());
         assertEquals("wrong number of legs", 5, legs.size());
         assertEquals(TransportMode.walk, legs.get(0).getMode());
         assertEquals(TransportMode.pt, legs.get(1).getMode());
@@ -359,7 +360,7 @@ public class SwissRailRaptorTest {
         f.config.planCalcScore().setUtilityOfLineSwitch(0);
         RaptorParameters raptorParams = RaptorUtils.createParameters(f.config);
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
-        List<Leg> legs = router.calcRoute(new FakeFacility(new Coord(11900, 5100)), new FakeFacility(new Coord(24100, 4950)), 6.0*3600 - 5.0*60, null);
+        List<Leg> legs = router.calcRoute(new FakeFacility(new Coord(11900, 5100)), new FakeFacility(new Coord(24100, 4950)), 6.0*3600 - 5.0*60, null, new Attributes());
         assertEquals("wrong number of legs", 5, legs.size());
         assertEquals(TransportMode.walk, legs.get(0).getMode());
         assertEquals(TransportMode.pt, legs.get(1).getMode());
@@ -375,7 +376,7 @@ public class SwissRailRaptorTest {
         raptorParams = RaptorUtils.createParameters(config);
         Assert.assertEquals(-transferUtility, raptorParams.getTransferPenaltyFixCostPerTransfer(), 0.0);
         router = createTransitRouter(f.schedule, config, f.network);
-        legs = router.calcRoute(new FakeFacility(new Coord(11900, 5100)), new FakeFacility(new Coord(24100, 4950)), 6.0*3600 - 5.0*60, null);
+        legs = router.calcRoute(new FakeFacility(new Coord(11900, 5100)), new FakeFacility(new Coord(24100, 4950)), 6.0*3600 - 5.0*60, null, new Attributes());
         assertEquals(3, legs.size());
         assertEquals(TransportMode.walk, legs.get(0).getMode());
         assertEquals(TransportMode.pt, legs.get(1).getMode());
@@ -398,7 +399,7 @@ public class SwissRailRaptorTest {
         f.config.planCalcScore().setUtilityOfLineSwitch(0);
         f.config.transitRouter().setAdditionalTransferTime(0);
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
-        List<Leg> legs = router.calcRoute(new FakeFacility(new Coord(11900, 5100)), new FakeFacility(new Coord(24100, 4950)), 6.0*3600 - 5.0*60, null);
+        List<Leg> legs = router.calcRoute(new FakeFacility(new Coord(11900, 5100)), new FakeFacility(new Coord(24100, 4950)), 6.0*3600 - 5.0*60, null, new Attributes());
         assertEquals("wrong number of legs",5, legs.size());
         assertEquals(TransportMode.walk, legs.get(0).getMode());
         assertEquals(TransportMode.pt, legs.get(1).getMode());
@@ -411,7 +412,7 @@ public class SwissRailRaptorTest {
         Config config = ConfigUtils.createConfig();
         config.transitRouter().setAdditionalTransferTime(3*60 + 1);
         router = createTransitRouter(f.schedule, config, f.network); // this is necessary to update the router for any change in config.
-        legs = router.calcRoute(new FakeFacility(new Coord(11900, 5100)), new FakeFacility(new Coord(24100, 4950)), 6.0*3600 - 5.0*60, null);
+        legs = router.calcRoute(new FakeFacility(new Coord(11900, 5100)), new FakeFacility(new Coord(24100, 4950)), 6.0*3600 - 5.0*60, null, new Attributes());
         assertEquals("wrong number of legs",3, legs.size());
         assertEquals(TransportMode.walk, legs.get(0).getMode());
         assertEquals(TransportMode.pt, legs.get(1).getMode());
@@ -430,7 +431,7 @@ public class SwissRailRaptorTest {
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
         Coord fromCoord = new Coord(3800, 5100);
         Coord toCoord = new Coord(16100, 5050);
-        List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 25.0*3600, null);
+        List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 25.0*3600, null, new Attributes());
         
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
     }
@@ -442,7 +443,7 @@ public class SwissRailRaptorTest {
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
         double x = +42000;
         double x1 = -2000;
-        List<Leg> legs = router.calcRoute(new FakeFacility(new Coord(x1, 0)), new FakeFacility(new Coord(x, 0)), 5.5*3600, null); // should map to stops A and I
+        List<Leg> legs = router.calcRoute(new FakeFacility(new Coord(x1, 0)), new FakeFacility(new Coord(x, 0)), 5.5*3600, null, new Attributes()); // should map to stops A and I
         assertEquals(3, legs.size());
         assertEquals(TransportMode.walk, legs.get(0).getMode());
         assertEquals(TransportMode.pt, legs.get(1).getMode());
@@ -466,7 +467,7 @@ public class SwissRailRaptorTest {
         f.scenario.getConfig().transitRouter().setExtensionRadius(0.0);
 
         TransitRouter router = createTransitRouter(f.schedule, f.scenario.getConfig(), f.scenario.getNetwork());
-        List<Leg> legs = router.calcRoute(new FakeFacility(f.coord2), new FakeFacility(f.coord4), 990, null);
+        List<Leg> legs = router.calcRoute(new FakeFacility(f.coord2), new FakeFacility(f.coord4), 990, null, new Attributes());
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
     }
 
@@ -484,7 +485,7 @@ public class SwissRailRaptorTest {
         f.scenario.getConfig().transitRouter().setExtensionRadius(0.0);
 
         TransitRouter router = createTransitRouter(f.schedule, f.scenario.getConfig(), f.scenario.getNetwork());
-        List<Leg> legs = router.calcRoute(new FakeFacility(f.coord2), new FakeFacility(f.coord6), 990, null);
+        List<Leg> legs = router.calcRoute(new FakeFacility(f.coord2), new FakeFacility(f.coord6), 990, null, new Attributes());
         
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
     }
@@ -498,7 +499,7 @@ public class SwissRailRaptorTest {
             TransitRouter router = createTransitRouter(f.schedule, f.config, f.scenario.getNetwork());
             Coord fromCoord = f.fromFacility.getCoord();
             Coord toCoord = f.toFacility.getCoord();
-            List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0 * 3600 + 50 * 60, null);
+            List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0 * 3600 + 50 * 60, null, new Attributes());
             double legDuration = calcTripDuration(new ArrayList<>(legs));
             Assert.assertEquals(5, legs.size());
             Assert.assertEquals(100, legs.get(0).getTravelTime().seconds(), 0.0);    // 0.1km with 1m/s walk speed -> 100s; arrival at 07:51:40
@@ -518,7 +519,7 @@ public class SwissRailRaptorTest {
                     f.scenario.getNetwork(), // use a walk router in case no PT path is found
                     walkRoutingModule);
 
-            List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(f.fromFacility, f.toFacility, 7.0 * 3600 + 50 * 60, null);
+            List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(f.fromFacility, f.toFacility, 7.0 * 3600 + 50 * 60, null, new Attributes());
             double tripDuration = calcTripDuration(planElements);
             Assert.assertEquals(9, planElements.size());
             Assert.assertEquals(100, ((Leg) planElements.get(0)).getTravelTime().seconds(), 0.0);    // 0.1km with 1m/s walk speed -> 100s; arrival at 07:51:40
@@ -537,7 +538,7 @@ public class SwissRailRaptorTest {
             TransitRouter router = createTransitRouter(f.schedule, f.config, f.scenario.getNetwork());
             Coord fromCoord = f.fromFacility.getCoord();
             Coord toCoord = f.toFacility.getCoord();
-            List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null);
+            List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null, new Attributes());
             double legDuration = calcTripDuration(new ArrayList<>(legs));
             Assert.assertEquals(5, legs.size());
 			Assert.assertEquals(100, legs.get(0).getTravelTime().seconds(), 0.0);	// 0.1km with 1m/s walk speed -> 100s; arrival at 07:51:40
@@ -556,7 +557,7 @@ public class SwissRailRaptorTest {
                     f.scenario.getNetwork(), // use a walk router in case no PT path is found
                     walkRoutingModule);
 
-            List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null);
+            List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null, new Attributes());
             double tripDuration = calcTripDuration(planElements);
             Assert.assertEquals(9, planElements.size());
 			Assert.assertEquals(100, ((Leg)planElements.get(0)).getTravelTime().seconds(), 0.0);	// 0.1km with 1m/s walk speed -> 100s; arrival at 07:51:40
@@ -573,7 +574,7 @@ public class SwissRailRaptorTest {
             TransitRouter router = createTransitRouter(f.schedule, f.config, f.scenario.getNetwork());
             Coord fromCoord = f.fromFacility.getCoord();
             Coord toCoord = f.toFacility.getCoord();
-            List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null);
+            List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null, new Attributes());
             Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
 
             RoutingModule walkRoutingModule = DefaultRoutingModules.createTeleportationRouter(TransportMode.transit_walk, f.scenario,
@@ -586,7 +587,7 @@ public class SwissRailRaptorTest {
                     walkRoutingModule);
 
             TransitRouterWrapper wrapper = new TransitRouterWrapper(router, f.schedule, f.scenario.getNetwork(), routingModule);
-            List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null);
+            List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null, new Attributes());
             Assert.assertNull("The router should not find a route and return null, but did return something else.", planElements);
         }
     }
@@ -618,7 +619,7 @@ public class SwissRailRaptorTest {
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.scenario.getNetwork());
         Coord fromCoord = new Coord(5010, 1010);
         Coord toCoord = new Coord(5010, 5010);
-        List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 8.0*3600-2*60, null);
+        List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 8.0*3600-2*60, null, new Attributes());
         assertEquals(7, legs.size());
         assertEquals(TransportMode.walk, legs.get(0).getMode());
         assertEquals(TransportMode.pt, legs.get(1).getMode());
@@ -654,7 +655,7 @@ public class SwissRailRaptorTest {
         Coord fromCoord = new Coord(16000, 100); // stop N
         Coord toCoord = new Coord(24000, 9950); // stop L
         double depTime = 5.0 * 3600 + 50 * 60;
-        List<Leg> legs = raptor.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime,null);
+        List<Leg> legs = raptor.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime,null, new Attributes());
 
         for (Leg leg : legs) {
             System.out.println(leg);
@@ -682,7 +683,7 @@ public class SwissRailRaptorTest {
         Coord fromCoord = new Coord(3800, 5100);
         Coord toCoord = new Coord(28100, 4950);
         double depTime = 5.0 * 3600 + 50 * 60;
-        List<RaptorRoute> routes = raptor.calcRoutes(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 600, depTime, depTime + 3600, null);
+        List<RaptorRoute> routes = raptor.calcRoutes(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 600, depTime, depTime + 3600, null, new Attributes());
 
         for (int i = 0; i < routes.size(); i++) {
             RaptorRoute route = routes.get(i);
@@ -732,7 +733,7 @@ public class SwissRailRaptorTest {
         Coord fromCoord = new Coord(3800, 5100);
         Coord toCoord = new Coord(28100, 4950);
         double depTime = 5.0 * 3600 + 50 * 60;
-        List<Leg> legs = raptor.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime, null);
+        List<Leg> legs = raptor.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime, null, new Attributes());
         // this test mostly checks that there are no Exceptions.
         Assert.assertEquals(3, legs.size());
     }
@@ -748,7 +749,7 @@ public class SwissRailRaptorTest {
             Coord fromCoord = new Coord(0, 100);
             Coord toCoord = new Coord(20000, 100);
             double depTime = 6.0 * 3600;
-            List<RaptorRoute> routes = raptor.calcRoutes(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 300, depTime, depTime + 300, null);
+            List<RaptorRoute> routes = raptor.calcRoutes(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 300, depTime, depTime + 300, null, new Attributes());
             Assert.assertEquals(1, routes.size());
             RaptorRoute route1 = routes.get(0);
 
@@ -768,7 +769,7 @@ public class SwissRailRaptorTest {
             Coord fromCoord = new Coord(0, 100);
             Coord toCoord = new Coord(20000, 100);
             double depTime = 6.0 * 3600;
-            List<RaptorRoute> routes = raptor.calcRoutes(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 300, depTime, depTime + 300, null);
+            List<RaptorRoute> routes = raptor.calcRoutes(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 300, depTime, depTime + 300, null, new Attributes());
             Assert.assertEquals(1, routes.size());
             RaptorRoute route1 = routes.get(0);
 
@@ -788,7 +789,7 @@ public class SwissRailRaptorTest {
             Coord fromCoord = new Coord(0, 100);
             Coord toCoord = new Coord(20000, 100);
             double depTime = 6.0 * 3600;
-            List<RaptorRoute> routes = raptor.calcRoutes(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 300, depTime, depTime + 300, null);
+            List<RaptorRoute> routes = raptor.calcRoutes(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 300, depTime, depTime + 300, null, new Attributes());
             Assert.assertEquals(1, routes.size());
             RaptorRoute route1 = routes.get(0);
 
@@ -808,7 +809,7 @@ public class SwissRailRaptorTest {
             Coord fromCoord = new Coord(0, 100);
             Coord toCoord = new Coord(40000, 100);
             double depTime = 6.0 * 3600;
-            List<RaptorRoute> routes = raptor.calcRoutes(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 300, depTime, depTime + 300, null);
+            List<RaptorRoute> routes = raptor.calcRoutes(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 300, depTime, depTime + 300, null, new Attributes());
             Assert.assertEquals(1, routes.size());
             RaptorRoute route1 = routes.get(0);
 
@@ -848,7 +849,7 @@ public class SwissRailRaptorTest {
 
         Coord fromCoord = f.fromFacility.getCoord();
         Coord toCoord = f.toFacility.getCoord();
-        List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null);
+        List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null, new Attributes());
         for (Leg leg : legs) {
             System.out.println(leg);
         }
@@ -902,7 +903,7 @@ public class SwissRailRaptorTest {
 
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
         Coord toCoord = new Coord(16100, 10050);
-        List<Leg> legs = router.calcRoute(new FakeFacility(new Coord(3800, 5100)), new FakeFacility(toCoord), 6.0*3600, null);
+        List<Leg> legs = router.calcRoute(new FakeFacility(new Coord(3800, 5100)), new FakeFacility(toCoord), 6.0*3600, null, new Attributes());
         assertEquals(5, legs.size());
         assertEquals(TransportMode.walk, legs.get(0).getMode());
         assertEquals("rail", legs.get(1).getMode());
@@ -921,7 +922,7 @@ public class SwissRailRaptorTest {
         { // test default, from C to G the red line is the fastest/cheapest
 
             TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
-            List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 6.0 * 3600 - 5 * 60, null);
+            List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 6.0 * 3600 - 5 * 60, null, new Attributes());
             assertEquals(3, legs.size());
             assertEquals(TransportMode.walk, legs.get(0).getMode());
             assertEquals("pt", legs.get(1).getMode());
@@ -965,7 +966,7 @@ public class SwissRailRaptorTest {
 
         { // test with similar costs, the red line should still be cheaper
             TransitRouter router = createTransitRouter(f.schedule, config, f.network);
-            List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 6.0 * 3600 - 5 * 60, null);
+            List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 6.0 * 3600 - 5 * 60, null, new Attributes());
             assertEquals(3, legs.size());
             assertEquals(TransportMode.walk, legs.get(0).getMode());
             assertEquals("rail", legs.get(1).getMode());
@@ -991,7 +992,7 @@ public class SwissRailRaptorTest {
             config.planCalcScore().addModeParams(roadParams);
 
             TransitRouter router = createTransitRouter(f.schedule, config, f.network);
-            List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 6.0 * 3600 - 5 * 60, null);
+            List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 6.0 * 3600 - 5 * 60, null, new Attributes());
             assertEquals(3, legs.size());
             assertEquals(TransportMode.walk, legs.get(0).getMode());
             assertEquals("road", legs.get(1).getMode());
@@ -1018,7 +1019,7 @@ public class SwissRailRaptorTest {
         Coord fromCoord = new Coord(3800, 5100);
         Coord toCoord = new Coord(8100, 5050);
 
-        List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 11.0*3600, null);
+        List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 11.0*3600, null, new Attributes());
 
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
     }

--- a/matsim/src/test/java/org/matsim/core/controler/PrepareForSimImplTest.java
+++ b/matsim/src/test/java/org/matsim/core/controler/PrepareForSimImplTest.java
@@ -52,6 +52,7 @@ import org.matsim.core.router.TripRouter;
 import org.matsim.core.router.TripStructureUtils;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import com.google.inject.Provider;
 
@@ -776,7 +777,7 @@ public class PrepareForSimImplTest {
 	private class DummyRoutingModule implements RoutingModule {
 		@Override
 		public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double departureTime,
-				Person person) {
+				Person person, Attributes attributes) {
 			return Collections.singletonList(PopulationUtils.createLeg("dummyMode"));
 		}
 	}

--- a/matsim/src/test/java/org/matsim/core/mobsim/qsim/NetsimRoutingConsistencyTest.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/qsim/NetsimRoutingConsistencyTest.java
@@ -60,6 +60,7 @@ import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleUtils;
 
@@ -178,7 +179,7 @@ public class NetsimRoutingConsistencyTest {
 					router);
 
 			Leg leg = (Leg) routingModule
-					.calcRoute(new LinkWrapperFacility(link12), new LinkWrapperFacility(link45), 0.0, person).get(0);
+					.calcRoute(new LinkWrapperFacility(link12), new LinkWrapperFacility(link45), 0.0, person, new Attributes()).get(0);
 
 			plan.addActivity(startActivity);
 			plan.addLeg(leg);

--- a/matsim/src/test/java/org/matsim/core/router/FallbackRoutingModuleTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/FallbackRoutingModuleTest.java
@@ -26,6 +26,7 @@ import org.matsim.core.replanning.strategies.DefaultPlanStrategiesModule;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.facilities.Facility;
 import org.matsim.testcases.MatsimTestUtils;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 public class FallbackRoutingModuleTest{
 	@Rule public MatsimTestUtils utils = new MatsimTestUtils();
@@ -79,7 +80,7 @@ public class FallbackRoutingModuleTest{
 			@Override public void install(){
 				this.addRoutingModuleBinding( "abcd" ).toInstance( new RoutingModule(){
 					@Override
-					public List<? extends PlanElement> calcRoute( Facility fromFacility, Facility toFacility, double departureTime, Person person ){
+					public List<? extends PlanElement> calcRoute( Facility fromFacility, Facility toFacility, double departureTime, Person person, Attributes tripAttributes ){
 						return null;
 					}
 				} );

--- a/matsim/src/test/java/org/matsim/core/router/InvertertedNetworkRoutingTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/InvertertedNetworkRoutingTest.java
@@ -32,6 +32,7 @@ import org.matsim.core.router.costcalculators.*;
 import org.matsim.core.router.util.*;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.vehicles.Vehicle;
 import org.junit.Assert;
 
@@ -103,7 +104,7 @@ public class InvertertedNetworkRoutingTest {
 	private NetworkRoute calcRoute(LinkToLinkRoutingModule router, final Facility fromFacility,
             final Facility toFacility, final Person person)
 	{
-        Leg leg = (Leg)router.calcRoute(fromFacility, toFacility, 0.0, person).get(0);
+        Leg leg = (Leg)router.calcRoute(fromFacility, toFacility, 0.0, person, new Attributes()).get(0);
         return (NetworkRoute) leg.getRoute();
 	}
 	

--- a/matsim/src/test/java/org/matsim/core/router/NetworkRoutingModuleTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/NetworkRoutingModuleTest.java
@@ -69,7 +69,7 @@ public class NetworkRoutingModuleTest {
 		            routeAlgo);
 		Facility fromFacility = FacilitiesUtils.toFacility( fromAct, f.s.getActivityFacilities() );
 		Facility toFacility = FacilitiesUtils.toFacility( toAct, f.s.getActivityFacilities() );
-		List<? extends PlanElement> result = routingModule.calcRoute(fromFacility, toFacility, 7.0*3600, person) ;
+		List<? extends PlanElement> result = routingModule.calcRoute(fromFacility, toFacility, 7.0*3600, person, fromAct.getAttributes()) ;
 		Assert.assertEquals(1, result.size() );
 		Leg leg = (Leg)result.get(0) ;
 		Assert.assertEquals(100.0, leg.getTravelTime().seconds(), 1e-8);
@@ -102,7 +102,7 @@ public class NetworkRoutingModuleTest {
 							routeAlgo);
 
 			List<? extends PlanElement> results = router.calcRoute( FacilitiesUtils.toFacility(fromAct, f.s.getActivityFacilities() ),
-				  FacilitiesUtils.toFacility(toAct, f.s.getActivityFacilities() ), 8.*3600, person ) ;
+				  FacilitiesUtils.toFacility(toAct, f.s.getActivityFacilities() ), 8.*3600, person, fromAct.getAttributes() ) ;
 			Assert.assertEquals( 1, results.size() );
 			Leg leg = (Leg) results.get(0) ;
 
@@ -131,7 +131,7 @@ public class NetworkRoutingModuleTest {
 							routeAlgo);
 
 			List<? extends PlanElement> result = router.calcRoute( FacilitiesUtils.toFacility(fromAct, f.s.getActivityFacilities() ), FacilitiesUtils.toFacility(toAct,
-				  f.s.getActivityFacilities() ), 7.*3600, person ) ;
+				  f.s.getActivityFacilities() ), 7.*3600, person, fromAct.getAttributes() ) ;
 			
 			Assert.assertEquals( 1, result.size() ) ; 
 			Leg leg = (Leg) result.get(0) ;

--- a/matsim/src/test/java/org/matsim/core/router/PseudoTransitRoutingModuleTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/PseudoTransitRoutingModuleTest.java
@@ -114,7 +114,7 @@ public class PseudoTransitRoutingModuleTest {
 			Facility fromFacility = FacilitiesUtils.toFacility(fromAct, f.s.getActivityFacilities() ) ;
 			Facility toFacility = FacilitiesUtils.toFacility(toAct, f.s.getActivityFacilities() );
 			
-			List<? extends PlanElement> result = tripRouter.calcRoute("mode", fromFacility, toFacility, 7.0*3600., person) ;
+			List<? extends PlanElement> result = tripRouter.calcRoute("mode", fromFacility, toFacility, 7.0*3600., person, fromAct.getAttributes()) ;
 			Gbl.assertIf( result.size()==1);
 			Leg newLeg = (Leg) result.get(0) ;
 

--- a/matsim/src/test/java/org/matsim/core/router/TripRouterFactoryImplTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/TripRouterFactoryImplTest.java
@@ -43,6 +43,7 @@ import org.matsim.core.router.costcalculators.OnlyTimeDependentTravelDisutilityF
 import org.matsim.core.scenario.ScenarioByInstanceModule;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import javax.inject.Provider;
 
@@ -124,7 +125,8 @@ public class TripRouterFactoryImplTest {
 				new LinkFacility( l1 ),
 				new LinkFacility( l3 ),
 				0,
-				PopulationUtils.getFactory().createPerson(Id.create("toto", Person.class)));
+				PopulationUtils.getFactory().createPerson(Id.create("toto", Person.class)),
+				new Attributes());
 
 		Leg l = (Leg) trip.get( 0 );
 		if ( !scenario.getConfig().plansCalcRoute().getAccessEgressType().equals(PlansCalcRouteConfigGroup.AccessEgressType.none) ) {
@@ -199,7 +201,8 @@ public class TripRouterFactoryImplTest {
 				new LinkFacility( l1 ),
 				new LinkFacility( l3 ),
 				0,
-				PopulationUtils.getFactory().createPerson(Id.create("toto", Person.class)));
+				PopulationUtils.getFactory().createPerson(Id.create("toto", Person.class)),
+				new Attributes());
 
 		Leg l = (Leg) trip.get( 0 );
 		if ( !scenario.getConfig().plansCalcRoute().getAccessEgressType().equals(PlansCalcRouteConfigGroup.AccessEgressType.none) ) {

--- a/matsim/src/test/java/org/matsim/core/router/costcalculators/RandomizingTimeDistanceTravelDisutilityTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/costcalculators/RandomizingTimeDistanceTravelDisutilityTest.java
@@ -110,7 +110,7 @@ public class RandomizingTimeDistanceTravelDisutilityTest {
 		            router);
 		Facility fromFacility = FacilitiesUtils.toFacility( fromAct, f.s.getActivityFacilities() );
 		Facility toFacility = FacilitiesUtils.toFacility( toAct, f.s.getActivityFacilities() );
-		List<? extends PlanElement> result = routingModule.calcRoute(fromFacility, toFacility, 7.0*3600, person) ;
+		List<? extends PlanElement> result = routingModule.calcRoute(fromFacility, toFacility, 7.0*3600, person, fromAct.getAttributes()) ;
 		Assert.assertEquals(1, result.size() );
 		Leg leg = (Leg) result.get(0) ;				
 		return (NetworkRoute) leg.getRoute();

--- a/matsim/src/test/java/org/matsim/core/router/old/PlanRouterTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/old/PlanRouterTest.java
@@ -46,6 +46,7 @@ import org.matsim.core.utils.io.IOUtils;
 import org.matsim.examples.ExamplesUtils;
 import org.matsim.facilities.Facility;
 import org.matsim.testcases.MatsimTestUtils;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.vehicles.Vehicle;
 
 import java.util.Arrays;
@@ -102,11 +103,11 @@ public class PlanRouterTest {
         final Id<Vehicle> newVehicleId = Id.create(2, Vehicle.class);
         final RoutingModule routingModule = new RoutingModule() {
               @Override
-              public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double departureTime, Person person) {
+              public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double departureTime, Person person, Attributes attributes) {
                   List<? extends PlanElement> trip = DefaultRoutingModules.createPureNetworkRouter("car", scenario.getPopulation().getFactory(),
                   		scenario.getNetwork(),
                   		leastCostAlgoFactory.createPathCalculator(scenario.getNetwork(), disutilityFactory.createTravelDisutility(travelTime), travelTime)
-                  		).calcRoute(fromFacility, toFacility, departureTime, person);
+                  		).calcRoute(fromFacility, toFacility, departureTime, person, attributes);
                   ((NetworkRoute) TripStructureUtils.getLegs(trip).get(0).getRoute()).setVehicleId(newVehicleId);
                   return trip;
               }

--- a/matsim/src/test/java/org/matsim/pt/router/TransitRouterCustomDataTest.java
+++ b/matsim/src/test/java/org/matsim/pt/router/TransitRouterCustomDataTest.java
@@ -44,6 +44,7 @@ import org.matsim.pt.transitSchedule.api.TransitRouteStop;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitScheduleFactory;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.vehicles.Vehicle;
 
 /**
@@ -71,7 +72,7 @@ public class TransitRouterCustomDataTest {
 		TransitRouterImpl router = new TransitRouterImpl(trConfig, new PreparedTransitSchedule(scenario.getTransitSchedule()), transitNetwork, transitRouterNetworkTravelTimeAndDisutility, disutility);
 
 		double x = -100;
-		List<Leg> legs = router.calcRoute(new FakeFacility( new Coord(x, (double) 0)), new FakeFacility( new Coord((double) 3100, (double) 0)), 5.9*3600, null);
+		List<Leg> legs = router.calcRoute(new FakeFacility( new Coord(x, (double) 0)), new FakeFacility( new Coord((double) 3100, (double) 0)), 5.9*3600, null, new Attributes());
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
 		
 		/* the following is not really nice as a test, but I had to somehow

--- a/matsim/src/test/java/org/matsim/pt/router/TransitRouterImplTest.java
+++ b/matsim/src/test/java/org/matsim/pt/router/TransitRouterImplTest.java
@@ -65,6 +65,7 @@ import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitScheduleFactory;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 import org.matsim.testcases.MatsimTestCase;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * @author mrieser
@@ -97,7 +98,7 @@ public class TransitRouterImplTest {
 		TransitRouter router = createTransitRouter(f.schedule, trConfig, routerType);
 		Coord fromCoord = new Coord(3800, 5100);
 		Coord toCoord = new Coord(16100, 5050);
-		List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null);
+		List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null, new Attributes());
 		assertEquals(3, legs.size());
 		assertEquals(TransportMode.walk, legs.get(0).getMode());
 		assertEquals(TransportMode.pt, legs.get(1).getMode());
@@ -145,7 +146,7 @@ public class TransitRouterImplTest {
 		TransitRouter router = createTransitRouter(f.schedule, trConfig, routerType);
 		Coord fromCoord = new Coord((double) 3800, (double) 5100);
 		Coord toCoord = new Coord((double) 4100, (double) 5050);
-		List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null);
+		List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null, new Attributes());
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
 	}
 
@@ -159,7 +160,7 @@ public class TransitRouterImplTest {
 		TransitRouter router = createTransitRouter(f.schedule, trConfig, routerType);
 		Coord fromCoord = new Coord((double) 4000, (double) 3000);
 		Coord toCoord = new Coord((double) 8000, (double) 3000);
-		List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null);
+		List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null, new Attributes());
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
 	}
 
@@ -176,7 +177,7 @@ public class TransitRouterImplTest {
 
 		double inVehicleTime = 7.0*60; // travel time from A to B
 		for (int min = 0; min < 30; min += 3) {
-			List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600 + min*60, null);
+			List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600 + min*60, null, new Attributes());
 			assertEquals(3, legs.size()); // walk-pt-walk
 			double actualTravelTime = 0.0;
 			for (Leg leg : legs) {
@@ -196,7 +197,7 @@ public class TransitRouterImplTest {
 				f.scenario.getConfig().vspExperimental());
 		TransitRouter router = createTransitRouter(f.schedule, trConfig, routerType);
 		Coord toCoord = new Coord((double) 16100, (double) 10050);
-		List<Leg> legs = router.calcRoute(new FakeFacility(new Coord((double) 3800, (double) 5100)), new FakeFacility(toCoord), 6.0*3600, null);
+		List<Leg> legs = router.calcRoute(new FakeFacility(new Coord((double) 3800, (double) 5100)), new FakeFacility(toCoord), 6.0*3600, null, new Attributes());
 		assertEquals(5, legs.size());
 		assertEquals(TransportMode.walk, legs.get(0).getMode());
 		assertEquals(TransportMode.pt, legs.get(1).getMode());
@@ -234,7 +235,7 @@ public class TransitRouterImplTest {
 		TransitRouter router = createTransitRouter(f.schedule, config, routerType);
 		Coord fromCoord = new Coord((double) 3800, (double) 5100);
 		Coord toCoord = new Coord((double) 16100, (double) 10050);
-		List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 6.0*3600, null);
+		List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 6.0*3600, null, new Attributes());
 		Leg leg1 = legs.get(1);
 		TransitPassengerRoute route1 = (TransitPassengerRoute) leg1.getRoute();
 		Coord coord1 = f.schedule.getFacilities().get(route1.getEgressStopId()).getCoord();
@@ -255,7 +256,7 @@ public class TransitRouterImplTest {
 				f.scenario.getConfig().vspExperimental());
 		TransitRouter router = createTransitRouter(f.schedule, trConfig, routerType);
 		Coord toCoord = new Coord((double) 28100, (double) 4950);
-		List<Leg> legs = router.calcRoute(new FakeFacility( new Coord((double) 3800, (double) 5100)), new FakeFacility(toCoord), 5.0*3600 + 40.0*60, null);
+		List<Leg> legs = router.calcRoute(new FakeFacility( new Coord((double) 3800, (double) 5100)), new FakeFacility(toCoord), 5.0*3600 + 40.0*60, null, new Attributes());
 		assertEquals(4, legs.size());
 		assertEquals(TransportMode.walk, legs.get(0).getMode());
 		assertEquals(TransportMode.pt, legs.get(1).getMode());
@@ -298,7 +299,7 @@ public class TransitRouterImplTest {
 				f.scenario.getConfig().vspExperimental());
 		trConfig.setUtilityOfLineSwitch_utl(0);
 		TransitRouter router = createTransitRouter(f.schedule, trConfig, routerType);
-		List<Leg> legs = router.calcRoute(new FakeFacility(new Coord((double) 11900, (double) 5100)), new FakeFacility(new Coord((double) 24100, (double) 4950)), 6.0*3600 - 5.0*60, null);
+		List<Leg> legs = router.calcRoute(new FakeFacility(new Coord((double) 11900, (double) 5100)), new FakeFacility(new Coord((double) 24100, (double) 4950)), 6.0*3600 - 5.0*60, null, new Attributes());
 		assertEquals(5, legs.size());
 		assertEquals(TransportMode.walk, legs.get(0).getMode());
 		assertEquals(TransportMode.pt, legs.get(1).getMode());
@@ -309,7 +310,7 @@ public class TransitRouterImplTest {
 		assertEquals(TransportMode.walk, legs.get(4).getMode());
 
 		trConfig.setUtilityOfLineSwitch_utl(300.0 * trConfig.getMarginalUtilityOfTravelTimePt_utl_s()); // corresponds to 5 minutes transit travel time
-		legs = router.calcRoute(new FakeFacility(new Coord((double) 11900, (double) 5100)), new FakeFacility(new Coord((double) 24100, (double) 4950)), 6.0*3600 - 5.0*60, null);
+		legs = router.calcRoute(new FakeFacility(new Coord((double) 11900, (double) 5100)), new FakeFacility(new Coord((double) 24100, (double) 4950)), 6.0*3600 - 5.0*60, null, new Attributes());
 		assertEquals(3, legs.size());
 		assertEquals(TransportMode.walk, legs.get(0).getMode());
 		assertEquals(TransportMode.pt, legs.get(1).getMode());
@@ -335,7 +336,7 @@ public class TransitRouterImplTest {
 		trConfig.setUtilityOfLineSwitch_utl(0);
 		assertEquals(0, trConfig.getAdditionalTransferTime(), 1e-8);
 		TransitRouter router = createTransitRouter(f.schedule, trConfig, routerType);
-		List<Leg> legs = router.calcRoute(new FakeFacility(new Coord((double) 11900, (double) 5100)), new FakeFacility(new Coord((double) 24100, (double) 4950)), 6.0*3600 - 5.0*60, null);
+		List<Leg> legs = router.calcRoute(new FakeFacility(new Coord((double) 11900, (double) 5100)), new FakeFacility(new Coord((double) 24100, (double) 4950)), 6.0*3600 - 5.0*60, null, new Attributes());
 		assertEquals(5, legs.size());
 		assertEquals(TransportMode.walk, legs.get(0).getMode());
 		assertEquals(TransportMode.pt, legs.get(1).getMode());
@@ -347,7 +348,7 @@ public class TransitRouterImplTest {
 
 		trConfig.setAdditionalTransferTime(3.0*60); // 3 mins already enough, as there is a small distance to walk anyway which adds some time
 		router = createTransitRouter(f.schedule, trConfig, routerType); // this is necessary to update the router for any change in config. At least raptor transit router fails without this. Amit Sep'17.
-		legs = router.calcRoute(new FakeFacility(new Coord((double) 11900, (double) 5100)), new FakeFacility(new Coord((double) 24100, (double) 4950)), 6.0*3600 - 5.0*60, null);
+		legs = router.calcRoute(new FakeFacility(new Coord((double) 11900, (double) 5100)), new FakeFacility(new Coord((double) 24100, (double) 4950)), 6.0*3600 - 5.0*60, null, new Attributes());
 		assertEquals(3, legs.size());
 		assertEquals(TransportMode.walk, legs.get(0).getMode());
 		assertEquals(TransportMode.pt, legs.get(1).getMode());
@@ -365,7 +366,7 @@ public class TransitRouterImplTest {
 		trConfig.setBeelineWalkSpeed(0.1); // something very slow, so the agent does not walk over night
 		TransitRouter router = createTransitRouter(f.schedule, trConfig, routerType);
 		Coord toCoord = new Coord((double) 16100, (double) 5050);
-		List<Leg> legs = router.calcRoute(new FakeFacility(new Coord((double) 3800, (double) 5100)), new FakeFacility(toCoord), 25.0*3600, null);
+		List<Leg> legs = router.calcRoute(new FakeFacility(new Coord((double) 3800, (double) 5100)), new FakeFacility(toCoord), 25.0*3600, null, new Attributes());
 		assertEquals(3, legs.size());
 		assertEquals(TransportMode.walk, legs.get(0).getMode());
 		assertEquals(TransportMode.pt, legs.get(1).getMode());
@@ -395,7 +396,7 @@ public class TransitRouterImplTest {
 		TransitRouter router = createTransitRouter(f.schedule, trConfig, routerType);
 		double x = +42000;
 		double x1 = -2000;
-		List<Leg> legs = router.calcRoute(new FakeFacility(new Coord(x1, (double) 0)), new FakeFacility(new Coord(x, (double) 0)), 5.5*3600, null); // should map to stops A and I
+		List<Leg> legs = router.calcRoute(new FakeFacility(new Coord(x1, (double) 0)), new FakeFacility(new Coord(x, (double) 0)), 5.5*3600, null, new Attributes()); // should map to stops A and I
 		assertEquals(3, legs.size());
 		assertEquals(TransportMode.walk, legs.get(0).getMode());
 		assertEquals(TransportMode.pt, legs.get(1).getMode());
@@ -418,7 +419,7 @@ public class TransitRouterImplTest {
 		f.routerConfig.setMarginalUtilityOfTravelTimePt_utl_s(-1.0 / 3600.0 - 6.0/3600.0);
 		f.routerConfig.setUtilityOfLineSwitch_utl(0.2); // must be relatively low in this example, otherwise it's cheaper to walk the whole distance...
 		TransitRouter router = createTransitRouter(f.schedule, f.routerConfig, routerType);
-		List<Leg> legs = router.calcRoute(new FakeFacility(f.coord1), new FakeFacility(f.coord7), 990, null);
+		List<Leg> legs = router.calcRoute(new FakeFacility(f.coord1), new FakeFacility(f.coord7), 990, null, new Attributes());
 		assertEquals(5, legs.size());
 		assertEquals(TransportMode.walk, legs.get(0).getMode());
 		assertEquals(TransportMode.pt, legs.get(1).getMode());
@@ -448,7 +449,7 @@ public class TransitRouterImplTest {
 		f.routerConfig.setExtensionRadius(0.0);
 
 		TransitRouter router = createTransitRouter(f.schedule, f.routerConfig, routerType);
-		List<Leg> legs = router.calcRoute(new FakeFacility(f.coord2), new FakeFacility(f.coord4), 990, null);
+		List<Leg> legs = router.calcRoute(new FakeFacility(f.coord2), new FakeFacility(f.coord4), 990, null, new Attributes());
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
 	}
 
@@ -464,7 +465,7 @@ public class TransitRouterImplTest {
 		f.routerConfig.setExtensionRadius(0.0);
 
 		TransitRouter router = createTransitRouter(f.schedule, f.routerConfig, routerType);
-		List<Leg> legs = router.calcRoute(new FakeFacility(f.coord2), new FakeFacility(f.coord6), 990, null);
+		List<Leg> legs = router.calcRoute(new FakeFacility(f.coord2), new FakeFacility(f.coord6), 990, null, new Attributes());
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
 	}
 
@@ -477,7 +478,7 @@ public class TransitRouterImplTest {
 			TransitRouter router = createTransitRouter(f.schedule, f.routerConfig, routerType);
 			Coord fromCoord = f.fromFacility.getCoord();
 			Coord toCoord = f.toFacility.getCoord();
-			List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null);
+			List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null, new Attributes());
 			double legDuration = calcTripDuration(new ArrayList<>(legs));
 			Assert.assertEquals(5, legs.size());
 			Assert.assertEquals(100, legs.get(0).getTravelTime().seconds(), 0.0);	// 0.1km with 1m/s walk speed -> 100s; arrival at 07:51:40
@@ -496,7 +497,7 @@ public class TransitRouterImplTest {
 	                f.scenario.getNetwork(), // use a walk router in case no PT path is found
 	                walkRoutingModule);
 			
-			List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null);
+			List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null, new Attributes());
 			double tripDuration = calcTripDuration(planElements);
 			Assert.assertEquals(9, planElements.size());
 			Assert.assertEquals(100, ((Leg)planElements.get(0)).getTravelTime().seconds(), 0.0);	// 0.1km with 1m/s walk speed -> 100s; arrival at 07:51:40
@@ -513,7 +514,7 @@ public class TransitRouterImplTest {
 			TransitRouter router = createTransitRouter(f.schedule, f.routerConfig, routerType);
 			Coord fromCoord = f.fromFacility.getCoord();
 			Coord toCoord = f.toFacility.getCoord();
-			List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null);
+			List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null, new Attributes());
 			double legDuration = calcTripDuration(new ArrayList<>(legs));
 			Assert.assertEquals(5, legs.size());
 			Assert.assertEquals(100, legs.get(0).getTravelTime().seconds(), 0.0);	// 0.1km with 1m/s walk speed -> 100s; arrival at 07:51:40
@@ -532,7 +533,7 @@ public class TransitRouterImplTest {
 	                f.scenario.getNetwork(), // use a walk router in case no PT path is found
 	                walkRoutingModule);
 			
-			List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null);
+			List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null, new Attributes());
 			double tripDuration = calcTripDuration(planElements);
 			Assert.assertEquals(9, planElements.size());
 			Assert.assertEquals(100, ((Leg)planElements.get(0)).getTravelTime().seconds(), 0.0);	// 0.1km with 1m/s walk speed -> 100s; arrival at 07:51:40
@@ -549,7 +550,7 @@ public class TransitRouterImplTest {
 			TransitRouter router = createTransitRouter(f.schedule, f.routerConfig, routerType);
 			Coord fromCoord = f.fromFacility.getCoord();
 			Coord toCoord = f.toFacility.getCoord();
-			List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null);
+			List<Leg> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null, new Attributes());
 	        Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
 			
 			RoutingModule walkRoutingModule = DefaultRoutingModules.createTeleportationRouter(TransportMode.walk, f.scenario,
@@ -561,7 +562,7 @@ public class TransitRouterImplTest {
 	                f.scenario.getNetwork(), // use a walk router in case no PT path is found
 	                walkRoutingModule);
 			
-			List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null);
+			List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null, new Attributes());
 	        Assert.assertNull("The router should not find a route and return null, but did return something else.", planElements);
 		}
 	}


### PR DESCRIPTION
Following up on #1349, this is a proposal of having trip-specific attributes, which can be passed on to the routing modules. This allows routers to take into account trip-specific criteria, e.g. the use of certain service requirements for a DRT or taxi trip, or the use of special connections in an adapted public transport router.

The implementation here passes the attributes of the *preceding activity* on to the `RoutingModule` so they can be treated as "trip attributes". Later on, we could potentially make this explicit by introducing `<tripAttributes></tripAttributes>` in the definition of an activity.

Let me know what you think.