### PR TITLE
deploy to GitHub Packages; add snapshot and release deployment workflows

### DIFF
--- a/.github/workflows/deploy-on-pr-merge.yaml
+++ b/.github/workflows/deploy-on-pr-merge.yaml
@@ -1,0 +1,39 @@
+name: deploy-on-pr-merge
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy-snapshot:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v2
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      # Build and publish are separated so we start deploying only after all jars are built successfully
+      - name: Build jars
+        run: mvn -pl -distribution package --batch-mode -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests
+
+      - name: Publish jars to GitHub Packages
+        run: mvn -pl -distribution deploy --batch-mode -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+    env:
+      MAVEN_OPTS: -Xmx2g

--- a/.github/workflows/deploy-on-release-created.yaml
+++ b/.github/workflows/deploy-on-release-created.yaml
@@ -1,0 +1,42 @@
+name: deploy-on-release-created
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  deploy-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v2
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Set MATSim version
+        run: mvn versions:set --batch-mode -DnewVersion=${{ github.event.release.tag_name }} -DgenerateBackupPoms=false
+
+      # Build and publish are separated so we start deploying only after all jars are built successfully
+      - name: Build jars
+        run: mvn -pl -distribution package --batch-mode -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests
+
+      - name: Publish jars to GitHub Packages
+        run: mvn -pl -distribution deploy --batch-mode -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+    env:
+      MAVEN_OPTS: -Xmx2g

--- a/.github/workflows/verify-push.yaml
+++ b/.github/workflows/verify-push.yaml
@@ -1,6 +1,12 @@
 name: verify-push
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches-ignore:
+      - 'master' #no need to run after merging to master
+    tags-ignore:
+      - '*' #do not run on pushing tags
+  pull_request:
 
 jobs:
   build:

--- a/pom.xml
+++ b/pom.xml
@@ -64,22 +64,18 @@
             <id>ch.sbb</id>
             <url>https://schweizerischebundesbahnen.bintray.com/simba.mvn</url>
         </repository>
-        <repository>
-            <!-- For MATSim snapshots: -->
-            <id>ojo-snapshots</id>
-            <url>https://oss.jfrog.org/libs-snapshot</url>
-        </repository>
     </repositories>
 
     <distributionManagement>
         <repository>
-            <id>bintray</id>
-            <url>https://api.bintray.com/maven/matsim/matsim/matsim</url>
+            <id>github</id>
+            <name>GitHub Maven Packages</name>
+            <url>https://maven.pkg.github.com/matsim-org/matsim-libs</url>
         </repository>
         <snapshotRepository>
-            <id>oss-jfrog-artifactory</id>
-            <name>artifactory-snapshots</name>
-            <url>https://oss.jfrog.org/oss-snapshot-local</url>
+            <id>github</id>
+            <name>GitHub Maven Packages</name>
+            <url>https://maven.pkg.github.com/matsim-org/matsim-libs</url>
         </snapshotRepository>
     </distributionManagement>
 


### PR DESCRIPTION
First steps addressing issues in #1378:
- migrate to GitHub packages
- add workflows that automatically deploy snapshots and (GitHub) releases

I tested this setup on a toy repo that resembles the matsim repo structure: https://github.com/michalmac/try-out-github-packages.

I was able to deploy to GitHub packages and then use the deployed jars in another local project. One caveat though: a public read token needs to be used (this is a current limitation of GitHub Packages). This is the currently suggested approach by GitHub according to https://github.community/t/partial-support-for-maven-snapshots/115628/12:
```xml
<repository>
  <id>github-public</id>
  <url>https://public:xxxxxxxxxxxxxxxxx@maven.pkg.github.com/michalmac/try-out-github-packages/</url>
</repository>
```

GitHub offers some control over published packages (incl. deleting them to some extend).

It is still unclear about the available storage limit. In my billing, I can see some usage reported (in contrast to Actions which do not give any minutes reported in the billing).