### PR TITLE
DVRP: Switch to speedy routers

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SingleInsertionDetourPathCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SingleInsertionDetourPathCalculator.java
@@ -42,7 +42,7 @@ import org.matsim.contrib.dvrp.path.VrpPaths;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.core.mobsim.framework.events.MobsimBeforeCleanupEvent;
 import org.matsim.core.mobsim.framework.listeners.MobsimBeforeCleanupListener;
-import org.matsim.core.router.FastAStarLandmarksFactory;
+import org.matsim.core.router.speedy.SpeedyALTFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.LeastCostPathCalculator.Path;
 import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
@@ -72,7 +72,7 @@ public class SingleInsertionDetourPathCalculator implements DetourPathCalculator
 			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, TravelDisutility travelDisutility,
 			DrtConfigGroup drtCfg) {
 		this(network, travelTime, travelDisutility, drtCfg.getNumberOfThreads(),
-				new FastAStarLandmarksFactory(drtCfg.getNumberOfThreads()));
+				new SpeedyALTFactory());
 	}
 
 	@VisibleForTesting

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DefaultDrtRouteUpdater.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DefaultDrtRouteUpdater.java
@@ -33,8 +33,8 @@ import org.matsim.core.controler.events.ReplanningEvent;
 import org.matsim.core.controler.events.ShutdownEvent;
 import org.matsim.core.controler.listener.ShutdownListener;
 import org.matsim.core.population.routes.RouteFactories;
-import org.matsim.core.router.FastAStarEuclideanFactory;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
+import org.matsim.core.router.speedy.SpeedyALTFactory;
 import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
 import org.matsim.core.router.util.TravelTime;
 
@@ -58,9 +58,7 @@ public class DefaultDrtRouteUpdater implements ShutdownListener, DrtRouteUpdater
 		this.network = network;
 		this.population = population;
 
-		// Euclidean with overdoFactor > 1.0 could lead to 'experiencedTT < unsharedRideTT',
-		// while the benefit would be a marginal reduction of computation time ==> so stick to 1.0
-		LeastCostPathCalculatorFactory factory = new FastAStarEuclideanFactory();
+		LeastCostPathCalculatorFactory factory = new SpeedyALTFactory();
 		// XXX uses the global.numberOfThreads, not drt.numberOfThreads, as this is executed in the replanning phase
 		executorService = new ExecutorServiceWithResource<>(IntStream.range(0, config.global().getNumberOfThreads())
 				.mapToObj(i -> new DrtRouteCreator(drtCfg, network, factory, travelTime, travelDisutilityFactory))
@@ -80,7 +78,8 @@ public class DefaultDrtRouteUpdater implements ShutdownListener, DrtRouteUpdater
 		Link fromLink = network.getLinks().get(drtLeg.getRoute().getStartLinkId());
 		Link toLink = network.getLinks().get(drtLeg.getRoute().getEndLinkId());
 		RouteFactories routeFactories = population.getFactory().getRouteFactories();
-		drtLeg.setRoute(drtRouteCreator.createRoute(drtLeg.getDepartureTime().seconds(), fromLink, toLink, routeFactories));
+		drtLeg.setRoute(
+				drtRouteCreator.createRoute(drtLeg.getDepartureTime().seconds(), fromLink, toLink, routeFactories));
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -63,9 +63,9 @@ import org.matsim.contrib.dvrp.run.ModalProviders;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
-import org.matsim.core.router.FastAStarLandmarksFactory;
 import org.matsim.core.router.RoutingModule;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
+import org.matsim.core.router.speedy.SpeedyALTFactory;
 import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.scenario.ScenarioUtils;
@@ -138,7 +138,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 					.asEagerSingleton();
 		}
 
-		bindModal(DrtRouteUpdater.class).toProvider(new ModalProviders.AbstractProvider<>(getMode()) {
+		bindModal(DrtRouteUpdater.class).toProvider(new ModalProviders.AbstractProvider<DrtRouteUpdater>(getMode()) {
 			@Inject
 			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
 			private TravelTime travelTime;
@@ -183,7 +183,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 		private DrtRouteCreatorProvider(DrtConfigGroup drtCfg) {
 			super(drtCfg.getMode());
 			this.drtCfg = drtCfg;
-			leastCostPathCalculatorFactory = new FastAStarLandmarksFactory(drtCfg.getNumberOfThreads());
+			leastCostPathCalculatorFactory = new SpeedyALTFactory();
 		}
 
 		@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/EmptyVehicleRelocator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/EmptyVehicleRelocator.java
@@ -32,7 +32,7 @@ import org.matsim.contrib.dvrp.path.VrpPaths;
 import org.matsim.contrib.dvrp.schedule.Schedule;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.core.mobsim.framework.MobsimTimer;
-import org.matsim.core.router.FastAStarEuclideanFactory;
+import org.matsim.core.router.speedy.SpeedyALTFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
@@ -55,7 +55,7 @@ public class EmptyVehicleRelocator {
 		this.travelTime = travelTime;
 		this.timer = timer;
 		this.taskFactory = taskFactory;
-		router = new FastAStarEuclideanFactory().createPathCalculator(network, travelDisutility, travelTime);
+		router = new SpeedyALTFactory().createPathCalculator(network, travelDisutility, travelTime);
 	}
 
 	public void relocateVehicle(DvrpVehicle vehicle, Link link) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/DrtRoutingModuleTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/DrtRoutingModuleTest.java
@@ -47,8 +47,8 @@ import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.network.io.MatsimNetworkReader;
 import org.matsim.core.population.routes.GenericRouteImpl;
-import org.matsim.core.router.FastAStarEuclideanFactory;
 import org.matsim.core.router.TeleportationRoutingModule;
+import org.matsim.core.router.speedy.SpeedyDijkstraFactory;
 import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
 import org.matsim.core.utils.collections.QuadTrees;
 import org.matsim.facilities.ActivityFacilities;
@@ -91,7 +91,7 @@ public class DrtRoutingModuleTest {
 		AccessEgressFacilityFinder stopFinder = new ClosestAccessEgressFacilityFinder(drtCfg.getMaxWalkDistance(),
 				scenario.getNetwork(), QuadTrees.createQuadTree(drtStops.values()));
 		DrtRouteCreator drtRouteCreator = new DrtRouteCreator(drtCfg, scenario.getNetwork(),
-				new FastAStarEuclideanFactory(), new FreeSpeedTravelTime(), TimeAsTravelDisutility::new);
+				new SpeedyDijkstraFactory(), new FreeSpeedTravelTime(), TimeAsTravelDisutility::new);
 		DefaultMainLegRouter mainRouter = new DefaultMainLegRouter(drtMode, scenario.getNetwork(),
 				scenario.getPopulation().getFactory(), drtRouteCreator);
 		DvrpRoutingModule dvrpRoutingModule = new DvrpRoutingModule(mainRouter, walkRouter, walkRouter, stopFinder,

--- a/contribs/dvrp/pom.xml
+++ b/contribs/dvrp/pom.xml
@@ -37,16 +37,6 @@
 			<version>14.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
-			<groupId>org.matsim.contrib</groupId>
-			<artifactId>locationchoice</artifactId>
-			<version>14.0-SNAPSHOT</version>
-		</dependency>
-		<dependency>
-			<groupId>org.matsim.contrib</groupId>
-			<artifactId>sbb-extensions</artifactId>
-			<version>14.0-SNAPSHOT</version>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-math3</artifactId>
 		</dependency>

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxi/OneTaxiModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxi/OneTaxiModule.java
@@ -38,8 +38,8 @@ import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpModes;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentSourceQSimModule;
-import org.matsim.core.router.AStarEuclideanFactory;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
+import org.matsim.core.router.speedy.SpeedyDijkstraFactory;
 
 import com.google.inject.Singleton;
 
@@ -61,7 +61,7 @@ public class OneTaxiModule extends AbstractDvrpModeModule {
 		DvrpModes.registerDvrpMode(binder(), getMode());
 		install(new DvrpModeRoutingNetworkModule(getMode(), false));
 
-		install(new DvrpModeRoutingModule(getMode(), new AStarEuclideanFactory()));
+		install(new DvrpModeRoutingModule(getMode(), new SpeedyDijkstraFactory()));
 		bindModal(TravelDisutilityFactory.class).toInstance(TimeAsTravelDisutility::new);
 
 		install(new FleetModule(getMode(), fleetSpecificationUrl));

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxi/OneTaxiOptimizer.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxi/OneTaxiOptimizer.java
@@ -41,7 +41,7 @@ import org.matsim.contrib.dvrp.schedule.StayTask;
 import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.framework.MobsimTimer;
-import org.matsim.core.router.DijkstraFactory;
+import org.matsim.core.router.speedy.SpeedyDijkstraFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
@@ -73,7 +73,7 @@ public final class OneTaxiOptimizer implements VrpOptimizer {
 		this.eventsManager = eventsManager;
 		this.timer = timer;
 		travelTime = new FreeSpeedTravelTime();
-		router = new DijkstraFactory().createPathCalculator(network, new TimeAsTravelDisutility(travelTime),
+		router = new SpeedyDijkstraFactory().createPathCalculator(network, new TimeAsTravelDisutility(travelTime),
 				travelTime);
 
 		vehicle = fleet.getVehicles().values().iterator().next();

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/OneTruckOptimizer.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/OneTruckOptimizer.java
@@ -39,7 +39,7 @@ import org.matsim.contrib.dvrp.schedule.Schedules;
 import org.matsim.contrib.dvrp.schedule.StayTask;
 import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.core.mobsim.framework.MobsimTimer;
-import org.matsim.core.router.DijkstraFactory;
+import org.matsim.core.router.speedy.SpeedyDijkstraFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
@@ -69,7 +69,7 @@ final class OneTruckOptimizer implements VrpOptimizer {
 			MobsimTimer timer) {
 		this.timer = timer;
 		travelTime = new FreeSpeedTravelTime();
-		router = new DijkstraFactory().createPathCalculator(network, new TimeAsTravelDisutility(travelTime),
+		router = new SpeedyDijkstraFactory().createPathCalculator(network, new TimeAsTravelDisutility(travelTime),
 				travelTime);
 
 		vehicle = fleet.getVehicles().values().iterator().next();

--- a/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingsearch/sim/SetupParking.java
+++ b/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingsearch/sim/SetupParking.java
@@ -42,8 +42,8 @@ import org.matsim.core.controler.Controler;
 import org.matsim.core.mobsim.qsim.PopulationModule;
 import org.matsim.core.mobsim.qsim.components.QSimComponentsConfig;
 import org.matsim.core.mobsim.qsim.components.StandardQSimComponentConfigurator;
-import org.matsim.core.router.AStarEuclideanFactory;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
+import org.matsim.core.router.speedy.SpeedyALTFactory;
 
 import com.google.inject.Key;
 import com.google.inject.name.Names;
@@ -70,7 +70,7 @@ public class SetupParking {
 						.toInstance(TimeAsTravelDisutility::new);
 				bind(Network.class).annotatedWith(DvrpModes.mode(TransportMode.car))
 						.to(Key.get(Network.class, Names.named(DvrpGlobalRoutingNetworkProvider.DVRP_ROUTING)));
-				install(new DvrpModeRoutingModule(TransportMode.car, new AStarEuclideanFactory()));
+				install(new DvrpModeRoutingModule(TransportMode.car, new SpeedyALTFactory()));
 				bind(Network.class).annotatedWith(Names.named(DvrpGlobalRoutingNetworkProvider.DVRP_ROUTING))
 						.to(Network.class)
 						.asEagerSingleton();

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/ETaxiOptimizerProvider.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/ETaxiOptimizerProvider.java
@@ -41,7 +41,7 @@ import org.matsim.contrib.zone.SquareGridSystem;
 import org.matsim.contrib.zone.ZonalSystem;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.framework.MobsimTimer;
-import org.matsim.core.router.FastAStarEuclideanFactory;
+import org.matsim.core.router.speedy.SpeedyALTFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
@@ -92,8 +92,8 @@ public class ETaxiOptimizerProvider implements Provider<TaxiOptimizer> {
 			return new RuleBasedETaxiOptimizer(eventsManager, taxiCfg, fleet, eScheduler, scheduleTimingUpdater,
 					chargingInfrastructure, zonalRegisters, dispatchFinder, requestInserter);
 		} else if (type.equals(AssignmentETaxiOptimizerParams.SET_NAME)) {
-			LeastCostPathCalculator router = new FastAStarEuclideanFactory().createPathCalculator(network,
-					travelDisutility, travelTime);
+			LeastCostPathCalculator router = new SpeedyALTFactory().createPathCalculator(network, travelDisutility,
+					travelTime);
 			return new AssignmentETaxiOptimizer(eventsManager, taxiCfg, fleet, timer, network, travelTime,
 					travelDisutility, eScheduler, scheduleTimingUpdater, chargingInfrastructure, router);
 		} else {

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/ETaxiModeQSimModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/ETaxiModeQSimModule.java
@@ -51,8 +51,8 @@ import org.matsim.contrib.taxi.vrpagent.TaxiActionCreator;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.controler.MatsimServices;
 import org.matsim.core.mobsim.framework.MobsimTimer;
-import org.matsim.core.router.FastAStarLandmarksFactory;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
+import org.matsim.core.router.speedy.SpeedyALTFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
@@ -118,8 +118,8 @@ public class ETaxiModeQSimModule extends AbstractDvrpModeQSimModule {
 				Network network = getModalInstance(Network.class);
 				TravelDisutility travelDisutility = getModalInstance(
 						TravelDisutilityFactory.class).createTravelDisutility(travelTime);
-				LeastCostPathCalculator router = new FastAStarLandmarksFactory(
-						getConfig().global()).createPathCalculator(network, travelDisutility, travelTime);
+				LeastCostPathCalculator router = new SpeedyALTFactory().createPathCalculator(network, travelDisutility,
+						travelTime);
 				return new ETaxiScheduler(taxiCfg, fleet, taxiScheduleInquiry, travelTime, router);
 			}
 		}).asEagerSingleton();

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/assignment/AssignmentRequestInserter.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/assignment/AssignmentRequestInserter.java
@@ -30,7 +30,7 @@ import org.matsim.contrib.taxi.optimizer.assignment.VehicleAssignmentProblem.Ass
 import org.matsim.contrib.taxi.passenger.TaxiRequest;
 import org.matsim.contrib.taxi.scheduler.TaxiScheduler;
 import org.matsim.core.mobsim.framework.MobsimTimer;
-import org.matsim.core.router.FastAStarEuclideanFactory;
+import org.matsim.core.router.speedy.SpeedyALTFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
@@ -50,7 +50,7 @@ public class AssignmentRequestInserter implements UnplannedRequestInserter {
 	public AssignmentRequestInserter(Fleet fleet, Network network, MobsimTimer timer, TravelTime travelTime,
 			TravelDisutility travelDisutility, TaxiScheduler scheduler, AssignmentTaxiOptimizerParams params) {
 		this(fleet, timer, network, travelTime, travelDisutility, scheduler, params,
-				new FastAStarEuclideanFactory().createPathCalculator(network, travelDisutility, travelTime));
+				new SpeedyALTFactory().createPathCalculator(network, travelDisutility, travelTime));
 	}
 
 	public AssignmentRequestInserter(Fleet fleet, MobsimTimer timer, Network network, TravelTime travelTime,

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/assignment/VehicleAssignmentProblem.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/assignment/VehicleAssignmentProblem.java
@@ -63,7 +63,7 @@ public class VehicleAssignmentProblem<D> {
 	private AssignmentDestinationData<D> dData;
 
 	public VehicleAssignmentProblem(Network network, TravelTime travelTime, TravelDisutility travelDisutility) {
-		// we do not need Euclidean router when there is no kNN filtering
+		// we do not need router when there is no kNN filtering
 		this(network, travelTime, travelDisutility, null, -1, -1);
 	}
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeModule.java
@@ -32,8 +32,8 @@ import org.matsim.contrib.taxi.fare.TaxiFareHandler;
 import org.matsim.contrib.taxi.util.stats.TaxiStatsDumper;
 import org.matsim.core.controler.IterationCounter;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
-import org.matsim.core.router.FastAStarLandmarksFactory;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
+import org.matsim.core.router.speedy.SpeedyALTFactory;
 
 /**
  * @author michalm
@@ -53,7 +53,7 @@ public final class TaxiModeModule extends AbstractDvrpModeModule {
 		install(new DvrpModeRoutingNetworkModule(getMode(), taxiCfg.isUseModeFilteredSubnetwork()));
 		bindModal(TravelDisutilityFactory.class).toInstance(TimeAsTravelDisutility::new);
 
-		install(new DvrpModeRoutingModule(getMode(), new FastAStarLandmarksFactory(getConfig().global())));
+		install(new DvrpModeRoutingModule(getMode(), new SpeedyALTFactory()));
 
 		install(new FleetModule(getMode(), taxiCfg.getTaxisFileUrl(getConfig().getContext()),
 				taxiCfg.isChangeStartLinkToLastLinkInSchedule()));

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeQSimModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeQSimModule.java
@@ -48,8 +48,8 @@ import org.matsim.contrib.taxi.vrpagent.TaxiActionCreator;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.controler.MatsimServices;
 import org.matsim.core.mobsim.framework.MobsimTimer;
-import org.matsim.core.router.FastAStarLandmarksFactory;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
+import org.matsim.core.router.speedy.SpeedyALTFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
@@ -113,8 +113,8 @@ public class TaxiModeQSimModule extends AbstractDvrpModeQSimModule {
 				Network network = getModalInstance(Network.class);
 				TravelDisutility travelDisutility = getModalInstance(
 						TravelDisutilityFactory.class).createTravelDisutility(travelTime);
-				LeastCostPathCalculator router = new FastAStarLandmarksFactory(
-						getConfig().global()).createPathCalculator(network, travelDisutility, travelTime);
+				LeastCostPathCalculator router = new SpeedyALTFactory().createPathCalculator(network, travelDisutility,
+						travelTime);
 				return new TaxiScheduler(taxiCfg, fleet, taxiScheduleInquiry, travelTime, router);
 			}
 		}).asEagerSingleton();


### PR DESCRIPTION
Only `BestDispatchFinder` (in taxi) still uses the old "fast" multi-node Dijkstra. Migrating from "fast" to "speedy" will be handled in a separate PR.