### PR TITLE
Rename mode routing params to teleported mode params; remove fallback behavior for bushwhacking

### DIFF
--- a/matsim/src/main/java/org/matsim/core/config/groups/PlansCalcRouteConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/PlansCalcRouteConfigGroup.java
@@ -85,7 +85,14 @@ public final class PlansCalcRouteConfigGroup extends ConfigGroup {
 																		"settings for helper modes such as for " + TransportMode.non_network_walk;
 	private boolean clearingDefaultModeRoutingParams = false ;
 	// ---
-
+	public static class TeleportedModeParams extends ModeRoutingParams {
+		public TeleportedModeParams( String mode ){
+			super( mode );
+		}
+	}
+	/**
+	 * @deprecated -- try to use {@link TeleportedModeParams} to be consistent with xml config (not always possible).
+	 */
 	public static class ModeRoutingParams extends ReflectiveConfigGroup implements MatsimParameters {
 		public static final String SET_TYPE = "teleportedModeParameters";
 		public static final String MODE = "mode";
@@ -321,6 +328,12 @@ public final class PlansCalcRouteConfigGroup extends ConfigGroup {
 			throw new RuntimeException( "you cannot set the clearing of the default mode routing params to false after you have already cleared once." ) ;
 		}
 	}
+	public void clearTeleportedModeParams() {
+		this.clearModeRoutingParams();
+	}
+	/**
+	 * @deprecated -- use {@link #clearTeleportedModeParams()} to be consistent with naming in xml config.
+	 */
 	public void clearModeRoutingParams( ) {
 		// This is essentially a config switch, except that it cannot be set back to false once it was set to true.
 
@@ -361,6 +374,9 @@ public final class PlansCalcRouteConfigGroup extends ConfigGroup {
 		super.addParameterSet( set );
 	}
 
+	public void addTeleportedModeParams( final TeleportedModeParams pars ) {
+		this.addModeRoutingParams( pars );
+	}
 	public void addModeRoutingParams(final ModeRoutingParams pars) {
 		testForLocked() ;
 		addParameterSet( pars );

--- a/matsim/src/main/java/org/matsim/core/config/groups/PlansCalcRouteConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/PlansCalcRouteConfigGroup.java
@@ -377,11 +377,19 @@ public final class PlansCalcRouteConfigGroup extends ConfigGroup {
 	public void addTeleportedModeParams( final TeleportedModeParams pars ) {
 		this.addModeRoutingParams( pars );
 	}
+	/**
+	 * @deprecated -- try to use {@link #addTeleportedModeParams(TeleportedModeParams)} instead.
+	 */
 	public void addModeRoutingParams(final ModeRoutingParams pars) {
 		testForLocked() ;
 		addParameterSet( pars );
 	}
-	
+	public void removeTeleportedModeParams( String key ){
+		this.removeModeRoutingParams( key );
+	}
+	/**
+	 * @deprecated -- try to use {@link #removeTeleportedModeParams(String)} instead.
+	 */
 	public void removeModeRoutingParams( String key ) {
 		testForLocked() ;
 		for ( ConfigGroup pars : getParameterSets( ModeRoutingParams.SET_TYPE ) ) {

--- a/matsim/src/main/java/org/matsim/core/config/groups/PlansCalcRouteConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/PlansCalcRouteConfigGroup.java
@@ -113,7 +113,7 @@ public final class PlansCalcRouteConfigGroup extends ConfigGroup {
 		"Please do not set teleportedModeFreespeedFactor as well as teleportedModeSpeed for the same mode, but if you do, +" +
 		"teleportedModeFreespeedFactor wins over teleportedModeSpeed.";
 		
-		static final String TELEPORTED_MODE_FREESPEED_LIMIT_CMT = "When using freespeed factor, a speed limit on the free speed. "
+		private static final String TELEPORTED_MODE_FREESPEED_LIMIT_CMT = "When using freespeed factor, a speed limit on the free speed. "
 				+ "Link travel time will be $= factor * [ min( link_freespeed, freespeed_limit) ]" ;
 
 		public ModeRoutingParams(final String mode) {

--- a/matsim/src/main/java/org/matsim/core/config/groups/QSimConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/QSimConfigGroup.java
@@ -95,7 +95,7 @@ public final class QSimConfigGroup extends ReflectiveConfigGroup {
 	@Positive
 	private double stuckTime = 10;
 	private boolean removeStuckVehicles = false;
-	private boolean usePersonIdForMissingVehicleId = true;
+	private boolean usePersonIdForMissingVehicleId = false;
 	@Positive
 	private int numberOfThreads = 1;
 	private TrafficDynamics trafficDynamics = TrafficDynamics.queue ;
@@ -536,11 +536,13 @@ public final class QSimConfigGroup extends ReflectiveConfigGroup {
 
 	@StringSetter( VEHICLES_SOURCE)
 	public final void setVehiclesSource( VehiclesSource source ) {
+		// yyyy This setting triggers behavior in PrepareForSim, the result of which is also used by the router.  A better place for this switch might be in the vehicles config group. kai, may'21
 		testForLocked();
 		this.vehiclesSource = source ;
 	}
 	@StringGetter( VEHICLES_SOURCE )
 	public final VehiclesSource getVehiclesSource() {
+		// yyyy This setting triggers behavior in PrepareForSim, the result of which is also used by the router.  A better place for this switch might be in the vehicles config group. kai, may'21
 		return this.vehiclesSource ;
 	}
 

--- a/matsim/src/main/java/org/matsim/core/config/groups/QSimConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/QSimConfigGroup.java
@@ -95,7 +95,7 @@ public final class QSimConfigGroup extends ReflectiveConfigGroup {
 	@Positive
 	private double stuckTime = 10;
 	private boolean removeStuckVehicles = false;
-	private boolean usePersonIdForMissingVehicleId = false;
+	private boolean usePersonIdForMissingVehicleId = true;
 	@Positive
 	private int numberOfThreads = 1;
 	private TrafficDynamics trafficDynamics = TrafficDynamics.queue ;

--- a/matsim/src/main/java/org/matsim/core/controler/PrepareForSimImpl.java
+++ b/matsim/src/main/java/org/matsim/core/controler/PrepareForSimImpl.java
@@ -60,6 +60,8 @@ import javax.inject.Provider;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static org.matsim.core.config.groups.QSimConfigGroup.VehiclesSource.modeVehicleTypesFromVehiclesData;
+
 public final class PrepareForSimImpl implements PrepareForSim, PrepareForMobsim {
 	// I think it is ok to have this public final.  Since one may want to use it as a delegate.  kai, may'18
 	// but how should that work with a non-public constructor? kai, jun'18
@@ -246,11 +248,17 @@ public final class PrepareForSimImpl implements PrepareForSim, PrepareForMobsim 
 			switch (qSimConfigGroup.getVehiclesSource()) {
 				case defaultVehicle:
 					type = VehicleUtils.getDefaultVehicleType();
-					if (!scenario.getVehicles().getVehicleTypes().containsKey(type.getId()))
-						scenario.getVehicles().addVehicleType(type);
+					if (!scenario.getVehicles().getVehicleTypes().containsKey(type.getId())){
+						scenario.getVehicles().addVehicleType( type );
+					}
 					break;
 				case modeVehicleTypesFromVehiclesData:
 					type = scenario.getVehicles().getVehicleTypes().get(Id.create(mode, VehicleType.class));
+					if ( type==null ) {
+						log.fatal( "Could not find requested vehicle type =" + type + ". With config setting " + modeVehicleTypesFromVehiclesData.toString() + ", you need");
+						log.fatal( "to add, for each mode that performs network routing and/or is used as network/main mode in the qsim, a vehicle type for that mode." );
+						throw new RuntimeException("Could not find requested vehicle type = " + type + ". See above.");
+					}
 					break;
 				default:
 					throw new RuntimeException(qSimConfigGroup.getVehiclesSource().toString() + " is not implemented yet.");


### PR DESCRIPTION
In the xml config it says "teleportedModeParameters", in the code "ModeRoutingParams".  Adapting the code towards the xml config.  For the time being, the code provides the consistently named classes/methods _in addition_ to the existing ones, and sets the existing ones to deprecated.

Also, while cleaning up, disabling the old fallback parameters for a bushwhacking leg.  Now need to be explicitly defined.  I tried to provide a sufficiently expressive error message.