### PR TITLE
SwissRailRaptor with trip length awareness 

### DIFF
--- a/matsim/src/main/java/ch/sbb/matsim/config/SwissRailRaptorConfigGroup.java
+++ b/matsim/src/main/java/ch/sbb/matsim/config/SwissRailRaptorConfigGroup.java
@@ -420,7 +420,7 @@ public class SwissRailRaptorConfigGroup extends ReflectiveConfigGroup {
         private static final String PARAM_PERSON_FILTER_VALUE = "personFilterValue";
         private static final String PARAM_STOP_FILTER_ATTRIBUTE = "stopFilterAttribute";
         private static final String PARAM_STOP_FILTER_VALUE = "stopFilterValue";
-        private static final String PARAM_PERCENT_TRIP_SEARCH_RADIUS = "percentTripSearchRadius";
+        private static final String PARAM_SHARE_TRIP_SEARCH_RADIUS = "percentTripSearchRadius";
 
         private String mode;
         private double maxRadius;
@@ -431,7 +431,7 @@ public class SwissRailRaptorConfigGroup extends ReflectiveConfigGroup {
         private String personFilterValue;
         private String stopFilterAttribute;
         private String stopFilterValue;
-        private double percentTripSearchRadius = Double.POSITIVE_INFINITY;
+        private double shareTripSearchRadius = Double.POSITIVE_INFINITY;
 
         public IntermodalAccessEgressParameterSet() {
             super(TYPE);
@@ -536,14 +536,14 @@ public class SwissRailRaptorConfigGroup extends ReflectiveConfigGroup {
             return this ;
         }
         
-        @StringGetter(PARAM_PERCENT_TRIP_SEARCH_RADIUS)
-        public double getPercentTripSearchRadius() {
-            return percentTripSearchRadius;
+        @StringGetter(PARAM_SHARE_TRIP_SEARCH_RADIUS)
+        public double getShareTripSearchRadius() {
+            return shareTripSearchRadius;
         }
 
-        @StringSetter(PARAM_PERCENT_TRIP_SEARCH_RADIUS)
-        public IntermodalAccessEgressParameterSet setPercentTripSearchRadius(double percentTripSearchRadius) {
-            this.percentTripSearchRadius = percentTripSearchRadius;
+        @StringSetter(PARAM_SHARE_TRIP_SEARCH_RADIUS)
+        public IntermodalAccessEgressParameterSet setShareTripSearchRadius(double shareTripSearchRadius) {
+            this.shareTripSearchRadius = shareTripSearchRadius;
             return this ;
         }
 
@@ -558,7 +558,7 @@ public class SwissRailRaptorConfigGroup extends ReflectiveConfigGroup {
             map.put(PARAM_MAX_RADIUS, "Radius from the origin / destination coord in which transit stops are accessible by this mode.");
             map.put(PARAM_INITIAL_SEARCH_RADIUS, "Radius from the origin / destination coord in which transit stops are searched. Only if less than 2 transit stops are found the search radius is increased step-wise until the maximum search radius set in param radius is reached.");
             map.put(PARAM_SEARCH_EXTENSION_RADIUS, "If less than 2 stops were found in initialSearchRadius take the distance of the closest transit stop and add this extension radius to search again.The search radius will not exceed the maximum search radius set in param radius.");
-            map.put(PARAM_PERCENT_TRIP_SEARCH_RADIUS, "The share of the trip crowfly distance within which the stops for access and egress will be searched for. This is a harder constraint than initial search radius. Default is positive infinity.");
+            map.put(PARAM_SHARE_TRIP_SEARCH_RADIUS, "The share of the trip crowfly distance within which the stops for access and egress will be searched for. This is a harder constraint than initial search radius. Default is positive infinity.");
             
             return map;
         }

--- a/matsim/src/main/java/ch/sbb/matsim/config/SwissRailRaptorConfigGroup.java
+++ b/matsim/src/main/java/ch/sbb/matsim/config/SwissRailRaptorConfigGroup.java
@@ -420,6 +420,7 @@ public class SwissRailRaptorConfigGroup extends ReflectiveConfigGroup {
         private static final String PARAM_PERSON_FILTER_VALUE = "personFilterValue";
         private static final String PARAM_STOP_FILTER_ATTRIBUTE = "stopFilterAttribute";
         private static final String PARAM_STOP_FILTER_VALUE = "stopFilterValue";
+        private static final String PARAM_PERCENT_TRIP_SEARCH_RADIUS = "percentTripSearchRadius";
 
         private String mode;
         private double maxRadius;
@@ -430,6 +431,7 @@ public class SwissRailRaptorConfigGroup extends ReflectiveConfigGroup {
         private String personFilterValue;
         private String stopFilterAttribute;
         private String stopFilterValue;
+        private double percentTripSearchRadius = Double.POSITIVE_INFINITY;
 
         public IntermodalAccessEgressParameterSet() {
             super(TYPE);
@@ -533,6 +535,17 @@ public class SwissRailRaptorConfigGroup extends ReflectiveConfigGroup {
             this.stopFilterValue = stopFilterValue;
             return this ;
         }
+        
+        @StringGetter(PARAM_PERCENT_TRIP_SEARCH_RADIUS)
+        public double getPercentTripSearchRadius() {
+            return percentTripSearchRadius;
+        }
+
+        @StringSetter(PARAM_PERCENT_TRIP_SEARCH_RADIUS)
+        public IntermodalAccessEgressParameterSet setPercentTripSearchRadius(double percentTripSearchRadius) {
+            this.percentTripSearchRadius = percentTripSearchRadius;
+            return this ;
+        }
 
         @Override
         public Map<String, String> getComments() {
@@ -545,6 +558,8 @@ public class SwissRailRaptorConfigGroup extends ReflectiveConfigGroup {
             map.put(PARAM_MAX_RADIUS, "Radius from the origin / destination coord in which transit stops are accessible by this mode.");
             map.put(PARAM_INITIAL_SEARCH_RADIUS, "Radius from the origin / destination coord in which transit stops are searched. Only if less than 2 transit stops are found the search radius is increased step-wise until the maximum search radius set in param radius is reached.");
             map.put(PARAM_SEARCH_EXTENSION_RADIUS, "If less than 2 stops were found in initialSearchRadius take the distance of the closest transit stop and add this extension radius to search again.The search radius will not exceed the maximum search radius set in param radius.");
+            map.put(PARAM_PERCENT_TRIP_SEARCH_RADIUS, "The share of the trip crowfly distance within which the stops for access and egress will be searched for. This is a harder constraint than initial search radius. Default is positive infinity.");
+            
             return map;
         }
     }

--- a/matsim/src/main/java/ch/sbb/matsim/config/SwissRailRaptorConfigGroup.java
+++ b/matsim/src/main/java/ch/sbb/matsim/config/SwissRailRaptorConfigGroup.java
@@ -420,7 +420,7 @@ public class SwissRailRaptorConfigGroup extends ReflectiveConfigGroup {
         private static final String PARAM_PERSON_FILTER_VALUE = "personFilterValue";
         private static final String PARAM_STOP_FILTER_ATTRIBUTE = "stopFilterAttribute";
         private static final String PARAM_STOP_FILTER_VALUE = "stopFilterValue";
-        private static final String PARAM_SHARE_TRIP_SEARCH_RADIUS = "percentTripSearchRadius";
+        private static final String PARAM_SHARE_TRIP_SEARCH_RADIUS = "shareTripSearchRadius";
 
         private String mode;
         private double maxRadius;

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/DefaultRaptorStopFinder.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/DefaultRaptorStopFinder.java
@@ -164,7 +164,7 @@ public class DefaultRaptorStopFinder implements RaptorStopFinder {
             }
             
             double distance = CoordUtils.calcEuclideanDistance(fromFacility.getCoord(), toFacility.getCoord());
-            double tripBasedSearchRadius = distance * paramset.getPercentTripSearchRadius();
+            double tripBasedSearchRadius = distance * paramset.getShareTripSearchRadius();
             double searchRadius = Math.min(paramset.getInitialSearchRadius(), paramset.getMaxRadius());
             searchRadius  = Math.min(searchRadius, tripBasedSearchRadius);
             Collection<TransitStopFacility> stopFacilities = filteredStopsQT.getDisk(x, y, searchRadius);

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/DefaultRaptorStopFinder.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/DefaultRaptorStopFinder.java
@@ -64,12 +64,12 @@ public class DefaultRaptorStopFinder implements RaptorStopFinder {
 	}
 
 	@Override
-	public List<InitialStop> findStops(Facility facility, Person person, double departureTime, RaptorParameters parameters, SwissRailRaptorData data, RaptorStopFinder.Direction type) {
+	public List<InitialStop> findStops(Facility fromFacility, Facility toFacility, Person person, double departureTime, RaptorParameters parameters, SwissRailRaptorData data, RaptorStopFinder.Direction type) {
 		if (type == Direction.ACCESS) {
-			return findAccessStops(facility, person, departureTime, parameters, data);
+			return findAccessStops(fromFacility, person, departureTime, parameters, data);
 		}
 		if (type == Direction.EGRESS) {
-			return findEgressStops(facility, person, departureTime, parameters, data);
+			return findEgressStops(toFacility, person, departureTime, parameters, data);
 		}
 		return Collections.emptyList();
 	}

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/DefaultRaptorStopFinder.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/DefaultRaptorStopFinder.java
@@ -66,23 +66,24 @@ public class DefaultRaptorStopFinder implements RaptorStopFinder {
 	@Override
 	public List<InitialStop> findStops(Facility fromFacility, Facility toFacility, Person person, double departureTime, RaptorParameters parameters, SwissRailRaptorData data, RaptorStopFinder.Direction type) {
 		if (type == Direction.ACCESS) {
-			return findAccessStops(fromFacility, person, departureTime, parameters, data);
+			return findAccessStops(fromFacility, toFacility, person, departureTime, parameters, data);
 		}
 		if (type == Direction.EGRESS) {
-			return findEgressStops(toFacility, person, departureTime, parameters, data);
+			return findEgressStops(fromFacility, toFacility, person, departureTime, parameters, data);
 		}
 		return Collections.emptyList();
 	}
 
-	private List<InitialStop> findAccessStops(Facility facility, Person person, double departureTime, RaptorParameters parameters, SwissRailRaptorData data) {
+	private List<InitialStop> findAccessStops(Facility fromFacility, Facility toFacility, Person person, double departureTime,
+			RaptorParameters parameters, SwissRailRaptorData data) {
 		SwissRailRaptorConfigGroup srrCfg = parameters.getConfig();
 		if (srrCfg.isUseIntermodalAccessEgress()) {
-			return findIntermodalStops(facility, person, departureTime, Direction.ACCESS, parameters, data);
+			return findIntermodalStops(fromFacility, toFacility, person, departureTime, Direction.ACCESS, parameters, data);
 		} else {
 			double distanceFactor = data.config.getBeelineWalkDistanceFactor();
-			List<TransitStopFacility> stops = findNearbyStops(facility, parameters, data);
+			List<TransitStopFacility> stops = findNearbyStops(fromFacility, parameters, data);
 			List<InitialStop> initialStops = stops.stream().map(stop -> {
-				double beelineDistance = CoordUtils.calcEuclideanDistance(stop.getCoord(), facility.getCoord());
+				double beelineDistance = CoordUtils.calcEuclideanDistance(stop.getCoord(), fromFacility.getCoord());
 				double travelTime = Math.ceil(beelineDistance / parameters.getBeelineWalkSpeed());
 				double disutility = travelTime * -parameters.getMarginalUtilityOfTravelTime_utl_s(TransportMode.walk);
 				return new InitialStop(stop, disutility, travelTime, beelineDistance * distanceFactor, TransportMode.walk);
@@ -91,15 +92,15 @@ public class DefaultRaptorStopFinder implements RaptorStopFinder {
 		}
 	}
 
-	private List<InitialStop> findEgressStops(Facility facility, Person person, double departureTime, RaptorParameters parameters, SwissRailRaptorData data) {
+	private List<InitialStop> findEgressStops(Facility fromFacility, Facility toFacility, Person person, double departureTime, RaptorParameters parameters, SwissRailRaptorData data) {
 		SwissRailRaptorConfigGroup srrCfg = parameters.getConfig();
 		if (srrCfg.isUseIntermodalAccessEgress()) {
-			return findIntermodalStops(facility, person, departureTime, Direction.EGRESS, parameters, data);
+			return findIntermodalStops(fromFacility, toFacility, person, departureTime, Direction.EGRESS, parameters, data);
 		} else {
 			double distanceFactor = data.config.getBeelineWalkDistanceFactor();
-			List<TransitStopFacility> stops = findNearbyStops(facility, parameters, data);
+			List<TransitStopFacility> stops = findNearbyStops(toFacility, parameters, data);
 			List<InitialStop> initialStops = stops.stream().map(stop -> {
-				double beelineDistance = CoordUtils.calcEuclideanDistance(stop.getCoord(), facility.getCoord());
+				double beelineDistance = CoordUtils.calcEuclideanDistance(stop.getCoord(), toFacility.getCoord());
 				double travelTime = Math.ceil(beelineDistance / parameters.getBeelineWalkSpeed());
 				double disutility = travelTime * -parameters.getMarginalUtilityOfTravelTime_utl_s(TransportMode.walk);
 				return new InitialStop(stop, disutility, travelTime, beelineDistance * distanceFactor, TransportMode.walk);
@@ -108,22 +109,24 @@ public class DefaultRaptorStopFinder implements RaptorStopFinder {
 		}
 	}
 
-	private List<InitialStop> findIntermodalStops(Facility facility, Person person, double departureTime, Direction direction, RaptorParameters parameters, SwissRailRaptorData data) {
+	private List<InitialStop> findIntermodalStops(Facility fromFacility, Facility toFacility, Person person, double departureTime,
+			Direction direction, RaptorParameters parameters, SwissRailRaptorData data) {
 		SwissRailRaptorConfigGroup srrCfg = parameters.getConfig();
+		Facility facility = Direction.ACCESS == direction ? fromFacility : toFacility;
 		double x = facility.getCoord().getX();
 		double y = facility.getCoord().getY();
 		List<InitialStop> initialStops = new ArrayList<>();
         switch (srrCfg.getIntermodalAccessEgressModeSelection()) {
             case CalcLeastCostModePerStop:
                 for (IntermodalAccessEgressParameterSet parameterSet : srrCfg.getIntermodalAccessEgressParameterSets()) {
-                    addInitialStopsForParamSet(facility, person, departureTime, direction, parameters, data, x, y, initialStops, parameterSet);
+                    addInitialStopsForParamSet(fromFacility, toFacility, person, departureTime, direction, parameters, data, x, y, initialStops, parameterSet);
                 }
                 break;
             case RandomSelectOneModePerRoutingRequestAndDirection:
                 int counter = 0;
                 do {
                     int rndSelector = random.nextInt(srrCfg.getIntermodalAccessEgressParameterSets().size());
-                    addInitialStopsForParamSet(facility, person, departureTime, direction, parameters, data, x, y,
+                    addInitialStopsForParamSet(fromFacility, toFacility, person, departureTime, direction, parameters, data, x, y,
                             initialStops, srrCfg.getIntermodalAccessEgressParameterSets().get(rndSelector));
                     counter++;
                     // try again if no initial stop was found for the parameterset. Avoid infinite loop by limiting number of tries.
@@ -135,7 +138,7 @@ public class DefaultRaptorStopFinder implements RaptorStopFinder {
         return initialStops;
     }
 
-    private void addInitialStopsForParamSet(Facility facility, Person person, double departureTime, Direction direction, RaptorParameters parameters, SwissRailRaptorData data, double x, double y, List<InitialStop> initialStops, IntermodalAccessEgressParameterSet paramset) {
+    private void addInitialStopsForParamSet(Facility fromFacility, Facility toFacility, Person person, double departureTime, Direction direction, RaptorParameters parameters, SwissRailRaptorData data, double x, double y, List<InitialStop> initialStops, IntermodalAccessEgressParameterSet paramset) {
         String mode = paramset.getMode();
         String linkIdAttribute = paramset.getLinkIdAttribute();
         String personFilterAttribute = paramset.getPersonFilterAttribute();
@@ -143,6 +146,7 @@ public class DefaultRaptorStopFinder implements RaptorStopFinder {
         String stopFilterAttribute = paramset.getStopFilterAttribute();
         String stopFilterValue = paramset.getStopFilterValue();
 
+        Facility facility = Direction.ACCESS == direction ? fromFacility : toFacility;
         boolean personMatches = true;
         if (personFilterAttribute != null) {
             Object attr = person.getAttributes().getAttribute(personFilterAttribute);
@@ -158,7 +162,11 @@ public class DefaultRaptorStopFinder implements RaptorStopFinder {
             } else {
                 filteredStopsQT = data.stopsQT;
             }
+            
+            double distance = CoordUtils.calcEuclideanDistance(fromFacility.getCoord(), toFacility.getCoord());
+            double tripBasedSearchRadius = distance * paramset.getPercentTripSearchRadius();
             double searchRadius = Math.min(paramset.getInitialSearchRadius(), paramset.getMaxRadius());
+            searchRadius  = Math.min(searchRadius, tripBasedSearchRadius);
             Collection<TransitStopFacility> stopFacilities = filteredStopsQT.getDisk(x, y, searchRadius);
             if (stopFacilities.size() < 2) {
                 TransitStopFacility nearestStop = filteredStopsQT.getClosest(x, y);

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/RaptorStopFinder.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/RaptorStopFinder.java
@@ -15,6 +15,6 @@ public interface RaptorStopFinder {
 
 	public enum Direction { ACCESS, EGRESS }
 
-	List<InitialStop> findStops(Facility facility, Person person, double departureTime, RaptorParameters parameters, SwissRailRaptorData data, Direction type);
+	List<InitialStop> findStops(Facility fromFacility, Facility toFacility, Person person, double departureTime, RaptorParameters parameters, SwissRailRaptorData data, Direction type);
 
 }

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptor.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptor.java
@@ -62,8 +62,8 @@ public class SwissRailRaptor implements TransitRouter {
         if (parameters.getConfig().isUseRangeQuery()) {
             return this.performRangeQuery(fromFacility, toFacility, departureTime, person, parameters);
         }
-        List<InitialStop> accessStops = findAccessStops(fromFacility, person, departureTime, parameters);
-        List<InitialStop> egressStops = findEgressStops(toFacility, person, departureTime, parameters);
+        List<InitialStop> accessStops = findAccessStops(fromFacility, toFacility, person, departureTime, parameters);
+        List<InitialStop> egressStops = findEgressStops(fromFacility, toFacility, person, departureTime, parameters);
 
         RaptorRoute foundRoute = this.raptor.calcLeastCostRoute(departureTime, fromFacility, toFacility, accessStops, egressStops, parameters, person);
         RaptorRoute directWalk = createDirectWalk(fromFacility, toFacility, departureTime, person, parameters);
@@ -151,8 +151,8 @@ public class SwissRailRaptor implements TransitRouter {
 
     public List<Leg> calcRoute(Facility fromFacility, Facility toFacility, double earliestDepartureTime, double desiredDepartureTime, double latestDepartureTime, Person person, RaptorRouteSelector selector) {
         RaptorParameters parameters = this.parametersForPerson.getRaptorParameters(person);
-        List<InitialStop> accessStops = findAccessStops(fromFacility, person, desiredDepartureTime, parameters);
-        List<InitialStop> egressStops = findEgressStops(toFacility, person, desiredDepartureTime, parameters);
+        List<InitialStop> accessStops = findAccessStops(fromFacility, toFacility, person, desiredDepartureTime, parameters);
+        List<InitialStop> egressStops = findEgressStops(fromFacility, toFacility, person, desiredDepartureTime, parameters);
 
         List<RaptorRoute> foundRoutes = this.raptor.calcRoutes(earliestDepartureTime, desiredDepartureTime, latestDepartureTime, fromFacility, toFacility, accessStops, egressStops, parameters, person);
         RaptorRoute foundRoute = selector.selectOne(foundRoutes, desiredDepartureTime);
@@ -187,8 +187,8 @@ public class SwissRailRaptor implements TransitRouter {
 
     public List<RaptorRoute> calcRoutes(Facility fromFacility, Facility toFacility, double earliestDepartureTime, double desiredDepartureTime, double latestDepartureTime, Person person) {
         RaptorParameters parameters = this.parametersForPerson.getRaptorParameters(person);
-        List<InitialStop> accessStops = findAccessStops(fromFacility, person, desiredDepartureTime, parameters);
-        List<InitialStop> egressStops = findEgressStops(toFacility, person, desiredDepartureTime, parameters);
+        List<InitialStop> accessStops = findAccessStops(fromFacility, toFacility, person, desiredDepartureTime, parameters);
+        List<InitialStop> egressStops = findEgressStops(fromFacility, toFacility, person, desiredDepartureTime, parameters);
 
         List<RaptorRoute> foundRoutes = this.raptor.calcRoutes(earliestDepartureTime, desiredDepartureTime, latestDepartureTime, fromFacility, toFacility, accessStops, egressStops, parameters, person);
         RaptorRoute directWalk = createDirectWalk(fromFacility, toFacility, desiredDepartureTime, person, parameters);
@@ -227,7 +227,7 @@ public class SwissRailRaptor implements TransitRouter {
 
     public Map<Id<TransitStopFacility>, SwissRailRaptorCore.TravelInfo> calcTree(Facility fromFacility, double departureTime, Person person) {
         RaptorParameters parameters = this.parametersForPerson.getRaptorParameters(person);
-        List<InitialStop> accessStops = findAccessStops(fromFacility, person, departureTime, parameters);
+        List<InitialStop> accessStops = findAccessStops(fromFacility, fromFacility, person, departureTime, parameters);
         return this.calcLeastCostTree(accessStops, departureTime, parameters, person);
     }
 
@@ -239,12 +239,12 @@ public class SwissRailRaptor implements TransitRouter {
         return this.data;
     }
 
-    private List<InitialStop> findAccessStops(Facility facility, Person person, double departureTime, RaptorParameters parameters) {
-        return this.stopFinder.findStops(facility, person, departureTime, parameters, this.data, RaptorStopFinder.Direction.ACCESS);
+    private List<InitialStop> findAccessStops(Facility fromFacility, Facility toFacility, Person person, double departureTime, RaptorParameters parameters) {
+        return this.stopFinder.findStops(fromFacility, toFacility, person, departureTime, parameters, this.data, RaptorStopFinder.Direction.ACCESS);
     }
 
-    private List<InitialStop> findEgressStops(Facility facility, Person person, double departureTime, RaptorParameters parameters) {
-        return this.stopFinder.findStops(facility, person, departureTime, parameters, this.data, RaptorStopFinder.Direction.EGRESS);
+    private List<InitialStop> findEgressStops(Facility fromFacility, Facility toFacility, Person person, double departureTime, RaptorParameters parameters) {
+        return this.stopFinder.findStops(fromFacility, toFacility, person, departureTime, parameters, this.data, RaptorStopFinder.Direction.EGRESS);
     }
 
     // TODO: replace with call to FallbackRoutingModule ?!

--- a/matsim/src/test/java/ch/sbb/matsim/config/SwissRailRaptorConfigGroupTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/config/SwissRailRaptorConfigGroupTest.java
@@ -147,6 +147,7 @@ public class SwissRailRaptorConfigGroupTest {
             paramset1.setMaxRadius(2000);
             paramset1.setInitialSearchRadius(1500);
             paramset1.setSearchExtensionRadius(1000);
+            paramset1.setShareTripSearchRadius(0.01);
             paramset1.setPersonFilterAttribute(null);
             paramset1.setStopFilterAttribute("bikeAndRail");
             paramset1.setStopFilterValue("true");
@@ -179,6 +180,7 @@ public class SwissRailRaptorConfigGroupTest {
         Assert.assertEquals(2000, paramSet1.getMaxRadius(), 0.0);
         Assert.assertEquals(1500, paramSet1.getInitialSearchRadius(), 0.0);
         Assert.assertEquals(1000, paramSet1.getSearchExtensionRadius(), 0.0);
+        Assert.assertEquals(0.01, paramSet1.getShareTripSearchRadius(), 0.0);
         Assert.assertNull(paramSet1.getPersonFilterAttribute());
         Assert.assertNull(paramSet1.getPersonFilterValue());
         Assert.assertNull(paramSet1.getLinkIdAttribute());
@@ -190,6 +192,7 @@ public class SwissRailRaptorConfigGroupTest {
         Assert.assertEquals(5000, paramSet2.getMaxRadius(), 0.0);
         Assert.assertEquals(3000, paramSet2.getInitialSearchRadius(), 0.0);
         Assert.assertEquals(2000, paramSet2.getSearchExtensionRadius(), 0.0);
+        Assert.assertEquals(Double.POSITIVE_INFINITY, paramSet2.getShareTripSearchRadius(), 0.0);
         Assert.assertEquals("sff_user", paramSet2.getPersonFilterAttribute());
         Assert.assertEquals("true", paramSet2.getPersonFilterValue());
         Assert.assertEquals("linkId_sff", paramSet2.getLinkIdAttribute());

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorIntermodalTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorIntermodalTest.java
@@ -897,7 +897,7 @@ public class SwissRailRaptorIntermodalTest {
         bikeAccess.setLinkIdAttribute("accessLinkId_bike");
         bikeAccess.setStopFilterValue("true");
         bikeAccess.setSearchExtensionRadius(0.0);
-        bikeAccess.setPercentTripSearchRadius(0.0001);
+        bikeAccess.setShareTripSearchRadius(0.0001);
         f.srrConfig.addIntermodalAccessEgress(bikeAccess);
 
         SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), null, RaptorUtils.createStaticConfig(f.config), f.scenario.getNetwork(), null);

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorIntermodalTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorIntermodalTest.java
@@ -859,6 +859,83 @@ public class SwissRailRaptorIntermodalTest {
         
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs2);        
     }
+    /**
+     * 
+     * The agent has a super-fast bike. So in theory it is faster to travel
+     * from stop_3 to the destination. However, with the introduced trip share
+     * constraint it will still take the closest stop accessible by the bike.
+     * If this constraint is not used the agent will take pt_3 stop as an 
+     * access stop to his final destination.
+     * 
+     */
+    @Test
+    public void testIntermodalTrip_tripLengthShare() {
+        IntermodalFixture f = new IntermodalFixture();
+
+        PlanCalcScoreConfigGroup.ModeParams walk = new PlanCalcScoreConfigGroup.ModeParams(TransportMode.walk);
+        walk.setMarginalUtilityOfTraveling(0.0);
+        f.config.planCalcScore().addModeParams(walk);
+
+        Map<String, RoutingModule> routingModules = new HashMap<>();
+        routingModules.put(TransportMode.walk,
+            new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3));
+        routingModules.put(TransportMode.bike,
+            new TeleportationRoutingModule(TransportMode.bike, f.scenario, 60, 1.0));
+
+        f.srrConfig.setUseIntermodalAccessEgress(true);
+        IntermodalAccessEgressParameterSet walkAccess = new IntermodalAccessEgressParameterSet();
+        walkAccess.setMode(TransportMode.walk);
+        walkAccess.setMaxRadius(1000);
+        walkAccess.setInitialSearchRadius(1000);
+        walkAccess.setSearchExtensionRadius(0.0);
+        f.srrConfig.addIntermodalAccessEgress(walkAccess);
+        IntermodalAccessEgressParameterSet bikeAccess = new IntermodalAccessEgressParameterSet();
+        bikeAccess.setMode(TransportMode.bike);
+        bikeAccess.setMaxRadius(30000);
+        bikeAccess.setInitialSearchRadius(30000);
+        bikeAccess.setStopFilterAttribute("bikeAccessible");
+        bikeAccess.setLinkIdAttribute("accessLinkId_bike");
+        bikeAccess.setStopFilterValue("true");
+        bikeAccess.setSearchExtensionRadius(0.0);
+        bikeAccess.setPercentTripSearchRadius(0.0001);
+        f.srrConfig.addIntermodalAccessEgress(bikeAccess);
+
+        SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), null, RaptorUtils.createStaticConfig(f.config), f.scenario.getNetwork(), null);
+        DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
+        SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f.scenario.getConfig()).with(stopFinder).build();
+
+        Facility fromFac = new FakeFacility(new Coord(8500, 10000), Id.create("from", Link.class));
+        Facility toFac = new FakeFacility(new Coord(40000, 10500), Id.create("to", Link.class));
+
+        List<Leg> legs = raptor.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson);
+        for (Leg leg : legs) {
+            System.out.println(leg);
+        }
+
+        Assert.assertEquals("wrong number of legs.", 5, legs.size());
+        Leg leg = legs.get(0);
+        Assert.assertEquals(TransportMode.bike, leg.getMode());
+        Assert.assertEquals(Id.create("from", Link.class), leg.getRoute().getStartLinkId());
+        Assert.assertEquals(Id.create("bike_0", Link.class), leg.getRoute().getEndLinkId());
+        leg = legs.get(1);
+        Assert.assertEquals(TransportMode.walk, leg.getMode());
+        Assert.assertEquals(Id.create("bike_0", Link.class), leg.getRoute().getStartLinkId());
+        Assert.assertEquals(Id.create("pt_0", Link.class), leg.getRoute().getEndLinkId());
+        leg = legs.get(2);
+        Assert.assertEquals(TransportMode.pt, leg.getMode());
+        Assert.assertEquals(Id.create("pt_0", Link.class), leg.getRoute().getStartLinkId());
+        Assert.assertEquals(Id.create("pt_5", Link.class), leg.getRoute().getEndLinkId());
+        leg = legs.get(3);
+        Assert.assertEquals(TransportMode.walk, leg.getMode());
+        Assert.assertEquals(Id.create("pt_5", Link.class), leg.getRoute().getStartLinkId());
+        Assert.assertEquals(Id.create("bike_5", Link.class), leg.getRoute().getEndLinkId());
+        leg = legs.get(4);
+        Assert.assertEquals(TransportMode.bike, leg.getMode());
+        Assert.assertEquals(Id.create("bike_5", Link.class), leg.getRoute().getStartLinkId());
+        Assert.assertEquals(Id.create("to", Link.class), leg.getRoute().getEndLinkId());
+    }
+    
+    
 
     /* for test of intermodal routing requiring transfers at the beginning or end of the pt trip,
      * the normal IntermodalFixture does not work, so create a special mini scenario here.


### PR DESCRIPTION
We have been working with the intermodal feature of the SwissRailRaptor extensively lately. Through this work we have encountered few places where SRR could be improved. 

One of the biggest challenges with intermodal router is the computation time. Imagine a situation where you have a trip that is 1km long, but your search radius for a particular access/egress service is 5 km. It is hard to imagine that a person would search for a stop further than the length of the trip itself. Therefore, it would be good to have a settable parameter than can be used to limit the search radius depending on the length of the trip. Currently, however, this cannot easily be added, as the [RaptorStopFinder](https://github.com/matsim-org/matsim-libs/blob/1cd0cd7bb65e7af9fd7abfec0bf8e61cc90acf46/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/RaptorStopFinder.java#L18) does not take both start and end facility as arguments. This pull request:

- adds both starting and ending facility to the stop finder
- adds the parameter that can be used to adjust the search radius dependent on the trip crowfly distance.
- adapts intermodal and config tests

