### PR TITLE
Add tripDurationHandling option to improve timing in plan-based routing

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/prepare/population/CloseTrajectories.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/population/CloseTrajectories.java
@@ -83,7 +83,7 @@ public class CloseTrajectories implements MATSimAppCommand {
 			if (time > threshold * 60)
 				continue;
 
-			TimeInterpretation timeInterpretation = TimeInterpretation.create(ActivityDurationInterpretation.tryEndTimeThenDuration);
+			TimeInterpretation timeInterpretation = TimeInterpretation.create(ActivityDurationInterpretation.tryEndTimeThenDuration, PlansConfigGroup.TripDurationHandling.ignoreDelays);
 			double endTime = timeInterpretation.decideOnActivityEndTime(lastAct, lastAct.getStartTime().orElse(Double.NaN))
 					.orElseThrow(() -> new IllegalStateException("Could not determine end time"));
 

--- a/matsim/src/main/java/org/matsim/core/config/groups/PlansConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/PlansConfigGroup.java
@@ -41,6 +41,18 @@ public final class PlansConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	public enum ActivityDurationInterpretation { minOfDurationAndEndTime, tryEndTimeThenDuration, @Deprecated endTimeOnly }
+	
+	/**
+	 * Defines how trip durations are interpreted when routing along a plan
+	 */
+	public enum TripDurationHandling { 
+		/** When routing along a plan, the nominal end times of activities are using as departure times of the following trips */
+		ignoreDelays
+		, 
+		/** When routing along a plan, travel times are accumulated and activity end times may be shifted, if necessary */
+		shiftActivityEndTimes 
+	}
+	
 	private static final String INPUT_FILE = "inputPlansFile";
 	private static final String INPUT_PERSON_ATTRIBUTES_FILE = "inputPersonAttributesFile";
 	private static final String NETWORK_ROUTE_TYPE = "networkRouteType";
@@ -56,7 +68,10 @@ public final class PlansConfigGroup extends ReflectiveConfigGroup {
 	//--
 	
 	private static final String ACTIVITY_DURATION_INTERPRETATION="activityDurationInterpretation" ;
+	private static final String TRIP_DURATION_HANDLING="tripDurationHandling";
+	
 	private ActivityDurationInterpretation activityDurationInterpretation = ActivityDurationInterpretation.tryEndTimeThenDuration ;
+	private TripDurationHandling tripDurationHandling = TripDurationHandling.ignoreDelays;
 
 	//--
 
@@ -87,6 +102,9 @@ public final class PlansConfigGroup extends ReflectiveConfigGroup {
 		comments.put(ACTIVITY_DURATION_INTERPRETATION, "String:" + str + ". Anything besides " 
 				+ PlansConfigGroup.ActivityDurationInterpretation.minOfDurationAndEndTime + " will internally use a different " +
 		"(simpler) version of the TimeAllocationMutator.") ;
+		comments.put(TRIP_DURATION_HANDLING, "Defines how departure times are interpreted in rerouting applications. If set to '" + TripDurationHandling.ignoreDelays + "', " + 
+				"the departure time of a trip when routing along a plan will always be the nominal (plan-based) activity end time. If set to '" + TripDurationHandling.shiftActivityEndTimes + "', " + 
+				"routing along a plan will accumulate travel times and shift activity end times if necessary");
 		
 		comments.put(REMOVING_UNNECESSARY_PLAN_ATTRIBUTES, "(not tested) will remove plan attributes that are presumably not used, such as " +
                 "activityStartTime. default=false. Use with Caution!");
@@ -203,7 +221,17 @@ public final class PlansConfigGroup extends ReflectiveConfigGroup {
 		}
 		this.activityDurationInterpretation = actDurInterpret;
 	}
+	
+	@StringGetter(TRIP_DURATION_HANDLING)
+	public PlansConfigGroup.TripDurationHandling getTripDurationHandling() {
+		return this.tripDurationHandling ;
+	}
 
+	@StringSetter(TRIP_DURATION_HANDLING)
+	public void setTripDurationHandling( final PlansConfigGroup.TripDurationHandling value ) {
+		this.tripDurationHandling = value;
+	}
+	
 	// ---
 	
 	private static final String REMOVING_UNNECESSARY_PLAN_ATTRIBUTES = "removingUnnecessaryPlanAttributes";

--- a/matsim/src/main/java/org/matsim/core/mobsim/jdeqsim/EndLegMessage.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/jdeqsim/EndLegMessage.java
@@ -49,7 +49,7 @@ public class EndLegMessage extends EventMessage {
 		super(scheduler, vehicle);
 		this.priority = JDEQSimConfigGroup.PRIORITY_ARRIVAL_MESSAGE;
 		if ( vehicle == null ) {
-			this.timeInterpretation = TimeInterpretation.create(PlansConfigGroup.ActivityDurationInterpretation.minOfDurationAndEndTime);
+			this.timeInterpretation = TimeInterpretation.create(PlansConfigGroup.ActivityDurationInterpretation.minOfDurationAndEndTime, PlansConfigGroup.TripDurationHandling.ignoreDelays);
 			// need this for some test cases. kai, nov'13
 		} else {
 			this.timeInterpretation = timeInterpretation ;

--- a/matsim/src/test/java/org/matsim/core/mobsim/jdeqsim/TestMessageFactory.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/jdeqsim/TestMessageFactory.java
@@ -102,7 +102,7 @@ public class TestMessageFactory extends MatsimTestCase{
 		Scheduler scheduler=new Scheduler(new MessageQueue());
 		Person person= PopulationUtils.getFactory().createPerson(Id.create("abc", Person.class));
 		
-		TimeInterpretation timeInterpretation = TimeInterpretation.create(PlansConfigGroup.ActivityDurationInterpretation.minOfDurationAndEndTime);
+		TimeInterpretation timeInterpretation = TimeInterpretation.create(PlansConfigGroup.ActivityDurationInterpretation.minOfDurationAndEndTime, PlansConfigGroup.TripDurationHandling.ignoreDelays);
 		Vehicle vehicle=new Vehicle(scheduler, person, timeInterpretation );
 		
 		assertEquals(true,MessageFactory.getEndLegMessage(scheduler, vehicle, timeInterpretation).scheduler==scheduler);
@@ -127,7 +127,7 @@ public class TestMessageFactory extends MatsimTestCase{
 		Scheduler scheduler=new Scheduler(new MessageQueue());
 		Person person= PopulationUtils.getFactory().createPerson(Id.create("abc", Person.class));
 		
-		TimeInterpretation timeInterpretation = TimeInterpretation.create(PlansConfigGroup.ActivityDurationInterpretation.minOfDurationAndEndTime);
+		TimeInterpretation timeInterpretation = TimeInterpretation.create(PlansConfigGroup.ActivityDurationInterpretation.minOfDurationAndEndTime, PlansConfigGroup.TripDurationHandling.ignoreDelays);
 		Vehicle vehicle=new Vehicle(scheduler, person, timeInterpretation );
 		
 		assertEquals(true,MessageFactory.getEndLegMessage(scheduler, vehicle, timeInterpretation).scheduler==scheduler);

--- a/matsim/src/test/java/org/matsim/core/utils/timing/TimeInterpretationTest.java
+++ b/matsim/src/test/java/org/matsim/core/utils/timing/TimeInterpretationTest.java
@@ -1,0 +1,135 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * ArgumentParserTest.java
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2007 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.core.utils.timing;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.api.core.v01.population.Activity;
+import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Plan;
+import org.matsim.api.core.v01.population.PlanElement;
+import org.matsim.api.core.v01.population.PopulationFactory;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.config.groups.PlanCalcScoreConfigGroup.ActivityParams;
+import org.matsim.core.config.groups.PlansConfigGroup.TripDurationHandling;
+import org.matsim.core.controler.Controler;
+import org.matsim.core.controler.OutputDirectoryHierarchy;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.testcases.MatsimTestCase;
+
+public class TimeInterpretationTest extends MatsimTestCase {
+	@Test
+	public void testIgnoreDelays() {
+		Config config = ConfigUtils.createConfig();
+		config.plans().setTripDurationHandling(TripDurationHandling.ignoreDelays);
+
+		Controler controller = prepareController(config);
+		controller.run();
+
+		Person person = controller.getScenario().getPopulation().getPersons().values().iterator().next();
+		List<? extends PlanElement> elements = person.getSelectedPlan().getPlanElements();
+
+		Leg firstLeg = (Leg) elements.get(1);
+		Leg secondLeg = (Leg) elements.get(3);
+
+		assertEquals(15600.0, firstLeg.getTravelTime().seconds());
+		assertEquals(28800.0, firstLeg.getDepartureTime().seconds());
+		assertEquals(43200.0, secondLeg.getDepartureTime().seconds());
+		// End time was NOT shifted (although arrival is later), second departure is assumed at 12:00
+	}
+
+	@Test
+	public void testShiftActivityEndTime() {
+		Config config = ConfigUtils.createConfig();
+		config.plans().setTripDurationHandling(TripDurationHandling.shiftActivityEndTimes);
+
+		Controler controller = prepareController(config);
+		controller.run();
+
+		Person person = controller.getScenario().getPopulation().getPersons().values().iterator().next();
+		List<? extends PlanElement> elements = person.getSelectedPlan().getPlanElements();
+
+		Leg firstLeg = (Leg) elements.get(1);
+		Leg secondLeg = (Leg) elements.get(3);
+
+		assertEquals(15600.0, firstLeg.getTravelTime().seconds());
+		assertEquals(28800.0, firstLeg.getDepartureTime().seconds());
+		assertEquals(44400.0, secondLeg.getDepartureTime().seconds());
+		// End time WAS shifted (because arrival is later), second departure is assumed at 12:20
+	}
+
+	private Controler prepareController(Config config) {
+		config.controler()
+				.setOverwriteFileSetting(OutputDirectoryHierarchy.OverwriteFileSetting.overwriteExistingFiles);
+		config.controler().setLastIteration(0);
+
+		ActivityParams genericParams = new ActivityParams("generic");
+		genericParams.setScoringThisActivityAtAll(false);
+		config.planCalcScore().addActivityParams(genericParams);
+
+		Scenario scenario = ScenarioUtils.createScenario(config);
+
+		Node firstNode = scenario.getNetwork().getFactory().createNode(Id.createNodeId("firstNode"),
+				new Coord(0.0, 0.0));
+		Node secondNode = scenario.getNetwork().getFactory().createNode(Id.createNodeId("secondeNode"),
+				new Coord(0.0, 0.0));
+		Link link = scenario.getNetwork().getFactory().createLink(Id.createLinkId("link"), firstNode, secondNode);
+
+		scenario.getNetwork().addNode(firstNode);
+		scenario.getNetwork().addNode(secondNode);
+		scenario.getNetwork().addLink(link);
+
+		PopulationFactory factory = scenario.getPopulation().getFactory();
+
+		Person person = factory.createPerson(Id.createPersonId("person"));
+		scenario.getPopulation().addPerson(person);
+
+		Plan plan = factory.createPlan();
+		person.addPlan(plan);
+
+		Activity firstActivity = factory.createActivityFromCoord("generic", new Coord(0.0, 0.0));
+		firstActivity.setEndTime(8.0 * 3600.0);
+		plan.addActivity(firstActivity);
+
+		Leg firstLeg = factory.createLeg("walk");
+		plan.addLeg(firstLeg);
+
+		Activity secondActivity = factory.createActivityFromCoord("generic", new Coord(10.0 * 1e3, 0.0)); // 10km
+		secondActivity.setEndTime(12.0 * 3600.0);
+		plan.addActivity(secondActivity);
+
+		Leg secondLeg = factory.createLeg("walk");
+		plan.addLeg(secondLeg);
+
+		Activity thirdActivity = factory.createActivityFromCoord("generic", new Coord(0.0, 0.0));
+		plan.addActivity(thirdActivity);
+
+		return new Controler(scenario);
+	}
+}


### PR DESCRIPTION
This PR adds a new option to the `plans` config group. It is called `tripDurationHandling` and controls how leg departure times are assumed during plan-based routing, e.g. in the `ReRoute` strategy. We look at situations where the first activity of a plan has an end time of 08:00:00, and the second one has an end time of 12:00:00. After both activities, there is a leg, which gets routed during `ReRoute` or in `PrepareForSim`. If the mode is slow, it may happen that the agent only arrives *after* the end time of the second activity. This also happens frequently when, initially, the network is heavily congested. In such a case, *currently*, MATSim would still route the second trip with a departure time of 12:00:00, as it is defined in the plan. This case is handled by the default setting `ignoreDelays` of the new `tripDurationHandling` option. Alternatively, `shiftActivityEndTimes` can be chosen, which will make sure that travel times are accumulated while routing alone a plan, and routing can never be performed "in the past". This means, if an activity is defined by an activity end time, but the preceding trip only arrives after this end time, the next leg will be routed immediately. This, in turn, also means that the router will assume the correct travel times at this time.

To summarize:
- `tripDurationHandling = ignoreDelays` -> Default an current behaviour, always route from the given activity end times
- `tripDurationHandling = shiftActivityEndTimes` -> Accumulate travel and activity time, and route with departure times that correspond to those accumulated times

See `TimeInterpretationTest` for a straight-forward example.

Closes #929.