### PR TITLE
add field "reference" to PersonMoneyEvent.java

### DIFF
--- a/matsim/src/main/java/org/matsim/api/core/v01/events/PersonMoneyEvent.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/PersonMoneyEvent.java
@@ -41,11 +41,13 @@ public final class PersonMoneyEvent extends Event implements HasPersonId {
 	public static final String ATTRIBUTE_AMOUNT = "amount";
 	public static final String ATTRIBUTE_PURPOSE = "purpose";
 	public static final String ATTRIBUTE_TRANSACTION_PARTNER = "transactionPartner";
+	public static final String ATTRIBUTE_REFERENCE = "reference";
 
 	private final Id<Person> personId;
 	private final double amount;
 	private final String purpose;
 	private final String transactionPartner;
+	private final String reference;
 
 	/**
 	 * Creates a new event describing that the given <tt>agent</tt> has <em>gained</em>
@@ -62,21 +64,32 @@ public final class PersonMoneyEvent extends Event implements HasPersonId {
 	 * @param amount
 	 * @param purpose (not required by dtd)
 	 * @param transactionPartner (not required by dtd)
+	 * @param reference (not required by dtd)
 	 */
 	public PersonMoneyEvent(final double time, final Id<Person> agentId, final double amount, final String purpose,
-				final String transactionPartner) {
+				final String transactionPartner, final String reference) {
 		super(time);
 		this.personId = agentId;
 		this.amount = amount;
 		this.purpose = purpose;
 		this.transactionPartner = transactionPartner;
+		this.reference = reference;
 	}
 	/**
-	 * @deprecated -- add "purpose" and "transactionPartner"
+	 * @deprecated -- add "purpose" and "transactionPartner" and "reference"
 	 */
-	@Deprecated // add "purpose" and "transactionPartner"
+	@Deprecated // add "purpose" and "transactionPartner" and "reference"
 	public PersonMoneyEvent(final double time, final Id<Person> agentId, final double amount) {
-		this( time, agentId, amount, null, null);
+		this( time, agentId, amount, null, null, null);
+	}
+
+	/**
+	 * @deprecated -- add "reference"
+	 */
+	@Deprecated // add "purpose" and "transactionPartner" and "reference"
+	public PersonMoneyEvent(final double time, final Id<Person> agentId, final double amount, final String purpose,
+							final String transactionPartner) {
+		this( time, agentId, amount, purpose, transactionPartner, null);
 	}
 
 	public Id<Person> getPersonId() {
@@ -95,6 +108,10 @@ public final class PersonMoneyEvent extends Event implements HasPersonId {
 		return this.transactionPartner;
 	}
 
+	public String getReference() {
+		return this.reference;
+	}
+
 	@Override
 	public String getEventType() {
 		return EVENT_TYPE;
@@ -110,6 +127,9 @@ public final class PersonMoneyEvent extends Event implements HasPersonId {
 		}
 		if (this.transactionPartner != null) {
 			attr.put(ATTRIBUTE_TRANSACTION_PARTNER, this.transactionPartner);
+		}
+		if (this.reference != null) {
+			attr.put(ATTRIBUTE_REFERENCE, this.reference);
 		}
 		return attr;
 	}

--- a/matsim/src/main/java/org/matsim/api/core/v01/events/PersonMoneyEvent.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/PersonMoneyEvent.java
@@ -86,7 +86,7 @@ public final class PersonMoneyEvent extends Event implements HasPersonId {
 	/**
 	 * @deprecated -- add "reference"
 	 */
-	@Deprecated // add "purpose" and "transactionPartner" and "reference"
+	@Deprecated // add "reference"
 	public PersonMoneyEvent(final double time, final Id<Person> agentId, final double amount, final String purpose,
 							final String transactionPartner) {
 		this( time, agentId, amount, purpose, transactionPartner, null);


### PR DESCRIPTION
The idea is to help associating the PersonMoneyEvent with when and where it occurred. Recently introduced "purpose" and "transactionPartner" are helpful to categorize PersonMoneyEvents, but are not sufficient to e.g. associate a drt fare PersonMoneyEvent to the drt leg respectively the drt request id the fare had to be paid for. Right now only the event time can sometimes help, but some fare systems have daily fares or deduct the fare only at the end of the day which makes association very hard. It can also help to differentiate between a daily drt subscription fare and a drt fare related to a certain drt leg. Similar use cases seem plausible for car tolls (e.g. purpose="toll", transactionPartner="Berlin_city_center_cordon_toll", reference="entry_07:38:20") or pt fares (e.g. purpose="ptFare", transactionPartner="Flextrain", reference="train123_stop234_to_stop345"). Like "purpose" and "transactionPartner" it would be to some extend a free text field which is only relevant to analysis for now.