### PR TITLE
fix: change artifact ids to lowercase

### DIFF
--- a/contribs/cadytsIntegration/pom.xml
+++ b/contribs/cadytsIntegration/pom.xml
@@ -6,7 +6,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.matsim.contrib</groupId>
-  <artifactId>cadytsIntegration</artifactId>
+  <artifactId>cadyts-integration</artifactId>
   <name>cadytsIntegration</name>
     <build>
         <plugins>

--- a/contribs/commercialTrafficApplications/pom.xml
+++ b/contribs/commercialTrafficApplications/pom.xml
@@ -6,7 +6,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.matsim.contrib</groupId>
-  <artifactId>commercialTrafficApplications</artifactId>
+  <artifactId>commercial-traffic-applications</artifactId>
   <name>commercialTrafficApplications</name>
 
     <dependencies>

--- a/contribs/eventsBasedPTRouter/pom.xml
+++ b/contribs/eventsBasedPTRouter/pom.xml
@@ -6,7 +6,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.matsim.contrib</groupId>
-  <artifactId>eventsBasedPTRouter</artifactId>
+  <artifactId>events-based-pt-router</artifactId>
   <name>eventsBasedPTRouter</name>
   <build>
     <plugins>

--- a/contribs/pseudosimulation/pom.xml
+++ b/contribs/pseudosimulation/pom.xml
@@ -24,7 +24,7 @@
     </dependency>
     <dependency>
       <groupId>org.matsim.contrib</groupId>
-      <artifactId>eventsBasedPTRouter</artifactId>
+      <artifactId>events-based-pt-router</artifactId>
       <version>14.0-SNAPSHOT</version>
     </dependency>
     <dependency>

--- a/contribs/vsp/pom.xml
+++ b/contribs/vsp/pom.xml
@@ -136,7 +136,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
-			<artifactId>cadytsIntegration</artifactId>
+			<artifactId>cadyts-integration</artifactId>
 			<version>14.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -37,7 +37,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
-			<artifactId>cadytsIntegration</artifactId>
+			<artifactId>cadyts-integration</artifactId>
 			<version>14.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
@@ -82,7 +82,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
-			<artifactId>eventsBasedPTRouter</artifactId>
+			<artifactId>events-based-pt-router</artifactId>
 			<version>14.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
According to https://maven.apache.org/guides/mini/guide-naming-conventions.html we should use lowercase latter in artifact ids. We are violating this rule in: `cadytsIntegration`, `commercialTrafficApplications` and `eventsBasedPTRouter`.

Not obeying this rule causes problems with uploading artifacts to GitHub Packages. Also some mvn plugins may not work.

Since we are just about to bump to `14.0-SNAPSHOT`, I think this is the best moment to switch to lowercase (as we will avoid issues like `cadytsIntegration-13.0-SNAPSHOT` being different than `cadyts-integration-13.0-SNAPSHOT`, which would likely lead to some hard to find bugs).