### PR TITLE
Digitial elevation model for noise

### DIFF
--- a/contribs/noise/pom.xml
+++ b/contribs/noise/pom.xml
@@ -22,6 +22,18 @@
             <version>${geotools.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-coverage</artifactId>
+            <version>${geotools.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-geotiff</artifactId>
+            <version>${geotools.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
 			<groupId>org.openstreetmap.osmosis</groupId>
 			<artifactId>osmosis-xml</artifactId>
 			<version>0.47</version>
@@ -34,6 +46,5 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-
     </dependencies>
 </project>

--- a/contribs/noise/src/main/java/org/matsim/contrib/noise/DEMContext.java
+++ b/contribs/noise/src/main/java/org/matsim/contrib/noise/DEMContext.java
@@ -1,0 +1,12 @@
+package org.matsim.contrib.noise;
+
+import org.opengis.geometry.DirectPosition;
+
+public interface DEMContext {
+
+    /**
+     * Returns the elevation at the given position.
+     */
+    float getElevation(DirectPosition position);
+
+}

--- a/contribs/noise/src/main/java/org/matsim/contrib/noise/DEMContextImpl.java
+++ b/contribs/noise/src/main/java/org/matsim/contrib/noise/DEMContextImpl.java
@@ -32,7 +32,6 @@ public class DEMContextImpl implements DEMContext {
         }
     }
 
-
     @Override
     public float getElevation(DirectPosition position) {
         float[] sample =  (float[])coverage.evaluate(position);

--- a/contribs/noise/src/main/java/org/matsim/contrib/noise/DEMContextImpl.java
+++ b/contribs/noise/src/main/java/org/matsim/contrib/noise/DEMContextImpl.java
@@ -1,0 +1,41 @@
+package org.matsim.contrib.noise;
+
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.gce.geotiff.GeoTiffReader;
+import org.geotools.util.factory.Hints;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.opengis.geometry.DirectPosition;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * @author nkuehnel
+ */
+public class DEMContextImpl implements DEMContext {
+
+    private GridCoverage2D coverage;
+
+    @Inject
+    DEMContextImpl(Config config) {
+        NoiseConfigGroup noiseParams = ConfigUtils.addOrGetModule(config, NoiseConfigGroup.class);
+        if (noiseParams.isUseDEM()) {
+            File file = new File(noiseParams.getDEMFile());
+            try {
+                GeoTiffReader reader = new GeoTiffReader(file, new Hints(Hints.FORCE_LONGITUDE_FIRST_AXIS_ORDER, Boolean.TRUE));
+                coverage = reader.read(null);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+
+    @Override
+    public float getElevation(DirectPosition position) {
+        float[] sample =  (float[])coverage.evaluate(position);
+        return sample[0];
+    }
+}

--- a/contribs/noise/src/main/java/org/matsim/contrib/noise/NoiseComputationModule.java
+++ b/contribs/noise/src/main/java/org/matsim/contrib/noise/NoiseComputationModule.java
@@ -66,6 +66,7 @@ public final class NoiseComputationModule extends AbstractModule {
 				}
 				this.bind(RoadSurfaceContext.class).in(Singleton.class);
 				this.bind(IntersectionContext.class).in(Singleton.class);
+				this.bind(DEMContext.class).to(DEMContextImpl.class).in(Singleton.class);
 
 				break;
 			default:

--- a/contribs/noise/src/main/java/org/matsim/contrib/noise/NoiseConfigGroup.java
+++ b/contribs/noise/src/main/java/org/matsim/contrib/noise/NoiseConfigGroup.java
@@ -31,11 +31,8 @@ import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ReflectiveConfigGroup;
 import org.matsim.core.utils.collections.CollectionUtils;
 import org.matsim.core.utils.geometry.transformations.TransformationFactory;
-import org.matsim.core.utils.io.IOUtils;
 import org.matsim.core.utils.misc.StringUtils;
 
-import java.io.BufferedReader;
-import java.io.IOException;
 import java.net.URL;
 import java.util.*;
 
@@ -87,6 +84,8 @@ public final class NoiseConfigGroup extends ReflectiveConfigGroup {
 	private static final String NOISE_BARRIERS_SOURCE_CRS = "source coordinate reference system of noise barriers geojson file";
 	private static final String NETWORK_MODES_TO_IGNORE = "networkModesToIgnore";
 	private static final String NOISE_COMPUTATION_METHOD = "noiseComputationMethod";
+	private static final String USE_DEM = "useDGM";
+	private static final String DEM_FILE = "DGMFile";
 
 	public NoiseConfigGroup() {
 		super(GROUP_NAME);
@@ -143,6 +142,9 @@ public final class NoiseConfigGroup extends ReflectiveConfigGroup {
 	private boolean considerNoiseBarriers = false;
     private String noiseBarriersFilePath = null;
     private String noiseBarriersSourceCrs = null;
+
+    private boolean useDEM = false;
+    private String demFile = null;
 
     public enum NoiseComputationMethod {
         RLS90,RLS19
@@ -203,7 +205,10 @@ public final class NoiseConfigGroup extends ReflectiveConfigGroup {
         comments.put(NOISE_BARRIERS_GEOJSON_FILE, "Path to the geojson file for noise barriers.");
         comments.put(NOISE_BARRIERS_SOURCE_CRS, "Source coordinate reference system of noise barriers geojson file.");
 
-        comments.put(NETWORK_MODES_TO_IGNORE, "Specifies the network modes to be excluded from the noise computation, e.g. 'bike'.");
+		comments.put(USE_DEM, "Set to 'true' if a DEM (digital elevation model) should be used for road gradients. Otherwise set to 'false'.");
+		comments.put(DEM_FILE, "Path to the geoTiff file of the DEM.");
+
+		comments.put(NETWORK_MODES_TO_IGNORE, "Specifies the network modes to be excluded from the noise computation, e.g. 'bike'.");
 
         comments.put(NOISE_COMPUTATION_METHOD, "Specifies the computation method of different guidelines: " + Arrays.toString(NoiseComputationMethod.values()));
 
@@ -753,6 +758,26 @@ public final class NoiseConfigGroup extends ReflectiveConfigGroup {
     public void setNoiseBarriersFilePath(String noiseBarriersFilePath) {
         this.noiseBarriersFilePath = noiseBarriersFilePath;
     }
+
+	@StringGetter(USE_DEM)
+	public boolean isUseDEM() {
+		return this.useDEM;
+	}
+
+	@StringSetter(USE_DEM)
+	public void setUseDEM(boolean useDEM) {
+		this.useDEM = useDEM;
+	}
+
+	@StringGetter(DEM_FILE)
+	public String getDEMFile() {
+		return this.demFile;
+	}
+
+	@StringSetter(DEM_FILE)
+	public void setDEMFilePath(String demFilePath) {
+		this.demFile = demFilePath;
+	}
 
     @StringGetter(NOISE_BARRIERS_SOURCE_CRS)
     public String getNoiseBarriersSourceCRS() {

--- a/contribs/noise/src/main/java/org/matsim/contrib/noise/RLS19NoiseEmission.java
+++ b/contribs/noise/src/main/java/org/matsim/contrib/noise/RLS19NoiseEmission.java
@@ -115,8 +115,6 @@ class RLS19NoiseEmission implements NoiseEmission {
         double pLkw1 = ((double) nLkw1) / m;
         double pLkw2 = ((double) nLkw2) / m;
 
-
-
         double singlePkwEmission
                 = calculateSingleVehicleEmission(noiseLink, pkw, vPkw);
         double singleLkw1Emission
@@ -165,13 +163,14 @@ class RLS19NoiseEmission implements NoiseEmission {
             Coord from = matsimLink.getFromNode().getCoord();
             Coord to = matsimLink.getToNode().getCoord();
 
-            DirectPosition positionFrom = new DirectPosition2D(crs, from.getX(), from.getY());
-            DirectPosition positionTo = new DirectPosition2D(crs, to.getX(), to.getY());
+            //MATSim coord's x/y are inversed to geotools/jts
+            DirectPosition positionFrom = new DirectPosition2D(crs, from.getY(), from.getX());
+            DirectPosition positionTo = new DirectPosition2D(crs, to.getY(), to.getX());
 
             float elevationFrom = demContext.getElevation(positionFrom);
             float elevationTo = demContext.getElevation(positionTo);
 
-            g = (elevationTo - elevationFrom) / matsimLink.getLength();
+            g = ((elevationTo - elevationFrom) / matsimLink.getLength()) * 100;
         } else {
             final Object gradient = matsimLink.getAttributes().getAttribute(GRADIENT);
             if(gradient != null) {

--- a/contribs/noise/src/main/java/org/matsim/contrib/noise/RLS19NoiseEmission.java
+++ b/contribs/noise/src/main/java/org/matsim/contrib/noise/RLS19NoiseEmission.java
@@ -2,10 +2,17 @@ package org.matsim.contrib.noise;
 
 import com.google.common.collect.Range;
 import com.google.inject.Inject;
+import org.geotools.geometry.DirectPosition2D;
+import org.geotools.referencing.CRS;
+import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
+import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
+import org.opengis.geometry.DirectPosition;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import static org.matsim.contrib.noise.RLS19VehicleType.*;
 
@@ -19,12 +26,21 @@ class RLS19NoiseEmission implements NoiseEmission {
     private final NoiseConfigGroup noiseParams;
     private final Network network;
     private final RoadSurfaceContext surfaceContext;
+    private final DEMContext demContext;
+    private CoordinateReferenceSystem crs;
 
     @Inject
-    RLS19NoiseEmission(Scenario scenario, RoadSurfaceContext surfaceContext) {
-        noiseParams = ConfigUtils.addOrGetModule(scenario.getConfig(), NoiseConfigGroup.class);
+    RLS19NoiseEmission(Scenario scenario, RoadSurfaceContext surfaceContext, DEMContext demContext) {
+        Config config = scenario.getConfig();
+        try {
+            crs = CRS.decode(config.global().getCoordinateSystem());
+        } catch (FactoryException e) {
+            e.printStackTrace();
+        }
+        noiseParams = ConfigUtils.addOrGetModule(config, NoiseConfigGroup.class);
         network = scenario.getNetwork();
         this.surfaceContext = surfaceContext;
+        this.demContext = demContext;
     }
 
     /**
@@ -130,10 +146,8 @@ class RLS19NoiseEmission implements NoiseEmission {
         double baseValue = calculateBaseVehicleTypeEmission(vehicleType, v);
         double surfaceCorrection = calculateSurfaceCorrection(vehicleType, link, v);
         double gradientCorrection = calculateGradientCorrection(link, v, vehicleType);
-        double reflectionCorrection = calculateReflectionCorrection();
 
-        double emission = baseValue + surfaceCorrection + gradientCorrection + reflectionCorrection;
-        return emission;
+        return baseValue + surfaceCorrection + gradientCorrection;
     }
 
 
@@ -146,10 +160,25 @@ class RLS19NoiseEmission implements NoiseEmission {
      */
     double calculateGradientCorrection(NoiseLink link, double v, RLS19VehicleType vehicleType) {
         double g = 0;
-        final Object gradient = network.getLinks().get(link.getId()).getAttributes().getAttribute(GRADIENT);
-        if(gradient != null) {
-            g = (Double) gradient;
+        Link matsimLink = network.getLinks().get(link.getId());
+        if(noiseParams.isUseDEM()) {
+            Coord from = matsimLink.getFromNode().getCoord();
+            Coord to = matsimLink.getToNode().getCoord();
+
+            DirectPosition positionFrom = new DirectPosition2D(crs, from.getX(), from.getY());
+            DirectPosition positionTo = new DirectPosition2D(crs, to.getX(), to.getY());
+
+            float elevationFrom = demContext.getElevation(positionFrom);
+            float elevationTo = demContext.getElevation(positionTo);
+
+            g = (elevationTo - elevationFrom) / matsimLink.getLength();
+        } else {
+            final Object gradient = matsimLink.getAttributes().getAttribute(GRADIENT);
+            if(gradient != null) {
+                g = (Double) gradient;
+            }
         }
+
         double correction = 0;
         switch (vehicleType) {
             case pkw:
@@ -194,12 +223,6 @@ class RLS19NoiseEmission implements NoiseEmission {
                 + 10 * Math.log10(1 + Math.pow(v / vehicleType.getEmissionParameterB(), vehicleType.getEmissionParameterC()));
         return emission;
     }
-
-    //TODO
-    private double calculateReflectionCorrection() {
-        return 0;
-    }
-
 
     private double calculateSurfaceCorrection(RLS19VehicleType type, NoiseLink link, double velocity) {
         return surfaceContext.calculateSurfaceCorrection(type, link, velocity);

--- a/contribs/noise/src/test/java/org/matsim/contrib/noise/NoiseRLS19IT.java
+++ b/contribs/noise/src/test/java/org/matsim/contrib/noise/NoiseRLS19IT.java
@@ -104,7 +104,7 @@ public class NoiseRLS19IT {
 
         NoiseLink noiseLink = new NoiseLink(link.getId());
 
-        RLS19NoiseEmission emission = new RLS19NoiseEmission(scenario, new RoadSurfaceContext(network));
+        RLS19NoiseEmission emission = new RLS19NoiseEmission(scenario, new RoadSurfaceContext(network), new DEMContextImpl(scenario.getConfig()));
 
         final double basePkwEmission = emission.calculateBaseVehicleTypeEmission(RLS19VehicleType.pkw, 40);
         Assert.assertEquals("Wrong base pkw emission!", 97.70334139531323, basePkwEmission, MatsimTestUtils.EPSILON);
@@ -169,7 +169,7 @@ public class NoiseRLS19IT {
         noiseContext.getNoiseLinks().put(link.getId(), noiseLink);
         noiseContext.getNoiseLinks().put(link2.getId(), noiseLink2);
 
-        RLS19NoiseEmission emission = new RLS19NoiseEmission(scenario, new RoadSurfaceContext(network));
+        RLS19NoiseEmission emission = new RLS19NoiseEmission(scenario, new RoadSurfaceContext(network), new DEMContextImpl(scenario.getConfig()));
         for (int i = 0; i < 1800; i++) {
             noiseLink.addEnteringAgent(RLS19VehicleType.pkw);
             noiseLink2.addEnteringAgent(RLS19VehicleType.pkw);


### PR DESCRIPTION
This PR adds support for digital elevation models (DEM) for the noise computation module. The DEM is used to estimate road gradients that may in- or decrease noise emissions of links. The gradient is simply calculated by taking the elevation difference of from- and to-node of a link divided by the link length.

The implemented code supports DEM in geoTiff format. For Europe, such a DEM can be downloaded free of cost (requires registration) from the Copernicus Programme:
https://land.copernicus.eu/imagery-in-situ/eu-dem/eu-dem-v1.1?tab=mapview 
Their DEM is represented as a raster of 25x25m accuracy. 

How to setup:
```
noiseParameters.setUseDEM(true);    
noiseParameters.setDEMFilePath("filePath.TIF");
```

The code works with geotools DirectPositions that are transformed into the coordinate reference system of the DEM. The network coordinates are assumed to be in the CRS of the global config setting during runtime.