### PR TITLE
Fix class cast

### DIFF
--- a/matsim/src/main/java/org/matsim/core/network/NetworkUtils.java
+++ b/matsim/src/main/java/org/matsim/core/network/NetworkUtils.java
@@ -650,7 +650,8 @@ public final class NetworkUtils {
 //		} else {
 //			throw new RuntimeException("wrong implementation of Link interface do getOrigId" ) ;
 //		}
-		return link.getAttributes().getAttribute(ORIGID).toString();
+		Object o = link.getAttributes().getAttribute(ORIGID);
+		return o == null ? null : o.toString();
 	}
 
 	public static void setOrigId( Link link, String id ) {

--- a/matsim/src/main/java/org/matsim/core/network/NetworkUtils.java
+++ b/matsim/src/main/java/org/matsim/core/network/NetworkUtils.java
@@ -650,7 +650,7 @@ public final class NetworkUtils {
 //		} else {
 //			throw new RuntimeException("wrong implementation of Link interface do getOrigId" ) ;
 //		}
-		return (String) link.getAttributes().getAttribute(ORIGID);
+		return link.getAttributes().getAttribute(ORIGID).toString();
 	}
 
 	public static void setOrigId( Link link, String id ) {


### PR DESCRIPTION
Some network converters store the original OSM Id as a String, and others as a Long. If the network used used a Long, then a ClassCastException was thrown. This pull request will (hopefully) fix that by changing the conversion to a String.