### PR TITLE
Dvrp vehicles from matsim vehicles

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -49,11 +49,11 @@ import org.matsim.contrib.dvrp.run.Modal;
 import org.matsim.contrib.util.ReflectiveConfigGroupWithConfigurableParameterSets;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigGroup;
+import org.matsim.core.config.groups.PlanCalcScoreConfigGroup;
+import org.matsim.core.config.groups.PlansCalcRouteConfigGroup;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
-import org.matsim.core.config.groups.PlanCalcScoreConfigGroup;
-import org.matsim.core.config.groups.PlansCalcRouteConfigGroup;
 
 public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableParameterSets implements Modal {
 	private static final Logger log = Logger.getLogger(DrtConfigGroup.class);
@@ -122,7 +122,10 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 	static final String MAX_WALK_DISTANCE_EXP = "Maximum beeline distance (in meters) to next stop location in stopbased system for access/egress walk leg to/from drt. If no stop can be found within this maximum distance will return null (in most cases caught by fallback routing module).";
 
 	public static final String VEHICLES_FILE = "vehiclesFile";
-	static final String VEHICLES_FILE_EXP = "An XML file specifying the vehicle fleet. The file format according to dvrp_vehicles_v1.dtd";
+	static final String VEHICLES_FILE_EXP = "An XML file specifying the vehicle fleet."
+			+ " The file format according to dvrp_vehicles_v1.dtd"
+			+ " If not provided, the vehicle specifications will be created from matsim vehicle file or provided via a custom binding."
+			+ " See FleetModule.";
 
 	public static final String TRANSIT_STOP_FILE = "transitStopFile";
 	static final String TRANSIT_STOP_FILE_EXP =
@@ -144,7 +147,6 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 
 	public static final String STORE_UNSHARED_PATH = "storeUnsharedPath";
 	static final String STORE_UNSHARED_PATH_EXP = "Store planned unshared drt route as a link sequence";
-
 
 	@NotBlank
 	private String mode = TransportMode.drt; // travel mode (passengers'/customers' perspective)
@@ -676,7 +678,7 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 	 * Convenience method that brings syntax closer to syntax in, e.g., {@link PlansCalcRouteConfigGroup} or {@link PlanCalcScoreConfigGroup}
 	 */
 	public final void addDrtInsertionSearchParams(final DrtInsertionSearchParams pars) {
-		addParameterSet( pars );
+		addParameterSet(pars);
 	}
 
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/DvrpVehicleSpecification.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/DvrpVehicleSpecification.java
@@ -20,9 +20,12 @@
 
 package org.matsim.contrib.dvrp.fleet;
 
+import java.util.Optional;
+
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Identifiable;
 import org.matsim.api.core.v01.network.Link;
+import org.matsim.vehicles.Vehicle;
 
 /**
  * DvrpVehicleSpecification is assumed to be immutable.
@@ -35,6 +38,10 @@ import org.matsim.api.core.v01.network.Link;
  * @author Michal Maciejewski (michalm)
  */
 public interface DvrpVehicleSpecification extends Identifiable<DvrpVehicle> {
+	//provided only if the vehicle specification is created from a corresponding standard matsim vehicle
+	//(see FleetModule)
+	Optional<Vehicle> getMatsimVehicle();
+
 	/**
 	 * @return id of the link where the vehicle stays at the beginning of simulation
 	 */

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/DvrpVehicleSpecificationWithMatsimVehicle.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/DvrpVehicleSpecificationWithMatsimVehicle.java
@@ -1,0 +1,103 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2021 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.dvrp.fleet;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.vehicles.Vehicle;
+import org.matsim.vehicles.Vehicles;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class DvrpVehicleSpecificationWithMatsimVehicle implements DvrpVehicleSpecification {
+
+	public static final String DVRP_MODE = "dvrpMode";
+	public static final String START_LINK = "startLink";
+	public static final String SERVICE_BEGIN_TIME = "serviceBeginTime";
+	public static final String SERVICE_END_TIME = "serviceEndTime";
+
+	public static FleetSpecification createFleetSpecificationFromMatsimVehicles(String mode, Vehicles vehicles) {
+		FleetSpecification fleetSpecification = new FleetSpecificationImpl();
+		vehicles.getVehicles()
+				.values()
+				.stream()
+				.filter(vehicle -> mode.equals(
+						vehicle.getAttributes().getAttribute(DVRP_MODE)))
+				.map(DvrpVehicleSpecificationWithMatsimVehicle::new)
+				.forEach(fleetSpecification::addVehicleSpecification);
+		return fleetSpecification;
+	}
+
+	private final Id<DvrpVehicle> id;
+	private final Vehicle matsimVehicle;// matsim vehicle is mutable!
+	private final Id<Link> startLinkId;
+	private final int capacity;
+
+	// time window
+	private final double serviceBeginTime;
+	private final double serviceEndTime;
+
+	public DvrpVehicleSpecificationWithMatsimVehicle(Vehicle matsimVehicle) {
+		id = Objects.requireNonNull(Id.create(matsimVehicle.getId(), DvrpVehicle.class));
+		this.matsimVehicle = matsimVehicle;
+
+		this.capacity = matsimVehicle.getType().getCapacity().getSeats();
+
+		var attributes = matsimVehicle.getAttributes();
+		this.startLinkId = Objects.requireNonNull(Id.createLinkId((String)attributes.getAttribute(START_LINK)));
+		this.serviceBeginTime = (double)attributes.getAttribute(SERVICE_BEGIN_TIME);
+		this.serviceEndTime = (double)attributes.getAttribute(SERVICE_END_TIME);
+	}
+
+	@Override
+	public Id<DvrpVehicle> getId() {
+		return id;
+	}
+
+	@Override
+	public Optional<Vehicle> getMatsimVehicle() {
+		return Optional.of(matsimVehicle);
+	}
+
+	@Override
+	public Id<Link> getStartLinkId() {
+		return startLinkId;
+	}
+
+	@Override
+	public int getCapacity() {
+		return capacity;
+	}
+
+	@Override
+	public double getServiceBeginTime() {
+		return serviceBeginTime;
+	}
+
+	@Override
+	public double getServiceEndTime() {
+		return serviceEndTime;
+	}
+}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/ImmutableDvrpVehicleSpecification.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/ImmutableDvrpVehicleSpecification.java
@@ -21,9 +21,11 @@
 package org.matsim.contrib.dvrp.fleet;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
+import org.matsim.vehicles.Vehicle;
 
 import com.google.common.base.MoreObjects;
 
@@ -66,6 +68,11 @@ public final class ImmutableDvrpVehicleSpecification implements DvrpVehicleSpeci
 	@Override
 	public Id<DvrpVehicle> getId() {
 		return id;
+	}
+
+	@Override
+	public Optional<Vehicle> getMatsimVehicle() {
+		return Optional.empty();
 	}
 
 	@Override

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricFleetModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricFleetModule.java
@@ -40,9 +40,6 @@ public class ElectricFleetModule extends AbstractModule {
 	@Inject
 	private EvConfigGroup evCfg;
 
-	@Inject
-	private QSimConfigGroup qSimCfg;
-
 	@Override
 	public void install() {
 		// 3 options:
@@ -57,7 +54,7 @@ public class ElectricFleetModule extends AbstractModule {
 						ConfigGroup.getInputFileURL(getConfig().getContext(), evCfg.getVehiclesFile()));
 				return fleetSpecification;
 			}).asEagerSingleton();
-		} else if (qSimCfg.getVehiclesSource() == QSimConfigGroup.VehiclesSource.fromVehiclesData) {
+		} else if (getConfig().qsim().getVehiclesSource() == QSimConfigGroup.VehiclesSource.fromVehiclesData) {
 			bind(ElectricFleetSpecification.class).toProvider(new Provider<>() {
 				@Inject
 				private Vehicles vehicles;

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleSpecificationWithMatsimVehicle.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleSpecificationWithMatsimVehicle.java
@@ -38,7 +38,7 @@ import com.google.common.collect.ImmutableList;
 public class ElectricVehicleSpecificationWithMatsimVehicle implements ElectricVehicleSpecification {
 	public static final String EV_ENGINE_HBEFA_TECHNOLOGY = "electricity";
 
-		public static final String INITIAL_ENERGY_kWh = "initialEnergyInKWh";
+	public static final String INITIAL_ENERGY_kWh = "initialEnergyInKWh";
 	public static final String CHARGER_TYPES = "chargerTypes";
 
 	public static ElectricFleetSpecification createFleetSpecificationFromMatsimVehicles(Vehicles vehicles) {

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
@@ -105,7 +105,10 @@ public final class TaxiConfigGroup extends ReflectiveConfigGroupWithConfigurable
 	// input
 	public static final String TAXIS_FILE = "taxisFile";
 	static final String TAXIS_FILE_EXP = "An XML file specifying the taxi fleet."
-			+ " The file format according to dvrp_vehicles_v1.dtd";
+			+ " The file format according to dvrp_vehicles_v1.dtd."
+			+ " If not provided, the vehicle specifications will be created from matsim vehicle file or provided via a custom binding."
+			+ " See FleetModule.";
+
 
 	// output
 	public static final String TIME_PROFILES = "timeProfiles";


### PR DESCRIPTION
The following options are allowed
- separate DVRP vehicles file
- from matsim vehicles
- custom binding (e.g. generated vehicles)

Different DVRP modes can choose different strategies.

This PR is about DVRP vehicles and is similar to #1605 (that was about EVs).