### PR TITLE
make jointDemandPackage a bit more customizable

### DIFF
--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/CommercialJobGenerator.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/CommercialJobGenerator.java
@@ -213,13 +213,13 @@ class CommercialJobGenerator implements BeforeMobsimListener, AfterMobsimListene
 					Double travelTimeToFirstJob = ((Leg) planElements.get(i+1)).getTravelTime().seconds();
 					Double departureTimeAtFirstJob = ((Leg) planElements.get(i+3)).getDepartureTime().seconds();
 					Double jobServiceDuration = (double) ((Activity) planElements.get(i+2)).getAttributes().getAttribute(SERVICE_DURATION_NAME);
-					Double initalLegDepartureTime = departureTimeAtFirstJob - jobServiceDuration - travelTimeToFirstJob*this.firsttourTraveltimeBuffer;
-					Double expactedArrivalTimeAtFirstJob = departureTimeAtFirstJob - travelTimeToFirstJob*this.firsttourTraveltimeBuffer;					
+					Double initialLegDepartureTime = departureTimeAtFirstJob - jobServiceDuration - travelTimeToFirstJob * this.firsttourTraveltimeBuffer;
+					Double expectedArrivalTimeAtFirstJob = departureTimeAtFirstJob - travelTimeToFirstJob*this.firsttourTraveltimeBuffer;
 					
 					//Set optimal endTimes to avoid an too early arrival at first job
-					 ((Activity) planElements.get(i+2)).getAttributes().putAttribute(EXPECTED_ARRIVALTIME_NAME, expactedArrivalTimeAtFirstJob );
-					currentActivity.setEndTime(initalLegDepartureTime);
-					((Leg) planElements.get(i+1)).setDepartureTime(initalLegDepartureTime);
+					 ((Activity) planElements.get(i+2)).getAttributes().putAttribute(EXPECTED_ARRIVALTIME_NAME, expectedArrivalTimeAtFirstJob );
+					currentActivity.setEndTime(initialLegDepartureTime);
+					((Leg) planElements.get(i+1)).setDepartureTime(initialLegDepartureTime);
 					
 				}
 			}
@@ -331,7 +331,10 @@ class CommercialJobGenerator implements BeforeMobsimListener, AfterMobsimListene
         }
     }
 
-    private void generateIterationServices() {
+	/**
+	 * generates the services (out of the person population) and assigns them to the carriers
+	 */
+	private void generateIterationServices() {
 
         Map<Person,Set<Activity>> customer2ActsWithJobs = new HashMap();
 

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/CommercialJobGenerator.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/CommercialJobGenerator.java
@@ -1,0 +1,46 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2007 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.commercialTrafficApplications.jointDemand.commercialJob;
+
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.contrib.freight.carrier.Carriers;
+import org.matsim.core.controler.listener.AfterMobsimListener;
+import org.matsim.core.controler.listener.BeforeMobsimListener;
+
+public interface CommercialJobGenerator extends BeforeMobsimListener, AfterMobsimListener {
+
+	/**
+	 * Converts Jsprit tours to MATSim freight agents and inserts them into the population
+	 */
+	default void createAndAddFreightAgents(Carriers carriers, Population population) {}
+
+	/**
+	 * generates the services (out of the person population) and assigns them to the carriers
+	 */
+	default void generateIterationServices(Carriers carriers, Population population) {}
+
+	/**
+	 * removes freight agents and their vehicles from the scenario
+	 * @param scenario
+	 */
+	default void removeFreightAgents(Scenario scenario) {}
+
+	}

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/CommercialJobGenerator.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/CommercialJobGenerator.java
@@ -27,6 +27,12 @@ import org.matsim.core.controler.listener.BeforeMobsimListener;
 
 public interface CommercialJobGenerator extends BeforeMobsimListener, AfterMobsimListener {
 
+	String COMMERCIALJOB_ACTIVITYTYPE_PREFIX = "commercialJob";
+	String CUSTOMER_ATTRIBUTE_NAME = "customer";
+	String SERVICEID_ATTRIBUTE_NAME = "serviceId";
+	String EXPECTED_ARRIVALTIME_NAME = "eta";
+	String SERVICE_DURATION_NAME = "duration";
+
 	/**
 	 * Converts Jsprit tours to MATSim freight agents and inserts them into the population
 	 */

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/CommercialJobGenerator.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/CommercialJobGenerator.java
@@ -128,7 +128,7 @@ class CommercialJobGenerator implements BeforeMobsimListener, AfterMobsimListene
 				driverPerson.addPlan(plainPlan);
 				plainPlan.setPerson(driverPerson);
 				scenario.getPopulation().addPerson(driverPerson);
-				builldVehicleAndDriver(carrier, driverPerson, carrierVehicle);
+				buildVehicleAndDriver(carrier, driverPerson, carrierVehicle);
 			}
 
 		}
@@ -141,7 +141,7 @@ class CommercialJobGenerator implements BeforeMobsimListener, AfterMobsimListene
 	 * @param driverPerson
 	 * @param carrierVehicle
 	 */
-	private void builldVehicleAndDriver(Carrier carrier, Person driverPerson, CarrierVehicle carrierVehicle) {
+	private void buildVehicleAndDriver(Carrier carrier, Person driverPerson, CarrierVehicle carrierVehicle) {
 		if (!scenario.getVehicles().getVehicleTypes().containsKey(carrierVehicle.getType().getId()))
 			scenario.getVehicles().addVehicleType(carrierVehicle.getType());
 		Id<Vehicle> vid = Id.createVehicleId(driverPerson.getId());
@@ -164,7 +164,7 @@ class CommercialJobGenerator implements BeforeMobsimListener, AfterMobsimListene
 	 * 
 	 * @param plan
 	 */
-	void manageJspritDepartureTimes(Plan plan) {
+	private void manageJspritDepartureTimes(Plan plan) {
 		List<PlanElement> planElements = plan.getPlanElements();
 
 		for (int i = 0; i < planElements.size(); i++) {
@@ -232,7 +232,7 @@ class CommercialJobGenerator implements BeforeMobsimListener, AfterMobsimListene
 	 * @param scheduledTour
 	 * @return
 	 */
-	Plan createPlainPlanFromTour(Carrier carrier, ScheduledTour scheduledTour) {
+	private Plan createPlainPlanFromTour(Carrier carrier, ScheduledTour scheduledTour) {
 
 		String carrierMode = CarrierUtils.getCarrierMode(carrier);
 

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/DefaultCommercialJobGenerator.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/DefaultCommercialJobGenerator.java
@@ -66,7 +66,7 @@ import static org.matsim.contrib.commercialTrafficApplications.jointDemand.comme
 /**
  * Generates carriers and tours depending on next iteration's freight demand
  */
-class CommercialJobGenerator implements BeforeMobsimListener, AfterMobsimListener {
+class DefaultCommercialJobGenerator implements BeforeMobsimListener, AfterMobsimListener {
 
 
     static final String COMMERCIALJOB_ACTIVITYTYPE_PREFIX = "commercialJob";
@@ -88,12 +88,12 @@ class CommercialJobGenerator implements BeforeMobsimListener, AfterMobsimListene
     private Set<Id<Person>> freightDrivers = new HashSet<>();
     private Set<Id<Vehicle>> freightVehicles = new HashSet<>();
 
-    private final static Logger log = Logger.getLogger(CommercialJobGenerator.class);
+    private final static Logger log = Logger.getLogger(DefaultCommercialJobGenerator.class);
 
     private Set<String> drtModes = new HashSet<>();
 
     @Inject
-    /* package */ CommercialJobGenerator( Scenario scenario, Map<String, TravelTime> travelTimes, Carriers carriers ) {
+    /* package */ DefaultCommercialJobGenerator(Scenario scenario, Map<String, TravelTime> travelTimes, Carriers carriers ) {
         JointDemandConfigGroup cfg = JointDemandConfigGroup.get(scenario.getConfig());
         this.carriers = carriers;
         this.firsttourTraveltimeBuffer = cfg.getFirstLegTraveltimeBufferFactor();

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/DefaultCommercialJobGenerator.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/DefaultCommercialJobGenerator.java
@@ -366,7 +366,7 @@ class DefaultCommercialJobGenerator implements CommercialJobGenerator {
     }
 
     private void buildTours() throws InterruptedException, ExecutionException {
-        TourPlanning.runTourPlanningForCarriers(carriers,scenario, timeSliceWidth,carTT );
+        TourPlanning.runTourPlanningForCarriersWithNetBasedCosts(carriers,scenario, timeSliceWidth,carTT );
     }
 
     private static Id<CarrierService> createCarrierServiceIdXForCustomer(Person customer, int x) {

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/DefaultCommercialJobGenerator.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/DefaultCommercialJobGenerator.java
@@ -67,13 +67,7 @@ import static org.matsim.contrib.commercialTrafficApplications.jointDemand.comme
 class DefaultCommercialJobGenerator implements CommercialJobGenerator {
 
 
-    static final String COMMERCIALJOB_ACTIVITYTYPE_PREFIX = "commercialJob";
-    static final String CUSTOMER_ATTRIBUTE_NAME = "customer";
-    static final String SERVICEID_ATTRIBUTE_NAME = "serviceId";
-	static final String EXPECTED_ARRIVALTIME_NAME = "eta";
-	static final String SERVICE_DURATION_NAME = "duration";
-
-    private final double firsttourTraveltimeBuffer;
+	private final double firsttourTraveltimeBuffer;
     private final int timeSliceWidth;
 
     private Scenario scenario;

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/JointDemandModule.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/JointDemandModule.java
@@ -53,7 +53,7 @@ public class JointDemandModule extends AbstractModule {
 
         bind(ScoreCommercialJobs.class).in(Singleton.class);
         bind(TourLengthAnalyzer.class).in(Singleton.class);
-        addControlerListenerBinding().to(CommercialJobGenerator.class);
+        addControlerListenerBinding().to(DefaultCommercialJobGenerator.class);
         addControlerListenerBinding().to(CommercialTrafficAnalysisListener.class);
 //        addControlerListenerBinding().to(ScoreCommercialJobs.class);
 

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/JointDemandModule.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/JointDemandModule.java
@@ -53,9 +53,9 @@ public class JointDemandModule extends AbstractModule {
 
         bind(ScoreCommercialJobs.class).in(Singleton.class);
         bind(TourLengthAnalyzer.class).in(Singleton.class);
-        addControlerListenerBinding().to(DefaultCommercialJobGenerator.class);
+        bind(CommercialJobGenerator.class).to(DefaultCommercialJobGenerator.class).in(Singleton.class);
+        addControlerListenerBinding().to(CommercialJobGenerator.class);
         addControlerListenerBinding().to(CommercialTrafficAnalysisListener.class);
-//        addControlerListenerBinding().to(ScoreCommercialJobs.class);
 
         //bind strategy that enables to choose between operators
         addPlanStrategyBinding(ChangeCommercialJobOperator.SELECTOR_NAME).toProvider(new Provider<PlanStrategy>() {

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/ScoreCommercialJobs.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/ScoreCommercialJobs.java
@@ -81,9 +81,9 @@ class ScoreCommercialJobs implements ActivityStartEventHandler, ActivityEndEvent
             Queue<Id<CarrierService>> servicesServedByFreightAgent = new LinkedList<>();
             freightPlan.getPlanElements().stream()
                     .filter(pE -> pE instanceof Activity)
-                    .filter(act -> ((Activity) act).getType().startsWith(DefaultCommercialJobGenerator.COMMERCIALJOB_ACTIVITYTYPE_PREFIX))
+                    .filter(act -> ((Activity) act).getType().startsWith(CommercialJobGenerator.COMMERCIALJOB_ACTIVITYTYPE_PREFIX))
                     .forEach(act -> {
-                        Id<CarrierService> serviceId = Id.create((String) act.getAttributes().getAttribute(DefaultCommercialJobGenerator.SERVICEID_ATTRIBUTE_NAME),
+                        Id<CarrierService> serviceId = Id.create((String) act.getAttributes().getAttribute(CommercialJobGenerator.SERVICEID_ATTRIBUTE_NAME),
                                 CarrierService.class);
                         servicesServedByFreightAgent.add(serviceId);
                     });
@@ -95,13 +95,13 @@ class ScoreCommercialJobs implements ActivityStartEventHandler, ActivityEndEvent
     private void handleFreightActivityStart(ActivityStartEvent event) {
         if (event.getActType().equals(FreightConstants.END)) {
             activeDeliveryAgents.remove(event.getPersonId());
-        } else if (event.getActType().startsWith(DefaultCommercialJobGenerator.COMMERCIALJOB_ACTIVITYTYPE_PREFIX)) {
+        } else if (event.getActType().startsWith(CommercialJobGenerator.COMMERCIALJOB_ACTIVITYTYPE_PREFIX)) {
 
             Id<Carrier> carrierId = JointDemandUtils.getCarrierIdFromDriver(event.getPersonId());
             Carrier carrier = carriers.getCarriers().get(carrierId);
             CarrierService job = carrier.getServices().get(freightAgent2Jobs.get(event.getPersonId()).poll());
 
-            Id<Person> customerAboutToBeServed = Id.createPersonId((String) job.getAttributes().getAttribute(DefaultCommercialJobGenerator.CUSTOMER_ATTRIBUTE_NAME));
+            Id<Person> customerAboutToBeServed = Id.createPersonId((String) job.getAttributes().getAttribute(CommercialJobGenerator.CUSTOMER_ATTRIBUTE_NAME));
 
             double timeDifference = calcDifference(job, event.getTime());
             double score = scoreCalculator.calcScore(timeDifference);

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/ScoreCommercialJobs.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/ScoreCommercialJobs.java
@@ -25,7 +25,6 @@ import com.google.inject.Inject;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.events.ActivityEndEvent;
 import org.matsim.api.core.v01.events.ActivityStartEvent;
-import org.matsim.api.core.v01.events.PersonMoneyEvent;
 import org.matsim.api.core.v01.events.PersonScoreEvent;
 import org.matsim.api.core.v01.events.handler.ActivityEndEventHandler;
 import org.matsim.api.core.v01.events.handler.ActivityStartEventHandler;
@@ -82,9 +81,9 @@ class ScoreCommercialJobs implements ActivityStartEventHandler, ActivityEndEvent
             Queue<Id<CarrierService>> servicesServedByFreightAgent = new LinkedList<>();
             freightPlan.getPlanElements().stream()
                     .filter(pE -> pE instanceof Activity)
-                    .filter(act -> ((Activity) act).getType().startsWith(CommercialJobGenerator.COMMERCIALJOB_ACTIVITYTYPE_PREFIX))
+                    .filter(act -> ((Activity) act).getType().startsWith(DefaultCommercialJobGenerator.COMMERCIALJOB_ACTIVITYTYPE_PREFIX))
                     .forEach(act -> {
-                        Id<CarrierService> serviceId = Id.create((String) act.getAttributes().getAttribute(CommercialJobGenerator.SERVICEID_ATTRIBUTE_NAME),
+                        Id<CarrierService> serviceId = Id.create((String) act.getAttributes().getAttribute(DefaultCommercialJobGenerator.SERVICEID_ATTRIBUTE_NAME),
                                 CarrierService.class);
                         servicesServedByFreightAgent.add(serviceId);
                     });
@@ -96,13 +95,13 @@ class ScoreCommercialJobs implements ActivityStartEventHandler, ActivityEndEvent
     private void handleFreightActivityStart(ActivityStartEvent event) {
         if (event.getActType().equals(FreightConstants.END)) {
             activeDeliveryAgents.remove(event.getPersonId());
-        } else if (event.getActType().startsWith(CommercialJobGenerator.COMMERCIALJOB_ACTIVITYTYPE_PREFIX)) {
+        } else if (event.getActType().startsWith(DefaultCommercialJobGenerator.COMMERCIALJOB_ACTIVITYTYPE_PREFIX)) {
 
             Id<Carrier> carrierId = JointDemandUtils.getCarrierIdFromDriver(event.getPersonId());
             Carrier carrier = carriers.getCarriers().get(carrierId);
             CarrierService job = carrier.getServices().get(freightAgent2Jobs.get(event.getPersonId()).poll());
 
-            Id<Person> customerAboutToBeServed = Id.createPersonId((String) job.getAttributes().getAttribute(CommercialJobGenerator.CUSTOMER_ATTRIBUTE_NAME));
+            Id<Person> customerAboutToBeServed = Id.createPersonId((String) job.getAttributes().getAttribute(DefaultCommercialJobGenerator.CUSTOMER_ATTRIBUTE_NAME));
 
             double timeDifference = calcDifference(job, event.getTime());
             double score = scoreCalculator.calcScore(timeDifference);

--- a/contribs/commercialTrafficApplications/src/test/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/DefaultCommercialJobGeneratorTest.java
+++ b/contribs/commercialTrafficApplications/src/test/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/DefaultCommercialJobGeneratorTest.java
@@ -18,7 +18,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
-public class CommercialJobGeneratorTest {
+public class DefaultCommercialJobGeneratorTest {
 
 
     @Rule
@@ -27,14 +27,14 @@ public class CommercialJobGeneratorTest {
 
     @org.junit.Test
     @Ignore //set to ignore since this is tested in integration test anyways. Currently, this test here would fail anyways
-    //since we use the injector in CommercialJobGenerator.notifyBeforeMobsim()
+    //since we use the injector in DefaultCommercialJobGenerator.notifyBeforeMobsim()
     public void notifyBeforeMobsim() {
         Carriers carriers = TestScenarioGeneration.generateCarriers();
         Scenario scenario = TestScenarioGeneration.generateScenario();
         Map<String,TravelTime> travelTimes = new HashMap<>();
         travelTimes.put(TransportMode.car, new FreeSpeedTravelTime());
 
-        CommercialJobGenerator generator = new CommercialJobGenerator(scenario,travelTimes, carriers );
+        DefaultCommercialJobGenerator generator = new DefaultCommercialJobGenerator(scenario,travelTimes, carriers );
         new CarrierVehicleTypeWriter(CarrierVehicleTypes.getVehicleTypes(carriers)).write(utils.getOutputDirectory() + "vehicleTypes.xml");
         scenario.getConfig().controler().setOutputDirectory(utils.getOutputDirectory());
         int iteration = 0;


### PR DESCRIPTION
In commercialTrafficApplications, 
1. the `CommercialJobGenerator` is extracted to an interface, with the `DefaultCommercialJobGenerator` bound
2. Tour planning can now be started with a custom implementation of `VehicleRoutingTransportCosts`, which at the current state have to extend `NetworkBasedTransportCosts` because this type is needed for routing the carrier plans :( 