### PR TITLE
Workflow improvements

### DIFF
--- a/.github/workflows/deploy-on-pr-merge.yaml
+++ b/.github/workflows/deploy-on-pr-merge.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Publish jars to matsim maven repo
         # fail at end to deploy as many jars as possible
-        run: mvn -pl -distribution deploy --batch-mode --fail-at-end -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests -Dmaven.resources.skip=true
+        run: mvn -pl -distribution deploy --batch-mode --fail-at-end -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests -Dmaven.resources.skip=true -Dmaven.install.skip=true
         env:
           MAVEN_USERNAME: ${{ secrets.REPOMATSIM_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.REPOMATSIM_TOKEN }}

--- a/.github/workflows/deploy-on-pr-merge.yaml
+++ b/.github/workflows/deploy-on-pr-merge.yaml
@@ -44,9 +44,9 @@ jobs:
       - name: Build jars
         run: mvn -pl -distribution package --batch-mode -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests
 
-      - name: Publish jars to GitHub Packages
+      - name: Publish jars to matsim maven repo
         # fail at end to deploy as many jars as possible
-        run: mvn -pl -distribution deploy --batch-mode --fail-at-end -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests
+        run: mvn -pl -distribution deploy --batch-mode --fail-at-end -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests -Dmaven.resources.skip=true
         env:
           MAVEN_USERNAME: ${{ secrets.REPOMATSIM_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.REPOMATSIM_TOKEN }}

--- a/.github/workflows/deploy-on-release-created.yaml
+++ b/.github/workflows/deploy-on-release-created.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Publish jars to matsim maven repo
         # fail at end to deploy as many jars as possible
-        run: mvn -pl -distribution deploy --batch-mode --fail-at-end -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests -Dmaven.resources.skip=true
+        run: mvn -pl -distribution deploy --batch-mode --fail-at-end -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests -Dmaven.resources.skip=true -Dmaven.install.skip=true
         env:
           MAVEN_USERNAME: ${{ secrets.REPOMATSIM_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.REPOMATSIM_TOKEN }}

--- a/.github/workflows/deploy-on-release-created.yaml
+++ b/.github/workflows/deploy-on-release-created.yaml
@@ -37,9 +37,9 @@ jobs:
       - name: Build jars
         run: mvn -pl -distribution package --batch-mode -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests
 
-      - name: Publish jars to GitHub Packages
+      - name: Publish jars to matsim maven repo
         # fail at end to deploy as many jars as possible
-        run: mvn -pl -distribution deploy --batch-mode --fail-at-end -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests
+        run: mvn -pl -distribution deploy --batch-mode --fail-at-end -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests -Dmaven.resources.skip=true
         env:
           MAVEN_USERNAME: ${{ secrets.REPOMATSIM_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.REPOMATSIM_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
+                    <version>3.3.0</version>
                     <configuration>
                         <descriptors>
                             <descriptor>src/main/assembly/assembly-release.xml</descriptor>

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,11 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
                     <version>3.3.0</version>
                     <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,11 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
                     <version>3.3.0</version>
                     <configuration>


### PR DESCRIPTION
A series of little improvements in the `deploy-***` workflows:
- bump the mvn assemby plugin so `assembly.skipAssembly` flag is respected
- prevent unnecessary re-compilation when deploying already created jars (unnecessary copying resources was the trouble maker)
- stop installing jars to local mvn repo (and later caching them) in GH Actions when deploying to the remote maven repo