### PR TITLE
set vehicleId in NetworkRoute

### DIFF
--- a/matsim/src/main/java/org/matsim/core/router/NetworkRoutingInclAccessEgressModule.java
+++ b/matsim/src/main/java/org/matsim/core/router/NetworkRoutingInclAccessEgressModule.java
@@ -398,6 +398,7 @@ public final class NetworkRoutingInclAccessEgressModule implements RoutingModule
 			route.setTravelTime((int) path.travelTime);
 			route.setTravelCost(path.travelCost);
 			route.setDistance(RouteUtils.calcDistance(route, 1.0, 1.0, this.filteredNetwork));
+			route.setVehicleId(vehicleId);
 			leg.setRoute(route);
 			travTime = (int) path.travelTime;
 

--- a/matsim/src/main/java/org/matsim/core/router/NetworkRoutingModule.java
+++ b/matsim/src/main/java/org/matsim/core/router/NetworkRoutingModule.java
@@ -21,6 +21,7 @@ package org.matsim.core.router;
 import java.util.Arrays;
 import java.util.List;
 
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
@@ -35,6 +36,8 @@ import org.matsim.core.population.routes.RouteUtils;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.LeastCostPathCalculator.Path;
 import org.matsim.facilities.Facility;
+import org.matsim.vehicles.Vehicle;
+import org.matsim.vehicles.VehicleUtils;
 
 /**
  * This wraps a "computer science" {@link LeastCostPathCalculator}, which routes from a node to another node, into something that
@@ -92,6 +95,12 @@ public final class NetworkRoutingModule implements RoutingModule {
 			// (a "true" route)
 			Node startNode = fromLink.getToNode(); // start at the end of the "current" link
 			Node endNode = toLink.getFromNode(); // the target is the start of the link
+
+			/* The NetworkInclAccessEgressModule actually looks up the vehicle in the scenario and passes it to the routeAlgo as well as to the resulting route.
+			 * Here, we do not hold the scenario as a field (yet) and can not perform the lookup.
+			 * So i don't add it here (yet), in order not to break anything. But probably should be done in future.
+			 * ts, june '21
+			 */
 			Path path = this.routeAlgo.calcLeastCostPath(startNode, endNode, departureTime, person, null);
 			if (path == null)
 				throw new RuntimeException("No route found from node " + startNode.getId() + " to node " + endNode.getId() + " by mode " + this.mode + ".");


### PR DESCRIPTION
NetworkInclAccessEgressModule actually looks up the vehicle in the Scenario and passes it to router but then does not set it in the NetworkRoute. I am not sure if this is on purpose, but i suppose it is not. This is actually a problem for modes other than 'car', when later on the vehicleId can not be retrieved from the route and no vehicle can be parked/unparked in the qsim. See also [this issue in matsim-sharing](https://github.com/eqasim-org/matsim-sharing/issues/5). I see no good reason why not to set the vehicleId, please let me know if you have one.