### PR TITLE
freight carriers: set the leg mode according to CarrierUtils.getCarrierMode()

### DIFF
--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/CarrierAgent.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/CarrierAgent.java
@@ -17,10 +17,7 @@ import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Plan;
 import org.matsim.api.core.v01.population.Route;
-import org.matsim.contrib.freight.carrier.Carrier;
-import org.matsim.contrib.freight.carrier.CarrierVehicle;
-import org.matsim.contrib.freight.carrier.FreightConstants;
-import org.matsim.contrib.freight.carrier.ScheduledTour;
+import org.matsim.contrib.freight.carrier.*;
 import org.matsim.contrib.freight.carrier.Tour.TourActivity;
 import org.matsim.contrib.freight.carrier.Tour.TourElement;
 import org.matsim.core.gbl.Gbl;
@@ -267,7 +264,9 @@ class CarrierAgent
 					org.matsim.contrib.freight.carrier.Tour.Leg tourLeg = (org.matsim.contrib.freight.carrier.Tour.Leg) tourElement;
 					Route route = tourLeg.getRoute();
 					if(route == null) throw new IllegalStateException("missing route for carrier " + this.getId());
-					Leg leg = PopulationUtils.createLeg(TransportMode.car);
+					//this returns TransportMode.car if the attribute is null
+					Leg leg = PopulationUtils.createLeg(CarrierUtils.getCarrierMode(carrier));
+					//TODO we might need to set the route to null if the the mode is a drt mode
 					leg.setRoute(route);
 					leg.setDepartureTime(tourLeg.getExpectedDepartureTime());
 					leg.setTravelTime(tourLeg.getExpectedTransportTime());


### PR DESCRIPTION
Since some time now, it is possible to set an attribute for each carrier that is meant to determine it's mode if transport. This PR now realises that the corresponding agents perform legs of the specified mode. If no mode had been set, TransportMode.car is the default.

@kt86 