### PR TITLE
fix swing EDT threading issues; minor fixes & improvements

### DIFF
--- a/matsim/src/main/java/org/matsim/run/gui/AsyncFileInputProgressDialog.java
+++ b/matsim/src/main/java/org/matsim/run/gui/AsyncFileInputProgressDialog.java
@@ -19,7 +19,7 @@
  *                                                                         *
  * *********************************************************************** */
 
- package org.matsim.run.gui;
+package org.matsim.run.gui;
 
 import java.awt.Dimension;
 import java.awt.Toolkit;
@@ -37,85 +37,71 @@ import org.apache.log4j.Logger;
 
 /**
  * A dialog showing the progress on how far a {@link FileInputStream} has been consumed
- * asyncronously.
- * 
+ * asynchronously.
+ *
  * @author mrieser / Senozon AG
  */
 /*package*/ class AsyncFileInputProgressDialog extends JDialog {
 
 	private final static Logger log = Logger.getLogger(AsyncFileInputProgressDialog.class);
-	
+
 	private static final long serialVersionUID = 1L;
-	
-	public AsyncFileInputProgressDialog(final FileInputStream fis) {
-		this(fis, "Operation in Progress…");
+
+	final JProgressBar progressbar;
+
+	public AsyncFileInputProgressDialog() {
+		this("Operation in Progress…");
 	}
 
-	public AsyncFileInputProgressDialog(final FileInputStream fis, final String title) {
+	public AsyncFileInputProgressDialog(final String title) {
 		setTitle(title);
-		final JProgressBar progressbar = new JProgressBar(0, 1000);
+		progressbar = new JProgressBar(0, 1000);
 		GroupLayout groupLayout = new GroupLayout(getContentPane());
-		groupLayout.setHorizontalGroup(
-			groupLayout.createParallelGroup(Alignment.LEADING)
+		groupLayout.setHorizontalGroup(groupLayout.createParallelGroup(Alignment.LEADING)
 				.addGroup(groupLayout.createSequentialGroup()
-					.addContainerGap()
-					.addComponent(progressbar, GroupLayout.DEFAULT_SIZE, 300, Short.MAX_VALUE)
-					.addContainerGap())
-		);
-		groupLayout.setVerticalGroup(
-			groupLayout.createParallelGroup(Alignment.LEADING)
+						.addContainerGap()
+						.addComponent(progressbar, GroupLayout.DEFAULT_SIZE, 300, Short.MAX_VALUE)
+						.addContainerGap()));
+		groupLayout.setVerticalGroup(groupLayout.createParallelGroup(Alignment.LEADING)
 				.addGroup(groupLayout.createSequentialGroup()
-					.addContainerGap()
-					.addComponent(progressbar)
-					.addContainerGap())
-		);
+						.addContainerGap()
+						.addComponent(progressbar)
+						.addContainerGap()));
 		getContentPane().setLayout(groupLayout);
-		
-		Thread t = new Thread(new Runnable() {
 
-			@Override
-			public void run() {
-				FileChannel ch = fis.getChannel();
-				while (ch.isOpen()) {
-					try {
-						long size = ch.size();
-						long pos = ch.position();
-						final int progress = (int) ((((double) pos) / ((double) size)) * 1000.0);
-						SwingUtilities.invokeLater(new Runnable() {
-							@Override
-							public void run() {
-								progressbar.setValue(progress);
-							}
-						});
-						Thread.sleep(250);
-					} catch (InterruptedException | IOException e) {
-						log.error(e.getMessage(), e);
-					}
-				}
-			}
-			
-		}, "ProgressObserver");
-		
-		t.setDaemon(true);
-		t.start();
-		
 		this.setModal(false);
 		this.setResizable(false);
 		this.setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
 		this.pack();
-		
+
 		// center on screen
 		Dimension dim = Toolkit.getDefaultToolkit().getScreenSize();
 		int w = this.getSize().width;
 		int h = this.getSize().height;
-		int x = (dim.width-w)/2;
-		int y = (dim.height-h)/2;
+		int x = (dim.width - w) / 2;
+		int y = (dim.height - h) / 2;
 		this.setLocation(x, y);
-		
+
 		this.setVisible(true);
 	}
-	
-	public void close() {
-		this.setVisible(false);
+
+	// safe to call from outside the event dispatch thread
+	public void observeProgress(FileInputStream fis) {
+		Thread t = new Thread(() -> {
+			FileChannel ch = fis.getChannel();
+			while (ch.isOpen()) {
+				try {
+					long size = ch.size();
+					long pos = ch.position();
+					final int progress = (int)((((double)pos) / ((double)size)) * 1000.0);
+					SwingUtilities.invokeLater(() -> progressbar.setValue(progress));
+					Thread.sleep(250);
+				} catch (InterruptedException | IOException e) {
+					log.error(e.getMessage(), e);
+				}
+			}
+		}, "ProgressObserver");
+		t.setDaemon(true);
+		t.start();
 	}
 }

--- a/matsim/src/main/java/org/matsim/run/gui/ConfigEditor.java
+++ b/matsim/src/main/java/org/matsim/run/gui/ConfigEditor.java
@@ -19,35 +19,8 @@
  *                                                                         *
  * *********************************************************************** */
 
- package org.matsim.run.gui;
+package org.matsim.run.gui;
 
-import org.matsim.core.utils.io.IOUtils;
-
-import javax.swing.AbstractAction;
-import javax.swing.GroupLayout;
-import javax.swing.GroupLayout.Alignment;
-import javax.swing.JButton;
-import javax.swing.JFileChooser;
-import javax.swing.JFrame;
-import javax.swing.JScrollPane;
-import javax.swing.JTextPane;
-import javax.swing.KeyStroke;
-import javax.swing.LayoutStyle.ComponentPlacement;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
-import javax.swing.text.BadLocationException;
-import javax.swing.text.Document;
-import javax.swing.text.Element;
-import javax.swing.text.PlainDocument;
-import javax.swing.text.PlainView;
-import javax.swing.text.Segment;
-import javax.swing.text.StyledEditorKit;
-import javax.swing.text.Utilities;
-import javax.swing.text.View;
-import javax.swing.text.ViewFactory;
-import javax.swing.undo.CannotRedoException;
-import javax.swing.undo.CannotUndoException;
-import javax.swing.undo.UndoManager;
 import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.event.ActionEvent;
@@ -64,10 +37,38 @@ import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.swing.AbstractAction;
+import javax.swing.GroupLayout;
+import javax.swing.GroupLayout.Alignment;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.JTextPane;
+import javax.swing.KeyStroke;
+import javax.swing.LayoutStyle.ComponentPlacement;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import javax.swing.text.Element;
+import javax.swing.text.PlainDocument;
+import javax.swing.text.PlainView;
+import javax.swing.text.Segment;
+import javax.swing.text.StyledEditorKit;
+import javax.swing.text.Utilities;
+import javax.swing.text.ViewFactory;
+import javax.swing.undo.CannotRedoException;
+import javax.swing.undo.CannotUndoException;
+import javax.swing.undo.UndoManager;
+
+import org.matsim.core.utils.io.IOUtils;
+
 /**
  * @author mrieser
  */
-public class ConfigEditor extends JFrame {
+class ConfigEditor extends JDialog {
 
 	private static final boolean IS_MAC = System.getProperty("os.name").startsWith("Mac");
 
@@ -76,7 +77,8 @@ public class ConfigEditor extends JFrame {
 	private JTextPane xmlPane;
 	private ConfigChangeListener configChangeListener;
 
-	public ConfigEditor(File configFile, ConfigChangeListener configChangeListener) {
+	ConfigEditor(JFrame parent, File configFile, ConfigChangeListener configChangeListener) {
+		super(parent);
 		setTitle("Config Editor");
 		this.configChangeListener = configChangeListener;
 		this.configFile = configFile;
@@ -90,26 +92,22 @@ public class ConfigEditor extends JFrame {
 		JScrollPane scrollPane = new JScrollPane();
 
 		GroupLayout groupLayout = new GroupLayout(getContentPane());
-		groupLayout.setHorizontalGroup(
-			groupLayout.createParallelGroup(Alignment.LEADING)
+		groupLayout.setHorizontalGroup(groupLayout.createParallelGroup(Alignment.LEADING)
 				.addGroup(groupLayout.createSequentialGroup()
-					.addContainerGap()
-					.addComponent(this.btnSave)
-					.addPreferredGap(ComponentPlacement.RELATED)
-					.addComponent(btnSaveAs)
-					.addContainerGap(471, Short.MAX_VALUE))
-				.addComponent(scrollPane, Alignment.TRAILING, GroupLayout.DEFAULT_SIZE, 661, Short.MAX_VALUE)
-		);
-		groupLayout.setVerticalGroup(
-			groupLayout.createParallelGroup(Alignment.LEADING)
-				.addGroup(groupLayout.createSequentialGroup()
-					.addContainerGap()
-					.addGroup(groupLayout.createParallelGroup(Alignment.BASELINE)
+						.addContainerGap()
 						.addComponent(this.btnSave)
-						.addComponent(btnSaveAs))
-					.addPreferredGap(ComponentPlacement.RELATED)
-					.addComponent(scrollPane, GroupLayout.DEFAULT_SIZE, 456, Short.MAX_VALUE))
-		);
+						.addPreferredGap(ComponentPlacement.RELATED)
+						.addComponent(btnSaveAs)
+						.addContainerGap(471, Short.MAX_VALUE))
+				.addComponent(scrollPane, Alignment.TRAILING, GroupLayout.DEFAULT_SIZE, 661, Short.MAX_VALUE));
+		groupLayout.setVerticalGroup(groupLayout.createParallelGroup(Alignment.LEADING)
+				.addGroup(groupLayout.createSequentialGroup()
+						.addContainerGap()
+						.addGroup(groupLayout.createParallelGroup(Alignment.BASELINE)
+								.addComponent(this.btnSave)
+								.addComponent(btnSaveAs))
+						.addPreferredGap(ComponentPlacement.RELATED)
+						.addComponent(scrollPane, GroupLayout.DEFAULT_SIZE, 456, Short.MAX_VALUE)));
 
 		this.xmlPane = new JTextPane();
 		this.xmlPane.setContentType("text/xml");
@@ -146,16 +144,16 @@ public class ConfigEditor extends JFrame {
 		});
 	}
 
-	public void showEditor() {
+	void showEditor() {
 		setVisible(true);
 		this.xmlPane.requestFocus();
 	}
 
-	public void closeEditor() {
+	void closeEditor() {
 		setVisible(false);
 	}
 
-	public void saveAs() {
+	private void saveAs() {
 		SaveFileSaver chooser = new SaveFileSaver();
 		chooser.setSelectedFile(this.configFile);
 		int saveResult = chooser.showSaveDialog(null);
@@ -165,7 +163,7 @@ public class ConfigEditor extends JFrame {
 		}
 	}
 
-	public void save() {
+	private void save() {
 		String fullXml = this.xmlPane.getText();
 		try (BufferedWriter writer = IOUtils.getBufferedWriter(this.configFile.getAbsolutePath())) {
 			writer.write(fullXml);
@@ -210,8 +208,12 @@ public class ConfigEditor extends JFrame {
 		});
 
 		// Create keyboard accelerators for undo/redo actions (Ctrl+Z/Ctrl+Y)
-		textPane.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_Z, IS_MAC ? InputEvent.META_DOWN_MASK : InputEvent.CTRL_DOWN_MASK), UNDO_ACTION);
-		textPane.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_Y, IS_MAC ? InputEvent.META_DOWN_MASK : InputEvent.CTRL_DOWN_MASK), REDO_ACTION);
+		textPane.getInputMap()
+				.put(KeyStroke.getKeyStroke(KeyEvent.VK_Z,
+						IS_MAC ? InputEvent.META_DOWN_MASK : InputEvent.CTRL_DOWN_MASK), UNDO_ACTION);
+		textPane.getInputMap()
+				.put(KeyStroke.getKeyStroke(KeyEvent.VK_Y,
+						IS_MAC ? InputEvent.META_DOWN_MASK : InputEvent.CTRL_DOWN_MASK), REDO_ACTION);
 
 		return undoManager;
 	}
@@ -224,7 +226,9 @@ public class ConfigEditor extends JFrame {
 				save();
 			}
 		});
-		this.xmlPane.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_S, IS_MAC ? InputEvent.META_DOWN_MASK : InputEvent.CTRL_DOWN_MASK), SAVE_ACTION);
+		this.xmlPane.getInputMap()
+				.put(KeyStroke.getKeyStroke(KeyEvent.VK_S,
+						IS_MAC ? InputEvent.META_DOWN_MASK : InputEvent.CTRL_DOWN_MASK), SAVE_ACTION);
 	}
 
 	private void addCloseFunctionality() {
@@ -235,7 +239,9 @@ public class ConfigEditor extends JFrame {
 				ConfigEditor.this.setVisible(false);
 			}
 		});
-		this.xmlPane.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_W, IS_MAC ? InputEvent.META_DOWN_MASK : InputEvent.CTRL_DOWN_MASK), CLOSE_ACTION);
+		this.xmlPane.getInputMap()
+				.put(KeyStroke.getKeyStroke(KeyEvent.VK_W,
+						IS_MAC ? InputEvent.META_DOWN_MASK : InputEvent.CTRL_DOWN_MASK), CLOSE_ACTION);
 	}
 
 	private void loadConfig() {
@@ -253,23 +259,24 @@ public class ConfigEditor extends JFrame {
 		this.xmlPane.setCaretPosition(0);
 	}
 
-	public interface ConfigChangeListener {
+	interface ConfigChangeListener {
 		void configChanged(File newConfigFile);
 	}
 
-	/** XmlEditorKit based on https://boplicity.nl/knowledgebase/Java/Xml+syntax+highlighting+in+Swing+JTextPane.html
-	 *
+	/**
+	 * XmlEditorKit based on https://boplicity.nl/knowledgebase/Java/Xml+syntax+highlighting+in+Swing+JTextPane.html
+	 * <p>
 	 * Copyright 2006-2008 Kees de Kooter
 	 * Licensed under the Apache License, Version 2.0
 	 */
 
-	public static class XmlEditorKit extends StyledEditorKit {
+	private static class XmlEditorKit extends StyledEditorKit {
 
 		private static final long serialVersionUID = 2969169649596107757L;
 		private ViewFactory xmlViewFactory;
 
 		public XmlEditorKit() {
-			xmlViewFactory = new XmlViewFactory();
+			xmlViewFactory = XmlView::new;
 		}
 
 		@Override
@@ -283,30 +290,17 @@ public class ConfigEditor extends JFrame {
 		}
 	}
 
-	public static class XmlViewFactory implements ViewFactory {
-
-		/**
-		 * @see javax.swing.text.ViewFactory#create(javax.swing.text.Element)
-		 */
-		public View create(Element element) {
-
-			return new XmlView(element);
-		}
-
-	}
-
 	/**
 	 * Thanks: http://groups.google.com/group/de.comp.lang.java/msg/2bbeb016abad270
-	 *
+	 * <p>
 	 * IMPORTANT NOTE: regex should contain 1 group.
-	 *
+	 * <p>
 	 * Using PlainView here because we don't want line wrapping to occur.
 	 *
 	 * @author kees
 	 * date 13-jan-2006
-	 *
 	 */
-	public static class XmlView extends PlainView {
+	private static class XmlView extends PlainView {
 
 		private static HashMap<Pattern, Color> patternColors;
 		private static String TAG_PATTERN = "(</?[a-z\\-]*)\\s?>?";
@@ -322,14 +316,10 @@ public class ConfigEditor extends JFrame {
 			patternColors = new HashMap<>();
 			patternColors.put(Pattern.compile(TAG_CDATA_START), new Color(128, 128, 128));
 			patternColors.put(Pattern.compile(TAG_CDATA_END), new Color(128, 128, 128));
-			patternColors
-					.put(Pattern.compile(TAG_PATTERN), new Color(63, 127, 127));
-			patternColors.put(Pattern.compile(TAG_ATTRIBUTE_PATTERN), new Color(
-					127, 0, 127));
-			patternColors.put(Pattern.compile(TAG_END_PATTERN), new Color(63, 127,
-					127));
-			patternColors.put(Pattern.compile(TAG_ATTRIBUTE_VALUE), new Color(42,
-					0, 255));
+			patternColors.put(Pattern.compile(TAG_PATTERN), new Color(63, 127, 127));
+			patternColors.put(Pattern.compile(TAG_ATTRIBUTE_PATTERN), new Color(127, 0, 127));
+			patternColors.put(Pattern.compile(TAG_END_PATTERN), new Color(63, 127, 127));
+			patternColors.put(Pattern.compile(TAG_ATTRIBUTE_VALUE), new Color(42, 0, 255));
 			patternColors.put(Pattern.compile(TAG_COMMENT), new Color(63, 95, 191));
 		}
 
@@ -342,8 +332,7 @@ public class ConfigEditor extends JFrame {
 		}
 
 		@Override
-		protected int drawUnselectedText(Graphics graphics, int x, int y, int p0,
-																		 int p1) throws BadLocationException {
+		protected int drawUnselectedText(Graphics graphics, int x, int y, int p0, int p1) throws BadLocationException {
 
 			Document doc = getDocument();
 			String text = doc.getText(p0, p1 - p0);

--- a/matsim/src/main/java/org/matsim/run/gui/GUnZipper.java
+++ b/matsim/src/main/java/org/matsim/run/gui/GUnZipper.java
@@ -19,7 +19,7 @@
  *                                                                         *
  * *********************************************************************** */
 
- package org.matsim.run.gui;
+package org.matsim.run.gui;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -45,7 +45,7 @@ import org.apache.log4j.Logger;
 /*package*/ class GUnZipper {
 
 	private final static Logger log = Logger.getLogger(GUnZipper.class);
-	
+
 	public static void gzipFile() {
 		JFileChooser chooser = new JFileChooser();
 		int openResult = chooser.showOpenDialog(null);
@@ -62,7 +62,7 @@ import org.apache.log4j.Logger;
 			}
 		}
 	}
-	
+
 	public static void gunzipFile() {
 		JFileChooser chooser = new JFileChooser();
 		int openResult = chooser.showOpenDialog(null);
@@ -74,65 +74,56 @@ import org.apache.log4j.Logger;
 			int saveResult = chooser.showSaveDialog(null);
 			if (saveResult == JFileChooser.APPROVE_OPTION) {
 				File destFile = chooser.getSelectedFile();
-
 				doGunzip(srcFile, destFile);
 			}
 		}
 	}
-	
+
 	private static void doGzip(final File srcFile, final File destFile) {
-			new Thread(new Runnable() {
-				@Override
-				public void run() {
-					try (FileInputStream srcStream = new FileInputStream(srcFile);
-							FileOutputStream destStream = new FileOutputStream(destFile);
-							BufferedInputStream bSrcStream = new BufferedInputStream(srcStream, 4*1024*1024);
-							BufferedOutputStream bDestStream = new BufferedOutputStream(new GZIPOutputStream(destStream, 64*1024), 4*1024*1024)) {
-						AsyncFileInputProgressDialog gui = new AsyncFileInputProgressDialog(srcStream);
-						try {
-							doCopy(bSrcStream, bDestStream); 
-						} finally {
-							gui.close();
-						}
-					} catch (IOException e) {
-						log.error(e.getMessage(), e);
-						JOptionPane.showMessageDialog(null,
-						    e.getMessage(),
-						    "Error while gzipping",
-						    JOptionPane.ERROR_MESSAGE);
-					}
-				}
-			}, "gzipper").start();
+		AsyncFileInputProgressDialog gui = new AsyncFileInputProgressDialog();
+		new Thread(() -> {
+			try (FileInputStream srcStream = new FileInputStream(srcFile);
+					FileOutputStream destStream = new FileOutputStream(destFile);
+					BufferedInputStream bSrcStream = new BufferedInputStream(srcStream, 4 * 1024 * 1024);
+					BufferedOutputStream bDestStream = new BufferedOutputStream(
+							new GZIPOutputStream(destStream, 64 * 1024), 4 * 1024 * 1024)) {
+				gui.observeProgress(srcStream);
+				doCopy(bSrcStream, bDestStream);
+				SwingUtilities.invokeLater(gui::dispose);
+			} catch (IOException e) {
+				log.error(e.getMessage(), e);
+				SwingUtilities.invokeLater(gui::dispose);
+				SwingUtilities.invokeLater(
+						() -> JOptionPane.showMessageDialog(null, e.getMessage(), "Error while gzipping",
+								JOptionPane.ERROR_MESSAGE));
+			}
+		}, "gzipper").start();
 	}
 
 	private static void doGunzip(final File srcFile, final File destFile) {
-		new Thread(new Runnable() {
-			@Override
-			public void run() {
-				try (FileInputStream srcStream = new FileInputStream(srcFile);
-						FileOutputStream destStream = new FileOutputStream(destFile);
-						BufferedInputStream bSrcStream = new BufferedInputStream(new GZIPInputStream(srcStream, 64*1024), 4*1024*1024);
-						BufferedOutputStream bDestStream = new BufferedOutputStream(destStream, 4*1024*1024)) {
-					AsyncFileInputProgressDialog gui = new AsyncFileInputProgressDialog(srcStream);
-					try {
-						doCopy(bSrcStream, bDestStream);
-					} finally {
-						gui.close();
-					}
-				} catch (IOException e) {
-					log.error(e.getMessage(), e);
-					JOptionPane.showMessageDialog(null,
-							e.getMessage(),
-							"Error while gunzipping",
-							JOptionPane.ERROR_MESSAGE);
-				}
+		AsyncFileInputProgressDialog gui = new AsyncFileInputProgressDialog();
+		new Thread(() -> {
+			try (FileInputStream srcStream = new FileInputStream(srcFile);
+					FileOutputStream destStream = new FileOutputStream(destFile);
+					BufferedInputStream bSrcStream = new BufferedInputStream(new GZIPInputStream(srcStream, 64 * 1024),
+							4 * 1024 * 1024);
+					BufferedOutputStream bDestStream = new BufferedOutputStream(destStream, 4 * 1024 * 1024)) {
+				gui.observeProgress(srcStream);
+				doCopy(bSrcStream, bDestStream);
+				SwingUtilities.invokeLater(gui::dispose);
+			} catch (IOException e) {
+				log.error(e.getMessage(), e);
+				SwingUtilities.invokeLater(gui::dispose);
+				SwingUtilities.invokeLater(
+						() -> JOptionPane.showMessageDialog(null, e.getMessage(), "Error while gunzipping",
+								JOptionPane.ERROR_MESSAGE));
 			}
 		}, "gunzipper").start();
-			
+
 	}
 
 	private static void doCopy(InputStream src, OutputStream dest) throws IOException {
-		byte[] buffer = new byte[64*1024];
+		byte[] buffer = new byte[64 * 1024];
 		int bytesRead;
 		while ((bytesRead = src.read(buffer)) != -1) {
 			dest.write(buffer, 0, bytesRead);
@@ -141,19 +132,16 @@ import org.apache.log4j.Logger;
 	}
 
 	public static void main(String[] args) throws Throwable {
-		final JFrame frame = new JFrame();
-		frame.setBounds(100, 100, 600, 500);
-		SwingUtilities.invokeLater(new Runnable() {
-			@Override
-			public void run() {
-				frame.setVisible(true);
-				System.out.println("let's go");
-				gzipFile();
-				System.out.println("let's continue");
-				gunzipFile();
-				System.out.println("and we're done");
-				frame.setVisible(false);
-			}
+		SwingUtilities.invokeLater(() -> {
+			final JFrame frame = new JFrame();
+			frame.setBounds(100, 100, 600, 500);
+			frame.setVisible(true);
+			System.out.println("let's go");
+			gzipFile();
+			System.out.println("let's continue");
+			gunzipFile();
+			System.out.println("and we're done");
+			frame.dispose();
 		});
-	}	
+	}
 }

--- a/matsim/src/main/java/org/matsim/run/gui/Gui.java
+++ b/matsim/src/main/java/org/matsim/run/gui/Gui.java
@@ -19,14 +19,13 @@
  *                                                                         *
  * *********************************************************************** */
 
- package org.matsim.run.gui;
+package org.matsim.run.gui;
 
-import org.matsim.core.config.Config;
-import org.matsim.core.config.ConfigUtils;
-import org.matsim.core.config.ConfigWriter;
-import org.matsim.core.gbl.Gbl;
-import org.matsim.core.utils.io.IOUtils;
-import org.matsim.run.Controler;
+import java.awt.Desktop;
+import java.io.File;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import javax.swing.GroupLayout;
 import javax.swing.GroupLayout.Alignment;
@@ -45,22 +44,25 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.LayoutStyle.ComponentPlacement;
 import javax.swing.SwingUtilities;
-import java.awt.Desktop;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.io.File;
-import java.io.IOException;
-import java.util.LinkedHashMap;
-import java.util.Map;
+
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.config.ConfigWriter;
+import org.matsim.core.gbl.Gbl;
+import org.matsim.core.utils.io.IOUtils;
+import org.matsim.run.Controler;
+
+import com.google.common.base.Preconditions;
 
 /**
  * @author mrieser / Senozon AG
  */
 public class Gui extends JFrame {
-	
+
 	private static final long serialVersionUID = 1L;
-	
-	private static final JLabel lblFilepaths = new JLabel("Filepaths must either be absolute or relative to the location of the config file.") ;
+
+	private static final JLabel lblFilepaths = new JLabel(
+			"Filepaths must either be absolute or relative to the location of the config file.");
 	private static final JLabel lblJavaLocation = new JLabel("Java Location:");
 	private static final JLabel lblConfigurationFile = new JLabel("Configuration file:");
 	private static final JLabel lblOutputDirectory = new JLabel("Output Directory:");
@@ -68,25 +70,27 @@ public class Gui extends JFrame {
 	private static final JLabel lblMb = new JLabel("MB");
 	private static final JLabel lblYouAreUsingJavaVersion = new JLabel("You are using Java version:");
 	private static final JLabel lblYouAreUsingMATSimVersion = new JLabel("You are using MATSim version:");
-	
+
 	private JTextField txtConfigfilename;
 	private JTextField txtMatsimversion;
 	private JTextField txtRam;
 	private JTextField txtJvmversion;
 	private JTextField txtJvmlocation;
 	private JTextField txtOutput;
-	
+
 	private JButton btnStartMatsim;
 	private JProgressBar progressBar;
-	
+
 	private JTextArea textStdOut;
 	private JScrollPane scrollPane;
 	private JButton btnEdit;
-	
-	Map<String,JButton> preprocessButtons = new LinkedHashMap<>(  ) ;
-	Map<String,JButton> postprocessButtons = new LinkedHashMap<>(  ) ;
 
-	private ExeRunner exeRunner = null;
+	Map<String, JButton> preprocessButtons = new LinkedHashMap<>();
+	Map<String, JButton> postprocessButtons = new LinkedHashMap<>();
+
+	// volatile because set outside EDT (AWT thread), but EDT checks if it is null
+	private volatile ExeRunner exeRunner = null;
+
 	private JMenuBar menuBar;
 	private JMenu mnTools;
 	private JMenuItem mntmCompressFile;
@@ -102,269 +106,278 @@ public class Gui extends JFrame {
 	private File lastUsedDirectory;
 	private ConfigEditor editor = null;
 	private ScheduleValidatorWindow transitValidator = null;
-	
+
 	private Gui(final String title, final Class<?> mainClass) {
-		setTitle( title );
+		setTitle(title);
 		this.mainClass = mainClass.getCanonicalName();
+		setDefaultCloseOperation(DISPOSE_ON_CLOSE);
 	}
-	
+
 	private void createLayout() {
-		
-		this.lastUsedDirectory = new File( "." );
-		
+		this.lastUsedDirectory = new File(".");
+
 		txtConfigfilename = new JTextField();
-		txtConfigfilename.setText( "" );
-		txtConfigfilename.setColumns( 10 );
-		
-		btnStartMatsim = new JButton( "Start MATSim" );
-		btnStartMatsim.setEnabled( false );
-		
-		for ( JButton button : preprocessButtons.values() ) {
-			button.setEnabled( false );
+		txtConfigfilename.setText("");
+		txtConfigfilename.setColumns(10);
+
+		btnStartMatsim = new JButton("Start MATSim");
+		btnStartMatsim.setEnabled(false);
+
+		for (JButton button : preprocessButtons.values()) {
+			button.setEnabled(false);
 		}
-		for ( JButton button : postprocessButtons.values() ) {
-			button.setEnabled( false );
+		for (JButton button : postprocessButtons.values()) {
+			button.setEnabled(false);
 		}
-		
-		JButton btnChoose = new JButton( "Choose" );
-		btnChoose.addActionListener( new ActionListener() {
-			@Override
-			public void actionPerformed( ActionEvent e ) {
-				JFileChooser chooser = new JFileChooser();
-				chooser.setCurrentDirectory( Gui.this.lastUsedDirectory );
-				int result = chooser.showOpenDialog( null );
-				if ( result == JFileChooser.APPROVE_OPTION ) {
-					File f = chooser.getSelectedFile();
-					Gui.this.lastUsedDirectory = f.getParentFile();
-					loadConfigFile( f );
-					if ( Gui.this.editor != null ) {
-						Gui.this.editor.closeEditor();
-						Gui.this.editor = null;
-					}
+
+		JButton btnChoose = new JButton("Choose");
+		btnChoose.addActionListener(e -> {
+			JFileChooser chooser = new JFileChooser();
+			chooser.setCurrentDirectory(lastUsedDirectory);
+			int result = chooser.showOpenDialog(null);
+			if (result == JFileChooser.APPROVE_OPTION) {
+				File f = chooser.getSelectedFile();
+				lastUsedDirectory = f.getParentFile();
+				loadConfigFile(f);
+				if (editor != null) {
+					editor.closeEditor();
+					editor = null;
 				}
 			}
-		} );
-		
-		this.btnEdit = new JButton( "Edit…" );
-		this.btnEdit.setEnabled( false );
-		this.btnEdit.addActionListener( e -> {
-			if ( Gui.this.editor == null ) {
-				this.editor = new ConfigEditor( Gui.this.configFile, Gui.this::loadConfigFile );
+		});
+
+		this.btnEdit = new JButton("Edit…");
+		this.btnEdit.setEnabled(false);
+		this.btnEdit.addActionListener(e -> {
+			if (editor == null) {
+				this.editor = new ConfigEditor(this, configFile, Gui.this::loadConfigFile);
 			}
-			Gui.this.editor.showEditor();
-			Gui.this.editor.toFront();
-		} );
-		
+			editor.showEditor();
+			editor.toFront();
+		});
+
 		txtMatsimversion = new JTextField();
-		txtMatsimversion.setEditable( false );
-		txtMatsimversion.setText( Gbl.getBuildInfoString() );
-		txtMatsimversion.setColumns( 10 );
-		
-		
+		txtMatsimversion.setEditable(false);
+		txtMatsimversion.setText(Gbl.getBuildInfoString());
+		txtMatsimversion.setColumns(10);
+
 		txtRam = new JTextField();
-		txtRam.setText( "1024" );
-		txtRam.setColumns( 10 );
-		
-		String javaVersion = System.getProperty( "java.version" ) + "; "
-							   + System.getProperty( "java.vm.vendor" ) + "; "
-							   + System.getProperty( "java.vm.info" ) + "; "
-							   + System.getProperty( "sun.arch.data.model" ) + "-bit";
-		
+		txtRam.setText("1024");
+		txtRam.setColumns(10);
+
+		String javaVersion = System.getProperty("java.version")
+				+ "; "
+				+ System.getProperty("java.vm.vendor")
+				+ "; "
+				+ System.getProperty("java.vm.info")
+				+ "; "
+				+ System.getProperty("sun.arch.data.model")
+				+ "-bit";
+
 		txtJvmversion = new JTextField();
-		txtJvmversion.setEditable( false );
-		txtJvmversion.setText( javaVersion );
-		txtJvmversion.setColumns( 10 );
-		
+		txtJvmversion.setEditable(false);
+		txtJvmversion.setText(javaVersion);
+		txtJvmversion.setColumns(10);
+
 		String jvmLocation;
-		if ( System.getProperty( "os.name" ).startsWith( "Win" ) ) {
-			jvmLocation = System.getProperties().getProperty( "java.home" ) + File.separator + "bin" + File.separator + "java.exe";
+		if (System.getProperty("os.name").startsWith("Win")) {
+			jvmLocation = System.getProperties().getProperty("java.home")
+					+ File.separator
+					+ "bin"
+					+ File.separator
+					+ "java.exe";
 		} else {
-			jvmLocation = System.getProperties().getProperty( "java.home" ) + File.separator + "bin" + File.separator + "java";
+			jvmLocation = System.getProperties().getProperty("java.home")
+					+ File.separator
+					+ "bin"
+					+ File.separator
+					+ "java";
 		}
-		
+
 		txtJvmlocation = new JTextField();
-		txtJvmlocation.setEditable( false );
-		txtJvmlocation.setText( jvmLocation );
-		txtJvmlocation.setColumns( 10 );
-		
+		txtJvmlocation.setEditable(false);
+		txtJvmlocation.setText(jvmLocation);
+		txtJvmlocation.setColumns(10);
+
 		txtOutput = new JTextField();
-		txtOutput.setEditable( false );
-		txtOutput.setText( "" );
-		txtOutput.setColumns( 10 );
-		
+		txtOutput.setEditable(false);
+		txtOutput.setText("");
+		txtOutput.setColumns(10);
+
 		progressBar = new JProgressBar();
-		progressBar.setEnabled( false );
-		progressBar.setIndeterminate( true );
-		progressBar.setVisible( false );
-		
-		btnStartMatsim.addActionListener( new ActionListener() {
-			@Override
-			public void actionPerformed( ActionEvent e ) {
-				if ( exeRunner == null ) {
-					startMATSim();
-				} else {
-					stopMATSim();
+		progressBar.setEnabled(false);
+		progressBar.setIndeterminate(true);
+		progressBar.setVisible(false);
+
+		btnStartMatsim.addActionListener(e -> {
+			if (exeRunner == null) {
+				startMATSim();
+			} else {
+				stopMATSim();
+			}
+		});
+
+		JButton btnOpen = new JButton("Open");
+		btnOpen.addActionListener(e -> {
+			if (!txtOutput.getText().isEmpty()) {
+				try {
+					File f = new File(txtOutput.getText());
+					Desktop.getDesktop().open(f);
+				} catch (IOException ex) {
+					ex.printStackTrace();
 				}
 			}
-		} );
-		
-		JButton btnOpen = new JButton( "Open" );
-		btnOpen.addActionListener( new ActionListener() {
-			@Override
-			public void actionPerformed( ActionEvent e ) {
-				if ( !Gui.this.txtOutput.getText().isEmpty() ) {
+		});
+
+		JButton btnDelete = new JButton("Delete");
+		btnDelete.addActionListener(e -> {
+			if (!txtOutput.getText().isEmpty()) {
+				int i = JOptionPane.showOptionDialog(Gui.this,
+						"Do you really want to delete the output directory? This action cannot be undone.",
+						"Delete Output Directory", JOptionPane.DEFAULT_OPTION, JOptionPane.WARNING_MESSAGE, null,
+						new String[] { "Cancel", "Delete" }, "Cancel");
+				if (i == 1) {
 					try {
-						File f = new File( Gui.this.txtOutput.getText() );
-						Desktop.getDesktop().open( f );
-					} catch ( IOException ex ) {
+						IOUtils.deleteDirectoryRecursively(new File(txtOutput.getText()).toPath());
+					} catch (Exception ex) {
 						ex.printStackTrace();
 					}
 				}
 			}
-		} );
-		
-		JButton btnDelete = new JButton( "Delete" );
-		btnDelete.addActionListener( new ActionListener() {
-			@Override
-			public void actionPerformed( ActionEvent e ) {
-				if ( !Gui.this.txtOutput.getText().isEmpty() ) {
-					int i = JOptionPane.showOptionDialog( Gui.this, "Do you really want to delete the output directory? This action cannot be undone.", "Delete Output Directory", JOptionPane.DEFAULT_OPTION, JOptionPane.WARNING_MESSAGE, null, new String[]{"Cancel", "Delete"}, "Cancel" );
-					if ( i == 1 ) {
-						try {
-							IOUtils.deleteDirectoryRecursively( new File( Gui.this.txtOutput.getText() ).toPath() );
-						} catch ( Exception ex ) {
-							ex.printStackTrace();
-						}
-					}
-				}
-			}
-		} );
+		});
 
 		JTabbedPane tabbedPane = new JTabbedPane(JTabbedPane.TOP);
-//		scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-		
+		//		scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+
 		GroupLayout groupLayout = new GroupLayout(getContentPane());
-		
+
 		final GroupLayout.SequentialGroup prebuttonsSequentialGroup = groupLayout.createSequentialGroup();
-		final GroupLayout.ParallelGroup prebuttonsParallelGroup = groupLayout.createParallelGroup() ;
-		for ( JButton button : preprocessButtons.values() ) {
-			prebuttonsSequentialGroup.addComponent( button ) ;
-			prebuttonsParallelGroup.addComponent( button ) ;
+		final GroupLayout.ParallelGroup prebuttonsParallelGroup = groupLayout.createParallelGroup();
+		for (JButton button : preprocessButtons.values()) {
+			prebuttonsSequentialGroup.addComponent(button);
+			prebuttonsParallelGroup.addComponent(button);
 		}
 
 		final GroupLayout.SequentialGroup postbuttonsSequentialGroup = groupLayout.createSequentialGroup();
-		final GroupLayout.ParallelGroup postbuttonsParallelGroup = groupLayout.createParallelGroup() ;
-		for ( JButton button : postprocessButtons.values() ) {
-			postbuttonsSequentialGroup.addComponent( button ) ;
-			postbuttonsParallelGroup.addComponent( button ) ;
+		final GroupLayout.ParallelGroup postbuttonsParallelGroup = groupLayout.createParallelGroup();
+		for (JButton button : postprocessButtons.values()) {
+			postbuttonsSequentialGroup.addComponent(button);
+			postbuttonsParallelGroup.addComponent(button);
 		}
-		
-		groupLayout.setHorizontalGroup(
-			groupLayout.createParallelGroup(Alignment.TRAILING)
+
+		groupLayout.setHorizontalGroup(groupLayout.createParallelGroup(Alignment.TRAILING)
 				.addGroup(Alignment.LEADING, groupLayout.createSequentialGroup()
-					.addContainerGap()
-					.addGroup(groupLayout.createParallelGroup(Alignment.LEADING)
-							// a bunch of stuff that can in principle stretch from left to right (although most of it won't):
-						.addComponent(tabbedPane, GroupLayout.DEFAULT_SIZE, 729, Short.MAX_VALUE)
-						.addComponent( lblFilepaths ) // "Filepaths must either ..."
-						.addGroup( prebuttonsSequentialGroup )
-						.addGroup( postbuttonsSequentialGroup )
-						.addGroup(groupLayout.createSequentialGroup()
-							.addGroup(groupLayout.createParallelGroup(Alignment.LEADING)
-									// some stuff that stretches from left to somewhere1:
-								.addComponent( lblYouAreUsingMATSimVersion )
-								.addComponent( lblYouAreUsingJavaVersion )
-								.addComponent(lblJavaLocation)
-								.addComponent(lblConfigurationFile)
-								.addComponent(lblOutputDirectory)
-								.addComponent(lblMemory)
-								.addComponent(btnStartMatsim)
-							)
-								// a gap from somewhere1 to somewhere2:
-							.addPreferredGap(ComponentPlacement.RELATED)
-							.addGroup(groupLayout.createParallelGroup(Alignment.LEADING)
-									// stuff that stretches from somewhere2 to right:
+						.addContainerGap()
+						.addGroup(groupLayout.createParallelGroup(Alignment.LEADING)
+								// a bunch of stuff that can in principle stretch from left to right (although most of it won't):
+								.addComponent(tabbedPane, GroupLayout.DEFAULT_SIZE, 729, Short.MAX_VALUE)
+								.addComponent(lblFilepaths) // "Filepaths must either ..."
+								.addGroup(prebuttonsSequentialGroup)
+								.addGroup(postbuttonsSequentialGroup)
 								.addGroup(groupLayout.createSequentialGroup()
-									.addComponent(txtRam, GroupLayout.PREFERRED_SIZE, 69, GroupLayout.PREFERRED_SIZE)
-									.addPreferredGap(ComponentPlacement.RELATED)
-									.addComponent(lblMb)
-								)
-								.addComponent(txtMatsimversion, GroupLayout.DEFAULT_SIZE, 285, Short.MAX_VALUE)
-								.addComponent(txtJvmversion, GroupLayout.DEFAULT_SIZE, 285, Short.MAX_VALUE)
-								.addComponent(txtJvmlocation, GroupLayout.DEFAULT_SIZE, 285, Short.MAX_VALUE)
-								.addGroup(groupLayout.createSequentialGroup()
-									.addComponent(txtConfigfilename, GroupLayout.DEFAULT_SIZE, 188, Short.MAX_VALUE)
-									.addPreferredGap(ComponentPlacement.RELATED)
-									.addComponent(btnChoose)
-									.addPreferredGap(ComponentPlacement.RELATED)
-									.addComponent(btnEdit)
-								)
-								.addComponent(progressBar, GroupLayout.DEFAULT_SIZE, 285, Short.MAX_VALUE)
-								.addGroup(groupLayout.createSequentialGroup()
-									.addComponent(txtOutput, GroupLayout.DEFAULT_SIZE, 112, Short.MAX_VALUE)
-									.addPreferredGap(ComponentPlacement.RELATED)
-									.addComponent(btnOpen)
-									.addPreferredGap(ComponentPlacement.RELATED)
-									.addComponent(btnDelete)))))
-					.addContainerGap())
-		);
-		groupLayout.setVerticalGroup(
-			groupLayout.createParallelGroup(Alignment.LEADING)
+										.addGroup(groupLayout.createParallelGroup(Alignment.LEADING)
+												// some stuff that stretches from left to somewhere1:
+												.addComponent(lblYouAreUsingMATSimVersion)
+												.addComponent(lblYouAreUsingJavaVersion)
+												.addComponent(lblJavaLocation)
+												.addComponent(lblConfigurationFile)
+												.addComponent(lblOutputDirectory)
+												.addComponent(lblMemory)
+												.addComponent(btnStartMatsim))
+										// a gap from somewhere1 to somewhere2:
+										.addPreferredGap(ComponentPlacement.RELATED)
+										.addGroup(groupLayout.createParallelGroup(Alignment.LEADING)
+												// stuff that stretches from somewhere2 to right:
+												.addGroup(groupLayout.createSequentialGroup()
+														.addComponent(txtRam, GroupLayout.PREFERRED_SIZE, 69,
+																GroupLayout.PREFERRED_SIZE)
+														.addPreferredGap(ComponentPlacement.RELATED)
+														.addComponent(lblMb))
+												.addComponent(txtMatsimversion, GroupLayout.DEFAULT_SIZE, 285,
+														Short.MAX_VALUE)
+												.addComponent(txtJvmversion, GroupLayout.DEFAULT_SIZE, 285,
+														Short.MAX_VALUE)
+												.addComponent(txtJvmlocation, GroupLayout.DEFAULT_SIZE, 285,
+														Short.MAX_VALUE)
+												.addGroup(groupLayout.createSequentialGroup()
+														.addComponent(txtConfigfilename, GroupLayout.DEFAULT_SIZE, 188,
+																Short.MAX_VALUE)
+														.addPreferredGap(ComponentPlacement.RELATED)
+														.addComponent(btnChoose)
+														.addPreferredGap(ComponentPlacement.RELATED)
+														.addComponent(btnEdit))
+												.addComponent(progressBar, GroupLayout.DEFAULT_SIZE, 285,
+														Short.MAX_VALUE)
+												.addGroup(groupLayout.createSequentialGroup()
+														.addComponent(txtOutput, GroupLayout.DEFAULT_SIZE, 112,
+																Short.MAX_VALUE)
+														.addPreferredGap(ComponentPlacement.RELATED)
+														.addComponent(btnOpen)
+														.addPreferredGap(ComponentPlacement.RELATED)
+														.addComponent(btnDelete)))))
+						.addContainerGap()));
+		groupLayout.setVerticalGroup(groupLayout.createParallelGroup(Alignment.LEADING)
 				.addGroup(groupLayout.createSequentialGroup()
-					.addContainerGap()
-					.addGroup(groupLayout.createParallelGroup(Alignment.BASELINE)
-						.addComponent( lblYouAreUsingMATSimVersion )
-						.addComponent(txtMatsimversion, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE))
-					.addPreferredGap(ComponentPlacement.RELATED)
-					.addGroup(groupLayout.createParallelGroup(Alignment.BASELINE)
-						.addComponent( lblYouAreUsingJavaVersion )
-						.addComponent(txtJvmversion, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE))
-					.addPreferredGap(ComponentPlacement.RELATED)
-					.addGroup(groupLayout.createParallelGroup(Alignment.BASELINE)
-						.addComponent(lblJavaLocation)
-						.addComponent(txtJvmlocation, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE))
-					.addPreferredGap(ComponentPlacement.RELATED)
-					.addGroup(groupLayout.createParallelGroup(Alignment.BASELINE)
-						.addComponent(lblConfigurationFile)
-						.addComponent(txtConfigfilename, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
-						.addComponent(btnChoose)
-						.addComponent(btnEdit))
-					.addPreferredGap(ComponentPlacement.RELATED)
-					.addComponent( lblFilepaths )
-					.addPreferredGap(ComponentPlacement.RELATED)
-					.addGroup(groupLayout.createParallelGroup(Alignment.BASELINE)
-						.addComponent(lblOutputDirectory)
-						.addComponent(txtOutput, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
-						.addComponent(btnDelete)
-						.addComponent(btnOpen))
-					.addPreferredGap(ComponentPlacement.RELATED)
-					.addGroup(groupLayout.createParallelGroup(Alignment.BASELINE)
-						.addComponent(lblMemory)
-						.addComponent(txtRam, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
-						.addComponent(lblMb))
-					.addPreferredGap(ComponentPlacement.UNRELATED)
-					.addGroup( prebuttonsParallelGroup )
-					.addPreferredGap(ComponentPlacement.UNRELATED)
-					.addGroup(groupLayout.createParallelGroup(Alignment.LEADING)
-						.addComponent(btnStartMatsim)
-						.addComponent(progressBar, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE))
-					.addPreferredGap(ComponentPlacement.UNRELATED)
-					.addGroup( postbuttonsParallelGroup )
-					.addPreferredGap(ComponentPlacement.RELATED)
-					.addComponent(tabbedPane, GroupLayout.DEFAULT_SIZE, 180, Short.MAX_VALUE)
-					.addContainerGap())
-		);
-		
+						.addContainerGap()
+						.addGroup(groupLayout.createParallelGroup(Alignment.BASELINE)
+								.addComponent(lblYouAreUsingMATSimVersion)
+								.addComponent(txtMatsimversion, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE,
+										GroupLayout.PREFERRED_SIZE))
+						.addPreferredGap(ComponentPlacement.RELATED)
+						.addGroup(groupLayout.createParallelGroup(Alignment.BASELINE)
+								.addComponent(lblYouAreUsingJavaVersion)
+								.addComponent(txtJvmversion, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE,
+										GroupLayout.PREFERRED_SIZE))
+						.addPreferredGap(ComponentPlacement.RELATED)
+						.addGroup(groupLayout.createParallelGroup(Alignment.BASELINE)
+								.addComponent(lblJavaLocation)
+								.addComponent(txtJvmlocation, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE,
+										GroupLayout.PREFERRED_SIZE))
+						.addPreferredGap(ComponentPlacement.RELATED)
+						.addGroup(groupLayout.createParallelGroup(Alignment.BASELINE)
+								.addComponent(lblConfigurationFile)
+								.addComponent(txtConfigfilename, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE,
+										GroupLayout.PREFERRED_SIZE)
+								.addComponent(btnChoose)
+								.addComponent(btnEdit))
+						.addPreferredGap(ComponentPlacement.RELATED)
+						.addComponent(lblFilepaths)
+						.addPreferredGap(ComponentPlacement.RELATED)
+						.addGroup(groupLayout.createParallelGroup(Alignment.BASELINE)
+								.addComponent(lblOutputDirectory)
+								.addComponent(txtOutput, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE,
+										GroupLayout.PREFERRED_SIZE)
+								.addComponent(btnDelete)
+								.addComponent(btnOpen))
+						.addPreferredGap(ComponentPlacement.RELATED)
+						.addGroup(groupLayout.createParallelGroup(Alignment.BASELINE)
+								.addComponent(lblMemory)
+								.addComponent(txtRam, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE,
+										GroupLayout.PREFERRED_SIZE)
+								.addComponent(lblMb))
+						.addPreferredGap(ComponentPlacement.UNRELATED)
+						.addGroup(prebuttonsParallelGroup)
+						.addPreferredGap(ComponentPlacement.UNRELATED)
+						.addGroup(groupLayout.createParallelGroup(Alignment.LEADING)
+								.addComponent(btnStartMatsim)
+								.addComponent(progressBar, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE,
+										GroupLayout.PREFERRED_SIZE))
+						.addPreferredGap(ComponentPlacement.UNRELATED)
+						.addGroup(postbuttonsParallelGroup)
+						.addPreferredGap(ComponentPlacement.RELATED)
+						.addComponent(tabbedPane, GroupLayout.DEFAULT_SIZE, 180, Short.MAX_VALUE)
+						.addContainerGap()));
+
 		textStdOut = new JTextArea();
 		textStdOut.setWrapStyleWord(true);
 		textStdOut.setTabSize(4);
 		textStdOut.setEditable(false);
 		scrollPane = new JScrollPane(textStdOut);
 		tabbedPane.addTab("Output", null, scrollPane, null);
-		
+
 		JScrollPane scrollPane_1 = new JScrollPane();
 		tabbedPane.addTab("Warnings & Errors", null, scrollPane_1, null);
-		
+
 		textErrOut = new JTextArea();
 		textErrOut.setWrapStyleWord(true);
 		textErrOut.setTabSize(4);
@@ -372,67 +385,51 @@ public class Gui extends JFrame {
 		scrollPane_1.setViewportView(textErrOut);
 
 		getContentPane().setLayout(groupLayout);
-		
+
 		menuBar = new JMenuBar();
 		setJMenuBar(menuBar);
-		
+
 		mnTools = new JMenu("Tools");
 		menuBar.add(mnTools);
-		
+
 		mntmCompressFile = new JMenuItem("Compress File…");
 		mnTools.add(mntmCompressFile);
-		mntmCompressFile.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				GUnZipper.gzipFile();
-			}
-		});
-		
+		mntmCompressFile.addActionListener(e -> GUnZipper.gzipFile());
+
 		mntmUncompressFile = new JMenuItem("Uncompress File…");
 		mnTools.add(mntmUncompressFile);
-		mntmUncompressFile.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				GUnZipper.gunzipFile();
-			}
-		});
-		
+		mntmUncompressFile.addActionListener(e -> GUnZipper.gunzipFile());
+
 		mnTools.addSeparator();
-		
+
 		mntmCreateDefaultConfig = new JMenuItem("Create Default config.xml…");
 		mnTools.add(mntmCreateDefaultConfig);
-		mntmCreateDefaultConfig.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				SaveFileSaver chooser = new SaveFileSaver();
-				chooser.setSelectedFile(new File("defaultConfig.xml"));
-				int saveResult = chooser.showSaveDialog(null);
-				if (saveResult == JFileChooser.APPROVE_OPTION) {
-					File destFile = chooser.getSelectedFile();
-					Config config = ConfigUtils.createConfig();
-					new ConfigWriter(config).write(destFile.getAbsolutePath());
-				}
+		mntmCreateDefaultConfig.addActionListener(e -> {
+			SaveFileSaver chooser = new SaveFileSaver();
+			chooser.setSelectedFile(new File("defaultConfig.xml"));
+			int saveResult = chooser.showSaveDialog(null);
+			if (saveResult == JFileChooser.APPROVE_OPTION) {
+				File destFile = chooser.getSelectedFile();
+				Config config = ConfigUtils.createConfig();
+				new ConfigWriter(config).write(destFile.getAbsolutePath());
 			}
 		});
 
 		mntmCreateSamplePopulation = new JMenuItem("Create Sample Population…");
 		mnTools.add(mntmCreateSamplePopulation);
-		mntmCreateSamplePopulation.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				if (popSampler == null) {
-					popSampler = new PopulationSampler();
-					popSampler.pack();
-				}
-				popSampler.setVisible(true);
+		mntmCreateSamplePopulation.addActionListener(e -> {
+			if (popSampler == null) {
+				popSampler = new PopulationSampler(this);
+				popSampler.pack();
 			}
+			popSampler.setVisible(true);
 		});
 
 		JMenuItem mntmTransitValidator = new JMenuItem("Validate TransitSchedule…");
 		this.mnTools.add(mntmTransitValidator);
 		mntmTransitValidator.addActionListener(e -> {
 			if (this.transitValidator == null) {
-				this.transitValidator = new ScheduleValidatorWindow();
+				this.transitValidator = new ScheduleValidatorWindow(this);
 			}
 			String configFilename = this.txtConfigfilename.getText();
 			if (!configFilename.isEmpty()) {
@@ -446,81 +443,74 @@ public class Gui extends JFrame {
 			this.transitValidator.setVisible(true);
 		});
 	}
-	
-	public void startMATSim() {
+
+	private void startMATSim() {
 		progressBar.setVisible(true);
 		progressBar.setEnabled(true);
 		this.btnStartMatsim.setEnabled(false);
 
-		new Thread(new Runnable() {
-			@Override
-			public void run() {
-				String classpath = System.getProperty("java.class.path");
-				String[] cpParts = classpath.split(File.pathSeparator);
-				StringBuilder absoluteClasspath = new StringBuilder();
-				for (String cpPart : cpParts) {
-					if (absoluteClasspath.length() > 0) {
-						absoluteClasspath.append(File.pathSeparatorChar);
-					}
-					absoluteClasspath.append(new File(cpPart).getAbsolutePath());
-				}
-				String[] cmdArgs = new String[] {
-						txtJvmlocation.getText(),
-						"-cp",
-						absoluteClasspath.toString(),
-						"-Xmx" + txtRam.getText() + "m",
-						Gui.this.mainClass,
-						txtConfigfilename.getText()
-				};
-				Gui.this.textStdOut.setText("");
-				Gui.this.textErrOut.setText("");
-				Gui.this.exeRunner = ExeRunner.run(cmdArgs, Gui.this.textStdOut, Gui.this.textErrOut, new File(txtConfigfilename.getText()).getParent());
-				Gui.this.btnStartMatsim.setText("Stop MATSim");
-				Gui.this.btnStartMatsim.setEnabled(true);
-				int exitcode = exeRunner.waitForFinish();
-				Gui.this.exeRunner = null;
+		textStdOut.setText("");
+		textErrOut.setText("");
 
-				SwingUtilities.invokeLater(new Runnable() {
-					@Override
-					public void run() {
-						progressBar.setVisible(false);
-						btnStartMatsim.setText("Start MATSim");
-						btnStartMatsim.setEnabled(true);
-					}
-				});
-
-				if (exitcode != 0) {
-					Gui.this.textStdOut.append("\n");
-					Gui.this.textStdOut.append("The simulation did not run properly. Error/Exit code: " + exitcode);
-					Gui.this.textStdOut.setCaretPosition(Gui.this.textStdOut.getDocument().getLength());
-					Gui.this.textErrOut.append("\n");
-					Gui.this.textErrOut.append("The simulation did not run properly. Error/Exit code: " + exitcode);
-					Gui.this.textErrOut.setCaretPosition(Gui.this.textStdOut.getDocument().getLength());
-					throw new RuntimeException("There was a problem running MATSim. exit code: " + exitcode);
+		new Thread(() -> {
+			String classpath = System.getProperty("java.class.path");
+			String[] cpParts = classpath.split(File.pathSeparator);
+			StringBuilder absoluteClasspath = new StringBuilder();
+			for (String cpPart : cpParts) {
+				if (absoluteClasspath.length() > 0) {
+					absoluteClasspath.append(File.pathSeparatorChar);
 				}
+				absoluteClasspath.append(new File(cpPart).getAbsolutePath());
 			}
+			String[] cmdArgs = new String[] { txtJvmlocation.getText(), "-cp", absoluteClasspath.toString(),
+					"-Xmx" + txtRam.getText() + "m", mainClass, txtConfigfilename.getText() };
+			exeRunner = ExeRunner.run(cmdArgs, textStdOut, textErrOut,
+					new File(txtConfigfilename.getText()).getParent());
+			int exitcode = exeRunner.waitForFinish();
+			exeRunner = null;
+
+			SwingUtilities.invokeLater(() -> {
+				progressBar.setVisible(false);
+				btnStartMatsim.setText("Start MATSim");
+				btnStartMatsim.setEnabled(true);
+				if (exitcode != 0) {
+					textStdOut.append("\n");
+					textStdOut.append("The simulation did not run properly. Error/Exit code: " + exitcode);
+					textStdOut.setCaretPosition(textStdOut.getDocument().getLength());
+					textErrOut.append("\n");
+					textErrOut.append("The simulation did not run properly. Error/Exit code: " + exitcode);
+					textErrOut.setCaretPosition(textErrOut.getDocument().getLength());
+				}
+			});
+
+			if (exitcode != 0) {
+				throw new RuntimeException("There was a problem running MATSim. exit code: " + exitcode);
+			}
+
 		}).start();
-		
+
+		btnStartMatsim.setText("Stop MATSim");
+		btnStartMatsim.setEnabled(true);
 	}
-	
+
 	public void loadConfigFile(final File configFile) {
 		this.configFile = configFile;
 		String configFilename = configFile.getAbsolutePath();
-		
+
 		Config config = ConfigUtils.createConfig();
 		try {
 			ConfigUtils.loadConfig(config, configFilename);
 		} catch (Exception e) {
-			Gui.this.textStdOut.setText("");
-			Gui.this.textStdOut.append("The configuration file could not be loaded. Error message:\n");
-			Gui.this.textStdOut.append(e.getMessage());
-			Gui.this.textErrOut.setText("");
-			Gui.this.textErrOut.append("The configuration file could not be loaded. Error message:\n");
-			Gui.this.textErrOut.append(e.getMessage());
+			textStdOut.setText("");
+			textStdOut.append("The configuration file could not be loaded. Error message:\n");
+			textStdOut.append(e.getMessage());
+			textErrOut.setText("");
+			textErrOut.append("The configuration file could not be loaded. Error message:\n");
+			textErrOut.append(e.getMessage());
 			return;
 		}
 		txtConfigfilename.setText(configFilename);
-		
+
 		File par = configFile.getParentFile();
 		File outputDir = new File(par, config.controler().getOutputDirectory());
 		try {
@@ -528,108 +518,101 @@ public class Gui extends JFrame {
 		} catch (IOException e1) {
 			txtOutput.setText(outputDir.getAbsolutePath());
 		}
-		
+
 		btnStartMatsim.setEnabled(true);
 		btnEdit.setEnabled(true);
-		for ( JButton button : preprocessButtons.values() ) {
-			button.setEnabled( true );
+		for (JButton button : preprocessButtons.values()) {
+			button.setEnabled(true);
 		}
-		for ( JButton button : postprocessButtons.values() ) {
-			button.setEnabled( true );
+		for (JButton button : postprocessButtons.values()) {
+			button.setEnabled(true);
 		}
 	}
 
-	public void stopMATSim() {
+	private void stopMATSim() {
 		ExeRunner runner = this.exeRunner;
 		if (runner != null) {
 			runner.killProcess();
-			SwingUtilities.invokeLater(new Runnable() {
-				@Override
-				public void run() {
-					progressBar.setVisible(false);
-					btnStartMatsim.setText("Start MATSim");
-					btnStartMatsim.setEnabled(true);
-					
-					Gui.this.textStdOut.append("\n");
-					Gui.this.textStdOut.append("The simulation was stopped forcefully.");
-					Gui.this.textStdOut.setCaretPosition(Gui.this.textStdOut.getDocument().getLength());
-					Gui.this.textErrOut.append("\n");
-					Gui.this.textErrOut.append("The simulation was stopped forcefully.");
-					Gui.this.textErrOut.setCaretPosition(Gui.this.textStdOut.getDocument().getLength());
-				}
-			});
+
+			//TODO Double check if this works
+			exeRunner = null;
+
+			progressBar.setVisible(false);
+			btnStartMatsim.setText("Start MATSim");
+			btnStartMatsim.setEnabled(true);
+
+			textStdOut.append("\n");
+			textStdOut.append("The simulation was stopped forcefully.");
+			textStdOut.setCaretPosition(textStdOut.getDocument().getLength());
+			textErrOut.append("\n");
+			textErrOut.append("The simulation was stopped forcefully.");
+			textErrOut.setCaretPosition(textErrOut.getDocument().getLength());
 		}
 	}
-	
-	public static Gui show(final String title, final Class<?> mainClass) {
-		Gui gui = create( title, mainClass );
-		gui.run() ;
-		return gui;
+
+	public static void show(final String title, final Class<?> mainClass) {
+		show(title, mainClass, null);
 	}
-	
-	public  void run(  ) {
-		this.createLayout();
-		this.pack();
-		this.setLocationByPlatform(true);
-		this.setVisible(true);
-	}
-	
-	public static Gui create( final String title, final Class<?> mainClass ) {
+
+	public static void show(final String title, final Class<?> mainClass, File configFile) {
 		System.setProperty("apple.laf.useScreenMenuBar", "true");
-		
-		return new Gui(title, mainClass);
-	}
-	
-	public static void main(String[] args) {
-		Gui gui = Gui.show("MATSim", Controler.class);
-		if (args.length > 0) {
-			File configFile = new File(args[0]);
-			if (configFile.exists()) {
+
+		SwingUtilities.invokeLater(() -> {
+			Gui gui = new Gui(title, mainClass);
+			gui.createLayout();
+			gui.pack();
+			gui.setLocationByPlatform(true);
+			gui.setVisible(true);
+			if (configFile != null && configFile.exists()) {
 				gui.loadConfigFile(configFile);
 			}
-		}
+		});
 	}
-	
+
+	public static void main(String[] args) {
+		Preconditions.checkArgument(args.length < 2);
+		Gui.show("MATSim", Controler.class, args.length == 1 ? new File(args[0]) : null);
+	}
+
 	// Is it a problem to make the following available to the outside?  If so, why?  Would it
 	// be better to rather copy/paste the above code and start from there?  kai, jun/aug'18
-	
-	final JMenu getToolsMenu() {
-		// Is it a problem to make this available?  If so, why?  kai, jun'18
-		return this.mnTools ;
-	}
-	final void addToMenuBar(JMenu menuItem) {
-		this.menuBar.add(menuItem) ;
-	}
-	final void addPreprocessButton( String str, JButton button ) {
-		this.preprocessButtons.put( str, button );
-	}
-	
-	/**
-	 * @param str -- name.  These are named so that they can be replaced, and in theory removed.  Maybe not necessary. kai, sep'18
-	 * @param button
-	 */
-	final void addPostprocessButton( String str, JButton button ) {
-		this.postprocessButtons.put( str, button );
-	}
-	JTextArea getTextStdOut() {
-		return textStdOut;
-	}
-	JTextArea getTextErrOut() {
-		return textErrOut;
-	}
-	JTextField getTxtJvmlocation() {
-		return txtJvmlocation ;
-	}
-	JTextField getTxtRam() {
-		return this.txtRam ;
-	}
-//	@Deprecated // this should not be necessary. kai, aug'18
-//	String getMainClass() {
-//		return this.mainClass ;
-//	}
-	JTextField getTxtConfigfilename() {
-		return this.txtConfigfilename ;
-	}
-	
-	
+
+	//	final JMenu getToolsMenu() {
+	//		// Is it a problem to make this available?  If so, why?  kai, jun'18
+	//		return this.mnTools ;
+	//	}
+	//	final void addToMenuBar(JMenu menuItem) {
+	//		this.menuBar.add(menuItem) ;
+	//	}
+	//	final void addPreprocessButton( String str, JButton button ) {
+	//		this.preprocessButtons.put( str, button );
+	//	}
+	//
+	//	/**
+	//	 * @param str -- name.  These are named so that they can be replaced, and in theory removed.  Maybe not necessary. kai, sep'18
+	//	 * @param button
+	//	 */
+	//	final void addPostprocessButton( String str, JButton button ) {
+	//		this.postprocessButtons.put( str, button );
+	//	}
+	//	JTextArea getTextStdOut() {
+	//		return textStdOut;
+	//	}
+	//	JTextArea getTextErrOut() {
+	//		return textErrOut;
+	//	}
+	//	JTextField getTxtJvmlocation() {
+	//		return txtJvmlocation ;
+	//	}
+	//	JTextField getTxtRam() {
+	//		return this.txtRam ;
+	//	}
+	//	@Deprecated // this should not be necessary. kai, aug'18
+	//	String getMainClass() {
+	//		return this.mainClass ;
+	//	}
+	//	JTextField getTxtConfigfilename() {
+	//		return this.txtConfigfilename ;
+	//	}
+
 }

--- a/matsim/src/main/java/org/matsim/run/gui/PopulationSampler.java
+++ b/matsim/src/main/java/org/matsim/run/gui/PopulationSampler.java
@@ -19,22 +19,19 @@
  *                                                                         *
  * *********************************************************************** */
 
- package org.matsim.run.gui;
+package org.matsim.run.gui;
 
-import com.github.luben.zstd.ZstdInputStream;
-import org.matsim.core.config.ConfigUtils;
-import org.matsim.core.network.io.MatsimNetworkReader;
-import org.matsim.core.population.algorithms.PersonAlgorithm;
-import org.matsim.core.population.io.StreamingPopulationReader;
-import org.matsim.core.population.io.StreamingPopulationWriter;
-import org.matsim.core.scenario.MutableScenario;
-import org.matsim.core.scenario.ScenarioUtils;
-import org.matsim.core.utils.geometry.transformations.IdentityTransformation;
-import org.matsim.core.utils.io.UnicodeInputStream;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Locale;
+import java.util.zip.GZIPInputStream;
 
 import javax.swing.GroupLayout;
 import javax.swing.GroupLayout.Alignment;
 import javax.swing.JButton;
+import javax.swing.JDialog;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
@@ -43,19 +40,26 @@ import javax.swing.JSpinner;
 import javax.swing.JTextField;
 import javax.swing.LayoutStyle.ComponentPlacement;
 import javax.swing.SpinnerNumberModel;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.Locale;
-import java.util.zip.GZIPInputStream;
+import javax.swing.SwingUtilities;
+
+import org.apache.log4j.Logger;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.network.io.MatsimNetworkReader;
+import org.matsim.core.population.io.StreamingPopulationReader;
+import org.matsim.core.population.io.StreamingPopulationWriter;
+import org.matsim.core.scenario.MutableScenario;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.core.utils.geometry.transformations.IdentityTransformation;
+import org.matsim.core.utils.io.UnicodeInputStream;
+
+import com.github.luben.zstd.ZstdInputStream;
 
 /**
  * @author mrieser / Senozon AG
  */
-public final class PopulationSampler extends JFrame {
+final class PopulationSampler extends JDialog {
+
+	private final static Logger log = Logger.getLogger(PopulationSampler.class);
 
 	private static final long serialVersionUID = 1L;
 
@@ -63,90 +67,79 @@ public final class PopulationSampler extends JFrame {
 	private JSpinner pctSpinner;
 	private JButton btnChoose;
 	private JButton btnCreateSample;
-	
-	public PopulationSampler() {
+
+	PopulationSampler(JFrame parent) {
+		super(parent);
 		setTitle("Create Population Sample");
-		
+
 		this.btnChoose = new JButton("Choose…");
-		
+
 		JLabel lblinput = new JLabel("Input Population:");
 		this.txtPath = new JTextField("");
 		JLabel lblpercentage = new JLabel("Sample Size:");
 		this.pctSpinner = new JSpinner(new SpinnerNumberModel(10, 1, 100, 1));
 		JLabel lblPercentage = new JLabel("%");
 		btnCreateSample = new JButton("Create Sample…");
-		
+
 		GroupLayout groupLayout = new GroupLayout(getContentPane());
-		groupLayout.setHorizontalGroup(
-			groupLayout.createParallelGroup(Alignment.LEADING)
+		groupLayout.setHorizontalGroup(groupLayout.createParallelGroup(Alignment.LEADING)
 				.addGroup(groupLayout.createSequentialGroup()
-					.addContainerGap()
-					.addGroup(groupLayout.createParallelGroup(Alignment.LEADING)
-						.addGroup(groupLayout.createSequentialGroup()
-							.addGroup(groupLayout.createParallelGroup(Alignment.LEADING)
+						.addContainerGap()
+						.addGroup(groupLayout.createParallelGroup(Alignment.LEADING)
+								.addGroup(groupLayout.createSequentialGroup()
+										.addGroup(groupLayout.createParallelGroup(Alignment.LEADING)
+												.addComponent(lblinput)
+												.addComponent(lblpercentage))
+										.addPreferredGap(ComponentPlacement.RELATED)
+										.addGroup(groupLayout.createParallelGroup(Alignment.LEADING)
+												.addGroup(groupLayout.createSequentialGroup()
+														.addComponent(pctSpinner, GroupLayout.PREFERRED_SIZE,
+																GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE)
+														.addPreferredGap(ComponentPlacement.RELATED)
+														.addComponent(lblPercentage, GroupLayout.DEFAULT_SIZE,
+																GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE)
+														.addGap(0, 20, Short.MAX_VALUE))
+												.addGroup(groupLayout.createSequentialGroup()
+														.addComponent(txtPath, GroupLayout.DEFAULT_SIZE, 170,
+																Short.MAX_VALUE)
+														.addPreferredGap(ComponentPlacement.RELATED)
+														.addComponent(btnChoose))))
+								.addComponent(btnCreateSample, Alignment.TRAILING))
+						.addContainerGap()));
+		groupLayout.setVerticalGroup(groupLayout.createParallelGroup(Alignment.LEADING)
+				.addGroup(groupLayout.createSequentialGroup()
+						.addContainerGap()
+						.addGroup(groupLayout.createParallelGroup(Alignment.BASELINE)
+								.addComponent(btnChoose)
 								.addComponent(lblinput)
-								.addComponent(lblpercentage))
-							.addPreferredGap(ComponentPlacement.RELATED)
-							.addGroup(groupLayout.createParallelGroup(Alignment.LEADING)
-								.addGroup(groupLayout.createSequentialGroup()
-									.addComponent(pctSpinner, GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE, GroupLayout.PREFERRED_SIZE)
-									.addPreferredGap(ComponentPlacement.RELATED)
-									.addComponent(lblPercentage, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE)
-									.addGap(0, 20, Short.MAX_VALUE))
-								.addGroup(groupLayout.createSequentialGroup()
-									.addComponent(txtPath, GroupLayout.DEFAULT_SIZE, 170, Short.MAX_VALUE)
-									.addPreferredGap(ComponentPlacement.RELATED)
-									.addComponent(btnChoose))))
-						.addComponent(btnCreateSample, Alignment.TRAILING))
-					.addContainerGap())
-		);
-		groupLayout.setVerticalGroup(
-			groupLayout.createParallelGroup(Alignment.LEADING)
-				.addGroup(groupLayout.createSequentialGroup()
-					.addContainerGap()
-					.addGroup(groupLayout.createParallelGroup(Alignment.BASELINE)
-						.addComponent(btnChoose)
-						.addComponent(lblinput)
-						.addComponent(txtPath))
-					.addPreferredGap(ComponentPlacement.RELATED)
-					.addGroup(groupLayout.createParallelGroup(Alignment.BASELINE)
-						.addComponent(lblpercentage)
-						.addComponent(lblPercentage)
-						.addComponent(pctSpinner))
-					.addPreferredGap(ComponentPlacement.UNRELATED)
-					.addComponent(btnCreateSample)
-					.addContainerGap())
-		);
+								.addComponent(txtPath))
+						.addPreferredGap(ComponentPlacement.RELATED)
+						.addGroup(groupLayout.createParallelGroup(Alignment.BASELINE)
+								.addComponent(lblpercentage)
+								.addComponent(lblPercentage)
+								.addComponent(pctSpinner))
+						.addPreferredGap(ComponentPlacement.UNRELATED)
+						.addComponent(btnCreateSample)
+						.addContainerGap()));
 		getContentPane().setLayout(groupLayout);
-		
+
 		setupComponents();
 	}
-	
+
 	private void setupComponents() {
-		this.btnChoose.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				JFileChooser chooser = new JFileChooser();
-				int result = chooser.showOpenDialog(null);
-				if (result == JFileChooser.APPROVE_OPTION) {
-					File f = chooser.getSelectedFile();
-					String filename = f.getAbsolutePath();
-					PopulationSampler.this.txtPath.setText(filename);
-				}
+		this.btnChoose.addActionListener(e -> {
+			JFileChooser chooser = new JFileChooser();
+			int result = chooser.showOpenDialog(null);
+			if (result == JFileChooser.APPROVE_OPTION) {
+				File f = chooser.getSelectedFile();
+				String filename = f.getAbsolutePath();
+				PopulationSampler.this.txtPath.setText(filename);
 			}
 		});
 
-		this.btnCreateSample.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				new Thread(new Runnable() {
-					@Override
-					public void run() {
-						createSample();
-					}
-				}, "SampleCreator").start();
-				PopulationSampler.this.setVisible(false);
-			}
+		this.btnCreateSample.addActionListener(e -> {
+			createSample();
+			PopulationSampler.this.setVisible(false);
 		});
 	}
 
@@ -154,101 +147,89 @@ public final class PopulationSampler extends JFrame {
 		final String srcFilename = PopulationSampler.this.txtPath.getText();
 		File srcFile = new File(srcFilename);
 		if (!srcFile.exists()) {
-			JOptionPane.showMessageDialog(null,
-			    "The specified file could not be found: " + srcFilename,
-			    "File not found!",
-			    JOptionPane.ERROR_MESSAGE);
+			JOptionPane.showMessageDialog(null, "The specified file could not be found: " + srcFilename,
+					"File not found!", JOptionPane.ERROR_MESSAGE);
 			return;
 		}
 
 		final String namePart = srcFilename.substring(0, srcFilename.toLowerCase(Locale.ROOT).lastIndexOf(".xml"));
-		final int percentage = ((Integer) PopulationSampler.this.pctSpinner.getValue()).intValue();
+		final int percentage = (Integer)PopulationSampler.this.pctSpinner.getValue();
 		final double samplesize = percentage / 100.0;
 
 		JFileChooser chooser = new SaveFileSaver();
 		chooser.setCurrentDirectory(srcFile.getParentFile());
-		chooser.setSelectedFile(new File(srcFile.getParentFile(), namePart + "." + Integer.toString(percentage) + "pct.xml.gz"));
+		chooser.setSelectedFile(new File(srcFile.getParentFile(), namePart + "." + percentage + "pct.xml.gz"));
 		int saveResult = chooser.showSaveDialog(PopulationSampler.this);
 		if (saveResult == JFileChooser.APPROVE_OPTION) {
 			File destFile = chooser.getSelectedFile();
-			try {
-				createSample(srcFile, null, samplesize, destFile);
-			} catch (RuntimeException | IOException ex) {
-				ex.printStackTrace();
-				destFile.delete();
-				JOptionPane.showMessageDialog(null,
-				    "<html>It looks like the population file cannot be parsed without a network file.<br />Please select a matching network file in the next dialog.</html>",
-				    "Problems creating population sample",
-				    JOptionPane.WARNING_MESSAGE);
-				
-				JFileChooser netChooser = new JFileChooser();
-				netChooser.setCurrentDirectory(srcFile.getParentFile());
-				int result = netChooser.showOpenDialog(PopulationSampler.this);
-				if (result == JFileChooser.APPROVE_OPTION) {
-					File networkFile = netChooser.getSelectedFile();
-					try {
-						createSample(srcFile, networkFile, samplesize, destFile);
-					} catch (RuntimeException | IOException ex2) {
-						ex.printStackTrace();
-						destFile.delete();
-						JOptionPane.showMessageDialog(null,
-						    "The population sample cannot be created, as not all necessary data is available.",
-						    "Cannot create population sample",
-						    JOptionPane.ERROR_MESSAGE);
-					}
-				}
-			}
-		}		
-		
-	}
-	
-	private static void createSample(final File inputPopulationFile, final File networkFile, final double samplesize, final File outputPopulationFile) throws RuntimeException, IOException {
-		MutableScenario sc = ScenarioUtils.createMutableScenario(ConfigUtils.createConfig());
-		
-		if (networkFile != null) {
-			try (FileInputStream fis = new FileInputStream(networkFile);
-					 BufferedInputStream is = getBufferedInputStream(inputPopulationFile.getName(), fis)
-					) {
-				AsyncFileInputProgressDialog gui = new AsyncFileInputProgressDialog(fis, "Loading Network…");
-				try {
-					new MatsimNetworkReader(sc.getNetwork()).parse(is);
-				} finally {
-					gui.close();
-				}
-			}
+			doCreateSample(srcFile, null, samplesize, destFile);
 		}
-		
-//		Population pop = (Population) sc.getPopulation();
-		StreamingPopulationReader reader = new StreamingPopulationReader( sc ) ;
+	}
 
-		StreamingPopulationWriter writer = null;
-		try {
-		
-			writer = new StreamingPopulationWriter(new IdentityTransformation(), samplesize);
-			writer.startStreaming(outputPopulationFile.getAbsolutePath());
-			final PersonAlgorithm algo = writer;
-			
-			reader.addAlgorithm(algo);
+	private void doCreateSample(File inputPopulationFile, File networkFile, double samplesize,
+			File outputPopulationFile) {
+		AsyncFileInputProgressDialog gui = new AsyncFileInputProgressDialog();
+
+		new Thread(() -> {
+			MutableScenario sc = ScenarioUtils.createMutableScenario(ConfigUtils.createConfig());
+
+			if (networkFile != null) {
+				SwingUtilities.invokeLater(() -> gui.setTitle("Loading Network…"));
+				try (FileInputStream fis = new FileInputStream(networkFile);
+						BufferedInputStream is = getBufferedInputStream(networkFile.getName(), fis)) {
+					new MatsimNetworkReader(sc.getNetwork()).parse(is);
+				} catch (IOException | RuntimeException e) {
+					log.error(e.getMessage(), e);
+					SwingUtilities.invokeLater(gui::dispose);
+					SwingUtilities.invokeLater(() -> JOptionPane.showMessageDialog(null,
+							"Error while reading the network file: " + e.getMessage(),
+							"Cannot create population sample", JOptionPane.ERROR_MESSAGE));
+					return;
+				}
+			}
+
+			SwingUtilities.invokeLater(() -> gui.setTitle("Creating Population Sample…"));
+			StreamingPopulationReader reader = new StreamingPopulationReader(sc);
+			StreamingPopulationWriter writer = null;
 
 			try (FileInputStream fis = new FileInputStream(inputPopulationFile);
-				BufferedInputStream is = getBufferedInputStream(inputPopulationFile.getName(), fis)
-				) {
-				AsyncFileInputProgressDialog gui = new AsyncFileInputProgressDialog(fis, "Creating Population Sample…");
-				try {
-//					new MatsimPopulationReader(sc).parse(is);
-					reader.parse(is);
-				} finally {
-					gui.close();
+					BufferedInputStream is = getBufferedInputStream(inputPopulationFile.getName(), fis)) {
+				writer = new StreamingPopulationWriter(new IdentityTransformation(), samplesize);
+				writer.startStreaming(outputPopulationFile.getAbsolutePath());
+				reader.addAlgorithm(writer);
+				reader.parse(is);
+				SwingUtilities.invokeLater(gui::dispose);
+				writer.closeStreaming();
+			} catch (RuntimeException | IOException e) {
+				log.error(e.getMessage(), e);
+				SwingUtilities.invokeLater(gui::dispose);
+
+				if (writer != null) {
+					writer.closeStreaming();
+					outputPopulationFile.delete();
+				}
+
+				if (e instanceof RuntimeException && networkFile == null) {
+					//just making a guess that providing the corresponding network will solve the issue
+					SwingUtilities.invokeLater(() -> {
+						JOptionPane.showMessageDialog(null,
+								"<html>It looks like the population file cannot be parsed without a network file.<br />Please select a matching network file in the next dialog.</html>",
+								"Problems creating population sample", JOptionPane.WARNING_MESSAGE);
+						JFileChooser netChooser = new JFileChooser();
+						netChooser.setCurrentDirectory(inputPopulationFile.getParentFile());
+						int result = netChooser.showOpenDialog(this);
+						if (result == JFileChooser.APPROVE_OPTION) {
+							doCreateSample(inputPopulationFile, netChooser.getSelectedFile(), samplesize,
+									outputPopulationFile);
+						}
+					});
+				} else {
+					SwingUtilities.invokeLater(() -> JOptionPane.showMessageDialog(null,
+							"The population sample cannot be created, as not all necessary data is available.",
+							"Cannot create population sample", JOptionPane.ERROR_MESSAGE));
 				}
 			}
-		} catch (NullPointerException e) {
-			throw new RuntimeException(e);
-		} finally {
-			if (writer != null) {
-				writer.closeStreaming();
-			}
-		}
-
+		}, "sampler").start();
 	}
 
 	private static BufferedInputStream getBufferedInputStream(String filename, FileInputStream fis) throws IOException {

--- a/matsim/src/main/java/org/matsim/run/gui/ScheduleValidatorWindow.java
+++ b/matsim/src/main/java/org/matsim/run/gui/ScheduleValidatorWindow.java
@@ -1,5 +1,20 @@
 package org.matsim.run.gui;
 
+import java.awt.HeadlessException;
+import java.io.File;
+
+import javax.swing.GroupLayout;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.table.DefaultTableModel;
+
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.core.config.Config;
@@ -10,23 +25,10 @@ import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitScheduleReader;
 import org.matsim.pt.utils.TransitScheduleValidator;
 
-import javax.swing.GroupLayout;
-import javax.swing.JButton;
-import javax.swing.JFileChooser;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
-import javax.swing.JTextField;
-import javax.swing.SwingUtilities;
-import javax.swing.table.DefaultTableModel;
-import java.awt.HeadlessException;
-import java.io.File;
-
 /**
  * @author mrieser / Simunto GmbH
  */
-public class ScheduleValidatorWindow extends JFrame {
+public class ScheduleValidatorWindow extends JDialog {
 
 	private File lastUsedDirectory;
 	private final JTextField txtScheduleFilename;
@@ -35,8 +37,9 @@ public class ScheduleValidatorWindow extends JFrame {
 	private final JTable resultTable;
 	private final JButton btnValidate;
 
-	public ScheduleValidatorWindow() throws HeadlessException {
-		super("Transit Schedule Validator");
+	public ScheduleValidatorWindow(JFrame parent) throws HeadlessException {
+		super(parent);
+		setTitle("Transit Schedule Validator");
 
 		// UI elements
 		JLabel lblSchedule = new JLabel("Transit Schedule:");
@@ -54,8 +57,9 @@ public class ScheduleValidatorWindow extends JFrame {
 		this.resultTableModel = new DefaultTableModel(0, 2) {
 			@Override
 			public String getColumnName(int column) {
-				return new String[]{"Type", "Message"}[column];
+				return new String[] { "Type", "Message" }[column];
 			}
+
 			@Override
 			public boolean isCellEditable(int row, int column) {
 				return false;
@@ -68,7 +72,7 @@ public class ScheduleValidatorWindow extends JFrame {
 
 		// behavior
 
-		this.lastUsedDirectory = new File( "." );
+		this.lastUsedDirectory = new File(".");
 
 		btnChooseSchedule.addActionListener(e -> {
 			JFileChooser chooser = new JFileChooser();
@@ -97,55 +101,40 @@ public class ScheduleValidatorWindow extends JFrame {
 		// layout
 
 		GroupLayout groupLayout = new GroupLayout(getContentPane());
-		groupLayout.setHorizontalGroup(
-				groupLayout.createSequentialGroup()
-					.addContainerGap()
-					.addGroup(groupLayout.createParallelGroup()
-							.addGroup(groupLayout.createSequentialGroup()
-									.addGroup(groupLayout.createParallelGroup()
-											.addComponent(lblSchedule)
-											.addComponent(lblNetwork)
-											.addComponent(this.btnValidate)
-											.addComponent(lblOutput)
-									)
-									.addGroup(groupLayout.createParallelGroup()
-											.addComponent(this.txtScheduleFilename)
-											.addComponent(this.txtNetworkFilename)
-									)
-									.addGroup(groupLayout.createParallelGroup()
-											.addComponent(btnChooseSchedule)
-											.addComponent(btnChooseNetwork)
-									)
-							)
-							.addComponent(outputPane, GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE, Short.MAX_VALUE)
-					)
-					.addContainerGap()
-		);
+		groupLayout.setHorizontalGroup(groupLayout.createSequentialGroup()
+				.addContainerGap()
+				.addGroup(groupLayout.createParallelGroup()
+						.addGroup(groupLayout.createSequentialGroup()
+								.addGroup(groupLayout.createParallelGroup()
+										.addComponent(lblSchedule)
+										.addComponent(lblNetwork)
+										.addComponent(this.btnValidate)
+										.addComponent(lblOutput))
+								.addGroup(groupLayout.createParallelGroup()
+										.addComponent(this.txtScheduleFilename)
+										.addComponent(this.txtNetworkFilename))
+								.addGroup(groupLayout.createParallelGroup()
+										.addComponent(btnChooseSchedule)
+										.addComponent(btnChooseNetwork)))
+						.addComponent(outputPane, GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE, Short.MAX_VALUE))
+				.addContainerGap());
 
-		groupLayout.setVerticalGroup(
-				groupLayout.createSequentialGroup()
-						.addContainerGap()
-						.addGroup(groupLayout.createParallelGroup(GroupLayout.Alignment.BASELINE)
-								.addComponent(lblSchedule)
-								.addComponent(this.txtScheduleFilename)
-								.addComponent(btnChooseSchedule)
-						)
-						.addGroup(groupLayout.createParallelGroup(GroupLayout.Alignment.BASELINE)
-								.addComponent(lblNetwork)
-								.addComponent(this.txtNetworkFilename)
-								.addComponent(btnChooseNetwork)
-						)
-						.addGroup(groupLayout.createParallelGroup(GroupLayout.Alignment.BASELINE)
-								.addComponent(this.btnValidate)
-						)
-						.addGroup(groupLayout.createParallelGroup(GroupLayout.Alignment.BASELINE)
-								.addComponent(lblOutput)
-						)
-						.addGroup(groupLayout.createParallelGroup(GroupLayout.Alignment.BASELINE)
-								.addComponent(outputPane, 200, Short.MAX_VALUE, Short.MAX_VALUE)
-						)
-						.addContainerGap()
-		);
+		groupLayout.setVerticalGroup(groupLayout.createSequentialGroup()
+				.addContainerGap()
+				.addGroup(groupLayout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+						.addComponent(lblSchedule)
+						.addComponent(this.txtScheduleFilename)
+						.addComponent(btnChooseSchedule))
+				.addGroup(groupLayout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+						.addComponent(lblNetwork)
+						.addComponent(this.txtNetworkFilename)
+						.addComponent(btnChooseNetwork))
+				.addGroup(
+						groupLayout.createParallelGroup(GroupLayout.Alignment.BASELINE).addComponent(this.btnValidate))
+				.addGroup(groupLayout.createParallelGroup(GroupLayout.Alignment.BASELINE).addComponent(lblOutput))
+				.addGroup(groupLayout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+						.addComponent(outputPane, 200, Short.MAX_VALUE, Short.MAX_VALUE))
+				.addContainerGap());
 
 		getContentPane().setLayout(groupLayout);
 
@@ -167,7 +156,7 @@ public class ScheduleValidatorWindow extends JFrame {
 	public void run() {
 		this.btnValidate.setEnabled(false);
 		this.resultTableModel.setRowCount(0);
-		this.resultTableModel.addRow(new Object[]{"", "Validating transit schedule..."});
+		this.resultTableModel.addRow(new Object[] { "", "Validating transit schedule..." });
 
 		new Thread(() -> {
 			String scheduleFilename = this.txtScheduleFilename.getText();
@@ -190,13 +179,13 @@ public class ScheduleValidatorWindow extends JFrame {
 			SwingUtilities.invokeLater(() -> {
 				this.resultTableModel.setRowCount(0);
 				if (result.isValid()) {
-					this.resultTableModel.addRow(new Object[]{"SUCCESS", "The schedule appears valid"});
+					this.resultTableModel.addRow(new Object[] { "SUCCESS", "The schedule appears valid" });
 				}
 				for (String message : result.getWarnings()) {
-					this.resultTableModel.addRow(new Object[]{"WARNING", message});
+					this.resultTableModel.addRow(new Object[] { "WARNING", message });
 				}
 				for (String message : result.getErrors()) {
-					this.resultTableModel.addRow(new Object[]{"ERROR", message});
+					this.resultTableModel.addRow(new Object[] { "ERROR", message });
 				}
 				this.btnValidate.setEnabled(true);
 			});
@@ -205,6 +194,6 @@ public class ScheduleValidatorWindow extends JFrame {
 	}
 
 	public static void main(String[] args) {
-		new ScheduleValidatorWindow().setVisible(true);
+		new ScheduleValidatorWindow(null).setVisible(true);
 	}
 }


### PR DESCRIPTION
Aims at fixing issues reported in #1462

This PR reworks the way long-running operations (non-GUI threads) interact with the GUI thread (Event Dispatch Thread, EDT). In the old implementation lots of calls to GUI components were made from outside the EDT, which is practically always non-thread-safe and may lead to some odd behaviour (incl. deadlocks). Now all operations on GUI components (in all dialogs) are only executed from the EDT.

Calling `Gui.show()` is now thread-safe. No need to change anything in other customised GUIs (e.g. `AccessibilityGUI`)
