### PR TITLE
Migrated ModeChoiceCoverage analysis tool from matsim-berlin to matsim-libs

### DIFF
--- a/matsim/src/main/java/org/matsim/analysis/ModeChoiceCoverageControlerListener.java
+++ b/matsim/src/main/java/org/matsim/analysis/ModeChoiceCoverageControlerListener.java
@@ -1,0 +1,240 @@
+package org.matsim.analysis;
+
+import org.apache.log4j.Logger;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Plan;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.core.config.groups.ControlerConfigGroup;
+import org.matsim.core.config.groups.PlanCalcScoreConfigGroup;
+import org.matsim.core.controler.OutputDirectoryHierarchy;
+import org.matsim.core.controler.events.IterationEndsEvent;
+import org.matsim.core.controler.events.ShutdownEvent;
+import org.matsim.core.controler.events.StartupEvent;
+import org.matsim.core.controler.listener.IterationEndsListener;
+import org.matsim.core.controler.listener.ShutdownListener;
+import org.matsim.core.controler.listener.StartupListener;
+import org.matsim.core.router.AnalysisMainModeIdentifier;
+import org.matsim.core.router.MainModeIdentifier;
+import org.matsim.core.router.TripStructureUtils;
+import org.matsim.core.router.TripStructureUtils.Trip;
+import org.matsim.core.utils.charts.XYLineChart;
+import org.matsim.core.utils.io.IOUtils;
+
+import javax.inject.Inject;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.util.*;
+import java.util.Map.Entry;
+
+/**
+ * Calculates mode choice coverage at the end of each iteration, based on the main mode identifier of a trip chain.
+ * Mode choice coverage percentage of trips have used a certain mode at least once (or 5x, 10x, …) in previous iterations.
+ *
+ * @author jakobrehmann
+ */
+public class ModeChoiceCoverageControlerListener implements StartupListener, IterationEndsListener,
+        ShutdownListener {
+
+    private final static Logger log = Logger.getLogger(ModeStatsControlerListener.class);
+
+
+    private final Map<Integer, BufferedWriter> modeOutMap = new HashMap<>();
+
+    private final Population population;
+    private final String modeFileName;
+    private final boolean createPNG;
+    private final ControlerConfigGroup controlerConfigGroup;
+    private final MainModeIdentifier mainModeIdentifier;
+
+    private int minIteration = 0;
+    private int firstIteration = -1;
+
+    private final Integer[] limits = new Integer[]{1, 5, 10};
+
+    private final Map<Integer, Map<String, Map<Integer, Double>>> modeCCHistory = new HashMap<>();
+    //            Map<Iter   , Map<Mode  , Map<Limit  , Pct   >>>
+    private final Map<Id<Person>, Map<Integer, Map<String, Integer>>> modesUsedPerPersonTrip = new LinkedHashMap<>();
+    //            Map<Person    , Map<Trip # , Map<Mode  , Count  >>>
+    private static final String FILENAME_MODESTATS = "modeChoiceCoverage";
+
+    // Keep all modes encountered so far in a sorted set to ensure output is written for modes sorted by mode.
+    private final Set<String> modes;
+
+
+    @Inject
+    ModeChoiceCoverageControlerListener(ControlerConfigGroup controlerConfigGroup, Population population1, OutputDirectoryHierarchy controlerIO,
+                                        PlanCalcScoreConfigGroup scoreConfig, AnalysisMainModeIdentifier mainModeIdentifier) {
+
+        this.controlerConfigGroup = controlerConfigGroup;
+        this.population = population1;
+        this.modeFileName = controlerIO.getOutputFilename(FILENAME_MODESTATS);
+        //		this.createPNG = controlerConfigGroup.isCreateGraphs();
+        this.createPNG = true;
+
+        this.modes = new TreeSet<>();
+        //		this.modes.addAll(scoreConfig.getAllModes());
+
+        this.mainModeIdentifier = mainModeIdentifier;
+    }
+
+    @Override
+    public void notifyStartup(final StartupEvent event) {
+        this.minIteration = controlerConfigGroup.getFirstIteration();
+    }
+
+    @Override
+    public void notifyIterationEnds(final IterationEndsEvent event) {
+
+        if (firstIteration < 0) {
+            firstIteration = event.getIteration();
+        }
+
+        /*
+         *  modesUsedPerPersonTrip: for each person-trip, how many times (iterations) was each mode used. The following code adds the
+         * 	mode information from the current iteration to the modesUsedPerPersonTrip.
+         */
+
+        updateModesUsedPerPerson();
+
+
+        /*
+         *	Looks through modesUsedPerPersonTrip at each person-trip. How many of those person trips have used each mode more than the
+         *  predefined limits.
+         */
+        int totalPersonTripCount = 0;
+        Map<Integer, Map<String, Double>> modeCountCurrentIteration = new TreeMap<>();
+        //Map<Limit, Map<Mode  , TotalTripCount >>
+
+        for (Map<Integer, Map<String, Integer>> mapForPerson : modesUsedPerPersonTrip.values()) {
+            //Map<Trip # , Map<Mode  , Count  >>
+            for (Map<String, Integer> mapForPersonTrip : mapForPerson.values()) {
+                //Map<Mode  , Count >
+                totalPersonTripCount++;
+                for (String mode : mapForPersonTrip.keySet()) {
+                    Integer realCount = mapForPersonTrip.get(mode);
+                    for (Integer limit : limits) {
+                        Map<String, Double> modeCountMap = modeCountCurrentIteration.computeIfAbsent(limit, k -> new TreeMap<>());
+                        Double modeCount = modeCountMap.computeIfAbsent(mode, k -> 0.);
+                        if (realCount >= limit) {
+                            modeCount++;
+                        }
+                        modeCountMap.put(mode, modeCount);
+                        modeCountCurrentIteration.put(limit, modeCountMap);
+                    }
+                }
+            }
+        }
+        // Calculates mcc share for each mode in current iteration, and updates modeCCHistory accordingly
+        for (Integer limit : limits) {
+            Map<String, Double> modeCnt = modeCountCurrentIteration.get(limit);
+            this.modes.addAll(modeCnt.keySet()); // potentially adds new modes to setthat just showed up in current iter
+            Map<String, Map<Integer, Double>> modeIterationShareMap = modeCCHistory.computeIfAbsent(limit, k -> new HashMap<>());
+            for (String mode : modes) {
+                Double cnt = modeCnt.get(mode);
+                double share = 0.;
+                if (cnt != null) {
+                    share = cnt / totalPersonTripCount;
+                }
+
+                log.info("-- mode choice coverage (" + limit + "x) of mode " + mode + " = " + share);
+
+                Map<Integer, Double> iterationShareMap = modeIterationShareMap.get(mode);
+
+                // If this is the first iteration where the mode shows up, add zeros to all previous iterations in history
+                if (iterationShareMap == null) {
+                    iterationShareMap = new TreeMap<>();
+                    for (int iter = firstIteration; iter < event.getIteration(); iter++) {
+                        iterationShareMap.put(iter, 0.0);
+                    }
+                    modeIterationShareMap.put(mode, iterationShareMap);
+                }
+
+                iterationShareMap.put(event.getIteration(), share);
+            }
+        }
+
+
+        // Print MCC Stats to output file
+        for (Integer limit : limits) {
+            Map<String, Map<Integer, Double>> modeIterationShareMap = modeCCHistory.get(limit);
+
+            BufferedWriter modeOut = IOUtils.getBufferedWriter(this.modeFileName + limit + "x.txt");
+            try {
+                modeOut.write("Iteration");
+                for (String mode : modes) {
+                    modeOut.write("\t" + mode);
+                }
+                modeOut.write("\n");
+                for (int iter = firstIteration; iter <= event.getIteration(); iter++) {
+                    modeOut.write(String.valueOf(iter));
+                    for (String mode : modes) {
+                        modeOut.write("\t" + modeIterationShareMap.get(mode).get(iter));
+                    }
+                    modeOut.write("\n");
+                }
+
+                modeOut.flush();
+                modeOut.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        // Produce Graphs
+        if (this.createPNG && event.getIteration() > this.minIteration) {
+            produceGraphs();
+        }
+
+    }
+
+    private void updateModesUsedPerPerson() {
+        for (Person person : this.population.getPersons().values()) {
+
+            Map<Integer, Map<String, Integer>> mapForPerson = modesUsedPerPersonTrip.computeIfAbsent(person.getId(), v -> new LinkedHashMap<>());
+
+            Plan plan = person.getSelectedPlan();
+            Integer tripNumber = 0;
+            for (Trip trip : TripStructureUtils.getTrips(plan)) {
+
+                tripNumber++;
+                String mode = this.mainModeIdentifier.identifyMainMode(trip.getTripElements());
+
+                Map<String, Integer> mapForPersonTrip = mapForPerson.computeIfAbsent(tripNumber, v -> new HashMap<>());
+
+                Integer modeCount = mapForPersonTrip.getOrDefault(mode, 0);
+                mapForPersonTrip.put(mode, modeCount + 1);
+
+            }
+        }
+    }
+
+    private void produceGraphs() {
+        for (Integer limit : limits) {
+            XYLineChart chart = new XYLineChart("Mode Choice Coverage (Mode Used >= " + limit + "x per trip)", "iteration", "mode choice coverage");
+            for (Entry<String, Map<Integer, Double>> entry : modeCCHistory.get(limit).entrySet()) {
+                String mode = entry.getKey();
+                Map<Integer, Double> history = entry.getValue();
+                chart.addSeries(mode, history);
+            }
+            chart.addMatsimLogo();
+            chart.saveAsPng(this.modeFileName + limit + "x" + ".png", 800, 600);
+        }
+    }
+
+    @Override
+    public void notifyShutdown(final ShutdownEvent controlerShudownEvent) {
+
+        //        for (BufferedWriter modeOut : modeOutMap.values()) {
+        //            try {
+        //                modeOut.close();
+        //            } catch (IOException e) {
+        //                e.printStackTrace();
+        //            }
+        //        }
+    }
+
+    public final Map<Integer, Map<String, Map<Integer, Double>>> getModeChoiceCoverageHistory() {
+        return Collections.unmodifiableMap(modeCCHistory);
+    }
+}

--- a/matsim/src/test/java/org/matsim/analysis/ModeChoiceCoverageControlerListenerTest.java
+++ b/matsim/src/test/java/org/matsim/analysis/ModeChoiceCoverageControlerListenerTest.java
@@ -1,0 +1,246 @@
+package org.matsim.analysis;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.population.*;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.config.groups.ControlerConfigGroup;
+import org.matsim.core.config.groups.ControlerConfigGroup.CompressionType;
+import org.matsim.core.config.groups.PlanCalcScoreConfigGroup;
+import org.matsim.core.controler.OutputDirectoryHierarchy;
+import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
+import org.matsim.core.controler.events.IterationEndsEvent;
+import org.matsim.core.controler.events.StartupEvent;
+import org.matsim.core.population.PopulationUtils;
+import org.matsim.testcases.MatsimTestUtils;
+
+import java.util.Map;
+
+/**
+ *
+ * Tests ModeChoiceCoverageControlerListener
+ *
+ * @author jakobrehmann
+ * adapted from Aravind "ModeStatsControlerListenerTest"
+ *
+ */
+public class ModeChoiceCoverageControlerListenerTest {
+
+    @Rule
+    public MatsimTestUtils utils = new MatsimTestUtils();
+
+
+    @Test
+    public void testChangePlanModes() {
+
+        Population population = PopulationUtils.createPopulation(ConfigUtils.createConfig());
+        PlanCalcScoreConfigGroup scoreConfig = new PlanCalcScoreConfigGroup();
+        TransportPlanningMainModeIdentifier transportId = new TransportPlanningMainModeIdentifier();
+
+        ControlerConfigGroup controlerConfigGroup = new ControlerConfigGroup();
+        OutputDirectoryHierarchy controlerIO = new OutputDirectoryHierarchy("/ModeChoiceCoverageControlerListener",
+                OverwriteFileSetting.overwriteExistingFiles, CompressionType.gzip);
+
+        Person person = PopulationUtils.getFactory().createPerson(Id.create(1, Person.class));
+        population.addPerson(person);
+
+        ModeChoiceCoverageControlerListener modeCC = new ModeChoiceCoverageControlerListener(controlerConfigGroup, population, controlerIO, scoreConfig, transportId);
+        modeCC.notifyStartup(new StartupEvent(null));
+
+        // Iteration 0: walk - walk
+        Plan plan1 = makePlan(person, TransportMode.walk, TransportMode.walk);
+        person.addPlan(plan1);
+        person.setSelectedPlan(plan1);
+
+        modeCC.notifyIterationEnds(new IterationEndsEvent(null, 0,false));
+        Map<Integer, Map<String, Map<Integer, Double>>> modeChoiceCoverageHistory = modeCC.getModeChoiceCoverageHistory();
+        Assert.assertEquals( "There should only be one mode in the mode modeCCHistory",
+                1, modeChoiceCoverageHistory.get(1).keySet().size());
+        Assert.assertEquals( "Since all trips were completed with walk, mcc for walk should be 1.0 (or 100%)",
+                (Double) 1.0, modeChoiceCoverageHistory.get(1).get(TransportMode.walk).get(0));
+
+        // Iteration 1: walk - bike
+        Plan plan2 = makePlan(person, TransportMode.walk, TransportMode.bike);
+        person.addPlan(plan2);
+        person.setSelectedPlan(plan2);
+
+        modeCC.notifyIterationEnds(new IterationEndsEvent(null, 1,false));
+        Assert.assertEquals( "There should now be two modes in modeCCHistory",
+                2, modeChoiceCoverageHistory.get(1).keySet().size());
+        Assert.assertEquals( "Since all trips were completed with walk (in previous iterations), mcc for walk should be 1.0 (or 100%)",
+                (Double) 1.0, modeChoiceCoverageHistory.get(1).get(TransportMode.walk).get(1));
+        Assert.assertEquals( "The mcc for bike from the 0th iteration should be 0.0, since bike only showed up in this iteration",
+                (Double) 0.0, modeChoiceCoverageHistory.get(1).get(TransportMode.bike).get(0));
+        Assert.assertEquals( "Since 1 of 2 trips were completed with bike, mcc for bike should be 0.5 (or 50%)",
+                (Double) 0.5, modeChoiceCoverageHistory.get(1).get(TransportMode.bike).get(1));
+
+        // Iteration 3: bike - walk
+        Plan plan3 = makePlan(person, TransportMode.bike, TransportMode.walk);
+        person.addPlan(plan3);
+        person.setSelectedPlan(plan3);
+
+        modeCC.notifyIterationEnds(new IterationEndsEvent(null, 2,false));
+        Assert.assertEquals( "There should still be two modes in modeCCHistory",
+                2, modeChoiceCoverageHistory.get(1).keySet().size());
+        Assert.assertEquals( "Since all trips were completed with walk (in previous iterations), mcc for walk should be 1.0 (or 100%)",
+                (Double) 1.0, modeChoiceCoverageHistory.get(1).get(TransportMode.walk).get(2));
+        Assert.assertEquals( "Since all trips were completed with bike (in previous iterations), mcc for bike should be 1.0 (or 100%)",
+                (Double) 1.0, modeChoiceCoverageHistory.get(1).get(TransportMode.bike).get(2));
+    }
+
+    @Test
+    public void testTwoAgents() {
+        Population population = PopulationUtils.createPopulation(ConfigUtils.createConfig());
+        PlanCalcScoreConfigGroup scoreConfig = new PlanCalcScoreConfigGroup();
+        TransportPlanningMainModeIdentifier transportId = new TransportPlanningMainModeIdentifier();
+
+        ControlerConfigGroup controlerConfigGroup = new ControlerConfigGroup();
+        OutputDirectoryHierarchy controlerIO = new OutputDirectoryHierarchy("/ModeChoiceCoverageControlerListener",
+                OverwriteFileSetting.overwriteExistingFiles, CompressionType.gzip);
+
+        Person person1 = PopulationUtils.getFactory().createPerson(Id.create(1, Person.class));
+        Person person2 = PopulationUtils.getFactory().createPerson(Id.create(2, Person.class));
+        population.addPerson(person1);
+        population.addPerson(person2);
+
+
+        ModeChoiceCoverageControlerListener modeCC = new ModeChoiceCoverageControlerListener(controlerConfigGroup, population, controlerIO, scoreConfig, transportId);
+        modeCC.notifyStartup(new StartupEvent(null));
+
+        // Iteration 0: walk - walk
+        Plan person1plan1 = makePlan(person1, TransportMode.walk, TransportMode.walk);
+        person1.addPlan(person1plan1);
+        person1.setSelectedPlan(person1plan1);
+
+        Plan person2plan1 = makePlan(person2, TransportMode.walk, TransportMode.walk);
+        person2.addPlan(person2plan1);
+        person2.setSelectedPlan(person2plan1);
+
+        modeCC.notifyIterationEnds(new IterationEndsEvent(null, 0,false));
+        Map<Integer, Map<String, Map<Integer, Double>>> modeChoiceCoverageHistory = modeCC.getModeChoiceCoverageHistory();
+        Assert.assertEquals( "There should only be one mode in the mode modeCCHistory",
+                1, modeChoiceCoverageHistory.get(1).keySet().size());
+        Assert.assertEquals( "Since all trips were completed with walk, mcc for walk should be 1.0 (or 100%)",
+                (Double) 1.0, modeChoiceCoverageHistory.get(1).get(TransportMode.walk).get(0));
+
+        // Iteration 1: p1: walk - bike, p2: walk - walk
+        Plan person1plan2 = makePlan(person1, TransportMode.walk, TransportMode.bike);
+        person1.addPlan(person1plan2);
+        person1.setSelectedPlan(person1plan2);
+
+        Plan person2plan2 = makePlan(person2, TransportMode.walk, TransportMode.walk);
+        person2.addPlan(person2plan2);
+        person2.setSelectedPlan(person2plan2);
+
+        modeCC.notifyIterationEnds(new IterationEndsEvent(null, 1,false));
+        Assert.assertEquals( "There should now be two modes in modeCCHistory",
+                2, modeChoiceCoverageHistory.get(1).keySet().size());
+        Assert.assertEquals( "Since all trips were completed with walk (in previous iterations), mcc for walk should be 1.0 (or 100%)",
+                (Double) 1.0, modeChoiceCoverageHistory.get(1).get(TransportMode.walk).get(1));
+        Assert.assertEquals( "Since 1 of 4 trips were completed with bike, mcc for bike should be 0.25 (or 25%)",
+                (Double) 0.25, modeChoiceCoverageHistory.get(1).get(TransportMode.bike).get(1));
+
+        // Iteration 3: p1: walk - walk, p2: bike - bike
+        Plan person1plan3 = makePlan(person1, TransportMode.walk, TransportMode.walk);
+        person1.addPlan(person1plan3);
+        person1.setSelectedPlan(person1plan3);
+
+        Plan person2plan3 = makePlan(person1, TransportMode.bike, TransportMode.bike);
+        person2.addPlan(person2plan3);
+        person2.setSelectedPlan(person2plan3);
+
+        modeCC.notifyIterationEnds(new IterationEndsEvent(null, 2,false));
+        Assert.assertEquals( "There should still be two modes in modeCCHistory",
+                2, modeChoiceCoverageHistory.get(1).keySet().size());
+        Assert.assertEquals( "Since all trips were completed with walk (in previous iterations), mcc for walk should be 1.0 (or 100%)",
+                (Double) 1.0, modeChoiceCoverageHistory.get(1).get(TransportMode.walk).get(2));
+        Assert.assertEquals( "Since 3 of 4 trips were completed with bike (in previous iterations), mcc for bike should be 0.75 (or 75%)",
+                (Double) 0.75, modeChoiceCoverageHistory.get(1).get(TransportMode.bike).get(2));
+    }
+
+    @Test
+    public void testDifferentLevels() {
+
+        Population population = PopulationUtils.createPopulation(ConfigUtils.createConfig());
+        PlanCalcScoreConfigGroup scoreConfig = new PlanCalcScoreConfigGroup();
+        TransportPlanningMainModeIdentifier transportId = new TransportPlanningMainModeIdentifier();
+
+        ControlerConfigGroup controlerConfigGroup = new ControlerConfigGroup();
+        OutputDirectoryHierarchy controlerIO = new OutputDirectoryHierarchy("/ModeChoiceCoverageControlerListener",
+                OverwriteFileSetting.overwriteExistingFiles, CompressionType.gzip);
+
+        Person person = PopulationUtils.getFactory().createPerson(Id.create(1, Person.class));
+        population.addPerson(person);
+
+        ModeChoiceCoverageControlerListener modeCC = new ModeChoiceCoverageControlerListener(controlerConfigGroup, population, controlerIO, scoreConfig, transportId);
+        modeCC.notifyStartup(new StartupEvent(null));
+
+        // After 1 iteration
+        Plan plan1 = makePlan(person, TransportMode.walk, TransportMode.walk);
+        person.addPlan(plan1);
+        person.setSelectedPlan(plan1);
+
+        modeCC.notifyIterationEnds(new IterationEndsEvent(null, 0,false));
+        Map<Integer, Map<String, Map<Integer, Double>>> modeChoiceCoverageHistory = modeCC.getModeChoiceCoverageHistory();
+        Assert.assertEquals("1x threshold should be met after 1 iteration",
+                (Double) 1.0, modeChoiceCoverageHistory.get(1).get("walk").get(0));
+        Assert.assertEquals("5x threshold should NOT be met after 1 iteration",
+                (Double) 0.0, modeChoiceCoverageHistory.get(5).get("walk").get(0));
+        Assert.assertEquals("10x threshold should NOT be met after 1 iteration",
+                (Double) 0.0, modeChoiceCoverageHistory.get(10).get("walk").get(0));
+
+
+        // After 5 iterations
+        for (int i = 1; i < 5; i++) {
+            modeCC.notifyIterationEnds(new IterationEndsEvent(null, i,false));
+        }
+
+        Assert.assertEquals("1x threshold should be met after 5 iterations",
+                (Double) 1.0, modeChoiceCoverageHistory.get(1).get("walk").get(4));
+        Assert.assertEquals("5x threshold should be met after 5 iterations",
+                (Double) 1.0, modeChoiceCoverageHistory.get(5).get("walk").get(4));
+        Assert.assertEquals("10x threshold should NOT be met after 5 iterations",
+                (Double) 0.0, modeChoiceCoverageHistory.get(10).get("walk").get(4));
+
+        // After 10 iterations
+        for (int i = 5; i < 10; i++) {
+            modeCC.notifyIterationEnds(new IterationEndsEvent(null, i,false));
+        }
+
+        Assert.assertEquals("1x threshold should be met after 10 iterations",
+                (Double) 1.0, modeChoiceCoverageHistory.get(1).get("walk").get(9));
+        Assert.assertEquals("5x threshold should be met after 10 iterations",
+                (Double) 1.0, modeChoiceCoverageHistory.get(5).get("walk").get(9));
+        Assert.assertEquals("10x threshold should be met after 10 iterations",
+                (Double) 1.0, modeChoiceCoverageHistory.get(10).get("walk").get(9));
+
+    }
+
+
+    private Plan makePlan( Person person, String modeLeg1, String modeLeg2) {
+        Plan plan = PopulationUtils.createPlan(person);
+
+        final Id<Link> link1 = Id.create(10723, Link.class);
+        final Id<Link> link2 = Id.create(123160, Link.class);
+
+        Activity act1 = PopulationUtils.createActivityFromLinkId("home", link1);
+        plan.addActivity(act1);
+
+        Leg leg1 = PopulationUtils.createLeg(modeLeg1);
+        plan.addLeg(leg1);
+
+        Activity act2 = PopulationUtils.createActivityFromLinkId("work", link2);
+        plan.addActivity(act2);
+
+        Leg leg2 = PopulationUtils.createLeg(modeLeg2);
+        plan.addLeg(leg2);
+
+        Activity act3 = PopulationUtils.createActivityFromLinkId("home", link1);
+        plan.addActivity(act3);
+        return plan;
+    }
+}

--- a/matsim/src/test/java/org/matsim/analysis/ModeChoiceCoverageControlerListenerTest.java
+++ b/matsim/src/test/java/org/matsim/analysis/ModeChoiceCoverageControlerListenerTest.java
@@ -42,7 +42,7 @@ public class ModeChoiceCoverageControlerListenerTest {
         TransportPlanningMainModeIdentifier transportId = new TransportPlanningMainModeIdentifier();
 
         ControlerConfigGroup controlerConfigGroup = new ControlerConfigGroup();
-        OutputDirectoryHierarchy controlerIO = new OutputDirectoryHierarchy("/ModeChoiceCoverageControlerListener",
+        OutputDirectoryHierarchy controlerIO = new OutputDirectoryHierarchy(utils.getOutputDirectory() + "/ModeChoiceCoverageControlerListener",
                 OverwriteFileSetting.overwriteExistingFiles, CompressionType.gzip);
 
         Person person = PopulationUtils.getFactory().createPerson(Id.create(1, Person.class));
@@ -99,7 +99,7 @@ public class ModeChoiceCoverageControlerListenerTest {
         TransportPlanningMainModeIdentifier transportId = new TransportPlanningMainModeIdentifier();
 
         ControlerConfigGroup controlerConfigGroup = new ControlerConfigGroup();
-        OutputDirectoryHierarchy controlerIO = new OutputDirectoryHierarchy("/ModeChoiceCoverageControlerListener",
+        OutputDirectoryHierarchy controlerIO = new OutputDirectoryHierarchy(utils.getOutputDirectory() + "/ModeChoiceCoverageControlerListener",
                 OverwriteFileSetting.overwriteExistingFiles, CompressionType.gzip);
 
         Person person1 = PopulationUtils.getFactory().createPerson(Id.create(1, Person.class));
@@ -170,7 +170,7 @@ public class ModeChoiceCoverageControlerListenerTest {
         TransportPlanningMainModeIdentifier transportId = new TransportPlanningMainModeIdentifier();
 
         ControlerConfigGroup controlerConfigGroup = new ControlerConfigGroup();
-        OutputDirectoryHierarchy controlerIO = new OutputDirectoryHierarchy("/ModeChoiceCoverageControlerListener",
+        OutputDirectoryHierarchy controlerIO = new OutputDirectoryHierarchy(utils.getOutputDirectory() + "/ModeChoiceCoverageControlerListener",
                 OverwriteFileSetting.overwriteExistingFiles, CompressionType.gzip);
 
         Person person = PopulationUtils.getFactory().createPerson(Id.create(1, Person.class));


### PR DESCRIPTION
ModeChoiceCoverage is a ControlerListener that does the following calculation in each iteration: the percentage of trips have used a certain mode at least once (or 5x, 10x, …) in all previous iterations. In essence, this tool can be used to check whether enough iterations have been completed for agents to make full use of the mode choice innovation strategy. The results of this analysis are printed as outputs in text-based and graphical forms.