### PR TITLE
3 ways of creating an EV fleet specification

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/EvConfigGroup.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/EvConfigGroup.java
@@ -19,12 +19,14 @@
 
 package org.matsim.contrib.ev;
 
-import org.matsim.core.config.Config;
-import org.matsim.core.config.ReflectiveConfigGroup;
+import java.util.Map;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
-import java.util.Map;
+
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ReflectiveConfigGroup;
 
 public final class EvConfigGroup extends ReflectiveConfigGroup {
 	public static final String GROUP_NAME = "ev";
@@ -48,12 +50,13 @@ public final class EvConfigGroup extends ReflectiveConfigGroup {
 	static final String CHARGERS_FILE_EXP = "Location of the chargers file";
 
 	public static final String VEHICLES_FILE = "vehiclesFile";
-	static final String VEHICLES_FILE_EXP = "Location of the vehicles file";
+	static final String VEHICLES_FILE_EXP = "Location of the vehicles file."
+			+ " If not provided, the vehicle specifications will be created from matsim vehicle file or provided via a custom binding."
+			+ " See ElectricFleetModule.";
 
 	// output
 	public static final String TIME_PROFILES = "timeProfiles";
 	static final String TIME_PROFILES_EXP = "If true, SOC time profile plots will be created";
-
 
 	// no need to simulate with 1-second time step
 	@Positive
@@ -68,7 +71,7 @@ public final class EvConfigGroup extends ReflectiveConfigGroup {
 	@NotNull
 	private String chargersFile = null;
 
-	@NotNull
+	@Nullable
 	private String vehiclesFile = null;
 
 	private boolean timeProfiles = false;

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricFleetModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricFleetModule.java
@@ -25,8 +25,10 @@ import org.matsim.contrib.ev.charging.ChargingPower;
 import org.matsim.contrib.ev.discharging.AuxEnergyConsumption;
 import org.matsim.contrib.ev.discharging.DriveEnergyConsumption;
 import org.matsim.core.config.ConfigGroup;
+import org.matsim.core.config.groups.QSimConfigGroup;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
+import org.matsim.vehicles.Vehicles;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -38,14 +40,35 @@ public class ElectricFleetModule extends AbstractModule {
 	@Inject
 	private EvConfigGroup evCfg;
 
+	@Inject
+	private QSimConfigGroup qSimCfg;
+
 	@Override
 	public void install() {
-		bind(ElectricFleetSpecification.class).toProvider(() -> {
-			ElectricFleetSpecification fleetSpecification = new ElectricFleetSpecificationImpl();
-			new ElectricFleetReader(fleetSpecification).parse(
-					ConfigGroup.getInputFileURL(getConfig().getContext(), evCfg.getVehiclesFile()));
-			return fleetSpecification;
-		}).asEagerSingleton();
+		// 3 options:
+		// - vehicle specifications provided in a separate XML file (http://matsim.org/files/dtd/electric_vehicles_v1.dtd)
+		// - vehicle specifications derived from the "standard" matsim vehicles (only if they are read from a file,
+		//     i.e. VehiclesSource.fromVehiclesData)
+		// - vehicle specifications provided via a custom binding for ElectricFleetSpecification
+		if (evCfg.getVehiclesFile() != null) {
+			bind(ElectricFleetSpecification.class).toProvider(() -> {
+				ElectricFleetSpecification fleetSpecification = new ElectricFleetSpecificationImpl();
+				new ElectricFleetReader(fleetSpecification).parse(
+						ConfigGroup.getInputFileURL(getConfig().getContext(), evCfg.getVehiclesFile()));
+				return fleetSpecification;
+			}).asEagerSingleton();
+		} else if (qSimCfg.getVehiclesSource() == QSimConfigGroup.VehiclesSource.fromVehiclesData) {
+			bind(ElectricFleetSpecification.class).toProvider(new Provider<>() {
+				@Inject
+				private Vehicles vehicles;
+
+				@Override
+				public ElectricFleetSpecification get() {
+					return ElectricVehicleSpecificationWithMatsimVehicle.createFleetSpecificationFromMatsimVehicles(
+							vehicles);
+				}
+			}).asEagerSingleton();
+		}
 
 		installQSimModule(new AbstractQSimModule() {
 			@Override

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleSpecification.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleSpecification.java
@@ -20,7 +20,10 @@
 
 package org.matsim.contrib.ev.fleet;
 
+import java.util.Optional;
+
 import org.matsim.api.core.v01.Identifiable;
+import org.matsim.vehicles.Vehicle;
 
 import com.google.common.collect.ImmutableList;
 
@@ -29,6 +32,10 @@ import com.google.common.collect.ImmutableList;
  */
 public interface ElectricVehicleSpecification extends Identifiable<ElectricVehicle> {
 	String DEFAULT_VEHICLE_TYPE = "defaultVehicleType";
+
+	//provided only if the vehicle specification is created from a corresponding standard matsim vehicle
+	//(see ElectricFleetModule)
+	Optional<Vehicle> getMatsimVehicle();
 
 	String getVehicleType();
 

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleSpecificationWithMatsimVehicle.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleSpecificationWithMatsimVehicle.java
@@ -3,7 +3,7 @@
  * project: org.matsim.*
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2019 by the members listed in the COPYING,        *
+ * copyright       : (C) 2021 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -20,51 +20,62 @@
 
 package org.matsim.contrib.ev.fleet;
 
+import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
 
 import org.matsim.api.core.v01.Id;
+import org.matsim.contrib.ev.EvUnits;
 import org.matsim.vehicles.Vehicle;
+import org.matsim.vehicles.VehicleUtils;
+import org.matsim.vehicles.Vehicles;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 
 /**
- * Immutable implementation of ElectricVehicleSpecification
- *
  * @author Michal Maciejewski (michalm)
  */
-public final class ImmutableElectricVehicleSpecification implements ElectricVehicleSpecification {
+public class ElectricVehicleSpecificationWithMatsimVehicle implements ElectricVehicleSpecification {
+	public static final String EV_ENGINE_HBEFA_TECHNOLOGY = "electricity";
+
+		public static final String INITIAL_ENERGY_kWh = "initialEnergyInKWh";
+	public static final String CHARGER_TYPES = "chargerTypes";
+
+	public static ElectricFleetSpecification createFleetSpecificationFromMatsimVehicles(Vehicles vehicles) {
+		ElectricFleetSpecification fleetSpecification = new ElectricFleetSpecificationImpl();
+		vehicles.getVehicles()
+				.values()
+				.stream()
+				.filter(vehicle -> EV_ENGINE_HBEFA_TECHNOLOGY.equals(
+						VehicleUtils.getHbefaTechnology(vehicle.getType().getEngineInformation())))
+				.map(ElectricVehicleSpecificationWithMatsimVehicle::new)
+				.forEach(fleetSpecification::addVehicleSpecification);
+		return fleetSpecification;
+	}
+
 	private final Id<ElectricVehicle> id;
+	private final Vehicle matsimVehicle;// matsim vehicle is mutable!
 	private final String vehicleType;
 	private final ImmutableList<String> chargerTypes;
 	private final double initialSoc;
 	private final double batteryCapacity;
 
-	private ImmutableElectricVehicleSpecification(Builder builder) {
-		id = Objects.requireNonNull(builder.id);
-		vehicleType = Objects.requireNonNull(builder.vehicleType);
-		chargerTypes = Objects.requireNonNull(builder.chargerTypes);
-		initialSoc = Objects.requireNonNull(builder.initialSoc);
-		batteryCapacity = Objects.requireNonNull(builder.batteryCapacity);
+	public ElectricVehicleSpecificationWithMatsimVehicle(Vehicle matsimVehicle) {
+		id = Objects.requireNonNull(Id.create(matsimVehicle.getId(), ElectricVehicle.class));
+		this.matsimVehicle = matsimVehicle;
+		vehicleType = matsimVehicle.getType().getId().toString();
+
+		//provided per vehicle type (in engine info)
+		var engineInfo = matsimVehicle.getType().getEngineInformation();
+		chargerTypes = ImmutableList.copyOf((Collection<String>)engineInfo.getAttributes().getAttribute(CHARGER_TYPES));
+		batteryCapacity = VehicleUtils.getEnergyCapacity(engineInfo) * EvUnits.J_PER_kWh;
+
+		//provided per vehicle
+		initialSoc = (double)matsimVehicle.getAttributes().getAttribute(INITIAL_ENERGY_kWh) * EvUnits.J_PER_kWh;
 
 		if (initialSoc < 0 || initialSoc > batteryCapacity) {
 			throw new IllegalArgumentException("Invalid initialSoc/batteryCapacity of vehicle: " + id);
 		}
-	}
-
-	public static Builder newBuilder() {
-		return new Builder();
-	}
-
-	public static Builder newBuilder(ElectricVehicleSpecification copy) {
-		Builder builder = new Builder();
-		builder.id = copy.getId();
-		builder.vehicleType = copy.getVehicleType();
-		builder.chargerTypes = copy.getChargerTypes();
-		builder.initialSoc = copy.getInitialSoc();
-		builder.batteryCapacity = copy.getBatteryCapacity();
-		return builder;
 	}
 
 	@Override
@@ -74,7 +85,7 @@ public final class ImmutableElectricVehicleSpecification implements ElectricVehi
 
 	@Override
 	public Optional<Vehicle> getMatsimVehicle() {
-		return Optional.empty();
+		return Optional.of(matsimVehicle);
 	}
 
 	@Override
@@ -95,56 +106,5 @@ public final class ImmutableElectricVehicleSpecification implements ElectricVehi
 	@Override
 	public double getBatteryCapacity() {
 		return batteryCapacity;
-	}
-
-	@Override
-	public String toString() {
-		return MoreObjects.toStringHelper(this)
-				.add("id", id)
-				.add("vehicleType", vehicleType)
-				.add("chargerTypes", chargerTypes)
-				.add("initialSoc", initialSoc)
-				.add("batteryCapacity", batteryCapacity)
-				.toString();
-	}
-
-	public static final class Builder {
-		private Id<ElectricVehicle> id;
-		private String vehicleType;
-		private ImmutableList<String> chargerTypes;
-		private Double initialSoc;
-		private Double batteryCapacity;
-
-		private Builder() {
-		}
-
-		public Builder id(Id<ElectricVehicle> val) {
-			id = val;
-			return this;
-		}
-
-		public Builder vehicleType(String val) {
-			vehicleType = val;
-			return this;
-		}
-
-		public Builder chargerTypes(ImmutableList<String> val) {
-			chargerTypes = val;
-			return this;
-		}
-
-		public Builder initialSoc(double val) {
-			initialSoc = val;
-			return this;
-		}
-
-		public Builder batteryCapacity(double val) {
-			batteryCapacity = val;
-			return this;
-		}
-
-		public ImmutableElectricVehicleSpecification build() {
-			return new ImmutableElectricVehicleSpecification(this);
-		}
 	}
 }


### PR DESCRIPTION
Three options:
- from a separate EV file (EV config) -- this is the existing approach
- from the "standard" matsim vehicles (if `QSimConfigGroup.VehiclesSource.fromVehiclesData` is selected)
- via a custom binding (e.g. generated vehicles)