### PR TITLE
Streamline routing parameters

### DIFF
--- a/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/SwissRailRaptorAccessibilityContributionCalculator.java
+++ b/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/SwissRailRaptorAccessibilityContributionCalculator.java
@@ -31,6 +31,7 @@ import org.matsim.facilities.*;
 import org.matsim.pt.transitSchedule.TransitStopFacilityImpl;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -139,7 +140,7 @@ class SwissRailRaptorAccessibilityContributionCalculator implements Accessibilit
             Map<Id<? extends BasicLocation>, AggregationObject> aggregatedOpportunities, Double departureTime) {
         double expSum = 0.;
 
-        final Map<Id<TransitStopFacility>, SwissRailRaptorCore.TravelInfo> idTravelInfoMap = raptor.calcTree(origin, departureTime, null);
+        final Map<Id<TransitStopFacility>, SwissRailRaptorCore.TravelInfo> idTravelInfoMap = raptor.calcTree(origin, departureTime, null, new Attributes());
 
         for (final AggregationObject destination : aggregatedOpportunities.values()) {
             //compute direct walk costs

--- a/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/TripRouterAccessibilityContributionCalculator.java
+++ b/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/TripRouterAccessibilityContributionCalculator.java
@@ -49,6 +49,7 @@ import org.matsim.facilities.ActivityFacilitiesFactory;
 import org.matsim.facilities.ActivityFacilitiesFactoryImpl;
 import org.matsim.facilities.ActivityFacility;
 import org.matsim.facilities.ActivityFacilityImpl;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * @author nagel, dziemke
@@ -132,7 +133,7 @@ class TripRouterAccessibilityContributionCalculator implements AccessibilityCont
 			ActivityFacility destinationFacility = activityFacilitiesFactory.createActivityFacility(null, destination.getNearestBasicLocation().getCoord());
 
 			Gbl.assertNotNull(tripRouter);
-			List<? extends PlanElement> plan = tripRouter.calcRoute(mode, origin, destinationFacility, departureTime, null);
+			List<? extends PlanElement> plan = tripRouter.calcRoute(mode, origin, destinationFacility, departureTime, null, new Attributes());
 
 			double utility = 0.;
 			List<Leg> legs = TripStructureUtils.getLegs(plan);

--- a/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/relocation/qsim/Guidance.java
+++ b/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/relocation/qsim/Guidance.java
@@ -15,6 +15,7 @@ import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.LeastCostPathCalculator.Path;
 import org.matsim.core.utils.misc.OptionalTime;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * Mostly copied from tutorial.programming.ownMobsimAgentUsingRouter.MyGuidance
@@ -37,7 +38,7 @@ public class Guidance {
         String mainMode = TransportMode.car;
         Facility startFacility = new LinkWrapperFacility(startLink);
         Facility destinationFacility = new LinkWrapperFacility(destinationLink);
-        List<? extends PlanElement> trip = router.calcRoute(mainMode, startFacility, destinationFacility, departureTime, person);
+        List<? extends PlanElement> trip = router.calcRoute(mainMode, startFacility, destinationFacility, departureTime, person, new Attributes());
         Path path = lcpc.calcLeastCostPath(startLink.getToNode(), destinationLink.getFromNode(), now, person, null);
         if (path.links.size() == 0)
         	return destinationLink.getId();
@@ -49,7 +50,7 @@ public class Guidance {
     public synchronized OptionalTime getExpectedTravelTime(Link startLink, Link destinationLink, double departureTime, String mode, Person person) {
         Facility startFacility = new LinkWrapperFacility(startLink);
         Facility destinationFacility = new LinkWrapperFacility(destinationLink);
-        List<? extends PlanElement> trip = router.calcRoute(mode, startFacility, destinationFacility, departureTime, person);
+        List<? extends PlanElement> trip = router.calcRoute(mode, startFacility, destinationFacility, departureTime, person, new Attributes());
 		Route route = ((Leg) trip.get(0)).getRoute();
 
 		return route != null ? route.getTravelTime() : OptionalTime.undefined();
@@ -58,7 +59,7 @@ public class Guidance {
     public synchronized double getExpectedTravelDistance(Link startLink, Link destinationLink, double departureTime, String mode, Person person) {
         Facility startFacility = new LinkWrapperFacility(startLink);
         Facility destinationFacility = new LinkWrapperFacility(destinationLink);
-        List<? extends PlanElement> trip = router.calcRoute(mode, startFacility, destinationFacility, departureTime, person);
+        List<? extends PlanElement> trip = router.calcRoute(mode, startFacility, destinationFacility, departureTime, person, new Attributes());
 		Route route = ((Leg) trip.get(0)).getRoute();
 
 		double distance = route != null ? route.getDistance() : null;

--- a/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/router/FreeFloatingRoutingModule.java
+++ b/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/router/FreeFloatingRoutingModule.java
@@ -8,6 +8,7 @@ import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.router.RoutingModule;
+import org.matsim.core.router.RoutingRequest;
 import org.matsim.facilities.Facility;
 
 public class FreeFloatingRoutingModule implements RoutingModule {
@@ -16,8 +17,9 @@ public class FreeFloatingRoutingModule implements RoutingModule {
 		
 	}
 	@Override
-	public List<? extends PlanElement> calcRoute(Facility fromFacility,
-			Facility toFacility, double departureTime, Person person) {
+	public List<? extends PlanElement> calcRoute(RoutingRequest request) {
+		final Facility fromFacility = request.getFromFacility();
+		final Facility toFacility = request.getToFacility();
 		
 		final List<PlanElement> trip = new ArrayList<>();
 						

--- a/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/router/OneWayCarsharingRoutingModule.java
+++ b/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/router/OneWayCarsharingRoutingModule.java
@@ -15,6 +15,7 @@ import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.router.RoutingModule;
+import org.matsim.core.router.RoutingRequest;
 import org.matsim.facilities.Facility;
 
 public class OneWayCarsharingRoutingModule implements RoutingModule{
@@ -22,8 +23,9 @@ public class OneWayCarsharingRoutingModule implements RoutingModule{
 		
 	}
 	@Override
-	public List<? extends PlanElement> calcRoute(Facility fromFacility,
-			Facility toFacility, double departureTime, Person person) {
+	public List<? extends PlanElement> calcRoute(RoutingRequest request) {
+		final Facility fromFacility = request.getFromFacility();
+		final Facility toFacility = request.getToFacility();
 		
 		final List<PlanElement> trip = new ArrayList<PlanElement>();		
 		

--- a/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/router/TwoWayCarsharingRoutingModule.java
+++ b/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/router/TwoWayCarsharingRoutingModule.java
@@ -4,18 +4,20 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.matsim.api.core.v01.population.Leg;
-import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.router.RoutingModule;
+import org.matsim.core.router.RoutingRequest;
 import org.matsim.facilities.Facility;
 
 public class TwoWayCarsharingRoutingModule implements RoutingModule {
 	
 	
 	@Override
-	public List<? extends PlanElement> calcRoute(Facility fromFacility,
-			Facility toFacility, double departureTime, Person person) {
+	public List<? extends PlanElement> calcRoute(RoutingRequest request) {
+		final Facility fromFacility = request.getFromFacility();
+		final Facility toFacility = request.getToFacility();
+		
 		final List<PlanElement> trip = new ArrayList<>();
 		
 		final Leg leg1 = PopulationUtils.createLeg("twoway");

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/estimators/AbstractTripRouterEstimator.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/estimators/AbstractTripRouterEstimator.java
@@ -64,7 +64,7 @@ public abstract class AbstractTripRouterEstimator implements TripEstimator {
 		if (!isPrerouted(mode, trip)) {
 			// II) Perform the routing
 			List<? extends PlanElement> elements = tripRouter.calcRoute(mode, originFacility, destinationFacility,
-					trip.getDepartureTime(), person);
+					trip.getDepartureTime(), person, trip.getOriginActivity().getAttributes());
 
 			// III) Perform utility estimation
 			return estimateTripCandidate(person, mode, trip, previousTrips, elements);

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/DrtRoutingModuleTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/DrtRoutingModuleTest.java
@@ -107,7 +107,7 @@ public class DrtRoutingModuleTest {
 		Activity w = (Activity)p1.getSelectedPlan().getPlanElements().get(2);
 		Facility wf = FacilitiesUtils.toFacility(w, facilities);
 
-		List<? extends PlanElement> routedList = dvrpRoutingModule.calcRoute(DefaultRoutingRequest.of(hf, wf, 8 * 3600, p1));
+		List<? extends PlanElement> routedList = dvrpRoutingModule.calcRoute(DefaultRoutingRequest.withoutAttributes(hf, wf, 8 * 3600, p1));
 
 		Assert.assertEquals(5, routedList.size());
 
@@ -162,7 +162,7 @@ public class DrtRoutingModuleTest {
 		Activity w2 = (Activity)p2.getSelectedPlan().getPlanElements().get(2);
 		Facility wf2 = FacilitiesUtils.toFacility(w2, facilities);
 
-		List<? extends PlanElement> routedList2 = dvrpRoutingModule.calcRoute(DefaultRoutingRequest.of(hf2, wf2, 8 * 3600, p2));
+		List<? extends PlanElement> routedList2 = dvrpRoutingModule.calcRoute(DefaultRoutingRequest.withoutAttributes(hf2, wf2, 8 * 3600, p2));
 
 		Assert.assertNull(routedList2);
 
@@ -174,7 +174,7 @@ public class DrtRoutingModuleTest {
 		Activity w3 = (Activity)p3.getSelectedPlan().getPlanElements().get(2);
 		Facility wf3 = FacilitiesUtils.toFacility(w3, facilities);
 
-		List<? extends PlanElement> routedList3 = dvrpRoutingModule.calcRoute(DefaultRoutingRequest.of(hf3, wf3, 8 * 3600, p3));
+		List<? extends PlanElement> routedList3 = dvrpRoutingModule.calcRoute(DefaultRoutingRequest.withoutAttributes(hf3, wf3, 8 * 3600, p3));
 
 		Assert.assertNull(routedList3);
 
@@ -186,7 +186,7 @@ public class DrtRoutingModuleTest {
 		Activity w4 = (Activity)p4.getSelectedPlan().getPlanElements().get(2);
 		Facility wf4 = FacilitiesUtils.toFacility(w4, facilities);
 
-		List<? extends PlanElement> routedList4 = dvrpRoutingModule.calcRoute(DefaultRoutingRequest.of(hf4, wf4, 8 * 3600, p4));
+		List<? extends PlanElement> routedList4 = dvrpRoutingModule.calcRoute(DefaultRoutingRequest.withoutAttributes(hf4, wf4, 8 * 3600, p4));
 
 		Assert.assertNull(routedList4);
 
@@ -198,7 +198,7 @@ public class DrtRoutingModuleTest {
 		Activity w5 = (Activity)p5.getSelectedPlan().getPlanElements().get(2);
 		Facility wf5 = FacilitiesUtils.toFacility(w5, facilities);
 
-		List<? extends PlanElement> routedList5 = dvrpRoutingModule.calcRoute(DefaultRoutingRequest.of(hf5, wf5, 8 * 3600, p5));
+		List<? extends PlanElement> routedList5 = dvrpRoutingModule.calcRoute(DefaultRoutingRequest.withoutAttributes(hf5, wf5, 8 * 3600, p5));
 
 		// TODO: Asserts are prepared for interpreting maxWalkingDistance as a real maximum, but routing still works wrongly
 		Assert.assertNull(routedList5);
@@ -211,7 +211,7 @@ public class DrtRoutingModuleTest {
 		Activity w6 = (Activity)p6.getSelectedPlan().getPlanElements().get(2);
 		Facility wf6 = FacilitiesUtils.toFacility(w6, facilities);
 
-		List<? extends PlanElement> routedList6 = dvrpRoutingModule.calcRoute(DefaultRoutingRequest.of(hf6, wf6, 8 * 3600, p6));
+		List<? extends PlanElement> routedList6 = dvrpRoutingModule.calcRoute(DefaultRoutingRequest.withoutAttributes(hf6, wf6, 8 * 3600, p6));
 
 		// TODO: Asserts are prepared for interpreting maxWalkingDistance as a real maximum, but routing still works wrongly
 		Assert.assertNull(routedList6);

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/DrtRoutingModuleTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/DrtRoutingModuleTest.java
@@ -48,6 +48,7 @@ import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.network.io.MatsimNetworkReader;
 import org.matsim.core.population.routes.GenericRouteImpl;
+import org.matsim.core.router.DefaultRoutingRequest;
 import org.matsim.core.router.TeleportationRoutingModule;
 import org.matsim.core.router.speedy.SpeedyDijkstraFactory;
 import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
@@ -106,7 +107,7 @@ public class DrtRoutingModuleTest {
 		Activity w = (Activity)p1.getSelectedPlan().getPlanElements().get(2);
 		Facility wf = FacilitiesUtils.toFacility(w, facilities);
 
-		List<? extends PlanElement> routedList = dvrpRoutingModule.calcRoute(hf, wf, 8 * 3600, p1);
+		List<? extends PlanElement> routedList = dvrpRoutingModule.calcRoute(DefaultRoutingRequest.of(hf, wf, 8 * 3600, p1));
 
 		Assert.assertEquals(5, routedList.size());
 
@@ -161,7 +162,7 @@ public class DrtRoutingModuleTest {
 		Activity w2 = (Activity)p2.getSelectedPlan().getPlanElements().get(2);
 		Facility wf2 = FacilitiesUtils.toFacility(w2, facilities);
 
-		List<? extends PlanElement> routedList2 = dvrpRoutingModule.calcRoute(hf2, wf2, 8 * 3600, p2);
+		List<? extends PlanElement> routedList2 = dvrpRoutingModule.calcRoute(DefaultRoutingRequest.of(hf2, wf2, 8 * 3600, p2));
 
 		Assert.assertNull(routedList2);
 
@@ -173,7 +174,7 @@ public class DrtRoutingModuleTest {
 		Activity w3 = (Activity)p3.getSelectedPlan().getPlanElements().get(2);
 		Facility wf3 = FacilitiesUtils.toFacility(w3, facilities);
 
-		List<? extends PlanElement> routedList3 = dvrpRoutingModule.calcRoute(hf3, wf3, 8 * 3600, p3);
+		List<? extends PlanElement> routedList3 = dvrpRoutingModule.calcRoute(DefaultRoutingRequest.of(hf3, wf3, 8 * 3600, p3));
 
 		Assert.assertNull(routedList3);
 
@@ -185,7 +186,7 @@ public class DrtRoutingModuleTest {
 		Activity w4 = (Activity)p4.getSelectedPlan().getPlanElements().get(2);
 		Facility wf4 = FacilitiesUtils.toFacility(w4, facilities);
 
-		List<? extends PlanElement> routedList4 = dvrpRoutingModule.calcRoute(hf4, wf4, 8 * 3600, p4);
+		List<? extends PlanElement> routedList4 = dvrpRoutingModule.calcRoute(DefaultRoutingRequest.of(hf4, wf4, 8 * 3600, p4));
 
 		Assert.assertNull(routedList4);
 
@@ -197,7 +198,7 @@ public class DrtRoutingModuleTest {
 		Activity w5 = (Activity)p5.getSelectedPlan().getPlanElements().get(2);
 		Facility wf5 = FacilitiesUtils.toFacility(w5, facilities);
 
-		List<? extends PlanElement> routedList5 = dvrpRoutingModule.calcRoute(hf5, wf5, 8 * 3600, p5);
+		List<? extends PlanElement> routedList5 = dvrpRoutingModule.calcRoute(DefaultRoutingRequest.of(hf5, wf5, 8 * 3600, p5));
 
 		// TODO: Asserts are prepared for interpreting maxWalkingDistance as a real maximum, but routing still works wrongly
 		Assert.assertNull(routedList5);
@@ -210,13 +211,13 @@ public class DrtRoutingModuleTest {
 		Activity w6 = (Activity)p6.getSelectedPlan().getPlanElements().get(2);
 		Facility wf6 = FacilitiesUtils.toFacility(w6, facilities);
 
-		List<? extends PlanElement> routedList6 = dvrpRoutingModule.calcRoute(hf6, wf6, 8 * 3600, p6);
+		List<? extends PlanElement> routedList6 = dvrpRoutingModule.calcRoute(DefaultRoutingRequest.of(hf6, wf6, 8 * 3600, p6));
 
 		// TODO: Asserts are prepared for interpreting maxWalkingDistance as a real maximum, but routing still works wrongly
 		Assert.assertNull(routedList6);
 
 	}
-
+	
 	@Test
 	public void testRouteDescriptionHandling() {
 		String oldRouteFormat = "600 400";

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DefaultMainLegRouter.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DefaultMainLegRouter.java
@@ -30,6 +30,7 @@ import org.matsim.api.core.v01.population.PopulationFactory;
 import org.matsim.api.core.v01.population.Route;
 import org.matsim.core.population.routes.RouteFactories;
 import org.matsim.core.router.RoutingModule;
+import org.matsim.core.router.RoutingRequest;
 import org.matsim.facilities.Facility;
 
 import com.google.common.base.Preconditions;
@@ -57,8 +58,11 @@ public class DefaultMainLegRouter implements RoutingModule {
 	}
 
 	@Override
-	public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double departureTime,
-			Person person) {
+	public List<? extends PlanElement> calcRoute(RoutingRequest request) {
+		final Facility fromFacility = request.getFromFacility();
+		final Facility toFacility = request.getToFacility();
+		final double departureTime = request.getDepartureTime();
+		
 		Link accessActLink = Preconditions.checkNotNull(modalNetwork.getLinks().get(fromFacility.getLinkId()),
 				"link: %s does not exist in the network of mode: %s", fromFacility.getLinkId(), mode);
 		Link egressActLink = Preconditions.checkNotNull(modalNetwork.getLinks().get(toFacility.getLinkId()),

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpRoutingModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpRoutingModule.java
@@ -33,7 +33,9 @@ import org.matsim.api.core.v01.population.Activity;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.population.PopulationUtils;
+import org.matsim.core.router.DefaultRoutingRequest;
 import org.matsim.core.router.RoutingModule;
+import org.matsim.core.router.RoutingRequest;
 import org.matsim.core.router.TripRouter;
 import org.matsim.facilities.Facility;
 
@@ -66,8 +68,12 @@ public class DvrpRoutingModule implements RoutingModule {
 	}
 
 	@Override
-	public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double departureTime,
-			Person person) {
+	public List<? extends PlanElement> calcRoute(RoutingRequest request) {
+		final Facility fromFacility = request.getFromFacility();
+		final Facility toFacility = request.getToFacility();
+		final double departureTime = request.getDepartureTime();
+		final Person person = request.getPerson();
+		
 		Optional<Pair<Facility, Facility>> stops = stopFinder.findFacilities(
 				Objects.requireNonNull(fromFacility, "fromFacility is null"),
 				Objects.requireNonNull(toFacility, "toFacility is null"));
@@ -98,7 +104,7 @@ public class DvrpRoutingModule implements RoutingModule {
 		double now = departureTime;
 
 		// access (sub-)trip:
-		List<? extends PlanElement> accessTrip = accessRouter.calcRoute(fromFacility, accessFacility, now, person);
+		List<? extends PlanElement> accessTrip = accessRouter.calcRoute(DefaultRoutingRequest.of(fromFacility, accessFacility, now, person));
 		if (!accessTrip.isEmpty()) {
 			trip.addAll(accessTrip);
 			for (PlanElement planElement : accessTrip) {
@@ -111,14 +117,14 @@ public class DvrpRoutingModule implements RoutingModule {
 		}
 
 		// dvrp proper leg:
-		List<? extends PlanElement> drtLeg = mainRouter.calcRoute(accessFacility, egressFacility, now, person);
+		List<? extends PlanElement> drtLeg = mainRouter.calcRoute(DefaultRoutingRequest.of(accessFacility, egressFacility, now, person));
 		trip.addAll(drtLeg);
 		for (PlanElement planElement : drtLeg) {
 			now = TripRouter.calcEndOfPlanElement(now, planElement, scenario.getConfig());
 		}
 
 		now++;
-		List<? extends PlanElement> egressTrip = egressRouter.calcRoute(egressFacility, toFacility, now, person);
+		List<? extends PlanElement> egressTrip = egressRouter.calcRoute(DefaultRoutingRequest.of(egressFacility, toFacility, now, person));
 		if (!egressTrip.isEmpty()) {
 			// interaction activity:
 			trip.add(createDrtStageActivity(egressFacility, now));

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpRoutingModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpRoutingModule.java
@@ -104,7 +104,7 @@ public class DvrpRoutingModule implements RoutingModule {
 		double now = departureTime;
 
 		// access (sub-)trip:
-		List<? extends PlanElement> accessTrip = accessRouter.calcRoute(DefaultRoutingRequest.of(fromFacility, accessFacility, now, person));
+		List<? extends PlanElement> accessTrip = accessRouter.calcRoute(DefaultRoutingRequest.of(fromFacility, accessFacility, now, person, request.getAttributes()));
 		if (!accessTrip.isEmpty()) {
 			trip.addAll(accessTrip);
 			for (PlanElement planElement : accessTrip) {
@@ -117,14 +117,14 @@ public class DvrpRoutingModule implements RoutingModule {
 		}
 
 		// dvrp proper leg:
-		List<? extends PlanElement> drtLeg = mainRouter.calcRoute(DefaultRoutingRequest.of(accessFacility, egressFacility, now, person));
+		List<? extends PlanElement> drtLeg = mainRouter.calcRoute(DefaultRoutingRequest.of(accessFacility, egressFacility, now, person, request.getAttributes()));
 		trip.addAll(drtLeg);
 		for (PlanElement planElement : drtLeg) {
 			now = TripRouter.calcEndOfPlanElement(now, planElement, scenario.getConfig());
 		}
 
 		now++;
-		List<? extends PlanElement> egressTrip = egressRouter.calcRoute(DefaultRoutingRequest.of(egressFacility, toFacility, now, person));
+		List<? extends PlanElement> egressTrip = egressRouter.calcRoute(DefaultRoutingRequest.of(egressFacility, toFacility, now, person, request.getAttributes()));
 		if (!egressTrip.isEmpty()) {
 			// interaction activity:
 			trip.add(createDrtStageActivity(egressFacility, now));

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/routing/EvNetworkRoutingModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/routing/EvNetworkRoutingModule.java
@@ -106,7 +106,7 @@ public final class EvNetworkRoutingModule implements RoutingModule {
 		final double departureTime = request.getDepartureTime();
 		final Person person = request.getPerson();
 
-		List<? extends PlanElement> basicRoute = delegate.calcRoute(DefaultRoutingRequest.of(fromFacility, toFacility, departureTime, person));
+		List<? extends PlanElement> basicRoute = delegate.calcRoute(request);
 		Id<ElectricVehicle> evId = Id.create(person.getId() + vehicleSuffix, ElectricVehicle.class);
 		if (!electricFleet.getVehicleSpecifications().containsKey(evId)) {
 			return basicRoute;
@@ -152,7 +152,7 @@ public final class EvNetworkRoutingModule implements RoutingModule {
 						continue;
 					}
 					List<? extends PlanElement> routeSegment = delegate.calcRoute(DefaultRoutingRequest.of(lastFrom, nexttoFacility,
-							lastArrivaltime, person));
+							lastArrivaltime, person, request.getAttributes()));
 					Leg lastLeg = (Leg)routeSegment.get(0);
 					lastArrivaltime = lastLeg.getDepartureTime().seconds() + lastLeg.getTravelTime().seconds();
 					stagedRoute.add(lastLeg);
@@ -165,7 +165,7 @@ public final class EvNetworkRoutingModule implements RoutingModule {
 					stagedRoute.add(chargeAct);
 					lastFrom = nexttoFacility;
 				}
-				stagedRoute.addAll(delegate.calcRoute(DefaultRoutingRequest.of(lastFrom, toFacility, lastArrivaltime, person)));
+				stagedRoute.addAll(delegate.calcRoute(DefaultRoutingRequest.of(lastFrom, toFacility, lastArrivaltime, person, request.getAttributes())));
 
 				return stagedRoute;
 

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/routing/EvNetworkRoutingModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/routing/EvNetworkRoutingModule.java
@@ -48,8 +48,10 @@ import org.matsim.core.gbl.MatsimRandom;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.population.routes.NetworkRoute;
+import org.matsim.core.router.DefaultRoutingRequest;
 import org.matsim.core.router.LinkWrapperFacility;
 import org.matsim.core.router.RoutingModule;
+import org.matsim.core.router.RoutingRequest;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.facilities.Facility;
@@ -98,10 +100,13 @@ public final class EvNetworkRoutingModule implements RoutingModule {
 	}
 
 	@Override
-	public List<? extends PlanElement> calcRoute(final Facility fromFacility, final Facility toFacility,
-			final double departureTime, final Person person) {
+	public List<? extends PlanElement> calcRoute(RoutingRequest request) {
+		final Facility fromFacility = request.getFromFacility();
+		final Facility toFacility = request.getToFacility();
+		final double departureTime = request.getDepartureTime();
+		final Person person = request.getPerson();
 
-		List<? extends PlanElement> basicRoute = delegate.calcRoute(fromFacility, toFacility, departureTime, person);
+		List<? extends PlanElement> basicRoute = delegate.calcRoute(DefaultRoutingRequest.of(fromFacility, toFacility, departureTime, person));
 		Id<ElectricVehicle> evId = Id.create(person.getId() + vehicleSuffix, ElectricVehicle.class);
 		if (!electricFleet.getVehicleSpecifications().containsKey(evId)) {
 			return basicRoute;
@@ -146,8 +151,8 @@ public final class EvNetworkRoutingModule implements RoutingModule {
 					if (nexttoFacility.getLinkId().equals(lastFrom.getLinkId())) {
 						continue;
 					}
-					List<? extends PlanElement> routeSegment = delegate.calcRoute(lastFrom, nexttoFacility,
-							lastArrivaltime, person);
+					List<? extends PlanElement> routeSegment = delegate.calcRoute(DefaultRoutingRequest.of(lastFrom, nexttoFacility,
+							lastArrivaltime, person));
 					Leg lastLeg = (Leg)routeSegment.get(0);
 					lastArrivaltime = lastLeg.getDepartureTime().seconds() + lastLeg.getTravelTime().seconds();
 					stagedRoute.add(lastLeg);
@@ -160,7 +165,7 @@ public final class EvNetworkRoutingModule implements RoutingModule {
 					stagedRoute.add(chargeAct);
 					lastFrom = nexttoFacility;
 				}
-				stagedRoute.addAll(delegate.calcRoute(lastFrom, toFacility, lastArrivaltime, person));
+				stagedRoute.addAll(delegate.calcRoute(DefaultRoutingRequest.of(lastFrom, toFacility, lastArrivaltime, person)));
 
 				return stagedRoute;
 

--- a/contribs/eventsBasedPTRouter/src/main/java/org/matsim/contrib/eventsBasedPTRouter/TransitRouterVariableImpl.java
+++ b/contribs/eventsBasedPTRouter/src/main/java/org/matsim/contrib/eventsBasedPTRouter/TransitRouterVariableImpl.java
@@ -40,6 +40,7 @@ import org.matsim.api.core.v01.population.Route;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.population.routes.RouteUtils;
 import org.matsim.core.router.InitialNode;
+import org.matsim.core.router.RoutingRequest;
 import org.matsim.core.router.TripStructureUtils;
 import org.matsim.core.router.util.LeastCostPathCalculator.Path;
 import org.matsim.core.router.util.PreProcessDijkstra;
@@ -110,7 +111,12 @@ public class TransitRouterVariableImpl implements TransitRouter {
 			return new HashMap<>();
 	}
 	    @Override
-	public List<Leg> calcRoute(final Facility fromFacility, final Facility toFacility, final double departureTime, final Person person) {
+	public List<Leg> calcRoute(RoutingRequest request) {
+	    final Facility fromFacility = request.getFromFacility();
+	    final Facility toFacility = request.getToFacility();
+	    final double departureTime = request.getDepartureTime();
+	    final Person person = request.getPerson();
+	    	
 		// find possible start stops
 		Map<Node, InitialNode> wrappedFromNodes = this.locateWrappedNearestTransitNodes(person, fromFacility.getCoord(), departureTime);
 		// find possible end stops

--- a/contribs/locationchoice/src/main/java/org/matsim/contrib/locationchoice/timegeography/RecursiveLocationMutator.java
+++ b/contribs/locationchoice/src/main/java/org/matsim/contrib/locationchoice/timegeography/RecursiveLocationMutator.java
@@ -185,7 +185,7 @@ class RecursiveLocationMutator extends AbstractLocationMutator{
 			  FacilitiesUtils.toFacility( fromAct, null ),
 			  FacilitiesUtils.toFacility( toAct, null ),
 				fromAct.getEndTime().seconds(),
-				person );
+				person, fromAct.getAttributes() );
 
 		if ( trip.size() != 1 ) {
 			throw new IllegalStateException( "This method can only be used with "+

--- a/contribs/matrixbasedptrouter/src/main/java/org/matsim/contrib/matrixbasedptrouter/MatrixBasedPtRoutingModule.java
+++ b/contribs/matrixbasedptrouter/src/main/java/org/matsim/contrib/matrixbasedptrouter/MatrixBasedPtRoutingModule.java
@@ -32,6 +32,7 @@ import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.api.core.v01.population.Route;
 import org.matsim.core.population.routes.GenericRouteFactory;
 import org.matsim.core.router.RoutingModule;
+import org.matsim.core.router.RoutingRequest;
 import org.matsim.facilities.Facility;
 
 import javax.inject.Inject;
@@ -69,7 +70,11 @@ public final class MatrixBasedPtRoutingModule implements RoutingModule {
 	}
 	
 	@Override
-	public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double departureTime, Person person) {
+	public List<? extends PlanElement> calcRoute(RoutingRequest request) {
+		final Facility fromFacility = request.getFromFacility();
+		final Facility toFacility = request.getToFacility();
+		final double departureTime = request.getDepartureTime();
+		
 		Leg newLeg = scenario.getPopulation().getFactory().createLeg( TransportMode.pt );
 		Id<Link> startLinkId = fromFacility.getLinkId();
 		Id<Link> endLinkId = toFacility.getLinkId();

--- a/contribs/minibus/src/main/java/org/matsim/contrib/minibus/performance/PPlanRouter.java
+++ b/contribs/minibus/src/main/java/org/matsim/contrib/minibus/performance/PPlanRouter.java
@@ -98,7 +98,7 @@ final class PPlanRouter implements PlanAlgorithm, PersonAlgorithm {
 								toFacility( trip.getOriginActivity() ),
 								toFacility( trip.getDestinationActivity() ),
 								calcEndOfActivity( trip.getOriginActivity() , plan ),
-								plan.getPerson() );
+								plan.getPerson(), trip.getOriginActivity().getAttributes() );
 
 					TripRouter.insertTrip(
 							plan, 

--- a/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingsearch/DynAgent/agentLogic/ParkingAgentLogic.java
+++ b/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingsearch/DynAgent/agentLogic/ParkingAgentLogic.java
@@ -48,6 +48,7 @@ import org.matsim.contrib.parking.parkingsearch.sim.ParkingSearchConfigGroup;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.population.routes.NetworkRoute;
+import org.matsim.core.router.DefaultRoutingRequest;
 import org.matsim.core.router.LinkWrapperFacility;
 import org.matsim.core.router.RoutingModule;
 import org.matsim.core.utils.misc.Time;
@@ -201,7 +202,7 @@ public class ParkingAgentLogic implements DynAgentLogic {
 		Leg currentPlannedLeg = (Leg) currentPlanElement;
 		Facility fromFacility = new LinkWrapperFacility (network.getLinks().get(agent.getCurrentLinkId()));
 		Facility toFacility = new LinkWrapperFacility (network.getLinks().get(currentPlannedLeg.getRoute().getEndLinkId()));
-		List<? extends PlanElement> walkTrip = walkRouter.calcRoute(fromFacility, toFacility, now, plan.getPerson());
+		List<? extends PlanElement> walkTrip = walkRouter.calcRoute(DefaultRoutingRequest.of(fromFacility, toFacility, now, plan.getPerson()));
 		if (walkTrip.size() != 1 || ! (walkTrip.get(0) instanceof Leg)) {
 			String message = "walkRouter returned something else than a single Leg, e.g. it routes walk on the network with non_network_walk to access the network. Not implemented in parking yet!";
 			log.error(message);
@@ -261,7 +262,7 @@ public class ParkingAgentLogic implements DynAgentLogic {
     		Facility fromFacility = new LinkWrapperFacility (network.getLinks().get(agent.getCurrentLinkId()));
             Id<Link> teleportedParkLink = this.teleportationLogic.getVehicleLocation(agent.getCurrentLinkId(), vehicleId, parkLink, now, currentLeg.getMode());
     		Facility toFacility = new LinkWrapperFacility (network.getLinks().get(teleportedParkLink));
-    		List<? extends PlanElement> walkTrip = walkRouter.calcRoute(fromFacility, toFacility, now, plan.getPerson());
+    		List<? extends PlanElement> walkTrip = walkRouter.calcRoute(DefaultRoutingRequest.of(fromFacility, toFacility, now, plan.getPerson()));
     		if (walkTrip.size() != 1 || ! (walkTrip.get(0) instanceof Leg)) {
     			String message = "walkRouter returned something else than a single Leg, e.g. it routes walk on the network with non_network_walk to access the network. Not implemented in parking yet!";
     			log.error(message);

--- a/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingsearch/DynAgent/agentLogic/ParkingAgentLogic.java
+++ b/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingsearch/DynAgent/agentLogic/ParkingAgentLogic.java
@@ -202,7 +202,7 @@ public class ParkingAgentLogic implements DynAgentLogic {
 		Leg currentPlannedLeg = (Leg) currentPlanElement;
 		Facility fromFacility = new LinkWrapperFacility (network.getLinks().get(agent.getCurrentLinkId()));
 		Facility toFacility = new LinkWrapperFacility (network.getLinks().get(currentPlannedLeg.getRoute().getEndLinkId()));
-		List<? extends PlanElement> walkTrip = walkRouter.calcRoute(DefaultRoutingRequest.of(fromFacility, toFacility, now, plan.getPerson()));
+		List<? extends PlanElement> walkTrip = walkRouter.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFacility, toFacility, now, plan.getPerson()));
 		if (walkTrip.size() != 1 || ! (walkTrip.get(0) instanceof Leg)) {
 			String message = "walkRouter returned something else than a single Leg, e.g. it routes walk on the network with non_network_walk to access the network. Not implemented in parking yet!";
 			log.error(message);
@@ -262,7 +262,7 @@ public class ParkingAgentLogic implements DynAgentLogic {
     		Facility fromFacility = new LinkWrapperFacility (network.getLinks().get(agent.getCurrentLinkId()));
             Id<Link> teleportedParkLink = this.teleportationLogic.getVehicleLocation(agent.getCurrentLinkId(), vehicleId, parkLink, now, currentLeg.getMode());
     		Facility toFacility = new LinkWrapperFacility (network.getLinks().get(teleportedParkLink));
-    		List<? extends PlanElement> walkTrip = walkRouter.calcRoute(DefaultRoutingRequest.of(fromFacility, toFacility, now, plan.getPerson()));
+    		List<? extends PlanElement> walkTrip = walkRouter.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFacility, toFacility, now, plan.getPerson()));
     		if (walkTrip.size() != 1 || ! (walkTrip.get(0) instanceof Leg)) {
     			String message = "walkRouter returned something else than a single Leg, e.g. it routes walk on the network with non_network_walk to access the network. Not implemented in parking yet!";
     			log.error(message);

--- a/contribs/pseudosimulation/src/main/java/org/matsim/contrib/pseudosimulation/trafficinfo/deterministic/DeterministicStopStopTimeCalculator.java
+++ b/contribs/pseudosimulation/src/main/java/org/matsim/contrib/pseudosimulation/trafficinfo/deterministic/DeterministicStopStopTimeCalculator.java
@@ -7,9 +7,11 @@ import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.contrib.eventsBasedPTRouter.stopStopTimes.StopStopTime;
 import org.matsim.contrib.eventsBasedPTRouter.stopStopTimes.StopStopTimeCalculator;
+import org.matsim.core.router.DefaultRoutingRequest;
 import org.matsim.pt.router.TransitRouter;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -35,7 +37,7 @@ public class DeterministicStopStopTimeCalculator implements StopStopTimeCalculat
 		TransitStopFacility originFacility = schedule.getFacilities().get(stopOId);
 		TransitStopFacility destinationFacility = schedule.getFacilities().get(stopDId);
 
-		List<? extends PlanElement> legs = transitRouter.calcRoute(originFacility, destinationFacility, time, null);
+		List<? extends PlanElement> legs = transitRouter.calcRoute(DefaultRoutingRequest.withoutAttributes(originFacility, destinationFacility, time, null));
 		return legs.stream().mapToDouble(l -> ((Leg)l).getTravelTime().seconds()).sum();
 	}
 

--- a/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/jointtrips/ImportedJointRoutesChecker.java
+++ b/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/jointtrips/ImportedJointRoutesChecker.java
@@ -71,7 +71,7 @@ public class ImportedJointRoutesChecker implements PlanAlgorithm, PersonAlgorith
 						  FacilitiesUtils.toFacility( origin, null ),
 						  FacilitiesUtils.toFacility( dest, null ),
 							now,
-							plan.getPerson());
+							plan.getPerson(), origin.getAttributes());
 
 				if (trip.size() != 1) {
 					throw new RuntimeException( "unexpected trip length "+trip.size()+" for "+trip+" for mode "+l.getMode());

--- a/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/jointtrips/router/DriverRoutingModule.java
+++ b/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/jointtrips/router/DriverRoutingModule.java
@@ -53,17 +53,10 @@ public class DriverRoutingModule implements RoutingModule {
 
 	@Override
 	public List<? extends PlanElement> calcRoute(RoutingRequest request) {
-		final Facility fromFacility = request.getFromFacility();
-		final Facility toFacility = request.getToFacility();
 		final double departureTime = request.getDepartureTime();
-		final Person person = request.getPerson();
 		
 		List<? extends PlanElement> trip =
-			carRoutingModule.calcRoute(DefaultRoutingRequest.of(
-					fromFacility,
-					toFacility, 
-					departureTime,
-					person));
+			carRoutingModule.calcRoute(request);
 
 		if (trip.size() != 1) {
 			throw new RuntimeException( "unexpected trip size for trip "+trip+" for mode "+mode );

--- a/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/jointtrips/router/DriverRoutingModule.java
+++ b/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/jointtrips/router/DriverRoutingModule.java
@@ -29,7 +29,9 @@ import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.api.core.v01.population.PopulationFactory;
 import org.matsim.contrib.socnetsim.jointtrips.population.DriverRoute;
 import org.matsim.core.population.routes.NetworkRoute;
+import org.matsim.core.router.DefaultRoutingRequest;
 import org.matsim.core.router.RoutingModule;
+import org.matsim.core.router.RoutingRequest;
 import org.matsim.facilities.Facility;
 
 /**
@@ -50,17 +52,18 @@ public class DriverRoutingModule implements RoutingModule {
 	}
 
 	@Override
-	public List<? extends PlanElement> calcRoute(
-			final Facility fromFacility,
-			final Facility toFacility, 
-			final double departureTime,
-			final Person person) {
+	public List<? extends PlanElement> calcRoute(RoutingRequest request) {
+		final Facility fromFacility = request.getFromFacility();
+		final Facility toFacility = request.getToFacility();
+		final double departureTime = request.getDepartureTime();
+		final Person person = request.getPerson();
+		
 		List<? extends PlanElement> trip =
-			carRoutingModule.calcRoute(
+			carRoutingModule.calcRoute(DefaultRoutingRequest.of(
 					fromFacility,
 					toFacility, 
 					departureTime,
-					person);
+					person));
 
 		if (trip.size() != 1) {
 			throw new RuntimeException( "unexpected trip size for trip "+trip+" for mode "+mode );

--- a/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/jointtrips/router/PassengerRoutingModule.java
+++ b/contribs/socnetsim/src/main/java/org/matsim/contrib/socnetsim/jointtrips/router/PassengerRoutingModule.java
@@ -28,6 +28,7 @@ import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.api.core.v01.population.PopulationFactory;
 import org.matsim.api.core.v01.population.Route;
 import org.matsim.core.router.RoutingModule;
+import org.matsim.core.router.RoutingRequest;
 import org.matsim.facilities.Facility;
 
 import org.matsim.contrib.socnetsim.jointtrips.population.PassengerRoute;
@@ -47,11 +48,11 @@ public class PassengerRoutingModule implements RoutingModule {
 	}
 
 	@Override
-	public List<? extends PlanElement> calcRoute(
-			final Facility fromFacility,
-			final Facility toFacility,
-			final double departureTime,
-			final Person person) {
+	public List<? extends PlanElement> calcRoute(RoutingRequest request) {
+		final Facility fromFacility = request.getFromFacility();
+		final Facility toFacility = request.getToFacility();
+		final double departureTime = request.getDepartureTime();
+		
 		Leg l = popFactory.createLeg( modeName );
 		l.setDepartureTime( departureTime );
 		Route r = new PassengerRoute( fromFacility.getLinkId() , toFacility.getLinkId() );

--- a/contribs/socnetsim/src/test/java/org/matsim/contrib/socnetsim/jointtrips/router/JointPlanRouterTest.java
+++ b/contribs/socnetsim/src/test/java/org/matsim/contrib/socnetsim/jointtrips/router/JointPlanRouterTest.java
@@ -44,6 +44,7 @@ import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.population.routes.RouteUtils;
 import org.matsim.core.router.RoutingModule;
+import org.matsim.core.router.RoutingRequest;
 import org.matsim.core.router.TripRouter;
 import org.matsim.core.router.TripStructureUtils;
 import org.matsim.core.scenario.ScenarioUtils;
@@ -98,6 +99,8 @@ public class JointPlanRouterTest {
 		final PassengerRoute newRoute = (PassengerRoute) leg.getRoute();
 		assertNotNull(
 				"new passenger route is null",
+
+
 				newRoute);
 
 		assertEquals(
@@ -178,11 +181,10 @@ public class JointPlanRouterTest {
 					new RoutingModule() {
 
 						@Override
-						public List<? extends PlanElement> calcRoute(
-								final Facility fromFacility,
-								final Facility toFacility,
-								final double departureTime,
-								final Person person) {
+						public List<? extends PlanElement> calcRoute(RoutingRequest request) {
+							final Facility fromFacility = request.getFromFacility();
+							final Facility toFacility = request.getToFacility();
+							
 							NetworkRoute route = RouteUtils.createNetworkRoute(List.of(fromFacility.getLinkId(), toFacility.getLinkId()), null);
 							route.setTravelTime(10);
 							Leg leg =  PopulationUtils.createLeg(TransportMode.car);

--- a/contribs/socnetsim/src/test/java/org/matsim/contrib/socnetsim/sharedvehicles/PlanRouterWithVehicleRessourcesTest.java
+++ b/contribs/socnetsim/src/test/java/org/matsim/contrib/socnetsim/sharedvehicles/PlanRouterWithVehicleRessourcesTest.java
@@ -41,6 +41,7 @@ import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.population.routes.RouteUtils;
 import org.matsim.core.router.PlanRouter;
 import org.matsim.core.router.RoutingModule;
+import org.matsim.core.router.RoutingRequest;
 import org.matsim.core.router.TripRouter;
 import org.matsim.core.router.TripStructureUtils;
 import org.matsim.core.router.TripStructureUtils.Trip;
@@ -105,11 +106,10 @@ public class PlanRouterWithVehicleRessourcesTest {
 				TransportMode.car,
 				new RoutingModule() {
 					@Override
-					public List<? extends PlanElement> calcRoute(
-							final Facility fromFacility,
-							final Facility toFacility,
-							final double departureTime,
-							final Person p) {
+					public List<? extends PlanElement> calcRoute(RoutingRequest request) {
+						final Facility fromFacility = request.getFromFacility();
+						final Facility toFacility = request.getToFacility();
+						
 						final List<PlanElement> legs = new ArrayList<PlanElement>();
 
 						for (int i=0; i < 5; i++) {

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/DefaultRaptorStopFinder.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/DefaultRaptorStopFinder.java
@@ -32,6 +32,7 @@ import org.matsim.core.utils.collections.QuadTree;
 import org.matsim.core.utils.geometry.CoordUtils;
 import org.matsim.facilities.Facility;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import ch.sbb.matsim.config.SwissRailRaptorConfigGroup;
 import ch.sbb.matsim.config.SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet;
@@ -65,21 +66,21 @@ public class DefaultRaptorStopFinder implements RaptorStopFinder {
 	}
 
 	@Override
-	public List<InitialStop> findStops(Facility fromFacility, Facility toFacility, Person person, double departureTime, RaptorParameters parameters, SwissRailRaptorData data, RaptorStopFinder.Direction type) {
+	public List<InitialStop> findStops(Facility fromFacility, Facility toFacility, Person person, double departureTime, Attributes routingAttributes, RaptorParameters parameters, SwissRailRaptorData data, RaptorStopFinder.Direction type) {
 		if (type == Direction.ACCESS) {
-			return findAccessStops(fromFacility, toFacility, person, departureTime, parameters, data);
+			return findAccessStops(fromFacility, toFacility, person, departureTime, routingAttributes, parameters, data);
 		}
 		if (type == Direction.EGRESS) {
-			return findEgressStops(fromFacility, toFacility, person, departureTime, parameters, data);
+			return findEgressStops(fromFacility, toFacility, person, departureTime, routingAttributes, parameters, data);
 		}
 		return Collections.emptyList();
 	}
 
 	private List<InitialStop> findAccessStops(Facility fromFacility, Facility toFacility, Person person, double departureTime,
-			RaptorParameters parameters, SwissRailRaptorData data) {
+			Attributes routingAttributes, RaptorParameters parameters, SwissRailRaptorData data) {
 		SwissRailRaptorConfigGroup srrCfg = parameters.getConfig();
 		if (srrCfg.isUseIntermodalAccessEgress()) {
-			return findIntermodalStops(fromFacility, toFacility, person, departureTime, Direction.ACCESS, parameters, data);
+			return findIntermodalStops(fromFacility, toFacility, person, departureTime, routingAttributes, Direction.ACCESS, parameters, data);
 		} else {
 			double distanceFactor = data.config.getBeelineWalkDistanceFactor();
 			List<TransitStopFacility> stops = findNearbyStops(fromFacility, parameters, data);
@@ -93,10 +94,10 @@ public class DefaultRaptorStopFinder implements RaptorStopFinder {
 		}
 	}
 
-	private List<InitialStop> findEgressStops(Facility fromFacility, Facility toFacility, Person person, double departureTime, RaptorParameters parameters, SwissRailRaptorData data) {
+	private List<InitialStop> findEgressStops(Facility fromFacility, Facility toFacility, Person person, double departureTime, Attributes routingAttributes, RaptorParameters parameters, SwissRailRaptorData data) {
 		SwissRailRaptorConfigGroup srrCfg = parameters.getConfig();
 		if (srrCfg.isUseIntermodalAccessEgress()) {
-			return findIntermodalStops(fromFacility, toFacility, person, departureTime, Direction.EGRESS, parameters, data);
+			return findIntermodalStops(fromFacility, toFacility, person, departureTime, routingAttributes, Direction.EGRESS, parameters, data);
 		} else {
 			double distanceFactor = data.config.getBeelineWalkDistanceFactor();
 			List<TransitStopFacility> stops = findNearbyStops(toFacility, parameters, data);
@@ -111,7 +112,7 @@ public class DefaultRaptorStopFinder implements RaptorStopFinder {
 	}
 
 	private List<InitialStop> findIntermodalStops(Facility fromFacility, Facility toFacility, Person person, double departureTime,
-			Direction direction, RaptorParameters parameters, SwissRailRaptorData data) {
+			Attributes routingAttributes, Direction direction, RaptorParameters parameters, SwissRailRaptorData data) {
 		SwissRailRaptorConfigGroup srrCfg = parameters.getConfig();
 		Facility facility = Direction.ACCESS == direction ? fromFacility : toFacility;
 		double x = facility.getCoord().getX();
@@ -120,14 +121,14 @@ public class DefaultRaptorStopFinder implements RaptorStopFinder {
         switch (srrCfg.getIntermodalAccessEgressModeSelection()) {
             case CalcLeastCostModePerStop:
                 for (IntermodalAccessEgressParameterSet parameterSet : srrCfg.getIntermodalAccessEgressParameterSets()) {
-                    addInitialStopsForParamSet(fromFacility, toFacility, person, departureTime, direction, parameters, data, x, y, initialStops, parameterSet);
+                    addInitialStopsForParamSet(fromFacility, toFacility, person, departureTime, routingAttributes, direction, parameters, data, x, y, initialStops, parameterSet);
                 }
                 break;
             case RandomSelectOneModePerRoutingRequestAndDirection:
                 int counter = 0;
                 do {
                     int rndSelector = random.nextInt(srrCfg.getIntermodalAccessEgressParameterSets().size());
-                    addInitialStopsForParamSet(fromFacility, toFacility, person, departureTime, direction, parameters, data, x, y,
+                    addInitialStopsForParamSet(fromFacility, toFacility, person, departureTime, routingAttributes, direction, parameters, data, x, y,
                             initialStops, srrCfg.getIntermodalAccessEgressParameterSets().get(rndSelector));
                     counter++;
                     // try again if no initial stop was found for the parameterset. Avoid infinite loop by limiting number of tries.
@@ -139,7 +140,7 @@ public class DefaultRaptorStopFinder implements RaptorStopFinder {
         return initialStops;
     }
 
-    private void addInitialStopsForParamSet(Facility fromFacility, Facility toFacility, Person person, double departureTime, Direction direction, RaptorParameters parameters, SwissRailRaptorData data, double x, double y, List<InitialStop> initialStops, IntermodalAccessEgressParameterSet paramset) {
+    private void addInitialStopsForParamSet(Facility fromFacility, Facility toFacility, Person person, double departureTime, Attributes routingAttributes, Direction direction, RaptorParameters parameters, SwissRailRaptorData data, double x, double y, List<InitialStop> initialStops, IntermodalAccessEgressParameterSet paramset) {
         String mode = paramset.getMode();
         String linkIdAttribute = paramset.getLinkIdAttribute();
         String personFilterAttribute = paramset.getPersonFilterAttribute();
@@ -188,12 +189,12 @@ public class DefaultRaptorStopFinder implements RaptorStopFinder {
                 List<? extends PlanElement> routeParts;
                 if (direction == Direction.ACCESS) {
                     RoutingModule module = this.routingModules.get(mode);
-                    routeParts = module.calcRoute(DefaultRoutingRequest.of(facility, stopFacility, departureTime, person));
+                    routeParts = module.calcRoute(DefaultRoutingRequest.of(facility, stopFacility, departureTime, person, routingAttributes));
                 } else { // it's Egress
                     // We don't know the departure time for the egress trip, so just use the original departureTime,
                     // although it is wrong and might result in a wrong traveltime and thus wrong route.
                     RoutingModule module = this.routingModules.get(mode);
-                    routeParts = module.calcRoute(DefaultRoutingRequest.of(stopFacility, facility, departureTime, person));
+                    routeParts = module.calcRoute(DefaultRoutingRequest.of(stopFacility, facility, departureTime, person, routingAttributes));
                     if (routeParts == null) {
                         // the router for the access/egress mode could not find a route, skip that access/egress mode
                         continue;

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/DefaultRaptorStopFinder.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/DefaultRaptorStopFinder.java
@@ -26,6 +26,7 @@ import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.gbl.MatsimRandom;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.population.routes.RouteUtils;
+import org.matsim.core.router.DefaultRoutingRequest;
 import org.matsim.core.router.RoutingModule;
 import org.matsim.core.utils.collections.QuadTree;
 import org.matsim.core.utils.geometry.CoordUtils;
@@ -187,12 +188,12 @@ public class DefaultRaptorStopFinder implements RaptorStopFinder {
                 List<? extends PlanElement> routeParts;
                 if (direction == Direction.ACCESS) {
                     RoutingModule module = this.routingModules.get(mode);
-                    routeParts = module.calcRoute(facility, stopFacility, departureTime, person);
+                    routeParts = module.calcRoute(DefaultRoutingRequest.of(facility, stopFacility, departureTime, person));
                 } else { // it's Egress
                     // We don't know the departure time for the egress trip, so just use the original departureTime,
                     // although it is wrong and might result in a wrong traveltime and thus wrong route.
                     RoutingModule module = this.routingModules.get(mode);
-                    routeParts = module.calcRoute(stopFacility, facility, departureTime, person);
+                    routeParts = module.calcRoute(DefaultRoutingRequest.of(stopFacility, facility, departureTime, person));
                     if (routeParts == null) {
                         // the router for the access/egress mode could not find a route, skip that access/egress mode
                         continue;

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/RaptorStopFinder.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/RaptorStopFinder.java
@@ -2,6 +2,7 @@ package ch.sbb.matsim.routing.pt.raptor;
 
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import java.util.List;
 
@@ -15,6 +16,6 @@ public interface RaptorStopFinder {
 
 	public enum Direction { ACCESS, EGRESS }
 
-	List<InitialStop> findStops(Facility fromFacility, Facility toFacility, Person person, double departureTime, RaptorParameters parameters, SwissRailRaptorData data, Direction type);
+	List<InitialStop> findStops(Facility fromFacility, Facility toFacility, Person person, double departureTime, Attributes routingAttributes, RaptorParameters parameters, SwissRailRaptorData data, Direction type);
 
 }

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptor.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptor.java
@@ -14,15 +14,16 @@ import java.util.Map;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.TransportMode;
-import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.config.Config;
 import org.matsim.core.population.PopulationUtils;
+import org.matsim.core.router.RoutingRequest;
 import org.matsim.core.utils.geometry.CoordUtils;
 import org.matsim.facilities.Facility;
 import org.matsim.pt.router.TransitRouter;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import ch.sbb.matsim.config.SwissRailRaptorConfigGroup;
 import ch.sbb.matsim.routing.pt.raptor.RaptorRoute.RoutePart;
@@ -59,13 +60,19 @@ public class SwissRailRaptor implements TransitRouter {
     }
 
     @Override
-    public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double departureTime, Person person) {
+    public List<? extends PlanElement> calcRoute(RoutingRequest request) {
+    	final Facility fromFacility = request.getFromFacility();
+    	final Facility toFacility = request.getToFacility();
+    	final double departureTime = request.getDepartureTime();
+    	final Person person = request.getPerson();
+    	final Attributes routingAttributes = request.getAttributes();
+    	
         RaptorParameters parameters = this.parametersForPerson.getRaptorParameters(person);
         if (parameters.getConfig().isUseRangeQuery()) {
-            return this.performRangeQuery(fromFacility, toFacility, departureTime, person, parameters);
+            return this.performRangeQuery(fromFacility, toFacility, departureTime, person, routingAttributes, parameters);
         }
-        List<InitialStop> accessStops = findAccessStops(fromFacility, toFacility, person, departureTime, parameters);
-        List<InitialStop> egressStops = findEgressStops(fromFacility, toFacility, person, departureTime, parameters);
+        List<InitialStop> accessStops = findAccessStops(fromFacility, toFacility, person, departureTime, routingAttributes, parameters);
+        List<InitialStop> egressStops = findEgressStops(fromFacility, toFacility, person, departureTime, routingAttributes, parameters);
 
         RaptorRoute foundRoute = this.raptor.calcLeastCostRoute(departureTime, fromFacility, toFacility, accessStops, egressStops, parameters, person);
         RaptorRoute directWalk = createDirectWalk(fromFacility, toFacility, departureTime, person, parameters);
@@ -125,7 +132,7 @@ public class SwissRailRaptor implements TransitRouter {
 		return true;
 	}
 
-    private List<? extends PlanElement> performRangeQuery(Facility fromFacility, Facility toFacility, double desiredDepartureTime, Person person, RaptorParameters parameters) {
+    private List<? extends PlanElement> performRangeQuery(Facility fromFacility, Facility toFacility, double desiredDepartureTime, Person person, Attributes routingAttributes, RaptorParameters parameters) {
         SwissRailRaptorConfigGroup srrConfig = parameters.getConfig();
 
         String subpopulation = PopulationUtils.getSubpopulation(person);
@@ -144,17 +151,17 @@ public class SwissRailRaptor implements TransitRouter {
             selector.setBetaDepartureTime(params.getBetaDepartureTime());
         }
 
-        return this.calcRoute(fromFacility, toFacility, earliestDepartureTime, desiredDepartureTime, latestDepartureTime, person, this.defaultRouteSelector);
+        return this.calcRoute(fromFacility, toFacility, earliestDepartureTime, desiredDepartureTime, latestDepartureTime, person, routingAttributes, this.defaultRouteSelector);
     }
 
-    public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double earliestDepartureTime, double desiredDepartureTime, double latestDepartureTime, Person person) {
-        return calcRoute(fromFacility, toFacility, earliestDepartureTime, desiredDepartureTime, latestDepartureTime, person, this.defaultRouteSelector);
+    public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double earliestDepartureTime, double desiredDepartureTime, double latestDepartureTime, Person person, Attributes routingAttributes) {
+        return calcRoute(fromFacility, toFacility, earliestDepartureTime, desiredDepartureTime, latestDepartureTime, person, routingAttributes, this.defaultRouteSelector);
     }
 
-    public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double earliestDepartureTime, double desiredDepartureTime, double latestDepartureTime, Person person, RaptorRouteSelector selector) {
+    public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double earliestDepartureTime, double desiredDepartureTime, double latestDepartureTime, Person person, Attributes routingAttributes, RaptorRouteSelector selector) {
         RaptorParameters parameters = this.parametersForPerson.getRaptorParameters(person);
-        List<InitialStop> accessStops = findAccessStops(fromFacility, toFacility, person, desiredDepartureTime, parameters);
-        List<InitialStop> egressStops = findEgressStops(fromFacility, toFacility, person, desiredDepartureTime, parameters);
+        List<InitialStop> accessStops = findAccessStops(fromFacility, toFacility, person, desiredDepartureTime, routingAttributes, parameters);
+        List<InitialStop> egressStops = findEgressStops(fromFacility, toFacility, person, desiredDepartureTime, routingAttributes, parameters);
 
         List<RaptorRoute> foundRoutes = this.raptor.calcRoutes(earliestDepartureTime, desiredDepartureTime, latestDepartureTime, fromFacility, toFacility, accessStops, egressStops, parameters, person);
         RaptorRoute foundRoute = selector.selectOne(foundRoutes, desiredDepartureTime);
@@ -187,10 +194,10 @@ public class SwissRailRaptor implements TransitRouter {
         return legs;
     }
 
-    public List<RaptorRoute> calcRoutes(Facility fromFacility, Facility toFacility, double earliestDepartureTime, double desiredDepartureTime, double latestDepartureTime, Person person) {
+    public List<RaptorRoute> calcRoutes(Facility fromFacility, Facility toFacility, double earliestDepartureTime, double desiredDepartureTime, double latestDepartureTime, Person person, Attributes routingAttributes) {
         RaptorParameters parameters = this.parametersForPerson.getRaptorParameters(person);
-        List<InitialStop> accessStops = findAccessStops(fromFacility, toFacility, person, desiredDepartureTime, parameters);
-        List<InitialStop> egressStops = findEgressStops(fromFacility, toFacility, person, desiredDepartureTime, parameters);
+        List<InitialStop> accessStops = findAccessStops(fromFacility, toFacility, person, desiredDepartureTime, routingAttributes, parameters);
+        List<InitialStop> egressStops = findEgressStops(fromFacility, toFacility, person, desiredDepartureTime, routingAttributes, parameters);
 
         List<RaptorRoute> foundRoutes = this.raptor.calcRoutes(earliestDepartureTime, desiredDepartureTime, latestDepartureTime, fromFacility, toFacility, accessStops, egressStops, parameters, person);
         RaptorRoute directWalk = createDirectWalk(fromFacility, toFacility, desiredDepartureTime, person, parameters);
@@ -227,9 +234,9 @@ public class SwissRailRaptor implements TransitRouter {
         return this.calcLeastCostTree(accessStops, departureTime, parameters, person);
     }
 
-    public Map<Id<TransitStopFacility>, SwissRailRaptorCore.TravelInfo> calcTree(Facility fromFacility, double departureTime, Person person) {
+    public Map<Id<TransitStopFacility>, SwissRailRaptorCore.TravelInfo> calcTree(Facility fromFacility, double departureTime, Person person, Attributes routingAttributes) {
         RaptorParameters parameters = this.parametersForPerson.getRaptorParameters(person);
-        List<InitialStop> accessStops = findAccessStops(fromFacility, fromFacility, person, departureTime, parameters);
+        List<InitialStop> accessStops = findAccessStops(fromFacility, fromFacility, person, departureTime, routingAttributes, parameters);
         return this.calcLeastCostTree(accessStops, departureTime, parameters, person);
     }
 
@@ -241,12 +248,12 @@ public class SwissRailRaptor implements TransitRouter {
         return this.data;
     }
 
-    private List<InitialStop> findAccessStops(Facility fromFacility, Facility toFacility, Person person, double departureTime, RaptorParameters parameters) {
-        return this.stopFinder.findStops(fromFacility, toFacility, person, departureTime, parameters, this.data, RaptorStopFinder.Direction.ACCESS);
+    private List<InitialStop> findAccessStops(Facility fromFacility, Facility toFacility, Person person, double departureTime, Attributes routingAttributes, RaptorParameters parameters) {
+        return this.stopFinder.findStops(fromFacility, toFacility, person, departureTime, routingAttributes, parameters, this.data, RaptorStopFinder.Direction.ACCESS);
     }
 
-    private List<InitialStop> findEgressStops(Facility fromFacility, Facility toFacility, Person person, double departureTime, RaptorParameters parameters) {
-        return this.stopFinder.findStops(fromFacility, toFacility, person, departureTime, parameters, this.data, RaptorStopFinder.Direction.EGRESS);
+    private List<InitialStop> findEgressStops(Facility fromFacility, Facility toFacility, Person person, double departureTime, Attributes routingAttributes, RaptorParameters parameters) {
+        return this.stopFinder.findStops(fromFacility, toFacility, person, departureTime, routingAttributes, parameters, this.data, RaptorStopFinder.Direction.EGRESS);
     }
 
     // TODO: replace with call to FallbackRoutingModule ?!

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorRoutingModule.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorRoutingModule.java
@@ -17,7 +17,9 @@ import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.population.PopulationUtils;
+import org.matsim.core.router.DefaultRoutingRequest;
 import org.matsim.core.router.RoutingModule;
+import org.matsim.core.router.RoutingRequest;
 import org.matsim.facilities.Facility;
 import org.matsim.pt.routes.TransitPassengerRoute;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
@@ -52,11 +54,16 @@ public class SwissRailRaptorRoutingModule implements RoutingModule {
     }
 
     @Override
-    public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double departureTime, Person person) {
+    public List<? extends PlanElement> calcRoute(RoutingRequest request) {
+    	final Facility fromFacility = request.getFromFacility();
+    	final Facility toFacility = request.getToFacility();
+    	final double departureTime = request.getDepartureTime();
+    	final Person person = request.getPerson();
+    	
         List<? extends PlanElement> legs = this.raptor.calcRoute(fromFacility, toFacility, departureTime, person);
         return legs != null ?
                 fillWithActivities(legs) :
-                walkRouter.calcRoute(fromFacility, toFacility, departureTime, person);
+                walkRouter.calcRoute(DefaultRoutingRequest.of(fromFacility, toFacility, departureTime, person));
     }
 
     private List<? extends PlanElement> fillWithActivities(List<? extends PlanElement> segments) {

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorRoutingModule.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorRoutingModule.java
@@ -55,15 +55,10 @@ public class SwissRailRaptorRoutingModule implements RoutingModule {
 
     @Override
     public List<? extends PlanElement> calcRoute(RoutingRequest request) {
-    	final Facility fromFacility = request.getFromFacility();
-    	final Facility toFacility = request.getToFacility();
-    	final double departureTime = request.getDepartureTime();
-    	final Person person = request.getPerson();
-    	
-        List<? extends PlanElement> legs = this.raptor.calcRoute(fromFacility, toFacility, departureTime, person);
+        List<? extends PlanElement> legs = this.raptor.calcRoute(request);
         return legs != null ?
                 fillWithActivities(legs) :
-                walkRouter.calcRoute(DefaultRoutingRequest.of(fromFacility, toFacility, departureTime, person));
+                walkRouter.calcRoute(request);
     }
 
     private List<? extends PlanElement> fillWithActivities(List<? extends PlanElement> segments) {

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/PreplanningEngine.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/PreplanningEngine.java
@@ -346,7 +346,7 @@ public final class PreplanningEngine implements MobsimEngine {
 			Facility toFacility = tripInfo.getPickupLocation();
 			double departureTime = tripInfo.getExpectedBoardingTime() - 900.; // always depart 15min before pickup
 			List<? extends PlanElement> planElements = tripRouter.calcRoute(TransportMode.walk, fromFacility,
-					toFacility, departureTime, null);
+					toFacility, departureTime, null, inputTrip.getOriginActivity().getAttributes());
 			;
 			// not sure if this works for walk, but it should ...
 
@@ -384,7 +384,7 @@ public final class PreplanningEngine implements MobsimEngine {
 			}
 			double departureTime = tripInfo.getExpectedBoardingTime() + expectedTravelTime;
 			List<? extends PlanElement> planElements = tripRouter.calcRoute(TransportMode.walk, fromFacility,
-					toFacility, departureTime, null);
+					toFacility, departureTime, null, inputTrip.getOriginActivity().getAttributes());
 
 			result.addAll(planElements);
 		}

--- a/matsim/src/main/java/org/matsim/core/router/DefaultRoutingRequest.java
+++ b/matsim/src/main/java/org/matsim/core/router/DefaultRoutingRequest.java
@@ -5,22 +5,20 @@ import org.matsim.facilities.Facility;
 import org.matsim.utils.objectattributes.attributable.Attributes;
 
 public class DefaultRoutingRequest implements RoutingRequest {
-	private final Attributes attributes = new Attributes();
+	private final Attributes attributes;
 
 	private final Facility fromFactility;
 	private final Facility toFacility;
 	private double departureTime;
 	private final Person person;
 
-	public DefaultRoutingRequest(Facility fromFacility, Facility toFacility, double departureTime, Person person) {
+	protected DefaultRoutingRequest(Facility fromFacility, Facility toFacility, double departureTime, Person person,
+			Attributes attributes) {
 		this.fromFactility = fromFacility;
 		this.toFacility = toFacility;
 		this.departureTime = departureTime;
 		this.person = person;
-	}
-
-	public DefaultRoutingRequest(Facility fromFacility, Facility toFacility, double departureTime) {
-		this(fromFacility, toFacility, departureTime, null);
+		this.attributes = attributes;
 	}
 
 	@Override
@@ -48,7 +46,13 @@ public class DefaultRoutingRequest implements RoutingRequest {
 		return person;
 	}
 
-	static public RoutingRequest of(Facility fromFacility, Facility toFacility, double departureTime, Person person) {
-		return new DefaultRoutingRequest(fromFacility, toFacility, departureTime, person);
+	static public RoutingRequest of(Facility fromFacility, Facility toFacility, double departureTime, Person person,
+			Attributes attributes) {
+		return new DefaultRoutingRequest(fromFacility, toFacility, departureTime, person, attributes);
+	}
+
+	static public RoutingRequest withoutAttributes(Facility fromFacility, Facility toFacility, double departureTime,
+			Person person) {
+		return new DefaultRoutingRequest(fromFacility, toFacility, departureTime, person, new Attributes());
 	}
 }

--- a/matsim/src/main/java/org/matsim/core/router/DefaultRoutingRequest.java
+++ b/matsim/src/main/java/org/matsim/core/router/DefaultRoutingRequest.java
@@ -1,0 +1,54 @@
+package org.matsim.core.router;
+
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
+
+public class DefaultRoutingRequest implements RoutingRequest {
+	private final Attributes attributes = new Attributes();
+
+	private final Facility fromFactility;
+	private final Facility toFacility;
+	private double departureTime;
+	private final Person person;
+
+	public DefaultRoutingRequest(Facility fromFacility, Facility toFacility, double departureTime, Person person) {
+		this.fromFactility = fromFacility;
+		this.toFacility = toFacility;
+		this.departureTime = departureTime;
+		this.person = person;
+	}
+
+	public DefaultRoutingRequest(Facility fromFacility, Facility toFacility, double departureTime) {
+		this(fromFacility, toFacility, departureTime, null);
+	}
+
+	@Override
+	public Attributes getAttributes() {
+		return attributes;
+	}
+
+	@Override
+	public Facility getFromFacility() {
+		return fromFactility;
+	}
+
+	@Override
+	public Facility getToFacility() {
+		return toFacility;
+	}
+
+	@Override
+	public double getDepartureTime() {
+		return departureTime;
+	}
+
+	@Override
+	public Person getPerson() {
+		return person;
+	}
+
+	static public RoutingRequest of(Facility fromFacility, Facility toFacility, double departureTime, Person person) {
+		return new DefaultRoutingRequest(fromFacility, toFacility, departureTime, person);
+	}
+}

--- a/matsim/src/main/java/org/matsim/core/router/FallbackRoutingModuleDefaultImpl.java
+++ b/matsim/src/main/java/org/matsim/core/router/FallbackRoutingModuleDefaultImpl.java
@@ -29,7 +29,12 @@ class FallbackRoutingModuleDefaultImpl implements  FallbackRoutingModule {
 	@Inject private Population population ;
 	@Inject private Network network ;
 
-	@Override public List<? extends PlanElement> calcRoute( Facility fromFacility, Facility toFacility, double departureTime, Person person ){
+	@Override public List<? extends PlanElement> calcRoute( RoutingRequest request ){
+		final Facility fromFacility = request.getFromFacility();
+		final Facility toFacility = request.getToFacility();
+		final double departureTime = request.getDepartureTime();
+		final Person person = request.getPerson();
+		
 		Leg leg = population.getFactory().createLeg( TransportMode.walk ) ;
 		Coord fromCoord = FacilitiesUtils.decideOnCoord( fromFacility, network, config );
 		Coord toCoord = FacilitiesUtils.decideOnCoord( toFacility, network, config ) ;

--- a/matsim/src/main/java/org/matsim/core/router/FreespeedFactorRoutingModule.java
+++ b/matsim/src/main/java/org/matsim/core/router/FreespeedFactorRoutingModule.java
@@ -56,11 +56,12 @@ public final class FreespeedFactorRoutingModule implements RoutingModule {
 	}
 
 	@Override
-	public List<? extends PlanElement> calcRoute(
-			final Facility fromFacility,
-			final Facility toFacility,
-			final double departureTime,
-			final Person person) {
+	public List<? extends PlanElement> calcRoute(RoutingRequest request) {
+		final Facility fromFacility = request.getFromFacility();
+		final Facility toFacility = request.getToFacility();
+		final double departureTime = request.getDepartureTime();
+		final Person person = request.getPerson();
+		
 		Leg newLeg = this.populationFactory.createLeg( this.mode );
 		newLeg.setDepartureTime( departureTime );
 

--- a/matsim/src/main/java/org/matsim/core/router/LinkToLinkRoutingModule.java
+++ b/matsim/src/main/java/org/matsim/core/router/LinkToLinkRoutingModule.java
@@ -65,8 +65,12 @@ class LinkToLinkRoutingModule implements RoutingModule {
     }
 
     @Override
-    public List<? extends PlanElement> calcRoute( final Facility fromFacility,
-								  final Facility toFacility, final double departureTime, final Person person) {
+    public List<? extends PlanElement> calcRoute(RoutingRequest request) {
+		final Facility fromFacility = request.getFromFacility();
+		final Facility toFacility = request.getToFacility();
+		final double departureTime = request.getDepartureTime();
+		final Person person = request.getPerson();
+		
         Leg newLeg = this.populationFactory.createLeg( this.mode );
 		
 		Gbl.assertNotNull(fromFacility);

--- a/matsim/src/main/java/org/matsim/core/router/NetworkRoutingInclAccessEgressModule.java
+++ b/matsim/src/main/java/org/matsim/core/router/NetworkRoutingInclAccessEgressModule.java
@@ -54,6 +54,7 @@ import org.matsim.core.router.util.LeastCostPathCalculator.Path;
 import org.matsim.core.utils.geometry.CoordUtils;
 import org.matsim.facilities.FacilitiesUtils;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleUtils;
 
@@ -143,7 +144,7 @@ public final class NetworkRoutingInclAccessEgressModule implements RoutingModule
 		// === access:
 		{
 			List<? extends PlanElement> accessTrip = computeAccessTripFromFacilityToLinkIfNecessary(fromFacility, person, accessActLink, now, populationFactory, mode,
-					scenario.getConfig());
+					scenario.getConfig(), request.getAttributes());
 			if(accessTrip == null ) return null; //access trip could not get routed so we return null for the entire trip => will lead to the tripRouter to call fallbackRoutingModule
 			for (PlanElement planElement : accessTrip) {
 				now = TripRouter.calcEndOfPlanElement(now, planElement, config);
@@ -164,7 +165,7 @@ public final class NetworkRoutingInclAccessEgressModule implements RoutingModule
 		// === egress:
 		{
 			List<PlanElement> egressTrip = computeEgressTripFromLinkToFacilityIfNecessary(toFacility, person, egressActLink, now, result.get(result.size() - 1), populationFactory, mode,
-					scenario.getConfig());
+					scenario.getConfig(), request.getAttributes());
 			if(egressTrip == null ) return null; //egress trip could not get routed so we return null for the entire trip => will lead to the tripRouter to call fallbackRoutingModule
 			result.addAll(egressTrip);
 		}
@@ -175,7 +176,7 @@ public final class NetworkRoutingInclAccessEgressModule implements RoutingModule
 	private List<PlanElement> computeEgressTripFromLinkToFacilityIfNecessary(final Facility toFacility, final Person person,
 																final Link egressActLink, double departureTime, PlanElement previousPlanElement,
 																final PopulationFactory populationFactory, final String stageActivityType,
-																Config config) {
+																Config config, Attributes routingAttributes) {
 
 		log.debug("do bushwhacking leg from link=" + egressActLink.getId() + " to facility=" + toFacility.toString());
 
@@ -220,7 +221,7 @@ public final class NetworkRoutingInclAccessEgressModule implements RoutingModule
 			egressTrip.add(egressLeg);
 		} else {
 			Facility fromFacility = FacilitiesUtils.wrapLinkAndCoord(egressActLink,startCoord);
-			List<? extends PlanElement> networkRoutedEgressTrip = egressFromNetworkRouter.calcRoute(DefaultRoutingRequest.of(fromFacility, toFacility, departureTime, person));
+			List<? extends PlanElement> networkRoutedEgressTrip = egressFromNetworkRouter.calcRoute(DefaultRoutingRequest.of(fromFacility, toFacility, departureTime, person, routingAttributes));
 			if(networkRoutedEgressTrip == null) return null;
 			if (this.accessEgressType.equals(PlansCalcRouteConfigGroup.AccessEgressType.accessEgressModeToLinkPlusTimeConstant)){
 				double egressTime = NetworkUtils.getLinkEgressTime(egressActLink,mode).orElseThrow(()->new RuntimeException("Egress Time not set for link "+ egressActLink.getId().toString()));
@@ -246,7 +247,7 @@ public final class NetworkRoutingInclAccessEgressModule implements RoutingModule
 	private List<? extends PlanElement> computeAccessTripFromFacilityToLinkIfNecessary(final Facility fromFacility, final Person person,
 																  final Link accessActLink, double departureTime,
 																  final PopulationFactory populationFactory, final String stageActivityType,
-																  Config config) {
+																  Config config, Attributes routingAttributes) {
 		if (isNotNeedingBushwhackingLeg(fromFacility)) {
 			return Collections.emptyList();
 		}
@@ -287,7 +288,7 @@ public final class NetworkRoutingInclAccessEgressModule implements RoutingModule
 //			now += accessTime;
 		} else {
 			Facility toFacility = FacilitiesUtils.wrapLinkAndCoord(accessActLink,endCoord);
-			List<? extends PlanElement> networkRoutedAccessTrip = accessToNetworkRouter.calcRoute(DefaultRoutingRequest.of(fromFacility, toFacility, departureTime, person));
+			List<? extends PlanElement> networkRoutedAccessTrip = accessToNetworkRouter.calcRoute(DefaultRoutingRequest.of(fromFacility, toFacility, departureTime, person, routingAttributes));
 			if (networkRoutedAccessTrip == null) return null; //no access trip could be computed for accessMode
 			if (this.accessEgressType.equals(PlansCalcRouteConfigGroup.AccessEgressType.accessEgressModeToLinkPlusTimeConstant)){
 				double accessTime = NetworkUtils.getLinkAccessTime(accessActLink,mode).orElseThrow(()->new RuntimeException("Access Time not set for link "+ accessActLink.getId().toString()));

--- a/matsim/src/main/java/org/matsim/core/router/NetworkRoutingInclAccessEgressModule.java
+++ b/matsim/src/main/java/org/matsim/core/router/NetworkRoutingInclAccessEgressModule.java
@@ -120,13 +120,14 @@ public final class NetworkRoutingInclAccessEgressModule implements RoutingModule
 	}
 
 	@Override
-	public synchronized List<? extends PlanElement> calcRoute(
-			final Facility fromFacility,
-			final Facility toFacility,
-			final double departureTime,
-			final Person person) {
+	public synchronized List<? extends PlanElement> calcRoute(RoutingRequest request) {
 		// I need this "synchronized" since I want mobsim agents to be able to call this during the mobsim.  So when the
 		// mobsim is multi-threaded, multiple agents might call this here at the same time.  kai, nov'17
+		
+		final Facility fromFacility = request.getFromFacility();
+		final Facility toFacility = request.getToFacility();
+		final double departureTime = request.getDepartureTime();
+		final Person person = request.getPerson();
 
 		Gbl.assertNotNull(fromFacility);
 		Gbl.assertNotNull(toFacility);
@@ -219,7 +220,7 @@ public final class NetworkRoutingInclAccessEgressModule implements RoutingModule
 			egressTrip.add(egressLeg);
 		} else {
 			Facility fromFacility = FacilitiesUtils.wrapLinkAndCoord(egressActLink,startCoord);
-			List<? extends PlanElement> networkRoutedEgressTrip = egressFromNetworkRouter.calcRoute(fromFacility, toFacility, departureTime, person);
+			List<? extends PlanElement> networkRoutedEgressTrip = egressFromNetworkRouter.calcRoute(DefaultRoutingRequest.of(fromFacility, toFacility, departureTime, person));
 			if(networkRoutedEgressTrip == null) return null;
 			if (this.accessEgressType.equals(PlansCalcRouteConfigGroup.AccessEgressType.accessEgressModeToLinkPlusTimeConstant)){
 				double egressTime = NetworkUtils.getLinkEgressTime(egressActLink,mode).orElseThrow(()->new RuntimeException("Egress Time not set for link "+ egressActLink.getId().toString()));
@@ -286,7 +287,7 @@ public final class NetworkRoutingInclAccessEgressModule implements RoutingModule
 //			now += accessTime;
 		} else {
 			Facility toFacility = FacilitiesUtils.wrapLinkAndCoord(accessActLink,endCoord);
-			List<? extends PlanElement> networkRoutedAccessTrip = accessToNetworkRouter.calcRoute(fromFacility, toFacility, departureTime, person);
+			List<? extends PlanElement> networkRoutedAccessTrip = accessToNetworkRouter.calcRoute(DefaultRoutingRequest.of(fromFacility, toFacility, departureTime, person));
 			if (networkRoutedAccessTrip == null) return null; //no access trip could be computed for accessMode
 			if (this.accessEgressType.equals(PlansCalcRouteConfigGroup.AccessEgressType.accessEgressModeToLinkPlusTimeConstant)){
 				double accessTime = NetworkUtils.getLinkAccessTime(accessActLink,mode).orElseThrow(()->new RuntimeException("Access Time not set for link "+ accessActLink.getId().toString()));

--- a/matsim/src/main/java/org/matsim/core/router/NetworkRoutingModule.java
+++ b/matsim/src/main/java/org/matsim/core/router/NetworkRoutingModule.java
@@ -71,8 +71,12 @@ public final class NetworkRoutingModule implements RoutingModule {
 	}
 
 	@Override
-	public List<? extends PlanElement> calcRoute(final Facility fromFacility, final Facility toFacility, final double departureTime,
-			final Person person) {		
+	public List<? extends PlanElement> calcRoute(RoutingRequest request) {
+		final Facility fromFacility = request.getFromFacility();
+		final Facility toFacility = request.getToFacility();
+		final double departureTime = request.getDepartureTime();
+		final Person person = request.getPerson();
+		
 		Leg newLeg = this.populationFactory.createLeg( this.mode );
 
 		Gbl.assertNotNull(fromFacility);

--- a/matsim/src/main/java/org/matsim/core/router/PlanRouter.java
+++ b/matsim/src/main/java/org/matsim/core/router/PlanRouter.java
@@ -96,7 +96,7 @@ public class PlanRouter implements PlanAlgorithm, PersonAlgorithm {
 						  FacilitiesUtils.toFacility( oldTrip.getOriginActivity(), facilities ),
 						  FacilitiesUtils.toFacility( oldTrip.getDestinationActivity(), facilities ),
 							calcEndOfActivity( oldTrip.getOriginActivity() , plan, tripRouter.getConfig() ),
-							plan.getPerson() );
+							plan.getPerson(), oldTrip.getOriginActivity().getAttributes() );
 			putVehicleFromOldTripIntoNewTripIfMeaningful(oldTrip, newTrip);
 			TripRouter.insertTrip(
 					plan, 

--- a/matsim/src/main/java/org/matsim/core/router/RoutingModule.java
+++ b/matsim/src/main/java/org/matsim/core/router/RoutingModule.java
@@ -21,11 +21,9 @@ package org.matsim.core.router;
 
 import java.util.List;
 
-import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
-import org.matsim.facilities.Facility;
 
 /**
  * Defines classes responsible for routing for a given
@@ -45,19 +43,16 @@ public interface RoutingModule {
 	 * using {@link TravelTime} and/or {@link TravelDisutility}
 	 * estimators, this method is responsible for setting the person to the argument
 	 * person in those estimators before running the shortest path algorithm.
+	 * 
+	 * The method parameters prior to MATSim 14 have been collected in a RoutingRequest object. 
+	 * To retrofit older code, use DefaultRoutingRequest.of(...) to wrap your method arguments.
 	 *
-	 * @param fromFacility a {@link Facility} representing the departure location
-	 * @param toFacility a {@link Facility} representing the arrival location
-	 * @param departureTime the departure time
-	 * @param person the {@link Person} to route
+	 * @param request a {@link RoutingRequest} represents origin, destination, departure time, etc.
 	 * @return a list of {@link PlanElement}, in proper order, representing the trip.
 	 */
-	public List<? extends PlanElement> calcRoute(
-			Facility fromFacility,
-			Facility toFacility,
-			double departureTime,
-			Person person);
+	public List<? extends PlanElement> calcRoute(RoutingRequest request);
+	
 	// NOTE: It makes some sense to _not_ have the vehicle as an argument here ... since that only makes sense for vehicular modes. kai, feb'19
-
+	// NOTE: But now we have replaced the arguments with the RoutingRequest interface, which could now have a derived VehicularRoutingRequest if needed. shoerl, aug'21
 }
 

--- a/matsim/src/main/java/org/matsim/core/router/RoutingRequest.java
+++ b/matsim/src/main/java/org/matsim/core/router/RoutingRequest.java
@@ -1,0 +1,19 @@
+package org.matsim.core.router;
+
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributable;
+
+/**
+ * Defines the characteristics of a route to be found, independent of transport
+ * mode
+ */
+public interface RoutingRequest extends Attributable {
+	Facility getFromFacility();
+
+	Facility getToFacility();
+
+	double getDepartureTime();
+
+	Person getPerson();
+}

--- a/matsim/src/main/java/org/matsim/core/router/TeleportationRoutingModule.java
+++ b/matsim/src/main/java/org/matsim/core/router/TeleportationRoutingModule.java
@@ -59,11 +59,12 @@ public class TeleportationRoutingModule implements RoutingModule {
 	}
 
 	@Override
-	public List<? extends PlanElement> calcRoute(
-			final Facility fromFacility,
-			final Facility toFacility,
-			final double departureTime,
-			final Person person) {
+	public List<? extends PlanElement> calcRoute(RoutingRequest request) {
+		final Facility fromFacility = request.getFromFacility();
+		final Facility toFacility = request.getToFacility();
+		final double departureTime = request.getDepartureTime();
+		final Person person = request.getPerson();
+		
 		Leg newLeg = this.scenario.getPopulation().getFactory().createLeg( this.mode );
 		newLeg.setDepartureTime( departureTime );
 

--- a/matsim/src/main/java/org/matsim/core/router/TransitRouterWrapper.java
+++ b/matsim/src/main/java/org/matsim/core/router/TransitRouterWrapper.java
@@ -36,6 +36,7 @@ import org.matsim.facilities.Facility;
 import org.matsim.pt.router.TransitRouter;
 import org.matsim.pt.routes.TransitPassengerRoute;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * Wraps a {@link TransitRouter}.
@@ -72,16 +73,7 @@ public class TransitRouterWrapper implements RoutingModule {
 	 */
 	@Override
 	public List<? extends PlanElement> calcRoute(RoutingRequest request) {
-		final Facility fromFacility = request.getFromFacility();
-		final Facility toFacility = request.getToFacility();
-		final double departureTime = request.getDepartureTime();
-		final Person person = request.getPerson();
-		
-		List<? extends PlanElement> baseTrip = router.calcRoute(
-				fromFacility,
-				toFacility,
-				departureTime,
-				person);
+		List<? extends PlanElement> baseTrip = router.calcRoute(request);
 
 		// the previous approach was to return null when no trip was found and
 		// not to replace the trip if so.
@@ -89,7 +81,7 @@ public class TransitRouterWrapper implements RoutingModule {
 		// Thus, every module should return a valid trip. When available, the "main
 		// mode" flag should be put to the mode of the routing module.
 		return baseTrip != null ?
-				fillWithActivities(baseTrip, fromFacility, toFacility, departureTime, person) :
+				fillWithActivities(baseTrip, request) :
 					null;
 	}
 
@@ -98,9 +90,12 @@ public class TransitRouterWrapper implements RoutingModule {
 	 * must be filled in (distance, travel-time in routes).
 	 */
 	private List<PlanElement> fillWithActivities(
-			final List<? extends PlanElement> baseTrip,
-			final Facility fromFacility,
-			final Facility toFacility, double departureTime, Person person) {
+			final List<? extends PlanElement> baseTrip, RoutingRequest request) {
+		final Facility fromFacility = request.getFromFacility();
+		final Facility toFacility = request.getToFacility();
+		final double departureTime = request.getDepartureTime();
+		final Person person = request.getPerson();
+		
 		List<PlanElement> trip = new ArrayList<>();
 		Coord nextCoord = null;
 		int i = 0;
@@ -117,7 +112,7 @@ public class TransitRouterWrapper implements RoutingModule {
 				}
 				// (*)
 				Route route = createWalkRoute(fromFacility, departureTime, person,
-						leg.getTravelTime().seconds(), firstToFacility);
+						leg.getTravelTime().seconds(), firstToFacility, request.getAttributes());
 				leg.setRoute(route);
 			} else {
 				if (leg.getRoute() instanceof TransitPassengerRoute) {
@@ -140,7 +135,7 @@ public class TransitRouterWrapper implements RoutingModule {
 						Facility lastFromFacility = this.transitSchedule.getFacilities().get(tRoute.getEgressStopId());
 
 						Route route = createWalkRoute(lastFromFacility, departureTime, person,
-								leg.getTravelTime().seconds(), toFacility);
+								leg.getTravelTime().seconds(), toFacility, request.getAttributes());
 						leg.setRoute(route);
 					}
 					Activity act = PopulationUtils.createStageActivityFromCoordLinkIdAndModePrefix(nextCoord, leg.getRoute().getStartLinkId(), TransportMode.pt);
@@ -153,13 +148,13 @@ public class TransitRouterWrapper implements RoutingModule {
 		return trip;
 	}
 
-	private Route createWalkRoute(final Facility fromFacility, double departureTime, Person person, double travelTime, Facility firstToFacility) {
+	private Route createWalkRoute(final Facility fromFacility, double departureTime, Person person, double travelTime, Facility firstToFacility, Attributes routingAttributes) {
 		// yyyy I extracted this method to make a bit more transparent that it is used twice.  But I don't know why it is done in this way
 		// (take distance from newly computed walk leg, but take travelTime from elsewhere).  Possibly, the problem is that the TransitRouter 
 		// historically just does not compute the distances.  kai, may'17
 		
 		Route route = RouteUtils.createGenericRouteImpl(fromFacility.getLinkId(), firstToFacility.getLinkId());
-		final List<? extends PlanElement> walkRoute = walkRouter.calcRoute(DefaultRoutingRequest.of(fromFacility, firstToFacility, departureTime, person));
+		final List<? extends PlanElement> walkRoute = walkRouter.calcRoute(DefaultRoutingRequest.of(fromFacility, firstToFacility, departureTime, person, routingAttributes));
 		route.setDistance(((Leg) walkRoute.get(0)).getRoute().getDistance());
 		route.setTravelTime(travelTime);
 		return route;

--- a/matsim/src/main/java/org/matsim/core/router/TransitRouterWrapper.java
+++ b/matsim/src/main/java/org/matsim/core/router/TransitRouterWrapper.java
@@ -71,11 +71,12 @@ public class TransitRouterWrapper implements RoutingModule {
 	 * @return the list of legs returned by the transit router.
 	 */
 	@Override
-	public List<? extends PlanElement> calcRoute(
-			final Facility fromFacility,
-			final Facility toFacility,
-			final double departureTime,
-			final Person person) {
+	public List<? extends PlanElement> calcRoute(RoutingRequest request) {
+		final Facility fromFacility = request.getFromFacility();
+		final Facility toFacility = request.getToFacility();
+		final double departureTime = request.getDepartureTime();
+		final Person person = request.getPerson();
+		
 		List<? extends PlanElement> baseTrip = router.calcRoute(
 				fromFacility,
 				toFacility,
@@ -158,7 +159,7 @@ public class TransitRouterWrapper implements RoutingModule {
 		// historically just does not compute the distances.  kai, may'17
 		
 		Route route = RouteUtils.createGenericRouteImpl(fromFacility.getLinkId(), firstToFacility.getLinkId());
-		final List<? extends PlanElement> walkRoute = walkRouter.calcRoute(fromFacility, firstToFacility, departureTime, person);
+		final List<? extends PlanElement> walkRoute = walkRouter.calcRoute(DefaultRoutingRequest.of(fromFacility, firstToFacility, departureTime, person));
 		route.setDistance(((Leg) walkRoute.get(0)).getRoute().getDistance());
 		route.setTravelTime(travelTime);
 		return route;

--- a/matsim/src/main/java/org/matsim/core/router/TripRouter.java
+++ b/matsim/src/main/java/org/matsim/core/router/TripRouter.java
@@ -41,6 +41,7 @@ import org.matsim.core.config.Config;
 import org.matsim.core.gbl.Gbl;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import com.google.common.base.Preconditions;
 
@@ -160,7 +161,8 @@ public final class TripRouter implements MatsimExtensionPoint {
 			final Facility fromFacility,
 			final Facility toFacility,
 			final double departureTime,
-			final Person person) {
+			final Person person,
+			final Attributes routingAttributes) {
 		// I need this "synchronized" since I want mobsim agents to be able to call this during the mobsim.  So when the
 		// mobsim is multi-threaded, multiple agents might call this here at the same time.  kai, nov'17
 
@@ -170,15 +172,17 @@ public final class TripRouter implements MatsimExtensionPoint {
 		RoutingModule module = routingModules.get( mainMode );
 
 		if (module != null) {
-			List<? extends PlanElement> trip =
-					module.calcRoute(DefaultRoutingRequest.of(
-						fromFacility,
-						toFacility,
-						departureTime,
-						person));
+			RoutingRequest request = DefaultRoutingRequest.of(
+					fromFacility,
+					toFacility,
+					departureTime,
+					person,
+					routingAttributes);
+					
+			List<? extends PlanElement> trip = module.calcRoute(request);
 
 			if ( trip == null ) {
-				trip = fallbackRoutingModule.calcRoute(DefaultRoutingRequest.of( fromFacility, toFacility, departureTime, person )) ;
+				trip = fallbackRoutingModule.calcRoute(request) ;
 			}
 			for (Leg leg: TripStructureUtils.getLegs(trip)) {
 				TripStructureUtils.setRoutingMode(leg, mainMode);

--- a/matsim/src/main/java/org/matsim/core/router/TripRouter.java
+++ b/matsim/src/main/java/org/matsim/core/router/TripRouter.java
@@ -171,14 +171,14 @@ public final class TripRouter implements MatsimExtensionPoint {
 
 		if (module != null) {
 			List<? extends PlanElement> trip =
-					module.calcRoute(
+					module.calcRoute(DefaultRoutingRequest.of(
 						fromFacility,
 						toFacility,
 						departureTime,
-						person);
+						person));
 
 			if ( trip == null ) {
-				trip = fallbackRoutingModule.calcRoute( fromFacility, toFacility, departureTime, person ) ;
+				trip = fallbackRoutingModule.calcRoute(DefaultRoutingRequest.of( fromFacility, toFacility, departureTime, person )) ;
 			}
 			for (Leg leg: TripStructureUtils.getLegs(trip)) {
 				TripStructureUtils.setRoutingMode(leg, mainMode);

--- a/matsim/src/main/java/org/matsim/pt/router/TransitRouter.java
+++ b/matsim/src/main/java/org/matsim/pt/router/TransitRouter.java
@@ -21,15 +21,14 @@ package org.matsim.pt.router;
 
 import java.util.List;
 
-import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PlanElement;
-import org.matsim.facilities.Facility;
+import org.matsim.core.router.RoutingRequest;
 
 /**
  * @author mrieser
  */
 public interface TransitRouter {
 
-	public abstract List<? extends PlanElement> calcRoute(final Facility fromFacility, final Facility toFacility, final double departureTime, final Person person);
+	public abstract List<? extends PlanElement> calcRoute(RoutingRequest request);
 
 }

--- a/matsim/src/main/java/org/matsim/pt/router/TransitRouterImpl.java
+++ b/matsim/src/main/java/org/matsim/pt/router/TransitRouterImpl.java
@@ -26,6 +26,7 @@ import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.router.InitialNode;
+import org.matsim.core.router.RoutingRequest;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.utils.geometry.CoordUtils;
 import org.matsim.facilities.Facility;
@@ -111,7 +112,12 @@ public class TransitRouterImpl extends AbstractTransitRouter implements TransitR
     }
 
     @Override
-    public List<? extends PlanElement> calcRoute( final Facility fromFacility, final Facility toFacility, final double departureTime, final Person person) {
+    public List<? extends PlanElement> calcRoute( final RoutingRequest request ) {
+    	final Facility fromFacility = request.getFromFacility();
+    	final Facility toFacility = request.getToFacility();
+    	final double departureTime = request.getDepartureTime();
+    	final Person person = request.getPerson();
+    	
         // find possible start stops
         Map<Node, InitialNode> wrappedFromNodes = this.locateWrappedNearestTransitNodes(person,
                 fromFacility.getCoord(),

--- a/matsim/src/main/java/org/matsim/withinday/utils/EditRoutes.java
+++ b/matsim/src/main/java/org/matsim/withinday/utils/EditRoutes.java
@@ -28,6 +28,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
+import org.matsim.api.core.v01.population.Activity;
 import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Plan;
@@ -149,7 +150,7 @@ public final class EditRoutes {
 	 */
 	@Deprecated // not consistent with access/egress approach; can only be used if you know exactly what you are doing.  
 	// Maybe replanXxx is already sufficient?  Otherwise use EditTrips or EditPlans.  kai, nov'17
-	public static boolean relocateFutureLegRoute(Leg leg, Id<Link> fromLinkId, Id<Link> toLinkId, Person person, Network network, TripRouter tripRouter) {
+	public static boolean relocateFutureLegRoute(Leg leg, Id<Link> fromLinkId, Id<Link> toLinkId, Person person, Network network, TripRouter tripRouter, Activity fromActivity) {
 		// TripRouter variant; everything else uses the PathCalculator
 		
 		Link fromLink = network.getLinks().get(fromLinkId);
@@ -159,7 +160,7 @@ public final class EditRoutes {
 		Facility toFacility = new LinkWrapperFacility(toLink);
 
 		List<? extends PlanElement> planElements = tripRouter.calcRoute(leg.getMode(), fromFacility, toFacility,
-				leg.getDepartureTime().seconds(), person);
+				leg.getDepartureTime().seconds(), person, fromActivity.getAttributes());
 
 		if (planElements.size() != 1) {
 			throw new RuntimeException("Expected a list of PlanElements containing exactly one element, " +

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/RaptorStopFinderTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/RaptorStopFinderTest.java
@@ -19,6 +19,7 @@ import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.groups.PlanCalcScoreConfigGroup;
 import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.population.routes.RouteUtils;
+import org.matsim.core.router.DefaultRoutingRequest;
 import org.matsim.core.router.RoutingModule;
 import org.matsim.core.router.TeleportationRoutingModule;
 import org.matsim.core.scenario.ScenarioUtils;
@@ -84,7 +85,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
 
             Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
             
@@ -112,7 +113,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -156,7 +157,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f1.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -213,7 +214,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
             
             Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
             
@@ -247,7 +248,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -298,7 +299,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -353,7 +354,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -401,7 +402,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
 
             Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
             
@@ -430,7 +431,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -474,7 +475,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f1.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -531,7 +532,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
 
             Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
             
@@ -566,7 +567,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -618,7 +619,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -674,7 +675,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -735,7 +736,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f1.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -780,7 +781,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f1.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -825,7 +826,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f1.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -879,7 +880,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -931,7 +932,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -979,7 +980,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f1.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -1025,7 +1026,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f1.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -1071,7 +1072,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f1.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -1126,7 +1127,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -1179,7 +1180,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -1242,7 +1243,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -1289,7 +1290,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f1.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -1347,7 +1348,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -1402,7 +1403,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -1454,7 +1455,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -1502,7 +1503,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f1.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f1.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -1561,7 +1562,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -1617,7 +1618,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -1690,7 +1691,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -1756,7 +1757,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -1818,7 +1819,7 @@ public class RaptorStopFinderTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f0.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(this.fromFac, this.toFac, 7 * 3600, f0.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorCapacitiesTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorCapacitiesTest.java
@@ -25,6 +25,7 @@ import org.matsim.core.events.EventsUtils;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.population.routes.RouteUtils;
+import org.matsim.core.router.DefaultRoutingRequest;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.scoring.functions.SubpopulationScoringParameters;
 import org.matsim.core.utils.misc.Time;
@@ -68,7 +69,7 @@ public class SwissRailRaptorCapacitiesTest {
 		Facility fromFacility = new FakeFacility(new Coord(900, 900), Id.create("aa", Link.class));
 		Facility toFacility = new FakeFacility(new Coord(7100, 1100), Id.create("cd", Link.class));
 
-		List<? extends PlanElement> route1 = raptor.calcRoute(fromFacility, toFacility, Time.parseTime("07:00:00"), null);
+		List<? extends PlanElement> route1 = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFacility, toFacility, Time.parseTime("07:00:00"), null));
 		Assert.assertNotNull(route1);
 		System.out.println("uncongested route:");
 		for (PlanElement leg : route1) {
@@ -171,7 +172,7 @@ public class SwissRailRaptorCapacitiesTest {
 		tracker.handleEvent(new PersonEntersVehicleEvent(Time.parseTime("07:20:25"), person9, vehicle3));
 		tracker.handleEvent(new VehicleDepartsAtFacilityEvent(Time.parseTime("07:20:30"), vehicle3, f.stopAId, 0));
 
-		List<? extends PlanElement> route2 = raptor.calcRoute(fromFacility, toFacility, Time.parseTime("07:00:00"), null);
+		List<? extends PlanElement> route2 = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFacility, toFacility, Time.parseTime("07:00:00"), null));
 		Assert.assertNotNull(route2);
 		System.out.println("congested route:");
 		for (PlanElement leg : route2) {

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorInVehicleCostTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorInVehicleCostTest.java
@@ -25,6 +25,7 @@ import org.matsim.core.events.EventsUtils;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.population.routes.RouteUtils;
+import org.matsim.core.router.DefaultRoutingRequest;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.scoring.functions.SubpopulationScoringParameters;
 import org.matsim.core.utils.misc.Time;
@@ -121,7 +122,7 @@ public class SwissRailRaptorInVehicleCostTest {
 		Facility fromFacility = new FakeFacility(new Coord(900, 900), Id.create("aa", Link.class));
 		Facility toFacility = new FakeFacility(new Coord(7100, 1100), Id.create("cd", Link.class));
 
-		List<? extends PlanElement> route1 = raptor.calcRoute(fromFacility, toFacility, Time.parseTime("07:00:00"), null);
+		List<? extends PlanElement> route1 = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFacility, toFacility, Time.parseTime("07:00:00"), null));
 		Assert.assertNotNull(route1);
 
 		System.out.println("calculated route:");

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorIntermodalTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorIntermodalTest.java
@@ -27,7 +27,9 @@ import org.matsim.core.config.groups.PlanCalcScoreConfigGroup;
 import org.matsim.core.population.routes.GenericRouteImpl;
 import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.population.routes.RouteUtils;
+import org.matsim.core.router.DefaultRoutingRequest;
 import org.matsim.core.router.RoutingModule;
+import org.matsim.core.router.RoutingRequest;
 import org.matsim.core.router.TeleportationRoutingModule;
 import org.matsim.core.router.TripRouter;
 import org.matsim.core.scenario.ScenarioUtils;
@@ -848,8 +850,7 @@ public class SwissRailRaptorIntermodalTest {
         		new RoutingModule() {
 
 					@Override
-					public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility,
-							double departureTime, Person person) {
+					public List<? extends PlanElement> calcRoute(RoutingRequest request) {
 						return null;
 					}
         	
@@ -959,8 +960,10 @@ public class SwissRailRaptorIntermodalTest {
             new RoutingModule() {
 				
 				@Override
-				public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double departureTime,
-						Person person) {
+				public List<? extends PlanElement> calcRoute(RoutingRequest request) {
+					final Facility fromFacility = request.getFromFacility();
+					final Facility toFacility = request.getToFacility();
+					final double departureTime = request.getDepartureTime();
 					
 					Coord bikeCoord = CoordUtils.createCoord(9500, 10000);
 					
@@ -1078,8 +1081,10 @@ public class SwissRailRaptorIntermodalTest {
             new RoutingModule() {
 				
 				@Override
-				public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double departureTime,
-						Person person) {
+				public List<? extends PlanElement> calcRoute(RoutingRequest request) {
+					final Facility fromFacility = request.getFromFacility();
+					final Facility toFacility = request.getToFacility();
+					final double departureTime = request.getDepartureTime();
 					
 					Coord bikeCoord = CoordUtils.createCoord(9500, 10000);
 					
@@ -1140,7 +1145,7 @@ public class SwissRailRaptorIntermodalTest {
         Facility fromFac = new FakeFacility(new Coord(9500, 10000), Id.create("from", Link.class));
         Facility toFac = new FakeFacility(new Coord(50000, 10500), Id.create("to", Link.class));
 
-        List<? extends PlanElement> legs = ssrrModule.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson);
+        List<? extends PlanElement> legs = ssrrModule.calcRoute(DefaultRoutingRequest.of(fromFac, toFac, 7*3600, f.dummyPerson));
         for (PlanElement leg : legs) {
             System.out.println(leg);
         }

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorIntermodalTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorIntermodalTest.java
@@ -43,6 +43,7 @@ import org.matsim.pt.transitSchedule.api.TransitRouteStop;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.pt.transitSchedule.api.TransitScheduleFactory;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -91,7 +92,7 @@ public class SwissRailRaptorIntermodalTest {
         Facility fromFac = new FakeFacility(new Coord(10000, 10500), Id.create("from", Link.class));
         Facility toFac = new FakeFacility(new Coord(50000, 10500), Id.create("to", Link.class));
 
-        List<? extends PlanElement> legs = raptor.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson);
+        List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFac, toFac, 7*3600, f.dummyPerson));
         for (PlanElement leg : legs) {
             System.out.println(leg);
         }
@@ -166,7 +167,7 @@ public class SwissRailRaptorIntermodalTest {
         Facility fromFac = new FakeFacility(new Coord(10000, 10500), Id.create("from", Link.class));
         Facility toFac = new FakeFacility(new Coord(50000, 10500), Id.create("to", Link.class));
 
-        List<? extends PlanElement> planElements = tripRouter.calcRoute(TransportMode.pt, fromFac, toFac, 7*3600, f.dummyPerson);
+        List<? extends PlanElement> planElements = tripRouter.calcRoute(TransportMode.pt, fromFac, toFac, 7*3600, f.dummyPerson, new Attributes());
 
         for (PlanElement pe : planElements) {
             System.out.println(pe);
@@ -228,7 +229,7 @@ public class SwissRailRaptorIntermodalTest {
         Facility fromFac = new FakeFacility(new Coord(10000, 10500), Id.create("from", Link.class));
         Facility toFac = new FakeFacility(new Coord(50000, 10500), Id.create("to", Link.class));
 
-        List<? extends PlanElement> legs = raptor.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson);
+        List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFac, toFac, 7*3600, f.dummyPerson));
         for (PlanElement leg : legs) {
             System.out.println(leg);
         }
@@ -283,7 +284,7 @@ public class SwissRailRaptorIntermodalTest {
         Facility fromFac = new FakeFacility(new Coord(10000, 9000), Id.create("from", Link.class));
         Facility toFac = new FakeFacility(new Coord(11000, 11000), Id.create("to", Link.class));
 
-        List<? extends PlanElement> legs = raptor.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson);
+        List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFac, toFac, 7*3600, f.dummyPerson));
 
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
     }
@@ -334,7 +335,7 @@ public class SwissRailRaptorIntermodalTest {
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
         SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f.scenario.getConfig()).with(stopFinder).build();
 
-        List<? extends PlanElement> legs = raptor.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson);
+        List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFac, toFac, 7*3600, f.dummyPerson));
         for (PlanElement leg : legs) {
             System.out.println(leg);
         }
@@ -351,7 +352,7 @@ public class SwissRailRaptorIntermodalTest {
         stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
         raptor = new SwissRailRaptor.Builder(data, f.scenario.getConfig()).with(stopFinder).build();
 
-        legs = raptor.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson);
+        legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFac, toFac, 7*3600, f.dummyPerson));
         for (PlanElement leg1 : legs) {
             System.out.println(leg1);
         }
@@ -421,7 +422,7 @@ public class SwissRailRaptorIntermodalTest {
         Facility fromFac = new FakeFacility(new Coord(10000, 10500), Id.create("from", Link.class));
         Facility toFac = new FakeFacility(new Coord(10500, 10500), Id.create("to", Link.class));
 
-        List<? extends PlanElement> legs = raptor.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson);
+        List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFac, toFac, 7*3600, f.dummyPerson));
         
         /* 
          * Going by access/egress mode bike from "fromFac" to stop 3 (which is bikeAccessible) and from there by bike
@@ -474,7 +475,7 @@ public class SwissRailRaptorIntermodalTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFac, toFac, 7 * 3600, f.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -504,7 +505,7 @@ public class SwissRailRaptorIntermodalTest {
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f.scenario.getConfig()).with(stopFinder).build();
 
-            List<? extends PlanElement> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f.dummyPerson);
+            List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFac, toFac, 7 * 3600, f.dummyPerson));
             for (PlanElement leg : legs) {
                 System.out.println(leg);
             }
@@ -580,7 +581,7 @@ public class SwissRailRaptorIntermodalTest {
             for (int i = 0; i < 1000; i++) {
                 SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f.scenario.getConfig()).with(stopFinder).build();
 
-                List<? extends PlanElement> legs = raptor.calcRoute(fromFac, toFac, 7 * 3600, f.dummyPerson);
+                List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFac, toFac, 7 * 3600, f.dummyPerson));
 
                 { // Test 1: Checks whether the amount of legs is correct, whether the legs have the correct modes,
                   // and whether the legs start and end on the correct links
@@ -643,7 +644,7 @@ public class SwissRailRaptorIntermodalTest {
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), f.routingModules);
         SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f.scenario.getConfig()).with(stopFinder).build();
 
-        List<? extends PlanElement> legs = raptor.calcRoute(fromFac, toFac, 8 * 3600 - 900, f.dummyPerson);
+        List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFac, toFac, 8 * 3600 - 900, f.dummyPerson));
         for (PlanElement leg : legs) {
             System.out.println(leg);
         }
@@ -698,7 +699,7 @@ public class SwissRailRaptorIntermodalTest {
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), f.routingModules);
         SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f.scenario.getConfig()).with(stopFinder).build();
 
-        List<? extends PlanElement> legs = raptor.calcRoute(fromFac, toFac, 7.5 * 3600 + 900, f.dummyPerson);
+        List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFac, toFac, 7.5 * 3600 + 900, f.dummyPerson));
         for (PlanElement leg : legs) {
             System.out.println(leg);
         }
@@ -733,7 +734,7 @@ public class SwissRailRaptorIntermodalTest {
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), f.routingModules);
         SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f.scenario.getConfig()).with(stopFinder).build();
 
-        List<? extends PlanElement> legs = raptor.calcRoute(fromFac, toFac, 8 * 3600 - 900, f.dummyPerson);
+        List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFac, toFac, 8 * 3600 - 900, f.dummyPerson));
         for (PlanElement leg : legs) {
             System.out.println(leg);
         }
@@ -783,7 +784,7 @@ public class SwissRailRaptorIntermodalTest {
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), f.routingModules);
         SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f.scenario.getConfig()).with(stopFinder).build();
 
-        List<? extends PlanElement> legs = raptor.calcRoute(fromFac, toFac, 7.5 * 3600, f.dummyPerson);
+        List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFac, toFac, 7.5 * 3600, f.dummyPerson));
 
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
     }
@@ -816,7 +817,7 @@ public class SwissRailRaptorIntermodalTest {
         DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), f.routingModules);
         SwissRailRaptor raptor = new SwissRailRaptor.Builder(data, f.scenario.getConfig()).with(stopFinder).build();
 
-        List<? extends PlanElement> legs = raptor.calcRoute(fromFac, toFac, 8 * 3600 - 900, f.dummyPerson);
+        List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFac, toFac, 8 * 3600 - 900, f.dummyPerson));
         for (PlanElement leg : legs) {
             System.out.println(leg);
         }
@@ -860,7 +861,7 @@ public class SwissRailRaptorIntermodalTest {
         DefaultRaptorStopFinder stopFinder2 = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), f.routingModules);
         SwissRailRaptor raptor2 = new SwissRailRaptor.Builder(data2, f.scenario.getConfig()).with(stopFinder2).build();
 
-        List<? extends PlanElement> legs2 = raptor2.calcRoute(fromFac, toFac, 8 * 3600 - 900, f.dummyPerson);
+        List<? extends PlanElement> legs2 = raptor2.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFac, toFac, 8 * 3600 - 900, f.dummyPerson));
         
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs2);        
     }
@@ -912,7 +913,7 @@ public class SwissRailRaptorIntermodalTest {
         Facility fromFac = new FakeFacility(new Coord(8500, 10000), Id.create("from", Link.class));
         Facility toFac = new FakeFacility(new Coord(40000, 10500), Id.create("to", Link.class));
 
-        List<? extends PlanElement> legs = raptor.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson);
+        List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFac, toFac, 7*3600, f.dummyPerson));
         for (PlanElement leg : legs) {
             System.out.println(leg);
         }
@@ -1023,7 +1024,7 @@ public class SwissRailRaptorIntermodalTest {
         Facility fromFac = new FakeFacility(new Coord(9500, 10000), Id.create("from", Link.class));
         Facility toFac = new FakeFacility(new Coord(50000, 10500), Id.create("to", Link.class));
 
-        List<? extends PlanElement> legs = raptor.calcRoute(fromFac, toFac, 7*3600, f.dummyPerson);
+        List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFac, toFac, 7*3600, f.dummyPerson));
         for (PlanElement leg : legs) {
             System.out.println(leg);
         }
@@ -1145,7 +1146,7 @@ public class SwissRailRaptorIntermodalTest {
         Facility fromFac = new FakeFacility(new Coord(9500, 10000), Id.create("from", Link.class));
         Facility toFac = new FakeFacility(new Coord(50000, 10500), Id.create("to", Link.class));
 
-        List<? extends PlanElement> legs = ssrrModule.calcRoute(DefaultRoutingRequest.of(fromFac, toFac, 7*3600, f.dummyPerson));
+        List<? extends PlanElement> legs = ssrrModule.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFac, toFac, 7*3600, f.dummyPerson));
         for (PlanElement leg : legs) {
             System.out.println(leg);
         }

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorTest.java
@@ -46,6 +46,7 @@ import org.matsim.pt.transitSchedule.api.TransitScheduleFactory;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 import org.matsim.testcases.MatsimTestCase;
 import org.matsim.testcases.MatsimTestUtils;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -77,7 +78,7 @@ public class SwissRailRaptorTest {
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
         Coord fromCoord = new Coord(3800, 5100);
         Coord toCoord = new Coord(16100, 5050);
-        List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null);
+        List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null));
         assertEquals(3, legs.size());
         assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
         assertEquals(TransportMode.pt, ((Leg)legs.get(1)).getMode());
@@ -111,7 +112,7 @@ public class SwissRailRaptorTest {
         Coord toCoord = new Coord(16100, 5050);
         Id<Link> fromLinkId = Id.create("ffrroomm", Link.class);
         Id<Link> toLinkId = Id.create("ttoo", Link.class);
-        List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord, fromLinkId), new FakeFacility(toCoord, toLinkId), 5.0*3600, null);
+        List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord, fromLinkId), new FakeFacility(toCoord, toLinkId), 5.0*3600, null));
         assertEquals(3, legs.size());
         assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
         assertEquals(fromLinkId, ((Leg)legs.get(0)).getRoute().getStartLinkId());
@@ -141,7 +142,7 @@ public class SwissRailRaptorTest {
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
         Coord fromCoord = new Coord(3800, 5100);
         Coord toCoord = new Coord(16100, 5050);
-        List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null);
+        List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null));
         assertEquals(3, legs.size());
         assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
         assertEquals(TransportMode.pt, ((Leg)legs.get(1)).getMode());
@@ -162,7 +163,7 @@ public class SwissRailRaptorTest {
         Coord fromCoord = new Coord(3800, 5100);
         Coord toCoord = new Coord(16100, 5050);
         double depTime = 5.0 * 3600;
-        List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 300, depTime, depTime + 300, null);
+        List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 300, depTime, depTime + 300, null, new Attributes());
         assertEquals(3, legs.size());
         assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
         assertEquals(TransportMode.pt, ((Leg)legs.get(1)).getMode());
@@ -189,7 +190,7 @@ public class SwissRailRaptorTest {
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
         Coord fromCoord = new Coord(3800, 5100);
         Coord toCoord = new Coord(4100, 5050);
-        List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null);
+        List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null));
         
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
     }
@@ -206,7 +207,7 @@ public class SwissRailRaptorTest {
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
         Coord fromCoord = new Coord(4000, 3000);
         Coord toCoord = new Coord(8000, 3000);
-        List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null);
+        List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null));
         
         assertEquals(1, legs.size());
         assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
@@ -225,7 +226,7 @@ public class SwissRailRaptorTest {
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
         Coord fromCoord = new Coord(4000, 3000);
         Coord toCoord = new Coord(8000, 3000);
-        List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null);
+        List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null));
         
         assertEquals(3, legs.size());
         assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
@@ -256,7 +257,7 @@ public class SwissRailRaptorTest {
 
         double inVehicleTime = 7.0*60; // travel time from A to B
         for (int min = 0; min < 30; min += 3) {
-            List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600 + min*60, null);
+            List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600 + min*60, null));
             assertEquals(3, legs.size()); // walk-pt-walk
             double actualTravelTime = 0.0;
             for (PlanElement leg : legs) {
@@ -275,7 +276,7 @@ public class SwissRailRaptorTest {
         RaptorParameters raptorParams = RaptorUtils.createParameters(f.config);
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
         Coord toCoord = new Coord(16100, 10050);
-        List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(new Coord(3800, 5100)), new FakeFacility(toCoord), 6.0*3600, null);
+        List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(new Coord(3800, 5100)), new FakeFacility(toCoord), 6.0*3600, null));
         assertEquals(5, legs.size());
         assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
         assertEquals(TransportMode.pt, ((Leg)legs.get(1)).getMode());
@@ -317,7 +318,7 @@ public class SwissRailRaptorTest {
         RaptorParameters raptorParams = RaptorUtils.createParameters(f.config);
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
         Coord toCoord = new Coord(28100, 4950);
-        List<? extends PlanElement> legs = router.calcRoute(new FakeFacility( new Coord(3800, 5100)), new FakeFacility(toCoord), 5.0*3600 + 40.0*60, null);
+        List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility( new Coord(3800, 5100)), new FakeFacility(toCoord), 5.0*3600 + 40.0*60, null));
         assertEquals("wrong number of legs", 5, legs.size());
         assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
         assertEquals(TransportMode.pt, ((Leg)legs.get(1)).getMode());
@@ -360,7 +361,7 @@ public class SwissRailRaptorTest {
         f.config.planCalcScore().setUtilityOfLineSwitch(0);
         RaptorParameters raptorParams = RaptorUtils.createParameters(f.config);
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
-        List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(new Coord(11900, 5100)), new FakeFacility(new Coord(24100, 4950)), 6.0*3600 - 5.0*60, null);
+        List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(new Coord(11900, 5100)), new FakeFacility(new Coord(24100, 4950)), 6.0*3600 - 5.0*60, null));
         assertEquals("wrong number of legs", 5, legs.size());
         assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
         assertEquals(TransportMode.pt, ((Leg)legs.get(1)).getMode());
@@ -376,7 +377,7 @@ public class SwissRailRaptorTest {
         raptorParams = RaptorUtils.createParameters(config);
         Assert.assertEquals(-transferUtility, raptorParams.getTransferPenaltyFixCostPerTransfer(), 0.0);
         router = createTransitRouter(f.schedule, config, f.network);
-        legs = router.calcRoute(new FakeFacility(new Coord(11900, 5100)), new FakeFacility(new Coord(24100, 4950)), 6.0*3600 - 5.0*60, null);
+        legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(new Coord(11900, 5100)), new FakeFacility(new Coord(24100, 4950)), 6.0*3600 - 5.0*60, null));
         assertEquals(3, legs.size());
         assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
         assertEquals(TransportMode.pt, ((Leg)legs.get(1)).getMode());
@@ -399,7 +400,7 @@ public class SwissRailRaptorTest {
         f.config.planCalcScore().setUtilityOfLineSwitch(0);
         f.config.transitRouter().setAdditionalTransferTime(0);
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
-        List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(new Coord(11900, 5100)), new FakeFacility(new Coord(24100, 4950)), 6.0*3600 - 5.0*60, null);
+        List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(new Coord(11900, 5100)), new FakeFacility(new Coord(24100, 4950)), 6.0*3600 - 5.0*60, null));
         assertEquals("wrong number of legs",5, legs.size());
         assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
         assertEquals(TransportMode.pt, ((Leg)legs.get(1)).getMode());
@@ -412,7 +413,7 @@ public class SwissRailRaptorTest {
         Config config = ConfigUtils.createConfig();
         config.transitRouter().setAdditionalTransferTime(3*60 + 1);
         router = createTransitRouter(f.schedule, config, f.network); // this is necessary to update the router for any change in config.
-        legs = router.calcRoute(new FakeFacility(new Coord(11900, 5100)), new FakeFacility(new Coord(24100, 4950)), 6.0*3600 - 5.0*60, null);
+        legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(new Coord(11900, 5100)), new FakeFacility(new Coord(24100, 4950)), 6.0*3600 - 5.0*60, null));
         assertEquals("wrong number of legs",3, legs.size());
         assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
         assertEquals(TransportMode.pt, ((Leg)legs.get(1)).getMode());
@@ -431,7 +432,7 @@ public class SwissRailRaptorTest {
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
         Coord fromCoord = new Coord(3800, 5100);
         Coord toCoord = new Coord(16100, 5050);
-        List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 25.0*3600, null);
+        List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 25.0*3600, null));
         
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
     }
@@ -443,7 +444,7 @@ public class SwissRailRaptorTest {
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
         double x = +42000;
         double x1 = -2000;
-        List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(new Coord(x1, 0)), new FakeFacility(new Coord(x, 0)), 5.5*3600, null); // should map to stops A and I
+        List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(new Coord(x1, 0)), new FakeFacility(new Coord(x, 0)), 5.5*3600, null)); // should map to stops A and I
         assertEquals(3, legs.size());
         assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
         assertEquals(TransportMode.pt, ((Leg)legs.get(1)).getMode());
@@ -467,7 +468,7 @@ public class SwissRailRaptorTest {
         f.scenario.getConfig().transitRouter().setExtensionRadius(0.0);
 
         TransitRouter router = createTransitRouter(f.schedule, f.scenario.getConfig(), f.scenario.getNetwork());
-        List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(f.coord2), new FakeFacility(f.coord4), 990, null);
+        List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(f.coord2), new FakeFacility(f.coord4), 990, null));
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
     }
 
@@ -485,7 +486,7 @@ public class SwissRailRaptorTest {
         f.scenario.getConfig().transitRouter().setExtensionRadius(0.0);
 
         TransitRouter router = createTransitRouter(f.schedule, f.scenario.getConfig(), f.scenario.getNetwork());
-        List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(f.coord2), new FakeFacility(f.coord6), 990, null);
+        List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(f.coord2), new FakeFacility(f.coord6), 990, null));
         
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
     }
@@ -499,7 +500,7 @@ public class SwissRailRaptorTest {
             TransitRouter router = createTransitRouter(f.schedule, f.config, f.scenario.getNetwork());
             Coord fromCoord = f.fromFacility.getCoord();
             Coord toCoord = f.toFacility.getCoord();
-            List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0 * 3600 + 50 * 60, null);
+            List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0 * 3600 + 50 * 60, null));
             double legDuration = calcTripDuration(new ArrayList<>(legs));
             Assert.assertEquals(5, legs.size());
             Assert.assertEquals(100, ((Leg)legs.get(0)).getTravelTime().seconds(), 0.0);    // 0.1km with 1m/s walk speed -> 100s; arrival at 07:51:40
@@ -519,7 +520,7 @@ public class SwissRailRaptorTest {
                     f.scenario.getNetwork(), // use a walk router in case no PT path is found
                     walkRoutingModule);
 
-            List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(DefaultRoutingRequest.of(f.fromFacility, f.toFacility, 7.0 * 3600 + 50 * 60, null));
+            List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(DefaultRoutingRequest.withoutAttributes(f.fromFacility, f.toFacility, 7.0 * 3600 + 50 * 60, null));
             double tripDuration = calcTripDuration(planElements);
             Assert.assertEquals(9, planElements.size());
             Assert.assertEquals(100, ((Leg) planElements.get(0)).getTravelTime().seconds(), 0.0);    // 0.1km with 1m/s walk speed -> 100s; arrival at 07:51:40
@@ -538,7 +539,7 @@ public class SwissRailRaptorTest {
             TransitRouter router = createTransitRouter(f.schedule, f.config, f.scenario.getNetwork());
             Coord fromCoord = f.fromFacility.getCoord();
             Coord toCoord = f.toFacility.getCoord();
-            List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null);
+            List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null));
             double legDuration = calcTripDuration(new ArrayList<>(legs));
             Assert.assertEquals(5, legs.size());
 			Assert.assertEquals(100, ((Leg)legs.get(0)).getTravelTime().seconds(), 0.0);	// 0.1km with 1m/s walk speed -> 100s; arrival at 07:51:40
@@ -557,7 +558,7 @@ public class SwissRailRaptorTest {
                     f.scenario.getNetwork(), // use a walk router in case no PT path is found
                     walkRoutingModule);
 
-            List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(DefaultRoutingRequest.of(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null));
+            List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(DefaultRoutingRequest.withoutAttributes(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null));
             double tripDuration = calcTripDuration(planElements);
             Assert.assertEquals(9, planElements.size());
 			Assert.assertEquals(100, ((Leg)planElements.get(0)).getTravelTime().seconds(), 0.0);	// 0.1km with 1m/s walk speed -> 100s; arrival at 07:51:40
@@ -574,7 +575,7 @@ public class SwissRailRaptorTest {
             TransitRouter router = createTransitRouter(f.schedule, f.config, f.scenario.getNetwork());
             Coord fromCoord = f.fromFacility.getCoord();
             Coord toCoord = f.toFacility.getCoord();
-            List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null);
+            List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null));
             Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
 
             RoutingModule walkRoutingModule = DefaultRoutingModules.createTeleportationRouter(TransportMode.transit_walk, f.scenario,
@@ -587,7 +588,7 @@ public class SwissRailRaptorTest {
                     walkRoutingModule);
 
             TransitRouterWrapper wrapper = new TransitRouterWrapper(router, f.schedule, f.scenario.getNetwork(), routingModule);
-            List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(DefaultRoutingRequest.of(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null));
+            List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(DefaultRoutingRequest.withoutAttributes(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null));
             Assert.assertNull("The router should not find a route and return null, but did return something else.", planElements);
         }
     }
@@ -619,7 +620,7 @@ public class SwissRailRaptorTest {
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.scenario.getNetwork());
         Coord fromCoord = new Coord(5010, 1010);
         Coord toCoord = new Coord(5010, 5010);
-        List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 8.0*3600-2*60, null);
+        List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 8.0*3600-2*60, null));
         assertEquals(7, legs.size());
         assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
         assertEquals(TransportMode.pt, ((Leg)legs.get(1)).getMode());
@@ -655,7 +656,7 @@ public class SwissRailRaptorTest {
         Coord fromCoord = new Coord(16000, 100); // stop N
         Coord toCoord = new Coord(24000, 9950); // stop L
         double depTime = 5.0 * 3600 + 50 * 60;
-        List<? extends PlanElement> legs = raptor.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime,null);
+        List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime,null));
 
         for (PlanElement leg : legs) {
             System.out.println(leg);
@@ -683,7 +684,7 @@ public class SwissRailRaptorTest {
         Coord fromCoord = new Coord(3800, 5100);
         Coord toCoord = new Coord(28100, 4950);
         double depTime = 5.0 * 3600 + 50 * 60;
-        List<RaptorRoute> routes = raptor.calcRoutes(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 600, depTime, depTime + 3600, null);
+        List<RaptorRoute> routes = raptor.calcRoutes(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 600, depTime, depTime + 3600, null, new Attributes());
 
         for (int i = 0; i < routes.size(); i++) {
             RaptorRoute route = routes.get(i);
@@ -733,7 +734,7 @@ public class SwissRailRaptorTest {
         Coord fromCoord = new Coord(3800, 5100);
         Coord toCoord = new Coord(28100, 4950);
         double depTime = 5.0 * 3600 + 50 * 60;
-        List<? extends PlanElement> legs = raptor.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime, null);
+        List<? extends PlanElement> legs = raptor.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime, null));
         // this test mostly checks that there are no Exceptions.
         Assert.assertEquals(3, legs.size());
     }
@@ -749,7 +750,7 @@ public class SwissRailRaptorTest {
             Coord fromCoord = new Coord(0, 100);
             Coord toCoord = new Coord(20000, 100);
             double depTime = 6.0 * 3600;
-            List<RaptorRoute> routes = raptor.calcRoutes(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 300, depTime, depTime + 300, null);
+            List<RaptorRoute> routes = raptor.calcRoutes(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 300, depTime, depTime + 300, null, new Attributes());
             Assert.assertEquals(1, routes.size());
             RaptorRoute route1 = routes.get(0);
 
@@ -769,7 +770,7 @@ public class SwissRailRaptorTest {
             Coord fromCoord = new Coord(0, 100);
             Coord toCoord = new Coord(20000, 100);
             double depTime = 6.0 * 3600;
-            List<RaptorRoute> routes = raptor.calcRoutes(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 300, depTime, depTime + 300, null);
+            List<RaptorRoute> routes = raptor.calcRoutes(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 300, depTime, depTime + 300, null, new Attributes());
             Assert.assertEquals(1, routes.size());
             RaptorRoute route1 = routes.get(0);
 
@@ -789,7 +790,7 @@ public class SwissRailRaptorTest {
             Coord fromCoord = new Coord(0, 100);
             Coord toCoord = new Coord(20000, 100);
             double depTime = 6.0 * 3600;
-            List<RaptorRoute> routes = raptor.calcRoutes(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 300, depTime, depTime + 300, null);
+            List<RaptorRoute> routes = raptor.calcRoutes(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 300, depTime, depTime + 300, null, new Attributes());
             Assert.assertEquals(1, routes.size());
             RaptorRoute route1 = routes.get(0);
 
@@ -809,7 +810,7 @@ public class SwissRailRaptorTest {
             Coord fromCoord = new Coord(0, 100);
             Coord toCoord = new Coord(40000, 100);
             double depTime = 6.0 * 3600;
-            List<RaptorRoute> routes = raptor.calcRoutes(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 300, depTime, depTime + 300, null);
+            List<RaptorRoute> routes = raptor.calcRoutes(new FakeFacility(fromCoord), new FakeFacility(toCoord), depTime - 300, depTime, depTime + 300, null, new Attributes());
             Assert.assertEquals(1, routes.size());
             RaptorRoute route1 = routes.get(0);
 
@@ -849,7 +850,7 @@ public class SwissRailRaptorTest {
 
         Coord fromCoord = f.fromFacility.getCoord();
         Coord toCoord = f.toFacility.getCoord();
-        List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null);
+        List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null));
         for (PlanElement leg : legs) {
             System.out.println(leg);
         }
@@ -903,7 +904,7 @@ public class SwissRailRaptorTest {
 
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
         Coord toCoord = new Coord(16100, 10050);
-        List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(new Coord(3800, 5100)), new FakeFacility(toCoord), 6.0*3600, null);
+        List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(new Coord(3800, 5100)), new FakeFacility(toCoord), 6.0*3600, null));
         assertEquals(5, legs.size());
         assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
         assertEquals("rail", ((Leg)legs.get(1)).getMode());
@@ -922,7 +923,7 @@ public class SwissRailRaptorTest {
         { // test default, from C to G the red line is the fastest/cheapest
 
             TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
-            List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 6.0 * 3600 - 5 * 60, null);
+            List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 6.0 * 3600 - 5 * 60, null));
             assertEquals(3, legs.size());
             assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
             assertEquals("pt", ((Leg)legs.get(1)).getMode());
@@ -966,7 +967,7 @@ public class SwissRailRaptorTest {
 
         { // test with similar costs, the red line should still be cheaper
             TransitRouter router = createTransitRouter(f.schedule, config, f.network);
-            List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 6.0 * 3600 - 5 * 60, null);
+            List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 6.0 * 3600 - 5 * 60, null));
             assertEquals(3, legs.size());
             assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
             assertEquals("rail", ((Leg)legs.get(1)).getMode());
@@ -992,7 +993,7 @@ public class SwissRailRaptorTest {
             config.planCalcScore().addModeParams(roadParams);
 
             TransitRouter router = createTransitRouter(f.schedule, config, f.network);
-            List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 6.0 * 3600 - 5 * 60, null);
+            List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 6.0 * 3600 - 5 * 60, null));
             assertEquals(3, legs.size());
             assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
             assertEquals("road", ((Leg)legs.get(1)).getMode());
@@ -1019,7 +1020,7 @@ public class SwissRailRaptorTest {
         Coord fromCoord = new Coord(3800, 5100);
         Coord toCoord = new Coord(8100, 5050);
 
-        List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 11.0*3600, null);
+        List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 11.0*3600, null));
 
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
     }

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorTest.java
@@ -26,6 +26,7 @@ import org.matsim.core.config.groups.PlansCalcRouteConfigGroup;
 import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.population.routes.RouteUtils;
 import org.matsim.core.router.DefaultRoutingModules;
+import org.matsim.core.router.DefaultRoutingRequest;
 import org.matsim.core.router.RoutingModule;
 import org.matsim.core.router.TransitRouterWrapper;
 import org.matsim.core.scenario.MutableScenario;
@@ -518,7 +519,7 @@ public class SwissRailRaptorTest {
                     f.scenario.getNetwork(), // use a walk router in case no PT path is found
                     walkRoutingModule);
 
-            List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(f.fromFacility, f.toFacility, 7.0 * 3600 + 50 * 60, null);
+            List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(DefaultRoutingRequest.of(f.fromFacility, f.toFacility, 7.0 * 3600 + 50 * 60, null));
             double tripDuration = calcTripDuration(planElements);
             Assert.assertEquals(9, planElements.size());
             Assert.assertEquals(100, ((Leg) planElements.get(0)).getTravelTime().seconds(), 0.0);    // 0.1km with 1m/s walk speed -> 100s; arrival at 07:51:40
@@ -556,7 +557,7 @@ public class SwissRailRaptorTest {
                     f.scenario.getNetwork(), // use a walk router in case no PT path is found
                     walkRoutingModule);
 
-            List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null);
+            List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(DefaultRoutingRequest.of(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null));
             double tripDuration = calcTripDuration(planElements);
             Assert.assertEquals(9, planElements.size());
 			Assert.assertEquals(100, ((Leg)planElements.get(0)).getTravelTime().seconds(), 0.0);	// 0.1km with 1m/s walk speed -> 100s; arrival at 07:51:40
@@ -586,7 +587,7 @@ public class SwissRailRaptorTest {
                     walkRoutingModule);
 
             TransitRouterWrapper wrapper = new TransitRouterWrapper(router, f.schedule, f.scenario.getNetwork(), routingModule);
-            List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null);
+            List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(DefaultRoutingRequest.of(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null));
             Assert.assertNull("The router should not find a route and return null, but did return something else.", planElements);
         }
     }

--- a/matsim/src/test/java/org/matsim/core/controler/PrepareForSimImplTest.java
+++ b/matsim/src/test/java/org/matsim/core/controler/PrepareForSimImplTest.java
@@ -48,6 +48,7 @@ import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.router.MainModeIdentifierImpl;
 import org.matsim.core.router.RoutingModule;
+import org.matsim.core.router.RoutingRequest;
 import org.matsim.core.router.TripRouter;
 import org.matsim.core.router.TripStructureUtils;
 import org.matsim.core.scenario.ScenarioUtils;
@@ -775,8 +776,7 @@ public class PrepareForSimImplTest {
 	
 	private class DummyRoutingModule implements RoutingModule {
 		@Override
-		public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double departureTime,
-				Person person) {
+		public List<? extends PlanElement> calcRoute(RoutingRequest request) {
 			return Collections.singletonList(PopulationUtils.createLeg("dummyMode"));
 		}
 	}

--- a/matsim/src/test/java/org/matsim/core/mobsim/qsim/NetsimRoutingConsistencyTest.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/qsim/NetsimRoutingConsistencyTest.java
@@ -179,7 +179,7 @@ public class NetsimRoutingConsistencyTest {
 					router);
 
 			Leg leg = (Leg) routingModule
-					.calcRoute(DefaultRoutingRequest.of(new LinkWrapperFacility(link12), new LinkWrapperFacility(link45), 0.0, person)).get(0);
+					.calcRoute(DefaultRoutingRequest.withoutAttributes(new LinkWrapperFacility(link12), new LinkWrapperFacility(link45), 0.0, person)).get(0);
 
 			plan.addActivity(startActivity);
 			plan.addLeg(leg);

--- a/matsim/src/test/java/org/matsim/core/mobsim/qsim/NetsimRoutingConsistencyTest.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/qsim/NetsimRoutingConsistencyTest.java
@@ -51,6 +51,7 @@ import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
 import org.matsim.core.events.EventsUtils;
+import org.matsim.core.router.DefaultRoutingRequest;
 import org.matsim.core.router.DijkstraFactory;
 import org.matsim.core.router.LinkWrapperFacility;
 import org.matsim.core.router.NetworkRoutingModule;
@@ -178,7 +179,7 @@ public class NetsimRoutingConsistencyTest {
 					router);
 
 			Leg leg = (Leg) routingModule
-					.calcRoute(new LinkWrapperFacility(link12), new LinkWrapperFacility(link45), 0.0, person).get(0);
+					.calcRoute(DefaultRoutingRequest.of(new LinkWrapperFacility(link12), new LinkWrapperFacility(link45), 0.0, person)).get(0);
 
 			plan.addActivity(startActivity);
 			plan.addLeg(leg);

--- a/matsim/src/test/java/org/matsim/core/router/FallbackRoutingModuleTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/FallbackRoutingModuleTest.java
@@ -79,7 +79,7 @@ public class FallbackRoutingModuleTest{
 			@Override public void install(){
 				this.addRoutingModuleBinding( "abcd" ).toInstance( new RoutingModule(){
 					@Override
-					public List<? extends PlanElement> calcRoute( Facility fromFacility, Facility toFacility, double departureTime, Person person ){
+					public List<? extends PlanElement> calcRoute( RoutingRequest request ){
 						return null;
 					}
 				} );

--- a/matsim/src/test/java/org/matsim/core/router/InvertertedNetworkRoutingTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/InvertertedNetworkRoutingTest.java
@@ -103,7 +103,7 @@ public class InvertertedNetworkRoutingTest {
 	private NetworkRoute calcRoute(LinkToLinkRoutingModule router, final Facility fromFacility,
             final Facility toFacility, final Person person)
 	{
-        Leg leg = (Leg)router.calcRoute(fromFacility, toFacility, 0.0, person).get(0);
+        Leg leg = (Leg)router.calcRoute(DefaultRoutingRequest.of(fromFacility, toFacility, 0.0, person)).get(0);
         return (NetworkRoute) leg.getRoute();
 	}
 	

--- a/matsim/src/test/java/org/matsim/core/router/InvertertedNetworkRoutingTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/InvertertedNetworkRoutingTest.java
@@ -103,7 +103,7 @@ public class InvertertedNetworkRoutingTest {
 	private NetworkRoute calcRoute(LinkToLinkRoutingModule router, final Facility fromFacility,
             final Facility toFacility, final Person person)
 	{
-        Leg leg = (Leg)router.calcRoute(DefaultRoutingRequest.of(fromFacility, toFacility, 0.0, person)).get(0);
+        Leg leg = (Leg)router.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFacility, toFacility, 0.0, person)).get(0);
         return (NetworkRoute) leg.getRoute();
 	}
 	

--- a/matsim/src/test/java/org/matsim/core/router/NetworkRoutingModuleTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/NetworkRoutingModuleTest.java
@@ -69,7 +69,7 @@ public class NetworkRoutingModuleTest {
 		            routeAlgo);
 		Facility fromFacility = FacilitiesUtils.toFacility( fromAct, f.s.getActivityFacilities() );
 		Facility toFacility = FacilitiesUtils.toFacility( toAct, f.s.getActivityFacilities() );
-		List<? extends PlanElement> result = routingModule.calcRoute(fromFacility, toFacility, 7.0*3600, person) ;
+		List<? extends PlanElement> result = routingModule.calcRoute(DefaultRoutingRequest.of(fromFacility, toFacility, 7.0*3600, person)) ;
 		Assert.assertEquals(1, result.size() );
 		Leg leg = (Leg)result.get(0) ;
 		Assert.assertEquals(100.0, leg.getTravelTime().seconds(), 1e-8);
@@ -101,8 +101,8 @@ public class NetworkRoutingModuleTest {
 							f.s.getNetwork(),
 							routeAlgo);
 
-			List<? extends PlanElement> results = router.calcRoute( FacilitiesUtils.toFacility(fromAct, f.s.getActivityFacilities() ),
-				  FacilitiesUtils.toFacility(toAct, f.s.getActivityFacilities() ), 8.*3600, person ) ;
+			List<? extends PlanElement> results = router.calcRoute( DefaultRoutingRequest.of( FacilitiesUtils.toFacility(fromAct, f.s.getActivityFacilities() ),
+				  FacilitiesUtils.toFacility(toAct, f.s.getActivityFacilities() ), 8.*3600, person ) ) ;
 			Assert.assertEquals( 1, results.size() );
 			Leg leg = (Leg) results.get(0) ;
 
@@ -130,8 +130,8 @@ public class NetworkRoutingModuleTest {
 							f.s.getNetwork(),
 							routeAlgo);
 
-			List<? extends PlanElement> result = router.calcRoute( FacilitiesUtils.toFacility(fromAct, f.s.getActivityFacilities() ), FacilitiesUtils.toFacility(toAct,
-				  f.s.getActivityFacilities() ), 7.*3600, person ) ;
+			List<? extends PlanElement> result = router.calcRoute( DefaultRoutingRequest.of( FacilitiesUtils.toFacility(fromAct, f.s.getActivityFacilities() ), FacilitiesUtils.toFacility(toAct,
+				  f.s.getActivityFacilities() ), 7.*3600, person ) ) ;
 			
 			Assert.assertEquals( 1, result.size() ) ; 
 			Leg leg = (Leg) result.get(0) ;

--- a/matsim/src/test/java/org/matsim/core/router/NetworkRoutingModuleTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/NetworkRoutingModuleTest.java
@@ -69,7 +69,7 @@ public class NetworkRoutingModuleTest {
 		            routeAlgo);
 		Facility fromFacility = FacilitiesUtils.toFacility( fromAct, f.s.getActivityFacilities() );
 		Facility toFacility = FacilitiesUtils.toFacility( toAct, f.s.getActivityFacilities() );
-		List<? extends PlanElement> result = routingModule.calcRoute(DefaultRoutingRequest.of(fromFacility, toFacility, 7.0*3600, person)) ;
+		List<? extends PlanElement> result = routingModule.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFacility, toFacility, 7.0*3600, person)) ;
 		Assert.assertEquals(1, result.size() );
 		Leg leg = (Leg)result.get(0) ;
 		Assert.assertEquals(100.0, leg.getTravelTime().seconds(), 1e-8);
@@ -101,7 +101,7 @@ public class NetworkRoutingModuleTest {
 							f.s.getNetwork(),
 							routeAlgo);
 
-			List<? extends PlanElement> results = router.calcRoute( DefaultRoutingRequest.of( FacilitiesUtils.toFacility(fromAct, f.s.getActivityFacilities() ),
+			List<? extends PlanElement> results = router.calcRoute( DefaultRoutingRequest.withoutAttributes( FacilitiesUtils.toFacility(fromAct, f.s.getActivityFacilities() ),
 				  FacilitiesUtils.toFacility(toAct, f.s.getActivityFacilities() ), 8.*3600, person ) ) ;
 			Assert.assertEquals( 1, results.size() );
 			Leg leg = (Leg) results.get(0) ;
@@ -130,7 +130,7 @@ public class NetworkRoutingModuleTest {
 							f.s.getNetwork(),
 							routeAlgo);
 
-			List<? extends PlanElement> result = router.calcRoute( DefaultRoutingRequest.of( FacilitiesUtils.toFacility(fromAct, f.s.getActivityFacilities() ), FacilitiesUtils.toFacility(toAct,
+			List<? extends PlanElement> result = router.calcRoute( DefaultRoutingRequest.withoutAttributes( FacilitiesUtils.toFacility(fromAct, f.s.getActivityFacilities() ), FacilitiesUtils.toFacility(toAct,
 				  f.s.getActivityFacilities() ), 7.*3600, person ) ) ;
 			
 			Assert.assertEquals( 1, result.size() ) ; 

--- a/matsim/src/test/java/org/matsim/core/router/PseudoTransitRoutingModuleTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/PseudoTransitRoutingModuleTest.java
@@ -51,6 +51,7 @@ import org.matsim.core.scenario.ScenarioByInstanceModule;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.facilities.FacilitiesUtils;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 public class PseudoTransitRoutingModuleTest {
 
@@ -114,7 +115,7 @@ public class PseudoTransitRoutingModuleTest {
 			Facility fromFacility = FacilitiesUtils.toFacility(fromAct, f.s.getActivityFacilities() ) ;
 			Facility toFacility = FacilitiesUtils.toFacility(toAct, f.s.getActivityFacilities() );
 			
-			List<? extends PlanElement> result = tripRouter.calcRoute("mode", fromFacility, toFacility, 7.0*3600., person) ;
+			List<? extends PlanElement> result = tripRouter.calcRoute("mode", fromFacility, toFacility, 7.0*3600., person, new Attributes()) ;
 			Gbl.assertIf( result.size()==1);
 			Leg newLeg = (Leg) result.get(0) ;
 

--- a/matsim/src/test/java/org/matsim/core/router/TripRouterFactoryImplTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/TripRouterFactoryImplTest.java
@@ -43,6 +43,7 @@ import org.matsim.core.router.costcalculators.OnlyTimeDependentTravelDisutilityF
 import org.matsim.core.scenario.ScenarioByInstanceModule;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import javax.inject.Provider;
 
@@ -124,7 +125,7 @@ public class TripRouterFactoryImplTest {
 				new LinkFacility( l1 ),
 				new LinkFacility( l3 ),
 				0,
-				PopulationUtils.getFactory().createPerson(Id.create("toto", Person.class)));
+				PopulationUtils.getFactory().createPerson(Id.create("toto", Person.class)), new Attributes());
 
 		Leg l = (Leg) trip.get( 0 );
 		if ( !scenario.getConfig().plansCalcRoute().getAccessEgressType().equals(PlansCalcRouteConfigGroup.AccessEgressType.none) ) {
@@ -199,7 +200,7 @@ public class TripRouterFactoryImplTest {
 				new LinkFacility( l1 ),
 				new LinkFacility( l3 ),
 				0,
-				PopulationUtils.getFactory().createPerson(Id.create("toto", Person.class)));
+				PopulationUtils.getFactory().createPerson(Id.create("toto", Person.class)), new Attributes());
 
 		Leg l = (Leg) trip.get( 0 );
 		if ( !scenario.getConfig().plansCalcRoute().getAccessEgressType().equals(PlansCalcRouteConfigGroup.AccessEgressType.none) ) {

--- a/matsim/src/test/java/org/matsim/core/router/costcalculators/RandomizingTimeDistanceTravelDisutilityTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/costcalculators/RandomizingTimeDistanceTravelDisutilityTest.java
@@ -43,6 +43,7 @@ import org.matsim.core.config.groups.PlanCalcScoreConfigGroup;
 import org.matsim.core.config.groups.PlanCalcScoreConfigGroup.ModeParams;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.population.routes.NetworkRoute;
+import org.matsim.core.router.DefaultRoutingRequest;
 import org.matsim.core.router.NetworkRoutingModule;
 import org.matsim.core.router.TripRouterFactoryBuilderWithDefaults;
 import org.matsim.core.router.util.LeastCostPathCalculator;
@@ -110,7 +111,7 @@ public class RandomizingTimeDistanceTravelDisutilityTest {
 		            router);
 		Facility fromFacility = FacilitiesUtils.toFacility( fromAct, f.s.getActivityFacilities() );
 		Facility toFacility = FacilitiesUtils.toFacility( toAct, f.s.getActivityFacilities() );
-		List<? extends PlanElement> result = routingModule.calcRoute(fromFacility, toFacility, 7.0*3600, person) ;
+		List<? extends PlanElement> result = routingModule.calcRoute(DefaultRoutingRequest.of(fromFacility, toFacility, 7.0*3600, person)) ;
 		Assert.assertEquals(1, result.size() );
 		Leg leg = (Leg) result.get(0) ;				
 		return (NetworkRoute) leg.getRoute();

--- a/matsim/src/test/java/org/matsim/core/router/costcalculators/RandomizingTimeDistanceTravelDisutilityTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/costcalculators/RandomizingTimeDistanceTravelDisutilityTest.java
@@ -111,7 +111,7 @@ public class RandomizingTimeDistanceTravelDisutilityTest {
 		            router);
 		Facility fromFacility = FacilitiesUtils.toFacility( fromAct, f.s.getActivityFacilities() );
 		Facility toFacility = FacilitiesUtils.toFacility( toAct, f.s.getActivityFacilities() );
-		List<? extends PlanElement> result = routingModule.calcRoute(DefaultRoutingRequest.of(fromFacility, toFacility, 7.0*3600, person)) ;
+		List<? extends PlanElement> result = routingModule.calcRoute(DefaultRoutingRequest.withoutAttributes(fromFacility, toFacility, 7.0*3600, person)) ;
 		Assert.assertEquals(1, result.size() );
 		Leg leg = (Leg) result.get(0) ;				
 		return (NetworkRoute) leg.getRoute();

--- a/matsim/src/test/java/org/matsim/core/router/old/PlanRouterTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/old/PlanRouterTest.java
@@ -102,11 +102,16 @@ public class PlanRouterTest {
         final Id<Vehicle> newVehicleId = Id.create(2, Vehicle.class);
         final RoutingModule routingModule = new RoutingModule() {
               @Override
-              public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double departureTime, Person person) {
+              public List<? extends PlanElement> calcRoute(RoutingRequest request) {
+            		final Facility fromFacility = request.getFromFacility();
+            		final Facility toFacility = request.getToFacility();
+            		final double departureTime = request.getDepartureTime();
+            		final Person person = request.getPerson();
+            		
                   List<? extends PlanElement> trip = DefaultRoutingModules.createPureNetworkRouter("car", scenario.getPopulation().getFactory(),
                   		scenario.getNetwork(),
                   		leastCostAlgoFactory.createPathCalculator(scenario.getNetwork(), disutilityFactory.createTravelDisutility(travelTime), travelTime)
-                  		).calcRoute(fromFacility, toFacility, departureTime, person);
+                  		).calcRoute(DefaultRoutingRequest.of(fromFacility, toFacility, departureTime, person));
                   ((NetworkRoute) TripStructureUtils.getLegs(trip).get(0).getRoute()).setVehicleId(newVehicleId);
                   return trip;
               }

--- a/matsim/src/test/java/org/matsim/core/router/old/PlanRouterTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/old/PlanRouterTest.java
@@ -111,7 +111,7 @@ public class PlanRouterTest {
                   List<? extends PlanElement> trip = DefaultRoutingModules.createPureNetworkRouter("car", scenario.getPopulation().getFactory(),
                   		scenario.getNetwork(),
                   		leastCostAlgoFactory.createPathCalculator(scenario.getNetwork(), disutilityFactory.createTravelDisutility(travelTime), travelTime)
-                  		).calcRoute(DefaultRoutingRequest.of(fromFacility, toFacility, departureTime, person));
+                  		).calcRoute(DefaultRoutingRequest.withoutAttributes(fromFacility, toFacility, departureTime, person));
                   ((NetworkRoute) TripStructureUtils.getLegs(trip).get(0).getRoute()).setVehicleId(newVehicleId);
                   return trip;
               }

--- a/matsim/src/test/java/org/matsim/pt/router/TransitRouterCustomDataTest.java
+++ b/matsim/src/test/java/org/matsim/pt/router/TransitRouterCustomDataTest.java
@@ -36,6 +36,7 @@ import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.router.DefaultRoutingRequest;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.pt.router.TransitRouterNetwork.TransitRouterNetworkNode;
 import org.matsim.pt.transitSchedule.api.Departure;
@@ -72,7 +73,7 @@ public class TransitRouterCustomDataTest {
 		TransitRouterImpl router = new TransitRouterImpl(trConfig, new PreparedTransitSchedule(scenario.getTransitSchedule()), transitNetwork, transitRouterNetworkTravelTimeAndDisutility, disutility);
 
 		double x = -100;
-		List<? extends PlanElement> legs = router.calcRoute(new FakeFacility( new Coord(x, (double) 0)), new FakeFacility( new Coord((double) 3100, (double) 0)), 5.9*3600, null);
+		List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility( new Coord(x, (double) 0)), new FakeFacility( new Coord((double) 3100, (double) 0)), 5.9*3600, null));
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
 		
 		/* the following is not really nice as a test, but I had to somehow

--- a/matsim/src/test/java/org/matsim/pt/router/TransitRouterImplTest.java
+++ b/matsim/src/test/java/org/matsim/pt/router/TransitRouterImplTest.java
@@ -98,7 +98,7 @@ public class TransitRouterImplTest {
 		TransitRouter router = createTransitRouter(f.schedule, trConfig, routerType);
 		Coord fromCoord = new Coord(3800, 5100);
 		Coord toCoord = new Coord(16100, 5050);
-		List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null);
+		List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null));
 		assertEquals(3, legs.size());
 		assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
 		assertEquals(TransportMode.pt, ((Leg)legs.get(1)).getMode());
@@ -146,7 +146,7 @@ public class TransitRouterImplTest {
 		TransitRouter router = createTransitRouter(f.schedule, trConfig, routerType);
 		Coord fromCoord = new Coord((double) 3800, (double) 5100);
 		Coord toCoord = new Coord((double) 4100, (double) 5050);
-		List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null);
+		List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null));
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
 	}
 
@@ -160,7 +160,7 @@ public class TransitRouterImplTest {
 		TransitRouter router = createTransitRouter(f.schedule, trConfig, routerType);
 		Coord fromCoord = new Coord((double) 4000, (double) 3000);
 		Coord toCoord = new Coord((double) 8000, (double) 3000);
-		List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null);
+		List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null));
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
 	}
 
@@ -177,7 +177,7 @@ public class TransitRouterImplTest {
 
 		double inVehicleTime = 7.0*60; // travel time from A to B
 		for (int min = 0; min < 30; min += 3) {
-			List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600 + min*60, null);
+			List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600 + min*60, null));
 			assertEquals(3, legs.size()); // walk-pt-walk
 			double actualTravelTime = 0.0;
 			for (PlanElement leg : legs) {
@@ -197,7 +197,7 @@ public class TransitRouterImplTest {
 				f.scenario.getConfig().vspExperimental());
 		TransitRouter router = createTransitRouter(f.schedule, trConfig, routerType);
 		Coord toCoord = new Coord((double) 16100, (double) 10050);
-		List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(new Coord((double) 3800, (double) 5100)), new FakeFacility(toCoord), 6.0*3600, null);
+		List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(new Coord((double) 3800, (double) 5100)), new FakeFacility(toCoord), 6.0*3600, null));
 		assertEquals(5, legs.size());
 		assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
 		assertEquals(TransportMode.pt, ((Leg)legs.get(1)).getMode());
@@ -235,7 +235,7 @@ public class TransitRouterImplTest {
 		TransitRouter router = createTransitRouter(f.schedule, config, routerType);
 		Coord fromCoord = new Coord((double) 3800, (double) 5100);
 		Coord toCoord = new Coord((double) 16100, (double) 10050);
-		List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 6.0*3600, null);
+		List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 6.0*3600, null));
 		Leg leg1 = (Leg) legs.get(1);
 		TransitPassengerRoute route1 = (TransitPassengerRoute) leg1.getRoute();
 		Coord coord1 = f.schedule.getFacilities().get(route1.getEgressStopId()).getCoord();
@@ -256,7 +256,7 @@ public class TransitRouterImplTest {
 				f.scenario.getConfig().vspExperimental());
 		TransitRouter router = createTransitRouter(f.schedule, trConfig, routerType);
 		Coord toCoord = new Coord((double) 28100, (double) 4950);
-		List<? extends PlanElement> legs = router.calcRoute(new FakeFacility( new Coord((double) 3800, (double) 5100)), new FakeFacility(toCoord), 5.0*3600 + 40.0*60, null);
+		List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility( new Coord((double) 3800, (double) 5100)), new FakeFacility(toCoord), 5.0*3600 + 40.0*60, null));
 		assertEquals(4, legs.size());
 		assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
 		assertEquals(TransportMode.pt, ((Leg)legs.get(1)).getMode());
@@ -299,7 +299,7 @@ public class TransitRouterImplTest {
 				f.scenario.getConfig().vspExperimental());
 		trConfig.setUtilityOfLineSwitch_utl(0);
 		TransitRouter router = createTransitRouter(f.schedule, trConfig, routerType);
-		List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(new Coord((double) 11900, (double) 5100)), new FakeFacility(new Coord((double) 24100, (double) 4950)), 6.0*3600 - 5.0*60, null);
+		List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(new Coord((double) 11900, (double) 5100)), new FakeFacility(new Coord((double) 24100, (double) 4950)), 6.0*3600 - 5.0*60, null));
 		assertEquals(5, legs.size());
 		assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
 		assertEquals(TransportMode.pt, ((Leg)legs.get(1)).getMode());
@@ -310,7 +310,7 @@ public class TransitRouterImplTest {
 		assertEquals(TransportMode.walk, ((Leg)legs.get(4)).getMode());
 
 		trConfig.setUtilityOfLineSwitch_utl(300.0 * trConfig.getMarginalUtilityOfTravelTimePt_utl_s()); // corresponds to 5 minutes transit travel time
-		legs = router.calcRoute(new FakeFacility(new Coord((double) 11900, (double) 5100)), new FakeFacility(new Coord((double) 24100, (double) 4950)), 6.0*3600 - 5.0*60, null);
+		legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(new Coord((double) 11900, (double) 5100)), new FakeFacility(new Coord((double) 24100, (double) 4950)), 6.0*3600 - 5.0*60, null));
 		assertEquals(3, legs.size());
 		assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
 		assertEquals(TransportMode.pt, ((Leg)legs.get(1)).getMode());
@@ -336,7 +336,7 @@ public class TransitRouterImplTest {
 		trConfig.setUtilityOfLineSwitch_utl(0);
 		assertEquals(0, trConfig.getAdditionalTransferTime(), 1e-8);
 		TransitRouter router = createTransitRouter(f.schedule, trConfig, routerType);
-		List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(new Coord((double) 11900, (double) 5100)), new FakeFacility(new Coord((double) 24100, (double) 4950)), 6.0*3600 - 5.0*60, null);
+		List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(new Coord((double) 11900, (double) 5100)), new FakeFacility(new Coord((double) 24100, (double) 4950)), 6.0*3600 - 5.0*60, null));
 		assertEquals(5, legs.size());
 		assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
 		assertEquals(TransportMode.pt, ((Leg)legs.get(1)).getMode());
@@ -348,7 +348,7 @@ public class TransitRouterImplTest {
 
 		trConfig.setAdditionalTransferTime(3.0*60); // 3 mins already enough, as there is a small distance to walk anyway which adds some time
 		router = createTransitRouter(f.schedule, trConfig, routerType); // this is necessary to update the router for any change in config. At least raptor transit router fails without this. Amit Sep'17.
-		legs = router.calcRoute(new FakeFacility(new Coord((double) 11900, (double) 5100)), new FakeFacility(new Coord((double) 24100, (double) 4950)), 6.0*3600 - 5.0*60, null);
+		legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(new Coord((double) 11900, (double) 5100)), new FakeFacility(new Coord((double) 24100, (double) 4950)), 6.0*3600 - 5.0*60, null));
 		assertEquals(3, legs.size());
 		assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
 		assertEquals(TransportMode.pt, ((Leg)legs.get(1)).getMode());
@@ -366,7 +366,7 @@ public class TransitRouterImplTest {
 		trConfig.setBeelineWalkSpeed(0.1); // something very slow, so the agent does not walk over night
 		TransitRouter router = createTransitRouter(f.schedule, trConfig, routerType);
 		Coord toCoord = new Coord((double) 16100, (double) 5050);
-		List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(new Coord((double) 3800, (double) 5100)), new FakeFacility(toCoord), 25.0*3600, null);
+		List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(new Coord((double) 3800, (double) 5100)), new FakeFacility(toCoord), 25.0*3600, null));
 		assertEquals(3, legs.size());
 		assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
 		assertEquals(TransportMode.pt, ((Leg)legs.get(1)).getMode());
@@ -396,7 +396,7 @@ public class TransitRouterImplTest {
 		TransitRouter router = createTransitRouter(f.schedule, trConfig, routerType);
 		double x = +42000;
 		double x1 = -2000;
-		List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(new Coord(x1, (double) 0)), new FakeFacility(new Coord(x, (double) 0)), 5.5*3600, null); // should map to stops A and I
+		List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(new Coord(x1, (double) 0)), new FakeFacility(new Coord(x, (double) 0)), 5.5*3600, null)); // should map to stops A and I
 		assertEquals(3, legs.size());
 		assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
 		assertEquals(TransportMode.pt, ((Leg)legs.get(1)).getMode());
@@ -419,7 +419,7 @@ public class TransitRouterImplTest {
 		f.routerConfig.setMarginalUtilityOfTravelTimePt_utl_s(-1.0 / 3600.0 - 6.0/3600.0);
 		f.routerConfig.setUtilityOfLineSwitch_utl(0.2); // must be relatively low in this example, otherwise it's cheaper to walk the whole distance...
 		TransitRouter router = createTransitRouter(f.schedule, f.routerConfig, routerType);
-		List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(f.coord1), new FakeFacility(f.coord7), 990, null);
+		List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(f.coord1), new FakeFacility(f.coord7), 990, null));
 		assertEquals(5, legs.size());
 		assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
 		assertEquals(TransportMode.pt, ((Leg)legs.get(1)).getMode());
@@ -449,7 +449,7 @@ public class TransitRouterImplTest {
 		f.routerConfig.setExtensionRadius(0.0);
 
 		TransitRouter router = createTransitRouter(f.schedule, f.routerConfig, routerType);
-		List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(f.coord2), new FakeFacility(f.coord4), 990, null);
+		List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(f.coord2), new FakeFacility(f.coord4), 990, null));
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
 	}
 
@@ -465,7 +465,7 @@ public class TransitRouterImplTest {
 		f.routerConfig.setExtensionRadius(0.0);
 
 		TransitRouter router = createTransitRouter(f.schedule, f.routerConfig, routerType);
-		List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(f.coord2), new FakeFacility(f.coord6), 990, null);
+		List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(f.coord2), new FakeFacility(f.coord6), 990, null));
         Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
 	}
 
@@ -478,7 +478,7 @@ public class TransitRouterImplTest {
 			TransitRouter router = createTransitRouter(f.schedule, f.routerConfig, routerType);
 			Coord fromCoord = f.fromFacility.getCoord();
 			Coord toCoord = f.toFacility.getCoord();
-			List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null);
+			List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null));
 			double legDuration = calcTripDuration(new ArrayList<>(legs));
 			Assert.assertEquals(5, legs.size());
 			Assert.assertEquals(100, ((Leg)legs.get(0)).getTravelTime().seconds(), 0.0);	// 0.1km with 1m/s walk speed -> 100s; arrival at 07:51:40
@@ -497,7 +497,7 @@ public class TransitRouterImplTest {
 	                f.scenario.getNetwork(), // use a walk router in case no PT path is found
 	                walkRoutingModule);
 			
-			List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(DefaultRoutingRequest.of(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null));
+			List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(DefaultRoutingRequest.withoutAttributes(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null));
 			double tripDuration = calcTripDuration(planElements);
 			Assert.assertEquals(9, planElements.size());
 			Assert.assertEquals(100, ((Leg)planElements.get(0)).getTravelTime().seconds(), 0.0);	// 0.1km with 1m/s walk speed -> 100s; arrival at 07:51:40
@@ -514,7 +514,7 @@ public class TransitRouterImplTest {
 			TransitRouter router = createTransitRouter(f.schedule, f.routerConfig, routerType);
 			Coord fromCoord = f.fromFacility.getCoord();
 			Coord toCoord = f.toFacility.getCoord();
-			List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null);
+			List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null));
 			double legDuration = calcTripDuration(new ArrayList<>(legs));
 			Assert.assertEquals(5, legs.size());
 			Assert.assertEquals(100, ((Leg)legs.get(0)).getTravelTime().seconds(), 0.0);	// 0.1km with 1m/s walk speed -> 100s; arrival at 07:51:40
@@ -533,7 +533,7 @@ public class TransitRouterImplTest {
 	                f.scenario.getNetwork(), // use a walk router in case no PT path is found
 	                walkRoutingModule);
 			
-			List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(DefaultRoutingRequest.of(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null));
+			List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(DefaultRoutingRequest.withoutAttributes(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null));
 			double tripDuration = calcTripDuration(planElements);
 			Assert.assertEquals(9, planElements.size());
 			Assert.assertEquals(100, ((Leg)planElements.get(0)).getTravelTime().seconds(), 0.0);	// 0.1km with 1m/s walk speed -> 100s; arrival at 07:51:40
@@ -550,7 +550,7 @@ public class TransitRouterImplTest {
 			TransitRouter router = createTransitRouter(f.schedule, f.routerConfig, routerType);
 			Coord fromCoord = f.fromFacility.getCoord();
 			Coord toCoord = f.toFacility.getCoord();
-			List<? extends PlanElement> legs = router.calcRoute(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null);
+			List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 7.0*3600 + 50*60, null));
 	        Assert.assertNull("The router should not find a route and return null, but did return something else.", legs);
 			
 			RoutingModule walkRoutingModule = DefaultRoutingModules.createTeleportationRouter(TransportMode.walk, f.scenario,
@@ -562,7 +562,7 @@ public class TransitRouterImplTest {
 	                f.scenario.getNetwork(), // use a walk router in case no PT path is found
 	                walkRoutingModule);
 			
-			List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(DefaultRoutingRequest.of(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null));
+			List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(DefaultRoutingRequest.withoutAttributes(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null));
 	        Assert.assertNull("The router should not find a route and return null, but did return something else.", planElements);
 		}
 	}

--- a/matsim/src/test/java/org/matsim/pt/router/TransitRouterImplTest.java
+++ b/matsim/src/test/java/org/matsim/pt/router/TransitRouterImplTest.java
@@ -49,6 +49,7 @@ import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.population.routes.RouteUtils;
 import org.matsim.core.router.DefaultRoutingModules;
+import org.matsim.core.router.DefaultRoutingRequest;
 import org.matsim.core.router.RoutingModule;
 import org.matsim.core.router.TransitRouterWrapper;
 import org.matsim.core.scenario.MutableScenario;
@@ -496,7 +497,7 @@ public class TransitRouterImplTest {
 	                f.scenario.getNetwork(), // use a walk router in case no PT path is found
 	                walkRoutingModule);
 			
-			List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null);
+			List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(DefaultRoutingRequest.of(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null));
 			double tripDuration = calcTripDuration(planElements);
 			Assert.assertEquals(9, planElements.size());
 			Assert.assertEquals(100, ((Leg)planElements.get(0)).getTravelTime().seconds(), 0.0);	// 0.1km with 1m/s walk speed -> 100s; arrival at 07:51:40
@@ -532,7 +533,7 @@ public class TransitRouterImplTest {
 	                f.scenario.getNetwork(), // use a walk router in case no PT path is found
 	                walkRoutingModule);
 			
-			List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null);
+			List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(DefaultRoutingRequest.of(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null));
 			double tripDuration = calcTripDuration(planElements);
 			Assert.assertEquals(9, planElements.size());
 			Assert.assertEquals(100, ((Leg)planElements.get(0)).getTravelTime().seconds(), 0.0);	// 0.1km with 1m/s walk speed -> 100s; arrival at 07:51:40
@@ -561,7 +562,7 @@ public class TransitRouterImplTest {
 	                f.scenario.getNetwork(), // use a walk router in case no PT path is found
 	                walkRoutingModule);
 			
-			List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null);
+			List<PlanElement> planElements = (List<PlanElement>) wrapper.calcRoute(DefaultRoutingRequest.of(f.fromFacility, f.toFacility, 7.0*3600 + 50*60, null));
 	        Assert.assertNull("The router should not find a route and return null, but did return something else.", planElements);
 		}
 	}


### PR DESCRIPTION
This PR is following up on PR #1383 for issue #1349. The idea is to streamline the routing process by not passing, origin, destination, departure time, person independently to `RoutingModule.calcRoute`, but to pass a consolidated object backed by an interface (`RoutingRequest`). Apart from simplifying the code, in the future, this will also allow passing context-specific (trip-specific) information to the routing modules, e.g. the vehicle type used for a certain trip, or specific service characteristics in on-demand services. For public transport, at some point, additional trip-specific requirements could be sent (avoiding certain stops areas, preferences for certain access modes, ...).

Plan for development:
- [x] Introduce `RoutingRequest`, adapt `RoutingModule` and all follow-up issues in the code
- [x] Introduce `DefaultRoutingRequest` holding the existing data (origin, destination, departure time, person) and wrap parameters in calls to `calcRoute` in `DefaultRoutingRequest.of( ... )`
- [x] Go through all uses of `DefaultRoutingRequest.of` to check whether request objects can be passed on directly instead of creating a new request object
- [x] Pass on information through DRT / SRR routing modules to secondary routing modules