### PR TITLE
Update geotools to 24.2

### DIFF
--- a/contribs/accessibility/pom.xml
+++ b/contribs/accessibility/pom.xml
@@ -30,14 +30,14 @@
 			</plugin>
 		</plugins>
 	</build>
-	
+
 	<repositories>
 		<repository>
 		    <id>jitpack.io</id>
 		    <url>https://jitpack.io</url>
 		</repository>
 	</repositories>
-		
+
 	<dependencies>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
@@ -90,6 +90,7 @@
 		<dependency>
 			<groupId>org.geotools.jdbc</groupId>
 			<artifactId>gt-jdbc-postgis</artifactId>
+			<version>${geotools.version}</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/contribs/accidents/pom.xml
+++ b/contribs/accidents/pom.xml
@@ -15,6 +15,7 @@
         <dependency>
             <groupId>org.geotools.jdbc</groupId>
             <artifactId>gt-jdbc-postgis</artifactId>
+            <version>${geotools.version}</version>
         </dependency>
 
     </dependencies>

--- a/contribs/bicycle/pom.xml
+++ b/contribs/bicycle/pom.xml
@@ -12,7 +12,7 @@
       <dependency>
           <groupId>org.geotools</groupId>
           <artifactId>gt-geotiff</artifactId>
-          <version>21.5</version>
+          <version>${geotools.version}</version>
       </dependency>
       <dependency>
           <groupId>org.matsim.contrib</groupId>

--- a/contribs/integration/pom.xml
+++ b/contribs/integration/pom.xml
@@ -85,6 +85,7 @@
 		<dependency>
 			<groupId>org.geotools.jdbc</groupId>
 			<artifactId>gt-jdbc-postgis</artifactId>
+			<version>${geotools.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>

--- a/contribs/noise/pom.xml
+++ b/contribs/noise/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-geojson</artifactId>
-            <version>21.5</version>
+            <version>${geotools.version}</version>
         </dependency>
         <dependency>
 			<groupId>org.openstreetmap.osmosis</groupId>

--- a/matsim/pom.xml
+++ b/matsim/pom.xml
@@ -210,18 +210,22 @@
 		<dependency>
 			<groupId>org.geotools</groupId>
 			<artifactId>gt-main</artifactId>
+			<version>${geotools.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.geotools</groupId>
 			<artifactId>gt-referencing</artifactId>
+			<version>${geotools.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.geotools</groupId>
 			<artifactId>gt-shapefile</artifactId>
+			<version>${geotools.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.geotools</groupId>
 			<artifactId>gt-epsg-hsql</artifactId>
+			<version>${geotools.version}</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>

--- a/matsim/src/test/java/org/matsim/core/utils/geometry/transformations/GeotoolsTransformationTest.java
+++ b/matsim/src/test/java/org/matsim/core/utils/geometry/transformations/GeotoolsTransformationTest.java
@@ -37,7 +37,7 @@ public class GeotoolsTransformationTest extends MatsimTestCase {
 		double x = 638748.9000000004;
 		double y = 9916839.69;
 		
-		double targetX = 100.24690901110905;
+		double targetX = 100.24690901110904;
 		double targetY = -0.7521976363533539;
 		double delta = 1e-16;
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <argLine></argLine>
 
-        <geotools.version>21.5</geotools.version>
+        <geotools.version>24.2</geotools.version>
         <guice.version>4.2.2</guice.version>
         <guava.version>30.0-jre</guava.version>
         <jackson.version>2.10.3</jackson.version>


### PR DESCRIPTION
For `pt2matsim` we had a couple of cases where the current `geotools` version seems to be outdated (for certain EPSG codes, etc.). This PR updates `geotools` to version `24.2` and unifies the version across all packages.