### PR TITLE
Extract dijkstra tree stop criteria

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/LeastCostPathTreeStopCriteria.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/LeastCostPathTreeStopCriteria.java
@@ -1,0 +1,72 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2021 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.dvrp.path;
+
+import java.util.BitSet;
+import java.util.Collection;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.core.router.speedy.LeastCostPathTree.StopCriterion;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class LeastCostPathTreeStopCriteria {
+
+	public static StopCriterion and(StopCriterion sc1, StopCriterion sc2) {
+		return (nodeIndex, arrivalTime, travelCost, distance, departureTime) ->//
+				sc1.stop(nodeIndex, arrivalTime, travelCost, distance, departureTime)//
+						&& sc2.stop(nodeIndex, arrivalTime, travelCost, distance, departureTime);
+	}
+
+	public static StopCriterion or(StopCriterion sc1, StopCriterion sc2) {
+		return (nodeIndex, arrivalTime, travelCost, distance, departureTime) ->//
+				sc1.stop(nodeIndex, arrivalTime, travelCost, distance, departureTime)//
+						|| sc2.stop(nodeIndex, arrivalTime, travelCost, distance, departureTime);
+	}
+
+	public static StopCriterion maxTravelTime(double maxTravelTime) {
+		return (nodeIndex, arrivalTime, travelCost, distance, departureTime) -> arrivalTime - departureTime
+				> maxTravelTime;
+	}
+
+	public static StopCriterion allEndNodesReached(Collection<Node> endNodes) {
+		Preconditions.checkArgument(!endNodes.isEmpty(), "At least one end node must be provided.");
+
+		final BitSet nodesToVisit = new BitSet(Id.getNumberOfIds(Node.class));
+		endNodes.forEach(node -> nodesToVisit.set(node.getId().index()));
+
+		return new StopCriterion() {
+			private int counter = nodesToVisit.cardinality();
+
+			public boolean stop(int nodeIndex, double arrivalTime, double travelCost, double distance,
+					double departureTime) {
+				if (nodesToVisit.get(nodeIndex)) {
+					counter--;
+				}
+				return counter == 0;
+			}
+		};
+	}
+}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/OneToManyPathCalculator.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/OneToManyPathCalculator.java
@@ -20,16 +20,16 @@
 
 package org.matsim.contrib.dvrp.path;
 
+import static java.util.stream.Collectors.toList;
+import static org.matsim.contrib.dvrp.path.LeastCostPathTreeStopCriteria.*;
 import static org.matsim.contrib.dvrp.path.VrpPaths.FIRST_LINK_TT;
 import static org.matsim.core.router.util.LeastCostPathCalculator.Path;
 
 import java.util.ArrayList;
-import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
@@ -39,7 +39,6 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
 import org.matsim.core.router.speedy.LeastCostPathTree;
-import org.matsim.core.router.speedy.LeastCostPathTree.StopCriterion;
 import org.matsim.core.utils.misc.OptionalTime;
 
 import com.google.common.base.Preconditions;
@@ -71,19 +70,20 @@ class OneToManyPathCalculator {
 		Preconditions.checkArgument(!Double.isNaN(maxTravelTime) && maxTravelTime >= 0);
 
 		int fromNodeIdx = getStartNode(fromLink).getId().index();
-		Stream<Node> toNodes = toLinks.stream().filter(link -> link != fromLink).map(this::getEndNode);
-		var multiNodeStopCriterion = new MultiNodeStopCriterion(toNodes);
+		var toNodes = toLinks.stream().filter(link -> link != fromLink).map(this::getEndNode).collect(toList());
+		if (toNodes.size() == 0) {
+			return;
+		}
 
-		StopCriterion stopCriterion = maxTravelTime < Double.POSITIVE_INFINITY ?
-				new MaxTravelTimeStopCriterion(maxTravelTime, multiNodeStopCriterion) :
-				multiNodeStopCriterion;
+		var allEndNodes = allEndNodesReached(toNodes);
+		var stopCriterion = maxTravelTime < Double.POSITIVE_INFINITY ?
+				or(maxTravelTime(maxTravelTime), allEndNodes) :
+				allEndNodes;
 
-		if (multiNodeStopCriterion.counter > 0) {
-			if (forwardSearch) {
-				dijkstraTree.calculate(fromNodeIdx, startTime, null, null, stopCriterion);
-			} else {
-				dijkstraTree.calculateBackwards(fromNodeIdx, startTime, null, null, stopCriterion);
-			}
+		if (forwardSearch) {
+			dijkstraTree.calculate(fromNodeIdx, startTime, null, null, stopCriterion);
+		} else {
+			dijkstraTree.calculateBackwards(fromNodeIdx, startTime, null, null, stopCriterion);
 		}
 	}
 
@@ -184,40 +184,5 @@ class OneToManyPathCalculator {
 				VrpPaths.getLastLinkTT(toLink, time + pathTravelTime) :
 				VrpPaths.getLastLinkTT(fromLink, time);
 		return FIRST_LINK_TT + lastLinkTT;
-	}
-
-	private static class MaxTravelTimeStopCriterion implements StopCriterion {
-		private final double maxTravelTime;
-		private final MultiNodeStopCriterion multiNodeStopCriterion;
-
-		private MaxTravelTimeStopCriterion(double maxTravelTime, MultiNodeStopCriterion multiNodeStopCriterion) {
-			this.maxTravelTime = maxTravelTime;
-			this.multiNodeStopCriterion = multiNodeStopCriterion;
-		}
-
-		@Override
-		public boolean stop(int nodeIndex, double arrivalTime, double travelCost, double distance,
-				double departureTime) {
-			return arrivalTime - departureTime > maxTravelTime //
-					|| multiNodeStopCriterion.stop(nodeIndex, arrivalTime, travelCost, distance, departureTime);
-		}
-	}
-
-	private static class MultiNodeStopCriterion implements StopCriterion {
-		private final BitSet nodesToVisit = new BitSet(Id.getNumberOfIds(Node.class));
-		private int counter;
-
-		public MultiNodeStopCriterion(Stream<Node> endNodes) {
-			endNodes.forEach(node -> nodesToVisit.set(node.getId().index()));
-			counter = nodesToVisit.cardinality();
-		}
-
-		public boolean stop(int nodeIndex, double arrivalTime, double travelCost, double distance,
-				double departureTime) {
-			if (nodesToVisit.get(nodeIndex)) {
-				counter--;
-			}
-			return counter == 0;
-		}
 	}
 }

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/path/LeastCostPathTreeStopCriteriaTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/path/LeastCostPathTreeStopCriteriaTest.java
@@ -1,0 +1,118 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2021 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.dvrp.path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.matsim.contrib.dvrp.path.LeastCostPathTreeStopCriteria.*;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.matsim.api.core.v01.Id;
+import org.matsim.core.router.speedy.LeastCostPathTree.StopCriterion;
+import org.matsim.testcases.fakes.FakeNode;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class LeastCostPathTreeStopCriteriaTest {
+
+	@Test
+	public void testAnd() {
+		StopCriterion scTrue = (nodeIndex, arrivalTime, travelCost, distance, departureTime) -> true;
+		StopCriterion scFalse = (nodeIndex, arrivalTime, travelCost, distance, departureTime) -> false;
+
+		// true && true  == true; otherwise false
+		assertThat(and(scTrue, scTrue).stop(0, 0, 0, 0, 0)).isTrue();
+		assertThat(and(scTrue, scFalse).stop(0, 0, 0, 0, 0)).isFalse();
+		assertThat(and(scFalse, scTrue).stop(0, 0, 0, 0, 0)).isFalse();
+		assertThat(and(scFalse, scFalse).stop(0, 0, 0, 0, 0)).isFalse();
+	}
+
+	@Test
+	public void testOr() {
+		StopCriterion scTrue = (nodeIndex, arrivalTime, travelCost, distance, departureTime) -> true;
+		StopCriterion scFalse = (nodeIndex, arrivalTime, travelCost, distance, departureTime) -> false;
+
+		// false || false == false; otherwise true
+		assertThat(or(scTrue, scTrue).stop(0, 0, 0, 0, 0)).isTrue();
+		assertThat(or(scTrue, scFalse).stop(0, 0, 0, 0, 0)).isTrue();
+		assertThat(or(scFalse, scTrue).stop(0, 0, 0, 0, 0)).isTrue();
+		assertThat(or(scFalse, scFalse).stop(0, 0, 0, 0, 0)).isFalse();
+	}
+
+	@Test
+	public void testMaxTravelTime() {
+		StopCriterion max100 = maxTravelTime(100);
+
+		//TT is 100 - continue
+		assertThat(max100.stop(0, 500, 0, 0, 400)).isFalse();
+
+		//TT is 101 - stop
+		assertThat(max100.stop(0, 501, 0, 0, 400)).isTrue();
+	}
+
+	@Test
+	public void testAllEndNodesReached_noEndNodes() {
+		assertThatThrownBy(() -> allEndNodesReached(List.of())).isExactlyInstanceOf(IllegalArgumentException.class)
+				.hasMessage("At least one end node must be provided.");
+	}
+
+	@Test
+	public void testAllEndNodesReached_oneEndNode() {
+		var endNode = new FakeNode(Id.createNodeId("end_node"));
+		var otherNode = new FakeNode(Id.createNodeId("other_node"));
+		StopCriterion noEndNodes = allEndNodesReached(List.of(endNode));
+
+		//endNode not yet reached
+		assertThat(noEndNodes.stop(otherNode.getId().index(), 0, 0, 0, 0)).isFalse();
+
+		//endNode now reached
+		assertThat(noEndNodes.stop(endNode.getId().index(), 0, 0, 0, 0)).isTrue();
+
+		//endNode already reached
+		assertThat(noEndNodes.stop(otherNode.getId().index(), 0, 0, 0, 0)).isTrue();
+	}
+
+	@Test
+	public void testAllendNodesReached_twoEndNodes() {
+		var endNode1 = new FakeNode(Id.createNodeId("end_node_1"));
+		var endNode2 = new FakeNode(Id.createNodeId("end_node_2"));
+		var otherNode = new FakeNode(Id.createNodeId("other_node"));
+		StopCriterion noEndNodes = allEndNodesReached(List.of(endNode1, endNode2));
+
+		//none end node yet reached
+		assertThat(noEndNodes.stop(otherNode.getId().index(), 0, 0, 0, 0)).isFalse();
+
+		//endNode1 now reached
+		assertThat(noEndNodes.stop(endNode1.getId().index(), 0, 0, 0, 0)).isFalse();
+
+		//endNode2 not yet reached
+		assertThat(noEndNodes.stop(otherNode.getId().index(), 0, 0, 0, 0)).isFalse();
+
+		//endNode2 now reached
+		assertThat(noEndNodes.stop(endNode2.getId().index(), 0, 0, 0, 0)).isTrue();
+
+		//both end nodes already reached
+		assertThat(noEndNodes.stop(otherNode.getId().index(), 0, 0, 0, 0)).isTrue();
+	}
+}


### PR DESCRIPTION
Both stop criteria (maxTravelTime, allEndNodesReached) were used internally in `OneToManyPathCalculator`, which is a dvrp-specific path search (takes links as input and returns `PathData`). Now they can be used for other purposes, e.g. replacing the old multi-node dijkstra.