### PR TITLE
Add service highway type to osm reader

### DIFF
--- a/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/LinkProperties.java
+++ b/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/LinkProperties.java
@@ -115,7 +115,7 @@ public class LinkProperties {
 	}
 
 	static LinkProperties createService() {
-		return new LinkProperties(LEVEL_RESIDENTIAL, 1, 15 / 3.6, 600, false);
+		return new LinkProperties(LEVEL_LIVING_STREET, 1, 15 / 3.6, 600, false);
 	}
 
 	static LinkProperties createLivingStreet() {

--- a/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/LinkProperties.java
+++ b/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/LinkProperties.java
@@ -114,6 +114,10 @@ public class LinkProperties {
         return new LinkProperties(LEVEL_RESIDENTIAL, 1, 15 / 3.6, 600, false);
 	}
 
+	static LinkProperties createService() {
+		return new LinkProperties(LEVEL_RESIDENTIAL, 1, 15 / 3.6, 600, false);
+	}
+
 	static LinkProperties createLivingStreet() {
         return new LinkProperties(LEVEL_LIVING_STREET, 1, 10 / 3.6, 300, false);
 	}
@@ -135,6 +139,7 @@ public class LinkProperties {
 		result.put(OsmTags.TERTIARY_LINK, createTertiaryLink());
 		result.put(OsmTags.UNCLASSIFIED, createUnclassified());
 		result.put(OsmTags.RESIDENTIAL, createResidential());
+		result.put(OsmTags.SERVICE, createService());
 		result.put(OsmTags.LIVING_STREET, createLivingStreet());
 		return result;
 	}


### PR DESCRIPTION
Service roads can be quite important in a fine-grained network. i.e, small streets to parking lots, possibly even with bus stops.