### PR TITLE
fail at end while deploying jars

### DIFF
--- a/.github/workflows/deploy-on-pr-merge.yaml
+++ b/.github/workflows/deploy-on-pr-merge.yaml
@@ -31,7 +31,8 @@ jobs:
         run: mvn -pl -distribution package --batch-mode -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests
 
       - name: Publish jars to GitHub Packages
-        run: mvn -pl -distribution deploy --batch-mode -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests
+        # fail at end to deploy as many jars as possible
+        run: mvn -pl -distribution deploy --batch-mode --fail-at-end -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests
         env:
           GITHUB_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/deploy-on-release-created.yaml
+++ b/.github/workflows/deploy-on-release-created.yaml
@@ -34,7 +34,8 @@ jobs:
         run: mvn -pl -distribution package --batch-mode -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests
 
       - name: Publish jars to GitHub Packages
-        run: mvn -pl -distribution deploy --batch-mode -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests
+        # fail at end to deploy as many jars as possible
+        run: mvn -pl -distribution deploy --batch-mode --fail-at-end -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests
         env:
           GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
Once the deployment has started, try to upload as many jars as possible. It should also help to identify the problematic jars/modules and simplify a potential manual re-deployment of the missing jars.