### PR TITLE
allow for setting arrivalOffset and departureOffset as OptionalTime in TransitRouteStop

### DIFF
--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitRouteStopImpl.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitRouteStopImpl.java
@@ -147,6 +147,16 @@ public class TransitRouteStopImpl implements TransitRouteStop {
 			return this;
 		}
 
+		public Builder departureOffset(OptionalTime val) {
+			departureOffset = val;
+			return this;
+		}
+
+		public Builder arrivalOffset(OptionalTime val) {
+			arrivalOffset = val;
+			return this;
+		}
+
 		public Builder awaitDepartureTime(boolean val) {
 			awaitDepartureTime = val;
 			return this;

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleFactoryImpl.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleFactoryImpl.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.core.population.routes.NetworkRoute;
+import org.matsim.core.utils.misc.OptionalTime;
 import org.matsim.pt.transitSchedule.api.Departure;
 import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
@@ -49,6 +50,11 @@ public class TransitScheduleFactoryImpl implements TransitScheduleFactory {
 
 	@Override
 	public TransitRouteStop createTransitRouteStop(final TransitStopFacility stop, final double arrivalDelay, final double departureDelay) {
+		return new TransitRouteStopImpl.Builder().stop(stop).arrivalOffset(arrivalDelay).departureOffset(departureDelay).build();
+	}
+
+	@Override
+	public TransitRouteStop createTransitRouteStop(final TransitStopFacility stop, final OptionalTime arrivalDelay, final OptionalTime departureDelay) {
 		return new TransitRouteStopImpl.Builder().stop(stop).arrivalOffset(arrivalDelay).departureOffset(departureDelay).build();
 	}
 

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/api/TransitScheduleFactory.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/api/TransitScheduleFactory.java
@@ -26,6 +26,7 @@ import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.core.api.internal.MatsimFactory;
 import org.matsim.core.population.routes.NetworkRoute;
+import org.matsim.core.utils.misc.OptionalTime;
 
 /**
  * @author mrieser
@@ -39,6 +40,8 @@ public interface TransitScheduleFactory extends MatsimFactory {
 	public abstract TransitRoute createTransitRoute(final Id<TransitRoute> routeId, final NetworkRoute route, final List<TransitRouteStop> stops, final String mode);
 
 	public abstract TransitRouteStop createTransitRouteStop(final TransitStopFacility stop, final double arrivalDelay, final double departureDelay);
+
+	public abstract TransitRouteStop createTransitRouteStop(final TransitStopFacility stop, final OptionalTime arrivalDelay, final OptionalTime departureDelay);
 
 	public abstract TransitRouteStop.Builder<?> createTransitRouteStopBuilder(final TransitStopFacility stop);
 


### PR DESCRIPTION
the variable type is already OptionalTime, but there is no setter accepting OptionalTime, only double. At first glance this might introduce more issues with TransitRouteStops having an undefined arrival or departure offset, but the public builder of TransitRouteStopImpl already sets those to OptionalTime.undefinedTime() by default and they remain undefined if the arrivalOffset setter of the builder is not called. Defined times for all but the first stop's arrival and the last stop's departure should be checked somewhere else, possibly during simulation startup.