### PR TITLE
deploy PR-labelled versions

### DIFF
--- a/.github/workflows/deploy-on-pr-merge.yaml
+++ b/.github/workflows/deploy-on-pr-merge.yaml
@@ -3,10 +3,16 @@ name: deploy-on-pr-merge
 on:
   push:
     branches:
-      - master
+      - master # snapshot deployment
+  pull_request:
+    types:
+      - closed # pr-labelled deployment (only if PR is merged to master)
 
 jobs:
   deploy-snapshot:
+    name: deploy snapshot/PR-labelled version
+    if: github.event_name == 'push' || (github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'master')
+
     runs-on: ubuntu-latest
 
     steps:
@@ -26,9 +32,13 @@ jobs:
         with:
           java-version: 11
           distribution: 'adopt'
-          server-id: matsim-snapshots
+          server-id: ${{ github.event_name == 'push' && 'matsim-snapshots' || 'matsim-releases' }} #choose mvn repo
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
+
+      - name: Set MATSim version (if PR-labelled version)
+        if: github.event_name == 'pull_request'
+        run: mvn versions:set --batch-mode -DnewVersion=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | sed 's/SNAPSHOT//')PR${{ github.event.pull_request.number }} -DgenerateBackupPoms=false
 
       # Build and publish are separated so we start deploying only after all jars are built successfully
       - name: Build jars


### PR DESCRIPTION
See discussion here: https://github.com/matsim-org/matsim-libs/issues/1378#issuecomment-804845481

The PR-labelled version (e.g. `14.0-PR1534`) is created and deployed on merging PR to master (and only master). This is how it looks on the test repo: https://github.com/michalmac/try-out-github-packages/packages/718303

The PR-labelled releases are meant to replace the weekly releases (and potentially even the standard snapshots). We could also think of publishing snapshots to GitHub Packages (for the developers who know all the risks behind) and PR-labelled versions to the matsim maven repo (for the general public)...

Happy to hear your thoughts :-)