### PR TITLE
quick fix for SingleInsertionDetourPathCalculator

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SingleInsertionDetourPathCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SingleInsertionDetourPathCalculator.java
@@ -24,6 +24,7 @@ import static org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Inse
 import static org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
 import static org.matsim.contrib.dvrp.path.VrpPaths.FIRST_LINK_TT;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -90,7 +91,9 @@ public class SingleInsertionDetourPathCalculator implements DetourPathCalculator
 		Link pickup = drtRequest.getFromLink();
 		Link dropoff = drtRequest.getToLink();
 
-		Preconditions.checkArgument(filteredInsertions.size() == 1);
+		if (filteredInsertions.isEmpty()) {
+			return new DetourData<>(new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>(), PathData.EMPTY);
+		}
 		var insertion = filteredInsertions.get(0);
 
 		double earliestPickupTime = drtRequest.getEarliestStartTime(); // optimistic


### PR DESCRIPTION
I noticed that there are Problems with `SelectiveInsertionSearch`. When no insertion is found with `ExtensiveInsertionSearch` the `MultiInsertionDetourPathCalculator.calculatePaths` function returns `DetourData` with empty HashMaps. However, the `SingleInsertionDetourPathCalculator.java.calculatePaths` function checks first if `filteredInsertions` has size one - when no insertion is viable this leads to an error.

This fix just checks first if `filteredInsertions` is empty and then returns new `DetourData` with empty HashMaps manually, that is probably not the most elegant solution but it works.