### PR TITLE
Auto-reset Id caches before each unit test

### DIFF
--- a/contribs/accessibility/src/test/java/org/matsim/contrib/accessibility/run/AccessibilityIntegrationTest.java
+++ b/contribs/accessibility/src/test/java/org/matsim/contrib/accessibility/run/AccessibilityIntegrationTest.java
@@ -128,6 +128,7 @@ public class AccessibilityIntegrationTest {
 		acg.setComputingAccessibilityForMode(Modes4Accessibility.walk, true);
 		acg.setComputingAccessibilityForMode(Modes4Accessibility.pt, false);
 		acg.setComputingAccessibilityForMode(Modes4Accessibility.matrixBasedPt, false);
+		acg.setUseParallelization(false);
 
 		ModeParams ptParams = new ModeParams(TransportMode.transit_walk);
 		config.planCalcScore().addModeParams(ptParams);

--- a/contribs/accessibility/test/input/org/matsim/contrib/accessibility/run/AccessibilityIntegrationTest/testWithBoundingBoxConfigFile/network.xml
+++ b/contribs/accessibility/test/input/org/matsim/contrib/accessibility/run/AccessibilityIntegrationTest/testWithBoundingBoxConfigFile/network.xml
@@ -30,20 +30,6 @@
 	<links capperiod="01:00:00" effectivecellsize="7.5" effectivelanewidth="3.75">
 		<link id="1" from="1" to="2" length="100.0" freespeed="2.7" capacity="500.0" permlanes="1.0" oneway="1" modes="car" >
 		</link>
-		<link id="10" from="6" to="4" length="100.0" freespeed="2.7" capacity="500.0" permlanes="1.0" oneway="1" modes="car" >
-		</link>
-		<link id="11" from="4" to="7" length="100.0" freespeed="2.7" capacity="500.0" permlanes="1.0" oneway="1" modes="car" >
-		</link>
-		<link id="12" from="7" to="4" length="100.0" freespeed="2.7" capacity="500.0" permlanes="1.0" oneway="1" modes="car" >
-		</link>
-		<link id="13" from="5" to="8" length="100.0" freespeed="2.7" capacity="500.0" permlanes="1.0" oneway="1" modes="car" >
-		</link>
-		<link id="14" from="8" to="5" length="100.0" freespeed="2.7" capacity="500.0" permlanes="1.0" oneway="1" modes="car" >
-		</link>
-		<link id="15" from="6" to="9" length="100.0" freespeed="2.7" capacity="500.0" permlanes="1.0" oneway="1" modes="car" >
-		</link>
-		<link id="16" from="9" to="6" length="100.0" freespeed="2.7" capacity="500.0" permlanes="1.0" oneway="1" modes="car" >
-		</link>
 		<link id="2" from="2" to="1" length="100.0" freespeed="2.7" capacity="500.0" permlanes="1.0" oneway="1" modes="car" >
 		</link>
 		<link id="3" from="1" to="3" length="100.0" freespeed="2.7" capacity="500.0" permlanes="1.0" oneway="1" modes="car" >
@@ -59,6 +45,20 @@
 		<link id="8" from="5" to="4" length="100.0" freespeed="2.7" capacity="500.0" permlanes="1.0" oneway="1" modes="car" >
 		</link>
 		<link id="9" from="4" to="6" length="100.0" freespeed="2.7" capacity="500.0" permlanes="1.0" oneway="1" modes="car" >
+		</link>
+		<link id="10" from="6" to="4" length="100.0" freespeed="2.7" capacity="500.0" permlanes="1.0" oneway="1" modes="car" >
+		</link>
+		<link id="11" from="4" to="7" length="100.0" freespeed="2.7" capacity="500.0" permlanes="1.0" oneway="1" modes="car" >
+		</link>
+		<link id="12" from="7" to="4" length="100.0" freespeed="2.7" capacity="500.0" permlanes="1.0" oneway="1" modes="car" >
+		</link>
+		<link id="13" from="5" to="8" length="100.0" freespeed="2.7" capacity="500.0" permlanes="1.0" oneway="1" modes="car" >
+		</link>
+		<link id="14" from="8" to="5" length="100.0" freespeed="2.7" capacity="500.0" permlanes="1.0" oneway="1" modes="car" >
+		</link>
+		<link id="15" from="6" to="9" length="100.0" freespeed="2.7" capacity="500.0" permlanes="1.0" oneway="1" modes="car" >
+		</link>
+		<link id="16" from="9" to="6" length="100.0" freespeed="2.7" capacity="500.0" permlanes="1.0" oneway="1" modes="car" >
 		</link>
 	</links>
 

--- a/contribs/analysis/src/test/java/org/matsim/contrib/analysis/kai/KNAnalysisEventsHandlerTest.java
+++ b/contribs/analysis/src/test/java/org/matsim/contrib/analysis/kai/KNAnalysisEventsHandlerTest.java
@@ -60,8 +60,8 @@ public class KNAnalysisEventsHandlerTest {
 	// yy this test is probably not doing anything with respect to some of the newer statistics, such as money. kai, mar'14 
 
 	public static final String BASE_FILE_NAME = "stats_";
-	public static final Id<Person> DEFAULT_PERSON_ID = Id.create(123, Person.class);
-	public static final Id<Link> DEFAULT_LINK_ID = Id.create(456, Link.class);
+	public final Id<Person> DEFAULT_PERSON_ID = Id.create(123, Person.class);
+	public final Id<Link> DEFAULT_LINK_ID = Id.create(456, Link.class);
 
 	private Scenario scenario = null ;
 	private Population population = null ;

--- a/contribs/bicycle/src/test/java/org/matsim/contrib/bicycle/BicycleLinkSpeedCalculatorTest.java
+++ b/contribs/bicycle/src/test/java/org/matsim/contrib/bicycle/BicycleLinkSpeedCalculatorTest.java
@@ -1,6 +1,6 @@
 package org.matsim.contrib.bicycle;
 
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
@@ -21,14 +21,14 @@ import static org.junit.Assert.assertTrue;
 
 public class BicycleLinkSpeedCalculatorTest {
 
-    private static final BicycleConfigGroup configGroup = new BicycleConfigGroup();
-    private static final double maxBicycleSpeed = 15;
-    private static final Network unusedNetwork = NetworkUtils.createNetwork();
+    private static final double MAX_BICYCLE_SPEED = 15;
 
-    @BeforeClass
-    public static void before() {
+    private final BicycleConfigGroup configGroup = new BicycleConfigGroup();
+    private final Network unusedNetwork = NetworkUtils.createNetwork();
 
-        configGroup.setMaxBicycleSpeedForRouting(maxBicycleSpeed);
+    @Before
+    public void before() {
+        configGroup.setMaxBicycleSpeedForRouting(MAX_BICYCLE_SPEED);
         configGroup.setBicycleMode("bike");
     }
 

--- a/contribs/common/src/test/java/org/matsim/contrib/common/diversitygeneration/planselectors/DiversityGeneratingPlansRemoverTest.java
+++ b/contribs/common/src/test/java/org/matsim/contrib/common/diversitygeneration/planselectors/DiversityGeneratingPlansRemoverTest.java
@@ -37,13 +37,13 @@ import java.util.TreeMap;
 public class DiversityGeneratingPlansRemoverTest {
 	private static final Logger log = Logger.getLogger( DiversityGeneratingPlansRemoverTest.class ) ;
 	
-	private static final Id<Node> node0 = Id.createNodeId( "node0" ) ;
-	private static final Id<Node> node1 = Id.createNodeId( "node1" ) ;
-	private static final Id<Node> node2 = Id.createNodeId( "node2" ) ;
-	private static final Id<Node> node3 = Id.createNodeId( "node3" ) ;
-	private static final Id<Link> link0_1 = Id.createLinkId( "dummy0-1" );
-	private static final Id<Link> link1_2 = Id.createLinkId( "dummy1-2" );
-	private static final Id<Link> link2_3 = Id.createLinkId( "dummyN" );
+	private final Id<Node> node0 = Id.createNodeId( "node0" ) ;
+	private final Id<Node> node1 = Id.createNodeId( "node1" ) ;
+	private final Id<Node> node2 = Id.createNodeId( "node2" ) ;
+	private final Id<Node> node3 = Id.createNodeId( "node3" ) ;
+	private final Id<Link> link0_1 = Id.createLinkId( "dummy0-1" );
+	private final Id<Link> link1_2 = Id.createLinkId( "dummy1-2" );
+	private final Id<Link> link2_3 = Id.createLinkId( "dummyN" );
 	
 	@Test
 	public void calcWeights() {
@@ -179,7 +179,7 @@ public class DiversityGeneratingPlansRemoverTest {
 		
 	}
 	
-	private static Plan createHwhPlan( final PopulationFactory pf ) {
+	private Plan createHwhPlan( final PopulationFactory pf ) {
 		Plan plan = pf.createPlan() ;
 		{
 			Activity act = pf.createActivityFromCoord( "home", new Coord(0.,0.) ) ;

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/passenger/DefaultPassengerEngineTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/passenger/DefaultPassengerEngineTest.java
@@ -68,7 +68,7 @@ import com.google.inject.name.Names;
 public class DefaultPassengerEngineTest {
 	private final PassengerEngineTestFixture fixture = new PassengerEngineTestFixture();
 
-	private static final Id<DvrpVehicle> VEHICLE_ID = Id.create("taxi1", DvrpVehicle.class);
+	private final Id<DvrpVehicle> VEHICLE_ID = Id.create("taxi1", DvrpVehicle.class);
 	private final DvrpVehicle oneTaxi = new DvrpVehicleImpl(ImmutableDvrpVehicleSpecification.newBuilder()
 			.id(VEHICLE_ID)
 			.serviceBeginTime(0)
@@ -98,16 +98,16 @@ public class DefaultPassengerEngineTest {
 
 		var requestId = Id.create("taxi_0", Request.class);
 		fixture.assertPassengerEvents(
-				new ActivityEndEvent(departureTime, PERSON_ID, fixture.linkAB.getId(), null, START_ACTIVITY),
-				new PersonDepartureEvent(departureTime, PERSON_ID, fixture.linkAB.getId(), MODE),
-				new PassengerRequestScheduledEvent(departureTime, MODE, requestId, PERSON_ID, VEHICLE_ID, 0,
+				new ActivityEndEvent(departureTime, fixture.PERSON_ID, fixture.linkAB.getId(), null, START_ACTIVITY),
+				new PersonDepartureEvent(departureTime, fixture.PERSON_ID, fixture.linkAB.getId(), MODE),
+				new PassengerRequestScheduledEvent(departureTime, MODE, requestId, fixture.PERSON_ID, VEHICLE_ID, 0,
 						scheduledDropoffTime),
-				new PersonEntersVehicleEvent(pickupStartTime, PERSON_ID, Id.createVehicleId(VEHICLE_ID)),
-				new PassengerPickedUpEvent(pickupStartTime, MODE, requestId, PERSON_ID, VEHICLE_ID),
-				new PassengerDroppedOffEvent(dropoffEndTime, MODE, requestId, PERSON_ID, VEHICLE_ID),
-				new PersonLeavesVehicleEvent(dropoffEndTime, PERSON_ID, Id.createVehicleId(VEHICLE_ID)),
-				new PersonArrivalEvent(dropoffEndTime, PERSON_ID, fixture.linkBA.getId(), MODE),
-				new ActivityStartEvent(dropoffEndTime, PERSON_ID, fixture.linkBA.getId(), null, END_ACTIVITY));
+				new PersonEntersVehicleEvent(pickupStartTime, fixture.PERSON_ID, Id.createVehicleId(VEHICLE_ID)),
+				new PassengerPickedUpEvent(pickupStartTime, MODE, requestId, fixture.PERSON_ID, VEHICLE_ID),
+				new PassengerDroppedOffEvent(dropoffEndTime, MODE, requestId, fixture.PERSON_ID, VEHICLE_ID),
+				new PersonLeavesVehicleEvent(dropoffEndTime, fixture.PERSON_ID, Id.createVehicleId(VEHICLE_ID)),
+				new PersonArrivalEvent(dropoffEndTime, fixture.PERSON_ID, fixture.linkBA.getId(), MODE),
+				new ActivityStartEvent(dropoffEndTime, fixture.PERSON_ID, fixture.linkBA.getId(), null, END_ACTIVITY));
 	}
 
 	@Test
@@ -119,10 +119,10 @@ public class DefaultPassengerEngineTest {
 		createQSim(requestValidator, OneTaxiOptimizer.class).run();
 
 		var requestId = Id.create("taxi_0", Request.class);
-		fixture.assertPassengerEvents(new ActivityEndEvent(0, PERSON_ID, fixture.linkAB.getId(), null, START_ACTIVITY),
-				new PersonDepartureEvent(0, PERSON_ID, fixture.linkAB.getId(), MODE),
-				new PassengerRequestRejectedEvent(0, MODE, requestId, PERSON_ID, "invalid"),
-				new PersonStuckEvent(0, PERSON_ID, fixture.linkAB.getId(), MODE));
+		fixture.assertPassengerEvents(new ActivityEndEvent(0, fixture.PERSON_ID, fixture.linkAB.getId(), null, START_ACTIVITY),
+				new PersonDepartureEvent(0, fixture.PERSON_ID, fixture.linkAB.getId(), MODE),
+				new PassengerRequestRejectedEvent(0, MODE, requestId, fixture.PERSON_ID, "invalid"),
+				new PersonStuckEvent(0, fixture.PERSON_ID, fixture.linkAB.getId(), MODE));
 	}
 
 	@Test
@@ -134,10 +134,10 @@ public class DefaultPassengerEngineTest {
 		createQSim(requestValidator, RejectingOneTaxiOptimizer.class).run();
 
 		var requestId = Id.create("taxi_0", Request.class);
-		fixture.assertPassengerEvents(new ActivityEndEvent(0, PERSON_ID, fixture.linkAB.getId(), null, START_ACTIVITY),
-				new PersonDepartureEvent(0, PERSON_ID, fixture.linkAB.getId(), MODE),
-				new PassengerRequestRejectedEvent(0, MODE, requestId, PERSON_ID, "rejecting_all_requests"),
-				new PersonStuckEvent(0, PERSON_ID, fixture.linkAB.getId(), MODE));
+		fixture.assertPassengerEvents(new ActivityEndEvent(0, fixture.PERSON_ID, fixture.linkAB.getId(), null, START_ACTIVITY),
+				new PersonDepartureEvent(0, fixture.PERSON_ID, fixture.linkAB.getId(), MODE),
+				new PassengerRequestRejectedEvent(0, MODE, requestId, fixture.PERSON_ID, "rejecting_all_requests"),
+				new PersonStuckEvent(0, fixture.PERSON_ID, fixture.linkAB.getId(), MODE));
 	}
 
 	private static class RejectingOneTaxiOptimizer implements VrpOptimizer {

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/passenger/PassengerEngineTestFixture.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/passenger/PassengerEngineTestFixture.java
@@ -57,7 +57,7 @@ import org.matsim.core.scenario.ScenarioUtils;
 public class PassengerEngineTestFixture {
 	static final String MODE = TransportMode.taxi;
 
-	static final Id<Person> PERSON_ID = Id.createPersonId("person1");
+	final Id<Person> PERSON_ID = Id.createPersonId("person1");
 	static final String START_ACTIVITY = "start";
 	static final String END_ACTIVITY = "end";
 

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/passenger/TeleportingPassengerEngineTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/passenger/TeleportingPassengerEngineTest.java
@@ -70,14 +70,14 @@ public class TeleportingPassengerEngineTest {
 		double arrivalTime = departureTime + travelTime;
 		var requestId = Id.create("taxi_0", Request.class);
 		fixture.assertPassengerEvents(
-				new ActivityEndEvent(departureTime, PERSON_ID, fixture.linkAB.getId(), null, START_ACTIVITY),
-				new PersonDepartureEvent(departureTime, PERSON_ID, fixture.linkAB.getId(), MODE),
-				new PassengerRequestScheduledEvent(departureTime, MODE, requestId, PERSON_ID, null, departureTime,
-						arrivalTime), new PassengerPickedUpEvent(departureTime, MODE, requestId, PERSON_ID, null),
-				new PassengerDroppedOffEvent(arrivalTime, MODE, requestId, PERSON_ID, null),
-				new TeleportationArrivalEvent(arrivalTime, PERSON_ID, travelDistance, MODE),
-				new PersonArrivalEvent(arrivalTime, PERSON_ID, fixture.linkBA.getId(), MODE),
-				new ActivityStartEvent(arrivalTime, PERSON_ID, fixture.linkBA.getId(), null, END_ACTIVITY));
+				new ActivityEndEvent(departureTime, fixture.PERSON_ID, fixture.linkAB.getId(), null, START_ACTIVITY),
+				new PersonDepartureEvent(departureTime, fixture.PERSON_ID, fixture.linkAB.getId(), MODE),
+				new PassengerRequestScheduledEvent(departureTime, MODE, requestId, fixture.PERSON_ID, null, departureTime,
+						arrivalTime), new PassengerPickedUpEvent(departureTime, MODE, requestId, fixture.PERSON_ID, null),
+				new PassengerDroppedOffEvent(arrivalTime, MODE, requestId, fixture.PERSON_ID, null),
+				new TeleportationArrivalEvent(arrivalTime, fixture.PERSON_ID, travelDistance, MODE),
+				new PersonArrivalEvent(arrivalTime, fixture.PERSON_ID, fixture.linkBA.getId(), MODE),
+				new ActivityStartEvent(arrivalTime, fixture.PERSON_ID, fixture.linkBA.getId(), null, END_ACTIVITY));
 	}
 
 	@Test
@@ -91,10 +91,10 @@ public class TeleportingPassengerEngineTest {
 
 		var requestId = Id.create("taxi_0", Request.class);
 		fixture.assertPassengerEvents(
-				new ActivityEndEvent(departureTime, PERSON_ID, fixture.linkAB.getId(), null, START_ACTIVITY),
-				new PersonDepartureEvent(departureTime, PERSON_ID, fixture.linkAB.getId(), MODE),
-				new PassengerRequestRejectedEvent(departureTime, MODE, requestId, PERSON_ID, "invalid"),
-				new PersonStuckEvent(departureTime, PERSON_ID, fixture.linkAB.getId(), MODE));
+				new ActivityEndEvent(departureTime, fixture.PERSON_ID, fixture.linkAB.getId(), null, START_ACTIVITY),
+				new PersonDepartureEvent(departureTime, fixture.PERSON_ID, fixture.linkAB.getId(), MODE),
+				new PassengerRequestRejectedEvent(departureTime, MODE, requestId, fixture.PERSON_ID, "invalid"),
+				new PersonStuckEvent(departureTime, fixture.PERSON_ID, fixture.linkAB.getId(), MODE));
 	}
 
 	private QSim createQSim(TeleportedRouteCalculator teleportedRouteCalculator,

--- a/contribs/freight/src/test/java/org/matsim/contrib/freight/jsprit/FixedCostsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/contrib/freight/jsprit/FixedCostsTest.java
@@ -24,7 +24,8 @@ import com.graphhopper.jsprit.core.algorithm.box.SchrimpfFactory;
 import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem;
 import com.graphhopper.jsprit.core.problem.solution.VehicleRoutingProblemSolution;
 import com.graphhopper.jsprit.core.util.Solutions;
-import org.junit.BeforeClass;
+
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.matsim.api.core.v01.Id;
@@ -54,10 +55,10 @@ public class FixedCostsTest extends MatsimTestCase {
 	@Rule
 	public MatsimTestUtils utils = new MatsimTestUtils() ;
 
-	Carriers carriers = new Carriers();
-	Carriers carriersPlannedAndRouted = new Carriers();
+	private final Carriers carriers = new Carriers();
+	private final Carriers carriersPlannedAndRouted = new Carriers();
 
-	@BeforeClass
+	@Before
 	public void setUp() throws Exception {
 		super.setUp();
 //        Create carrier with services; service1 nearby the depot, service2 at the opposite side of the network

--- a/contribs/freight/src/test/java/org/matsim/contrib/freight/utils/FreightUtilsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/contrib/freight/utils/FreightUtilsTest.java
@@ -15,7 +15,7 @@
  *   See also COPYING, LICENSE and WARRANTY file                           *
  *                                                                         *
  * *********************************************************************** */
-  
+
 package org.matsim.contrib.freight.utils;
 
 import java.net.URL;
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.log4j.Logger;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -62,26 +63,22 @@ public class FreightUtilsTest {
 	public MatsimTestUtils utils = new MatsimTestUtils();
 
 	private static final Logger log = Logger.getLogger(FreightUtilsTest.class);
-	
-	private static final Id<Carrier> CARRIER_SERVICES_ID = Id.create("CarrierWServices", Carrier.class);
-	private static final Id<Carrier> CARRIER_SHIPMENTS_ID = Id.create("CarrierWShipments", Carrier.class);
 
-	private static Carrier carrierWServices;
-	private static Carrier carrierWShipments;
+	private final Id<Carrier> CARRIER_SERVICES_ID = Id.create("CarrierWServices", Carrier.class);
+	private final Id<Carrier> CARRIER_SHIPMENTS_ID = Id.create("CarrierWShipments", Carrier.class);
 
-	private static Carrier carrierWShipmentsOnlyFromCarrierWServices;
-	private static Carrier carrierWShipmentsOnlyFromCarrierWShipments;
-	
-	/** Commented out because it is not working even as @Rule nor as @ClassRule due to different reasons, 
-	* e.g. @BeforeClass needs @ClassRule, but MatsimTestUtils does not work together with @ClassRule ;
-	*  MatsimTestUtils needs be static vs static not allowed in @Rule, KMT sep/18
-	**/
-//	@Rule
-//	public static MatsimTestUtils testUtils = new MatsimTestUtils();
-	
-	@BeforeClass
-	public static void setUp() {
-		
+	private Carrier carrierWServices;
+	private Carrier carrierWShipments;
+
+	private Carrier carrierWShipmentsOnlyFromCarrierWServices;
+	private Carrier carrierWShipmentsOnlyFromCarrierWShipments;
+
+	@Rule
+	public MatsimTestUtils testUtils = new MatsimTestUtils();
+
+	@Before
+	public void setUp() {
+
 		//Create carrier with services and shipments
 		Carriers carriersWithServicesAndShpiments = new Carriers();
 		carrierWServices = CarrierUtils.createCarrier(CARRIER_SERVICES_ID );
@@ -89,7 +86,7 @@ public class FreightUtilsTest {
 		CarrierUtils.addService(carrierWServices, service1);
 		CarrierService service2 = createMatsimService("Service2", "i(4,9)", 2);
 		CarrierUtils.addService(carrierWServices, service2);
-		
+
 		//Create carrier with shipments
 		carrierWShipments = CarrierUtils.createCarrier(CARRIER_SHIPMENTS_ID );
 		CarrierShipment shipment1 = createMatsimShipment("shipment1", "i(1,0)", "i(7,6)R", 1);
@@ -112,12 +109,12 @@ public class FreightUtilsTest {
 		carrierVehType.setMaximumVelocity( 10. ) ;
 		CarrierVehicleTypes vehicleTypes = new CarrierVehicleTypes() ;
 		vehicleTypes.getVehicleTypes().put(carrierVehType.getId(), carrierVehType);
-		
+
 		CarrierVehicle carrierVehicle = CarrierVehicle.Builder.newInstance(Id.create("gridVehicle", org.matsim.vehicles.Vehicle.class), Id.createLinkId("i(6,0)")).setEarliestStart(0.0).setLatestEnd(36000.0).setTypeId(carrierVehType.getId()).build();
-		CarrierCapabilities.Builder ccBuilder = CarrierCapabilities.Builder.newInstance() 
+		CarrierCapabilities.Builder ccBuilder = CarrierCapabilities.Builder.newInstance()
 				.addType(carrierVehType)
 				.addVehicle(carrierVehicle)
-				.setFleetSize(FleetSize.INFINITE);				
+				.setFleetSize(FleetSize.INFINITE);
 		carrierWServices.setCarrierCapabilities(ccBuilder.build());
 		carrierWShipments.setCarrierCapabilities(ccBuilder.build());
 
@@ -126,15 +123,15 @@ public class FreightUtilsTest {
 		carriersWithServicesAndShpiments.addCarrier(carrierWShipments);
 
 		// assign vehicle types to the carriers
-		new CarrierVehicleTypeLoader(carriersWithServicesAndShpiments).loadVehicleTypes(vehicleTypes) ;	
+		new CarrierVehicleTypeLoader(carriersWithServicesAndShpiments).loadVehicleTypes(vehicleTypes) ;
 
 		//load Network and build netbasedCosts for jsprit
 		Network network = NetworkUtils.createNetwork();
-		new MatsimNetworkReader(network).readFile(getPackageInputDirectory() + "grid-network.xml"); 
+		new MatsimNetworkReader(network).readFile(testUtils.getPackageInputDirectory() + "grid-network.xml");
 		Builder netBuilder = NetworkBasedTransportCosts.Builder.newInstance( network, vehicleTypes.getVehicleTypes().values() );
 		final NetworkBasedTransportCosts netBasedCosts = netBuilder.build() ;
 		netBuilder.setTimeSliceWidth(1800) ; // !!!!, otherwise it will not do anything.
-		
+
 
 		//Build jsprit, solve and route VRP for carrierService only -> need solution to convert Services to Shipments
 		VehicleRoutingProblem.Builder vrpBuilder = MatsimJspritFactory.createRoutingProblemBuilder(carrierWServices, network);
@@ -161,27 +158,27 @@ public class FreightUtilsTest {
 		carrierWShipmentsOnlyFromCarrierWShipments = carriersWithShipmentsOnly.getCarriers().get(CARRIER_SHIPMENTS_ID);		//with copied Shipments
 
 		// assign vehicle types to the carriers
-		new CarrierVehicleTypeLoader(carriersWithShipmentsOnly).loadVehicleTypes(vehicleTypes) ;	
+		new CarrierVehicleTypeLoader(carriersWithShipmentsOnly).loadVehicleTypes(vehicleTypes) ;
 	}
 
 
 	@Test //Should only have Services
 	public void numberOfInitalServicesIsCorrect() {
 		Assert.assertEquals(2, carrierWServices.getServices().size());
-		
+
 		int demandServices = 0;
 		for (CarrierService carrierService : carrierWServices.getServices().values()) {
 			demandServices += carrierService.getCapacityDemand();
 		}
 		Assert.assertEquals(4, demandServices);
-		
+
 		Assert.assertEquals(0, carrierWServices.getShipments().size());
 	}
-	
+
 	@Test //Should only have Shipments
 	public void numberOfInitialShipmentsIsCorrect() {
 		Assert.assertEquals(0, carrierWShipments.getServices().size());
-		
+
 		Assert.assertEquals(2, carrierWShipments.getShipments().size());
 		int demandShipments = 0;
 		for (CarrierShipment carrierShipment : carrierWShipments.getShipments().values()) {
@@ -189,11 +186,11 @@ public class FreightUtilsTest {
 		}
 		Assert.assertEquals(3, demandShipments);
 	}
-	
+
 	@Test
 	public void numberOfShipmentsFromCopiedShipmentsIsCorrect() {
 		Assert.assertEquals(0, carrierWShipmentsOnlyFromCarrierWShipments.getServices().size());
-		
+
 		Assert.assertEquals(2, carrierWShipmentsOnlyFromCarrierWShipments.getShipments().size());
 		int demandShipments = 0;
 		for (CarrierShipment carrierShipment : carrierWShipmentsOnlyFromCarrierWServices.getShipments().values()) {
@@ -201,11 +198,11 @@ public class FreightUtilsTest {
 		}
 		Assert.assertEquals(4, demandShipments);
 	}
-	
+
 	@Test
 	public void numberOfShipmentsFromConvertedServicesIsCorrect() {
 		Assert.assertEquals(0, carrierWShipmentsOnlyFromCarrierWServices.getServices().size());
-		
+
 		Assert.assertEquals(2, carrierWShipmentsOnlyFromCarrierWServices.getShipments().size());
 		int demandShipments = 0;
 		for (CarrierShipment carrierShipment : carrierWShipmentsOnlyFromCarrierWServices.getShipments().values()) {
@@ -213,7 +210,7 @@ public class FreightUtilsTest {
 		}
 		Assert.assertEquals(4, demandShipments);
 	}
-	
+
 	@Test
 	public void fleetAvailableAfterConvertingIsCorrect() {
 		Assert.assertEquals(FleetSize.INFINITE, carrierWShipmentsOnlyFromCarrierWServices.getCarrierCapabilities().getFleetSize());
@@ -227,7 +224,7 @@ public class FreightUtilsTest {
 			Assert.assertEquals("diesel", VehicleUtils.getHbefaTechnology(carrierVehicleType.getEngineInformation()));
 			Assert.assertEquals(0.015, VehicleUtils.getFuelConsumption(carrierVehicleType), 0.0);
 		}
-		
+
 		Assert.assertEquals(FleetSize.INFINITE, carrierWShipmentsOnlyFromCarrierWShipments.getCarrierCapabilities().getFleetSize());
 		Assert.assertEquals(1, carrierWShipmentsOnlyFromCarrierWShipments.getCarrierCapabilities().getVehicleTypes().size());
 		for ( VehicleType carrierVehicleType : carrierWShipmentsOnlyFromCarrierWShipments.getCarrierCapabilities().getVehicleTypes()){
@@ -277,8 +274,8 @@ public class FreightUtilsTest {
 		Assert.assertTrue("Not found Shipment1 after copiing", foundShipment1);
 		Assert.assertTrue("Not found Shipment2 after copiing", foundShipment2);
 	}
-	
-	
+
+
 	@Test
 	public void convertionOfServicesIsDoneCorrectly() {
 		boolean foundSercice1 = false;
@@ -314,8 +311,8 @@ public class FreightUtilsTest {
 		Assert.assertTrue("Not found converted Service1 after converting", foundSercice1);
 		Assert.assertTrue("Not found converted Service2 after converting", foundService2);
 	}
-	
-	/* Note: This test can be removed / modified when jsprit works properly with a combined Service and Shipment VRP. 
+
+	/* Note: This test can be removed / modified when jsprit works properly with a combined Service and Shipment VRP.
 	* Currently the capacity of the vehicle seems to be "ignored" in a way that the load within the tour is larger than the capacity;
 	* Maybe it is because of the misunderstanding, that a Service is modeled as "Pickup" and not as thought before as "Delivery". KMT sep18
 	*/
@@ -326,21 +323,21 @@ public class FreightUtilsTest {
 		CarrierUtils.addService(carrierMixedWServicesAndShipments, service1);
 		CarrierShipment shipment1 = createMatsimShipment("shipment1", "i(1,0)", "i(7,6)R", 1);
 		CarrierUtils.addShipment(carrierMixedWServicesAndShipments, shipment1);
-		
+
 		Network network = NetworkUtils.createNetwork();
-		new MatsimNetworkReader(network).readFile(getPackageInputDirectory() + "grid-network.xml"); 
-		
+		new MatsimNetworkReader(network).readFile(testUtils.getPackageInputDirectory() + "grid-network.xml");
+
 		MatsimJspritFactory.createRoutingProblemBuilder(carrierMixedWServicesAndShipments, network);
 	}
-	
+
 	private static CarrierShipment createMatsimShipment(String id, String from, String to, int size) {
 		Id<CarrierShipment> shipmentId = Id.create(id, CarrierShipment.class);
-		Id<Link> fromLinkId = null; 
+		Id<Link> fromLinkId = null;
 		Id<Link> toLinkId= null;
 
 		if(from != null ) {
 			fromLinkId = Id.create(from, Link.class);
-		} 
+		}
 		if(to != null ) {
 			toLinkId = Id.create(to, Link.class);
 		}
@@ -359,17 +356,6 @@ public class FreightUtilsTest {
 				.setServiceDuration(31.0)
 				.setServiceStartTimeWindow(TimeWindow.newInstance(3601.0, 36001.0))
 				.build();
-	}
-	
-	/**
-	 * Note: Manually added here, because MatsimTestUtils does not work with @BeforeClass; KMT sep/18
-	 * @return String location of the packageInputDirectory
-	 */
-	private static String getPackageInputDirectory() {
-		String classInputDirectory = "test/input/" + FreightUtilsTest.class.getCanonicalName().replace('.', '/') + "/";
-		String packageInputDirectory = classInputDirectory.substring(0, classInputDirectory.lastIndexOf('/'));
-		packageInputDirectory = packageInputDirectory.substring(0, packageInputDirectory.lastIndexOf('/') + 1);
-		return packageInputDirectory;
 	}
 
 	@Test

--- a/contribs/integration/src/test/java/org/matsim/integration/weekly/fundamentaldiagram/CreateAutomatedFDTest.java
+++ b/contribs/integration/src/test/java/org/matsim/integration/weekly/fundamentaldiagram/CreateAutomatedFDTest.java
@@ -322,11 +322,11 @@ public class CreateAutomatedFDTest {
 	
 	static class MySimplifiedRoundAndRoundAgent implements MobsimAgent, MobsimDriverAgent {
 
-		private static final Id<Link> ORIGIN_LINK_ID = Id.createLinkId("home");
-		private static final Id<Link> BASE_LINK_ID = Id.createLinkId(0);
-		private static final Id<Link> MIDDEL_LINK_ID_OF_TRACK = Id.createLinkId(1);
-		private static final Id<Link> LAST_LINK_ID_OF_TRACK = Id.createLinkId(2);
-		private static final Id<Link> DESTINATION_LINK_ID = Id.createLinkId("work");
+		private final Id<Link> ORIGIN_LINK_ID = Id.createLinkId("home");
+		private final Id<Link> BASE_LINK_ID = Id.createLinkId(0);
+		private final Id<Link> MIDDEL_LINK_ID_OF_TRACK = Id.createLinkId(1);
+		private final Id<Link> LAST_LINK_ID_OF_TRACK = Id.createLinkId(2);
+		private final Id<Link> DESTINATION_LINK_ID = Id.createLinkId("work");
 
 		public MySimplifiedRoundAndRoundAgent(Id<Person> agentId, double actEndTime, String travelMode) {
 			personId = agentId;

--- a/contribs/signals/src/test/java/org/matsim/contrib/signals/builder/Fixture.java
+++ b/contribs/signals/src/test/java/org/matsim/contrib/signals/builder/Fixture.java
@@ -19,6 +19,8 @@
  * *********************************************************************** */
 package org.matsim.contrib.signals.builder;
 
+import java.lang.reflect.Method;
+
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
@@ -34,7 +36,7 @@ import org.matsim.contrib.signals.data.conflicts.Direction;
 import org.matsim.contrib.signals.data.conflicts.IntersectionDirections;
 import org.matsim.contrib.signals.data.signalcontrol.v20.SignalGroupSettingsData;
 import org.matsim.contrib.signals.data.signalcontrol.v20.SignalPlanData;
-import org.matsim.contrib.signals.data.signalgroups.v20.*;
+import org.matsim.contrib.signals.data.signalgroups.v20.SignalGroupData;
 import org.matsim.contrib.signals.data.signalsystems.v20.SignalData;
 import org.matsim.contrib.signals.data.signalsystems.v20.SignalSystemControllerData;
 import org.matsim.contrib.signals.model.Signal;
@@ -50,33 +52,28 @@ import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.lanes.Lane;
 import org.matsim.testcases.MatsimTestUtils;
 
-import java.lang.reflect.Method;
-
-
 /**
  * @author dgrether
- *
  */
-public class Fixture{
+public class Fixture {
 
-	static final Id<Link> linkId1 = Id.create(1, Link.class);
-	static final Id<Link> linkId2 = Id.create(2, Link.class);
-	static final Id<Node> nodeId2 = Id.create(2, Node.class);
-	static final Id<SignalPlan> signalPlanId2 = Id.create(2, SignalPlan.class);
-	static final Id<SignalSystem> signalSystemId2 = Id.create(2, SignalSystem.class);
-	static final Id<SignalGroup> signalGroupId100 = Id.create(100, SignalGroup.class);
-	
+	final Id<Link> linkId1 = Id.create(1, Link.class);
+	final Id<Link> linkId2 = Id.create(2, Link.class);
+	final Id<Node> nodeId2 = Id.create(2, Node.class);
+	final Id<SignalPlan> signalPlanId2 = Id.create(2, SignalPlan.class);
+	final Id<SignalSystem> signalSystemId2 = Id.create(2, SignalSystem.class);
+	final Id<SignalGroup> signalGroupId100 = Id.create(100, SignalGroup.class);
+
 	// only available if 'TwoSignals'-Method is used
-	static final Id<SignalGroup> signalGroupId200 = Id.create(200, SignalGroup.class);
-	static final Id<Link> linkId6 = Id.create(6, Link.class);
-	static final Id<Node> nodeId6 = Id.create(6, Node.class);
-	
+	final Id<SignalGroup> signalGroupId200 = Id.create(200, SignalGroup.class);
+	final Id<Link> linkId6 = Id.create(6, Link.class);
+	final Id<Node> nodeId6 = Id.create(6, Node.class);
 
-	public Scenario createAndLoadTestScenarioOneSignal(Boolean useIntergreens){
+	public Scenario createAndLoadTestScenarioOneSignal(Boolean useIntergreens) {
 		Config conf = createConfigOneSignal(useIntergreens);
 		Scenario scenario = ScenarioUtils.loadScenario(conf);
 		scenario.addScenarioElement(SignalsData.ELEMENT_NAME, new SignalsDataLoader(conf).loadSignalsData());
-		
+
 		return scenario;
 	}
 
@@ -105,20 +102,21 @@ public class Fixture{
 		conf.qsim().setStuckTime(1000);
 		conf.qsim().setStartTime(0.0);
 		conf.qsim().setUsingFastCapacityUpdate(false);
-		SignalSystemsConfigGroup signalsConfig = ConfigUtils.addOrGetModule(conf, SignalSystemsConfigGroup.GROUP_NAME, SignalSystemsConfigGroup.class);
+		SignalSystemsConfigGroup signalsConfig = ConfigUtils.addOrGetModule(conf, SignalSystemsConfigGroup.GROUP_NAME,
+				SignalSystemsConfigGroup.class);
 		signalsConfig.setUseSignalSystems(true);
-		
+
 		if (useIntergreens) {
 			signalsConfig.setIntergreenTimesFile("testIntergreenTimes_v1.0.xml");
 			signalsConfig.setUseIntergreenTimes(true);
-			signalsConfig.setActionOnIntergreenViolation( ActionOnSignalSpecsViolation.EXCEPTION );
-		}			
+			signalsConfig.setActionOnIntergreenViolation(ActionOnSignalSpecsViolation.EXCEPTION);
+		}
 
 		this.setSignalSystemConfigValues(signalsConfig, testUtils);
 		return conf;
 	}
-	
-	private void setSignalSystemConfigValues(SignalSystemsConfigGroup signalsConfig, MatsimTestUtils testUtils){
+
+	private void setSignalSystemConfigValues(SignalSystemsConfigGroup signalsConfig, MatsimTestUtils testUtils) {
 		signalsConfig.setSignalSystemFile("testSignalSystems_v2.0.xml");
 		signalsConfig.setSignalGroupsFile("testSignalGroups_v2.0.xml");
 		signalsConfig.setSignalControlFile("testSignalControl_v2.0.xml");
@@ -127,50 +125,73 @@ public class Fixture{
 
 	public Scenario createAndLoadTestScenarioTwoSignals(boolean useConflictData) {
 		Config config = createConfigOneSignal(false);
-		SignalSystemsConfigGroup signalsConfig = ConfigUtils.addOrGetModule(config, SignalSystemsConfigGroup.GROUP_NAME, SignalSystemsConfigGroup.class);
+		SignalSystemsConfigGroup signalsConfig = ConfigUtils.addOrGetModule(config, SignalSystemsConfigGroup.GROUP_NAME,
+				SignalSystemsConfigGroup.class);
 		signalsConfig.setIntersectionLogic(IntersectionLogic.CONFLICTING_DIRECTIONS_NO_TURN_RESTRICTIONS);
 		signalsConfig.setActionOnConflictingDirectionViolation(ActionOnSignalSpecsViolation.EXCEPTION);
-		
+
 		Scenario scenario = ScenarioUtils.loadScenario(config);
 		scenario.addScenarioElement(SignalsData.ELEMENT_NAME, new SignalsDataLoader(config).loadSignalsData());
-		
+
 		// modify scenario
 		Network net = scenario.getNetwork();
 		net.addNode(net.getFactory().createNode(nodeId6, new Coord(0, 100)));
 		net.addLink(net.getFactory().createLink(linkId6, net.getNodes().get(nodeId2), net.getNodes().get(nodeId6)));
-		SignalsData signalsData = (SignalsData) scenario.getScenarioElement(SignalsData.ELEMENT_NAME);
+		SignalsData signalsData = (SignalsData)scenario.getScenarioElement(SignalsData.ELEMENT_NAME);
 		// add another lane, signal and group
 		Lane lane16 = scenario.getLanes().getFactory().createLane(Id.create("1-6", Lane.class));
 		// use default parameters for capacity, length ... and just specify the to-link:
 		lane16.addToLinkId(linkId6);
 		scenario.getLanes().getLanesToLinkAssignments().get(linkId1).addLane(lane16);
-		scenario.getLanes().getLanesToLinkAssignments().get(linkId1).getLanes().get(Id.create("1.ol", Lane.class)).addToLaneId(lane16.getId());;
-		SignalData secondSignal = signalsData.getSignalSystemsData().getFactory().createSignalData(Id.create(200, Signal.class));
+		scenario.getLanes()
+				.getLanesToLinkAssignments()
+				.get(linkId1)
+				.getLanes()
+				.get(Id.create("1.ol", Lane.class))
+				.addToLaneId(lane16.getId());
+		;
+		SignalData secondSignal = signalsData.getSignalSystemsData()
+				.getFactory()
+				.createSignalData(Id.create(200, Signal.class));
 		secondSignal.setLinkId(linkId1);
 		secondSignal.addLaneId(lane16.getId());
 		secondSignal.addTurningMoveRestriction(linkId6);
 		signalsData.getSignalSystemsData().getSignalSystemData().get(signalSystemId2).addSignalData(secondSignal);
-		SignalGroupData secondGroup = signalsData.getSignalGroupsData().getFactory().createSignalGroupData(signalSystemId2, signalGroupId200);
+		SignalGroupData secondGroup = signalsData.getSignalGroupsData()
+				.getFactory()
+				.createSignalGroupData(signalSystemId2, signalGroupId200);
 		secondGroup.addSignalId(secondSignal.getId());
 		signalsData.getSignalGroupsData().addSignalGroupData(secondGroup);
-		SignalSystemControllerData controllerData = signalsData.getSignalControlData().getSignalSystemControllerDataBySystemId().get(signalSystemId2);
+		SignalSystemControllerData controllerData = signalsData.getSignalControlData()
+				.getSignalSystemControllerDataBySystemId()
+				.get(signalSystemId2);
 		SignalPlanData planData = controllerData.getSignalPlanData().get(signalPlanId2);
-		SignalGroupSettingsData groupPlanSettings = signalsData.getSignalControlData().getFactory().createSignalGroupSettingsData(signalGroupId200);
+		SignalGroupSettingsData groupPlanSettings = signalsData.getSignalControlData()
+				.getFactory()
+				.createSignalGroupSettingsData(signalGroupId200);
 		groupPlanSettings.setOnset(5);
 		groupPlanSettings.setDropping(10);
 		planData.addSignalGroupSettings(groupPlanSettings);
 		// add conflict data
-		IntersectionDirections conflictsNode2 = signalsData.getConflictingDirectionsData().getFactory().createConflictingDirectionsContainerForIntersection(signalSystemId2, nodeId2);
-		Direction direction1 = signalsData.getConflictingDirectionsData().getFactory().createDirection(signalSystemId2, nodeId2, linkId1, linkId2, Id.create(linkId1 + "-" + linkId2, Direction.class));
-		Direction direction2 = signalsData.getConflictingDirectionsData().getFactory().createDirection(signalSystemId2, nodeId2, linkId1, linkId6, Id.create(linkId1 + "-" + linkId6, Direction.class));
+		IntersectionDirections conflictsNode2 = signalsData.getConflictingDirectionsData()
+				.getFactory()
+				.createConflictingDirectionsContainerForIntersection(signalSystemId2, nodeId2);
+		Direction direction1 = signalsData.getConflictingDirectionsData()
+				.getFactory()
+				.createDirection(signalSystemId2, nodeId2, linkId1, linkId2,
+						Id.create(linkId1 + "-" + linkId2, Direction.class));
+		Direction direction2 = signalsData.getConflictingDirectionsData()
+				.getFactory()
+				.createDirection(signalSystemId2, nodeId2, linkId1, linkId6,
+						Id.create(linkId1 + "-" + linkId6, Direction.class));
 		direction1.addConflictingDirection(direction2.getId());
 		direction2.addConflictingDirection(direction1.getId());
 		conflictsNode2.addDirection(direction1);
 		conflictsNode2.addDirection(direction2);
-		signalsData.getConflictingDirectionsData().addConflictingDirectionsForIntersection(signalSystemId2, nodeId2, conflictsNode2);
-		
+		signalsData.getConflictingDirectionsData()
+				.addConflictingDirectionsForIntersection(signalSystemId2, nodeId2, conflictsNode2);
+
 		return scenario;
 	}
 
-	
 }

--- a/contribs/signals/src/test/java/org/matsim/contrib/signals/builder/QSimSignalTest.java
+++ b/contribs/signals/src/test/java/org/matsim/contrib/signals/builder/QSimSignalTest.java
@@ -58,6 +58,8 @@ public class QSimSignalTest implements
 	@Rule
 	public MatsimTestUtils testUtils = new MatsimTestUtils();
 	
+	private final Fixture fixture = new Fixture();
+	
 	
 	/**
 	 * Tests the setup with a traffic light that shows all the time green
@@ -65,7 +67,7 @@ public class QSimSignalTest implements
 	@Test
 	public void testTrafficLightIntersection2arms1AgentV20() {
 		// configure and load standard scenario
-		Scenario scenario = new Fixture().createAndLoadTestScenarioOneSignal(false );
+		Scenario scenario = fixture.createAndLoadTestScenarioOneSignal(false );
 		
 		this.link2EnterTime = 38.0;
 		runQSimWithSignals(scenario, true);
@@ -78,16 +80,16 @@ public class QSimSignalTest implements
 	@Test
 	public void testSignalSystems1AgentGreenAtSec100() {		
 		// configure and load standard scenario
-		Scenario scenario = new Fixture().createAndLoadTestScenarioOneSignal(false );
+		Scenario scenario = fixture.createAndLoadTestScenarioOneSignal(false );
 		// modify scenario
 		SignalsData signalsData = (SignalsData) scenario.getScenarioElement(SignalsData.ELEMENT_NAME);
 		SignalSystemControllerData controllerData = signalsData.getSignalControlData().getSignalSystemControllerDataBySystemId().get(
-				Fixture.signalSystemId2 );
-		SignalPlanData planData = controllerData.getSignalPlanData().get( Fixture.signalPlanId2 );
+				fixture.signalSystemId2 );
+		SignalPlanData planData = controllerData.getSignalPlanData().get( fixture.signalPlanId2 );
 		planData.setStartTime(0.0);
 		planData.setEndTime(0.0);
 		planData.setCycleTime(5 * 3600);
-		SignalGroupSettingsData groupData = planData.getSignalGroupSettingsDataByGroupId().get( Fixture.signalGroupId100 );
+		SignalGroupSettingsData groupData = planData.getSignalGroupSettingsDataByGroupId().get( fixture.signalGroupId100 );
 		groupData.setDropping(0);
 		groupData.setOnset(100);
 
@@ -101,16 +103,16 @@ public class QSimSignalTest implements
 	@Test
 	public void testIntergreensAbortOneAgentDriving() {
 		//configure and load standard scenario
-		Scenario scenario = new Fixture().createAndLoadTestScenarioOneSignal(true );
+		Scenario scenario = fixture.createAndLoadTestScenarioOneSignal(true );
 		// modify scenario
 		SignalsData signalsData = (SignalsData) scenario.getScenarioElement(SignalsData.ELEMENT_NAME);
 		SignalSystemControllerData controllerData = signalsData.getSignalControlData().getSignalSystemControllerDataBySystemId().get(
-				Fixture.signalSystemId2 );
-		SignalPlanData planData = controllerData.getSignalPlanData().get( Fixture.signalPlanId2 );
+				fixture.signalSystemId2 );
+		SignalPlanData planData = controllerData.getSignalPlanData().get( fixture.signalPlanId2 );
 		planData.setStartTime(0.0);
 		planData.setEndTime(0.0);
 		planData.setCycleTime(60);
-		SignalGroupSettingsData groupData = planData.getSignalGroupSettingsDataByGroupId().get( Fixture.signalGroupId100 );
+		SignalGroupSettingsData groupData = planData.getSignalGroupSettingsDataByGroupId().get( fixture.signalGroupId100 );
 		groupData.setOnset(0);
 		groupData.setDropping(59);	
 		
@@ -123,16 +125,16 @@ public class QSimSignalTest implements
 	@Test
 	public void testIntergreensNoAbortOneAgentDriving() {
 		//configure and load standard scenario
-		Scenario scenario = new Fixture().createAndLoadTestScenarioOneSignal(true );
+		Scenario scenario = fixture.createAndLoadTestScenarioOneSignal(true );
 		// modify scenario
 		SignalsData signalsData = (SignalsData) scenario.getScenarioElement(SignalsData.ELEMENT_NAME);
 		SignalSystemControllerData controllerData = signalsData.getSignalControlData().getSignalSystemControllerDataBySystemId().get(
-				Fixture.signalSystemId2 );
-		SignalPlanData planData = controllerData.getSignalPlanData().get( Fixture.signalPlanId2 );
+				fixture.signalSystemId2 );
+		SignalPlanData planData = controllerData.getSignalPlanData().get( fixture.signalPlanId2 );
 		planData.setStartTime(0.0);
 		planData.setEndTime(0.0);
 		planData.setCycleTime(60);
-		SignalGroupSettingsData groupData = planData.getSignalGroupSettingsDataByGroupId().get( Fixture.signalGroupId100 );
+		SignalGroupSettingsData groupData = planData.getSignalGroupSettingsDataByGroupId().get( fixture.signalGroupId100 );
 		groupData.setOnset(30);
 		groupData.setDropping(25);	
 		
@@ -146,7 +148,7 @@ public class QSimSignalTest implements
 	@Test
 	public void testConflictingDirectionsAbortOneAgentDriving() {
 		//configure and load test scenario with data about conflicting directions
-		Scenario scenario = new Fixture().createAndLoadTestScenarioTwoSignals(true );
+		Scenario scenario = fixture.createAndLoadTestScenarioTwoSignals(true );
 
 		runQSimWithSignals(scenario, false);
 		Assert.assertFalse("The simulation should abort because of intergreens violation.", runQSimWithSignals(scenario, false));
@@ -158,12 +160,12 @@ public class QSimSignalTest implements
 	@Test
 	public void testConflictingDirectionsNoAbortOneAgentDriving() {
 		//configure and load test scenario with data about conflicting directions
-		Scenario scenario = new Fixture().createAndLoadTestScenarioTwoSignals(true );
+		Scenario scenario = fixture.createAndLoadTestScenarioTwoSignals(true );
 		SignalsData signalsData = (SignalsData) scenario.getScenarioElement(SignalsData.ELEMENT_NAME);
 		SignalGroupSettingsData group100setting = signalsData.getSignalControlData().getSignalSystemControllerDataBySystemId().get(
-				Fixture.signalSystemId2 ).getSignalPlanData().get(
-				Fixture.signalPlanId2 ).getSignalGroupSettingsDataByGroupId().get(
-				Fixture.signalGroupId100 );
+				fixture.signalSystemId2 ).getSignalPlanData().get(
+				fixture.signalPlanId2 ).getSignalGroupSettingsDataByGroupId().get(
+				fixture.signalGroupId100 );
 		group100setting.setOnset(15);
 
 		runQSimWithSignals(scenario, false);
@@ -222,10 +224,10 @@ public class QSimSignalTest implements
 	@Override
 	public void handleEvent(LinkEnterEvent e) {
 		log.info("Link id: " + e.getLinkId().toString() + " enter time: " + e.getTime());
-		if (e.getLinkId().equals( Fixture.linkId1 )){
+		if (e.getLinkId().equals( fixture.linkId1 )){
 			Assert.assertEquals(1.0, e.getTime(), MatsimTestUtils.EPSILON);
 		}
-		else if (e.getLinkId().equals( Fixture.linkId2 )){
+		else if (e.getLinkId().equals( fixture.linkId2 )){
 			Assert.assertEquals(this.link2EnterTime, e.getTime(), MatsimTestUtils.EPSILON);
 		}
 	}

--- a/contribs/signals/src/test/java/org/matsim/contrib/signals/controller/laemmerFix/LaemmerIT.java
+++ b/contribs/signals/src/test/java/org/matsim/contrib/signals/controller/laemmerFix/LaemmerIT.java
@@ -68,10 +68,10 @@ public class LaemmerIT {
 	
 	private static final int maxCycleTime = 90;
 	private static final int cycleIntergreenTime = 10;
-	private static final Id<SignalGroup> signalGroupId1 = Id.create("SignalGroup1", SignalGroup.class);
-	private static final Id<SignalGroup> signalGroupId1l = Id.create("SignalGroup1l", SignalGroup.class);
-	private static final Id<SignalGroup> signalGroupId2 = Id.create("SignalGroup2", SignalGroup.class);
-	private static final Id<SignalSystem> signalSystemId = Id.create("SignalSystem1", SignalSystem.class);
+	private final Id<SignalGroup> signalGroupId1 = Id.create("SignalGroup1", SignalGroup.class);
+	private final Id<SignalGroup> signalGroupId1l = Id.create("SignalGroup1l", SignalGroup.class);
+	private final Id<SignalGroup> signalGroupId2 = Id.create("SignalGroup2", SignalGroup.class);
+	private final Id<SignalSystem> signalSystemId = Id.create("SignalSystem1", SignalSystem.class);
 	
 	/**
 	 * single intersection with demand (equals flow capacity) only in NS-direction. signals should show green only for the NS-direction.

--- a/contribs/signals/src/test/java/org/matsim/contrib/signals/oneagent/ControlerTest.java
+++ b/contribs/signals/src/test/java/org/matsim/contrib/signals/oneagent/ControlerTest.java
@@ -23,9 +23,11 @@ import org.junit.Assert;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.events.LinkEnterEvent;
 import org.matsim.api.core.v01.events.handler.LinkEnterEventHandler;
+import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.signals.events.SignalGroupStateChangedEvent;
 import org.matsim.contrib.signals.events.SignalGroupStateChangedEventHandler;
 import org.matsim.core.controler.Controler;
@@ -92,22 +94,18 @@ public class ControlerTest {
 			}
 		});
 		
-		controler.addControlerListener(new IterationStartsListener() {
-			
-			@Override
-			public void notifyIterationStarts(IterationStartsEvent event) {
-				event.getServices().getEvents().addHandler(new EventsLogger());
+		controler.addControlerListener((IterationStartsListener)event -> {
+			event.getServices().getEvents().addHandler(new EventsLogger());
 
-				TestLink2EnterEventHandler enterHandler = new TestLink2EnterEventHandler();
-				if (0 == event.getIteration()) {
-					enterHandler.link2EnterTime = 38.0;
-				}
+			TestLink2EnterEventHandler enterHandler = new TestLink2EnterEventHandler();
+			if (0 == event.getIteration()) {
+				enterHandler.link2EnterTime = 38.0;
+			}
 
-				if (1 == event.getIteration()) {
-					enterHandler.link2EnterTime = 100.0;
-					SignalGroupStateChangedEventHandler signalsHandler0 = new TestSignalGroupStateChangedHandler();
-					event.getServices().getEvents().addHandler(signalsHandler0);
-				}
+			if (1 == event.getIteration()) {
+				enterHandler.link2EnterTime = 100.0;
+				SignalGroupStateChangedEventHandler signalsHandler0 = new TestSignalGroupStateChangedHandler();
+				event.getServices().getEvents().addHandler(signalsHandler0);
 			}
 		});
 		
@@ -134,12 +132,13 @@ public class ControlerTest {
 
 
 	private static final class TestLink2EnterEventHandler implements LinkEnterEventHandler {
+		final Id<Link> linkId2 = Id.create(2, Link.class);
 		double link2EnterTime = 0;
 		@Override
 		public void reset(int i) {}
 		@Override
 		public void handleEvent(LinkEnterEvent e){
-			if (e.getLinkId().equals(Fixture.linkId2)) {
+			if (e.getLinkId().equals(linkId2)) {
 				Assert.assertEquals(link2EnterTime,  e.getTime(), MatsimTestUtils.EPSILON);
 			}
 		}

--- a/contribs/signals/src/test/java/org/matsim/contrib/signals/oneagent/Fixture.java
+++ b/contribs/signals/src/test/java/org/matsim/contrib/signals/oneagent/Fixture.java
@@ -59,17 +59,17 @@ import org.matsim.testcases.MatsimTestUtils;
  */
 public class Fixture {
 
-	static final Id<Link> linkId1 = Id.create(1, Link.class);
-	static final Id<Link> linkId2 = Id.create(2, Link.class);
-	static final Id<Node> nodeId2 = Id.create(2, Node.class);
-	static final Id<SignalPlan> signalPlanId2 = Id.create(2, SignalPlan.class);
-	static final Id<SignalSystem> signalSystemId2 = Id.create(2, SignalSystem.class);
-	static final Id<SignalGroup> signalGroupId100 = Id.create(100, SignalGroup.class);
+	final Id<Link> linkId1 = Id.create(1, Link.class);
+	final Id<Link> linkId2 = Id.create(2, Link.class);
+	final Id<Node> nodeId2 = Id.create(2, Node.class);
+	final Id<SignalPlan> signalPlanId2 = Id.create(2, SignalPlan.class);
+	final Id<SignalSystem> signalSystemId2 = Id.create(2, SignalSystem.class);
+	final Id<SignalGroup> signalGroupId100 = Id.create(100, SignalGroup.class);
 	
 	// only available if 'TwoSignals'-Method is used
-	static final Id<SignalGroup> signalGroupId200 = Id.create(200, SignalGroup.class);
-	static final Id<Link> linkId6 = Id.create(6, Link.class);
-	static final Id<Node> nodeId6 = Id.create(6, Node.class);
+	final Id<SignalGroup> signalGroupId200 = Id.create(200, SignalGroup.class);
+	final Id<Link> linkId6 = Id.create(6, Link.class);
+	final Id<Node> nodeId6 = Id.create(6, Node.class);
 	
 
 	public Scenario createAndLoadTestScenarioOneSignal(Boolean useIntergreens){

--- a/contribs/socnetsim/src/test/java/org/matsim/contrib/socnetsim/framework/events/CourtesyEventsTest.java
+++ b/contribs/socnetsim/src/test/java/org/matsim/contrib/socnetsim/framework/events/CourtesyEventsTest.java
@@ -45,10 +45,10 @@ import org.matsim.contrib.socnetsim.framework.population.SocialNetworkImpl;
 public class CourtesyEventsTest {
 	private static final Logger log =
 		Logger.getLogger(CourtesyEventsTest.class);
-	public static final Id<Person> ID_1 = Id.create("tintin", Person.class);
-	public static final Id<Person> ID_2 = Id.create("milou", Person.class);
-	public static final Id<Link> LINK_ID = Id.createLinkId("Link");
-	public static final Id<ActivityFacility> FACILITY_ID = Id.create("Facility", ActivityFacility.class);
+	public final Id<Person> ID_1 = Id.create("tintin", Person.class);
+	public final Id<Person> ID_2 = Id.create("milou", Person.class);
+	public final Id<Link> LINK_ID = Id.createLinkId("Link");
+	public final Id<ActivityFacility> FACILITY_ID = Id.create("Facility", ActivityFacility.class);
 	public static final String TYPE = "type";
 
 	@Test

--- a/contribs/socnetsim/src/test/java/org/matsim/contrib/socnetsim/framework/scoring/GroupCompositionPenalizerTest.java
+++ b/contribs/socnetsim/src/test/java/org/matsim/contrib/socnetsim/framework/scoring/GroupCompositionPenalizerTest.java
@@ -55,7 +55,7 @@ import org.matsim.core.scoring.SumScoringFunction;
  */
 public class GroupCompositionPenalizerTest {
 	private static final Logger log = Logger.getLogger( GroupCompositionPenalizerTest.class );
-	private static final Id<Link> linkId = Id.createLinkId( 1 );
+	private final Id<Link> linkId = Id.createLinkId( 1 );
 	private final double utilOneCopart = 100;
 	private final double utilAlone = -1;
 

--- a/contribs/socnetsim/src/test/java/org/matsim/contrib/socnetsim/jointtrips/qsim/JointTravelingSimulationIntegrationTest.java
+++ b/contribs/socnetsim/src/test/java/org/matsim/contrib/socnetsim/jointtrips/qsim/JointTravelingSimulationIntegrationTest.java
@@ -103,15 +103,15 @@ public class JointTravelingSimulationIntegrationTest {
 	private static final int N_RANDOM_SCENARIOS = 20;
 	private static final int N_LAPS = 5;
 
-	private static final Id<Link> ORIGIN_LINK = Id.create("origin", Link.class);
-	private static final Id<Link> TO_PU_LINK = Id.create("toPu", Link.class);
-	private static final Id<Link> PU_LINK = Id.create("pu", Link.class);
-	private static final Id<Link> TRAVEL_LINK_1 = Id.create(1, Link.class);
-	private static final Id<Link> TRAVEL_LINK_2 = Id.create(2, Link.class);
-	private static final Id<Link> DO_LINK = Id.create("do", Link.class);
-	private static final Id<Link> TO_DESTINATION_LINK = Id.create("to_destination", Link.class);
-	private static final Id<Link> DESTINATION_LINK = Id.create("destination", Link.class);
-	private static final Id<Link> RETURN_LINK = Id.create("return", Link.class);
+	private final Id<Link> ORIGIN_LINK = Id.create("origin", Link.class);
+	private final Id<Link> TO_PU_LINK = Id.create("toPu", Link.class);
+	private final Id<Link> PU_LINK = Id.create("pu", Link.class);
+	private final Id<Link> TRAVEL_LINK_1 = Id.create(1, Link.class);
+	private final Id<Link> TRAVEL_LINK_2 = Id.create(2, Link.class);
+	private final Id<Link> DO_LINK = Id.create("do", Link.class);
+	private final Id<Link> TO_DESTINATION_LINK = Id.create("to_destination", Link.class);
+	private final Id<Link> DESTINATION_LINK = Id.create("destination", Link.class);
+	private final Id<Link> RETURN_LINK = Id.create("return", Link.class);
 
 	private static final String ORIGIN_ACT = "chill";
 	private static final String DESTINATION_ACT = "stress";
@@ -343,7 +343,7 @@ public class JointTravelingSimulationIntegrationTest {
 		}
 	}
 
-	private static Fixture createFixture(
+	private Fixture createFixture(
 			final boolean insertDummyActivities,
 			final RouteType routeType) {
 		switch ( routeType ) {
@@ -412,7 +412,7 @@ public class JointTravelingSimulationIntegrationTest {
 		}
 	}
 
-	private static Scenario createTestScenario(
+	private Scenario createTestScenario(
 			final Fixture fixture,
 			final Random random) {
 		final Config config = ConfigUtils.createConfig();
@@ -572,7 +572,7 @@ public class JointTravelingSimulationIntegrationTest {
 		return sc;
 	}
 
-	private static void createNetwork(final Network network) {
+	private void createNetwork(final Network network) {
 		int c = 0;
 		int d = 0;
 

--- a/contribs/vsp/src/test/java/org/matsim/integration/drtAndPt/PtAlongALine2Test.java
+++ b/contribs/vsp/src/test/java/org/matsim/integration/drtAndPt/PtAlongALine2Test.java
@@ -3,15 +3,11 @@ package org.matsim.integration.drtAndPt;
 import static java.util.stream.Collectors.toList;
 import static org.matsim.core.config.groups.PlansCalcRouteConfigGroup.ModeRoutingParams;
 
-import ch.sbb.matsim.config.SwissRailRaptorConfigGroup;
-import ch.sbb.matsim.config.SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet;
-import com.google.common.collect.ImmutableSet;
-import com.google.inject.Inject;
-import com.google.inject.Singleton;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
 import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -60,32 +56,41 @@ import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehiclesFactory;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import ch.sbb.matsim.config.SwissRailRaptorConfigGroup;
+import ch.sbb.matsim.config.SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet;
+
 //@RunWith(Parameterized.class)
-public class PtAlongALine2Test{
-	private static final Logger log = Logger.getLogger( PtAlongALine2Test.class );
+public class PtAlongALine2Test {
+	private static final Logger log = Logger.getLogger(PtAlongALine2Test.class);
 
-	@Rule public MatsimTestUtils utils = new MatsimTestUtils() ;
+	@Rule
+	public MatsimTestUtils utils = new MatsimTestUtils();
 
-	enum DrtMode { none, teleportBeeline, teleportBasedOnNetworkRoute, full, withPrebooking }
-	private DrtMode drtMode = DrtMode.withPrebooking ;
-	private boolean drt2 = true ;
-	private boolean drt3 = true ;
+	enum DrtMode {none, teleportBeeline, teleportBasedOnNetworkRoute, full, withPrebooking}
+
+	private DrtMode drtMode = DrtMode.withPrebooking;
+	private boolean drt2 = true;
+	private boolean drt3 = true;
 
 	// !! otfvis does not run within parameterized test :-( !!
 
-//	@Parameterized.Parameters(name = "{index}: DrtMode={0}")
-//	// the convention is that the output of the method marked by "@Parameters" is taken as input to the constructor
-//	// before running each test. kai, jul'16
-//	public static Collection<Object[]> createTestParams(){
-//		return Arrays.asList( new Object[][]{
-//				{ DrtMode.full },
-//				{ DrtMode.withPrebooking }
-//		} );
-//	}
-//
-//	public PtAlongALine2Test( DrtMode drtMode ) {
-//		this.drtMode = drtMode;
-//	}
+	//	@Parameterized.Parameters(name = "{index}: DrtMode={0}")
+	//	// the convention is that the output of the method marked by "@Parameters" is taken as input to the constructor
+	//	// before running each test. kai, jul'16
+	//	public static Collection<Object[]> createTestParams(){
+	//		return Arrays.asList( new Object[][]{
+	//				{ DrtMode.full },
+	//				{ DrtMode.withPrebooking }
+	//		} );
+	//	}
+	//
+	//	public PtAlongALine2Test( DrtMode drtMode ) {
+	//		this.drtMode = drtMode;
+	//	}
 
 	// !! otfvis does not run within parameterized test :-( !!
 
@@ -97,74 +102,92 @@ public class PtAlongALine2Test{
 		// * If "walk" is defined as intermodal access, then swiss rail raptor will call the correct RoutingModule, but afterwards change the mode of all
 		// legs to non_network_mode.
 
-		Config config = PtAlongALineTest.createConfig( utils.getOutputDirectory() );
+		Config config = PtAlongALineTest.createConfig(utils.getOutputDirectory());
 
 		// === GBL: ===
 
-		config.controler().setLastIteration( 0 );
+		config.controler().setLastIteration(0);
 
 		// === ROUTER: ===
 
 		config.plansCalcRoute().setAccessEgressType(AccessEgressType.accessEgressModeToLink);
 
-		config.qsim().setVehiclesSource( QSimConfigGroup.VehiclesSource.modeVehicleTypesFromVehiclesData );
+		config.qsim().setVehiclesSource(QSimConfigGroup.VehiclesSource.modeVehicleTypesFromVehiclesData);
 		// (as of today, will also influence router. kai, jun'19)
 
-		if(  drtMode == DrtMode.teleportBeeline ){// (configure teleportation router)
-			config.plansCalcRoute().addModeRoutingParams( new ModeRoutingParams().setMode( TransportMode.drt ).setTeleportedModeSpeed( 100. / 3.6 ) );
-			if( drt2 ){
-				config.plansCalcRoute().addModeRoutingParams( new ModeRoutingParams().setMode( "drt2" ).setTeleportedModeSpeed( 100. / 3.6 ) );
+		if (drtMode == DrtMode.teleportBeeline) {// (configure teleportation router)
+			config.plansCalcRoute()
+					.addModeRoutingParams(
+							new ModeRoutingParams().setMode(TransportMode.drt).setTeleportedModeSpeed(100. / 3.6));
+			if (drt2) {
+				config.plansCalcRoute()
+						.addModeRoutingParams(
+								new ModeRoutingParams().setMode("drt2").setTeleportedModeSpeed(100. / 3.6));
 			}
-			if( drt3 ){
-				config.plansCalcRoute().addModeRoutingParams( new ModeRoutingParams().setMode( "drt3" ).setTeleportedModeSpeed( 100. / 3.6 ) );
+			if (drt3) {
+				config.plansCalcRoute()
+						.addModeRoutingParams(
+								new ModeRoutingParams().setMode("drt3").setTeleportedModeSpeed(100. / 3.6));
 			}
 			// teleportation router for walk or bike is automatically defined.
-		} else if( drtMode == DrtMode.teleportBasedOnNetworkRoute ){// (route as network route)
-			Set<String> networkModes = new HashSet<>( );
-			networkModes.add( TransportMode.drt );
-			if( drt2 ){
-				networkModes.add( "drt2" );
+		} else if (drtMode == DrtMode.teleportBasedOnNetworkRoute) {// (route as network route)
+			Set<String> networkModes = new HashSet<>();
+			networkModes.add(TransportMode.drt);
+			if (drt2) {
+				networkModes.add("drt2");
 			}
-			if( drt3 ){
-				networkModes.add( "drt3" );
+			if (drt3) {
+				networkModes.add("drt3");
 			}
-			config.plansCalcRoute().setNetworkModes( networkModes );
+			config.plansCalcRoute().setNetworkModes(networkModes);
 		}
 
-		config.plansCalcRoute().addModeRoutingParams( new ModeRoutingParams().setMode( "walk" ).setTeleportedModeSpeed( 5. / 3.6 ) );
+		config.plansCalcRoute()
+				.addModeRoutingParams(new ModeRoutingParams().setMode("walk").setTeleportedModeSpeed(5. / 3.6));
 
 		// set up walk2 so we don't need walk in raptor:
-		config.plansCalcRoute().addModeRoutingParams( new ModeRoutingParams().setMode( "walk2" ).setTeleportedModeSpeed( 5. / 3.6 ) );
+		config.plansCalcRoute()
+				.addModeRoutingParams(new ModeRoutingParams().setMode("walk2").setTeleportedModeSpeed(5. / 3.6));
 
 		// === RAPTOR: ===
 		{
 			//config.transit().setRoutingAlgorithmType(TransitRoutingAlgorithmType.DijkstraBased); // we'll set up SwissRailRaptor ourself, so disable it here to prevent conflicts
-			SwissRailRaptorConfigGroup configRaptor = ConfigUtils.addOrGetModule(config, SwissRailRaptorConfigGroup.class);
+			SwissRailRaptorConfigGroup configRaptor = ConfigUtils.addOrGetModule(config,
+					SwissRailRaptorConfigGroup.class);
 
 			if (drtMode != DrtMode.none) {
 				configRaptor.setUseIntermodalAccessEgress(true);
 
 				//					paramSetXxx.setMode( TransportMode.walk ); // this does not work because sbb raptor treats it in a special way
-				configRaptor.addIntermodalAccessEgress(
-						new IntermodalAccessEgressParameterSet().setMode("walk2").setMaxRadius(1000000).setInitialSearchRadius(1000000).setSearchExtensionRadius(10000));
+				configRaptor.addIntermodalAccessEgress(new IntermodalAccessEgressParameterSet().setMode("walk2")
+						.setMaxRadius(1000000)
+						.setInitialSearchRadius(1000000)
+						.setSearchExtensionRadius(10000));
 				// (in principle, walk as alternative to drt will not work, since drt is always faster.  Need to give the ASC to the router!  However, with
 				// the reduced drt network we should be able to see differentiation.)
 
 				// drt
 				configRaptor.addIntermodalAccessEgress(
-						new IntermodalAccessEgressParameterSet().setMode( TransportMode.drt ).setMaxRadius( 1000000 ).setInitialSearchRadius( 1000000 ).setSearchExtensionRadius( 10000 ) );
+						new IntermodalAccessEgressParameterSet().setMode(TransportMode.drt)
+								.setMaxRadius(1000000)
+								.setInitialSearchRadius(1000000)
+								.setSearchExtensionRadius(10000));
 
-				if ( drt2 ){
+				if (drt2) {
 					//				paramSetDrt2.setPersonFilterAttribute( null );
 					//				paramSetDrt2.setStopFilterAttribute( null );
-					configRaptor.addIntermodalAccessEgress(
-							new IntermodalAccessEgressParameterSet().setMode( "drt2" ).setMaxRadius( 1000000 ).setInitialSearchRadius( 1000000 ).setSearchExtensionRadius( 10000 ) );
+					configRaptor.addIntermodalAccessEgress(new IntermodalAccessEgressParameterSet().setMode("drt2")
+							.setMaxRadius(1000000)
+							.setInitialSearchRadius(1000000)
+							.setSearchExtensionRadius(10000));
 				}
-				if ( drt3 ){
+				if (drt3) {
 					//				paramSetDrt2.setPersonFilterAttribute( null );
 					//				paramSetDrt2.setStopFilterAttribute( null );
-					configRaptor.addIntermodalAccessEgress(
-							new IntermodalAccessEgressParameterSet().setMode("drt3").setMaxRadius(1000000).setInitialSearchRadius(1000000).setSearchExtensionRadius(10000));
+					configRaptor.addIntermodalAccessEgress(new IntermodalAccessEgressParameterSet().setMode("drt3")
+							.setMaxRadius(1000000)
+							.setInitialSearchRadius(1000000)
+							.setSearchExtensionRadius(10000));
 				}
 			}
 
@@ -175,30 +198,33 @@ public class PtAlongALine2Test{
 		double margUtlTravPt = config.planCalcScore().getModes().get(TransportMode.pt).getMarginalUtilityOfTraveling();
 		if (drtMode != DrtMode.none) {
 			// (scoring parameters for drt modes)
-			config.planCalcScore().addModeParams(new ModeParams(TransportMode.drt).setMarginalUtilityOfTraveling(margUtlTravPt));
+			config.planCalcScore()
+					.addModeParams(new ModeParams(TransportMode.drt).setMarginalUtilityOfTraveling(margUtlTravPt));
 			if (drt2) {
-				config.planCalcScore().addModeParams(new ModeParams("drt2").setMarginalUtilityOfTraveling(margUtlTravPt));
+				config.planCalcScore()
+						.addModeParams(new ModeParams("drt2").setMarginalUtilityOfTraveling(margUtlTravPt));
 			}
 			if (drt3) {
-				config.planCalcScore().addModeParams(new ModeParams("drt3").setMarginalUtilityOfTraveling(margUtlTravPt));
+				config.planCalcScore()
+						.addModeParams(new ModeParams("drt3").setMarginalUtilityOfTraveling(margUtlTravPt));
 			}
 		}
 		config.planCalcScore().addModeParams(new ModeParams("walk2").setMarginalUtilityOfTraveling(margUtlTravPt));
 
 		// === QSIM: ===
 
-		config.qsim().setSimStarttimeInterpretation( QSimConfigGroup.StarttimeInterpretation.onlyUseStarttime );
+		config.qsim().setSimStarttimeInterpretation(QSimConfigGroup.StarttimeInterpretation.onlyUseStarttime);
 		// yy why?  kai, jun'19
 
 		// === DRT: ===
 
-		if ( drtMode== DrtMode.full || drtMode== DrtMode.withPrebooking ){
+		if (drtMode == DrtMode.full || drtMode == DrtMode.withPrebooking) {
 			// (configure full drt if applicable)
 
-			DvrpConfigGroup dvrpConfig = ConfigUtils.addOrGetModule( config, DvrpConfigGroup.class );
-			dvrpConfig.setNetworkModes( ImmutableSet.copyOf( Arrays.asList( TransportMode.drt, "drt2", "drt3" ) ) ) ;
+			DvrpConfigGroup dvrpConfig = ConfigUtils.addOrGetModule(config, DvrpConfigGroup.class);
+			dvrpConfig.setNetworkModes(ImmutableSet.copyOf(Arrays.asList(TransportMode.drt, "drt2", "drt3")));
 
-			MultiModeDrtConfigGroup mm = ConfigUtils.addOrGetModule( config, MultiModeDrtConfigGroup.class );
+			MultiModeDrtConfigGroup mm = ConfigUtils.addOrGetModule(config, MultiModeDrtConfigGroup.class);
 			{
 				DrtConfigGroup drtConfigGroup = new DrtConfigGroup().setMode(TransportMode.drt)
 						.setMaxTravelTimeAlpha(2.0)
@@ -212,7 +238,7 @@ public class PtAlongALine2Test{
 				mm.addParameterSet(drtConfigGroup);
 
 			}
-			if ( drt2 ) {
+			if (drt2) {
 				DrtConfigGroup drtConfigGroup = new DrtConfigGroup().setMode("drt2")
 						.setMaxTravelTimeAlpha(1.3)
 						.setMaxTravelTimeBeta(5. * 60.)
@@ -223,7 +249,7 @@ public class PtAlongALine2Test{
 				drtConfigGroup.addParameterSet(new ExtensiveInsertionSearchParams());
 				mm.addParameterSet(drtConfigGroup);
 			}
-			if ( drt3 ) {
+			if (drt3) {
 				DrtConfigGroup drtConfigGroup = new DrtConfigGroup().setMode("drt3")
 						.setMaxTravelTimeAlpha(1.3)
 						.setMaxTravelTimeBeta(5. * 60.)
@@ -235,114 +261,131 @@ public class PtAlongALine2Test{
 				mm.addParameterSet(drtConfigGroup);
 			}
 
-			for( DrtConfigGroup drtConfigGroup : mm.getModalElements() ){
-				DrtConfigs.adjustDrtConfig( drtConfigGroup, config.planCalcScore(), config.plansCalcRoute() );
+			for (DrtConfigGroup drtConfigGroup : mm.getModalElements()) {
+				DrtConfigs.adjustDrtConfig(drtConfigGroup, config.planCalcScore(), config.plansCalcRoute());
 			}
 		}
 
-		if ( drtMode== DrtMode.withPrebooking ) {
-			QSimComponentsConfigGroup qsimComponentsConfig = ConfigUtils.addOrGetModule( config, QSimComponentsConfigGroup.class );
+		if (drtMode == DrtMode.withPrebooking) {
+			QSimComponentsConfigGroup qsimComponentsConfig = ConfigUtils.addOrGetModule(config,
+					QSimComponentsConfigGroup.class);
 			List<String> components = qsimComponentsConfig.getActiveComponents();
-			components.remove( ActivityEngineModule.COMPONENT_NAME );
-			components.add( ActivityEngineWithWakeup.COMPONENT_NAME );
-			qsimComponentsConfig.setActiveComponents( components );
+			components.remove(ActivityEngineModule.COMPONENT_NAME);
+			components.add(ActivityEngineWithWakeup.COMPONENT_NAME);
+			qsimComponentsConfig.setActiveComponents(components);
 		}
-
 
 		// === VSP: ===
 
-		config.vspExperimental().setVspDefaultsCheckingLevel( VspExperimentalConfigGroup.VspDefaultsCheckingLevel.warn );
+		config.vspExperimental().setVspDefaultsCheckingLevel(VspExperimentalConfigGroup.VspDefaultsCheckingLevel.warn);
 
 		// ### SCENARIO: ###
 
-		Scenario scenario = PtAlongALineTest.createScenario(config , 30 );
+		Scenario scenario = new PtAlongALineFixture().createScenario(config, 30);
 
 		// Add Test Agents to Scenario
 		PopulationFactory pf = scenario.getPopulation().getFactory();
 
-		List<String> testAgents = Arrays.asList("2-3", "50-51" , "300-301", "550-551", "690-691", "800-801");
+		List<String> testAgents = Arrays.asList("2-3", "50-51", "300-301", "550-551", "690-691", "800-801");
 		for (String str : testAgents) {
-			Person testAgent = pf.createPerson( Id.createPersonId("agent" + str ));
-			scenario.getPopulation().addPerson( testAgent );
+			Person testAgent = pf.createPerson(Id.createPersonId("agent" + str));
+			scenario.getPopulation().addPerson(testAgent);
 			Plan plan = pf.createPlan();
-			testAgent.addPlan( plan );
+			testAgent.addPlan(plan);
 
-			Id<ActivityFacility> homeFacilityId = Id.create( str, ActivityFacility.class ) ;
-			Activity home = pf.createActivityFromActivityFacilityId( "dummy", homeFacilityId );
-			home.setEndTime( 7. * 3600. + 1. );
-			plan.addActivity( home );
+			Id<ActivityFacility> homeFacilityId = Id.create(str, ActivityFacility.class);
+			Activity home = pf.createActivityFromActivityFacilityId("dummy", homeFacilityId);
+			home.setEndTime(7. * 3600. + 1.);
+			plan.addActivity(home);
 
-			Leg leg = pf.createLeg( TransportMode.pt );
-			leg.setDepartureTime( 7. * 3600. );
-			leg.setTravelTime( 1800. );
-			plan.addLeg( leg );
+			Leg leg = pf.createLeg(TransportMode.pt);
+			leg.setDepartureTime(7. * 3600.);
+			leg.setTravelTime(1800.);
+			plan.addLeg(leg);
 
-			Activity shop = pf.createActivityFromActivityFacilityId( "dummy", Id.create("999-1000" , ActivityFacility.class));
-			plan.addActivity( shop );
+			Activity shop = pf.createActivityFromActivityFacilityId("dummy",
+					Id.create("999-1000", ActivityFacility.class));
+			plan.addActivity(shop);
 		}
 
-
-		if ( drtMode== DrtMode.full || drtMode== DrtMode.withPrebooking) {
-			scenario.getPopulation().getFactory().getRouteFactories().setRouteFactory( DrtRoute.class, new DrtRouteFactory() );
+		if (drtMode == DrtMode.full || drtMode == DrtMode.withPrebooking) {
+			scenario.getPopulation()
+					.getFactory()
+					.getRouteFactories()
+					.setRouteFactory(DrtRoute.class, new DrtRouteFactory());
 		}
-		if ( drtMode== DrtMode.withPrebooking ) {
+		if (drtMode == DrtMode.withPrebooking) {
 			for (Person person : scenario.getPopulation().getPersons().values()) {
-				person.getSelectedPlan().getAttributes().putAttribute( PreplanningEngine.PREBOOKING_OFFSET_ATTRIBUTE_NAME, 7200. );
+				person.getSelectedPlan()
+						.getAttributes()
+						.putAttribute(PreplanningEngine.PREBOOKING_OFFSET_ATTRIBUTE_NAME, 7200.);
 			}
 		}
 
 		// add drt modes to the car links' allowed modes in their respective service area
-		PtAlongALineTest.addModeToAllLinksBtwnGivenNodes(scenario.getNetwork(), 0, 400, TransportMode.drt );
-		if ( drt2 ){
-			PtAlongALineTest.addModeToAllLinksBtwnGivenNodes( scenario.getNetwork(), 700, 1000, "drt2" );
+		PtAlongALineTest.addModeToAllLinksBtwnGivenNodes(scenario.getNetwork(), 0, 400, TransportMode.drt);
+		if (drt2) {
+			PtAlongALineTest.addModeToAllLinksBtwnGivenNodes(scenario.getNetwork(), 700, 1000, "drt2");
 		}
-		if ( drt3 ){
-			PtAlongALineTest.addModeToAllLinksBtwnGivenNodes( scenario.getNetwork(), 500, 600, "drt3" );
+		if (drt3) {
+			PtAlongALineTest.addModeToAllLinksBtwnGivenNodes(scenario.getNetwork(), 500, 600, "drt3");
 		}
 		// TODO: reference somehow network creation, to ensure that these link ids exist
 
-
 		// The following is also for the router! kai, jun'19
 		VehiclesFactory vf = scenario.getVehicles().getFactory();
-		if ( drt2 ) {
-			scenario.getVehicles().addVehicleType( vf.createVehicleType( Id.create( "drt2", VehicleType.class ) ).setMaximumVelocity( 25./3.6 ) );
-		} if ( drt3 ) {
-			scenario.getVehicles().addVehicleType( vf.createVehicleType( Id.create( "drt3", VehicleType.class ) ).setMaximumVelocity( 25./3.6 ) );
+		if (drt2) {
+			scenario.getVehicles()
+					.addVehicleType(
+							vf.createVehicleType(Id.create("drt2", VehicleType.class)).setMaximumVelocity(25. / 3.6));
 		}
-		scenario.getVehicles().addVehicleType( vf.createVehicleType( Id.create( TransportMode.drt, VehicleType.class ) ).setMaximumVelocity( 25./3.6 ) );
+		if (drt3) {
+			scenario.getVehicles()
+					.addVehicleType(
+							vf.createVehicleType(Id.create("drt3", VehicleType.class)).setMaximumVelocity(25. / 3.6));
+		}
+		scenario.getVehicles()
+				.addVehicleType(vf.createVehicleType(Id.create(TransportMode.drt, VehicleType.class))
+						.setMaximumVelocity(25. / 3.6));
 
 		// (does not work without; I don't really know why. kai)
-		scenario.getVehicles().addVehicleType( vf.createVehicleType( Id.create( TransportMode.car, VehicleType.class ) ).setMaximumVelocity( 25./3.6 ) );
+		scenario.getVehicles()
+				.addVehicleType(vf.createVehicleType(Id.create(TransportMode.car, VehicleType.class))
+						.setMaximumVelocity(25. / 3.6));
 
-//		scenario.getPopulation().getPersons().values().removeIf( person -> !person.getId().toString().equals( "3" ) );
+		//		scenario.getPopulation().getPersons().values().removeIf( person -> !person.getId().toString().equals( "3" ) );
 
 		// ### CONTROLER: ###
 
 		Controler controler = new Controler(scenario);
 
-		if ( drtMode== DrtMode.full || drtMode== DrtMode.withPrebooking ){
-			controler.addOverridingModule( new DvrpModule() );
-			controler.addOverridingModule( new MultiModeDrtModule() );
-			if ( drt2 && drt3 ){
-				controler.configureQSimComponents( DvrpQSimComponents.activateModes( TransportMode.drt, "drt2", "drt3" ) );
+		if (drtMode == DrtMode.full || drtMode == DrtMode.withPrebooking) {
+			controler.addOverridingModule(new DvrpModule());
+			controler.addOverridingModule(new MultiModeDrtModule());
+			if (drt2 && drt3) {
+				controler.configureQSimComponents(DvrpQSimComponents.activateModes(TransportMode.drt, "drt2", "drt3"));
 			} else if (drt2) {
-				controler.configureQSimComponents( DvrpQSimComponents.activateModes( TransportMode.drt, "drt2" ) );
+				controler.configureQSimComponents(DvrpQSimComponents.activateModes(TransportMode.drt, "drt2"));
 			} else if (drt3) {
-				controler.configureQSimComponents( DvrpQSimComponents.activateModes( TransportMode.drt, "drt3" ) );
+				controler.configureQSimComponents(DvrpQSimComponents.activateModes(TransportMode.drt, "drt3"));
 			} else {
-				controler.configureQSimComponents( DvrpQSimComponents.activateModes( TransportMode.drt ) );
+				controler.configureQSimComponents(DvrpQSimComponents.activateModes(TransportMode.drt));
 			}
 		}
-		if ( drtMode== DrtMode.withPrebooking ) {
-			controler.addOverridingModule( new AbstractModule(){
-				@Override public void install(){
-					installQSimModule( new AbstractQSimModule(){
-						@Override protected void configureQSim(){
-							this.addQSimComponentBinding( ActivityEngineWithWakeup.COMPONENT_NAME ).to(ActivityEngineWithWakeup.class ).in( Singleton.class );
+		if (drtMode == DrtMode.withPrebooking) {
+			controler.addOverridingModule(new AbstractModule() {
+				@Override
+				public void install() {
+					installQSimModule(new AbstractQSimModule() {
+						@Override
+						protected void configureQSim() {
+							this.addQSimComponentBinding(ActivityEngineWithWakeup.COMPONENT_NAME)
+									.to(ActivityEngineWithWakeup.class)
+									.in(Singleton.class);
 						}
-					} );
+					});
 				}
-			} ) ;
+			});
 		}
 
 		// TODO: avoid really writing out these files. However so far it is unclear how
@@ -350,24 +393,22 @@ public class PtAlongALine2Test{
 		controler.addOverridingModule(
 				PtAlongALineTest.createGeneratedFleetSpecificationModule(TransportMode.drt, "DRT-", 30,
 						Id.createLinkId("0-1"), 1));
-		if ( drt2 ){
-			controler.addOverridingModule(
-					PtAlongALineTest.createGeneratedFleetSpecificationModule("drt2", "DRT2-", 10,
-							Id.createLinkId("999-1000"), 4));
+		if (drt2) {
+			controler.addOverridingModule(PtAlongALineTest.createGeneratedFleetSpecificationModule("drt2", "DRT2-", 10,
+					Id.createLinkId("999-1000"), 4));
 		}
-		if ( drt3 ){
-			controler.addOverridingModule(
-					PtAlongALineTest.createGeneratedFleetSpecificationModule("drt3", "DRT3-", 10,
-							Id.createLinkId("500-501"), 4));
+		if (drt3) {
+			controler.addOverridingModule(PtAlongALineTest.createGeneratedFleetSpecificationModule("drt3", "DRT3-", 10,
+					Id.createLinkId("500-501"), 4));
 		}
 
 		controler.addOverridingModule(
 				PtAlongALineTest.createGeneratedFleetSpecificationModule(TransportMode.drt, "DRT-", 30,
 						Id.createLinkId("0-1"), 1));
 
-		if ( "true".equals( System.getProperty( "runOTFVis" ) ) ){
+		if ("true".equals(System.getProperty("runOTFVis"))) {
 			// This will start otfvis
-			controler.addOverridingModule( new OTFVisLiveModule() );
+			controler.addOverridingModule(new OTFVisLiveModule());
 			// !! does not work together with parameterized tests :-( !!
 		}
 
@@ -391,7 +432,12 @@ public class PtAlongALine2Test{
 		 */
 		for (String agent : testAgents) {
 			System.out.println("\n\n**** AGENT : " + agent);
-			List<PlanElement> pes = controler.getScenario().getPopulation().getPersons().get(Id.createPersonId("agent" + agent )).getSelectedPlan().getPlanElements();
+			List<PlanElement> pes = controler.getScenario()
+					.getPopulation()
+					.getPersons()
+					.get(Id.createPersonId("agent" + agent))
+					.getSelectedPlan()
+					.getPlanElements();
 			pes.stream().filter(s -> s instanceof Leg).forEach(s -> System.out.println(s.toString()));
 		}
 
@@ -400,71 +446,115 @@ public class PtAlongALine2Test{
 		 * agent will just walk to the pt stop.
 		 */
 
-		List<PlanElement> planFullCase1 = controler.getScenario().getPopulation().getPersons().get(Id.createPersonId("agent" + testAgents.get(0) )).getSelectedPlan().getPlanElements();
-		List<Leg> planLegCase1 = planFullCase1.stream().filter(pe -> pe instanceof Leg).map(pe -> (Leg) pe).collect(toList()) ;
-		Assert.assertTrue("Incorrect Mode, case 1",planLegCase1.get(0).getMode().contains("walk"));
-		Assert.assertTrue("Incorrect Mode, case 1",planLegCase1.get(1).getMode().equals("pt"));
-		Assert.assertTrue("Incorrect Mode, case 1",planLegCase1.get(2).getMode().contains("walk"));
+		List<PlanElement> planFullCase1 = controler.getScenario()
+				.getPopulation()
+				.getPersons()
+				.get(Id.createPersonId("agent" + testAgents.get(0)))
+				.getSelectedPlan()
+				.getPlanElements();
+		List<Leg> planLegCase1 = planFullCase1.stream()
+				.filter(pe -> pe instanceof Leg)
+				.map(pe -> (Leg)pe)
+				.collect(toList());
+		Assert.assertTrue("Incorrect Mode, case 1", planLegCase1.get(0).getMode().contains("walk"));
+		Assert.assertTrue("Incorrect Mode, case 1", planLegCase1.get(1).getMode().equals("pt"));
+		Assert.assertTrue("Incorrect Mode, case 1", planLegCase1.get(2).getMode().contains("walk"));
 
 		/**
 		 * Case 2a: Agent starts at Link "50-51". This is within the drt service area. Agent is expected use drt as
 		 * intermodal access to the left pt stop. The plan should be walk -> drt -> walk -> pt -> walk
 		 */
 
-		List<PlanElement> planFullCase2a = controler.getScenario().getPopulation().getPersons().get(Id.createPersonId("agent" + testAgents.get(1) )).getSelectedPlan().getPlanElements();
-		List<Leg> planLegCase2a = planFullCase2a.stream().filter(pe -> pe instanceof Leg).map(pe -> (Leg) pe).collect(toList()) ;
-		Assert.assertTrue("Incorrect Mode, case 2a",planLegCase2a.get(0).getMode().contains("walk"));
-		Assert.assertTrue("Incorrect Mode, case 2a",planLegCase2a.get(1).getMode().equals("drt"));
-		Assert.assertTrue("Incorrect Mode, case 2a",planLegCase2a.get(2).getMode().contains("walk"));
-		Assert.assertTrue("Incorrect Mode, case 2a",planLegCase2a.get(3).getMode().equals("pt"));
-		Assert.assertTrue("Incorrect Mode, case 2a",planLegCase2a.get(4).getMode().contains("walk"));
+		List<PlanElement> planFullCase2a = controler.getScenario()
+				.getPopulation()
+				.getPersons()
+				.get(Id.createPersonId("agent" + testAgents.get(1)))
+				.getSelectedPlan()
+				.getPlanElements();
+		List<Leg> planLegCase2a = planFullCase2a.stream()
+				.filter(pe -> pe instanceof Leg)
+				.map(pe -> (Leg)pe)
+				.collect(toList());
+		Assert.assertTrue("Incorrect Mode, case 2a", planLegCase2a.get(0).getMode().contains("walk"));
+		Assert.assertTrue("Incorrect Mode, case 2a", planLegCase2a.get(1).getMode().equals("drt"));
+		Assert.assertTrue("Incorrect Mode, case 2a", planLegCase2a.get(2).getMode().contains("walk"));
+		Assert.assertTrue("Incorrect Mode, case 2a", planLegCase2a.get(3).getMode().equals("pt"));
+		Assert.assertTrue("Incorrect Mode, case 2a", planLegCase2a.get(4).getMode().contains("walk"));
 
 		/**
 		 * Case 2b: Agent starts at Link "300-301". This is within the drt service area. Agent is expected use drt as
 		 * intermodal access to the middle pt stop. The plan should be walk -> drt -> walk -> pt -> walk
 		 */
-		List<PlanElement> planFullCase2b = controler.getScenario().getPopulation().getPersons().get(Id.createPersonId("agent" + testAgents.get(2) )).getSelectedPlan().getPlanElements();
-		List<Leg> planLegCase2b = planFullCase2b.stream().filter(pe -> pe instanceof Leg).map(pe -> (Leg) pe).collect(toList()) ;
-		Assert.assertTrue("Incorrect Mode, case 2b",planLegCase2b.get(0).getMode().contains("walk"));
-		Assert.assertTrue("Incorrect Mode, case 2b",planLegCase2b.get(1).getMode().equals("drt"));
-		Assert.assertTrue("Incorrect Mode, case 2b",planLegCase2b.get(2).getMode().contains("walk"));
-		Assert.assertTrue("Incorrect Mode, case 2b",planLegCase2b.get(3).getMode().equals("pt"));
-		Assert.assertTrue("Incorrect Mode, case 2b",planLegCase2b.get(4).getMode().contains("walk"));
+		List<PlanElement> planFullCase2b = controler.getScenario()
+				.getPopulation()
+				.getPersons()
+				.get(Id.createPersonId("agent" + testAgents.get(2)))
+				.getSelectedPlan()
+				.getPlanElements();
+		List<Leg> planLegCase2b = planFullCase2b.stream()
+				.filter(pe -> pe instanceof Leg)
+				.map(pe -> (Leg)pe)
+				.collect(toList());
+		Assert.assertTrue("Incorrect Mode, case 2b", planLegCase2b.get(0).getMode().contains("walk"));
+		Assert.assertTrue("Incorrect Mode, case 2b", planLegCase2b.get(1).getMode().equals("drt"));
+		Assert.assertTrue("Incorrect Mode, case 2b", planLegCase2b.get(2).getMode().contains("walk"));
+		Assert.assertTrue("Incorrect Mode, case 2b", planLegCase2b.get(3).getMode().equals("pt"));
+		Assert.assertTrue("Incorrect Mode, case 2b", planLegCase2b.get(4).getMode().contains("walk"));
 
 		/**
 		 * Case 2c: Agent starts at Link "550-551". This is within the drt3 service area. Agent is expected use drt3 as
 		 * intermodal access to the middle pt stop. The plan should be walk -> drt3 -> walk -> pt -> walk
 		 */
-		List<PlanElement> planFullCase2c = controler.getScenario().getPopulation().getPersons().get(Id.createPersonId("agent" + testAgents.get(3) )).getSelectedPlan().getPlanElements();
-		List<Leg> planLegCase2c = planFullCase2c.stream().filter(pe -> pe instanceof Leg).map(pe -> (Leg) pe).collect(toList()) ;
-		Assert.assertTrue("Incorrect Mode, case 2c",planLegCase2c.get(0).getMode().contains("walk"));
-		Assert.assertTrue("Incorrect Mode, case 2c",planLegCase2c.get(1).getMode().equals("drt3"));
-		Assert.assertTrue("Incorrect Mode, case 2c",planLegCase2c.get(2).getMode().contains("walk"));
-		Assert.assertTrue("Incorrect Mode, case 2c",planLegCase2c.get(3).getMode().equals("pt"));
-		Assert.assertTrue("Incorrect Mode, case 2c",planLegCase2c.get(4).getMode().contains("walk"));
-
+		List<PlanElement> planFullCase2c = controler.getScenario()
+				.getPopulation()
+				.getPersons()
+				.get(Id.createPersonId("agent" + testAgents.get(3)))
+				.getSelectedPlan()
+				.getPlanElements();
+		List<Leg> planLegCase2c = planFullCase2c.stream()
+				.filter(pe -> pe instanceof Leg)
+				.map(pe -> (Leg)pe)
+				.collect(toList());
+		Assert.assertTrue("Incorrect Mode, case 2c", planLegCase2c.get(0).getMode().contains("walk"));
+		Assert.assertTrue("Incorrect Mode, case 2c", planLegCase2c.get(1).getMode().equals("drt3"));
+		Assert.assertTrue("Incorrect Mode, case 2c", planLegCase2c.get(2).getMode().contains("walk"));
+		Assert.assertTrue("Incorrect Mode, case 2c", planLegCase2c.get(3).getMode().equals("pt"));
+		Assert.assertTrue("Incorrect Mode, case 2c", planLegCase2c.get(4).getMode().contains("walk"));
 
 		/**
 		 * Case 3a: Agent starts at Link "690-691". This is not within any drt service areas. Agent is expected to use
 		 * transit_walk to get to his/her destination.
 		 */
-		List<PlanElement> planFullCase3a = controler.getScenario().getPopulation().getPersons().get(Id.createPersonId("agent" + testAgents.get(4) )).getSelectedPlan().getPlanElements();
-		List<Leg> planLegCase3a = planFullCase3a.stream().filter(pe -> pe instanceof Leg).map(pe -> (Leg) pe).collect(toList()) ;
-		Assert.assertTrue("Incorrect Mode, case 3a",planLegCase3a.get(0).getMode().equals("walk"));
-
+		List<PlanElement> planFullCase3a = controler.getScenario()
+				.getPopulation()
+				.getPersons()
+				.get(Id.createPersonId("agent" + testAgents.get(4)))
+				.getSelectedPlan()
+				.getPlanElements();
+		List<Leg> planLegCase3a = planFullCase3a.stream()
+				.filter(pe -> pe instanceof Leg)
+				.map(pe -> (Leg)pe)
+				.collect(toList());
+		Assert.assertTrue("Incorrect Mode, case 3a", planLegCase3a.get(0).getMode().equals("walk"));
 
 		/**
 		 * Case 3b: Agent starts at Link "800-801". This is within the drt2 service area. Agent is NOT expected to utilize
 		 * drt2, since s/he is on a pt trip, and can only use drt as access/egress to a pt stop. Therefore, the agent is
 		 * agent is expected to use transit_walk to get to his/her destination.
 		 */
-		List<PlanElement> planFullCase3b = controler.getScenario().getPopulation().getPersons().get(Id.createPersonId("agent" + testAgents.get(5) )).getSelectedPlan().getPlanElements();
-		List<Leg> planLegCase3b = planFullCase3b.stream().filter(pe -> pe instanceof Leg).map(pe -> (Leg) pe).collect(toList()) ;
-		Assert.assertTrue("Incorrect Mode, case 3b",planLegCase3b.get(0).getMode().equals("walk"));
+		List<PlanElement> planFullCase3b = controler.getScenario()
+				.getPopulation()
+				.getPersons()
+				.get(Id.createPersonId("agent" + testAgents.get(5)))
+				.getSelectedPlan()
+				.getPlanElements();
+		List<Leg> planLegCase3b = planFullCase3b.stream()
+				.filter(pe -> pe instanceof Leg)
+				.map(pe -> (Leg)pe)
+				.collect(toList());
+		Assert.assertTrue("Incorrect Mode, case 3b", planLegCase3b.get(0).getMode().equals("walk"));
 
 	}
-
-
 
 	@Test
 	public void intermodalAccessEgressPicksWrongVariant() {
@@ -485,36 +575,39 @@ public class PtAlongALine2Test{
 
 		// does now work with these lines of code in SwissRailRaptorCore (which solve problems in other tests) gleich, aug'19
 
-		Config config = PtAlongALineTest.createConfig( utils.getOutputDirectory() );
+		Config config = PtAlongALineTest.createConfig(utils.getOutputDirectory());
 
 		// === GBL: ===
 
-		config.controler().setLastIteration( 0 );
+		config.controler().setLastIteration(0);
 
 		// === ROUTER: ===
 
 		config.plansCalcRoute().setAccessEgressType(PlansCalcRouteConfigGroup.AccessEgressType.accessEgressModeToLink);
 
-		config.qsim().setVehiclesSource( QSimConfigGroup.VehiclesSource.modeVehicleTypesFromVehiclesData );
+		config.qsim().setVehiclesSource(QSimConfigGroup.VehiclesSource.modeVehicleTypesFromVehiclesData);
 		// (as of today, will also influence router. kai, jun'19)
 
-		config.plansCalcRoute().setNetworkModes( new HashSet<>( Arrays.asList( TransportMode.drt, "drt2" ) ) );
+		config.plansCalcRoute().setNetworkModes(new HashSet<>(Arrays.asList(TransportMode.drt, "drt2")));
 
 		// set up walk2 so we don't use faulty walk in raptor:
-		config.plansCalcRoute().addModeRoutingParams( new ModeRoutingParams( "walk2" ).setTeleportedModeSpeed( 5./3.6 ) );
+		config.plansCalcRoute().addModeRoutingParams(new ModeRoutingParams("walk2").setTeleportedModeSpeed(5. / 3.6));
 
-		config.plansCalcRoute().addModeRoutingParams( new ModeRoutingParams( TransportMode.walk ).setTeleportedModeSpeed( 0. ) );
+		config.plansCalcRoute()
+				.addModeRoutingParams(new ModeRoutingParams(TransportMode.walk).setTeleportedModeSpeed(0.));
 		// (when specifying "walk2", all default routing params are cleared.  However, swiss rail raptor needs "walk" to function. kai, feb'20)
 
 		// === RAPTOR: ===
 		{
-			SwissRailRaptorConfigGroup configRaptor = ConfigUtils.addOrGetModule( config, SwissRailRaptorConfigGroup.class ) ;
+			SwissRailRaptorConfigGroup configRaptor = ConfigUtils.addOrGetModule(config,
+					SwissRailRaptorConfigGroup.class);
 			configRaptor.setUseIntermodalAccessEgress(true);
 
 			// "walk":
-			configRaptor.addIntermodalAccessEgress( new IntermodalAccessEgressParameterSet().setMode( "walk2" )
-													.setMaxRadius( 1000000 ).setInitialSearchRadius( 1000000 )
-													.setSearchExtensionRadius( 10000 ) );
+			configRaptor.addIntermodalAccessEgress(new IntermodalAccessEgressParameterSet().setMode("walk2")
+					.setMaxRadius(1000000)
+					.setInitialSearchRadius(1000000)
+					.setSearchExtensionRadius(10000));
 			// (in principle, walk as alternative to drt will not work, since drt is always faster.  Need to give the ASC to the router!  However, with
 			// the reduced drt network we should be able to see differentiation.)
 
@@ -522,14 +615,16 @@ public class PtAlongALine2Test{
 			// don't know if this got cleaned up.  kai, feb'20
 
 			// drt
-			configRaptor.addIntermodalAccessEgress( new IntermodalAccessEgressParameterSet().setMode( TransportMode.drt )
-													.setMaxRadius( 1000000 ).setInitialSearchRadius( 1000000 )
-													.setSearchExtensionRadius( 10000 ) );
+			configRaptor.addIntermodalAccessEgress(new IntermodalAccessEgressParameterSet().setMode(TransportMode.drt)
+					.setMaxRadius(1000000)
+					.setInitialSearchRadius(1000000)
+					.setSearchExtensionRadius(10000));
 
-			if ( drt2 ){
-				configRaptor.addIntermodalAccessEgress( new IntermodalAccessEgressParameterSet().setMode( "drt2" )
-														.setMaxRadius( 1000000 ).setInitialSearchRadius( 1000000 )
-														.setSearchExtensionRadius( 10000 ) );
+			if (drt2) {
+				configRaptor.addIntermodalAccessEgress(new IntermodalAccessEgressParameterSet().setMode("drt2")
+						.setMaxRadius(1000000)
+						.setInitialSearchRadius(1000000)
+						.setSearchExtensionRadius(10000));
 
 				//				paramSetDrt2.setPersonFilterAttribute( null );
 				//				paramSetDrt2.setStopFilterAttribute( null );
@@ -538,81 +633,94 @@ public class PtAlongALine2Test{
 
 		// === SCORING: ===
 		{
-			double margUtlTravPt = config.planCalcScore().getModes().get( TransportMode.pt ).getMarginalUtilityOfTraveling();
-			config.planCalcScore().addModeParams( new ModeParams( TransportMode.drt ).setMarginalUtilityOfTraveling( margUtlTravPt ) );
-			config.planCalcScore().addModeParams( new ModeParams( "drt2" ).setMarginalUtilityOfTraveling( margUtlTravPt ) );
-			config.planCalcScore().addModeParams( new ModeParams( "walk2" ).setMarginalUtilityOfTraveling( margUtlTravPt ) );
+			double margUtlTravPt = config.planCalcScore()
+					.getModes()
+					.get(TransportMode.pt)
+					.getMarginalUtilityOfTraveling();
+			config.planCalcScore()
+					.addModeParams(new ModeParams(TransportMode.drt).setMarginalUtilityOfTraveling(margUtlTravPt));
+			config.planCalcScore().addModeParams(new ModeParams("drt2").setMarginalUtilityOfTraveling(margUtlTravPt));
+			config.planCalcScore().addModeParams(new ModeParams("walk2").setMarginalUtilityOfTraveling(margUtlTravPt));
 		}
 		// === QSIM: ===
 
-		config.qsim().setSimStarttimeInterpretation( QSimConfigGroup.StarttimeInterpretation.onlyUseStarttime );
+		config.qsim().setSimStarttimeInterpretation(QSimConfigGroup.StarttimeInterpretation.onlyUseStarttime);
 		// yy why?  kai, jun'19
 
-		config.qsim().setMainModes( Arrays.asList( TransportMode.car, TransportMode.drt, "drt2") );
+		config.qsim().setMainModes(Arrays.asList(TransportMode.car, TransportMode.drt, "drt2"));
 		// yyyy buses use the car network and so that needs to be defined as network mode.   !!!! :-( :-(
 
 		// === VSP: ===
 
-		config.vspExperimental().setVspDefaultsCheckingLevel( VspExperimentalConfigGroup.VspDefaultsCheckingLevel.warn );
+		config.vspExperimental().setVspDefaultsCheckingLevel(VspExperimentalConfigGroup.VspDefaultsCheckingLevel.warn);
 
 		// ### SCENARIO: ###
 
-		Scenario scenario = PtAlongALineTest.createScenario(config , 100 );
+		Scenario scenario = new PtAlongALineFixture().createScenario(config, 100);
 
-		PtAlongALineTest.addModeToAllLinksBtwnGivenNodes(scenario.getNetwork(), 0, 400, TransportMode.drt );
-		PtAlongALineTest.addModeToAllLinksBtwnGivenNodes( scenario.getNetwork(), 600, 1000, "drt2" );
-
+		PtAlongALineTest.addModeToAllLinksBtwnGivenNodes(scenario.getNetwork(), 0, 400, TransportMode.drt);
+		PtAlongALineTest.addModeToAllLinksBtwnGivenNodes(scenario.getNetwork(), 600, 1000, "drt2");
 
 		// The following is for the _router_, not the qsim!  kai, jun'19
 		VehiclesFactory vf = scenario.getVehicles().getFactory();
-		if ( drt2 ) {
-			scenario.getVehicles().addVehicleType( vf.createVehicleType( Id.create( "drt2", VehicleType.class ) ).setMaximumVelocity( 25./3.6 ) );
+		if (drt2) {
+			scenario.getVehicles()
+					.addVehicleType(
+							vf.createVehicleType(Id.create("drt2", VehicleType.class)).setMaximumVelocity(25. / 3.6));
 		}
-		scenario.getVehicles().addVehicleType( vf.createVehicleType( Id.create( TransportMode.drt, VehicleType.class ) ).setMaximumVelocity( 25./3.6 ) );
+		scenario.getVehicles()
+				.addVehicleType(vf.createVehicleType(Id.create(TransportMode.drt, VehicleType.class))
+						.setMaximumVelocity(25. / 3.6));
 
-		scenario.getVehicles().addVehicleType( vf.createVehicleType( Id.create( TransportMode.car, VehicleType.class ) ).setMaximumVelocity( 100./3.6 ) );
+		scenario.getVehicles()
+				.addVehicleType(vf.createVehicleType(Id.create(TransportMode.car, VehicleType.class))
+						.setMaximumVelocity(100. / 3.6));
 		// (does not work without; I don't really know why. kai)
 
-		scenario.getPopulation().getPersons().values().removeIf( person -> !person.getId().toString().equals( "3" ) );
+		scenario.getPopulation().getPersons().values().removeIf(person -> !person.getId().toString().equals("3"));
 
 		// ### CONTROLER: ###
 
 		Controler controler = new Controler(scenario);
 
 		// This will start otfvis.  Comment in if desired.
-//		controler.addOverridingModule( new OTFVisLiveModule() );
+		//		controler.addOverridingModule( new OTFVisLiveModule() );
 
-		controler.addOverridingModule( new AbstractModule(){
-			@Override public void install(){
-				this.addControlerListenerBinding().toInstance( new IterationEndsListener(){
-					@Inject private Population population ;
-					@Override public void notifyIterationEnds( IterationEndsEvent event ){
-						for( Person person : population.getPersons().values() ){
+		controler.addOverridingModule(new AbstractModule() {
+			@Override
+			public void install() {
+				this.addControlerListenerBinding().toInstance(new IterationEndsListener() {
+					@Inject
+					private Population population;
+
+					@Override
+					public void notifyIterationEnds(IterationEndsEvent event) {
+						for (Person person : population.getPersons().values()) {
 
 							// output to help with debugging:
-							log.warn("") ;
-							log.warn("selected plan for personId=" + person.getId() ) ;
-							for( PlanElement planElement : person.getSelectedPlan().getPlanElements() ){
-								log.warn( planElement ) ;
+							log.warn("");
+							log.warn("selected plan for personId=" + person.getId());
+							for (PlanElement planElement : person.getSelectedPlan().getPlanElements()) {
+								log.warn(planElement);
 							}
 							log.warn("");
 
 							// the trip should contain a true pt leg but does not:
-							List<Leg> legs = TripStructureUtils.getLegs( person.getSelectedPlan() );
-							boolean problem = true ;
-							for( Leg leg : legs ){
-								if ( TransportMode.pt.equals( leg.getMode() ) ) {
-									problem = false ;
-									break ;
+							List<Leg> legs = TripStructureUtils.getLegs(person.getSelectedPlan());
+							boolean problem = true;
+							for (Leg leg : legs) {
+								if (TransportMode.pt.equals(leg.getMode())) {
+									problem = false;
+									break;
 								}
 							}
-							Assert.assertFalse( problem );
+							Assert.assertFalse(problem);
 
 						}
 					}
-				} ) ;
+				});
 			}
-		} ) ;
+		});
 
 		controler.run();
 	}
@@ -622,68 +730,65 @@ public class PtAlongALine2Test{
 	public void networkWalkDoesNotWorkWithRaptor() {
 		// test fails with null pointer exception
 
-		Config config = PtAlongALineTest.createConfig( utils.getOutputDirectory() );
+		Config config = PtAlongALineTest.createConfig(utils.getOutputDirectory());
 
 		// === GBL: ===
 
-		config.controler().setLastIteration( 0 );
+		config.controler().setLastIteration(0);
 
 		// === ROUTER: ===
 
 		config.plansCalcRoute().setAccessEgressType(AccessEgressType.accessEgressModeToLink);
 
-		config.qsim().setVehiclesSource( QSimConfigGroup.VehiclesSource.modeVehicleTypesFromVehiclesData );
+		config.qsim().setVehiclesSource(QSimConfigGroup.VehiclesSource.modeVehicleTypesFromVehiclesData);
 		// (as of today, will also influence router. kai, jun'19)
 
 		// remove teleportation walk router:
-		config.plansCalcRoute().removeModeRoutingParams( TransportMode.walk );
+		config.plansCalcRoute().removeModeRoutingParams(TransportMode.walk);
 
 		// add network walk router:
-		Set<String> networkModes = new HashSet<>( config.plansCalcRoute().getNetworkModes() );
-		networkModes.add( TransportMode.walk );
-		config.plansCalcRoute().setNetworkModes( networkModes );
+		Set<String> networkModes = new HashSet<>(config.plansCalcRoute().getNetworkModes());
+		networkModes.add(TransportMode.walk);
+		config.plansCalcRoute().setNetworkModes(networkModes);
 
 		// === RAPTOR: ===
 		{
-			SwissRailRaptorConfigGroup configRaptor = ConfigUtils.addOrGetModule( config, SwissRailRaptorConfigGroup.class ) ;
+			SwissRailRaptorConfigGroup configRaptor = ConfigUtils.addOrGetModule(config,
+					SwissRailRaptorConfigGroup.class);
 
 			configRaptor.setUseIntermodalAccessEgress(true);
 			{
 				// Xxx
 				IntermodalAccessEgressParameterSet paramSetXxx = new IntermodalAccessEgressParameterSet();
-				paramSetXxx.setMode( TransportMode.walk );
-				paramSetXxx.setMaxRadius( 1000000 );
-				configRaptor.addIntermodalAccessEgress( paramSetXxx );
+				paramSetXxx.setMode(TransportMode.walk);
+				paramSetXxx.setMaxRadius(1000000);
+				configRaptor.addIntermodalAccessEgress(paramSetXxx);
 			}
 
 		}
 
 		// ### SCENARIO: ###
 
-		Scenario scenario = PtAlongALineTest.createScenario(config , 100 );
+		Scenario scenario = new PtAlongALineFixture().createScenario(config, 100);
 
-		PtAlongALineTest.addModeToAllLinksBtwnGivenNodes(scenario.getNetwork(), 0, 1000, TransportMode.walk );
-
+		PtAlongALineTest.addModeToAllLinksBtwnGivenNodes(scenario.getNetwork(), 0, 1000, TransportMode.walk);
 
 		// The following is in particular for the _router_, not the qsim!  kai, jun'19
 		VehiclesFactory vf = scenario.getVehicles().getFactory();
 		{
-			VehicleType vehType = vf.createVehicleType( Id.create( TransportMode.walk, VehicleType.class ) );
-			vehType.setMaximumVelocity( 4./3.6 );
-			scenario.getVehicles().addVehicleType( vehType );
+			VehicleType vehType = vf.createVehicleType(Id.create(TransportMode.walk, VehicleType.class));
+			vehType.setMaximumVelocity(4. / 3.6);
+			scenario.getVehicles().addVehicleType(vehType);
 		}
 
 		// ### CONTROLER: ###
 
 		Controler controler = new Controler(scenario);
 
-
 		// This will start otfvis.  Comment out if not needed.
-//		controler.addOverridingModule( new OTFVisLiveModule() );
+		//		controler.addOverridingModule( new OTFVisLiveModule() );
 
 		controler.run();
 	}
-
-
 
 }

--- a/contribs/vsp/src/test/java/org/matsim/integration/drtAndPt/PtAlongALineFixture.java
+++ b/contribs/vsp/src/test/java/org/matsim/integration/drtAndPt/PtAlongALineFixture.java
@@ -1,0 +1,318 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2021 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.integration.drtAndPt;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.NetworkFactory;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.api.core.v01.population.Activity;
+import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Plan;
+import org.matsim.api.core.v01.population.PopulationFactory;
+import org.matsim.core.config.Config;
+import org.matsim.core.gbl.MatsimRandom;
+import org.matsim.core.population.routes.NetworkRoute;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.core.utils.geometry.CoordUtils;
+import org.matsim.facilities.ActivityFacilitiesFactory;
+import org.matsim.facilities.ActivityFacility;
+import org.matsim.facilities.ActivityOption;
+import org.matsim.pt.transitSchedule.api.Departure;
+import org.matsim.pt.transitSchedule.api.TransitLine;
+import org.matsim.pt.transitSchedule.api.TransitRoute;
+import org.matsim.pt.transitSchedule.api.TransitRouteStop;
+import org.matsim.pt.transitSchedule.api.TransitSchedule;
+import org.matsim.pt.transitSchedule.api.TransitScheduleFactory;
+import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import org.matsim.pt.utils.TransitScheduleValidator;
+import org.matsim.vehicles.VehicleCapacity;
+import org.matsim.vehicles.VehicleType;
+import org.matsim.vehicles.VehiclesFactory;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+class PtAlongALineFixture {
+
+	private final Id<Link> TR_LINK_m1_0_ID = Id.createLinkId("trLinkm1-0");
+	private final Id<Link> TR_LINK_0_1_ID = Id.createLinkId("trLink0-1");
+	private final Id<Link> TR_LONG_LINK_LEFT_ID = Id.createLinkId("trLinkLongLeft");
+	private final Id<Link> TR_LINK_MIDDLE_ID = Id.createLinkId("trLinkMiddle");
+	private final Id<Link> TR_LONG_LINK_RIGHT_ID = Id.createLinkId("trLinkLongRight");
+	private final Id<Link> TR_LINK_LASTM1_LAST_ID = Id.createLinkId("trLinkLastm1-Last");
+	private final Id<Link> TR_LINK_LAST_LASTp1_ID = Id.createLinkId("trLinkLast-Lastp1");
+
+	private final Id<TransitStopFacility> tr_stop_fac_0_ID = Id.create("StopFac0", TransitStopFacility.class);
+	private final Id<TransitStopFacility> tr_stop_fac_10000_ID = Id.create("StopFac10000", TransitStopFacility.class);
+	private final Id<TransitStopFacility> tr_stop_fac_5000_ID = Id.create("StopFac5000", TransitStopFacility.class);
+
+	private final Id<VehicleType> busTypeID = Id.create("bus", VehicleType.class);
+
+	Scenario createScenario(Config config, long numberOfPersons) {
+		Scenario scenario = ScenarioUtils.createScenario(config);
+		// don't load anything
+
+		final int lastNodeIdx = 1000;
+		final double deltaX = 100.;
+
+		createAndAddCarNetwork(scenario, lastNodeIdx, deltaX);
+
+		createAndAddPopulation(scenario, "pt", numberOfPersons);
+
+		final double deltaY = 1000.;
+
+		createAndAddTransitNetwork(scenario, lastNodeIdx, deltaX, deltaY);
+
+		createAndAddTransitStopFacilities(scenario, lastNodeIdx, deltaX, deltaY);
+
+		createAndAddTransitVehicleType(scenario);
+
+		createAndAddTransitLine(scenario);
+
+		TransitScheduleValidator.printResult(
+				TransitScheduleValidator.validateAll(scenario.getTransitSchedule(), scenario.getNetwork()));
+		return scenario;
+	}
+
+	void createAndAddTransitNetwork(Scenario scenario, int lastNodeIdx, double deltaX, double deltaY) {
+		NetworkFactory nf = scenario.getNetwork().getFactory();
+
+		Node nodem1 = nf.createNode(Id.createNodeId("trNodeM1"), new Coord(-100, deltaY));
+		scenario.getNetwork().addNode(nodem1);
+		// ---
+		Node node0 = nf.createNode(Id.createNodeId("trNode0"), new Coord(0, deltaY));
+		scenario.getNetwork().addNode(node0);
+		createAndAddTransitLink(scenario, nodem1, node0, TR_LINK_m1_0_ID);
+		// ---
+		Node node1 = nf.createNode(Id.createNodeId("trNode1"), new Coord(deltaX, deltaY));
+		scenario.getNetwork().addNode(node1);
+		createAndAddTransitLink(scenario, node0, node1, TR_LINK_0_1_ID);
+		// ---
+		Node nodeMiddleLeft = nf.createNode(Id.createNodeId("trNodeMiddleLeft"),
+				new Coord(0.5 * (lastNodeIdx - 1) * deltaX, deltaY));
+		scenario.getNetwork().addNode(nodeMiddleLeft);
+		{
+			createAndAddTransitLink(scenario, node1, nodeMiddleLeft, TR_LONG_LINK_LEFT_ID);
+		}
+		// ---
+		Node nodeMiddleRight = nf.createNode(Id.createNodeId("trNodeMiddleRight"),
+				new Coord(0.5 * (lastNodeIdx + 1) * deltaX, deltaY));
+		scenario.getNetwork().addNode(nodeMiddleRight);
+		createAndAddTransitLink(scenario, nodeMiddleLeft, nodeMiddleRight, TR_LINK_MIDDLE_ID);
+		// ---
+		Node nodeLastm1 = nf.createNode(Id.createNodeId("trNodeLastm1"), new Coord((lastNodeIdx - 1) * deltaX, deltaY));
+		scenario.getNetwork().addNode(nodeLastm1);
+		createAndAddTransitLink(scenario, nodeMiddleRight, nodeLastm1, TR_LONG_LINK_RIGHT_ID);
+
+		// ---
+		Node nodeLast = nf.createNode(Id.createNodeId("trNodeLast"), new Coord(lastNodeIdx * deltaX, deltaY));
+		scenario.getNetwork().addNode(nodeLast);
+		createAndAddTransitLink(scenario, nodeLastm1, nodeLast, TR_LINK_LASTM1_LAST_ID);
+		// ---
+		Node nodeLastp1 = nf.createNode(Id.createNodeId("trNodeLastp1"),
+				new Coord(lastNodeIdx * deltaX + 100., deltaY));
+		scenario.getNetwork().addNode(nodeLastp1);
+		createAndAddTransitLink(scenario, nodeLast, nodeLastp1, TR_LINK_LAST_LASTp1_ID);
+	}
+
+	void createAndAddTransitStopFacilities(Scenario scenario, int lastNodeIdx, double deltaX, double deltaY) {
+		TransitSchedule schedule = scenario.getTransitSchedule();
+		TransitScheduleFactory tsf = schedule.getFactory();
+
+		TransitStopFacility stopFacility0 = tsf.createTransitStopFacility(tr_stop_fac_0_ID, new Coord(deltaX, deltaY),
+				false);
+		stopFacility0.setLinkId(TR_LINK_0_1_ID);
+		schedule.addStopFacility(stopFacility0);
+
+		TransitStopFacility stopFacility5000 = tsf.createTransitStopFacility(tr_stop_fac_5000_ID,
+				new Coord(0.5 * (lastNodeIdx - 1) * deltaX, deltaY), false);
+		stopFacility5000.setLinkId(TR_LINK_MIDDLE_ID);
+		stopFacility5000.getAttributes().putAttribute("drtAccessible", "true");
+		stopFacility5000.getAttributes().putAttribute("bikeAccessible", "true");
+
+		schedule.addStopFacility(stopFacility5000);
+
+		TransitStopFacility stopFacility10000 = tsf.createTransitStopFacility(tr_stop_fac_10000_ID,
+				new Coord((lastNodeIdx - 1) * deltaX, deltaY), false);
+		stopFacility10000.setLinkId(TR_LINK_LASTM1_LAST_ID);
+		schedule.addStopFacility(stopFacility10000);
+	}
+
+	void createAndAddTransitVehicleType(Scenario scenario) {
+		VehiclesFactory tvf = scenario.getTransitVehicles().getFactory();
+		VehicleType busType = tvf.createVehicleType(busTypeID);
+		{
+			VehicleCapacity capacity = busType.getCapacity();
+			capacity.setSeats(100);
+		}
+		{
+			busType.setMaximumVelocity(100. / 3.6);
+		}
+		scenario.getTransitVehicles().addVehicleType(busType);
+	}
+
+	void createAndAddTransitLine(Scenario scenario) {
+		PopulationFactory pf = scenario.getPopulation().getFactory();
+		TransitSchedule schedule = scenario.getTransitSchedule();
+		TransitScheduleFactory tsf = schedule.getFactory();
+		VehiclesFactory tvf = scenario.getTransitVehicles().getFactory();
+
+		List<Id<Link>> linkIds = new ArrayList<>();
+		linkIds.add(TR_LINK_0_1_ID);
+		linkIds.add(TR_LONG_LINK_LEFT_ID);
+		linkIds.add(TR_LINK_MIDDLE_ID);
+		linkIds.add(TR_LONG_LINK_RIGHT_ID);
+		linkIds.add(TR_LINK_LASTM1_LAST_ID);
+		NetworkRoute route = createNetworkRoute(TR_LINK_m1_0_ID, linkIds, TR_LINK_LAST_LASTp1_ID, pf);
+
+		List<TransitRouteStop> stops = new ArrayList<>();
+		{
+			stops.add(tsf.createTransitRouteStop(schedule.getFacilities().get(tr_stop_fac_0_ID), 0., 0.));
+			stops.add(tsf.createTransitRouteStop(schedule.getFacilities().get(tr_stop_fac_5000_ID), 1., 1.));
+			stops.add(tsf.createTransitRouteStop(schedule.getFacilities().get(tr_stop_fac_10000_ID), 1., 1.));
+		}
+		{
+			TransitRoute transitRoute = tsf.createTransitRoute(Id.create("route1", TransitRoute.class), route, stops,
+					"bus");
+			for (int ii = 0; ii < 100; ii++) {
+				String str = "tr_" + ii;
+
+				scenario.getTransitVehicles()
+						.addVehicle(tvf.createVehicle(Id.createVehicleId(str),
+								scenario.getTransitVehicles().getVehicleTypes().get(busTypeID)));
+
+				Departure departure = tsf.createDeparture(Id.create(str, Departure.class), 7. * 3600. + ii * 300);
+				departure.setVehicleId(Id.createVehicleId(str));
+				transitRoute.addDeparture(departure);
+			}
+			TransitLine line = tsf.createTransitLine(Id.create("line1", TransitLine.class));
+			line.addRoute(transitRoute);
+
+			schedule.addTransitLine(line);
+		}
+	}
+
+	static void createAndAddCarNetwork(Scenario scenario, int lastNodeIdx, double deltaX) {
+		// Construct a network and facilities along a line:
+		// 0 --(0-1)-- 1 --(2-1)-- 2 -- ...
+		// with a facility of same ID attached to each link.
+
+		NetworkFactory nf = scenario.getNetwork().getFactory();
+		ActivityFacilitiesFactory ff = scenario.getActivityFacilities().getFactory();
+
+		Node prevNode;
+		{
+			Node node = nf.createNode(Id.createNodeId(0), new Coord(0., 0.));
+			scenario.getNetwork().addNode(node);
+			prevNode = node;
+		}
+		for (int ii = 1; ii <= lastNodeIdx; ii++) {
+			Node node = nf.createNode(Id.createNodeId(ii), new Coord(ii * deltaX, 0.));
+			scenario.getNetwork().addNode(node);
+			// ---
+			addLinkAndFacility(scenario, nf, ff, prevNode, node);
+			addLinkAndFacility(scenario, nf, ff, node, prevNode);
+			// ---
+			prevNode = node;
+		}
+	}
+
+	private static void addLinkAndFacility(Scenario scenario, NetworkFactory nf, ActivityFacilitiesFactory ff,
+			Node prevNode, Node node) {
+		final String str = prevNode.getId() + "-" + node.getId();
+		Link link = nf.createLink(Id.createLinkId(str), prevNode, node);
+		Set<String> set = new HashSet<>();
+		set.add("car");
+		link.setAllowedModes(set);
+		link.setLength(CoordUtils.calcEuclideanDistance(prevNode.getCoord(), node.getCoord()));
+		link.setCapacity(3600.);
+		link.setFreespeed(50. / 3.6);
+		scenario.getNetwork().addLink(link);
+		// ---
+		ActivityFacility af = ff.createActivityFacility(Id.create(str, ActivityFacility.class), link.getCoord(),
+				link.getId());
+		ActivityOption option = ff.createActivityOption("shop");
+		af.addActivityOption(option);
+		scenario.getActivityFacilities().addActivityFacility(af);
+	}
+
+	private static NetworkRoute createNetworkRoute(Id<Link> startLinkId, List<Id<Link>> linkIds, Id<Link> endLinkId,
+			PopulationFactory pf) {
+		NetworkRoute route = pf.getRouteFactories().createRoute(NetworkRoute.class, startLinkId, endLinkId);
+		route.setLinkIds(startLinkId, linkIds, endLinkId);
+		return route;
+	}
+
+	private static void createAndAddTransitLink(Scenario scenario, Node node0, Node node1, Id<Link> TR_LINK_0_1_ID) {
+		Link trLink = scenario.getNetwork().getFactory().createLink(TR_LINK_0_1_ID, node0, node1);
+		trLink.setFreespeed(100. / 3.6);
+		trLink.setCapacity(100000.);
+		scenario.getNetwork().addLink(trLink);
+	}
+
+	static void createAndAddPopulation(Scenario scenario, String mode, long numberOfPersons) {
+		PopulationFactory pf = scenario.getPopulation().getFactory();
+		List<ActivityFacility> facilitiesAsList = new ArrayList<>(
+				scenario.getActivityFacilities().getFacilities().values());
+		final Id<ActivityFacility> activityFacilityId = facilitiesAsList.get(facilitiesAsList.size() - 1).getId();
+		for (int jj = 0; jj < numberOfPersons; jj++) {
+			Person person = pf.createPerson(Id.createPersonId(jj));
+			{
+				scenario.getPopulation().addPerson(person);
+				Plan plan = pf.createPlan();
+				person.addPlan(plan);
+
+				// --- 1st location at randomly selected facility:
+				int idx = MatsimRandom.getRandom().nextInt(facilitiesAsList.size());
+				;
+				Id<ActivityFacility> homeFacilityId = facilitiesAsList.get(idx).getId();
+				;
+				Activity home = pf.createActivityFromActivityFacilityId("dummy", homeFacilityId);
+				if (jj == 0) {
+					home.setEndTime(7.
+							* 3600.); // one agent one sec earlier so that for all others the initial acts are visible in VIA
+				} else {
+					home.setEndTime(7. * 3600. + 1.);
+				}
+				plan.addActivity(home);
+				{
+					Leg leg = pf.createLeg(mode);
+					leg.setDepartureTime(7. * 3600.);
+					leg.setTravelTime(1800.);
+					plan.addLeg(leg);
+				}
+				{
+					Activity shop = pf.createActivityFromActivityFacilityId("dummy", activityFacilityId);
+					plan.addActivity(shop);
+				}
+			}
+		}
+	}
+}

--- a/contribs/vsp/src/test/java/org/matsim/integration/drtAndPt/PtAlongALineTest.java
+++ b/contribs/vsp/src/test/java/org/matsim/integration/drtAndPt/PtAlongALineTest.java
@@ -1,26 +1,16 @@
 package org.matsim.integration.drtAndPt;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.api.core.v01.network.NetworkFactory;
-import org.matsim.api.core.v01.network.Node;
-import org.matsim.api.core.v01.population.Activity;
-import org.matsim.api.core.v01.population.Leg;
-import org.matsim.api.core.v01.population.Person;
-import org.matsim.api.core.v01.population.Plan;
-import org.matsim.api.core.v01.population.PopulationFactory;
 import org.matsim.contrib.drt.routing.DrtRoute;
 import org.matsim.contrib.drt.routing.DrtRouteFactory;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
@@ -44,24 +34,10 @@ import org.matsim.core.config.groups.StrategyConfigGroup;
 import org.matsim.core.config.groups.VspExperimentalConfigGroup;
 import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
-import org.matsim.core.gbl.MatsimRandom;
-import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.replanning.strategies.DefaultPlanStrategiesModule;
 import org.matsim.core.scenario.ScenarioUtils;
-import org.matsim.core.utils.geometry.CoordUtils;
-import org.matsim.facilities.ActivityFacilitiesFactory;
-import org.matsim.facilities.ActivityFacility;
-import org.matsim.facilities.ActivityOption;
-import org.matsim.pt.transitSchedule.api.Departure;
-import org.matsim.pt.transitSchedule.api.TransitLine;
-import org.matsim.pt.transitSchedule.api.TransitRoute;
-import org.matsim.pt.transitSchedule.api.TransitRouteStop;
-import org.matsim.pt.transitSchedule.api.TransitSchedule;
-import org.matsim.pt.transitSchedule.api.TransitScheduleFactory;
-import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 import org.matsim.pt.utils.TransitScheduleValidator;
 import org.matsim.testcases.MatsimTestUtils;
-import org.matsim.vehicles.VehicleCapacity;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehiclesFactory;
 import org.matsim.vis.otfvis.OTFVisConfigGroup;
@@ -70,36 +46,22 @@ import ch.sbb.matsim.config.SwissRailRaptorConfigGroup;
 import ch.sbb.matsim.config.SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet;
 import ch.sbb.matsim.routing.pt.raptor.SwissRailRaptorModule;
 
-public class PtAlongALineTest{
+public class PtAlongALineTest {
 
-	private static final Id<Link> TR_LINK_m1_0_ID = Id.createLinkId( "trLinkm1-0" );
-	private static final Id<Link> TR_LINK_0_1_ID = Id.createLinkId( "trLink0-1" );
-	private static final Id<Link> TR_LONG_LINK_LEFT_ID = Id.createLinkId( "trLinkLongLeft" );
-	private static final Id<Link> TR_LINK_MIDDLE_ID = Id.createLinkId( "trLinkMiddle" );
-	private static final Id<Link> TR_LONG_LINK_RIGHT_ID = Id.createLinkId( "trLinkLongRight" );
-	private static final Id<Link> TR_LINK_LASTM1_LAST_ID = Id.createLinkId( "trLinkLastm1-Last" );
-	private static final Id<Link> TR_LINK_LAST_LASTp1_ID = Id.createLinkId( "trLinkLast-Lastp1" ) ;
-
-	private static final Id<TransitStopFacility> tr_stop_fac_0_ID = Id.create( "StopFac0", TransitStopFacility.class );
-	private static final Id<TransitStopFacility> tr_stop_fac_10000_ID = Id.create( "StopFac10000", TransitStopFacility.class );
-	private static final Id<TransitStopFacility> tr_stop_fac_5000_ID = Id.create( "StopFac5000", TransitStopFacility.class );
-
-	private static final Id<VehicleType> busTypeID = Id.create( "bus", VehicleType.class );
-
-
-	@Rule public MatsimTestUtils utils = new MatsimTestUtils() ;
+	@Rule
+	public MatsimTestUtils utils = new MatsimTestUtils();
 
 	@Ignore
 	@Test
 	public void testPtAlongALine() {
 
-		Config config = createConfig( utils.getOutputDirectory() );
+		Config config = createConfig(utils.getOutputDirectory());
 
-		Scenario scenario = createScenario( config, 1000 );
+		Scenario scenario = new PtAlongALineFixture().createScenario(config, 1000);
 
-		Controler controler = new Controler( scenario ) ;
+		Controler controler = new Controler(scenario);
 
-		controler.run() ;
+		controler.run();
 	}
 
 	/**
@@ -110,18 +72,19 @@ public class PtAlongALineTest{
 	@Test
 	public void testPtAlongALineWithRaptorAndBike() {
 
-		Config config = createConfig( utils.getOutputDirectory() );
+		Config config = createConfig(utils.getOutputDirectory());
 
-		SwissRailRaptorConfigGroup configRaptor = createRaptorConfigGroup(1000000, 1000000);// (radius walk, radius bike)
+		SwissRailRaptorConfigGroup configRaptor = createRaptorConfigGroup(1000000,
+				1000000);// (radius walk, radius bike)
 		config.addModule(configRaptor);
 
-		Scenario scenario = createScenario( config, 1000 );
+		Scenario scenario = new PtAlongALineFixture().createScenario(config, 1000);
 
-		Controler controler = new Controler( scenario ) ;
+		Controler controler = new Controler(scenario);
 
-		controler.addOverridingModule(new SwissRailRaptorModule()) ;
+		controler.addOverridingModule(new SwissRailRaptorModule());
 
-		controler.run() ;
+		controler.run();
 	}
 
 	/**
@@ -132,19 +95,17 @@ public class PtAlongALineTest{
 	@Test
 	public void testDrtAlongALine() {
 
-
 		Config config = ConfigUtils.createConfig();
 
 		config.qsim().setSimStarttimeInterpretation(QSimConfigGroup.StarttimeInterpretation.onlyUseStarttime);
 		config.qsim().setInsertingWaitingVehiclesBeforeDrivingVehicles(true);
 		config.qsim().setSnapshotStyle(QSimConfigGroup.SnapshotStyle.queue);
 
-		config.transit().setUseTransit(true) ;
-
+		config.transit().setUseTransit(true);
 
 		DvrpConfigGroup dvrpConfig = ConfigUtils.addOrGetModule(config, DvrpConfigGroup.class);
 
-		MultiModeDrtConfigGroup multiModeDrtCfg = ConfigUtils.addOrGetModule(config, MultiModeDrtConfigGroup.class );
+		MultiModeDrtConfigGroup multiModeDrtCfg = ConfigUtils.addOrGetModule(config, MultiModeDrtConfigGroup.class);
 		{
 			DrtConfigGroup drtConfig = new DrtConfigGroup();
 			drtConfig.setMode("drt_A");
@@ -152,18 +113,19 @@ public class PtAlongALineTest{
 			drtConfig.setMaxWaitTime(900.);
 			drtConfig.setMaxTravelTimeAlpha(1.3);
 			drtConfig.setMaxTravelTimeBeta(10. * 60.);
-			drtConfig.setRejectRequestIfMaxWaitOrTravelTimeViolated( false );
+			drtConfig.setRejectRequestIfMaxWaitOrTravelTimeViolated(false);
 			drtConfig.setChangeStartLinkToLastLinkInSchedule(true);
 			multiModeDrtCfg.addParameterSet(drtConfig);
 		}
 
 		for (DrtConfigGroup drtCfg : multiModeDrtCfg.getModalElements()) {
-			DrtConfigs.adjustDrtConfig(drtCfg, config.planCalcScore(), config.plansCalcRoute() );
+			DrtConfigs.adjustDrtConfig(drtCfg, config.planCalcScore(), config.plansCalcRoute());
 		}
 
-		config.controler().setOutputDirectory( utils.getOutputDirectory() );
+		config.controler().setOutputDirectory(utils.getOutputDirectory());
 		config.controler().setLastIteration(0);
-		config.controler().setOverwriteFileSetting(OutputDirectoryHierarchy.OverwriteFileSetting.deleteDirectoryIfExists);
+		config.controler()
+				.setOverwriteFileSetting(OutputDirectoryHierarchy.OverwriteFileSetting.deleteDirectoryIfExists);
 
 		{
 			StrategyConfigGroup.StrategySettings stratSets = new StrategyConfigGroup.StrategySettings();
@@ -171,7 +133,7 @@ public class PtAlongALineTest{
 			stratSets.setWeight(0.1);
 			config.strategy().addStrategySettings(stratSets);
 			//
-			config.subtourModeChoice().setModes(new String[]{TransportMode.car, "drt_A"});
+			config.subtourModeChoice().setModes(new String[] { TransportMode.car, "drt_A" });
 		}
 		{
 			StrategyConfigGroup.StrategySettings stratSets = new StrategyConfigGroup.StrategySettings();
@@ -197,37 +159,40 @@ public class PtAlongALineTest{
 		final int lastNodeIdx = 1000;
 		final double deltaX = 100.;
 
-		createAndAddCarNetwork( scenario, lastNodeIdx, deltaX );
+		PtAlongALineFixture.createAndAddCarNetwork(scenario, lastNodeIdx, deltaX);
 
-		createAndAddPopulation( scenario , "drt_A", 1000);
+		PtAlongALineFixture.createAndAddPopulation(scenario, "drt_A", 1000);
 
 		final double deltaY = 1000.;
 
-		createAndAddTransitNetwork( scenario, lastNodeIdx, deltaX, deltaY );
+		var fixture = new PtAlongALineFixture();
 
-		createAndAddTransitStopFacilities( scenario, lastNodeIdx, deltaX, deltaY );
+		fixture.createAndAddTransitNetwork(scenario, lastNodeIdx, deltaX, deltaY);
 
-		createAndAddTransitVehicleType( scenario );
+		fixture.createAndAddTransitStopFacilities(scenario, lastNodeIdx, deltaX, deltaY);
 
-		createAndAddTransitLine( scenario );
+		fixture.createAndAddTransitVehicleType(scenario);
 
-		TransitScheduleValidator.printResult( TransitScheduleValidator.validateAll( scenario.getTransitSchedule(), scenario.getNetwork() ) );
+		fixture.createAndAddTransitLine(scenario);
+
+		TransitScheduleValidator.printResult(
+				TransitScheduleValidator.validateAll(scenario.getTransitSchedule(), scenario.getNetwork()));
 		// ---
 
-		scenario.getPopulation().getFactory().getRouteFactories().setRouteFactory(DrtRoute.class, new DrtRouteFactory());
-
+		scenario.getPopulation()
+				.getFactory()
+				.getRouteFactories()
+				.setRouteFactory(DrtRoute.class, new DrtRouteFactory());
 
 		Controler controler = new Controler(scenario);
 
 		controler.addOverridingModule(new DvrpModule());
-		controler.addOverridingModule(new MultiModeDrtModule() );
+		controler.addOverridingModule(new MultiModeDrtModule());
 
 		controler.configureQSimComponents(DvrpQSimComponents.activateModes("drt_A"));
 
-		controler.addOverridingModule(
-				PtAlongALineTest.createGeneratedFleetSpecificationModule("drt_A", "drtA-", 200,
-						Id.createLinkId("499-500"), 4));
-
+		controler.addOverridingModule(PtAlongALineTest.createGeneratedFleetSpecificationModule("drt_A", "drtA-", 200,
+				Id.createLinkId("499-500"), 4));
 
 		controler.run();
 	}
@@ -240,175 +205,146 @@ public class PtAlongALineTest{
 	@Ignore
 	@Test
 	public void testPtAlongALineWithRaptorAndDrtStopFilterAttribute() {
-		Config config = PtAlongALineTest.createConfig( utils.getOutputDirectory() );
+		Config config = PtAlongALineTest.createConfig(utils.getOutputDirectory());
 
-		config.qsim().setSimStarttimeInterpretation( QSimConfigGroup.StarttimeInterpretation.onlyUseStarttime );
+		config.qsim().setSimStarttimeInterpretation(QSimConfigGroup.StarttimeInterpretation.onlyUseStarttime);
 		// yy why?  kai, jun'19
 
-
 		config.plansCalcRoute().setAccessEgressType(PlansCalcRouteConfigGroup.AccessEgressType.accessEgressModeToLink);
-		ModeParams accessWalk = new ModeParams( TransportMode.non_network_walk );
+		ModeParams accessWalk = new ModeParams(TransportMode.non_network_walk);
 		accessWalk.setMarginalUtilityOfTraveling(0);
 		config.planCalcScore().addModeParams(accessWalk);
 
-			// (scoring parameters for drt modes)
-			{
-				ModeParams modeParams = new ModeParams(TransportMode.drt);
-				config.planCalcScore().addModeParams(modeParams);
-			}
+		// (scoring parameters for drt modes)
+		{
+			ModeParams modeParams = new ModeParams(TransportMode.drt);
+			config.planCalcScore().addModeParams(modeParams);
+		}
 
-		config.qsim().setVehiclesSource( QSimConfigGroup.VehiclesSource.modeVehicleTypesFromVehiclesData );
+		config.qsim().setVehiclesSource(QSimConfigGroup.VehiclesSource.modeVehicleTypesFromVehiclesData);
 		// (as of today, will also influence router. kai, jun'19)
 
-		config.controler().setLastIteration( 0 );
+		config.controler().setLastIteration(0);
 
 		{
 			// (raptor config)
 
-			SwissRailRaptorConfigGroup configRaptor = ConfigUtils.addOrGetModule( config, SwissRailRaptorConfigGroup.class ) ;
+			SwissRailRaptorConfigGroup configRaptor = ConfigUtils.addOrGetModule(config,
+					SwissRailRaptorConfigGroup.class);
 			configRaptor.setUseIntermodalAccessEgress(true);
 
 			// drt
 			IntermodalAccessEgressParameterSet paramSetDrt = new IntermodalAccessEgressParameterSet();
-			paramSetDrt.setMode( TransportMode.drt );
-			paramSetDrt.setMaxRadius( 1000000000 );
-//			paramSetDrt.setStopFilterAttribute( "drtAccessible" );
-//			paramSetDrt.setStopFilterValue( "true" );
-			configRaptor.addIntermodalAccessEgress( paramSetDrt );
-
+			paramSetDrt.setMode(TransportMode.drt);
+			paramSetDrt.setMaxRadius(1000000000);
+			//			paramSetDrt.setStopFilterAttribute( "drtAccessible" );
+			//			paramSetDrt.setStopFilterValue( "true" );
+			configRaptor.addIntermodalAccessEgress(paramSetDrt);
 
 		}
 
-
-
-			DvrpConfigGroup dvrpConfig = ConfigUtils.addOrGetModule( config, DvrpConfigGroup.class );
-			MultiModeDrtConfigGroup mm = ConfigUtils.addOrGetModule( config, MultiModeDrtConfigGroup.class );
+		DvrpConfigGroup dvrpConfig = ConfigUtils.addOrGetModule(config, DvrpConfigGroup.class);
+		MultiModeDrtConfigGroup mm = ConfigUtils.addOrGetModule(config, MultiModeDrtConfigGroup.class);
 		{
 			DrtConfigGroup drtConfig = new DrtConfigGroup();
-			drtConfig.setMaxTravelTimeAlpha( 1.3 );
-			drtConfig.setMaxTravelTimeBeta( 5. * 60. );
-			drtConfig.setStopDuration( 60. );
-			drtConfig.setMaxWaitTime( Double.MAX_VALUE );
-			drtConfig.setRejectRequestIfMaxWaitOrTravelTimeViolated( false );
-			drtConfig.setMode( TransportMode.drt );
-			mm.addParameterSet( drtConfig );
+			drtConfig.setMaxTravelTimeAlpha(1.3);
+			drtConfig.setMaxTravelTimeBeta(5. * 60.);
+			drtConfig.setStopDuration(60.);
+			drtConfig.setMaxWaitTime(Double.MAX_VALUE);
+			drtConfig.setRejectRequestIfMaxWaitOrTravelTimeViolated(false);
+			drtConfig.setMode(TransportMode.drt);
+			mm.addParameterSet(drtConfig);
 		}
 
-		for( DrtConfigGroup drtConfigGroup : mm.getModalElements() ){
-			DrtConfigs.adjustDrtConfig( drtConfigGroup, config.planCalcScore(), config.plansCalcRoute() );
+		for (DrtConfigGroup drtConfigGroup : mm.getModalElements()) {
+			DrtConfigs.adjustDrtConfig(drtConfigGroup, config.planCalcScore(), config.plansCalcRoute());
 		}
 
-		config.vspExperimental().setVspDefaultsCheckingLevel( VspExperimentalConfigGroup.VspDefaultsCheckingLevel.warn );
+		config.vspExperimental().setVspDefaultsCheckingLevel(VspExperimentalConfigGroup.VspDefaultsCheckingLevel.warn);
 
+		Scenario scenario = new PtAlongALineFixture().createScenario(config, 100);
 
-		Scenario scenario = createScenario(config , 100 );
+		scenario.getPopulation()
+				.getFactory()
+				.getRouteFactories()
+				.setRouteFactory(DrtRoute.class, new DrtRouteFactory());
 
-		scenario.getPopulation().getFactory().getRouteFactories().setRouteFactory( DrtRoute.class, new DrtRouteFactory() );
-
-		addModeToAllLinksBtwnGivenNodes(scenario.getNetwork(), 0, 1000, TransportMode.drt );
-
+		addModeToAllLinksBtwnGivenNodes(scenario.getNetwork(), 0, 1000, TransportMode.drt);
 
 		// The following is for the _router_, not the qsim!  kai, jun'19
 		VehiclesFactory vf = scenario.getVehicles().getFactory();
 		{
-			VehicleType vehType = vf.createVehicleType( Id.create( TransportMode.drt, VehicleType.class ) );
-			vehType.setMaximumVelocity( 50./3.6 );
-			scenario.getVehicles().addVehicleType( vehType );
-		}{
-			VehicleType vehType = vf.createVehicleType( Id.create( TransportMode.car, VehicleType.class ) );
-			vehType.setMaximumVelocity( 50./3.6 );
-			scenario.getVehicles().addVehicleType( vehType );
+			VehicleType vehType = vf.createVehicleType(Id.create(TransportMode.drt, VehicleType.class));
+			vehType.setMaximumVelocity(50. / 3.6);
+			scenario.getVehicles().addVehicleType(vehType);
+		}
+		{
+			VehicleType vehType = vf.createVehicleType(Id.create(TransportMode.car, VehicleType.class));
+			vehType.setMaximumVelocity(50. / 3.6);
+			scenario.getVehicles().addVehicleType(vehType);
 		}
 
 		// ===
 
 		Controler controler = new Controler(scenario);
 
-		controler.addOverridingModule(new SwissRailRaptorModule() ) ;
+		controler.addOverridingModule(new SwissRailRaptorModule());
 
-		controler.addOverridingModule( new DvrpModule() );
-		controler.addOverridingModule( new MultiModeDrtModule() );
-		controler.configureQSimComponents( DvrpQSimComponents.activateModes( TransportMode.drt ) );
+		controler.addOverridingModule(new DvrpModule());
+		controler.addOverridingModule(new MultiModeDrtModule());
+		controler.configureQSimComponents(DvrpQSimComponents.activateModes(TransportMode.drt));
 
 		controler.addOverridingModule(
 				PtAlongALineTest.createGeneratedFleetSpecificationModule(TransportMode.drt, "DRT-", 10,
 						Id.createLinkId("0-1"), 4));
 
-
 		// This will start otfvis.  Comment out if not needed.
-//		controler.addOverridingModule( new OTFVisLiveModule() );
+		//		controler.addOverridingModule( new OTFVisLiveModule() );
 
 		controler.run();
 	}
 
+	static Config createConfig(String outputDir) {
+		Config config = ConfigUtils.createConfig();
 
+		config.global().setNumberOfThreads(1);
 
-	static Config createConfig( String outputDir ){
-		Config config = ConfigUtils.createConfig() ;
+		config.controler().setOutputDirectory(outputDir);
+		config.controler().setLastIteration(0);
 
-		config.global().setNumberOfThreads( 1 );
+		config.plansCalcRoute().getModeRoutingParams().get(TransportMode.walk).setTeleportedModeSpeed(3.);
+		config.plansCalcRoute().getModeRoutingParams().get(TransportMode.bike).setTeleportedModeSpeed(10.);
 
-		config.controler().setOutputDirectory( outputDir ) ;
-		config.controler().setLastIteration( 0 );
+		config.qsim().setEndTime(24. * 3600.);
 
-		config.plansCalcRoute().getModeRoutingParams().get( TransportMode.walk ).setTeleportedModeSpeed( 3. );
-		config.plansCalcRoute().getModeRoutingParams().get( TransportMode.bike ).setTeleportedModeSpeed( 10. );
-
-		config.qsim().setEndTime( 24.*3600. );
-
-		config.transit().setUseTransit(true) ;
+		config.transit().setUseTransit(true);
 
 		// This configures otfvis:
-		OTFVisConfigGroup visConfig = ConfigUtils.addOrGetModule( config, OTFVisConfigGroup.class );
-		visConfig.setDrawTransitFacilities( false );
-		visConfig.setColoringScheme( OTFVisConfigGroup.ColoringScheme.bvg ) ;
+		OTFVisConfigGroup visConfig = ConfigUtils.addOrGetModule(config, OTFVisConfigGroup.class);
+		visConfig.setDrawTransitFacilities(false);
+		visConfig.setColoringScheme(OTFVisConfigGroup.ColoringScheme.bvg);
 		visConfig.setDrawTime(true);
 		visConfig.setDrawNonMovingItems(true);
 		visConfig.setAgentSize(125);
 		visConfig.setLinkWidth(30);
-		visConfig.setShowTeleportedAgents( true );
-		visConfig.setDrawTransitFacilities( true );
-//		{
-//			BufferedImage image = null ;
-//			Rectangle2D zoomstore = new Rectangle2D.Double( 0., 0., +100.*1000., +10.*1000. ) ;
-//			ZoomEntry zoomEntry = new ZoomEntry( image, zoomstore, "*Initial*" ) ;
-//			visConfig.addZoom( zoomEntry );
-//		}
+		visConfig.setShowTeleportedAgents(true);
+		visConfig.setDrawTransitFacilities(true);
+		//		{
+		//			BufferedImage image = null ;
+		//			Rectangle2D zoomstore = new Rectangle2D.Double( 0., 0., +100.*1000., +10.*1000. ) ;
+		//			ZoomEntry zoomEntry = new ZoomEntry( image, zoomstore, "*Initial*" ) ;
+		//			visConfig.addZoom( zoomEntry );
+		//		}
 
-		config.qsim().setSnapshotStyle( QSimConfigGroup.SnapshotStyle.kinematicWaves );
-		config.qsim().setTrafficDynamics( QSimConfigGroup.TrafficDynamics.kinematicWaves );
+		config.qsim().setSnapshotStyle(QSimConfigGroup.SnapshotStyle.kinematicWaves);
+		config.qsim().setTrafficDynamics(QSimConfigGroup.TrafficDynamics.kinematicWaves);
 
 		configureScoring(config);
 		return config;
 	}
 
-	static Scenario createScenario( Config config, long numberOfPersons ){
-		Scenario scenario = ScenarioUtils.createScenario( config );
-		// don't load anything
-
-		final int lastNodeIdx = 1000;
-		final double deltaX = 100.;
-
-		createAndAddCarNetwork( scenario, lastNodeIdx, deltaX );
-
-		createAndAddPopulation( scenario , "pt", numberOfPersons );
-
-		final double deltaY = 1000.;
-
-		createAndAddTransitNetwork( scenario, lastNodeIdx, deltaX, deltaY );
-
-		createAndAddTransitStopFacilities( scenario, lastNodeIdx, deltaX, deltaY );
-
-		createAndAddTransitVehicleType( scenario );
-
-		createAndAddTransitLine( scenario );
-
-		TransitScheduleValidator.printResult( TransitScheduleValidator.validateAll( scenario.getTransitSchedule(), scenario.getNetwork() ) );
-		return scenario;
-	}
-
 	private static void configureScoring(Config config) {
-		ModeParams accessWalk = new ModeParams( TransportMode.non_network_walk );
+		ModeParams accessWalk = new ModeParams(TransportMode.non_network_walk);
 		accessWalk.setMarginalUtilityOfTraveling(0);
 		config.planCalcScore().addModeParams(accessWalk);
 
@@ -435,7 +371,7 @@ public class PtAlongALineTest{
 		paramSetWalk.setMaxRadius(radiusWalk);
 		paramSetWalk.setPersonFilterAttribute(null);
 		paramSetWalk.setStopFilterAttribute(null);
-		configRaptor.addIntermodalAccessEgress(paramSetWalk );
+		configRaptor.addIntermodalAccessEgress(paramSetWalk);
 
 		// Bike
 		IntermodalAccessEgressParameterSet paramSetBike = new IntermodalAccessEgressParameterSet();
@@ -444,210 +380,9 @@ public class PtAlongALineTest{
 		paramSetBike.setPersonFilterAttribute(null);
 		//		paramSetBike.setStopFilterAttribute("bikeAccessible");
 		//		paramSetBike.setStopFilterValue("true");
-		configRaptor.addIntermodalAccessEgress(paramSetBike );
+		configRaptor.addIntermodalAccessEgress(paramSetBike);
 
 		return configRaptor;
-	}
-
-	private static void createAndAddTransitLine( Scenario scenario ){
-		PopulationFactory pf = scenario.getPopulation().getFactory();
-		;
-		TransitSchedule schedule = scenario.getTransitSchedule();
-		TransitScheduleFactory tsf = schedule.getFactory();
-		VehiclesFactory tvf = scenario.getTransitVehicles().getFactory();
-
-		List<Id<Link>> linkIds = new ArrayList<>() ;
-		linkIds.add( TR_LINK_0_1_ID ) ;
-		linkIds.add( TR_LONG_LINK_LEFT_ID ) ;
-		linkIds.add( TR_LINK_MIDDLE_ID ) ;
-		linkIds.add( TR_LONG_LINK_RIGHT_ID ) ;
-		linkIds.add( TR_LINK_LASTM1_LAST_ID ) ;
-		NetworkRoute route = createNetworkRoute( TR_LINK_m1_0_ID, linkIds, TR_LINK_LAST_LASTp1_ID, pf );
-
-		List<TransitRouteStop> stops = new ArrayList<>() ;
-		{
-			stops.add( tsf.createTransitRouteStop( schedule.getFacilities().get( tr_stop_fac_0_ID ), 0., 0. ) );
-			stops.add( tsf.createTransitRouteStop( schedule.getFacilities().get( tr_stop_fac_5000_ID ), 1., 1. ) );
-			stops.add( tsf.createTransitRouteStop( schedule.getFacilities().get( tr_stop_fac_10000_ID ), 1., 1. ) );
-		}
-		{
-			TransitRoute transitRoute = tsf.createTransitRoute( Id.create( "route1", TransitRoute.class ), route, stops, "bus" );
-			for ( int ii=0 ; ii<100 ; ii++ ){
-				String str = "tr_" + ii ;
-
-				scenario.getTransitVehicles().addVehicle( tvf.createVehicle( Id.createVehicleId( str ), scenario.getTransitVehicles().getVehicleTypes().get( busTypeID) ) );
-
-				Departure departure = tsf.createDeparture( Id.create( str, Departure.class ), 7. * 3600. + ii*300 ) ;
-				departure.setVehicleId( Id.createVehicleId( str ) );
-				transitRoute.addDeparture( departure );
-			}
-			TransitLine line = tsf.createTransitLine( Id.create( "line1", TransitLine.class ) );
-			line.addRoute( transitRoute );
-
-			schedule.addTransitLine( line );
-		}
-	}
-
-	private static void createAndAddTransitVehicleType( Scenario scenario ){
-		VehiclesFactory tvf = scenario.getTransitVehicles().getFactory();
-		VehicleType busType = tvf.createVehicleType( busTypeID );
-		{
-			VehicleCapacity capacity = busType.getCapacity() ;
-			capacity.setSeats( 100 );
-		}
-		{
-			busType.setMaximumVelocity( 100. / 3.6 );
-		}
-		scenario.getTransitVehicles().addVehicleType( busType );
-	}
-
-	private static void createAndAddTransitStopFacilities( Scenario scenario, int lastNodeIdx, double deltaX, double deltaY ){
-		TransitSchedule schedule = scenario.getTransitSchedule();
-		TransitScheduleFactory tsf = schedule.getFactory();
-
-		TransitStopFacility stopFacility0 = tsf.createTransitStopFacility( tr_stop_fac_0_ID, new Coord( deltaX, deltaY ), false );
-		stopFacility0.setLinkId( TR_LINK_0_1_ID );
-		schedule.addStopFacility( stopFacility0 );
-
-		TransitStopFacility stopFacility5000 = tsf.createTransitStopFacility( tr_stop_fac_5000_ID, new Coord( 0.5 * (lastNodeIdx - 1) * deltaX, deltaY ), false );
-		stopFacility5000.setLinkId( TR_LINK_MIDDLE_ID );
-		stopFacility5000.getAttributes().putAttribute( "drtAccessible", "true" );
-		stopFacility5000.getAttributes().putAttribute( "bikeAccessible", "true");
-
-		schedule.addStopFacility( stopFacility5000 );
-
-		TransitStopFacility stopFacility10000 = tsf.createTransitStopFacility( tr_stop_fac_10000_ID, new Coord( (lastNodeIdx - 1) * deltaX, deltaY ), false );
-		stopFacility10000.setLinkId( TR_LINK_LASTM1_LAST_ID );
-		schedule.addStopFacility( stopFacility10000 );
-	}
-
-	private static void createAndAddTransitNetwork( Scenario scenario, int lastNodeIdx, double deltaX, double deltaY ){
-		NetworkFactory nf = scenario.getNetwork().getFactory();
-		;
-
-		Node nodem1 = nf.createNode( Id.createNodeId("trNodeM1" ), new Coord(-100, deltaY ) );
-		scenario.getNetwork().addNode(nodem1);
-		// ---
-		Node node0 = nf.createNode( Id.createNodeId("trNode0" ), new Coord(0, deltaY ) );
-		scenario.getNetwork().addNode(node0);
-		createAndAddTransitLink( scenario, nodem1, node0, TR_LINK_m1_0_ID );
-		// ---
-		Node node1 = nf.createNode( Id.createNodeId("trNode1"), new Coord(deltaX, deltaY ) ) ;
-		scenario.getNetwork().addNode( node1 ) ;
-		createAndAddTransitLink( scenario, node0, node1, TR_LINK_0_1_ID );
-		// ---
-		Node nodeMiddleLeft = nf.createNode( Id.createNodeId("trNodeMiddleLeft") , new Coord( 0.5*(lastNodeIdx-1)*deltaX , deltaY ) ) ;
-		scenario.getNetwork().addNode( nodeMiddleLeft) ;
-		{
-			createAndAddTransitLink( scenario, node1, nodeMiddleLeft, TR_LONG_LINK_LEFT_ID );
-		}
-		// ---
-		Node nodeMiddleRight = nf.createNode( Id.createNodeId("trNodeMiddleRight") , new Coord( 0.5*(lastNodeIdx+1)*deltaX , deltaY ) ) ;
-		scenario.getNetwork().addNode( nodeMiddleRight ) ;
-		createAndAddTransitLink( scenario, nodeMiddleLeft, nodeMiddleRight, TR_LINK_MIDDLE_ID );
-		// ---
-		Node nodeLastm1 = nf.createNode( Id.createNodeId("trNodeLastm1") , new Coord( (lastNodeIdx-1)*deltaX , deltaY ) ) ;
-		scenario.getNetwork().addNode( nodeLastm1) ;
-		createAndAddTransitLink( scenario, nodeMiddleRight, nodeLastm1, TR_LONG_LINK_RIGHT_ID );
-
-		// ---
-		Node nodeLast = nf.createNode(Id.createNodeId("trNodeLast"), new Coord(lastNodeIdx*deltaX, deltaY ) ) ;
-		scenario.getNetwork().addNode(nodeLast);
-		createAndAddTransitLink( scenario, nodeLastm1, nodeLast, TR_LINK_LASTM1_LAST_ID );
-		// ---
-		Node nodeLastp1 = nf.createNode(Id.createNodeId("trNodeLastp1"), new Coord(lastNodeIdx*deltaX+100., deltaY ) ) ;
-		scenario.getNetwork().addNode(nodeLastp1);
-		createAndAddTransitLink( scenario, nodeLast, nodeLastp1, TR_LINK_LAST_LASTp1_ID );
-	}
-
-	private static void createAndAddPopulation( Scenario scenario, String mode, long numberOfPersons ){
-		PopulationFactory pf = scenario.getPopulation().getFactory();
-		List<ActivityFacility> facilitiesAsList = new ArrayList<>( scenario.getActivityFacilities().getFacilities().values() ) ;
-		final Id<ActivityFacility> activityFacilityId = facilitiesAsList.get( facilitiesAsList.size()-1 ).getId() ;
-		for( int jj = 0 ; jj < numberOfPersons ; jj++ ){
-			Person person = pf.createPerson( Id.createPersonId( jj ) );
-			{
-				scenario.getPopulation().addPerson( person );
-				Plan plan = pf.createPlan();
-				person.addPlan( plan );
-
-				// --- 1st location at randomly selected facility:
-				int idx = MatsimRandom.getRandom().nextInt( facilitiesAsList.size() );;
-				Id<ActivityFacility> homeFacilityId = facilitiesAsList.get( idx ).getId();;
-				Activity home = pf.createActivityFromActivityFacilityId( "dummy", homeFacilityId );
-				if ( jj==0 ){
-					home.setEndTime( 7. * 3600. ); // one agent one sec earlier so that for all others the initial acts are visible in VIA
-				} else {
-					home.setEndTime( 7. * 3600. + 1. );
-				}
-				plan.addActivity( home );
-				{
-					Leg leg = pf.createLeg( mode );
-					leg.setDepartureTime( 7. * 3600. );
-					leg.setTravelTime( 1800. );
-					plan.addLeg( leg );
-				}
-				{
-					Activity shop = pf.createActivityFromActivityFacilityId( "dummy", activityFacilityId );
-					plan.addActivity( shop );
-				}
-			}
-		}
-	}
-
-	private static void createAndAddCarNetwork( Scenario scenario, int lastNodeIdx, double deltaX ){
-		// Construct a network and facilities along a line:
-		// 0 --(0-1)-- 1 --(2-1)-- 2 -- ...
-		// with a facility of same ID attached to each link.
-
-		NetworkFactory nf = scenario.getNetwork().getFactory();
-		ActivityFacilitiesFactory ff = scenario.getActivityFacilities().getFactory();
-
-		Node prevNode;
-		{
-			Node node = nf.createNode( Id.createNodeId( 0 ), new Coord( 0., 0. ) );
-			scenario.getNetwork().addNode( node );
-			prevNode = node;
-		}
-		for( int ii = 1 ; ii <= lastNodeIdx ; ii++ ){
-			Node node = nf.createNode( Id.createNodeId( ii ), new Coord( ii * deltaX, 0. ) );
-			scenario.getNetwork().addNode( node );
-			// ---
-			addLinkAndFacility( scenario, nf, ff, prevNode, node );
-			addLinkAndFacility( scenario, nf, ff, node, prevNode );
-			// ---
-			prevNode = node;
-		}
-	}
-
-	private static void createAndAddTransitLink( Scenario scenario, Node node0, Node node1, Id<Link> TR_LINK_0_1_ID ){
-		Link trLink = scenario.getNetwork().getFactory().createLink( TR_LINK_0_1_ID, node0, node1 );
-		trLink.setFreespeed( 100. / 3.6 );
-		trLink.setCapacity( 100000. );
-		scenario.getNetwork().addLink( trLink );
-	}
-
-	private static NetworkRoute createNetworkRoute( Id<Link> startLinkId, List<Id<Link>> linkIds, Id<Link> endLinkId, PopulationFactory pf ){
-		NetworkRoute route = pf.getRouteFactories().createRoute( NetworkRoute.class, startLinkId, endLinkId ) ;
-		route.setLinkIds( startLinkId, linkIds, endLinkId ) ;
-		return route;
-	}
-
-	private static void addLinkAndFacility( Scenario scenario, NetworkFactory nf, ActivityFacilitiesFactory ff, Node prevNode, Node node ){
-		final String str = prevNode.getId() + "-" + node.getId();
-		Link link = nf.createLink( Id.createLinkId( str ), prevNode, node ) ;
-		Set<String> set = new HashSet<>() ;
-		set.add("car" ) ;
-		link.setAllowedModes( set ) ;
-		link.setLength( CoordUtils.calcEuclideanDistance( prevNode.getCoord(), node.getCoord() ) );
-		link.setCapacity( 3600. );
-		link.setFreespeed( 50./3.6 );
-		scenario.getNetwork().addLink( link );
-		// ---
-		ActivityFacility af = ff.createActivityFacility( Id.create( str, ActivityFacility.class ), link.getCoord(), link.getId() ) ;
-		ActivityOption option = ff.createActivityOption( "shop" ) ;
-		af.addActivityOption( option );
-		scenario.getActivityFacilities().addActivityFacility( af );
 	}
 
 	static AbstractDvrpModeModule createGeneratedFleetSpecificationModule(String mode, String vehPrefix,
@@ -678,15 +413,17 @@ public class PtAlongALineTest{
 		return fleetSpecification;
 	}
 
-	static void addModeToAllLinksBtwnGivenNodes( Network network, int fromNodeNumber, int toNodeNumber, String drtMode ) {
+	static void addModeToAllLinksBtwnGivenNodes(Network network, int fromNodeNumber, int toNodeNumber, String drtMode) {
 		for (int i = fromNodeNumber; i < toNodeNumber; i++) {
-			Set<String> newAllowedModes = new HashSet<>( network.getLinks().get( Id.createLinkId( i + "-" + (i + 1) ) ).getAllowedModes() );
+			Set<String> newAllowedModes = new HashSet<>(
+					network.getLinks().get(Id.createLinkId(i + "-" + (i + 1))).getAllowedModes());
 			newAllowedModes.add(drtMode);
-			network.getLinks().get(Id.createLinkId( i + "-" + (i+1) )).setAllowedModes( newAllowedModes );
+			network.getLinks().get(Id.createLinkId(i + "-" + (i + 1))).setAllowedModes(newAllowedModes);
 
-			newAllowedModes = new HashSet<>( network.getLinks().get( Id.createLinkId( (i + 1) + "-" + i ) ).getAllowedModes() );
+			newAllowedModes = new HashSet<>(
+					network.getLinks().get(Id.createLinkId((i + 1) + "-" + i)).getAllowedModes());
 			newAllowedModes.add(drtMode);
-			network.getLinks().get(Id.createLinkId( (i+1) + "-" + i )).setAllowedModes( newAllowedModes );
+			network.getLinks().get(Id.createLinkId((i + 1) + "-" + i)).setAllowedModes(newAllowedModes);
 		}
 	}
 

--- a/contribs/vsp/src/test/java/playground/vsp/scoring/IncomeDependentUtilityOfMoneyPersonScoringParametersTest.java
+++ b/contribs/vsp/src/test/java/playground/vsp/scoring/IncomeDependentUtilityOfMoneyPersonScoringParametersTest.java
@@ -28,17 +28,14 @@ public class IncomeDependentUtilityOfMoneyPersonScoringParametersTest {
 
 	@Rule
 	public MatsimTestUtils utils;
-	private static TransitConfigGroup transitConfigGroup;
-	private static ScenarioConfigGroup scenarioConfigGroup;
-	private static PlanCalcScoreConfigGroup planCalcScoreConfigGroup;
-	private static IncomeDependentUtilityOfMoneyPersonScoringParameters personScoringParams;
-	private static Population population;
+	private IncomeDependentUtilityOfMoneyPersonScoringParameters personScoringParams;
+	private Population population;
 
-	@BeforeClass
-	public static void setUp() throws Exception {
-		transitConfigGroup = new TransitConfigGroup();
-		scenarioConfigGroup = new ScenarioConfigGroup();
-		planCalcScoreConfigGroup = new PlanCalcScoreConfigGroup();
+	@Before
+	public void setUp() {
+		TransitConfigGroup transitConfigGroup = new TransitConfigGroup();
+		ScenarioConfigGroup scenarioConfigGroup = new ScenarioConfigGroup();
+		PlanCalcScoreConfigGroup planCalcScoreConfigGroup = new PlanCalcScoreConfigGroup();
 
 		PlanCalcScoreConfigGroup.ScoringParameterSet personParams = planCalcScoreConfigGroup.getOrCreateScoringParameters("person");
 		personParams.setMarginalUtilityOfMoney(1);
@@ -91,7 +88,10 @@ public class IncomeDependentUtilityOfMoneyPersonScoringParametersTest {
 			PopulationUtils.putPersonAttribute(freightWithIncome2, PERSONAL_INCOME_ATTRIBUTE_NAME, 0.5d);
 			population.addPerson(freightWithIncome2);
 		}
-		personScoringParams = new IncomeDependentUtilityOfMoneyPersonScoringParameters(population, planCalcScoreConfigGroup, scenarioConfigGroup, transitConfigGroup);
+		personScoringParams = new IncomeDependentUtilityOfMoneyPersonScoringParameters(population,
+				planCalcScoreConfigGroup,
+				scenarioConfigGroup,
+				transitConfigGroup);
 	}
 
 	@Test

--- a/matsim/src/test/java/org/matsim/analysis/CalcLegTimesTest.java
+++ b/matsim/src/test/java/org/matsim/analysis/CalcLegTimesTest.java
@@ -48,8 +48,8 @@ import org.matsim.testcases.MatsimTestCase;
 public class CalcLegTimesTest extends MatsimTestCase {
 
 	public static final String BASE_FILE_NAME = "legdurations.txt";
-	public static final Id<Person> DEFAULT_PERSON_ID = Id.create(123, Person.class);
-	public static final Id<Link> DEFAULT_LINK_ID = Id.create(456, Link.class);
+	public final Id<Person> DEFAULT_PERSON_ID = Id.create(123, Person.class);
+	public final Id<Link> DEFAULT_LINK_ID = Id.create(456, Link.class);
 
 	private Population population = null;
 	private Network network = null;

--- a/matsim/src/test/java/org/matsim/api/core/v01/AutoResetIdCaches.java
+++ b/matsim/src/test/java/org/matsim/api/core/v01/AutoResetIdCaches.java
@@ -1,0 +1,56 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2021 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.api.core.v01;
+
+import org.junit.runner.Description;
+import org.junit.runner.notification.RunListener;
+
+/**
+ * Auto-resets Id caches before each test is started. This helps to keep every single unit test independent of others
+ * (so things like execution order etc. will not impact them).
+ * <p>
+ * It is enabled in tests (run by maven) by registering them as listeners in the surefire and failsafe plugin configs:
+ * <pre>
+ * {@code
+ * <property>
+ * <name>listener</name>
+ * <value>org.matsim.api.core.v01.IdCacheCleaner</value>
+ * </property>
+ * }
+ * </pre>
+ * <p>
+ * IntelliJ does not support junit listeners out of the box. To enable them in IntelliJ, you can install a plugin
+ * https://plugins.jetbrains.com/plugin/15718-junit-4-surefire-listener
+ * <p>
+ * Not sure about Eclipse, but it seems that an additional plugin would be required (see:
+ * https://bugs.eclipse.org/bugs/show_bug.cgi?id=538885)
+ * <p>
+ * Since IDEs have a limited support for registering jUnit RunListeners via pom.xml, there may be cases where we need
+ * to explicitly reset the Id caches while setting up a test (to make them green in IDEs).
+ *
+ * @author Michal Maciejewski (michalm)
+ */
+public class AutoResetIdCaches extends RunListener {
+	@Override
+	public void testStarted(Description description) {
+		Id.resetCaches();
+	}
+}

--- a/matsim/src/test/java/org/matsim/core/network/filter/NetworkFilterManagerTest.java
+++ b/matsim/src/test/java/org/matsim/core/network/filter/NetworkFilterManagerTest.java
@@ -19,10 +19,10 @@
  *                                                                         *
  * *********************************************************************** */
 
- package org.matsim.core.network.filter;
+package org.matsim.core.network.filter;
 
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
@@ -40,10 +40,8 @@ import com.google.common.collect.ImmutableSet;
  */
 public class NetworkFilterManagerTest {
 
-	private static Network filterNetwork;
-	
 	private static final double DELTA = 0.00001;
-	
+
 	private static final double CAPACITY = 12.34;
 	private static final double FREESPEED = 13.888;
 	private static final double LENGTH = 777;
@@ -52,9 +50,11 @@ public class NetworkFilterManagerTest {
 	private static final String ATTRIBUTE_VALUE = "value";
 	private static final String ATTRIBUTE_KEY2 = "key2";
 	private static final int ATTRIBUTE_VALUE2 = 2;
-	
-	@BeforeClass
-	public static void prepareTestAllowedModes() {
+
+	private Network filterNetwork;
+
+	@Before
+	public void prepareTestAllowedModes() {
 		Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
 		Network network = scenario.getNetwork();
 
@@ -63,7 +63,7 @@ public class NetworkFilterManagerTest {
 		Node c = network.getFactory().createNode(Id.create("c", Node.class), new Coord(LENGTH, LENGTH));
 		Link ab = network.getFactory().createLink(Id.create("ab", Link.class), a, b);
 		Link ac = network.getFactory().createLink(Id.create("ac", Link.class), a, c);
-		
+
 		enrichLink(ab);
 		enrichLink(ac);
 
@@ -75,7 +75,7 @@ public class NetworkFilterManagerTest {
 
 		filterNetwork = network;
 	}
-	
+
 	private static void enrichLink(Link link) {
 		link.setAllowedModes(ImmutableSet.of("car"));
 		link.setCapacity(CAPACITY);
@@ -105,15 +105,15 @@ public class NetworkFilterManagerTest {
 				return true;
 			}
 		});
-		
+
 		Network filteredNetwork = networkFilterManager.applyFilters();
-		
+
 		Assert.assertEquals(2, filteredNetwork.getNodes().size());
 		Assert.assertTrue("must be added by nodefilter", filteredNetwork.getNodes().containsKey(Id.createNodeId("a")));
 		Assert.assertTrue("must be added for ab link", filteredNetwork.getNodes().containsKey(Id.createNodeId("b")));
-		
+
 		Assert.assertEquals(1, filteredNetwork.getLinks().size());
-		
+
 		Link ab = filteredNetwork.getLinks().get(Id.createLinkId("ab"));
 		Assert.assertEquals(CAPACITY, ab.getCapacity(), DELTA);
 		Assert.assertEquals(FREESPEED, ab.getFreespeed(), DELTA);

--- a/matsim/src/test/java/org/matsim/vehicles/MatsimVehicleWriterTest.java
+++ b/matsim/src/test/java/org/matsim/vehicles/MatsimVehicleWriterTest.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.apache.log4j.Logger;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.matsim.api.core.v01.Id;
 import org.matsim.testcases.MatsimTestCase;
 
@@ -41,7 +41,7 @@ public class MatsimVehicleWriterTest extends MatsimTestCase {
 	private Id<Vehicle> id42;
 	private Id<Vehicle> id42_23;
 
-	@BeforeClass
+	@Before
 	public void setUp() throws Exception {
 		super.setUp();
 

--- a/matsim/src/test/java/org/matsim/vehicles/VehicleReaderV1Test.java
+++ b/matsim/src/test/java/org/matsim/vehicles/VehicleReaderV1Test.java
@@ -21,7 +21,7 @@ package org.matsim.vehicles;
 
 import java.util.Map;
 
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.testcases.MatsimTestCase;
@@ -40,7 +40,7 @@ public class VehicleReaderV1Test extends MatsimTestCase {
 	private Map<Id<VehicleType>, VehicleType> vehicleTypes;
 	private Map<Id<Vehicle>, Vehicle> vehicles;
 
-	@BeforeClass
+	@Before
 	public void setUp() throws Exception {
 		super.setUp();
 		Vehicles veh = VehicleUtils.createVehiclesContainer();

--- a/matsim/src/test/java/org/matsim/vehicles/VehicleReaderV2Test.java
+++ b/matsim/src/test/java/org/matsim/vehicles/VehicleReaderV2Test.java
@@ -21,7 +21,7 @@ package org.matsim.vehicles;
 
 import java.util.Map;
 
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.testcases.MatsimTestCase;
@@ -40,7 +40,7 @@ public class VehicleReaderV2Test extends MatsimTestCase {
 	private Map<Id<VehicleType>, VehicleType> vehicleTypes;
 	private Map<Id<Vehicle>, Vehicle> vehicles;
 
-	@BeforeClass
+	@Before
 	public void setUp() throws Exception {
 		super.setUp();
 

--- a/matsim/src/test/java/org/matsim/vehicles/VehicleWriterV1Test.java
+++ b/matsim/src/test/java/org/matsim/vehicles/VehicleWriterV1Test.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.apache.log4j.Logger;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.matsim.api.core.v01.Id;
 import org.matsim.testcases.MatsimTestCase;
 
@@ -42,7 +42,7 @@ public class VehicleWriterV1Test extends MatsimTestCase {
 	private Id<Vehicle> id42;
 	private Id<Vehicle> id42_23;
 
-	@BeforeClass
+	@Before
 	public void setUp() throws Exception {
 		super.setUp();
 
@@ -54,7 +54,7 @@ public class VehicleWriterV1Test extends MatsimTestCase {
 		id42_23 = Id.create(" 42  23", Vehicle.class);
 	}
 
-	public void testWriter() throws FileNotFoundException, IOException {
+	public void testWriter() {
 
 		String outfileName = this.getOutputDirectory() + "testOutputVehicles.xml";
 

--- a/matsim/src/test/java/org/matsim/vehicles/VehicleWriterV2Test.java
+++ b/matsim/src/test/java/org/matsim/vehicles/VehicleWriterV2Test.java
@@ -23,7 +23,7 @@ import java.io.File;
 import java.util.Map;
 
 import org.apache.log4j.Logger;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.testcases.MatsimTestCase;
@@ -43,7 +43,7 @@ public class VehicleWriterV2Test extends MatsimTestCase {
 	private Map<Id<VehicleType>, VehicleType> vehicleTypes;
 	private Map<Id<Vehicle>, Vehicle> vehicles;
 
-	@BeforeClass
+	@Before
 	public void setUp() throws Exception {
 		super.setUp();
 		String outfileName = this.getOutputDirectory() + "../testOutputVehicles.xml";

--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,30 @@
                     </rules>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <properties>
+                        <property>
+                            <name>listener</name>
+                            <value>org.matsim.api.core.v01.AutoResetIdCaches</value>
+                        </property>
+                    </properties>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <properties>
+                        <property>
+                            <name>listener</name>
+                            <value>org.matsim.api.core.v01.AutoResetIdCaches</value>
+                        </property>
+                    </properties>
+                </configuration>
+            </plugin>
         </plugins>
 
         <pluginManagement>


### PR DESCRIPTION
From time to time we are experiencing failing tests on Jenkins, Appveyor or local machines despite getting green builds in our GitHub workflow. The most frequent cause is re-using the same Ids across in many tests (either explicitly via static fields or implicitly via the Id cache).

Because the sequence of executed tests will impact the mapping `Id.id` ->`Id.index`, and `index` is used when iterating the "`Id`-optimised" sets and maps, the iteration order becomes non-deterministic, to which many tests are quite sensitive (maybe too sensitive?).

After enabling the auto-resetting (*), a dozen of tests started to fail. They are fixed in this PR. The tricky one was the accessibility integration test, where the on-the-fly created config gave different results than the one read from a file (despite being equal).

After fixing the tests, I decided to keep on cleaning up and so I replaced all `@BeforeClass` with `@Before` and removed `static` from `Id` fields declared in test classes.

All changes made to the tests are grouped by module into separate commits, so it is easier for everyone to see what I have messed up with their tests :-)

==
(*) See the javadoc of `AutoResetIdCaches` for more technical info.