### PR TITLE
DRT: fix handling of request insertion retry queue

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
@@ -66,10 +66,9 @@ public class DefaultUnplannedRequestInserter implements UnplannedRequestInserter
 	public DefaultUnplannedRequestInserter(DrtConfigGroup drtCfg, Fleet fleet, MobsimTimer mobsimTimer,
 			EventsManager eventsManager, RequestInsertionScheduler insertionScheduler,
 			VehicleEntry.EntryFactory vehicleEntryFactory, DrtInsertionSearch<PathData> insertionSearch,
-			ForkJoinPool forkJoinPool) {
+			DrtRequestInsertionRetryQueue insertionRetryQueue, ForkJoinPool forkJoinPool) {
 		this(drtCfg.getMode(), fleet, mobsimTimer::getTimeOfDay, eventsManager, insertionScheduler, vehicleEntryFactory,
-				new DrtRequestInsertionRetryQueue(drtCfg.getDrtRequestInsertionRetryParams().
-						orElse(new DrtRequestInsertionRetryParams())), forkJoinPool, insertionSearch);
+				insertionRetryQueue, forkJoinPool, insertionSearch);
 	}
 
 	@VisibleForTesting

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DrtRequestInsertionRetryQueue.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DrtRequestInsertionRetryQueue.java
@@ -30,10 +30,10 @@ import org.matsim.contrib.drt.passenger.DrtRequest;
 /**
  * @author Michal Maciejewski (michalm)
  */
-class DrtRequestInsertionRetryQueue {
+public class DrtRequestInsertionRetryQueue {
 	private final DrtRequestInsertionRetryParams params;
 
-	DrtRequestInsertionRetryQueue(DrtRequestInsertionRetryParams params) {
+	public DrtRequestInsertionRetryQueue(DrtRequestInsertionRetryParams params) {
 		this.params = params;
 	}
 
@@ -48,10 +48,14 @@ class DrtRequestInsertionRetryQueue {
 		return true;
 	}
 
+	public boolean hasRequestsToRetryNow(double now) {
+		double maxLastAttemptTimeForRetry = now - params.getRetryInterval();
+		return !requestQueue.isEmpty() && requestQueue.getFirst().lastAttemptTime <= maxLastAttemptTimeForRetry;
+	}
+
 	List<DrtRequest> getRequestsToRetryNow(double now) {
-		double maxAttemptTimeForRetry = now - params.getRetryInterval();
 		List<DrtRequest> requests = new ArrayList<>();
-		while (!requestQueue.isEmpty() && requestQueue.getFirst().lastAttemptTime <= maxAttemptTimeForRetry) {
+		while (hasRequestsToRetryNow(now)) {
 			var entry = requestQueue.removeFirst();
 			//no guarantee that this method is called every second, so we need to calculate time delta, instead of
 			//directly using the retry interval

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/run/examples/RunDrtExampleIT.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/run/examples/RunDrtExampleIT.java
@@ -72,9 +72,9 @@ public class RunDrtExampleIT {
 		var expectedStats = Stats.newBuilder()
 				.rejectionRate(0.01)
 				.rejections(5)
-				.waitAverage(700.11)
-				.inVehicleTravelTimeMean(381.06)
-				.totalTravelTimeMean(1081.17)
+				.waitAverage(806.34)
+				.inVehicleTravelTimeMean(369.91)
+				.totalTravelTimeMean(1176.25)
 				.build();
 
 		verifyDrtCustomerStatsCloseToExpectedStats(utils.getOutputDirectory(), expectedStats);
@@ -159,12 +159,12 @@ public class RunDrtExampleIT {
 		double rejectionRate = Double.parseDouble(params.get("rejectionRate"));
 		double totalTravelTimeMean = Double.parseDouble(params.get("totalTravelTime_mean"));
 
-		var percentage = Percentage.withPercentage(1);
-		assertThat(expectedStats.rejectionRate).isCloseTo(rejectionRate, percentage);
-		assertThat(expectedStats.rejections).isCloseTo(rejections, percentage);
-		assertThat(expectedStats.waitAverage).isCloseTo(waitAverage, percentage);
-		assertThat(expectedStats.inVehicleTravelTimeMean).isCloseTo(inVehicleTravelTimeMean, percentage);
-		assertThat(expectedStats.totalTravelTimeMean).isCloseTo(totalTravelTimeMean, percentage);
+		var percentage = Percentage.withPercentage(0.00001);
+		assertThat(rejectionRate).isCloseTo(expectedStats.rejectionRate, percentage);
+		assertThat(rejections).isCloseTo(expectedStats.rejections, percentage);
+		assertThat(waitAverage).isCloseTo(expectedStats.waitAverage, percentage);
+		assertThat(inVehicleTravelTimeMean).isCloseTo(expectedStats.inVehicleTravelTimeMean, percentage);
+		assertThat(totalTravelTimeMean).isCloseTo(expectedStats.totalTravelTimeMean, percentage);
 	}
 
 	private static class Stats {


### PR DESCRIPTION
Fixes issue: reinsertion is not attempted until there is at least one new unplanned request