### PR TITLE
DVRP: provide initial dvrp travel times via binding

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpTravelTimeModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpTravelTimeModule.java
@@ -19,7 +19,10 @@
 
 package org.matsim.contrib.dvrp.trafficmonitoring;
 
+import java.net.URL;
+
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.contrib.dvrp.util.TimeDiscretizer;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.withinday.trafficmonitoring.WithinDayTravelTime;
@@ -40,7 +43,16 @@ public class DvrpTravelTimeModule extends AbstractModule {
 	private DvrpConfigGroup dvrpCfg;
 
 	public void install() {
-		addTravelTimeBinding(DvrpTravelTimeModule.DVRP_INITIAL).to(QSimFreeSpeedTravelTime.class).asEagerSingleton();
+		URL initialTravelTimesUrl = dvrpCfg.getInitialTravelTimesUrl(getConfig().getContext());
+		if (initialTravelTimesUrl != null) {
+			addTravelTimeBinding(DvrpTravelTimeModule.DVRP_INITIAL).toProvider(
+					() -> DvrpOfflineTravelTimes.loadTabularTravelTime(
+							new TimeDiscretizer(getConfig().travelTimeCalculator()), initialTravelTimesUrl))
+					.asEagerSingleton();
+		} else {
+			addTravelTimeBinding(DvrpTravelTimeModule.DVRP_INITIAL).to(QSimFreeSpeedTravelTime.class)
+					.asEagerSingleton();
+		}
 		addTravelTimeBinding(DvrpTravelTimeModule.DVRP_OBSERVED).to(
 				Key.get(TravelTime.class, Names.named(dvrpCfg.getMobsimMode())));
 		addTravelTimeBinding(DVRP_ESTIMATED).to(DvrpTravelTimeEstimator.class);

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/util/TimeDiscretizer.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/util/TimeDiscretizer.java
@@ -19,9 +19,9 @@
 
 package org.matsim.contrib.dvrp.util;
 
-import org.matsim.core.config.groups.TravelTimeCalculatorConfigGroup;
+import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.base.Preconditions;
+import org.matsim.core.config.groups.TravelTimeCalculatorConfigGroup;
 
 public class TimeDiscretizer {
 	public enum Type {
@@ -51,11 +51,16 @@ public class TimeDiscretizer {
 	private final Type type;
 
 	public TimeDiscretizer(TravelTimeCalculatorConfigGroup ttcConfig) {
-		this(ttcConfig.getMaxTime(), ttcConfig.getTraveltimeBinSize(), Type.OPEN_ENDED);
+		this(ttcConfig.getMaxTime(), ttcConfig.getTraveltimeBinSize());
+	}
+
+	public TimeDiscretizer(int maxTime, int timeInterval) {
+		this(maxTime, timeInterval, Type.OPEN_ENDED);
 	}
 
 	public TimeDiscretizer(int maxTime, int timeInterval, Type type) {
-		Preconditions.checkArgument(maxTime % timeInterval == 0);
+		checkArgument(timeInterval > 0, "interval size must be positive");
+		checkArgument(maxTime >= 0, "maxTime must not be negative");
 		this.timeInterval = timeInterval;
 		this.type = type;
 		// option: additional open-end bin
@@ -63,7 +68,7 @@ public class TimeDiscretizer {
 	}
 
 	public int getIdx(double time) {
-		Preconditions.checkArgument(time >= 0);
+		checkArgument(time >= 0);
 		int idx = (int)time / timeInterval;// rounding down
 		if (idx < intervalCount) {
 			return idx;

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOfflineTravelTimeEstimatorTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOfflineTravelTimeEstimatorTest.java
@@ -29,7 +29,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
-import org.matsim.core.config.groups.TravelTimeCalculatorConfigGroup;
+import org.matsim.contrib.dvrp.util.TimeDiscretizer;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.testcases.fakes.FakeLink;
@@ -57,17 +57,12 @@ public class DvrpOfflineTravelTimeEstimatorTest {
 		}
 	};
 
-	private final TravelTimeCalculatorConfigGroup ttCalcConfig = new TravelTimeCalculatorConfigGroup();
-
-	public DvrpOfflineTravelTimeEstimatorTest() {
-		//bins: [-inf, 100), [100, 200), [200, +inf)
-		ttCalcConfig.setMaxTime(200);
-		ttCalcConfig.setTraveltimeBinSize(100);
-	}
+	//bins: [-inf, 100), [100, 200), [200, +inf)
+	private final TimeDiscretizer timeDiscretizer = new TimeDiscretizer(200, 100);
 
 	@Test
 	public void getLinkTravelTime_timeAreCorrectlyBinned() {
-		var estimator = new DvrpOfflineTravelTimeEstimator(initialTT, null, network, ttCalcConfig, 0.25, null, null);
+		var estimator = new DvrpOfflineTravelTimeEstimator(initialTT, null, network, timeDiscretizer, 0.25, null);
 
 		//bin 0
 		assertThat(linkTravelTime(estimator, linkAB, -1)).isEqualTo(1);
@@ -103,7 +98,7 @@ public class DvrpOfflineTravelTimeEstimatorTest {
 			}
 		};
 
-		var estimator = new DvrpOfflineTravelTimeEstimator(initialTT, observedTT, network, ttCalcConfig, alpha, null,
+		var estimator = new DvrpOfflineTravelTimeEstimator(initialTT, observedTT, network, timeDiscretizer, alpha,
 				null);
 
 		//expected TTs for each time bin
@@ -131,7 +126,7 @@ public class DvrpOfflineTravelTimeEstimatorTest {
 	@Test
 	public void getLinkTravelTime_linkOutsideNetwork_fail() {
 		var linkOutsideNetwork = new FakeLink(Id.createLinkId("some-link"));
-		var estimator = new DvrpOfflineTravelTimeEstimator(initialTT, null, network, ttCalcConfig, 0.25, null, null);
+		var estimator = new DvrpOfflineTravelTimeEstimator(initialTT, null, network, timeDiscretizer, 0.25, null);
 
 		assertThatThrownBy(() -> linkTravelTime(estimator, linkOutsideNetwork, 0)).isExactlyInstanceOf(
 				NullPointerException.class)

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOfflineTravelTimesTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOfflineTravelTimesTest.java
@@ -31,6 +31,7 @@ import java.util.Objects;
 import org.junit.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
+import org.matsim.contrib.dvrp.util.TimeDiscretizer;
 
 import one.util.streamex.EntryStream;
 
@@ -46,35 +47,35 @@ public class DvrpOfflineTravelTimesTest {
 		//the matrix may have more than 2 rows (depends on how many link ids are cached)
 		var linkTTs = new double[Id.getNumberOfIds(Link.class)][];
 
-		linkTTs[linkIdA.index()] = new double[] { 0.0, 1.1, 2.2, 3.3 };
-		linkTTs[linkIdB.index()] = new double[] { 5.5, 6.6, 7.7, 8.8 };
+		linkTTs[linkIdA.index()] = new double[] { 0.0, 1.1, 2.2, 3.3, 4.4 };
+		linkTTs[linkIdB.index()] = new double[] { 5.5, 6.6, 7.7, 8.8, 9.9 };
 
 		var stringWriter = new StringWriter();
-		DvrpOfflineTravelTimes.saveLinkTravelTimes(900, 4, linkTTs, stringWriter);
+		DvrpOfflineTravelTimes.saveLinkTravelTimes(new TimeDiscretizer(3600, 900), linkTTs, stringWriter);
 
 		var lines = stringWriter.toString().split("\n");
 		assertThat(lines).hasSize(3);
-		assertThat(lines[0].split(";")).containsExactly("linkId", "0", "900", "1800", "2700");
-		assertThat(lines[1].split(";")).containsExactly("A", 0.0 + "", 1.1 + "", 2.2 + "", 3.3 + "");
-		assertThat(lines[2].split(";")).containsExactly("B", 5.5 + "", 6.6 + "", 7.7 + "", 8.8 + "");
+		assertThat(lines[0].split(";")).containsExactly("linkId", "0", "900", "1800", "2700", "3600");
+		assertThat(lines[1].split(";")).containsExactly("A", 0.0 + "", 1.1 + "", 2.2 + "", 3.3 + "", 4.4 + "");
+		assertThat(lines[2].split(";")).containsExactly("B", 5.5 + "", 6.6 + "", 7.7 + "", 8.8 + "", 9.9 + "");
 	}
 
 	@Test
 	public void loadLinkTravelTimes() throws IOException {
-		var line0 = String.join(";", "linkId", "0", "900", "1800", "2700");
-		var line1 = String.join(";", "A", 0.0 + "", 1.1 + "", 2.2 + "", 3.3 + "");
-		var line2 = String.join(";", "B", 5.5 + "", 6.6 + "", 7.7 + "", 8.8 + "");
+		var line0 = String.join(";", "linkId", "0", "900", "1800", "2700", "3600");
+		var line1 = String.join(";", "A", 0.0 + "", 1.1 + "", 2.2 + "", 3.3 + "", 4.4 + "");
+		var line2 = String.join(";", "B", 5.5 + "", 6.6 + "", 7.7 + "", 8.8 + "", 9.9 + "");
 		var lines = String.join("\n", line0, line1, line2);
 
 		var stringReader = new BufferedReader(new StringReader(lines));
-		var linkTTs = DvrpOfflineTravelTimes.loadLinkTravelTimes(900, 4, stringReader);
+		var linkTTs = DvrpOfflineTravelTimes.loadLinkTravelTimes(new TimeDiscretizer(3600, 900), stringReader);
 
 		//the matrix may have more than 2 rows (depends on how many link ids are cached)
 		//all rows are null (except for links A and B)
 		var existingLinkTTs = EntryStream.of(linkTTs).filterValues(Objects::nonNull).toMap();
 
 		assertThat(existingLinkTTs).containsOnlyKeys(linkIdA.index(), linkIdB.index());
-		assertThat(existingLinkTTs.get(linkIdA.index())).containsExactly(0.0, 1.1, 2.2, 3.3);
-		assertThat(existingLinkTTs.get(linkIdB.index())).containsExactly(5.5, 6.6, 7.7, 8.8);
+		assertThat(existingLinkTTs.get(linkIdA.index())).containsExactly(0.0, 1.1, 2.2, 3.3, 4.4);
+		assertThat(existingLinkTTs.get(linkIdB.index())).containsExactly(5.5, 6.6, 7.7, 8.8, 9.9);
 	}
 }


### PR DESCRIPTION
Use the existing `@Named(DvrpTravelTimeModule.DVRP_INITIAL) TravelTime` binding to provide the DVRP travel times loaded from a file. It's way more flexible.