### PR TITLE
Again trying to fix kinematic waves qsim

### DIFF
--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QueueWithBuffer.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QueueWithBuffer.java
@@ -191,6 +191,7 @@ final class QueueWithBuffer implements QLaneI, SignalizeableItem {
 	private double accumulatedInflowCap = 1. ;
 	
 	private final FlowEfficiencyCalculator flowEfficiencyCalculator;
+	private double maxFlowFromFdiag;
 
 	private QueueWithBuffer(AbstractQLink.QLinkInternalInterface qlink, final VehicleQ<QVehicle> vehicleQueue, Id<Lane> laneId,
 							double length, double effectiveNumberOfLanes, double flowCapacity_s, final NetsimEngineContext context,
@@ -399,7 +400,7 @@ final class QueueWithBuffer implements QLaneI, SignalizeableItem {
 				// yyyyyy this should possibly be getFreespeed(now). But if that's the case, then maxFlowFromFdiag would
 				// also have to be re-computed with each freespeed change. kai, feb'18
 				
-				final double maxFlowFromFdiag = (this.effectiveNumberOfLanes/context.effectiveCellSize) / ( 1./(HOLE_SPEED_KM_H/3.6) + 1/this.qLink.getFreespeed() ) ;
+				this.maxFlowFromFdiag = (this.effectiveNumberOfLanes/context.effectiveCellSize) / ( 1./(HOLE_SPEED_KM_H/3.6) + 1/this.qLink.getFreespeed() ) ;
 				final double minimumNumberOfLanesFromFdiag = this.flowCapacityPerTimeStep * context.effectiveCellSize * ( 1./(HOLE_SPEED_KM_H/3.6) + 1/this.qLink.getFreespeed() ); 
 						
 				if ( maxFlowFromFdiag < flowCapacityPerTimeStep ) {
@@ -560,7 +561,8 @@ final class QueueWithBuffer implements QLaneI, SignalizeableItem {
 				this.processArrivalOfHoles( ) ;
 				break;
 			case kinematicWaves:
-				this.accumulatedInflowCap = Math.min(accumulatedInflowCap + maxFlowUsedInQsim, maxFlowUsedInQsim);
+				this.accumulatedInflowCap = Math.min(accumulatedInflowCap + maxFlowFromFdiag, maxFlowFromFdiag);
+//				this.accumulatedInflowCap = Math.min(accumulatedInflowCap + maxFlowUsedInQsim, maxFlowUsedInQsim);
 				this.processArrivalOfHoles( ) ;
 				break;
 			default: throw new RuntimeException("The traffic dynmics "+context.qsimConfig.getTrafficDynamics()+" is not implemented yet.");

--- a/matsim/src/test/java/org/matsim/core/mobsim/qsim/QSimTest.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/qsim/QSimTest.java
@@ -1643,8 +1643,8 @@ public class QSimTest {
 		System.out.println("#vehicles 7-8: " + Integer.toString(volume[7]));
 		System.out.println("#vehicles 8-9: " + Integer.toString(volume[8]));
 
-		Assert.assertEquals(2979, volume[6]); // because of the kinematic waves and the 'increase lanes behavior' we should only have slightly less than half of the maximum flow in this hour
-		Assert.assertEquals(5958, volume[7]); // because of the kinematic waves and the 'increase lanes behavior' we should only have slightly less than the maximum flow in this hour
+		Assert.assertEquals(1920, volume[6]); // because of the kinematic waves and the 'increase lanes behavior' we should only have slightly less than half of the maximum flow in this hour
+		Assert.assertEquals(3840, volume[7]); // because of the kinematic waves and the 'increase lanes behavior' we should only have slightly less than the maximum flow in this hour
 	}
 
 	/**


### PR DESCRIPTION
This is a pull request is created to discuss some issues in the kinematicWaves behavior. In a recent pull request (https://github.com/matsim-org/matsim-libs/pull/1414), the consideration of the number of lanes was added to the computation of 'maxFlowFromFdiag'. Together with this change, also the logic of the accumulated inflow capacity was changed from
`this.accumulatedInflowCap = Math.min(accumulatedInflowCap + maxFlowFromFdiag, maxFlowFromFdiag)`
to
`this.accumulatedInflowCap = Math.min(accumulatedInflowCap + maxFlowUsedInQsim, maxFlowUsedInQsim)`.

After introducing this change, we observed a major increase in car travel times in the open Berlin scenario, which is why we again looked into the code and now tend to change this back to the old behavior. I am not convinced that the old approach is the correct one but it solves our congestion problem. I tested it with RunBerlinScenarioTest.eTest1pctUntilIteration1() in matsim-berlin, branch 5.6.

Yet, I see the following issues with the old approach:

- In some cases 'maxFlowFromFdiag' can  be much higher compared to the actual flow capacity (which is specified in the network) which means that the inflow is much different than the outflow!
- In the current version, there are two options to deal with the situation 'maxFlowFromFdiag < flowCapacityPerTimeStep': (a) reduce the flow capacity and (b) increase the number of lanes. In the (b) case `this.accumulatedInflowCap = Math.min(accumulatedInflowCap + maxFlowFromFdiag, maxFlowFromFdiag)` does not really make sense...

@tschlenther @vsp-gleich @rakow @michalmac 
