### PR TITLE
Bump "applicaiton" to matsim-analysis v3.3

### DIFF
--- a/contribs/application/pom.xml
+++ b/contribs/application/pom.xml
@@ -72,8 +72,7 @@
 		<dependency>
 			<groupId>com.github.matsim-vsp</groupId>
 			<artifactId>matsim-analysis</artifactId>
-			<!-- <version>v2.5</version> -->
-			<version>v3.2</version>
+			<version>v3.3</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.geotools</groupId>

--- a/contribs/application/pom.xml
+++ b/contribs/application/pom.xml
@@ -82,6 +82,10 @@
 					<groupId>org.matsim</groupId>
 					<artifactId>*</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.matsim.contrib</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 


### PR DESCRIPTION
v3.2 depends on 13.0-SNAPSHOT that is not in our mvn repo, which causes some minor build issues of different kinds. v3.3 depends on 14-PR1597.

This PR is submitted from a fork in order to test this path after fixing #1591