### PR TITLE
Make CarrierAgentTracker an interface

### DIFF
--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/CarrierAgent.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/CarrierAgent.java
@@ -17,10 +17,7 @@ import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Plan;
 import org.matsim.api.core.v01.population.Route;
-import org.matsim.contrib.freight.carrier.Carrier;
-import org.matsim.contrib.freight.carrier.CarrierVehicle;
-import org.matsim.contrib.freight.carrier.FreightConstants;
-import org.matsim.contrib.freight.carrier.ScheduledTour;
+import org.matsim.contrib.freight.carrier.*;
 import org.matsim.contrib.freight.carrier.Tour.TourActivity;
 import org.matsim.contrib.freight.carrier.Tour.TourElement;
 import org.matsim.core.gbl.Gbl;
@@ -267,12 +264,15 @@ class CarrierAgent
 					org.matsim.contrib.freight.carrier.Tour.Leg tourLeg = (org.matsim.contrib.freight.carrier.Tour.Leg) tourElement;
 					Route route = tourLeg.getRoute();
 					if(route == null) throw new IllegalStateException("missing route for carrier " + this.getId());
-					Leg leg = PopulationUtils.createLeg(TransportMode.car);
+					//this returns TransportMode.car if the attribute is null
+					Leg leg = PopulationUtils.createLeg(CarrierUtils.getCarrierMode(carrier));
+					//TODO we might need to set the route to null if the the mode is a drt mode
 					leg.setRoute(route);
 					leg.setDepartureTime(tourLeg.getExpectedDepartureTime());
 					leg.setTravelTime(tourLeg.getExpectedTransportTime());
-					leg.setTravelTime( tourLeg.getExpectedDepartureTime() + tourLeg.getExpectedTransportTime() - leg.getDepartureTime()
-							.seconds());
+					//the following is confusing and should be unnecessary. tschlenther, march '21
+//					leg.setTravelTime( tourLeg.getExpectedDepartureTime() + tourLeg.getExpectedTransportTime() - leg.getDepartureTime()
+//							.seconds());
 					plan.addLeg(leg);
 				} else if (tourElement instanceof TourActivity) {
 					TourActivity act = (TourActivity) tourElement;

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/CarrierAgent.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/CarrierAgent.java
@@ -9,7 +9,6 @@ import java.util.Map;
 
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.events.*;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Activity;
@@ -220,7 +219,7 @@ class CarrierAgent
 		Gbl.assertNotNull(carrierScoringFunction);
 	}
 
-	public CarrierAgent( CarrierAgentTracker lspCarrierTracker, Carrier carrier ){
+	public CarrierAgent(CarrierAgentTracker lspCarrierTracker, Carrier carrier ){
 		lspTracker = lspCarrierTracker;
 		this.carrier = carrier;
 		this.id = carrier.getId();

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/CarrierAgentTracker.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/CarrierAgentTracker.java
@@ -1,235 +1,43 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2007 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
 package org.matsim.contrib.freight.controler;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.events.*;
+import org.matsim.api.core.v01.events.Event;
 import org.matsim.api.core.v01.events.handler.*;
 import org.matsim.api.core.v01.population.Activity;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Plan;
 import org.matsim.contrib.freight.carrier.Carrier;
-import org.matsim.contrib.freight.carrier.Carriers;
 import org.matsim.contrib.freight.carrier.ScheduledTour;
-import org.matsim.contrib.freight.controler.CarrierAgent.CarrierDriverAgent;
-import org.matsim.contrib.freight.events.eventsCreator.LSPEventCreator;
-import org.matsim.core.api.experimental.events.EventsManager;
-import org.matsim.core.events.algorithms.Vehicle2DriverEventHandler;
-import org.matsim.core.gbl.Gbl;
-import org.matsim.core.scoring.ScoringFunction;
+import org.matsim.core.controler.listener.ScoringListener;
 
-/**
- * This keeps track of all carrierAgents during simulation.
- * 
- * @author mzilske, sschroeder
- *
- */
-public class CarrierAgentTracker implements ActivityStartEventHandler, ActivityEndEventHandler, PersonDepartureEventHandler, PersonArrivalEventHandler,
-						     LinkEnterEventHandler, LinkLeaveEventHandler, VehicleEntersTrafficEventHandler, VehicleLeavesTrafficEventHandler,
-						     PersonEntersVehicleEventHandler, PersonLeavesVehicleEventHandler 
-{
-	// yyyy not sure if this _has_ to be public, but current LSP design makes this necessary.  kai, sep'20
+import java.util.Collection;
 
-	private static final Logger log = Logger.getLogger( CarrierAgentTracker.class ) ;
+public interface CarrierAgentTracker extends ActivityStartEventHandler, ActivityEndEventHandler, PersonDepartureEventHandler, PersonArrivalEventHandler,
+		LinkEnterEventHandler, LinkLeaveEventHandler, VehicleEntersTrafficEventHandler, VehicleLeavesTrafficEventHandler, PersonEntersVehicleEventHandler, PersonLeavesVehicleEventHandler {
+	Collection<Plan> createPlans();
 
-	private final Carriers carriers;
+	CarrierAgent.CarrierDriverAgent getDriver(Id<Person> driverId);
 
-	private final Vehicle2DriverEventHandler vehicle2DriverEventHandler = new Vehicle2DriverEventHandler();
+	void notifyEventHappened(Event event, Carrier carrier, Activity activity, ScheduledTour scheduledTour, Id<Person> driverId, int activityCounter );
 
-	private final Collection<CarrierAgent> carrierAgents = new ArrayList<>();
-	
-	private final Map<Id<Person>, CarrierAgent> driverAgentMap = new HashMap<>();
-
-	private final EventsManager events;
-
-	private Collection<LSPEventCreator> lspEventCreators;
-
-	CarrierAgentTracker( Carriers carriers, CarrierScoringFunctionFactory carrierScoringFunctionFactory, EventsManager events ) {
-		this.events = events;
-		log.warn( "calling ctor; carrierScoringFunctionFactory=" + carrierScoringFunctionFactory.getClass() );
-		this.carriers = carriers;
-		createCarrierAgents(carrierScoringFunctionFactory);
-	}
-	public CarrierAgentTracker( Carriers carriers, Collection<LSPEventCreator> creators, EventsManager events ) {
-		// yyyy needs to be public with current setup. kai, sep'20
-
-		this.carriers = carriers;
-		this.lspEventCreators = creators;
-		this.events = events;
-		createCarrierAgents();
-
-		Gbl.assertNotNull( this.lspEventCreators );
-	}
-
-	private void createCarrierAgents(CarrierScoringFunctionFactory carrierScoringFunctionFactory) {
-		for (Carrier carrier : carriers.getCarriers().values()) {
-			log.warn( "" );
-			log.warn( "about to create scoring function for carrierId=" + carrier.getId() );
-			ScoringFunction carrierScoringFunction = carrierScoringFunctionFactory.createScoringFunction(carrier);
-			log.warn( "have now created scoring function for carrierId=" + carrier.getId() );
-			log.warn( "" );
-			CarrierAgent carrierAgent = new CarrierAgent( carrier, carrierScoringFunction );
-			carrierAgents.add(carrierAgent);
-		}
-	}
-	private void createCarrierAgents() {
-		for (Carrier carrier : carriers.getCarriers().values()) {
-			carrierAgents.add( new CarrierAgent( this, carrier ) );
-		}
-	}
-
-	/**
-	 * Returns the entire set of selected carrier plans.
-	 * 
-	 * @return collection of plans
-	 * @see Plan, CarrierPlan
-	 */
-	public Collection<Plan> createPlans() {
-		List<Plan> vehicleRoutes = new ArrayList<>();
-		for (CarrierAgent carrierAgent : carrierAgents) {
-			List<Plan> plansForCarrier = carrierAgent.createFreightDriverPlans();
-			vehicleRoutes.addAll(plansForCarrier);
-		}
-		return vehicleRoutes;
-	}
-
-	/**
-	 * Request all carrier agents to score their plans.
-	 * 
-	 */
-	public void scoreSelectedPlans() {
-		for (Carrier carrier : carriers.getCarriers().values()) {
-			CarrierAgent agent = findCarrierAgent(carrier.getId());
-			agent.scoreSelectedPlan();
-		}
-	}
-
-	@Override
-	public void reset(int iteration) {
-		vehicle2DriverEventHandler.reset(iteration );
-	}
-
-	private CarrierAgent findCarrierAgent(Id<Carrier> id) {
-		for (CarrierAgent agent : carrierAgents) {
-			if (agent.getId().equals(id)) {
-				return agent;
-			}
-		}
-		return null;
-	}
-
-	void notifyEventHappened( Event event, Carrier carrier, Activity activity, ScheduledTour scheduledTour, Id<Person> driverId, int activityCounter ) {
-		for( org.matsim.contrib.freight.events.eventsCreator.LSPEventCreator LSPEventCreator : lspEventCreators ) {
-			Event customEvent = LSPEventCreator.createEvent(event, carrier, activity, scheduledTour, driverId, activityCounter);
-			if(customEvent != null) {
-				events.processEvent(customEvent);
-			}
-		}
-	}
-	@Override
-	public void handleEvent(ActivityEndEvent event) {
-		final Id<Person> driverId = event.getPersonId();
-		CarrierAgent carrierAgent = getCarrierAgent( driverId );
-		if(carrierAgent == null) return;
-		carrierAgent.handleEvent(event, driverId );
-	}
-
-	@Override
-	public void handleEvent(LinkEnterEvent event) {
-		final Id<Person> driverId = vehicle2DriverEventHandler.getDriverOfVehicle( event.getVehicleId() );
-		CarrierAgent carrierAgent = getCarrierAgent( driverId );
-		if(carrierAgent == null) return;
-		carrierAgent.handleEvent(event, driverId );
-	}
-
-	@Override
-	public void handleEvent(ActivityStartEvent event) {
-		final Id<Person> driverId = event.getPersonId();
-		CarrierAgent carrierAgent = getCarrierAgent( driverId );
-		if(carrierAgent == null) return;
-		carrierAgent.handleEvent(event, driverId );
-	}
-
-
-	@Override
-	public void handleEvent(PersonArrivalEvent event) {
-		final Id<Person> driverId = event.getPersonId();
-		CarrierAgent carrierAgent = getCarrierAgent( driverId );
-		if(carrierAgent == null) return;
-		carrierAgent.handleEvent(event, driverId );
-	}
-
-	@Override
-	public void handleEvent(PersonDepartureEvent event) {
-		final Id<Person> driverId = event.getPersonId();
-		CarrierAgent carrierAgent = getCarrierAgent( driverId );
-		if(carrierAgent == null) return;
-		carrierAgent.handleEvent(event, driverId );
-	}
-
-	@Override
-	public void handleEvent(VehicleLeavesTrafficEvent event) {
-		vehicle2DriverEventHandler.handleEvent(event );
-		final Id<Person> driverId = event.getPersonId();
-		CarrierAgent carrierAgent = getCarrierAgent( driverId );
-		if(carrierAgent == null) return;
-		carrierAgent.handleEvent(event, driverId );
-	}
-
-	@Override
-	public void handleEvent(VehicleEntersTrafficEvent event) {
-		vehicle2DriverEventHandler.handleEvent(event );
-		final Id<Person> driverId = event.getPersonId();
-		CarrierAgent carrierAgent = getCarrierAgent( driverId );
-		if(carrierAgent == null) return;
-		carrierAgent.handleEvent(event, driverId );
-	}
-
-	@Override
-	public void handleEvent(LinkLeaveEvent event) {
-		final Id<Person> driverId = vehicle2DriverEventHandler.getDriverOfVehicle( event.getVehicleId() );
-		CarrierAgent carrierAgent = getCarrierAgent( driverId );
-		if(carrierAgent == null) return;
-		carrierAgent.handleEvent(event, driverId );
-	}
-
-	@Override
-	public void handleEvent(PersonEntersVehicleEvent event) {
-		final Id<Person> driverId = event.getPersonId();
-		CarrierAgent carrierAgent = getCarrierAgent( driverId );
-		if(carrierAgent == null) return;
-		carrierAgent.handleEvent(event, driverId );
-	}
-
-	@Override
-	public void handleEvent(PersonLeavesVehicleEvent event) {
-		final Id<Person> driverId = event.getPersonId();
-		CarrierAgent carrierAgent = getCarrierAgent( driverId );
-		if(carrierAgent == null) return;
-		carrierAgent.handleEvent(event, driverId );
-	}
-	private CarrierAgent getCarrierAgent(Id<Person> driverId) {
-		if(driverAgentMap.containsKey(driverId)){
-			return driverAgentMap.get(driverId);
-		}
-		for(CarrierAgent ca : carrierAgents){
-			if(ca.getDriverIds().contains(driverId)){
-				driverAgentMap.put(driverId, ca);
-				return ca;
-			}
-		}
-		return null;
-	}
-
-	CarrierDriverAgent getDriver(Id<Person> driverId){
-		CarrierAgent carrierAgent = getCarrierAgent(driverId);
-		if(carrierAgent == null) throw new IllegalStateException("missing carrier agent. cannot find carrierAgent to driver " + driverId);
-		return carrierAgent.getDriver(driverId);
-	}
-
+	void scoreSelectedPlans();
 }

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/CarrierModule.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/CarrierModule.java
@@ -27,7 +27,6 @@ import com.google.inject.Provider;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import org.matsim.api.core.v01.Scenario;
-import org.matsim.contrib.freight.Freight;
 import org.matsim.contrib.freight.FreightConfigGroup;
 import org.matsim.contrib.freight.carrier.CarrierPlanXmlWriterV2;
 import org.matsim.contrib.freight.carrier.CarrierVehicleTypeWriter;
@@ -86,9 +85,9 @@ public final class CarrierModule extends AbstractModule {
 			bind(CarrierScoringFunctionFactory.class).toInstance(scoringFunctionFactory);
 		}
 
-//		bind(CarrierControlerListener.class).in( Singleton.class );
 		bind(CarrierControlerListener.class).asEagerSingleton();
 		addControlerListenerBinding().to(CarrierControlerListener.class);
+		bind(CarrierAgentTracker.class).toProvider(CarrierControlerListener.class);
 
 		// this switches on certain qsim components:
 		QSimComponentsConfigGroup qsimComponents = ConfigUtils.addOrGetModule( getConfig(), QSimComponentsConfigGroup.class );
@@ -131,15 +130,6 @@ public final class CarrierModule extends AbstractModule {
 			}
 		} );
 
-	}
-
-	// We export CarrierAgentTracker, which is kept by the ControlerListener, which happens to re-create it every iteration.
-	// The freight QSim needs it (see below [[where?]]).
-	// yyyy this feels rather scary.  kai, oct'19
-	// Since we are exporting it anyways, we could as well also inject it.  kai, sep'20
-	@Provides
-	CarrierAgentTracker provideCarrierAgentTracker(CarrierControlerListener carrierControlerListener) {
-		return carrierControlerListener.getCarrierAgentTracker();
 	}
 
 	private static void writeAdditionalRunOutput( Config config, Carriers carriers ) {

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/DefaultCarrierAgentTracker.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/DefaultCarrierAgentTracker.java
@@ -1,0 +1,239 @@
+package org.matsim.contrib.freight.controler;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.log4j.Logger;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.events.*;
+import org.matsim.api.core.v01.population.Activity;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Plan;
+import org.matsim.contrib.freight.carrier.Carrier;
+import org.matsim.contrib.freight.carrier.Carriers;
+import org.matsim.contrib.freight.carrier.ScheduledTour;
+import org.matsim.contrib.freight.controler.CarrierAgent.CarrierDriverAgent;
+import org.matsim.contrib.freight.events.eventsCreator.LSPEventCreator;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.controler.events.ScoringEvent;
+import org.matsim.core.events.algorithms.Vehicle2DriverEventHandler;
+import org.matsim.core.gbl.Gbl;
+import org.matsim.core.scoring.ScoringFunction;
+
+/**
+ * This keeps track of all carrierAgents during simulation.
+ * 
+ * @author mzilske, sschroeder
+ *
+ */
+public class DefaultCarrierAgentTracker implements
+		CarrierAgentTracker {
+	// yyyy not sure if this _has_ to be public, but current LSP design makes this necessary.  kai, sep'20
+
+	private static final Logger log = Logger.getLogger( DefaultCarrierAgentTracker.class ) ;
+
+	private final Carriers carriers;
+
+	private final Vehicle2DriverEventHandler vehicle2DriverEventHandler = new Vehicle2DriverEventHandler();
+
+	private final Collection<CarrierAgent> carrierAgents = new ArrayList<>();
+	
+	private final Map<Id<Person>, CarrierAgent> driverAgentMap = new HashMap<>();
+
+	private final EventsManager events;
+
+	private Collection<LSPEventCreator> lspEventCreators;
+
+	DefaultCarrierAgentTracker(Carriers carriers, CarrierScoringFunctionFactory carrierScoringFunctionFactory, EventsManager events ) {
+		this.events = events;
+		log.warn( "calling ctor; carrierScoringFunctionFactory=" + carrierScoringFunctionFactory.getClass() );
+		this.carriers = carriers;
+		createCarrierAgents(carrierScoringFunctionFactory);
+	}
+	public DefaultCarrierAgentTracker(Carriers carriers, Collection<LSPEventCreator> creators, EventsManager events ) {
+		// yyyy needs to be public with current setup. kai, sep'20
+
+		this.carriers = carriers;
+		this.lspEventCreators = creators;
+		this.events = events;
+		createCarrierAgents();
+
+		Gbl.assertNotNull( this.lspEventCreators );
+	}
+
+	private void createCarrierAgents(CarrierScoringFunctionFactory carrierScoringFunctionFactory) {
+		for (Carrier carrier : carriers.getCarriers().values()) {
+			log.warn( "" );
+			log.warn( "about to create scoring function for carrierId=" + carrier.getId() );
+			ScoringFunction carrierScoringFunction = carrierScoringFunctionFactory.createScoringFunction(carrier);
+			log.warn( "have now created scoring function for carrierId=" + carrier.getId() );
+			log.warn( "" );
+			CarrierAgent carrierAgent = new CarrierAgent( carrier, carrierScoringFunction );
+			carrierAgents.add(carrierAgent);
+		}
+	}
+	private void createCarrierAgents() {
+		for (Carrier carrier : carriers.getCarriers().values()) {
+			carrierAgents.add( new CarrierAgent( this, carrier ) );
+		}
+	}
+
+	/**
+	 * Returns the entire set of selected carrier plans.
+	 * 
+	 * @return collection of plans
+	 * @see Plan, CarrierPlan
+	 */
+	@Override
+	public Collection<Plan> createPlans() {
+		List<Plan> vehicleRoutes = new ArrayList<>();
+		for (CarrierAgent carrierAgent : carrierAgents) {
+			List<Plan> plansForCarrier = carrierAgent.createFreightDriverPlans();
+			vehicleRoutes.addAll(plansForCarrier);
+		}
+		return vehicleRoutes;
+	}
+
+	/**
+	 * Request all carrier agents to score their plans.
+	 * 
+	 */
+	@Override
+	public void scoreSelectedPlans() {
+		for (Carrier carrier : carriers.getCarriers().values()) {
+			CarrierAgent agent = findCarrierAgent(carrier.getId());
+			agent.scoreSelectedPlan();
+		}
+	}
+
+	@Override
+	public void reset(int iteration) {
+		vehicle2DriverEventHandler.reset(iteration );
+	}
+
+	private CarrierAgent findCarrierAgent(Id<Carrier> id) {
+		for (CarrierAgent agent : carrierAgents) {
+			if (agent.getId().equals(id)) {
+				return agent;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public void notifyEventHappened(Event event, Carrier carrier, Activity activity, ScheduledTour scheduledTour, Id<Person> driverId, int activityCounter) {
+		for( org.matsim.contrib.freight.events.eventsCreator.LSPEventCreator LSPEventCreator : lspEventCreators ) {
+			Event customEvent = LSPEventCreator.createEvent(event, carrier, activity, scheduledTour, driverId, activityCounter);
+			if(customEvent != null) {
+				events.processEvent(customEvent);
+			}
+		}
+	}
+
+	@Override
+	public void handleEvent(ActivityEndEvent event) {
+		final Id<Person> driverId = event.getPersonId();
+		CarrierAgent carrierAgent = getCarrierAgent( driverId );
+		if(carrierAgent == null) return;
+		carrierAgent.handleEvent(event, driverId );
+	}
+
+	@Override
+	public void handleEvent(LinkEnterEvent event) {
+		final Id<Person> driverId = vehicle2DriverEventHandler.getDriverOfVehicle( event.getVehicleId() );
+		CarrierAgent carrierAgent = getCarrierAgent( driverId );
+		if(carrierAgent == null) return;
+		carrierAgent.handleEvent(event, driverId );
+	}
+
+	@Override
+	public void handleEvent(ActivityStartEvent event) {
+		final Id<Person> driverId = event.getPersonId();
+		CarrierAgent carrierAgent = getCarrierAgent( driverId );
+		if(carrierAgent == null) return;
+		carrierAgent.handleEvent(event, driverId );
+	}
+
+
+	@Override
+	public void handleEvent(PersonArrivalEvent event) {
+		final Id<Person> driverId = event.getPersonId();
+		CarrierAgent carrierAgent = getCarrierAgent( driverId );
+		if(carrierAgent == null) return;
+		carrierAgent.handleEvent(event, driverId );
+	}
+
+	@Override
+	public void handleEvent(PersonDepartureEvent event) {
+		final Id<Person> driverId = event.getPersonId();
+		CarrierAgent carrierAgent = getCarrierAgent( driverId );
+		if(carrierAgent == null) return;
+		carrierAgent.handleEvent(event, driverId );
+	}
+
+	@Override
+	public void handleEvent(VehicleLeavesTrafficEvent event) {
+		vehicle2DriverEventHandler.handleEvent(event );
+		final Id<Person> driverId = event.getPersonId();
+		CarrierAgent carrierAgent = getCarrierAgent( driverId );
+		if(carrierAgent == null) return;
+		carrierAgent.handleEvent(event, driverId );
+	}
+
+	@Override
+	public void handleEvent(VehicleEntersTrafficEvent event) {
+		vehicle2DriverEventHandler.handleEvent(event );
+		final Id<Person> driverId = event.getPersonId();
+		CarrierAgent carrierAgent = getCarrierAgent( driverId );
+		if(carrierAgent == null) return;
+		carrierAgent.handleEvent(event, driverId );
+	}
+
+	@Override
+	public void handleEvent(LinkLeaveEvent event) {
+		final Id<Person> driverId = vehicle2DriverEventHandler.getDriverOfVehicle( event.getVehicleId() );
+		CarrierAgent carrierAgent = getCarrierAgent( driverId );
+		if(carrierAgent == null) return;
+		carrierAgent.handleEvent(event, driverId );
+	}
+
+	@Override
+	public void handleEvent(PersonEntersVehicleEvent event) {
+		final Id<Person> driverId = event.getPersonId();
+		CarrierAgent carrierAgent = getCarrierAgent( driverId );
+		if(carrierAgent == null) return;
+		carrierAgent.handleEvent(event, driverId );
+	}
+
+	@Override
+	public void handleEvent(PersonLeavesVehicleEvent event) {
+		final Id<Person> driverId = event.getPersonId();
+		CarrierAgent carrierAgent = getCarrierAgent( driverId );
+		if(carrierAgent == null) return;
+		carrierAgent.handleEvent(event, driverId );
+	}
+
+	private CarrierAgent getCarrierAgent(Id<Person> driverId) {
+		if(driverAgentMap.containsKey(driverId)){
+			return driverAgentMap.get(driverId);
+		}
+		for(CarrierAgent ca : carrierAgents){
+			if(ca.getDriverIds().contains(driverId)){
+				driverAgentMap.put(driverId, ca);
+				return ca;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public CarrierDriverAgent getDriver(Id<Person> driverId){
+		CarrierAgent carrierAgent = getCarrierAgent(driverId);
+		if(carrierAgent == null) throw new IllegalStateException("missing carrier agent. cannot find carrierAgent to driver " + driverId);
+		return carrierAgent.getDriver(driverId);
+	}
+
+}

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/LSPAgentSource.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/LSPAgentSource.java
@@ -60,7 +60,7 @@ public class LSPAgentSource implements AgentSource {
 
 	private final QSim qsim;
 
-	@Inject LSPAgentSource( CarrierAgentTracker carrierAgentTracker, AgentFactory agentFactory, QSim qsim ) {
+	@Inject LSPAgentSource(CarrierAgentTracker carrierAgentTracker, AgentFactory agentFactory, QSim qsim ) {
 		this.vehicleRoutes = carrierAgentTracker.createPlans();
 		this.agentFactory = agentFactory;
 		this.qsim = qsim;


### PR DESCRIPTION
`CarrierAgentTracker` was `@Provided` by the `CarrierModule` before and now is made an interface to use injection.
As `CarrierAgentTracker` is also needed to trigger scoring, it does not have mobsim-scope. This is the reason why we can not put it behind it's own proper provider, because the `CarrierControlerListener` recreates the CarrierAgentTracker object outside of the mobsim.

Is there a specific reason why the AgentTracker or the  `CarrierScoringFunction` need to be reconstructed every iteration? If not, we could further simplify things by having one stable CarrierAgentTracker object which is a ControlerListener itself (so no need for CarrierControlerListener to trigger scoring). Even if the `CarrierAgent` should continue to get reconstructed every iteration, the `CarrierAgentTracker` could do that in that setup. 

I did these changes when i came across the JointDemand package, which ideally should use the `FreightAgentSource` instead of defining it's infrastructure that converts `CarrierPlans` into `MobsimAgents`.
In the end, i concluded that only a few lines in the `createPlans()` and `handleEvent(ActivityStartEvent)` methods of the new interface `CarrierAgentTracker` would have to be added. So this PR is a preparation to clean that up up and synchronize the packages a bit.
This would also lead to consistent handling of freight plans, in other words it would also adress issues mentioned in #1427, which deals with TimeWindowHandling. The freight contrib has it's logic to handle TimeWindows.

Additionally, i set the leg mode to `CarrierUtils.getCarrierMode(carrier)` in the `createPlans()` method, which returns `TransportMode.car` by default (Tests run though). That means, it should now be easy to let freight agents use other network modes while using the freight contrib.