### PR TITLE
upload matsim (core) assembly as release asset

### DIFF
--- a/.github/workflows/deploy-on-release-created.yaml
+++ b/.github/workflows/deploy-on-release-created.yaml
@@ -39,5 +39,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
+      - name: Upload matsim (core) assembly as release asset
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ github.token }}
+          file: matsim/target/matsim-${{ github.event.release.tag_name }}-release.zip
+          tag: ${{ github.event.release.tag_name }}
     env:
       MAVEN_OPTS: -Xmx2g


### PR DESCRIPTION
to replace the manual step of uploading them. Here's an example:
https://github.com/michalmac/try-out-github-packages/releases

![image](https://user-images.githubusercontent.com/9891415/114297754-d3035800-9ab2-11eb-8d4d-e0d4496df380.png)

=====

After merging this PR, the release process is almost fully automated. The following steps are required:
1. Bump the snapshot version on the master branch (e.g. `13.0-SNAPSHOT` -> `14.0-SNAPSHOT`)
2. Create the release branch (stemming from the last commit before the bumping, e.g. `13.x`). Note: Do not change version from  `13.0-SNAPSHOT` to  `13.0` in POMs (this is done by the workflow, also for any subsequent fix releases, e.g. `13.0.1`)
3. Create release on the GitHub page: provide the version number as the tag (e.g. `13.0`), and choose the corresponding branch (e.g. `13.x`)
![image](https://user-images.githubusercontent.com/9891415/114298014-6b4e0c80-9ab4-11eb-86b2-8309b7dc4a66.png)

After clicking "Publish release", the release workflow will be triggered: https://github.com/matsim-org/matsim-libs/blob/master/.github/workflows/deploy-on-release-created.yaml