### PR TITLE
make 13.x workflows consistent with those on master

### DIFF
--- a/.github/workflows/deploy-on-pr-merge.yaml
+++ b/.github/workflows/deploy-on-pr-merge.yaml
@@ -45,11 +45,11 @@ jobs:
 
       # Build and publish are separated so we start deploying only after all jars are built successfully
       - name: Build jars
-        run: mvn package --batch-mode -DskipTests
+        run: mvn package --batch-mode -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests
 
       - name: Publish jars to matsim maven repo
         # fail at end to deploy as many jars as possible
-        run: mvn deploy --batch-mode --fail-at-end -DskipTests -Dmaven.resources.skip=true -Dmaven.install.skip=true
+        run: mvn deploy --batch-mode --fail-at-end -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests -Dmaven.resources.skip=true -Dmaven.install.skip=true
         env:
           MAVEN_USERNAME: ${{ secrets.REPOMATSIM_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.REPOMATSIM_TOKEN }}

--- a/.github/workflows/deploy-on-release-created.yaml
+++ b/.github/workflows/deploy-on-release-created.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Publish jars to matsim maven repo
         # fail at end to deploy as many jars as possible
-        run: mvn deploy --batch-mode --fail-at-end -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests
+        run: mvn deploy --batch-mode --fail-at-end -DskipTests -Dmaven.resources.skip=true -Dmaven.install.skip=true
         env:
           MAVEN_USERNAME: ${{ secrets.REPOMATSIM_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.REPOMATSIM_TOKEN }}

--- a/.github/workflows/deploy-on-release-created.yaml
+++ b/.github/workflows/deploy-on-release-created.yaml
@@ -35,11 +35,11 @@ jobs:
 
       # Build and publish are separated so we start deploying only after all jars are built successfully
       - name: Build jars
-        run: mvn -pl -distribution package --batch-mode -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests
+        run: mvn package --batch-mode -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests
 
-      - name: Publish jars to GitHub Packages
+      - name: Publish jars to matsim maven repo
         # fail at end to deploy as many jars as possible
-        run: mvn -pl -distribution deploy --batch-mode --fail-at-end -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests
+        run: mvn deploy --batch-mode --fail-at-end -Dmaven.javadoc.skip -Dassembly.skipAssembly=true -DskipTests
         env:
           MAVEN_USERNAME: ${{ secrets.REPOMATSIM_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.REPOMATSIM_TOKEN }}


### PR DESCRIPTION
I noticed that javadoc is unnecessarily created for each PR-labelled version on 13.x.

Because the `pom.xml` files have changed on master after stemming out 13.x (e.g. a release profile was added), to keep master and 13.x builds behaving in the same way as master builds, we need little adjustments to the workflows on 13.x.