### PR TITLE
Emissions: Minor fix in decision if average table is needed or not

### DIFF
--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/EmissionModule.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/EmissionModule.java
@@ -177,7 +177,7 @@ public final class EmissionModule {
 			case directlyTryAverageTable:
 				return true;
 			default:
-				return true;
+				return false;
 		}
 	}
 


### PR DESCRIPTION
looks like there was a typo introduced in #1303

Fixing it by setting the default value to false --> if not set based on a config value to true, there is no need to create the average value table.