### PR TITLE
fix(OTFVis): disable "stepForward" buttons while playing in async live mode

### DIFF
--- a/contribs/otfvis/src/main/java/org/matsim/vis/otfvis/gui/OTFControlBar.java
+++ b/contribs/otfvis/src/main/java/org/matsim/vis/otfvis/gui/OTFControlBar.java
@@ -20,52 +20,58 @@
 
 package org.matsim.vis.otfvis.gui;
 
+import java.awt.Dimension;
+import java.awt.event.KeyEvent;
+import java.text.MessageFormat;
+
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JFormattedTextField;
+import javax.swing.JLabel;
+import javax.swing.JTextField;
+import javax.swing.JToolBar;
+import javax.swing.SwingUtilities;
+
 import org.matsim.core.gbl.MatsimResource;
 import org.matsim.core.utils.misc.Time;
 import org.matsim.vis.otfvis.OTFClientControl;
 import org.matsim.vis.otfvis.interfaces.OTFServer;
 import org.matsim.vis.otfvis.opengl.drawer.OTFOGLDrawer;
 
-import javax.swing.*;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
-import java.awt.*;
-import java.awt.event.*;
-import java.text.MessageFormat;
-
 public final class OTFControlBar extends JToolBar {
 
 	private static final long serialVersionUID = 1L;
 
-	private JButton playPauseButton;
+	private final JButton playPauseButton;
 
-	private JFormattedTextField timeField;
+	private final JFormattedTextField timeField;
 
-	private JFormattedTextField scaleField;
+	private final JFormattedTextField scaleField;
 
 	private final OTFHostControl hostControl;
 
-    private boolean synchronizedPlay = true;
+	private boolean synchronizedPlay = true;
 
-	private ImageIcon playIcon = null;
+	private final ImageIcon playIcon;
 
-	private ImageIcon pauseIcon = null;
+	private final ImageIcon pauseIcon;
 
 	private OTFAbortGoto progressBar = null;
 
 	private enum PlayOrPause {PLAY, PAUSE}
 
-    private final OTFOGLDrawer drawer;
+	private final OTFOGLDrawer drawer;
 
 	/*
 	 * The symbol which the play/pause button currently shows.
 	 * (NOT the mode we are in!)
 	 */
-	private PlayOrPause playOrPause = PlayOrPause.PLAY;
+	private PlayOrPause playOrPauseButtonMode = PlayOrPause.PLAY;
 
-	private OTFServer server;
+	private final OTFServer server;
 
-	public OTFControlBar(OTFServer server, final OTFHostControl hostControl, OTFOGLDrawer mainDrawer)  {
+	public OTFControlBar(OTFServer server, final OTFHostControl hostControl, OTFOGLDrawer mainDrawer) {
 		this.server = server;
 		this.hostControl = hostControl;
 		this.drawer = mainDrawer;
@@ -75,176 +81,139 @@ public final class OTFControlBar extends JToolBar {
 		pauseIcon = new ImageIcon(MatsimResource.getAsImage("otfvis/buttonPause.png"), "Pause");
 
 		if (!server.isLive()) {
-			JButton button2 = new JButton();
-			button2.putClientProperty("JButton.buttonType","icon");
-			button2.addActionListener(new ActionListener() {
-				@Override
-				public void actionPerformed(ActionEvent e) {
-					OTFControlBar.this.hostControl.toStart();
-					repaint();
-				}
+			JButton restartButton = new JButton();
+			restartButton.putClientProperty("JButton.buttonType", "icon");
+			restartButton.addActionListener(e -> {
+				OTFControlBar.this.hostControl.toStart();
+				repaint();
 			});
-			button2.setToolTipText("restart the server/simulation");
+			restartButton.setToolTipText("restart the server/simulation");
 			String imgLocation2 = "otfvis/" + "buttonRestart" + ".png";
 			ImageIcon icon2 = new ImageIcon(MatsimResource.getAsImage(imgLocation2), "Restart");
-			button2.setIcon(icon2);
-			add(button2);
-			JButton button1 = new JButton();
-			button1.putClientProperty("JButton.buttonType","icon");
-			button1.addActionListener(new ActionListener() {
-				@Override
-				public void actionPerformed(ActionEvent e) {
-					int bigStep = OTFClientControl.getInstance().getOTFVisConfig().getBigTimeStep();
-					hostControl.requestTimeStep(OTFControlBar.this.hostControl.getSimTime() - bigStep);
-				}
+			restartButton.setIcon(icon2);
+			add(restartButton);
+			JButton multiStepsBackwardButton = new JButton();
+			multiStepsBackwardButton.putClientProperty("JButton.buttonType", "icon");
+			multiStepsBackwardButton.addActionListener(e -> {
+				int bigStep = OTFClientControl.getInstance().getOTFVisConfig().getBigTimeStep();
+				hostControl.requestTimeStep(OTFControlBar.this.hostControl.getSimTime() - bigStep);
 			});
-			button1.setToolTipText("go several timesteps backwards");
+			multiStepsBackwardButton.setToolTipText("go several timesteps backwards");
 			String imgLocation1 = "otfvis/" + "buttonStepBB" + ".png";
 			ImageIcon icon1 = new ImageIcon(MatsimResource.getAsImage(imgLocation1), "<<");
-			button1.setIcon(icon1);
-			add(button1);
-			JButton button = new JButton();
-			button.putClientProperty("JButton.buttonType","icon");
-			button.addActionListener(new ActionListener() {
-				@Override
-				public void actionPerformed(ActionEvent e) {
-					hostControl.requestTimeStep(OTFControlBar.this.hostControl.getSimTime() - 1);
-				}
-			});
-			button.setToolTipText("go one timestep backwards");
+			multiStepsBackwardButton.setIcon(icon1);
+			add(multiStepsBackwardButton);
+			JButton singleStepBackwardButton = new JButton();
+			singleStepBackwardButton.putClientProperty("JButton.buttonType", "icon");
+			singleStepBackwardButton.addActionListener(
+					e -> hostControl.requestTimeStep(OTFControlBar.this.hostControl.getSimTime() - 1));
+			singleStepBackwardButton.setToolTipText("go one timestep backwards");
 			String imgLocation = "otfvis/" + "buttonStepB" + ".png";
 			ImageIcon icon = new ImageIcon(MatsimResource.getAsImage(imgLocation), "<");
-			button.setIcon(icon);
-			add(button);
+			singleStepBackwardButton.setIcon(icon);
+			add(singleStepBackwardButton);
 		}
 
-		JButton button2 = new JButton();
-		button2.putClientProperty("JButton.buttonType","icon");
-		button2.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				if (playOrPause == PlayOrPause.PLAY) {
-					playPauseButton.setIcon(pauseIcon);
-					OTFControlBar.this.hostControl.play(synchronizedPlay);
-					playOrPause = PlayOrPause.PAUSE;
-				} else if (playOrPause == PlayOrPause.PAUSE) {
-					playPauseButton.setIcon(playIcon);
-					OTFControlBar.this.hostControl.pause();
-					playOrPause = PlayOrPause.PLAY;
-				}
-			}
-		});
-		button2.setToolTipText("press to play simulation continuously");
+		JButton playOrPauseButton = new JButton();
+		playOrPauseButton.putClientProperty("JButton.buttonType", "icon");
+		playOrPauseButton.setToolTipText("press to play simulation continuously");
 		String imgLocation2 = "otfvis/" + "buttonPlay" + ".png";
 		ImageIcon icon2 = new ImageIcon(MatsimResource.getAsImage(imgLocation2), "PLAY");
-		button2.setIcon(icon2);
-		playPauseButton = button2;
-		add(playPauseButton);
-		JButton button1 = new JButton();
-		button1.putClientProperty("JButton.buttonType","icon");
-		button1.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				hostControl.requestTimeStep(OTFControlBar.this.hostControl.getSimTime() + 1);
-			}
-		});
-		button1.setToolTipText("go one timestep forward");
+		playOrPauseButton.setIcon(icon2);
+		this.playPauseButton = playOrPauseButton;
+		add(this.playPauseButton);
+		JButton singleStepForwardButton = new JButton();
+		singleStepForwardButton.putClientProperty("JButton.buttonType", "icon");
+		singleStepForwardButton.addActionListener(
+				e -> hostControl.requestTimeStep(OTFControlBar.this.hostControl.getSimTime() + 1));
+		singleStepForwardButton.setToolTipText("go one timestep forward");
 		String imgLocation1 = "otfvis/" + "buttonStepF" + ".png";
 		ImageIcon icon1 = new ImageIcon(MatsimResource.getAsImage(imgLocation1), ">");
-		button1.setIcon(icon1);
-		add(button1);
-		JButton button = new JButton();
-		button.putClientProperty("JButton.buttonType","icon");
-		button.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				int bigStep = OTFClientControl.getInstance().getOTFVisConfig().getBigTimeStep();
-				hostControl.requestTimeStep(OTFControlBar.this.hostControl.getSimTime() + bigStep);
-			}
+		singleStepForwardButton.setIcon(icon1);
+		add(singleStepForwardButton);
+		JButton multiStepForwardButton = new JButton();
+		multiStepForwardButton.putClientProperty("JButton.buttonType", "icon");
+		multiStepForwardButton.addActionListener(e -> {
+			int bigStep = OTFClientControl.getInstance().getOTFVisConfig().getBigTimeStep();
+			hostControl.requestTimeStep(OTFControlBar.this.hostControl.getSimTime() + bigStep);
 		});
-		button.setToolTipText("go several timesteps forward");
+		multiStepForwardButton.setToolTipText("go several timesteps forward");
 		String imgLocation = "otfvis/" + "buttonStepFF" + ".png";
 		ImageIcon icon = new ImageIcon(MatsimResource.getAsImage(imgLocation), ">>");
-		button.setIcon(icon);
-		add(button);
+		multiStepForwardButton.setIcon(icon);
+		add(multiStepForwardButton);
+
+		playOrPauseButton.addActionListener(e -> {
+			if (playOrPauseButtonMode == PlayOrPause.PLAY) {
+				this.playPauseButton.setIcon(pauseIcon);
+				//PlayPauseSimulationControl.doStep() cannot be called while playing in async mode
+				singleStepForwardButton.setEnabled(synchronizedPlay);
+				multiStepForwardButton.setEnabled(synchronizedPlay);
+				OTFControlBar.this.hostControl.play(synchronizedPlay);
+				playOrPauseButtonMode = PlayOrPause.PAUSE;
+			} else if (playOrPauseButtonMode == PlayOrPause.PAUSE) {
+				this.playPauseButton.setIcon(playIcon);
+				OTFControlBar.this.hostControl.pause();
+				playOrPauseButtonMode = PlayOrPause.PLAY;
+				singleStepForwardButton.setEnabled(true);
+				multiStepForwardButton.setEnabled(true);
+			}
+		});
+
 		MessageFormat format = new MessageFormat("{0,number,00}:{1,number,00}:{2,number,00}");
 		timeField = new JFormattedTextField(format);
-		timeField.setMaximumSize(new Dimension(100,30));
-		timeField.setMinimumSize(new Dimension(80,30));
+		timeField.setMaximumSize(new Dimension(100, 30));
+		timeField.setMinimumSize(new Dimension(80, 30));
 		timeField.setHorizontalAlignment(JTextField.CENTER);
-		add( timeField );
-		timeField.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				final int newTime_s = (int) Time.parseTime(timeField.getText());
-				progressBar = new OTFAbortGoto(OTFControlBar.this.server, newTime_s);
-				progressBar.start();
-				new Thread() {
-					@Override
-					public void run() {
-						OTFControlBar.this.hostControl.requestTimeStep(newTime_s);
-						progressBar.terminate = true;
-					}
-				}.start();
-			}
+		add(timeField);
+		timeField.addActionListener(e -> {
+			final int newTime_s = (int)Time.parseTime(timeField.getText());
+			progressBar = new OTFAbortGoto(OTFControlBar.this.server, newTime_s);
+			progressBar.start();
+			new Thread(() -> {
+				OTFControlBar.this.hostControl.requestTimeStep(newTime_s);
+				progressBar.terminate = true;
+			}).start();
 		});
-		hostControl.getSimTimeModel().addChangeListener(new ChangeListener() {
-			@Override
-			public void stateChanged(ChangeEvent e) {
-				SwingUtilities.invokeLater(new Runnable() {
-					@Override
-					public void run() {
-						timeField.setText(Time.writeTime(hostControl.getSimTime()));
-					}
-				});
-			}
-		});
+		hostControl.getSimTimeModel()
+				.addChangeListener(e -> SwingUtilities.invokeLater(
+						() -> timeField.setText(Time.writeTime(hostControl.getSimTime()))));
 		timeField.setText(Time.writeTime(hostControl.getSimTime()));
 
 		if (this.server.isLive()) {
 			final JCheckBox synchBox = new JCheckBox("Synch");
 			synchBox.setMnemonic(KeyEvent.VK_V);
 			synchBox.setSelected(synchronizedPlay);
-			synchBox.addItemListener(new ItemListener() {
-				@Override
-				public void itemStateChanged(ItemEvent e) {
-					OTFControlBar.this.hostControl.pause();
-					synchronizedPlay = synchBox.isSelected();
-					if (playOrPause == PlayOrPause.PAUSE) { // means: playing
-						OTFControlBar.this.hostControl.play(synchronizedPlay);
-					}
+			synchBox.addItemListener(e -> {
+				OTFControlBar.this.hostControl.pause();
+				synchronizedPlay = synchBox.isSelected();
+				if (playOrPauseButtonMode == PlayOrPause.PAUSE) { // means: playing
+					//PlayPauseSimulationControl.doStep() cannot be called while playing in async mode
+					singleStepForwardButton.setEnabled(synchronizedPlay);
+					multiStepForwardButton.setEnabled(synchronizedPlay);
+					OTFControlBar.this.hostControl.play(synchronizedPlay);
 				}
 			});
 			add(synchBox);
 		}
 
 		JLabel lab = new JLabel("Scale: ");
-		lab.setMaximumSize(new Dimension(100,30));
-		lab.setMinimumSize(new Dimension(80,30));
+		lab.setMaximumSize(new Dimension(100, 30));
+		lab.setMinimumSize(new Dimension(80, 30));
 		lab.setHorizontalAlignment(JLabel.RIGHT);
 		add(lab);
 		scaleField = new JFormattedTextField("1.0");
-		scaleField.setMaximumSize(new Dimension(50,30));
-		scaleField.setMinimumSize(new Dimension(30,30));
+		scaleField.setMaximumSize(new Dimension(50, 30));
+		scaleField.setMinimumSize(new Dimension(30, 30));
 		scaleField.setHorizontalAlignment(JTextField.CENTER);
-		add( scaleField );
-		scaleField.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				drawer.setScale(Float.parseFloat(scaleField.getText()));
-			}
-		});
-		drawer.addChangeListener(new ChangeListener() {
-			@Override
-			public void stateChanged(ChangeEvent e) {
-				updateScaleField();
-			}
-		});
+		add(scaleField);
+		scaleField.addActionListener(e -> drawer.setScale(Float.parseFloat(scaleField.getText())));
+		drawer.addChangeListener(e -> updateScaleField());
 		updateScaleField();
 	}
 
 	private void updateScaleField() {
-		scaleField.setText(String.valueOf((double) ((float)(Math.round(drawer.getScale()*100))/100)));
+		scaleField.setText(String.valueOf((double)((float)(Math.round(drawer.getScale() * 100)) / 100)));
 	}
 
 }

--- a/contribs/otfvis/src/main/java/org/matsim/vis/otfvis/gui/OTFHostControl.java
+++ b/contribs/otfvis/src/main/java/org/matsim/vis/otfvis/gui/OTFHostControl.java
@@ -66,12 +66,7 @@ public class OTFHostControl implements GLEventListener {
 			// Live mode without timesteps
 			simTime = new DefaultBoundedRangeModel(0 /* value */, 0 /* extent */, 0 /* value */, Integer.MAX_VALUE /* max */);
 		}
-		simTime.addChangeListener(new ChangeListener() {
-			@Override
-			public void stateChanged(ChangeEvent e) {
-				canvas.repaint();
-			}
-		});
+		simTime.addChangeListener(e -> canvas.repaint());
 		animator = new Animator();
 		animator.add(((GLAutoDrawable) canvas));
 		((GLAutoDrawable) canvas).addGLEventListener(this);
@@ -105,12 +100,7 @@ public class OTFHostControl implements GLEventListener {
 		log.debug("Pressed PLAY, creating animator.");
 		playing = true;
 		syncronizedPlay = synchronizedPlay;
-		new Thread(new Runnable() {
-			@Override
-			public void run() {
-				animator.start();
-			}
-		}).start();
+		new Thread(animator::start).start();
 		if (!synchronizedPlay) {
 			((OTFLiveServer) server).play();
 		}

--- a/matsim/src/main/java/org/matsim/core/mobsim/framework/PlayPauseSimulationControl.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/framework/PlayPauseSimulationControl.java
@@ -29,9 +29,9 @@ import org.matsim.core.mobsim.framework.listeners.MobsimBeforeCleanupListener;
 import org.matsim.core.mobsim.framework.listeners.MobsimBeforeSimStepListener;
 
 /**
- * Extracted the play/pause functionality from otfvis to make it available for other purposes (specifically, RMITs 
+ * Extracted the play/pause functionality from otfvis to make it available for other purposes (specifically, RMITs
  * CombineSim approach).
- * 
+ *
  * @author nagel
  */
 public class PlayPauseSimulationControl implements PlayPauseSimulationControlI {
@@ -56,7 +56,8 @@ public class PlayPauseSimulationControl implements PlayPauseSimulationControlI {
 		qSim.addQueueSimulationListeners(playPauseMobsimListener);
 	}
 
-	private class PlayPauseMobsimListener implements MobsimBeforeSimStepListener, MobsimAfterSimStepListener, MobsimBeforeCleanupListener {
+	private class PlayPauseMobsimListener
+			implements MobsimBeforeSimStepListener, MobsimAfterSimStepListener, MobsimBeforeCleanupListener {
 		@Override
 		public void notifyMobsimBeforeSimStep(MobsimBeforeSimStepEvent event) {
 			try {
@@ -65,15 +66,17 @@ public class PlayPauseSimulationControl implements PlayPauseSimulationControlI {
 				throw new RuntimeException(e);
 			}
 		}
+
 		@Override
 		public void notifyMobsimAfterSimStep(MobsimAfterSimStepEvent event) {
 			access.release();
-			localTime = (int) event.getSimulationTime();
+			localTime = (int)event.getSimulationTime();
 			// yy I am not so sure about the "int".  kai, nov'17
 			stepDone.arriveAndAwaitAdvance();
 			// This is arrival by one party.  If "pause" has been pressed before, we have a second party, and thus do not
 			// advance.
 		}
+
 		@Override
 		public void notifyMobsimBeforeCleanup(MobsimBeforeCleanupEvent e) {
 			localTime = Double.MAX_VALUE;
@@ -84,6 +87,8 @@ public class PlayPauseSimulationControl implements PlayPauseSimulationControlI {
 	@Override
 	public final void doStep(int time) {
 		if (status == Status.PLAY) {
+			// this may happen when clicking single/multi-step forward buttons while playing in the async mode,
+			// so that combination should be disabled in GUI, michalm
 			throw new IllegalStateException();
 		}
 		while (localTime < time) {
@@ -117,7 +122,7 @@ public class PlayPauseSimulationControl implements PlayPauseSimulationControlI {
 	}
 
 	public final boolean isFinished() {
-		return ( localTime == Double.MAX_VALUE ) ;
+		return (localTime == Double.MAX_VALUE);
 	}
 
 	public final double getLocalTime() {


### PR DESCRIPTION
This PR fixes #1447

Disabling the single/multi step buttons while playing in the async mode. It is still OK to click these buttons:
- in the sync mode (playing or paused)
- in the async mode (only when paused)