### PR TITLE
try to fix failing builds on jenkins (m2 cache issues?)

### DIFF
--- a/contribs/vsp/pom.xml
+++ b/contribs/vsp/pom.xml
@@ -130,7 +130,7 @@
 		<dependency>
 			<groupId>de.micromata.jak</groupId>
 			<artifactId>JavaAPIforKml</artifactId>
-			<version>2.2.0</version>
+			<version>2.2.1</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -324,6 +324,7 @@
                             <artifactId>maven-javadoc-plugin</artifactId>
                             <configuration>
                                 <doclint>none</doclint>
+                                <quiet>true</quiet>
                             </configuration>
                         </plugin>
                     </plugins>


### PR DESCRIPTION
mvn enforcer has some issues with one transitive dependency of ` JavaAPIforKml` (used in `vsp`):
```
[INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (enforce) @ vsp ---
[WARNING] Rule 2: org.apache.maven.plugins.enforcer.RequireReleaseDeps failed with message:
Found Banned Dependency: com.sun.xml.bind:jaxb-xjc:jar:2.2-SNAPSHOT
```
However, `JavaAPIforKml` depends on com.sun.xml.bind:jaxb-xjc:jar:2.2 (none-snapshot version)