### PR TITLE
Fix lane order for certain lanes to link assignments

### DIFF
--- a/matsim/src/main/java/org/matsim/lanes/LanesUtils.java
+++ b/matsim/src/main/java/org/matsim/lanes/LanesUtils.java
@@ -113,18 +113,20 @@ public final class LanesUtils {
 	public static List<ModelLane> createLanes(Link link, LanesToLinkAssignment lanesToLinkAssignment) {
 		List<ModelLane> queueLanes = new ArrayList<>();
 		List<Lane> sortedLanes =  new ArrayList<>(lanesToLinkAssignment.getLanes().values());
-		Collections.sort(sortedLanes, new Comparator<Lane>() {
-			@Override
-			public int compare(Lane o1, Lane o2) {
-				if (o1.getStartsAtMeterFromLinkEnd() < o2.getStartsAtMeterFromLinkEnd()) {
-					return -1;
-				} else if (o1.getStartsAtMeterFromLinkEnd() > o2.getStartsAtMeterFromLinkEnd()) {
-					return 1;
-				} else {
-					return 0;
+
+		// orders lanes by start on link an whether they are outgoing or not o the start is the same
+		sortedLanes.sort(Comparator.comparingDouble(Lane::getStartsAtMeterFromLinkEnd).thenComparing(
+				(l1, l2) -> {
+					boolean l1Outgoing = l1.getToLinkIds() != null && !l1.getToLinkIds().isEmpty();
+					boolean l2Outgoing = l2.getToLinkIds() != null && !l2.getToLinkIds().isEmpty();
+					if (l1Outgoing && !l2Outgoing)
+						return -1;
+					else if(l2Outgoing && !l1Outgoing)
+						return 1;
+					else
+						return 0;
 				}
-			}
-		});
+		));
 		Collections.reverse(sortedLanes);
 
 		List<ModelLane> laneList = new LinkedList<>();

--- a/matsim/src/test/java/org/matsim/lanes/LanesUtilsTest.java
+++ b/matsim/src/test/java/org/matsim/lanes/LanesUtilsTest.java
@@ -1,0 +1,84 @@
+package org.matsim.lanes;
+
+import org.junit.Test;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.NetworkFactory;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.scenario.ScenarioUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LanesUtilsTest {
+
+    private LanesToLinkAssignment createLaneAssignment(Scenario scenario, double inLength, double leftLength, double straightLength) {
+
+        // construct a link with effectively two lanes and one ingoing lane of zero length
+        // the ingoing lane is required for qsim to work at all with the lanes feature
+        Id<Link> linkIdBeforeIntersection = Id.createLinkId("1325764790002f");
+        Id<Link> nextLinkIdLeftTurn = Id.createLinkId("3624560720000f");
+        Id<Link> nextLinkIdStraight = Id.createLinkId("1325764790003f");
+
+        Id<Lane> inLaneId = Id.create("1325764790002f_in", Lane.class);
+        Id<Lane> leftTurnLaneId = Id.create("1325764790002f_left", Lane.class);
+        Id<Lane> straightLaneId = Id.create("1325764790002f_straight", Lane.class);
+
+        LanesFactory factory = scenario.getLanes().getFactory();
+        // add lanes for link "1325764790002f"
+        LanesToLinkAssignment laneLinkAssignment = factory.createLanesToLinkAssignment(linkIdBeforeIntersection);
+
+        Lane laneIn = factory.createLane(inLaneId);
+        laneIn.addToLaneId(leftTurnLaneId);
+        laneIn.addToLaneId(straightLaneId);
+        laneIn.setStartsAtMeterFromLinkEnd(inLength);
+        laneIn.setCapacityVehiclesPerHour(720. * 4);
+        laneIn.setNumberOfRepresentedLanes(4.0);
+        laneLinkAssignment.addLane(laneIn);
+
+        Lane lane0 = factory.createLane(leftTurnLaneId);
+        lane0.addToLinkId(nextLinkIdLeftTurn); // turn left towards check-in link
+        lane0.setStartsAtMeterFromLinkEnd(leftLength);
+        lane0.setCapacityVehiclesPerHour(720.);
+        laneLinkAssignment.addLane(lane0);
+
+        Lane lane1 = factory.createLane(straightLaneId);
+        lane1.addToLinkId(nextLinkIdStraight); // straight!
+        lane1.setStartsAtMeterFromLinkEnd(straightLength);
+        lane1.setCapacityVehiclesPerHour(720. * 3.0);
+        lane1.setNumberOfRepresentedLanes(3.0);
+        laneLinkAssignment.addLane(lane1);
+
+        return laneLinkAssignment;
+    }
+
+    @Test
+    public void correctOrder() {
+
+        Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+        NetworkFactory f = scenario.getNetwork().getFactory();
+
+        // left and straight lane start after the ingoing
+        LanesToLinkAssignment l2l = createLaneAssignment(scenario, 10, 8, 8);
+        Link link = f.createLink(
+                l2l.getLinkId(),
+                f.createNode(Id.createNodeId(1), new Coord(1,1)),
+                f.createNode(Id.createNodeId(2), new Coord(2,2))
+        );
+        link.setLength(10);
+
+
+        List<ModelLane> lanes = LanesUtils.createLanes(link, l2l);
+        assertThat(lanes).hasSize(3);
+
+        // lanes start at the beginning
+        l2l = createLaneAssignment(scenario, 10, 10, 10);
+        lanes = LanesUtils.createLanes(link, l2l);
+
+        assertThat(lanes).hasSize(3);
+
+    }
+}


### PR DESCRIPTION
The current lane implementation always expect one incoming lane. 
If one wants to make it of zero length and let the other lanes start immediately the code does not handle the order correcty. Occasionally it would work depending on the order the lanes have been added / written in the xml file.
This PR fixes the behavior and adds a test for this case.