### PR TITLE
Speedy multi source alt

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/core/router/speedy/SpeedyMultiSourceALT.java
+++ b/contribs/dvrp/src/main/java/org/matsim/core/router/speedy/SpeedyMultiSourceALT.java
@@ -1,0 +1,238 @@
+package org.matsim.core.router.speedy;
+
+import static java.util.stream.Collectors.joining;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.core.router.util.LeastCostPathCalculator.Path;
+import org.matsim.core.router.util.TravelDisutility;
+import org.matsim.core.router.util.TravelTime;
+import org.matsim.vehicles.Vehicle;
+
+/**
+ * This is a copy of SpeedyALT adapted for many-to-one search.
+ */
+public class SpeedyMultiSourceALT {
+
+	private final static Logger LOG = LogManager.getLogger(SpeedyMultiSourceALT.class);
+
+	private final SpeedyGraph graph;
+	private final SpeedyALTData astarData;
+	private final TravelTime tt;
+	private final TravelDisutility td;
+	private final double[] data; // 3 entries per node: cost to node, time, distance
+	private int currentIteration = Integer.MIN_VALUE;
+	private final int[] iterationIds;
+	private final int[] comingFrom;
+	private final int[] usedLink;
+	private final SpeedyGraph.LinkIterator outLI;
+	private final DAryMinHeap pq;
+
+	public SpeedyMultiSourceALT(SpeedyALTData astarData, TravelTime tt, TravelDisutility td) {
+		this.graph = astarData.graph;
+		this.astarData = astarData;
+		this.tt = tt;
+		this.td = td;
+		this.data = new double[this.graph.nodeCount * 3];
+		this.iterationIds = new int[this.graph.nodeCount];
+		this.comingFrom = new int[this.graph.nodeCount];
+		this.usedLink = new int[this.graph.nodeCount];
+		this.pq = new DAryMinHeap(this.graph.nodeCount, 6);
+		this.outLI = this.graph.getOutLinkIterator();
+		Arrays.fill(this.iterationIds, this.currentIteration);
+	}
+
+	public double getCost(int nodeIndex) {
+		return this.data[nodeIndex * 3];
+	}
+
+	private double getTimeRaw(int nodeIndex) {
+		return this.data[nodeIndex * 3 + 1];
+	}
+
+	private double getDistance(int nodeIndex) {
+		return this.data[nodeIndex * 3 + 2];
+	}
+
+	private void setData(int nodeIndex, double cost, double time, double distance) {
+		int index = nodeIndex * 3;
+		this.data[index] = cost;
+		this.data[index + 1] = time;
+		this.data[index + 2] = distance;
+		this.iterationIds[nodeIndex] = this.currentIteration;
+	}
+
+	public static class StartNode {
+		public final Node node;
+		public final double cost;
+		public final double time;
+
+		public StartNode(Node node, double cost, double time) {
+			this.node = node;
+			this.cost = cost;
+			this.time = time;
+		}
+	}
+
+	public Path calcLeastCostPath(List<StartNode> startNodes, Node endNode, Person person, Vehicle vehicle) {
+		this.currentIteration++;
+		if (this.currentIteration == Integer.MAX_VALUE) {
+			// reset iteration as we overflow
+			Arrays.fill(this.iterationIds, this.currentIteration);
+			this.currentIteration = Integer.MIN_VALUE;
+		}
+
+		int endNodeIndex = endNode.getId().index();
+		// TODO add support for dead ends
+		//  int endDeadend = this.astarData.getNodeDeadend(endNodeIndex);
+
+		this.pq.clear();
+		for (StartNode startNode : startNodes) {
+			int startNodeIndex = startNode.node.getId().index();
+			// TODO add support for dead ends
+			//  int startDeadend = this.astarData.getNodeDeadend(startNodeIndex);
+			double estimation = estimateMinTravelcostToDestination(startNodeIndex, endNodeIndex);
+
+			this.comingFrom[startNodeIndex] = -1;
+			setData(startNodeIndex, startNode.cost, startNode.time, 0);
+			this.pq.insert(startNodeIndex, startNode.cost + estimation);
+		}
+
+		boolean foundEndNode = false;
+
+		while (!this.pq.isEmpty()) {
+			final int nodeIdx = this.pq.poll();
+			if (nodeIdx == endNodeIndex) {
+				foundEndNode = true;
+				break;
+			}
+
+			// TODO add support for dead ends
+			//	int deadend = this.astarData.getNodeDeadend(nodeIdx);
+			//	if (deadend >= 0 && deadend != startDeadend && deadend != endDeadend) {
+			//		continue; // it's a dead-end we're not interested in
+			//	}
+
+			double currTime = getTimeRaw(nodeIdx);
+			double currCost = getCost(nodeIdx);
+			double currDistance = getDistance(nodeIdx);
+
+			this.outLI.reset(nodeIdx);
+			while (this.outLI.next()) {
+				int linkIdx = this.outLI.getLinkIndex();
+				Link link = this.graph.getLink(linkIdx);
+				int toNode = this.outLI.getToNodeIndex();
+
+				double travelTime = this.tt.getLinkTravelTime(link, currTime, person, vehicle);
+				double newTime = currTime + travelTime;
+				double travelCost = this.td.getLinkTravelDisutility(link, currTime, person, vehicle);
+				double newCost = currCost + travelCost;
+
+				if (this.iterationIds[toNode] == this.currentIteration) {
+					// this node was already visited in this route-query
+					double oldCost = getCost(toNode);
+					if (newCost < oldCost) {
+						double estimation = estimateMinTravelcostToDestination(toNode, endNodeIndex);
+						this.pq.decreaseKey(toNode, newCost + estimation);
+						setData(toNode, newCost, newTime, currDistance + link.getLength());
+						this.comingFrom[toNode] = nodeIdx;
+						this.usedLink[toNode] = linkIdx;
+					}
+				} else {
+					double estimation = estimateMinTravelcostToDestination(toNode, endNodeIndex);
+					setData(toNode, newCost, newTime, currDistance + link.getLength());
+					this.pq.insert(toNode, newCost + estimation);
+					this.comingFrom[toNode] = nodeIdx;
+					this.usedLink[toNode] = linkIdx;
+				}
+			}
+		}
+
+		if (foundEndNode) {
+			return constructPath(endNodeIndex);
+		}
+		LOG.warn("No route was found from nodes [" + startNodes.stream()
+				.map(n -> n.node.getId() + "")
+				.collect(joining(",")) + "] to node " + endNode.getId() + ". Some possible reasons:");
+		LOG.warn("  * Network is not connected.  Run NetworkCleaner().");
+		LOG.warn(
+				"  * Network for considered mode does not even exist.  Modes need to be entered for each link in network.xml.");
+		LOG.warn(
+				"  * Network for considered mode is not connected to starting or ending point of route.  Setting insertingAccessEgressWalk to true may help.");
+		LOG.warn("This will now return null, but it may fail later with a NullPointerException.");
+		return null;
+	}
+
+	private double estimateMinTravelcostToDestination(int nodeIdx, int destinationIdx) {
+		/* The ALT algorithm uses two lower bounds for each Landmark:
+		 * given: source node S, target node T, landmark L
+		 * then, due to the triangle inequality:
+		 *  1) ST + TL >= SL --> ST >= SL - TL
+		 *  2) LS + ST >= LT --> ST >= LT - LS
+		 * The algorithm is interested in the largest possible value of (SL-TL) and (LT-LS),
+		 * as this gives the closest approximation for the minimal travel time required to
+		 * go from S to T.
+		 */
+		double best = 0;
+		for (int i = 0, n = this.astarData.getLandmarksCount(); i < n; i++) {
+			double estimate = estimateMinTravelcostToDestinationForLandmark(nodeIdx, destinationIdx, i);
+			if (estimate > best) {
+				best = estimate;
+			}
+		}
+		return best;
+	}
+
+	private double estimateMinTravelcostToDestinationForLandmark(int nodeIdx, int destinationIdx, int landmarkIdx) {
+		double sl = this.astarData.getTravelCostToLandmark(nodeIdx, landmarkIdx);
+		double ls = this.astarData.getTravelCostFromLandmark(nodeIdx, landmarkIdx);
+		double tl = this.astarData.getTravelCostToLandmark(destinationIdx, landmarkIdx);
+		double lt = this.astarData.getTravelCostFromLandmark(destinationIdx, landmarkIdx);
+		double sltl = sl - tl;
+		double ltls = lt - ls;
+		return Math.max(sltl, ltls);
+	}
+
+	private Path constructPath(int endNodeIndex) {
+		double travelCost = getCost(endNodeIndex);
+		double arrivalTime = getTimeRaw(endNodeIndex);
+		if (Double.isInfinite(arrivalTime)) {
+			throw new RuntimeException("Undefined time on end node");
+		}
+
+		List<Node> nodes = new ArrayList<>();
+		List<Link> links = new ArrayList<>();
+
+		int nodeIndex = endNodeIndex;
+
+		nodes.add(this.graph.getNode(nodeIndex));
+
+		int linkIndex = this.usedLink[nodeIndex];
+		nodeIndex = this.comingFrom[nodeIndex];
+
+		while (nodeIndex >= 0) {
+			nodes.add(this.graph.getNode(nodeIndex));
+			links.add(this.graph.getLink(linkIndex));
+
+			linkIndex = this.usedLink[nodeIndex];
+			nodeIndex = this.comingFrom[nodeIndex];
+		}
+
+		Collections.reverse(nodes);
+		Collections.reverse(links);
+
+		double startTime = getTimeRaw(nodes.get(0).getId().index());
+		double travelTime = arrivalTime - startTime;
+
+		return new Path(nodes, links, travelTime, travelCost);
+	}
+
+}

--- a/contribs/dvrp/src/test/java/org/matsim/core/router/speedy/SpeedyMultiSourceALTBackwardTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/core/router/speedy/SpeedyMultiSourceALTBackwardTest.java
@@ -1,0 +1,133 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2021 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.core.router.speedy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.contrib.dvrp.router.TimeAsTravelDisutility;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.router.speedy.SpeedyMultiSourceALT.StartNode;
+import org.matsim.core.router.util.TravelDisutility;
+import org.matsim.core.router.util.TravelTime;
+import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
+
+/**
+ * A copy of SpeedyMultiSourceALTForwardTest (however the network is inverted and the computed paths as well)
+ *
+ * @author Michal Maciejewski (michalm)
+ */
+public class SpeedyMultiSourceALTBackwardTest {
+	private final Network network = NetworkUtils.createNetwork();
+
+	// single-direction links (from right to left, e.g. B->A, but not A->B)
+	//
+	//      B
+	//    /  \
+	//  A --- D
+	//   \  /  \
+	//    C --- E --- (A)
+
+	private final Node nodeA = createAndAddNode("A", new Coord(0, 0));
+	private final Node nodeB = createAndAddNode("B", new Coord(150, 150));
+	private final Node nodeC = createAndAddNode("C", new Coord(150, -150));
+	private final Node nodeD = createAndAddNode("D", new Coord(300, 0));
+	private final Node nodeE = createAndAddNode("E", new Coord(450, -150));
+
+	private final Link linkBA = createAndAddLink("BA", nodeB, nodeA, 10 * 15, 15);
+	private final Link linkCA = createAndAddLink("CA", nodeC, nodeA, 10 * 15, 15);
+	private final Link linkDA = createAndAddLink("DA", nodeD, nodeA, 10 * 15, 15);
+
+	private final Link linkDB = createAndAddLink("DB", nodeD, nodeB, 10 * 15, 15);
+
+	private final Link linkDC = createAndAddLink("DC", nodeD, nodeC, 10 * 15, 15);
+	private final Link linkEC = createAndAddLink("EC", nodeE, nodeC, 10 * 15, 15);
+
+	private final Link linkED = createAndAddLink("ED", nodeE, nodeD, 10 * 15, 15);
+
+	private final Link linkAE = createAndAddLink("AE", nodeA, nodeE, 10 * 15, 15);
+
+	private final TravelTime travelTime = new FreeSpeedTravelTime();
+	private final TravelDisutility travelDisutility = new TimeAsTravelDisutility(travelTime);
+	private final SpeedyGraph speedyGraph = new SpeedyGraph(network);
+	private final SpeedyALTData landmarks = new SpeedyALTData(speedyGraph, 3, travelDisutility);
+	private final SpeedyMultiSourceALT multiSourceALT = new SpeedyMultiSourceALT(landmarks, travelTime,
+			travelDisutility);
+
+	@Test
+	public void testOneSource_backward() {
+		var startNode = new StartNode(nodeB, 9999, 7777);
+		var path = multiSourceALT.calcLeastCostPath(List.of(startNode), nodeA, null, null, true);
+		assertThat(path.nodes).containsExactly(nodeA, nodeE, nodeD, nodeB);
+		assertThat(path.links).containsExactly(linkAE, linkED, linkDB);
+		assertThat(path.travelTime).isEqualTo(10 + 10 + 10);
+		assertThat(path.travelCost).isEqualTo(9999 + 10 + 10 + 10);
+	}
+
+	@Test
+	public void testManySources_backward_sameStartCost() {
+		var startNodeB = new StartNode(nodeB, 9999, 7777);
+		var startNodeC = new StartNode(nodeC, 9999, 7777);
+		var path = multiSourceALT.calcLeastCostPath(List.of(startNodeB, startNodeC), nodeA, null, null, true);
+		assertThat(path.nodes).containsExactly(nodeA, nodeE, nodeC);
+		assertThat(path.links).containsExactly(linkAE, linkEC);
+		assertThat(path.travelTime).isEqualTo(10 + 10);
+		assertThat(path.travelCost).isEqualTo(9999 + 10 + 10);
+	}
+
+	@Test
+	public void testManySources_backward_selectFartherNodeWithLowerCost() {
+		var startNodeB = new StartNode(nodeB, 100, 7777);
+		var startNodeC = new StartNode(nodeC, 111, 1111);
+		var path = multiSourceALT.calcLeastCostPath(List.of(startNodeB, startNodeC), nodeA, null, null, true);
+		assertThat(path.nodes).containsExactly(nodeA, nodeE, nodeD, nodeB);
+		assertThat(path.links).containsExactly(linkAE, linkED, linkDB);
+		assertThat(path.travelTime).isEqualTo(10 + 10 + 10);
+		assertThat(path.travelCost).isEqualTo(100 + 10 + 10 + 10);
+	}
+
+	@Test
+	public void testManySources_backward_selectNearestNodeWithHigherCost() {
+		var startNodeB = new StartNode(nodeB, 100, 7777);
+		var startNodeC = new StartNode(nodeC, 109, 1111);
+		var path = multiSourceALT.calcLeastCostPath(List.of(startNodeB, startNodeC), nodeA, null, null, true);
+		assertThat(path.nodes).containsExactly(nodeA, nodeE, nodeC);
+		assertThat(path.links).containsExactly(linkAE, linkEC);
+		assertThat(path.travelTime).isEqualTo(10 + 10);
+		assertThat(path.travelCost).isEqualTo(109 + 10 + 10);
+	}
+
+	private Node createAndAddNode(String id, Coord coord) {
+		return NetworkUtils.createAndAddNode(network, Id.createNodeId(id), coord);
+	}
+
+	private Link createAndAddLink(String id, Node fromNode, Node toNode, double length, double freespeed) {
+		return NetworkUtils.createAndAddLink(network, Id.createLinkId(id), fromNode, toNode, length, freespeed,
+				length / 7.5, 1);
+	}
+}

--- a/contribs/dvrp/src/test/java/org/matsim/core/router/speedy/SpeedyMultiSourceALTForwardTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/core/router/speedy/SpeedyMultiSourceALTForwardTest.java
@@ -40,7 +40,7 @@ import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
 /**
  * @author Michal Maciejewski (michalm)
  */
-public class SpeedyMultiSourceALTTest {
+public class SpeedyMultiSourceALTForwardTest {
 	private final Network network = NetworkUtils.createNetwork();
 
 	// single-direction links (from left to right, e.g. A->B, but not B->A)
@@ -78,9 +78,9 @@ public class SpeedyMultiSourceALTTest {
 			travelDisutility);
 
 	@Test
-	public void testOneSource() {
+	public void testOneSource_forward() {
 		var startNode = new StartNode(nodeB, 9999, 7777);
-		var path = multiSourceALT.calcLeastCostPath(List.of(startNode), nodeA, null, null);
+		var path = multiSourceALT.calcLeastCostPath(List.of(startNode), nodeA, null, null, false);
 		assertThat(path.nodes).containsExactly(nodeB, nodeD, nodeE, nodeA);
 		assertThat(path.links).containsExactly(linkBD, linkDE, linkEA);
 		assertThat(path.travelTime).isEqualTo(10 + 10 + 10);
@@ -88,10 +88,10 @@ public class SpeedyMultiSourceALTTest {
 	}
 
 	@Test
-	public void testManySources_sameStartCost() {
+	public void testManySources_forward_sameStartCost() {
 		var startNodeB = new StartNode(nodeB, 9999, 7777);
 		var startNodeC = new StartNode(nodeC, 9999, 7777);
-		var path = multiSourceALT.calcLeastCostPath(List.of(startNodeB, startNodeC), nodeA, null, null);
+		var path = multiSourceALT.calcLeastCostPath(List.of(startNodeB, startNodeC), nodeA, null, null, false);
 		assertThat(path.nodes).containsExactly(nodeC, nodeE, nodeA);
 		assertThat(path.links).containsExactly(linkCE, linkEA);
 		assertThat(path.travelTime).isEqualTo(10 + 10);
@@ -99,10 +99,10 @@ public class SpeedyMultiSourceALTTest {
 	}
 
 	@Test
-	public void testManySources_selectFartherNodeWithLowerCost() {
+	public void testManySources_forward_selectFartherNodeWithLowerCost() {
 		var startNodeB = new StartNode(nodeB, 100, 7777);
 		var startNodeC = new StartNode(nodeC, 111, 1111);
-		var path = multiSourceALT.calcLeastCostPath(List.of(startNodeB, startNodeC), nodeA, null, null);
+		var path = multiSourceALT.calcLeastCostPath(List.of(startNodeB, startNodeC), nodeA, null, null, false);
 		assertThat(path.nodes).containsExactly(nodeB, nodeD, nodeE, nodeA);
 		assertThat(path.links).containsExactly(linkBD, linkDE, linkEA);
 		assertThat(path.travelTime).isEqualTo(10 + 10 + 10);
@@ -110,10 +110,10 @@ public class SpeedyMultiSourceALTTest {
 	}
 
 	@Test
-	public void testManySources_selectNearestNodeWithHigherCost() {
+	public void testManySources_forward_selectNearestNodeWithHigherCost() {
 		var startNodeB = new StartNode(nodeB, 100, 7777);
 		var startNodeC = new StartNode(nodeC, 109, 1111);
-		var path = multiSourceALT.calcLeastCostPath(List.of(startNodeB, startNodeC), nodeA, null, null);
+		var path = multiSourceALT.calcLeastCostPath(List.of(startNodeB, startNodeC), nodeA, null, null, false);
 		assertThat(path.nodes).containsExactly(nodeC, nodeE, nodeA);
 		assertThat(path.links).containsExactly(linkCE, linkEA);
 		assertThat(path.travelTime).isEqualTo(10 + 10);

--- a/contribs/dvrp/src/test/java/org/matsim/core/router/speedy/SpeedyMultiSourceALTTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/core/router/speedy/SpeedyMultiSourceALTTest.java
@@ -1,0 +1,131 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2021 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.core.router.speedy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.contrib.dvrp.router.TimeAsTravelDisutility;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.router.speedy.SpeedyMultiSourceALT.StartNode;
+import org.matsim.core.router.util.TravelDisutility;
+import org.matsim.core.router.util.TravelTime;
+import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class SpeedyMultiSourceALTTest {
+	private final Network network = NetworkUtils.createNetwork();
+
+	// single-direction links (from left to right, e.g. A->B, but not B->A)
+	//
+	//      B
+	//    /  \
+	//  A --- D
+	//   \  /  \
+	//    C --- E --- (A)
+
+	private final Node nodeA = createAndAddNode("A", new Coord(0, 0));
+	private final Node nodeB = createAndAddNode("B", new Coord(150, 150));
+	private final Node nodeC = createAndAddNode("C", new Coord(150, -150));
+	private final Node nodeD = createAndAddNode("D", new Coord(300, 0));
+	private final Node nodeE = createAndAddNode("E", new Coord(450, -150));
+
+	private final Link linkAB = createAndAddLink("AB", nodeA, nodeB, 10 * 15, 15);
+	private final Link linkAC = createAndAddLink("AC", nodeA, nodeC, 10 * 15, 15);
+	private final Link linkAD = createAndAddLink("AD", nodeA, nodeD, 10 * 15, 15);
+
+	private final Link linkBD = createAndAddLink("BD", nodeB, nodeD, 10 * 15, 15);
+
+	private final Link linkCD = createAndAddLink("CD", nodeC, nodeD, 10 * 15, 15);
+	private final Link linkCE = createAndAddLink("CE", nodeC, nodeE, 10 * 15, 15);
+
+	private final Link linkDE = createAndAddLink("DE", nodeD, nodeE, 10 * 15, 15);
+
+	private final Link linkEA = createAndAddLink("EA", nodeE, nodeA, 10 * 15, 15);
+
+	private final TravelTime travelTime = new FreeSpeedTravelTime();
+	private final TravelDisutility travelDisutility = new TimeAsTravelDisutility(travelTime);
+	private final SpeedyGraph speedyGraph = new SpeedyGraph(network);
+	private final SpeedyALTData landmarks = new SpeedyALTData(speedyGraph, 3, travelDisutility);
+	private final SpeedyMultiSourceALT multiSourceALT = new SpeedyMultiSourceALT(landmarks, travelTime,
+			travelDisutility);
+
+	@Test
+	public void testOneSource() {
+		var startNode = new StartNode(nodeB, 9999, 7777);
+		var path = multiSourceALT.calcLeastCostPath(List.of(startNode), nodeA, null, null);
+		assertThat(path.nodes).containsExactly(nodeB, nodeD, nodeE, nodeA);
+		assertThat(path.links).containsExactly(linkBD, linkDE, linkEA);
+		assertThat(path.travelTime).isEqualTo(10 + 10 + 10);
+		assertThat(path.travelCost).isEqualTo(9999 + 10 + 10 + 10);
+	}
+
+	@Test
+	public void testManySources_sameStartCost() {
+		var startNodeB = new StartNode(nodeB, 9999, 7777);
+		var startNodeC = new StartNode(nodeC, 9999, 7777);
+		var path = multiSourceALT.calcLeastCostPath(List.of(startNodeB, startNodeC), nodeA, null, null);
+		assertThat(path.nodes).containsExactly(nodeC, nodeE, nodeA);
+		assertThat(path.links).containsExactly(linkCE, linkEA);
+		assertThat(path.travelTime).isEqualTo(10 + 10);
+		assertThat(path.travelCost).isEqualTo(9999 + 10 + 10);
+	}
+
+	@Test
+	public void testManySources_selectFartherNodeWithLowerCost() {
+		var startNodeB = new StartNode(nodeB, 100, 7777);
+		var startNodeC = new StartNode(nodeC, 111, 1111);
+		var path = multiSourceALT.calcLeastCostPath(List.of(startNodeB, startNodeC), nodeA, null, null);
+		assertThat(path.nodes).containsExactly(nodeB, nodeD, nodeE, nodeA);
+		assertThat(path.links).containsExactly(linkBD, linkDE, linkEA);
+		assertThat(path.travelTime).isEqualTo(10 + 10 + 10);
+		assertThat(path.travelCost).isEqualTo(100 + 10 + 10 + 10);
+	}
+
+	@Test
+	public void testManySources_selectNearestNodeWithHigherCost() {
+		var startNodeB = new StartNode(nodeB, 100, 7777);
+		var startNodeC = new StartNode(nodeC, 109, 1111);
+		var path = multiSourceALT.calcLeastCostPath(List.of(startNodeB, startNodeC), nodeA, null, null);
+		assertThat(path.nodes).containsExactly(nodeC, nodeE, nodeA);
+		assertThat(path.links).containsExactly(linkCE, linkEA);
+		assertThat(path.travelTime).isEqualTo(10 + 10);
+		assertThat(path.travelCost).isEqualTo(109 + 10 + 10);
+	}
+
+	private Node createAndAddNode(String id, Coord coord) {
+		return NetworkUtils.createAndAddNode(network, Id.createNodeId(id), coord);
+	}
+
+	private Link createAndAddLink(String id, Node fromNode, Node toNode, double length, double freespeed) {
+		return NetworkUtils.createAndAddLink(network, Id.createLinkId(id), fromNode, toNode, length, freespeed,
+				length / 7.5, 1);
+	}
+}


### PR DESCRIPTION
An initial implementation of multi-source ALT that is a modified version of Speedy ALT adapted for many-to-one search. The search can be done both forward and backward (*). Start nodes are be described with the initial cost and start time.

This PR is mainly meant to communicate the latest developments in this area. The first use case of the multi-source ALT will be replacing the old multi-node search used for finding the nearest taxi/request (will be done in a separate PR). Potentially, this multi-source ALT could be moved from `dvrp` to the matsim core.

(*) Forward vs backward:
Forward: find the best request (from a set of open requests) for a given taxi
Backward: find the best taxi (from a set of available taxis) for a given request