### PR TITLE
POM cleanups & re-config mvn enforcer 

### DIFF
--- a/contribs/application/pom.xml
+++ b/contribs/application/pom.xml
@@ -57,6 +57,10 @@
 					<groupId>org.geotools</groupId>
 					<artifactId>*</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.matsim</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 
@@ -65,6 +69,16 @@
 			<artifactId>matsim-analysis</artifactId>
 			<!-- <version>v2.5</version> -->
 			<version>v3.2</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.geotools</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.matsim</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 

--- a/contribs/cadytsIntegration/pom.xml
+++ b/contribs/cadytsIntegration/pom.xml
@@ -19,13 +19,6 @@
   		<artifactId>analysis</artifactId>
   		<version>14.0-SNAPSHOT</version>
   	</dependency>
-    <dependency>
-      <groupId>org.matsim</groupId>
-      <artifactId>matsim-examples</artifactId>
-      <version>14.0-SNAPSHOT</version>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
   <inceptionYear>2012</inceptionYear>
   <description>Provides integration of MATSim with Cadyts for automated calibration.</description>

--- a/contribs/emissions/pom.xml
+++ b/contribs/emissions/pom.xml
@@ -24,7 +24,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.3.1</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -38,7 +37,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
                 <configuration>
                     <excludes>
                         <exclude>**/*$*</exclude> <!-- exclude all inner classes -->

--- a/contribs/locationchoice/pom.xml
+++ b/contribs/locationchoice/pom.xml
@@ -26,12 +26,6 @@
             <artifactId>otfvis</artifactId>
             <version>14.0-SNAPSHOT</version>
         </dependency>
-        <dependency>
-            <groupId>org.matsim</groupId>
-            <artifactId>matsim-examples</artifactId>
-            <version>14.0-SNAPSHOT</version>
-            <scope>test</scope>
-        </dependency>
 	    <dependency>
 		    <groupId>org.matsim.contrib</groupId>
 		    <artifactId>analysis</artifactId>

--- a/contribs/multimodal/pom.xml
+++ b/contribs/multimodal/pom.xml
@@ -13,7 +13,6 @@
           <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
-              <version>2.8</version>
               <configuration>
                   <excludes>
                       <exclude>**/*$*</exclude> <!-- exclude all inner classes -->
@@ -29,11 +28,5 @@
       </plugins>
   </build>
   <dependencies>
-      <dependency>
-          <groupId>org.matsim</groupId>
-          <artifactId>matsim-examples</artifactId>
-          <version>14.0-SNAPSHOT</version>
-          <scope>test</scope>
-      </dependency>
   </dependencies>
 </project>

--- a/contribs/pom.xml
+++ b/contribs/pom.xml
@@ -36,7 +36,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>2.22.2</version>
 				<executions>
 					<execution>
 						<goals>
@@ -145,11 +144,8 @@
 			<!--it is not in weekly releases and then causes problems.  -->
 			<groupId>org.matsim</groupId>
 			<artifactId>matsim-examples</artifactId>
-			<!--<version>0.10.0</version>-->
-			<!--<version>0.11.0-apr17</version>-->
 			<scope>test</scope>
 			<version>${project.version}</version>
-			<!--(This has possibly no effect here, don't know.)-->
 		</dependency>
 		<dependency>
 			<!-- needed to compile in IntelliJ with Eclipse compiler -->
@@ -157,6 +153,4 @@
 			<artifactId>commons-logging</artifactId>
 		</dependency>
 	</dependencies>
-
-
 </project>

--- a/contribs/pseudosimulation/pom.xml
+++ b/contribs/pseudosimulation/pom.xml
@@ -30,11 +30,5 @@
       <artifactId>colt</artifactId>
       <version>1.2.0</version>
     </dependency>
-    <dependency>
-      <groupId>org.matsim</groupId>
-      <artifactId>matsim-examples</artifactId>
-      <version>14.0-SNAPSHOT</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/contribs/roadpricing/pom.xml
+++ b/contribs/roadpricing/pom.xml
@@ -47,11 +47,5 @@
 		</plugins>
 	</build>
 	<dependencies>
-		<dependency>
-			<groupId>org.matsim</groupId>
-			<artifactId>matsim-examples</artifactId>
-			<version>14.0-SNAPSHOT</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 </project>

--- a/matsim/pom.xml
+++ b/matsim/pom.xml
@@ -114,7 +114,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>2.22.2</version>
 				<executions>
 					<execution>
 						<goals>

--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,13 @@
                     <rules>
                         <requireUpperBoundDeps/>
                         <banDuplicatePomDependencyVersions/>
+						<requireReleaseDeps>
+							<failWhenParentIsSnapshot>false</failWhenParentIsSnapshot>
+							<excludes>
+								<exclude>org.matsim:*</exclude>
+								<exclude>org.matsim.contrib:*</exclude>
+							</excludes>
+						</requireReleaseDeps>
                     </rules>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,36 @@
                 <scope>test</scope>
             </dependency>
 
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.30</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+                <version>3.0.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.11</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jogamp.gluegen</groupId>
+                <artifactId>gluegen-rt</artifactId>
+                <version>2.4.0-matsim-1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jogamp.jogl</groupId>
+                <artifactId>jogl-all</artifactId>
+                <version>2.4.0-matsim-1</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 
@@ -194,9 +224,18 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
                 <configuration>
                     <rules>
-                        <dependencyConvergence/>
+                        <requireUpperBoundDeps/>
+                        <banDuplicatePomDependencyVersions/>
                     </rules>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,11 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>2.22.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>3.2.0</version>
                 </plugin>


### PR DESCRIPTION
Another PR in the POM cleaning up series (after #1491 and #1495).

The enforcer is now run in each build and does the following checks:
- [requireUpperBoundDeps](https://maven.apache.org/enforcer/enforcer-rules/requireUpperBoundDeps.html): to ensure the latest version of a (transitive) dependency is used. We had cases where accidently some older guava version was used (and similar...)
- [banDuplicatePomDependencyVersions](https://maven.apache.org/enforcer/enforcer-rules/banDuplicatePomDependencyVersions.html): just a simple check to prevent some basic duplication mistakes
- [requireReleaseDeps](https://maven.apache.org/enforcer/enforcer-rules/requireReleaseDeps.html): Necessary for major/weekly/PR releases to make them fully immutable. We must not depend on non-SNAPSHOT versions inside all matsim modules, otherwise matsim release versions may not behave deterministically.