### PR TITLE
New very fast network router: SpeedyALT

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/MultiInsertionDetourPathCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/MultiInsertionDetourPathCalculator.java
@@ -43,12 +43,11 @@ import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.core.mobsim.framework.events.MobsimBeforeCleanupEvent;
 import org.matsim.core.mobsim.framework.listeners.MobsimBeforeCleanupListener;
+import org.matsim.core.router.speedy.SpeedyGraph;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
 
 import com.google.common.annotations.VisibleForTesting;
-
-import ch.sbb.matsim.routing.graph.Graph;
 
 /**
  * @author michalm
@@ -66,7 +65,7 @@ public class MultiInsertionDetourPathCalculator implements DetourPathCalculator,
 	public MultiInsertionDetourPathCalculator(Network network,
 			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, TravelDisutility travelDisutility,
 			DrtConfigGroup drtCfg) {
-		Graph graph = new Graph(network);
+		SpeedyGraph graph = new SpeedyGraph(network);
 		IdMap<Node, Node> nodeMap = new IdMap<>(Node.class);
 		nodeMap.putAll(network.getNodes());
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/OneToManyPathCalculator.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/OneToManyPathCalculator.java
@@ -20,7 +20,6 @@
 
 package org.matsim.contrib.dvrp.path;
 
-import static ch.sbb.matsim.routing.graph.LeastCostPathTree.StopCriterion;
 import static org.matsim.contrib.dvrp.path.VrpPaths.FIRST_LINK_TT;
 import static org.matsim.core.router.util.LeastCostPathCalculator.Path;
 
@@ -39,11 +38,11 @@ import org.matsim.api.core.v01.IdMap;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
+import org.matsim.core.router.speedy.LeastCostPathTree;
+import org.matsim.core.router.speedy.LeastCostPathTree.StopCriterion;
 import org.matsim.core.utils.misc.OptionalTime;
 
 import com.google.common.base.Preconditions;
-
-import ch.sbb.matsim.routing.graph.LeastCostPathTree;
 
 /**
  * @author Michal Maciejewski (michalm)

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/OneToManyPathSearch.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/OneToManyPathSearch.java
@@ -35,11 +35,11 @@ import org.matsim.core.router.util.TravelTime;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 
-import ch.sbb.matsim.routing.graph.Graph;
-import ch.sbb.matsim.routing.graph.LeastCostPathTree;
+import org.matsim.core.router.speedy.SpeedyGraph;
+import org.matsim.core.router.speedy.LeastCostPathTree;
 
 public class OneToManyPathSearch {
-	public static OneToManyPathSearch createSearch(Graph graph, IdMap<Node, Node> nodeMap, TravelTime travelTime,
+	public static OneToManyPathSearch createSearch(SpeedyGraph graph, IdMap<Node, Node> nodeMap, TravelTime travelTime,
 			TravelDisutility travelDisutility, boolean lazyPathCreation) {
 		return new OneToManyPathSearch(nodeMap, new LeastCostPathTree(graph, travelTime, travelDisutility),
 				lazyPathCreation);

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/TravelTimeMatrices.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/TravelTimeMatrices.java
@@ -18,8 +18,8 @@ import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.utils.misc.Counter;
 import org.matsim.core.utils.misc.OptionalTime;
 
-import ch.sbb.matsim.routing.graph.Graph;
-import ch.sbb.matsim.routing.graph.LeastCostPathTree;
+import org.matsim.core.router.speedy.SpeedyGraph;
+import org.matsim.core.router.speedy.LeastCostPathTree;
 
 /**
  * Based on NetworkSkimMatrices from sbb-matsim-extensions
@@ -30,7 +30,7 @@ public final class TravelTimeMatrices {
 
 	public static Matrix calculateTravelTimeMatrix(Network routingNetwork, Map<Zone, Node> centralNodes,
 			double departureTime, TravelTime travelTime, TravelDisutility travelDisutility, int numberOfThreads) {
-		Graph graph = new Graph(routingNetwork);
+		SpeedyGraph graph = new SpeedyGraph(routingNetwork);
 		ExecutorServiceWithResource<LeastCostPathTree> executorService = new ExecutorServiceWithResource<>(
 				IntStream.range(0, numberOfThreads)
 						.mapToObj(i -> new LeastCostPathTree(graph, travelTime, travelDisutility))

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/path/OneToManyPathCalculatorTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/path/OneToManyPathCalculatorTest.java
@@ -42,8 +42,8 @@ import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
 
 import com.google.common.collect.ImmutableList;
 
-import ch.sbb.matsim.routing.graph.Graph;
-import ch.sbb.matsim.routing.graph.LeastCostPathTree;
+import org.matsim.core.router.speedy.SpeedyGraph;
+import org.matsim.core.router.speedy.LeastCostPathTree;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -64,7 +64,7 @@ public class OneToManyPathCalculatorTest {
 
 	private final IdMap<Node, Node> nodeMap = new IdMap<>(Node.class);
 
-	private final LeastCostPathTree dijkstraTree = new LeastCostPathTree(new Graph(network), new FreeSpeedTravelTime(),
+	private final LeastCostPathTree dijkstraTree = new LeastCostPathTree(new SpeedyGraph(network), new FreeSpeedTravelTime(),
 			new TimeAsTravelDisutility(new FreeSpeedTravelTime()));
 
 	@Before

--- a/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/analysis/skims/NetworkSkimMatrices.java
+++ b/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/analysis/skims/NetworkSkimMatrices.java
@@ -4,8 +4,8 @@
 
 package ch.sbb.matsim.analysis.skims;
 
-import ch.sbb.matsim.routing.graph.Graph;
-import ch.sbb.matsim.routing.graph.LeastCostPathTree;
+import org.matsim.core.router.speedy.SpeedyGraph;
+import org.matsim.core.router.speedy.LeastCostPathTree;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -43,7 +43,7 @@ public final class NetworkSkimMatrices {
 
     public static <T> NetworkIndicators<T> calculateSkimMatrices(Network xy2lNetwork, Network routingNetwork, Map<T, Coord[]> coordsPerZone, double departureTime, TravelTime travelTime,
             TravelDisutility travelDisutility, int numberOfThreads) {
-        Graph routingGraph = new Graph(routingNetwork);
+        SpeedyGraph routingGraph = new SpeedyGraph(routingNetwork);
         Map<T, Node[]> nodesPerZone = new HashMap<>();
         for (Map.Entry<T, Coord[]> e : coordsPerZone.entrySet()) {
             T zoneId = e.getKey();
@@ -95,7 +95,7 @@ public final class NetworkSkimMatrices {
         private final static Person PERSON = PopulationUtils.getFactory().createPerson(Id.create("thePerson", Person.class));
         private final ConcurrentLinkedQueue<T> originZones;
         private final Set<T> destinationZones;
-        private final Graph graph;
+        private final SpeedyGraph graph;
         private final Map<T, Node[]> nodesPerZone;
         private final NetworkIndicators<T> networkIndicators;
         private final TravelTime travelTime;
@@ -103,8 +103,8 @@ public final class NetworkSkimMatrices {
         private final double departureTime;
         private final Counter counter;
 
-        RowWorker(ConcurrentLinkedQueue<T> originZones, Set<T> destinationZones, Graph graph, Map<T, Node[]> nodesPerZone, NetworkIndicators<T> networkIndicators, double departureTime,
-                TravelTime travelTime, TravelDisutility travelDisutility, Counter counter) {
+        RowWorker(ConcurrentLinkedQueue<T> originZones, Set<T> destinationZones, SpeedyGraph graph, Map<T, Node[]> nodesPerZone, NetworkIndicators<T> networkIndicators, double departureTime,
+                  TravelTime travelTime, TravelDisutility travelDisutility, Counter counter) {
             this.originZones = originZones;
             this.destinationZones = destinationZones;
             this.graph = graph;

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/assignment/VehicleAssignmentProblem.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/assignment/VehicleAssignmentProblem.java
@@ -40,7 +40,7 @@ import org.matsim.core.router.util.TravelTime;
 
 import com.google.common.collect.Lists;
 
-import ch.sbb.matsim.routing.graph.Graph;
+import org.matsim.core.router.speedy.SpeedyGraph;
 
 /**
  * @author michalm
@@ -74,7 +74,7 @@ public class VehicleAssignmentProblem<D> {
 
 		IdMap<Node, Node> nodeMap = new IdMap<>(Node.class);
 		nodeMap.putAll(network.getNodes());
-		pathSearch = OneToManyPathSearch.createSearch(new Graph(network), nodeMap, travelTime, travelDisutility, false);
+		pathSearch = OneToManyPathSearch.createSearch(new SpeedyGraph(network), nodeMap, travelTime, travelDisutility, false);
 
 		// TODO this kNN is slow
 		destinationFinder = nearestDestinationLimit < 0 ?

--- a/matsim/src/main/java/org/matsim/core/config/groups/ControlerConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/ControlerConfigGroup.java
@@ -33,7 +33,7 @@ import java.util.*;
 public final class ControlerConfigGroup extends ReflectiveConfigGroup {
 	private static final Logger log = Logger.getLogger( ControlerConfigGroup.class );
 
-	public enum RoutingAlgorithmType {Dijkstra, AStarLandmarks, FastDijkstra, FastAStarLandmarks}
+	public enum RoutingAlgorithmType {Dijkstra, AStarLandmarks, FastDijkstra, FastAStarLandmarks, SpeedyALT}
 
 	public enum EventsFileFormat {xml, pb, json}
 
@@ -102,8 +102,7 @@ public final class ControlerConfigGroup extends ReflectiveConfigGroup {
 	@Override
 	public final Map<String, String> getComments() {
 		Map<String,String> map = super.getComments();
-		map.put(ROUTINGALGORITHM_TYPE, "The type of routing (least cost path) algorithm used, may have the values: " + RoutingAlgorithmType.Dijkstra + ", " + 
-				RoutingAlgorithmType.FastDijkstra + ", " + RoutingAlgorithmType.AStarLandmarks + " or "  + RoutingAlgorithmType.FastAStarLandmarks);
+		map.put(ROUTINGALGORITHM_TYPE, "The type of routing (least cost path) algorithm used, may have the values: " + Arrays.toString(RoutingAlgorithmType.values()));
 		map.put(RUNID, "An identifier for the current run which is used as prefix for output files and mentioned in output xml files etc.");
 		map.put(EVENTS_FILE_FORMAT, "Default="+EventsFileFormat.xml+"; Specifies the file format for writing events. Currently supported: " + Arrays.toString(EventsFileFormat.values()) + IOUtils.NATIVE_NEWLINE+ "\t\t" +
 				"Multiple values can be specified separated by commas (',').");

--- a/matsim/src/main/java/org/matsim/core/router/LeastCostPathCalculatorModule.java
+++ b/matsim/src/main/java/org/matsim/core/router/LeastCostPathCalculatorModule.java
@@ -25,6 +25,7 @@ package org.matsim.core.router;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.groups.ControlerConfigGroup;
 import org.matsim.core.controler.AbstractModule;
+import org.matsim.core.router.speedy.SpeedyALTFactory;
 import org.matsim.core.router.util.*;
 
 public class LeastCostPathCalculatorModule extends AbstractModule {
@@ -44,6 +45,8 @@ public class LeastCostPathCalculatorModule extends AbstractModule {
             bind(LeastCostPathCalculatorFactory.class).to(FastDijkstraFactory.class);
         } else if (config.controler().getRoutingAlgorithmType().equals(ControlerConfigGroup.RoutingAlgorithmType.FastAStarLandmarks)) {
             bind(LeastCostPathCalculatorFactory.class).to(FastAStarLandmarksFactory.class);
+        } else if (config.controler().getRoutingAlgorithmType().equals(ControlerConfigGroup.RoutingAlgorithmType.SpeedyALT)) {
+            bind(LeastCostPathCalculatorFactory.class).to(SpeedyALTFactory.class);
         }
     }
 

--- a/matsim/src/main/java/org/matsim/core/router/speedy/DAryMinHeap.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/DAryMinHeap.java
@@ -1,0 +1,231 @@
+package org.matsim.core.router.speedy;
+
+import java.util.NoSuchElementException;
+
+/**
+ * Implementation of a d-ary min-heap.
+ *
+ * A d-ary min-heap is a generalization of the binary min-heap,
+ * which provides better cpu cache locality and has faster decrease-key operations
+ * but slower poll operations. But in Dijkstra's algorithm, decrease-key is more common
+ * than poll, so it should still be beneficial.
+ *
+ * In most literature, the poll-operation is implemented by removing the top element and
+ * replacing it with the last entry in the heap, and then let this new root sift down again
+ * until the heap-conditions are all met. This requires multiple comparisons on each level (the
+ * value must be compared with each of its children).
+ *
+ * An alternative implementation tries to fix this in the following way: the "whole" at the root
+ * after removing the top is first sifted down by replacing it with the smaller of its children.
+ * This requires one less comparison, as only the children need to be compared against each other.
+ * Once there are no more children (the whole is at the bottom level), replace the whole with the
+ * last entry of the heap. Now, sift this entry up until the heap-conditions are all met.
+ *
+ * This implementation uses the alternative implementation for additional speedup.
+ *
+ * @author mrieser / Simunto, sponsored by SBB Swiss Federal Railways
+ */
+class DAryMinHeap {
+	private final int[] heap;
+	private final int[] pos;
+	private int size = 0;
+	private final int d;
+	private final double[] cost;
+
+	DAryMinHeap(int nodeCount, int d) {
+		this.heap = new int[nodeCount]; // worst case: every node is part of the heap
+		this.pos = new int[nodeCount]; // worst case: every node is part of the heap
+		this.cost = new double[nodeCount];
+		this.d = d;
+	}
+
+	void insert(int node, double cost) {
+		int i = this.size;
+		this.size++;
+
+		// sift up
+		int parent = parent(i);
+		while (i > 0 && cost < this.cost[parent]) {
+			this.heap[i] = this.heap[parent];
+			this.pos[this.heap[parent]] = i;
+			this.cost[i] = this.cost[parent];
+			i = parent;
+			parent = parent(parent);
+		}
+		this.heap[i] = node;
+		this.cost[i] = cost;
+		this.pos[node] = i;
+	}
+
+	void decreaseKey(int node, double cost) {
+		int i = this.pos[node];
+		if (i < 0 || this.heap[i] != node) {
+			System.err.println("oops "  + node + "   " + i + "   " + (i < 0 ? "" : this.heap[i]));
+			throw new NoSuchElementException();
+		}
+		if (this.cost[i] < cost) {
+			throw new IllegalArgumentException("existing cost is already smaller than new cost.");
+		}
+
+		// sift up
+		int parent = parent(i);
+		while (i > 0 && cost < this.cost[parent]) {
+			this.heap[i] = this.heap[parent];
+			this.cost[i] = this.cost[parent];
+			this.pos[this.heap[parent]] = i;
+			i = parent;
+			parent = parent(parent);
+		}
+		this.heap[i] = node;
+		this.cost[i] = cost;
+		this.pos[node] = i;
+	}
+
+	int poll() {
+		if (this.size == 0) {
+			throw new NoSuchElementException("heap is empty");
+		}
+		if (this.size == 1) {
+			this.size--;
+			return this.heap[0];
+		}
+
+		int root = this.heap[0];
+		this.pos[root] = -1;
+
+		fixWhole(0);
+		return root;
+	}
+
+	int peek() {
+		if (this.size == 0) {
+			throw new NoSuchElementException("heap is empty");
+		}
+		return this.heap[0];
+	}
+
+	public boolean remove(int node) {
+		int i = this.pos[node];
+		if (i < 0) {
+			return false;
+		}
+
+		this.fixWhole(i);
+		return true;
+	}
+
+	int size() {
+		return this.size;
+	}
+
+	boolean isEmpty() {
+		return this.size == 0;
+	}
+
+	void clear() {
+		this.size = 0;
+	}
+
+	private void fixWhole(int index) {
+		// move the whole down
+		while (true) {
+			int left = left(index);
+			if (left >= this.size) {
+				break;
+			}
+			int right = right(index);
+			if (right >= this.size) {
+				right = this.size - 1;
+			}
+
+			int smallest = left;
+			double smallestCost = this.cost[left];
+			for (int child = left + 1; child <= right; child++) {
+				double childCost = this.cost[child];
+				if (childCost <= smallestCost) {
+					if (childCost < smallestCost || this.heap[child] < this.heap[smallest]) {
+						smallest = child;
+						smallestCost = childCost;
+					}
+				}
+			}
+
+			this.heap[index] = this.heap[smallest];
+			this.cost[index] = smallestCost;
+			this.pos[this.heap[index]] = index;
+
+			index = smallest;
+		}
+
+		// move last entry to whole, unless the whole is already at the end
+		this.size--;
+		if (index < this.size) {
+			this.heap[index] = this.heap[this.size];
+			this.cost[index] = this.cost[this.size];
+			this.pos[this.heap[index]] = index;
+		}
+
+		// move entry up as far as needed
+		double nodeCost = this.cost[index];
+		while (index > 0) {
+			int parent = parent(index);
+			double parentCost = this.cost[parent];
+			if (nodeCost < parentCost) {
+				swap(index, parent);
+				index = parent;
+			} else {
+				break;
+			}
+		}
+	}
+
+	private int right(int i) {
+		return this.d * i + this.d;
+	}
+
+	private int left(int i) {
+		return this.d * i + 1;
+	}
+
+	private int parent(int i) {
+		return (i - 1) / this.d;
+	}
+
+	private void swap(int i, int parent) {
+		int tmp = this.heap[parent];
+		this.heap[parent] = this.heap[i];
+		this.pos[this.heap[i]] = parent;
+		this.heap[i] = tmp;
+		this.pos[tmp] = i;
+
+		double tmpC = this.cost[parent];
+		this.cost[parent] = this.cost[i];
+		this.cost[i] = tmpC;
+	}
+
+	public IntIterator iterator() {
+		return new HeapIntIterator();
+	}
+
+	public interface IntIterator {
+		boolean hasNext();
+		int next();
+	}
+
+	private class HeapIntIterator implements IntIterator {
+		private int pos = 0;
+
+		@Override
+		public boolean hasNext() {
+			return this.pos > DAryMinHeap.this.size;
+		}
+
+		@Override
+		public int next() {
+			int node = DAryMinHeap.this.heap[this.pos];
+			this.pos++;
+			return node;
+		}
+	}
+
+}

--- a/matsim/src/main/java/org/matsim/core/router/speedy/LeastCostPathTree.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/LeastCostPathTree.java
@@ -1,4 +1,4 @@
-package ch.sbb.matsim.routing.graph;
+package org.matsim.core.router.speedy;
 
 import java.util.Arrays;
 import java.util.NoSuchElementException;
@@ -10,7 +10,7 @@ import org.matsim.core.utils.misc.OptionalTime;
 import org.matsim.vehicles.Vehicle;
 
 /**
- * Implements a least-cost-path-tree upon a {@link Graph} datastructure. Besides using the more efficient Graph datastructure, it also makes use of a custom priority-queue implementation (NodeMinHeap)
+ * Implements a least-cost-path-tree upon a {@link SpeedyGraph} datastructure. Besides using the more efficient Graph datastructure, it also makes use of a custom priority-queue implementation (NodeMinHeap)
  * which operates directly on the least-cost-path-three data for additional performance gains.
  * <p>
  * In some limited tests, this resulted in a speed-up of at least a factor 2.5 compared to MATSim's default LeastCostPathTree.
@@ -20,16 +20,16 @@ import org.matsim.vehicles.Vehicle;
  */
 public class LeastCostPathTree {
 
-    private final Graph graph;
+    private final SpeedyGraph graph;
     private final TravelTime tt;
     private final TravelDisutility td;
     private final double[] data; // 3 entries per node: time, cost, distance
     private final int[] comingFrom;
-    private final Graph.LinkIterator outLI;
-    private final Graph.LinkIterator inLI;
+    private final SpeedyGraph.LinkIterator outLI;
+    private final SpeedyGraph.LinkIterator inLI;
     private final NodeMinHeap pq;
 
-    public LeastCostPathTree(Graph graph, TravelTime tt, TravelDisutility td) {
+    public LeastCostPathTree(SpeedyGraph graph, TravelTime tt, TravelDisutility td) {
         this.graph = graph;
         this.tt = tt;
         this.td = td;

--- a/matsim/src/main/java/org/matsim/core/router/speedy/NodeMinHeap.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/NodeMinHeap.java
@@ -1,0 +1,150 @@
+package org.matsim.core.router.speedy;
+
+import java.util.NoSuchElementException;
+
+/**
+ * @author mrieser / Simunto
+ */
+class NodeMinHeap {
+	private final int[] heap;
+	private final int[] pos;
+	private int size = 0;
+	private final CostGetter costGetter;
+	private final CostSetter costSetter;
+
+	public interface CostGetter {
+		double getCost(int index);
+	}
+
+	public interface CostSetter {
+		void setCost(int index, double cost);
+	}
+
+	NodeMinHeap(int nodeCount, CostGetter costGetter, CostSetter costSetter) {
+		this.heap = new int[nodeCount]; // worst case: every node is part of the heap
+		this.pos = new int[nodeCount];
+		this.costGetter = costGetter;
+		this.costSetter = costSetter;
+	}
+
+	void insert(int node) {
+		int i = this.size;
+		this.size++;
+
+		double nodeCost = this.costGetter.getCost(node);
+		// sift up
+		int parent = parent(i);
+		while (i > 0 && nodeCost < this.costGetter.getCost(this.heap[parent])) {
+			this.heap[i] = this.heap[parent];
+			this.pos[this.heap[parent]] = i;
+			i = parent;
+			parent = parent(parent);
+		}
+		this.heap[i] = node;
+		this.pos[node] = i;
+	}
+
+	void decreaseKey(int node, double cost) {
+		int i;
+		for (i = 0; i < this.size; i++) {
+			if (this.heap[i] == node) {
+				break;
+			}
+		}
+		if (this.costGetter.getCost(this.heap[i]) < cost) {
+			throw new IllegalArgumentException("existing cost is already smaller than new cost.");
+		}
+
+		this.costSetter.setCost(node, cost);
+
+		// sift up
+		int parent = parent(i);
+		while (i > 0 && cost < this.costGetter.getCost(this.heap[parent])) {
+			this.heap[i] = this.heap[parent];
+			this.pos[this.heap[parent]] = i;
+			i = parent;
+			parent = parent(parent);
+		}
+		this.heap[i] = node;
+		this.pos[node] = i;
+	}
+
+	int poll() {
+		if (this.size == 0) {
+			throw new NoSuchElementException("heap is empty");
+		}
+		if (this.size == 1) {
+			this.size--;
+			return this.heap[0];
+		}
+
+		int root = this.heap[0];
+
+		// remove the last item, set it as new root
+		int lastNode = this.heap[this.size - 1];
+		this.size--;
+		this.heap[0] = lastNode;
+		this.pos[lastNode] = 0;
+
+		// sift down
+		minHeapify(0);
+
+		return root;
+	}
+
+	int peek() {
+		if (this.size == 0) {
+			throw new NoSuchElementException("heap is empty");
+		}
+		return this.heap[0];
+	}
+
+	int size() {
+		return this.size;
+	}
+
+	boolean isEmpty() {
+		return this.size == 0;
+	}
+
+	void clear() {
+		this.size = 0;
+	}
+
+	private void minHeapify(int i) {
+		int left = left(i);
+		int right = right(i);
+		int smallest = i;
+
+		if (left <= (this.size - 1) && this.costGetter.getCost(this.heap[left]) < this.costGetter.getCost(this.heap[i])) {
+			smallest = left;
+		}
+		if (right <= (this.size - 1) && this.costGetter.getCost(this.heap[right]) < this.costGetter.getCost(this.heap[smallest])) {
+			smallest = right;
+		}
+		if (smallest != i) {
+			swap(i, smallest);
+			minHeapify(smallest);
+		}
+	}
+
+	private int right(int i) {
+		return 2 * i + 2;
+	}
+
+	private int left(int i) {
+		return 2 * i + 1;
+	}
+
+	private int parent(int i) {
+		return (i - 1) / 2;
+	}
+
+	private void swap(int i, int parent) {
+		int tmp = this.heap[parent];
+		this.heap[parent] = this.heap[i];
+		this.pos[this.heap[i]] = parent;
+		this.heap[i] = tmp;
+		this.pos[tmp] = i;
+	}
+}

--- a/matsim/src/main/java/org/matsim/core/router/speedy/SpeedyALT.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/SpeedyALT.java
@@ -1,0 +1,239 @@
+package org.matsim.core.router.speedy;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.core.router.util.LeastCostPathCalculator;
+import org.matsim.core.router.util.TravelDisutility;
+import org.matsim.core.router.util.TravelTime;
+import org.matsim.vehicles.Vehicle;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A very fast implementation of the ALT algorithm (A*-search with Landmarks and Triangle Inequality).
+ *
+ * Based on "Computing the Shortest Path: A* Search Meets Graph Theory" by Andrew V. Goldberg and Chris Harrelson, 2005.
+ *
+ * This implementation always looks at all landmarks and does not filter them, as performance measurements
+ * suggest that selecting and re-selecting landmarks regularly actually results in an overhead compared
+ * to to just calculate the values for each landmark in each step (using a typical value of 16 landmarks).
+ * This might be due to the fact that all values for each landmark are just next to each other in the memory,
+ * so when accessing the travelcosts to/from one landmark basically already loads the values of all landmarks in
+ * the CPU cache, making the calculation for the remaining landmarks very fast.
+ *
+ * This implementation is not thread-safe. In the case of multi-threading, every thread should use
+ * a separate instance. (But the used {@link SpeedyALTData} is thread-safe and can be shared by multiple
+ * instances).
+ *
+ * @author mrieser / Simunto, sponsored by SBB Swiss Federal Railways
+ */
+public class SpeedyALT implements LeastCostPathCalculator {
+
+	private final static Logger LOG = LogManager.getLogger(SpeedyALT.class);
+
+	private final SpeedyGraph graph;
+	private final SpeedyALTData astarData;
+	private final TravelTime tt;
+	private final TravelDisutility td;
+	private final double[] data; // 3 entries per node: cost to node, time, distance
+	private int currentIteration = Integer.MIN_VALUE;
+	private final int[] iterationIds;
+	private final int[] comingFrom;
+	private final int[] usedLink;
+	private final SpeedyGraph.LinkIterator outLI;
+	private final DAryMinHeap pq;
+
+	public SpeedyALT(SpeedyALTData astarData, TravelTime tt, TravelDisutility td) {
+		this.graph = astarData.graph;
+		this.astarData = astarData;
+		this.tt = tt;
+		this.td = td;
+		this.data = new double[this.graph.nodeCount * 3];
+		this.iterationIds = new int[this.graph.nodeCount];
+		this.comingFrom = new int[this.graph.nodeCount];
+		this.usedLink = new int[this.graph.nodeCount];
+		this.pq = new DAryMinHeap(this.graph.nodeCount, 6);
+		this.outLI = this.graph.getOutLinkIterator();
+		Arrays.fill(this.iterationIds, this.currentIteration);
+	}
+
+	public double getCost(int nodeIndex) {
+		return this.data[nodeIndex * 3];
+	}
+
+	private double getTimeRaw(int nodeIndex) {
+		return this.data[nodeIndex * 3 + 1];
+	}
+
+	private double getDistance(int nodeIndex) {
+		return this.data[nodeIndex * 3 + 2];
+	}
+
+	private void setData(int nodeIndex, double cost, double time, double distance) {
+		int index = nodeIndex * 3;
+		this.data[index] = cost;
+		this.data[index + 1] = time;
+		this.data[index + 2] = distance;
+		this.iterationIds[nodeIndex] = this.currentIteration;
+	}
+
+	@Override
+	public Path calcLeastCostPath(Node startNode, Node endNode, double startTime, Person person, Vehicle vehicle) {
+		this.currentIteration++;
+		if (this.currentIteration == Integer.MAX_VALUE) {
+			// reset iteration as we overflow
+			Arrays.fill(this.iterationIds, this.currentIteration);
+			this.currentIteration = Integer.MIN_VALUE;
+		}
+		int startNodeIndex = startNode.getId().index();
+		int endNodeIndex = endNode.getId().index();
+
+		int startDeadend = this.astarData.getNodeDeadend(startNodeIndex);
+		int endDeadend = this.astarData.getNodeDeadend(endNodeIndex);
+
+		double estimation = estimateMinTravelcostToDestination(startNodeIndex, endNodeIndex, endNode);
+
+		this.comingFrom[startNodeIndex] = -1;
+		setData(startNodeIndex, 0, startTime, 0);
+		this.pq.clear();
+		this.pq.insert(startNodeIndex, 0 + estimation);
+		boolean foundEndNode = false;
+
+		while (!this.pq.isEmpty()) {
+			final int nodeIdx = this.pq.poll();
+			if (nodeIdx == endNodeIndex) {
+				foundEndNode = true;
+				break;
+			}
+
+			// ignore dead-ends
+			int deadend = this.astarData.getNodeDeadend(nodeIdx);
+			if (deadend >= 0 && deadend != startDeadend && deadend != endDeadend) {
+				continue; // it's a dead-end we're not interested in
+			}
+
+			double currTime = getTimeRaw(nodeIdx);
+			double currCost = getCost(nodeIdx);
+			double currDistance = getDistance(nodeIdx);
+
+			this.outLI.reset(nodeIdx);
+			while (this.outLI.next()) {
+				int linkIdx = this.outLI.getLinkIndex();
+				Link link = this.graph.getLink(linkIdx);
+				int toNode = this.outLI.getToNodeIndex();
+
+				double travelTime = this.tt.getLinkTravelTime(link, currTime, person, vehicle);
+				double newTime = currTime + travelTime;
+				double travelCost = this.td.getLinkTravelDisutility(link, currTime, person, vehicle);
+				double newCost = currCost + travelCost;
+
+				if (this.iterationIds[toNode] == this.currentIteration) {
+					// this node was already visited in this route-query
+					double oldCost = getCost(toNode);
+					if (newCost < oldCost) {
+						estimation = estimateMinTravelcostToDestination(toNode, endNodeIndex, endNode);
+						this.pq.decreaseKey(toNode, newCost + estimation);
+						setData(toNode, newCost, newTime, currDistance + link.getLength());
+						this.comingFrom[toNode] = nodeIdx;
+						this.usedLink[toNode] = linkIdx;
+					}
+				} else {
+					estimation = estimateMinTravelcostToDestination(toNode, endNodeIndex, endNode);
+					setData(toNode, newCost, newTime, currDistance + link.getLength());
+					this.pq.insert(toNode, newCost + estimation);
+					this.comingFrom[toNode] = nodeIdx;
+					this.usedLink[toNode] = linkIdx;
+				}
+			}
+		}
+
+		if (foundEndNode) {
+			return constructPath(endNodeIndex, startTime);
+		}
+		LOG.warn("No route was found from node " + startNode.getId() + " to node " + endNode.getId() + ". Some possible reasons:");
+		LOG.warn("  * Network is not connected.  Run NetworkCleaner().") ;
+		LOG.warn("  * Network for considered mode does not even exist.  Modes need to be entered for each link in network.xml.");
+		LOG.warn("  * Network for considered mode is not connected to starting or ending point of route.  Setting insertingAccessEgressWalk to true may help.");
+		LOG.warn("This will now return null, but it may fail later with a NullPointerException.");
+		return null;
+	}
+
+	private double estimateMinTravelcostToDestination(int nodeIdx, int destinationIdx, Node destinationNode) {
+		/* The ALT algorithm uses two lower bounds for each Landmark:
+		 * given: source node S, target node T, landmark L
+		 * then, due to the triangle inequality:
+		 *  1) ST + TL >= SL --> ST >= SL - TL
+		 *  2) LS + ST >= LT --> ST >= LT - LS
+		 * The algorithm is interested in the largest possible value of (SL-TL) and (LT-LS),
+		 * as this gives the closest approximation for the minimal travel time required to
+		 * go from S to T.
+		 */
+		Node node = this.graph.getNode(nodeIdx);
+		Coord nodeCoord = node.getCoord();
+		Coord destCoord = destinationNode.getCoord();;
+		/* Normally, the distance needs to be computed using pythagoras formula, which includes a square root.
+		 * As the calculation of a square root is computationally expensive, we only look at a "Manhatten"-distance like value,
+		 * taking only the larger value of the x- or y-difference. We cannot use the actual Manhatten distance, as this could
+		 * be larger than the actual distance which would result in too high expected costs, and thus could result in non-shorted
+		 * paths to be found. */
+		double distance = Math.max(Math.abs(nodeCoord.getX() - destCoord.getX()), Math.abs(nodeCoord.getY() - destCoord.getY()));
+		double best = distance * this.astarData.getMinTravelCostPerLength();
+		for (int i = 0, n = this.astarData.getLandmarksCount(); i < n; i++) {
+			double estimate = estimateMinTravelcostToDestination(nodeIdx, destinationIdx, i);
+			if (estimate > best) {
+				best = estimate;
+			}
+		}
+		return best;
+	}
+
+	private double estimateMinTravelcostToDestination(int nodeIdx, int destinationIdx, int landmarkIdx) {
+		double sl = this.astarData.getTravelCostToLandmark(nodeIdx, landmarkIdx);
+		double ls = this.astarData.getTravelCostFromLandmark(nodeIdx, landmarkIdx);
+		double tl = this.astarData.getTravelCostToLandmark(destinationIdx, landmarkIdx);
+		double lt = this.astarData.getTravelCostFromLandmark(destinationIdx, landmarkIdx);
+		double sltl = sl - tl;
+		double ltls = lt - ls;
+		return Math.max(sltl, ltls);
+	}
+
+	private Path constructPath(int endNodeIndex, double startTime) {
+		double travelCost = getCost(endNodeIndex);
+		double arrivalTime = getTimeRaw(endNodeIndex);
+		if (Double.isInfinite(arrivalTime)) {
+			throw new RuntimeException("Undefined time on end node");
+		}
+		double travelTime = arrivalTime - startTime;
+
+		List<Node> nodes = new ArrayList<>();
+		List<Link> links = new ArrayList<>();
+
+		int nodeIndex = endNodeIndex;
+
+		nodes.add(this.graph.getNode(nodeIndex));
+
+		int linkIndex = this.usedLink[nodeIndex];
+		nodeIndex = this.comingFrom[nodeIndex];
+
+		while (nodeIndex >= 0) {
+			nodes.add(this.graph.getNode(nodeIndex));
+			links.add(this.graph.getLink(linkIndex));
+
+			linkIndex = this.usedLink[nodeIndex];
+			nodeIndex = this.comingFrom[nodeIndex];
+		}
+
+		Collections.reverse(nodes);
+		Collections.reverse(links);
+
+		return new Path(nodes, links, travelTime, travelCost);
+	}
+
+}

--- a/matsim/src/main/java/org/matsim/core/router/speedy/SpeedyALTData.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/SpeedyALTData.java
@@ -1,0 +1,317 @@
+package org.matsim.core.router.speedy;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.core.router.speedy.SpeedyGraph.LinkIterator;
+import org.matsim.core.router.util.TravelDisutility;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * Preprocessed data for the ALT algorithm, see {@link SpeedyALT}.
+ *
+ * This class is thread-safe and can safely be used by multiple threads.
+ *
+ * @author mrieser / Simunto, sponsored by SBB Swiss Federal Railways
+ */
+class SpeedyALTData {
+
+	private final static Logger LOG = LogManager.getLogger(SpeedyALTData.class);
+
+	final SpeedyGraph graph;
+	private final int landmarksCount;
+	private final TravelDisutility travelCosts;
+	private final int[] landmarksNodeIndices;
+	private final double[] nodesData; // for each node: 2 values per landmark
+	private final int[] deadendData;
+	private final double minTravelCostPerLength;
+
+	public SpeedyALTData(SpeedyGraph graph, int landmarksCount, TravelDisutility travelCosts) {
+		this.graph = graph;
+		this.landmarksCount = landmarksCount;
+		this.travelCosts = travelCosts;
+		this.landmarksNodeIndices = new int[landmarksCount];
+		this.nodesData = new double[graph.nodeCount * (landmarksCount * 2)];
+		this.deadendData = new int[graph.nodeCount];
+
+		this.findDeadEnds();
+		this.calcLandmarks();
+		this.minTravelCostPerLength = this.calcMinTravelCostPerLength();
+	}
+
+	private void findDeadEnds() {
+		LOG.info("find dead ends...");
+
+		LinkIterator outLI = this.graph.getOutLinkIterator();
+		LinkIterator inLI = this.graph.getInLinkIterator();
+		Arrays.fill(this.deadendData, -1);
+		Map<Integer, Integer> mergedDeadends = new HashMap<>();
+
+		for (int nodeIdx = 0; nodeIdx < this.graph.nodeCount; nodeIdx++) {
+			Node node = this.graph.getNode(nodeIdx);
+			if (node == null) continue; // not all indices might be in use
+
+			if (this.deadendData[nodeIdx] >= 0) continue; // already detected as part of dead-end
+
+			int nIdx = nodeIdx;
+			int otherNodeIndex = checkNodeForDeadend(this.deadendData, mergedDeadends, nIdx, nodeIdx, outLI, inLI);
+			while (otherNodeIndex >= 0) {
+				this.deadendData[nIdx] = nodeIdx;
+				nIdx = otherNodeIndex;
+				otherNodeIndex = checkNodeForDeadend(this.deadendData, mergedDeadends, nIdx, nodeIdx, outLI, inLI);
+			}
+		}
+		Map<Integer, Integer> mergers = new HashMap<>();
+		mergedDeadends.forEach((fromIdx, toIdx) -> {
+			int finalToIdx = toIdx;
+			Integer newToIdx = mergedDeadends.get(toIdx);
+			while (newToIdx != null && newToIdx != finalToIdx) {
+				finalToIdx = newToIdx;
+				newToIdx = mergedDeadends.get(finalToIdx);
+			}
+			mergers.put(fromIdx, finalToIdx);
+		});
+		for (int nodeIdx = 0; nodeIdx < this.graph.nodeCount; nodeIdx++) {
+			int deadend = this.deadendData[nodeIdx];
+			if (deadend >= 0) {
+				this.deadendData[nodeIdx] = mergers.getOrDefault(deadend, deadend);
+			}
+		}
+	}
+
+	private int checkNodeForDeadend(int[] deadends, Map<Integer, Integer> mergedDeadends, int nodeIdx, int currentDeadend, LinkIterator outLI, LinkIterator inLI) {
+		int otherNodeIndex = -1;
+
+		outLI.reset(nodeIdx);
+		while (outLI.next()) {
+			int toNodeIdx = outLI.getToNodeIndex();
+			if (deadends[toNodeIdx] >= 0) continue;
+
+			if (toNodeIdx != otherNodeIndex) {
+				if (otherNodeIndex == -1) otherNodeIndex = toNodeIdx;
+				else return -1; // there are more than one non-dead-end incident nodes
+			}
+		}
+
+		inLI.reset(nodeIdx);
+		while (inLI.next()) {
+			int fromNodeIdx = inLI.getFromNodeIndex();
+			if (deadends[fromNodeIdx] >= 0) continue;
+
+			if (fromNodeIdx != otherNodeIndex) {
+				if (otherNodeIndex == -1) otherNodeIndex = fromNodeIdx;
+				else return -1; // there are more than one non-dead-end incident nodes
+			}
+		}
+
+		outLI.reset(nodeIdx);
+		while (outLI.next()) {
+			int toNodeIdx = outLI.getToNodeIndex();
+			int deadend = deadends[toNodeIdx];
+			if (deadend >= 0) mergedDeadends.put(deadend, currentDeadend);
+		}
+		inLI.reset(nodeIdx);
+		while (inLI.next()) {
+			int fromNodeIdx = inLI.getFromNodeIndex();
+			int deadend = deadends[fromNodeIdx];
+			if (deadend >= 0) mergedDeadends.put(deadend, currentDeadend);
+		}
+
+		return otherNodeIndex;
+	}
+
+	private void calcLandmarks() {
+		LOG.info("calculate landmarks...");
+		Node firstNode = null;
+		for (int i = 0; i < this.graph.nodeCount; i++) {
+			firstNode = this.graph.getNode(i);
+			if (firstNode != null) {
+				break;
+			}
+		}
+
+		Future<double[]>[] trees = new Future[this.landmarksCount * 2];
+		ExecutorService executor = Executors.newFixedThreadPool(4);
+
+		int firstLandmarkIndex = firstNode.getId().index();
+		this.landmarksNodeIndices[0] = firstLandmarkIndex;
+		trees[0] = executor.submit(() -> calculateTreeForward(firstLandmarkIndex));
+		trees[1] = executor.submit(() -> calculateTreeBackward(firstLandmarkIndex));
+
+		for (int i = 1; i < this.landmarksCount; i++) {
+			int nextLandmark = calculateNextLandmark(i);
+			this.landmarksNodeIndices[i] = nextLandmark;
+
+			trees[i * 2] = executor.submit(() -> calculateTreeForward(nextLandmark));
+			trees[i * 2 + 1] = executor.submit(() -> calculateTreeBackward(nextLandmark));
+		}
+
+		for (int i = 0; i < trees.length; i++) {
+			try {
+				double[] data = trees[i].get();
+				setNodeData(data, i);
+			} catch (InterruptedException | ExecutionException e) {
+				LOG.error(e);
+			}
+		}
+		executor.shutdown();
+	}
+
+	private double calcMinTravelCostPerLength() {
+		LOG.info("calculate min travelcost...");
+		double minCost = Double.POSITIVE_INFINITY;
+		for (int linkIdx = 0; linkIdx < graph.linkCount; linkIdx++) {
+			Link link = this.graph.getLink(linkIdx);
+			if (link != null) {
+				double cost = this.travelCosts.getLinkMinimumTravelDisutility(link) / link.getLength();
+				if (cost < minCost) {
+					minCost = cost;
+				}
+			}
+		}
+		return minCost;
+	}
+
+	private void setNodeData(double[] data, int offset) {
+		int multiplier = this.landmarksCount * 2;
+		for (int i = 0; i < this.graph.nodeCount; i++) {
+			this.nodesData[i * multiplier + offset] = data[i];
+		}
+	}
+
+	private int calculateNextLandmark(int existingCount) {
+		double[] data = new double[this.graph.nodeCount];
+		Arrays.fill(data, Double.POSITIVE_INFINITY);
+		LinkIterator outLI = this.graph.getOutLinkIterator();
+
+		for (int i = 0; i < existingCount; i++) {
+			data[this.landmarksNodeIndices[i]] = 0;
+		}
+
+		NodeMinHeap pq = new NodeMinHeap(this.graph.nodeCount, i -> data[i], (i, c) -> data[i] = c);
+		for (int i = 0; i < existingCount; i++) {
+			pq.insert(this.landmarksNodeIndices[i]);
+		}
+
+		int lastNodeIdx = -1;
+		while (!pq.isEmpty()) {
+			final int nodeIdx = pq.poll();
+			lastNodeIdx = nodeIdx;
+			double currCost = data[nodeIdx];
+
+			outLI.reset(nodeIdx);
+			while (outLI.next()) {
+				int toNode = outLI.getToNodeIndex();
+
+				double newCost = currCost + 1;
+
+				double oldCost = data[toNode];
+				if (Double.isFinite(oldCost)) {
+					if (newCost < oldCost) {
+						pq.decreaseKey(toNode, newCost);
+					}
+				} else {
+					data[toNode] = newCost;
+					pq.insert(toNode);
+				}
+			}
+		}
+		return lastNodeIdx;
+	}
+
+	private double[] calculateTreeForward(int node) {
+		double[] data = new double[this.graph.nodeCount];
+		Arrays.fill(data, Double.POSITIVE_INFINITY);
+		LinkIterator outLI = this.graph.getOutLinkIterator();
+
+		data[node] = 0;
+
+		NodeMinHeap pq = new NodeMinHeap(this.graph.nodeCount, i -> data[i], (i, c) -> data[i] = c);
+		pq.insert(node);
+
+		while (!pq.isEmpty()) {
+			final int nodeIdx = pq.poll();
+			double currCost = data[nodeIdx];
+
+			outLI.reset(nodeIdx);
+			while (outLI.next()) {
+				int toNode = outLI.getToNodeIndex();
+
+				double newCost = currCost + this.travelCosts.getLinkMinimumTravelDisutility(this.graph.getLink(outLI.getLinkIndex()));
+
+				double oldCost = data[toNode];
+				if (Double.isFinite(oldCost)) {
+					if (newCost < oldCost) {
+						pq.decreaseKey(toNode, newCost);
+					}
+				} else {
+					data[toNode] = newCost;
+					pq.insert(toNode);
+				}
+			}
+		}
+		return data;
+	}
+
+	private double[] calculateTreeBackward(int node) {
+		double[] data = new double[this.graph.nodeCount];
+		Arrays.fill(data, Double.POSITIVE_INFINITY);
+		LinkIterator inLI = this.graph.getInLinkIterator();
+
+		data[node] = 0;
+
+		NodeMinHeap pq = new NodeMinHeap(this.graph.nodeCount, i -> data[i], (i, c) -> data[i] = c);
+		pq.insert(node);
+
+		while (!pq.isEmpty()) {
+			final int nodeIdx = pq.poll();
+			double currCost = data[nodeIdx];
+
+			inLI.reset(nodeIdx);
+			while (inLI.next()) {
+				int fromNode = inLI.getFromNodeIndex();
+
+				double newCost = currCost + this.travelCosts.getLinkMinimumTravelDisutility(this.graph.getLink(inLI.getLinkIndex()));
+
+				double oldCost = data[fromNode];
+				if (Double.isFinite(oldCost)) {
+					if (newCost < oldCost) {
+						pq.decreaseKey(fromNode, newCost);
+					}
+				} else {
+					data[fromNode] = newCost;
+					pq.insert(fromNode);
+				}
+			}
+		}
+		return data;
+	}
+
+	int getNodeDeadend(int nodeIndex) {
+		return this.deadendData[nodeIndex];
+	}
+
+	int getLandmarksCount() {
+		return this.landmarksCount;
+	}
+
+	double getTravelCostFromLandmark(int nodeIndex, int landmarkIndex) {
+		return this.nodesData[nodeIndex * (this.landmarksCount * 2) + 2 * landmarkIndex];
+	}
+
+	double getTravelCostToLandmark(int nodeIndex, int landmarkIndex) {
+		return this.nodesData[nodeIndex * (this.landmarksCount * 2) + 2 * landmarkIndex + 1];
+	}
+
+	public double getMinTravelCostPerLength() {
+		return this.minTravelCostPerLength;
+	}
+}

--- a/matsim/src/main/java/org/matsim/core/router/speedy/SpeedyALTFactory.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/SpeedyALTFactory.java
@@ -1,0 +1,35 @@
+package org.matsim.core.router.speedy;
+
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.core.router.util.LeastCostPathCalculator;
+import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
+import org.matsim.core.router.util.TravelDisutility;
+import org.matsim.core.router.util.TravelTime;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author mrieser / Simunto, sponsored by SBB Swiss Federal Railways
+ */
+public class SpeedyALTFactory implements LeastCostPathCalculatorFactory {
+
+	private final Map<Network, SpeedyGraph> graphs = new ConcurrentHashMap<>();
+	private final Map<SpeedyGraph, SpeedyALTData> landmarksData = new ConcurrentHashMap<>();
+
+	@Override
+	public LeastCostPathCalculator createPathCalculator(Network network, TravelDisutility travelCosts, TravelTime travelTimes) {
+		SpeedyGraph graph = this.graphs.get(network);
+		if (graph == null) {
+			graph = new SpeedyGraph(network);
+			this.graphs.put(network, graph);
+		}
+		SpeedyALTData landmarks = this.landmarksData.get(graph);
+		if (landmarks == null) {
+			landmarks = new SpeedyALTData(graph, 16, travelCosts);
+			this.landmarksData.put(graph, landmarks);
+		}
+		return new SpeedyALT(landmarks, travelTimes, travelCosts);
+	}
+
+}

--- a/matsim/src/main/java/org/matsim/core/router/speedy/SpeedyDijkstra.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/SpeedyDijkstra.java
@@ -1,0 +1,164 @@
+package org.matsim.core.router.speedy;
+
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.core.router.util.LeastCostPathCalculator;
+import org.matsim.core.router.util.TravelDisutility;
+import org.matsim.core.router.util.TravelTime;
+import org.matsim.vehicles.Vehicle;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A very fast implementation of Dijkstra's shortest path algorithm using a {@link SpeedyGraph}
+ * data structure.
+ *
+ * @author mrieser / Simunto, sponsored by SBB Swiss Federal Railways
+ */
+public class SpeedyDijkstra implements LeastCostPathCalculator {
+
+	private final SpeedyGraph graph;
+	private final TravelTime tt;
+	private final TravelDisutility td;
+	private final double[] data; // 3 entries per node: time, cost, distance
+	private int currentIteration = Integer.MIN_VALUE;
+	private final int[] iterationIds;
+	private final int[] comingFrom;
+	private final int[] usedLink;
+	private final SpeedyGraph.LinkIterator outLI;
+	private final DAryMinHeap pq;
+
+	public SpeedyDijkstra(SpeedyGraph graph, TravelTime tt, TravelDisutility td) {
+		this.graph = graph;
+		this.tt = tt;
+		this.td = td;
+		this.data = new double[graph.nodeCount * 3];
+		this.iterationIds = new int[graph.nodeCount];
+		this.comingFrom = new int[graph.nodeCount];
+		this.usedLink = new int[graph.nodeCount];
+		this.pq = new DAryMinHeap(graph.nodeCount, 6);
+		this.outLI = graph.getOutLinkIterator();
+	}
+
+	private double getCost(int nodeIndex) {
+		return this.data[nodeIndex * 3];
+	}
+
+	private double getTimeRaw(int nodeIndex) {
+		return this.data[nodeIndex * 3 + 1];
+	}
+
+	public double getDistance(int nodeIndex) {
+		return this.data[nodeIndex * 3 + 2];
+	}
+
+	private void setData(int nodeIndex, double cost, double time, double distance) {
+		int index = nodeIndex * 3;
+		this.data[index] = cost;
+		this.data[index + 1] = time;
+		this.data[index + 2] = distance;
+		this.iterationIds[nodeIndex] = this.currentIteration;
+	}
+
+	@Override
+	public Path calcLeastCostPath(Node startNode, Node endNode, double startTime, Person person, Vehicle vehicle) {
+		this.currentIteration++;
+		if (this.currentIteration == Integer.MAX_VALUE) {
+			// reset iteration as we overflow
+			Arrays.fill(this.iterationIds, this.currentIteration);
+			this.currentIteration = Integer.MIN_VALUE;
+		}
+
+		int startNodeIndex = startNode.getId().index();
+		int endNodeIndex = endNode.getId().index();
+
+		this.comingFrom[startNodeIndex] = -1;
+		setData(startNodeIndex, 0, startTime, 0);
+		this.pq.clear();
+		this.pq.insert(startNodeIndex, 0);
+		boolean foundEndNode = false;
+
+		while (!this.pq.isEmpty()) {
+			final int nodeIdx = this.pq.poll();
+			if (nodeIdx == endNodeIndex) {
+				foundEndNode = true;
+				break;
+			}
+
+			double currTime = getTimeRaw(nodeIdx);
+			if (Double.isInfinite(currTime)) {
+				throw new RuntimeException("Undefined Time");
+			}
+			double currCost = getCost(nodeIdx);
+			double currDistance = getDistance(nodeIdx);
+
+			this.outLI.reset(nodeIdx);
+			while (this.outLI.next()) {
+				int linkIdx = this.outLI.getLinkIndex();
+				Link link = this.graph.getLink(linkIdx);
+				int toNode = this.outLI.getToNodeIndex();
+
+				double travelTime = this.tt.getLinkTravelTime(link, currTime, person, vehicle);
+				double newTime = currTime + travelTime;
+				double newCost = currCost + this.td.getLinkTravelDisutility(link, currTime, person, vehicle);
+
+				if (this.iterationIds[toNode] == this.currentIteration) {
+					// this node was already visited in this route-query
+					double oldCost = getCost(toNode);
+					if (newCost < oldCost) {
+						this.pq.decreaseKey(toNode, newCost);
+						setData(toNode, newCost, newTime, currDistance + link.getLength());
+						this.comingFrom[toNode] = nodeIdx;
+						this.usedLink[toNode] = linkIdx;
+					}
+				} else {
+					setData(toNode, newCost, newTime, currDistance + link.getLength());
+					this.pq.insert(toNode, newCost);
+					this.comingFrom[toNode] = nodeIdx;
+					this.usedLink[toNode] = linkIdx;
+				}
+			}
+		}
+
+		if (foundEndNode) {
+			return constructPath(endNodeIndex, startTime);
+		}
+		return null;
+	}
+
+	private Path constructPath(int endNodeIndex, double startTime) {
+		double travelCost = getCost(endNodeIndex);
+		double arrivalTime = getTimeRaw(endNodeIndex);
+		if (Double.isInfinite(arrivalTime)) {
+			throw new RuntimeException("Undefined time on end node");
+		}
+		double travelTime = arrivalTime - startTime;
+
+		List<Node> nodes = new ArrayList<>();
+		List<Link> links = new ArrayList<>();
+
+		int nodeIndex = endNodeIndex;
+
+		nodes.add(this.graph.getNode(nodeIndex));
+
+		int linkIndex = this.usedLink[nodeIndex];
+		nodeIndex = this.comingFrom[nodeIndex];
+
+		while (nodeIndex >= 0) {
+			nodes.add(this.graph.getNode(nodeIndex));
+			links.add(this.graph.getLink(linkIndex));
+
+			linkIndex = this.usedLink[nodeIndex];
+			nodeIndex = this.comingFrom[nodeIndex];
+		}
+
+		Collections.reverse(nodes);
+		Collections.reverse(links);
+
+		return new Path(nodes, links, travelTime, travelCost);
+	}
+}

--- a/matsim/src/main/java/org/matsim/core/router/speedy/SpeedyDijkstraFactory.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/SpeedyDijkstraFactory.java
@@ -1,0 +1,28 @@
+package org.matsim.core.router.speedy;
+
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.core.router.util.LeastCostPathCalculator;
+import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
+import org.matsim.core.router.util.TravelDisutility;
+import org.matsim.core.router.util.TravelTime;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author mrieser / Simunto, sponsored by SBB Swiss Federal Railways
+ */
+public class SpeedyDijkstraFactory implements LeastCostPathCalculatorFactory {
+
+	private final Map<Network, SpeedyGraph> graphs = new ConcurrentHashMap<>();
+
+	@Override
+	public LeastCostPathCalculator createPathCalculator(Network network, TravelDisutility travelCosts, TravelTime travelTimes) {
+		SpeedyGraph graph = graphs.get(network);
+		if (graph == null) {
+			graph = new SpeedyGraph(network);
+			graphs.put(network, graph);
+		}
+		return new SpeedyDijkstra(graph, travelTimes, travelCosts);
+	}
+}

--- a/matsim/src/main/java/org/matsim/core/router/speedy/SpeedyGraph.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/SpeedyGraph.java
@@ -1,10 +1,11 @@
 package org.matsim.core.router.speedy;
 
-import java.util.Arrays;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
+
+import java.util.Arrays;
 
 /**
  * Implements a highly optimized data structure for representing a MATSim network. Optimized to use as little memory as possible, and thus to fit as much memory as possible into CPU caches for high
@@ -52,6 +53,7 @@ public class SpeedyGraph {
     private final int[] nodeData;
     private final int[] linkData;
     private final Link[] links;
+    private final Node[] nodes;
 
     public SpeedyGraph(Network network) {
         this.nodeCount = Id.getNumberOfIds(Node.class);
@@ -60,10 +62,14 @@ public class SpeedyGraph {
         this.nodeData = new int[nodeCount * NODE_SIZE];
         this.linkData = new int[linkCount * LINK_SIZE];
         this.links = new Link[linkCount];
+        this.nodes = new Node[nodeCount];
 
         Arrays.fill(this.nodeData, -1);
         Arrays.fill(this.linkData, -1);
 
+        for (Node node : network.getNodes().values()) {
+            this.nodes[node.getId().index()] = node;
+        }
         for (Link link : network.getLinks().values()) {
             addLink(link);
         }
@@ -126,6 +132,10 @@ public class SpeedyGraph {
 
     Link getLink(int index) {
         return this.links[index];
+    }
+
+    Node getNode(int index) {
+        return this.nodes[index];
     }
 
     public interface LinkIterator {

--- a/matsim/src/main/java/org/matsim/core/router/speedy/SpeedyGraph.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/SpeedyGraph.java
@@ -1,4 +1,4 @@
-package ch.sbb.matsim.routing.graph;
+package org.matsim.core.router.speedy;
 
 import java.util.Arrays;
 import org.matsim.api.core.v01.Id;
@@ -21,7 +21,7 @@ import org.matsim.api.core.v01.network.Node;
  *
  * @author mrieser
  */
-public class Graph {
+public class SpeedyGraph {
 
     /*
      * memory consumption:
@@ -53,7 +53,7 @@ public class Graph {
     private final int[] linkData;
     private final Link[] links;
 
-    public Graph(Network network) {
+    public SpeedyGraph(Network network) {
         this.nodeCount = Id.getNumberOfIds(Node.class);
         this.linkCount = Id.getNumberOfIds(Link.class);
 
@@ -147,11 +147,11 @@ public class Graph {
 
     private static abstract class AbstractLinkIterator implements LinkIterator {
 
-        final Graph graph;
+        final SpeedyGraph graph;
         int nodeIdx = -1;
         int linkIdx = -1;
 
-        AbstractLinkIterator(Graph graph) {
+        AbstractLinkIterator(SpeedyGraph graph) {
             this.graph = graph;
         }
 
@@ -192,7 +192,7 @@ public class Graph {
 
     private static class OutLinkIterator extends AbstractLinkIterator {
 
-        OutLinkIterator(Graph graph) {
+        OutLinkIterator(SpeedyGraph graph) {
             super(graph);
         }
 
@@ -216,7 +216,7 @@ public class Graph {
 
     private static class InLinkIterator extends AbstractLinkIterator {
 
-        InLinkIterator(Graph graph) {
+        InLinkIterator(SpeedyGraph graph) {
             super(graph);
         }
 

--- a/matsim/src/test/java/org/matsim/core/router/RoutingIT.java
+++ b/matsim/src/test/java/org/matsim/core/router/RoutingIT.java
@@ -40,6 +40,8 @@ import org.matsim.core.population.algorithms.PersonAlgorithm;
 import org.matsim.core.population.io.PopulationReader;
 import org.matsim.core.router.costcalculators.FreespeedTravelTimeAndDisutility;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
+import org.matsim.core.router.speedy.SpeedyALTFactory;
+import org.matsim.core.router.speedy.SpeedyDijkstraFactory;
 import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
@@ -82,7 +84,20 @@ public class RoutingIT {
 			}
 		});
 	}
-	@Test	
+	@Test
+	public void testSpeedyDijkstra() {
+		doTest(new RouterProvider() {
+			@Override
+			public String getName() {
+				return "SpeedyDijkstra";
+			}
+			@Override
+			public LeastCostPathCalculatorFactory getFactory(final Network network, final TravelDisutility costCalc, final TravelTime timeCalc) {
+				return new SpeedyDijkstraFactory();
+			}
+		});
+	}
+	@Test
 	public void testDijkstraPruneDeadEnds() {
 		doTest(new RouterProvider() {
 			@Override
@@ -157,6 +172,19 @@ public class RoutingIT {
 			@Override
 			public LeastCostPathCalculatorFactory getFactory(final Network network, final TravelDisutility costCalc, final TravelTime timeCalc) {
 				return new FastAStarLandmarksFactory(2);
+			}
+		});
+	}
+	@Test
+	public void testSpeedyALT() {
+		doTest(new RouterProvider() {
+			@Override
+			public String getName() {
+				return "SpeedyALT";
+			}
+			@Override
+			public LeastCostPathCalculatorFactory getFactory(final Network network, final TravelDisutility costCalc, final TravelTime timeCalc) {
+				return new SpeedyALTFactory();
 			}
 		});
 	}

--- a/matsim/src/test/java/org/matsim/core/router/speedy/DAryMinHeapTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/speedy/DAryMinHeapTest.java
@@ -1,0 +1,118 @@
+package org.matsim.core.router.speedy;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Random;
+
+/**
+ * @author mrieser / Simunto
+ */
+public class DAryMinHeapTest {
+
+	@Test
+	public void testPoll() {
+		double cost[] = new double[10];
+		DAryMinHeap pq = new DAryMinHeap(20, 3);
+
+		cost[0] = 5;
+		cost[1] = 2;
+		cost[2] = 4;
+		cost[3] = 8;
+		cost[4] = 10;
+		cost[5] = 1;
+		cost[6] = 3;
+		cost[7] = 6;
+
+		pq.insert(2, cost[2]);
+		pq.insert(1, cost[1]);
+		pq.insert(0, cost[0]);
+
+		Assert.assertEquals(3, pq.size());
+
+		Assert.assertEquals(1, pq.poll());
+		Assert.assertEquals(2, pq.poll());
+		Assert.assertEquals(0, pq.poll());
+
+		Assert.assertTrue(pq.isEmpty());
+
+		for (int i = 0; i < 8; i++) {
+			pq.insert(i, cost[i]);
+		}
+
+		Assert.assertEquals(5, pq.poll());
+		Assert.assertEquals(1, pq.poll());
+		Assert.assertEquals(6, pq.poll());
+		Assert.assertEquals(2, pq.poll());
+		Assert.assertEquals(0, pq.poll());
+		Assert.assertEquals(7, pq.poll());
+		Assert.assertEquals(3, pq.poll());
+		Assert.assertEquals(4, pq.poll());
+		Assert.assertTrue(pq.isEmpty());
+	}
+
+	@Test
+	public void testDecreaseKey() {
+		DAryMinHeap pq = new DAryMinHeap(20, 4);
+
+		pq.insert(2, 4);
+		pq.insert(1, 2);
+		pq.insert(0, 5);
+
+		pq.decreaseKey(2, 1.0);
+
+		Assert.assertEquals(2, pq.poll());
+		Assert.assertEquals(1, pq.poll());
+		Assert.assertEquals(0, pq.poll());
+		Assert.assertTrue(pq.isEmpty());
+	}
+
+	@Test
+	public void stresstest() {
+		int cnt = 2000;
+		double[] cost = new double[cnt];
+		Random r = new Random(20190210L);
+		for (int i = 0; i < cnt; i++) {
+			cost[i] = (int) (r.nextDouble() * cnt * 100);
+		}
+
+		DAryMinHeap pq = new DAryMinHeap(cnt, 2);
+
+		for (int i = 0; i < cnt; i++) {
+			pq.insert(i, cost[i]);
+		}
+		double lastCost = -1;
+		int step = 0;
+		while (!pq.isEmpty()) {
+			step++;
+			int node = pq.poll();
+			double nodeCost = cost[node];
+			Assert.assertTrue(step + ": " + lastCost + " <= " + nodeCost, lastCost <= nodeCost);
+			lastCost = nodeCost;
+		}
+
+		// start again, but add some decreaseKey operations
+		for (int i = 0; i < cnt; i++) {
+			pq.insert(i, cost[i]);
+		}
+
+		for (int i = 0; i < cnt; i++) {
+			double newCost = (int) (r.nextDouble() * cnt * 100);
+			if (newCost < cost[i]) {
+				pq.decreaseKey(i, newCost);
+				cost[i] = newCost;
+			}
+		}
+
+		lastCost = -1;
+		step = 0;
+		while (!pq.isEmpty()) {
+			step++;
+			int node = pq.poll();
+			double nodeCost = cost[node];
+			Assert.assertTrue(step + ": " + lastCost + " <= " + nodeCost, lastCost <= nodeCost);
+			lastCost = nodeCost;
+		}
+
+	}
+}

--- a/matsim/src/test/java/org/matsim/core/router/speedy/SpeedyALTTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/speedy/SpeedyALTTest.java
@@ -1,0 +1,42 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * DijkstraTest.java
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2008 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.core.router.speedy;
+
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.core.config.groups.PlanCalcScoreConfigGroup;
+import org.matsim.core.router.AbstractLeastCostPathCalculatorTest;
+import org.matsim.core.router.costcalculators.FreespeedTravelTimeAndDisutility;
+import org.matsim.core.router.util.LeastCostPathCalculator;
+
+/**
+ * @author mrieser
+ */
+public class SpeedyALTTest extends AbstractLeastCostPathCalculatorTest {
+	
+	@Override
+	protected LeastCostPathCalculator getLeastCostPathCalculator(final Network network) {
+		FreespeedTravelTimeAndDisutility travelTimeCostCalculator = new FreespeedTravelTimeAndDisutility(new PlanCalcScoreConfigGroup());
+		SpeedyGraph g = new SpeedyGraph(network);
+		SpeedyALTData altData = new SpeedyALTData(g, 16, travelTimeCostCalculator);
+		return new SpeedyALT(altData, travelTimeCostCalculator, travelTimeCostCalculator);
+	}
+	
+}

--- a/matsim/src/test/java/org/matsim/core/router/speedy/SpeedyDijkstraTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/speedy/SpeedyDijkstraTest.java
@@ -1,0 +1,42 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * DijkstraTest.java
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2008 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.core.router.speedy;
+
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.core.config.groups.PlanCalcScoreConfigGroup;
+import org.matsim.core.router.AbstractLeastCostPathCalculatorTest;
+import org.matsim.core.router.Dijkstra;
+import org.matsim.core.router.costcalculators.FreespeedTravelTimeAndDisutility;
+import org.matsim.core.router.util.LeastCostPathCalculator;
+
+/**
+ * @author mrieser
+ */
+public class SpeedyDijkstraTest extends AbstractLeastCostPathCalculatorTest {
+	
+	@Override
+	protected LeastCostPathCalculator getLeastCostPathCalculator(final Network network) {
+		FreespeedTravelTimeAndDisutility travelTimeCostCalculator = new FreespeedTravelTimeAndDisutility(new PlanCalcScoreConfigGroup());
+		SpeedyGraph g = new SpeedyGraph(network);
+		return new SpeedyDijkstra(g, travelTimeCostCalculator, travelTimeCostCalculator);
+	}
+	
+}

--- a/matsim/src/test/java/org/matsim/core/router/speedy/SpeedyGraphTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/speedy/SpeedyGraphTest.java
@@ -1,6 +1,5 @@
-package ch.sbb.matsim.routing.graph;
+package org.matsim.core.router.speedy;
 
-import ch.sbb.matsim.routing.graph.Graph.LinkIterator;
 import org.junit.Assert;
 import org.junit.Test;
 import org.matsim.api.core.v01.Coord;
@@ -10,18 +9,19 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.NetworkFactory;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.router.speedy.SpeedyGraph.LinkIterator;
 
 /**
  * @author mrieser
  */
-public class GraphTest {
+public class SpeedyGraphTest {
 
     @Test
     public void testConstruction() {
         Fixture f = new Fixture();
         Network network = f.network;
 
-        Graph graph = new Graph(network);
+        SpeedyGraph graph = new SpeedyGraph(network);
 
         // test out-links
 

--- a/matsim/src/test/java/org/matsim/integration/replanning/ReRoutingIT.java
+++ b/matsim/src/test/java/org/matsim/integration/replanning/ReRoutingIT.java
@@ -24,6 +24,8 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.util.EnumSet;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,6 +35,7 @@ import org.matsim.core.config.Config;
 import org.matsim.core.config.groups.ControlerConfigGroup.EventsFileFormat;
 import org.matsim.core.config.groups.ControlerConfigGroup.RoutingAlgorithmType;
 import org.matsim.core.controler.Controler;
+import org.matsim.core.gbl.Gbl;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.utils.io.IOUtils;
@@ -125,19 +128,26 @@ public class ReRoutingIT {
 		controler.getConfig().controler().setCreateGraphs(false);
 		controler.getConfig().controler().setDumpDataAtEnd(false);
 		controler.run();
-		this.evaluate();
+		this.evaluate("plans_speedyALT.xml.gz");
 	}
 
 	private void evaluate() throws MalformedURLException {
+		this.evaluate("plans.xml.gz");
+	}
+
+	private final static Logger LOG = LogManager.getLogger(ReRoutingIT.class);
+	private void evaluate(String plansFilename) throws MalformedURLException {
 		Config config = utils.loadConfig(IOUtils.extendUrl(utils.classInputResourcePath(), "config.xml"));
 		config.network().setInputFile(IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("berlin"), "network.xml.gz").toString());
-		config.plans().setInputFile(IOUtils.extendUrl(utils.classInputResourcePath(), "plans.xml.gz").toString());
+		config.plans().setInputFile(IOUtils.extendUrl(utils.classInputResourcePath(), plansFilename).toString());
 		Scenario referenceScenario = ScenarioUtils.loadScenario(config);
 
 		config.plans().setInputFile(new File(utils.getOutputDirectory() + "ITERS/it.1/1.plans.xml.gz").toURI().toURL().toString());
 		Scenario scenario = ScenarioUtils.loadScenario(config);
 
+		Gbl.startMeasurement();
 		final boolean isEqual = PopulationUtils.equalPopulation(referenceScenario.getPopulation(), scenario.getPopulation());
+		Gbl.printElapsedTime();
 		if ( !isEqual ) {
 			new PopulationWriter(referenceScenario.getPopulation(), scenario.getNetwork()).write(utils.getOutputDirectory() + "/reference_population.xml.gz");
 			new PopulationWriter(scenario.getPopulation(), scenario.getNetwork()).write(utils.getOutputDirectory() + "/output_population.xml.gz");

--- a/matsim/src/test/java/org/matsim/integration/replanning/ReRoutingIT.java
+++ b/matsim/src/test/java/org/matsim/integration/replanning/ReRoutingIT.java
@@ -116,7 +116,18 @@ public class ReRoutingIT {
 		controler.run();
 		this.evaluate();
 	}
-	
+
+	@Test
+	public void testReRoutingSpeedyALT() throws MalformedURLException {
+		Scenario scenario = this.loadScenario();
+		scenario.getConfig().controler().setRoutingAlgorithmType(RoutingAlgorithmType.SpeedyALT);
+		Controler controler = new Controler(scenario);
+		controler.getConfig().controler().setCreateGraphs(false);
+		controler.getConfig().controler().setDumpDataAtEnd(false);
+		controler.run();
+		this.evaluate();
+	}
+
 	private void evaluate() throws MalformedURLException {
 		Config config = utils.loadConfig(IOUtils.extendUrl(utils.classInputResourcePath(), "config.xml"));
 		config.network().setInputFile(IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("berlin"), "network.xml.gz").toString());


### PR DESCRIPTION
This PR provides a new very fast car/network router: SpeedyALT.

It is an implementation of the ALT algorithm (also known as A*-Search with Landmarks and Triangle Inequality), but highly optimized. Still, the code is rather compact and hopefully easy to understand and maintain. (it should definitely be easier to understand than the current FastAStarLandmarks, which is distributed over 4 hierarchies of inheritance, with additional delegation etc).

In my testing, routing several thousand realistic trips across Switzerland on a detailed navigation network, the speed-up over `FastAStarLandmarks` was around 3 (in detail: 2.97 single-threaded and 3.44 multi-threaded). Speed-up over `AStarLandmarks` (the current default router in MATSim) is around 6, and against `Dijkstra` the speed-up is over 20. Clearly, those values may depend on the actual scenario used, but in any case they should be substantial.  Initialization time was halfed compared to `(Fast)AStarLandmarks`, saving additional time in each replanning phase.