### PR TITLE
Temporary solution for m1 mac users

### DIFF
--- a/contribs/hybridsim/pom.xml
+++ b/contribs/hybridsim/pom.xml
@@ -53,8 +53,11 @@
         <version>0.6.1</version>
         <configuration>
           <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+<!--          <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:osx-x86_64</protocArtifact>--> <!-- for m1 mac user-->
+
           <pluginId>grpc-java</pluginId>
           <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+<!--          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:osx-x86_64</pluginArtifact>--> <!-- for m1 mac user-->
           <useArgumentFile>true</useArgumentFile>
         </configuration>
         <executions>

--- a/contribs/protobuf/pom.xml
+++ b/contribs/protobuf/pom.xml
@@ -48,6 +48,7 @@
                 <version>0.6.1</version>
                 <configuration>
                     <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+<!--                    <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:osx-x86_64</protocArtifact>--> <!-- for m1 mac user-->
                     <useArgumentFile>true</useArgumentFile>
                 </configuration>
                 <executions>


### PR DESCRIPTION
To solve for the build error on m1 MacBook, the following line needs to be changed. Simply replace the original line with the line in the comment.

@michalmac : May I know if there is any other better solution for this issue? For now, I will need to un-do the changes in the pom file before I can create any PR...