### PR TITLE
Save/load dvrp travel times

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigGroup.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigGroup.java
@@ -19,6 +19,7 @@
 
 package org.matsim.contrib.dvrp.run;
 
+import java.net.URL;
 import java.util.Map;
 
 import javax.annotation.Nullable;
@@ -34,6 +35,7 @@ import org.matsim.contrib.dynagent.run.DynQSimConfigConsistencyChecker;
 import org.matsim.contrib.util.ReflectiveConfigGroupWithConfigurableParameterSets;
 import org.matsim.contrib.zone.skims.DvrpTravelTimeMatrixParams;
 import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.utils.misc.StringUtils;
 
 import com.google.common.collect.ImmutableSet;
@@ -97,6 +99,11 @@ public final class DvrpConfigGroup extends ReflectiveConfigGroupWithConfigurable
 	// In DVRP 'time < currentTime' may only happen for backward path search, a adding proper search termination
 	// criterion should prevent this from happening
 
+	private static final String INITIAL_TRAVEL_TIMES_FILE = "initialTravelTimesFile";
+	private static final String INITIAL_TRAVEL_TIMES_FILE_EXP =
+			"File containing the initial link travel time estimates."
+					+ " Ignored if null";
+
 	// used for building route; empty ==> no filtering (routing network equals scenario.network)
 	@NotNull
 	private ImmutableSet<String> networkModes = ImmutableSet.of(TransportMode.car);
@@ -110,6 +117,9 @@ public final class DvrpConfigGroup extends ReflectiveConfigGroupWithConfigurable
 
 	@PositiveOrZero
 	private double travelTimeEstimationBeta = 0; // [s], 0 ==> only offline TT estimation
+
+	@Nullable
+	private String initialTravelTimesFile = null;
 
 	@Nullable
 	private DvrpTravelTimeMatrixParams travelTimeMatrixParams;
@@ -243,5 +253,27 @@ public final class DvrpConfigGroup extends ReflectiveConfigGroupWithConfigurable
 			addParameterSet(new DvrpTravelTimeMatrixParams());
 		}
 		return travelTimeMatrixParams;
+	}
+
+	/**
+	 * @return {@value #INITIAL_TRAVEL_TIMES_FILE_EXP}
+	 */
+	@StringGetter(INITIAL_TRAVEL_TIMES_FILE)
+	@Nullable
+	public String getInitialTravelTimesFile() {
+		return initialTravelTimesFile;
+	}
+
+	/**
+	 * @param initialTravelTimesFile {@value #INITIAL_TRAVEL_TIMES_FILE_EXP}
+	 */
+	@StringSetter(INITIAL_TRAVEL_TIMES_FILE)
+	public void setInitialTravelTimesFile(@Nullable String initialTravelTimesFile) {
+		this.initialTravelTimesFile = initialTravelTimesFile;
+	}
+
+	@Nullable
+	public URL getInitialTravelTimesUrl(URL context) {
+		return initialTravelTimesFile == null ? null : ConfigGroup.getInputFileURL(context, initialTravelTimesFile);
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOfflineTravelTimeEstimator.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOfflineTravelTimeEstimator.java
@@ -21,13 +21,19 @@ package org.matsim.contrib.dvrp.trafficmonitoring;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import java.net.URL;
+
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.dvrp.router.DvrpGlobalRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.core.config.Config;
 import org.matsim.core.config.groups.TravelTimeCalculatorConfigGroup;
+import org.matsim.core.controler.OutputDirectoryHierarchy;
+import org.matsim.core.controler.events.AfterMobsimEvent;
+import org.matsim.core.controler.listener.AfterMobsimListener;
 import org.matsim.core.mobsim.framework.events.MobsimBeforeCleanupEvent;
 import org.matsim.core.mobsim.framework.listeners.MobsimBeforeCleanupListener;
 import org.matsim.core.router.util.TravelTime;
@@ -47,9 +53,11 @@ import com.google.inject.name.Named;
  *
  * @author michalm
  */
-public class DvrpOfflineTravelTimeEstimator implements DvrpTravelTimeEstimator, MobsimBeforeCleanupListener {
+public class DvrpOfflineTravelTimeEstimator
+		implements DvrpTravelTimeEstimator, MobsimBeforeCleanupListener, AfterMobsimListener {
 	private final TravelTime observedTT;
 	private final Network network;
+	private final OutputDirectoryHierarchy outputDirectoryHierarchy;
 
 	private final int interval;
 	private final int intervalCount;
@@ -60,14 +68,18 @@ public class DvrpOfflineTravelTimeEstimator implements DvrpTravelTimeEstimator, 
 	public DvrpOfflineTravelTimeEstimator(@Named(DvrpTravelTimeModule.DVRP_INITIAL) TravelTime initialTT,
 			@Named(DvrpTravelTimeModule.DVRP_OBSERVED) TravelTime observedTT,
 			@Named(DvrpGlobalRoutingNetworkProvider.DVRP_ROUTING) Network network,
-			TravelTimeCalculatorConfigGroup ttCalcConfig, DvrpConfigGroup dvrpConfig) {
-		this(initialTT, observedTT, network, ttCalcConfig, dvrpConfig.getTravelTimeEstimationAlpha());
+			TravelTimeCalculatorConfigGroup ttCalcConfig, DvrpConfigGroup dvrpConfig, Config config,
+			OutputDirectoryHierarchy outputDirectoryHierarchy) {
+		this(initialTT, observedTT, network, ttCalcConfig, dvrpConfig.getTravelTimeEstimationAlpha(),
+				dvrpConfig.getInitialTravelTimesUrl(config.getContext()), outputDirectoryHierarchy);
 	}
 
 	public DvrpOfflineTravelTimeEstimator(TravelTime initialTT, TravelTime observedTT, Network network,
-			TravelTimeCalculatorConfigGroup ttCalcConfig, double travelTimeEstimationAlpha) {
+			TravelTimeCalculatorConfigGroup ttCalcConfig, double travelTimeEstimationAlpha, URL initialTravelTimesUrl,
+			OutputDirectoryHierarchy outputDirectoryHierarchy) {
 		this.observedTT = observedTT;
 		this.network = network;
+		this.outputDirectoryHierarchy = outputDirectoryHierarchy;
 
 		alpha = travelTimeEstimationAlpha;
 		checkArgument(alpha > 0 && alpha <= 1, "travelTimeEstimationAlpha must be in (0,1]");
@@ -77,11 +89,17 @@ public class DvrpOfflineTravelTimeEstimator implements DvrpTravelTimeEstimator, 
 		intervalCount = TimeBinUtils.getTimeBinCount(ttCalcConfig.getMaxTime(), interval);
 		checkArgument(intervalCount > 0, "number of intervals must be positive");
 
-		linkTTs = new double[Id.getNumberOfIds(Link.class)][];
-		//allocate arrays only for the links in the network
-		network.getLinks().values().forEach(link -> linkTTs[link.getId().index()] = new double[intervalCount]);
-
-		updateTTs(initialTT, 1.);
+		if (initialTravelTimesUrl != null) {
+			linkTTs = DvrpOfflineTravelTimes.loadLinkTravelTimes(interval, intervalCount, initialTravelTimesUrl);
+			//make sure all TTs are loaded
+			network.getLinks().values().forEach(link -> Preconditions.checkNotNull(linkTTs[link.getId().index()]));
+		} else {
+			linkTTs = new double[Id.getNumberOfIds(Link.class)][];
+			//allocate arrays only for the links in the network
+			network.getLinks().values().forEach(link -> linkTTs[link.getId().index()] = new double[intervalCount]);
+			//init linkTTs
+			updateTTs(initialTT, 1.);
+		}
 	}
 
 	@Override
@@ -100,6 +118,12 @@ public class DvrpOfflineTravelTimeEstimator implements DvrpTravelTimeEstimator, 
 	@Override
 	public void notifyMobsimBeforeCleanup(@SuppressWarnings("rawtypes") MobsimBeforeCleanupEvent e) {
 		updateTTs(observedTT, alpha);
+	}
+
+	@Override
+	public void notifyAfterMobsim(AfterMobsimEvent event) {
+		DvrpOfflineTravelTimes.saveLinkTravelTimes(interval, intervalCount, linkTTs,
+				outputDirectoryHierarchy.getIterationFilename(event.getIteration(), "dvrp_travel_times.csv.gz"));
 	}
 
 	private void updateTTs(TravelTime travelTime, double alpha) {

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOfflineTravelTimes.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOfflineTravelTimes.java
@@ -1,0 +1,115 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2021 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.dvrp.trafficmonitoring;
+
+import static com.google.common.base.Verify.verify;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Writer;
+import java.net.URL;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.core.utils.io.IOUtils;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+class DvrpOfflineTravelTimes {
+	private static final String DELIMITER = ";";
+
+	static void saveLinkTravelTimes(int interval, int intervalCount, double[][] linkTTs, String filename) {
+		try (Writer writer = IOUtils.getBufferedWriter(filename)) {
+			saveLinkTravelTimes(interval, intervalCount, linkTTs, writer);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	static void saveLinkTravelTimes(int interval, int intervalCount, double[][] linkTTs, Writer writer)
+			throws IOException {
+		Preconditions.checkArgument(interval > 0);
+		Preconditions.checkArgument(intervalCount > 0);
+
+		//header row
+		writer.append("linkId" + DELIMITER);
+		for (int i = 0; i < intervalCount; i++) {
+			int time = i * interval;
+			writer.append(time + DELIMITER);
+		}
+		writer.append('\n');
+
+		//regular rows
+		for (int idx = 0; idx < linkTTs.length; idx++) {
+			double[] ttRow = linkTTs[idx];
+
+			// rows in linkTTs that are null are skipped
+			if (ttRow != null) {
+				Preconditions.checkArgument(ttRow.length == intervalCount);
+
+				writer.append(Id.get(idx, Link.class) + DELIMITER);
+				for (int t = 0; t < intervalCount; t++) {
+					writer.append(ttRow[t] + DELIMITER);// some precision lost while writing TTs
+				}
+				writer.append('\n');
+			}
+		}
+	}
+
+	static double[][] loadLinkTravelTimes(int interval, int intervalCount, URL url) {
+		try (BufferedReader reader = IOUtils.getBufferedReader(url)) {
+			return loadLinkTravelTimes(interval, intervalCount, reader);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	static double[][] loadLinkTravelTimes(int interval, int intervalCount, BufferedReader reader) throws IOException {
+		Preconditions.checkArgument(interval > 0);
+		Preconditions.checkArgument(intervalCount > 0);
+
+		double[][] linkTTs = new double[Id.getNumberOfIds(Link.class)][];
+		//header row
+		String[] headerLine = reader.readLine().split(";");
+		verify(intervalCount == headerLine.length - 1);
+		verify(headerLine[0].equals("linkId"));
+		for (int i = 0; i < intervalCount; i++) {
+			verify(Integer.parseInt(headerLine[i + 1]) == i * interval);
+		}
+
+		//regular rows
+		// rows in linkTTs for which we do not have TT data, will remain null
+		reader.lines().map(line -> line.split(DELIMITER)).forEach(cells -> {
+			int linkIndex = Id.createLinkId(cells[0]).index();
+			double[] row = linkTTs[linkIndex] = new double[intervalCount];
+			verify(row.length == cells.length - 1);
+
+			for (int i = 0; i < row.length; i++) {
+				row[i] = Double.parseDouble(cells[i + 1]);
+			}
+		});
+
+		return linkTTs;
+	}
+}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpTravelTimeModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpTravelTimeModule.java
@@ -47,6 +47,7 @@ public class DvrpTravelTimeModule extends AbstractModule {
 
 		bind(DvrpOfflineTravelTimeEstimator.class).asEagerSingleton();
 		addMobsimListenerBinding().to(DvrpOfflineTravelTimeEstimator.class);
+		addControlerListenerBinding().to(DvrpOfflineTravelTimeEstimator.class);
 
 		if (dvrpCfg.getTravelTimeEstimationBeta() > 0) {// online estimation
 			bind(DvrpOnlineTravelTimeEstimator.class).asEagerSingleton();

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOfflineTravelTimeEstimatorTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOfflineTravelTimeEstimatorTest.java
@@ -1,0 +1,143 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2021 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.dvrp.trafficmonitoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.core.config.groups.TravelTimeCalculatorConfigGroup;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.router.util.TravelTime;
+import org.matsim.testcases.fakes.FakeLink;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class DvrpOfflineTravelTimeEstimatorTest {
+	private final Network network = NetworkUtils.createNetwork();
+	private final Node nodeA = NetworkUtils.createAndAddNode(network, Id.createNodeId("A"), new Coord());
+	private final Node nodeB = NetworkUtils.createAndAddNode(network, Id.createNodeId("B"), new Coord());
+	private final Link linkAB = NetworkUtils.createAndAddLink(network, Id.createLinkId("A_B"), nodeA, nodeB, 100, 10,
+			10, 1);
+
+	private final TravelTime initialTT = (link, time, person, vehicle) -> {
+		Preconditions.checkArgument(link == linkAB);
+		if (time < 100) {
+			return 1; // bin 0
+		} else if (time < 200) {
+			return 2; // bin 1
+		} else {
+			return 3; // bin 2
+		}
+	};
+
+	private final TravelTimeCalculatorConfigGroup ttCalcConfig = new TravelTimeCalculatorConfigGroup();
+
+	public DvrpOfflineTravelTimeEstimatorTest() {
+		//bins: [-inf, 100), [100, 200), [200, +inf)
+		ttCalcConfig.setMaxTime(200);
+		ttCalcConfig.setTraveltimeBinSize(100);
+	}
+
+	@Test
+	public void getLinkTravelTime_timeAreCorrectlyBinned() {
+		var estimator = new DvrpOfflineTravelTimeEstimator(initialTT, null, network, ttCalcConfig, 0.25);
+
+		//bin 0
+		assertThat(linkTravelTime(estimator, linkAB, -1)).isEqualTo(1);
+		assertThat(linkTravelTime(estimator, linkAB, 0)).isEqualTo(1);
+		assertThat(linkTravelTime(estimator, linkAB, 99)).isEqualTo(1);
+
+		//bin 1
+		assertThat(linkTravelTime(estimator, linkAB, 100)).isEqualTo(2);
+		assertThat(linkTravelTime(estimator, linkAB, 199)).isEqualTo(2);
+
+		//bin 2
+		assertThat(linkTravelTime(estimator, linkAB, 200)).isEqualTo(3);
+		assertThat(linkTravelTime(estimator, linkAB, 99999)).isEqualTo(3);
+	}
+
+	@Test
+	public void getLinkTravelTime_exponentialAveragingOverIterations() {
+		double alpha = 0.25;
+
+		//observed TTs for each time bin
+		int observedTT_0 = 10;
+		int observedTT_1 = 20;
+		int observedTT_2 = 30;
+
+		TravelTime observedTT = (link, time, person, vehicle) -> {
+			Preconditions.checkArgument(link == linkAB);
+			if (time < 100) {
+				return observedTT_0;
+			} else if (time < 200) {
+				return observedTT_1;
+			} else {
+				return observedTT_2;
+			}
+		};
+
+		var estimator = new DvrpOfflineTravelTimeEstimator(initialTT, observedTT, network, ttCalcConfig, alpha);
+
+		//expected TTs for each time bin
+		double expectedTT_0 = 1;
+		double expectedTT_1 = 2;
+		double expectedTT_2 = 3;
+
+		//run iterations 0..10
+		for (int i = 0; i < 10; i++) {
+			//assert TTs during simulation
+			assertThat(linkTravelTime(estimator, linkAB, 0)).isEqualTo(expectedTT_0);
+			assertThat(linkTravelTime(estimator, linkAB, 100)).isEqualTo(expectedTT_1);
+			assertThat(linkTravelTime(estimator, linkAB, 200)).isEqualTo(expectedTT_2);
+
+			//update TTs using observed TTs
+			estimator.notifyMobsimBeforeCleanup(null);
+
+			//update expected TTs (for next iteration)
+			expectedTT_0 = (1 - alpha) * expectedTT_0 + alpha * observedTT_0;
+			expectedTT_1 = (1 - alpha) * expectedTT_1 + alpha * observedTT_1;
+			expectedTT_2 = (1 - alpha) * expectedTT_2 + alpha * observedTT_2;
+		}
+	}
+
+	@Test
+	public void getLinkTravelTime_linkOutsideNetwork_fail() {
+		var linkOutsideNetwork = new FakeLink(Id.createLinkId("some-link"));
+		var estimator = new DvrpOfflineTravelTimeEstimator(initialTT, null, network, ttCalcConfig, 0.25);
+
+		assertThatThrownBy(() -> linkTravelTime(estimator, linkOutsideNetwork, 0)).isExactlyInstanceOf(
+				NullPointerException.class)
+				.hasMessage("Link (%s) does not belong to network. No travel time data.", linkOutsideNetwork.getId());
+	}
+
+	private double linkTravelTime(DvrpTravelTimeEstimator estimator, Link link, double startTime) {
+		return estimator.getLinkTravelTime(link, startTime, null, null);
+	}
+}

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOfflineTravelTimeEstimatorTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOfflineTravelTimeEstimatorTest.java
@@ -67,7 +67,7 @@ public class DvrpOfflineTravelTimeEstimatorTest {
 
 	@Test
 	public void getLinkTravelTime_timeAreCorrectlyBinned() {
-		var estimator = new DvrpOfflineTravelTimeEstimator(initialTT, null, network, ttCalcConfig, 0.25);
+		var estimator = new DvrpOfflineTravelTimeEstimator(initialTT, null, network, ttCalcConfig, 0.25, null, null);
 
 		//bin 0
 		assertThat(linkTravelTime(estimator, linkAB, -1)).isEqualTo(1);
@@ -103,7 +103,8 @@ public class DvrpOfflineTravelTimeEstimatorTest {
 			}
 		};
 
-		var estimator = new DvrpOfflineTravelTimeEstimator(initialTT, observedTT, network, ttCalcConfig, alpha);
+		var estimator = new DvrpOfflineTravelTimeEstimator(initialTT, observedTT, network, ttCalcConfig, alpha, null,
+				null);
 
 		//expected TTs for each time bin
 		double expectedTT_0 = 1;
@@ -130,7 +131,7 @@ public class DvrpOfflineTravelTimeEstimatorTest {
 	@Test
 	public void getLinkTravelTime_linkOutsideNetwork_fail() {
 		var linkOutsideNetwork = new FakeLink(Id.createLinkId("some-link"));
-		var estimator = new DvrpOfflineTravelTimeEstimator(initialTT, null, network, ttCalcConfig, 0.25);
+		var estimator = new DvrpOfflineTravelTimeEstimator(initialTT, null, network, ttCalcConfig, 0.25, null, null);
 
 		assertThatThrownBy(() -> linkTravelTime(estimator, linkOutsideNetwork, 0)).isExactlyInstanceOf(
 				NullPointerException.class)

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOfflineTravelTimesTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOfflineTravelTimesTest.java
@@ -1,0 +1,80 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2021 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.dvrp.trafficmonitoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.Objects;
+
+import org.junit.Test;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+
+import one.util.streamex.EntryStream;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class DvrpOfflineTravelTimesTest {
+	private final Id<Link> linkIdA = Id.createLinkId("A");
+	private final Id<Link> linkIdB = Id.createLinkId("B");
+
+	@Test
+	public void saveLinkTravelTimes() throws IOException {
+		//the matrix may have more than 2 rows (depends on how many link ids are cached)
+		var linkTTs = new double[Id.getNumberOfIds(Link.class)][];
+
+		linkTTs[linkIdA.index()] = new double[] { 0.0, 1.1, 2.2, 3.3 };
+		linkTTs[linkIdB.index()] = new double[] { 5.5, 6.6, 7.7, 8.8 };
+
+		var stringWriter = new StringWriter();
+		DvrpOfflineTravelTimes.saveLinkTravelTimes(900, 4, linkTTs, stringWriter);
+
+		var lines = stringWriter.toString().split("\n");
+		assertThat(lines).hasSize(3);
+		assertThat(lines[0].split(";")).containsExactly("linkId", "0", "900", "1800", "2700");
+		assertThat(lines[1].split(";")).containsExactly("A", 0.0 + "", 1.1 + "", 2.2 + "", 3.3 + "");
+		assertThat(lines[2].split(";")).containsExactly("B", 5.5 + "", 6.6 + "", 7.7 + "", 8.8 + "");
+	}
+
+	@Test
+	public void loadLinkTravelTimes() throws IOException {
+		var line0 = String.join(";", "linkId", "0", "900", "1800", "2700");
+		var line1 = String.join(";", "A", 0.0 + "", 1.1 + "", 2.2 + "", 3.3 + "");
+		var line2 = String.join(";", "B", 5.5 + "", 6.6 + "", 7.7 + "", 8.8 + "");
+		var lines = String.join("\n", line0, line1, line2);
+
+		var stringReader = new BufferedReader(new StringReader(lines));
+		var linkTTs = DvrpOfflineTravelTimes.loadLinkTravelTimes(900, 4, stringReader);
+
+		//the matrix may have more than 2 rows (depends on how many link ids are cached)
+		//all rows are null (except for links A and B)
+		var existingLinkTTs = EntryStream.of(linkTTs).filterValues(Objects::nonNull).toMap();
+
+		assertThat(existingLinkTTs).containsOnlyKeys(linkIdA.index(), linkIdB.index());
+		assertThat(existingLinkTTs.get(linkIdA.index())).containsExactly(0.0, 1.1, 2.2, 3.3);
+		assertThat(existingLinkTTs.get(linkIdB.index())).containsExactly(5.5, 6.6, 7.7, 8.8);
+	}
+}

--- a/matsim/src/main/java/org/matsim/core/trafficmonitoring/TimeBinUtils.java
+++ b/matsim/src/main/java/org/matsim/core/trafficmonitoring/TimeBinUtils.java
@@ -19,16 +19,12 @@
 
 package org.matsim.core.trafficmonitoring;
 
-public class TimeBinUtils
-{
-    public static int getTimeBinIndex(double time, int travelTimeBinSize, int travelTimeBinCount)
-    {
-        return Math.min((int)time / travelTimeBinSize, travelTimeBinCount - 1);
-    }
+public class TimeBinUtils {
+	public static int getTimeBinIndex(double time, int travelTimeBinSize, int travelTimeBinCount) {
+		return Math.min((int)time / travelTimeBinSize, travelTimeBinCount - 1);
+	}
 
-
-    public static int getTimeBinCount(int maxTime, int travelTimeBinSize)
-    {
-        return maxTime / travelTimeBinSize + 1;
-    }
+	public static int getTimeBinCount(int maxTime, int travelTimeBinSize) {
+		return maxTime / travelTimeBinSize + 1;
+	}
 }


### PR DESCRIPTION
After each iteration, `DVRP_ROUTING` travel times are saved (after being updated). Since we are using exponential moving averaging, we can use the travel times stored at the end of iteration `n` to warm restart simulation from iteration `n+1` (e.g. that the simulation had been unexpectedly terminated).

Files with travel times are named according to this pattern: `ITERS\it.${iter_number}\${iter_number}.dvrp_travel_times.csv.gz`.

To use previously stored travel times, you need to specify `initialTravelTimesFile` inside `DvrpConfigGroup`.