### PR TITLE
Pass arguments in DRT route creation to allow trip-based requirements

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DefaultDrtRouteUpdater.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DefaultDrtRouteUpdater.java
@@ -17,13 +17,16 @@
  * *********************************************************************** */
 package org.matsim.contrib.drt.routing;
 
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Population;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
@@ -33,14 +36,16 @@ import org.matsim.core.controler.events.ReplanningEvent;
 import org.matsim.core.controler.events.ShutdownEvent;
 import org.matsim.core.controler.listener.ShutdownListener;
 import org.matsim.core.population.routes.RouteFactories;
+import org.matsim.core.router.TripStructureUtils;
+import org.matsim.core.router.TripStructureUtils.Trip;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
 import org.matsim.core.router.speedy.SpeedyALTFactory;
 import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
 import org.matsim.core.router.util.TravelTime;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
+import com.google.common.util.concurrent.Futures;
 import com.google.inject.name.Named;
-
-import one.util.streamex.StreamEx;
 
 /**
  * @author michalm (Michal Maciejewski)
@@ -67,19 +72,28 @@ public class DefaultDrtRouteUpdater implements ShutdownListener, DrtRouteUpdater
 
 	@Override
 	public void notifyReplanning(ReplanningEvent event) {
-		Stream<Leg> drtLegs = StreamEx.of(population.getPersons().values())
-				.flatMap(p -> p.getSelectedPlan().getPlanElements().stream())
-				.select(Leg.class)
-				.filterBy(Leg::getMode, drtCfg.getMode());
-		executorService.submitRunnablesAndWait(drtLegs.map(l -> (router -> updateDrtRoute(router, l))));
+		List<Future<?>> futures = new LinkedList<>();
+		
+		for (Person person : population.getPersons().values()) {
+			for (Trip trip : TripStructureUtils.getTrips(person.getSelectedPlan())) {
+				for (Leg leg : trip.getLegsOnly()) {
+					if (leg.getMode().equals(drtCfg.getMode())) {
+						futures.add(executorService.submitRunnable(router -> updateDrtRoute(router, person, trip.getTripAttributes(), leg)));
+					}
+				}
+			}
+		}
+		
+		futures.forEach(Futures::getUnchecked);
 	}
 
-	private void updateDrtRoute(DrtRouteCreator drtRouteCreator, Leg drtLeg) {
+	private void updateDrtRoute(DrtRouteCreator drtRouteCreator, Person person, Attributes tripAttributes, Leg drtLeg) {
 		Link fromLink = network.getLinks().get(drtLeg.getRoute().getStartLinkId());
 		Link toLink = network.getLinks().get(drtLeg.getRoute().getEndLinkId());
 		RouteFactories routeFactories = population.getFactory().getRouteFactories();
 		drtLeg.setRoute(
-				drtRouteCreator.createRoute(drtLeg.getDepartureTime().seconds(), fromLink, toLink, routeFactories));
+				drtRouteCreator.createRoute(drtLeg.getDepartureTime().seconds(), fromLink, toLink, 
+						person, tripAttributes, routeFactories));
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRouteCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRouteCreator.java
@@ -21,6 +21,7 @@ package org.matsim.contrib.drt.routing;
 
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Route;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
@@ -28,14 +29,14 @@ import org.matsim.contrib.dvrp.path.VrpPaths;
 import org.matsim.contrib.dvrp.router.DefaultMainLegRouter;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.core.population.routes.RouteFactories;
+import org.matsim.core.router.RoutingRequest;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
 import org.matsim.core.router.util.TravelTime;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import com.google.inject.name.Named;
-
-import java.util.List;
 
 /**
  * @author jbischoff
@@ -69,7 +70,7 @@ public class DrtRouteCreator implements DefaultMainLegRouter.RouteCreator {
 	}
 
 	public Route createRoute(double departureTime, Link accessActLink, Link egressActLink,
-			RouteFactories routeFactories) {
+			Person person, Attributes tripAttributes, RouteFactories routeFactories) {
 		VrpPathWithTravelData unsharedPath = VrpPaths.calcAndCreatePath(accessActLink, egressActLink, departureTime,
 				router, travelTime);
 		double unsharedRideTime = unsharedPath.getTravelTime();//includes first & last link

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DefaultMainLegRouter.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DefaultMainLegRouter.java
@@ -32,6 +32,7 @@ import org.matsim.core.population.routes.RouteFactories;
 import org.matsim.core.router.RoutingModule;
 import org.matsim.core.router.RoutingRequest;
 import org.matsim.facilities.Facility;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -41,7 +42,8 @@ import com.google.common.collect.ImmutableList;
  */
 public class DefaultMainLegRouter implements RoutingModule {
 	public interface RouteCreator {
-		Route createRoute(double departureTime, Link accessActLink, Link egressActLink, RouteFactories routeFactories);
+		Route createRoute(double departureTime, Link accessActLink, Link egressActLink,
+				Person person, Attributes tripAttributes, RouteFactories routeFactories);
 	}
 
 	private final String mode;
@@ -68,7 +70,7 @@ public class DefaultMainLegRouter implements RoutingModule {
 		Link egressActLink = Preconditions.checkNotNull(modalNetwork.getLinks().get(toFacility.getLinkId()),
 				"link: %s does not exist in the network of mode: %s", toFacility.getLinkId(), mode);
 		Route route = routeCreator.createRoute(departureTime, accessActLink, egressActLink,
-				populationFactory.getRouteFactories());
+				request.getPerson(), request.getAttributes(), populationFactory.getRouteFactories());
 
 		Leg leg = populationFactory.createLeg(mode);
 		leg.setDepartureTime(departureTime);

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DefaultMainLegRouter.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DefaultMainLegRouter.java
@@ -42,8 +42,12 @@ import com.google.common.collect.ImmutableList;
  */
 public class DefaultMainLegRouter implements RoutingModule {
 	public interface RouteCreator {
-		Route createRoute(double departureTime, Link accessActLink, Link egressActLink,
-				Person person, Attributes tripAttributes, RouteFactories routeFactories);
+		/**
+		 * Creates a route based on basic trip characteristics (departure time, origin
+		 * and destination location) and potential person- or trip-based requirements.
+		 */
+		Route createRoute(double departureTime, Link accessActLink, Link egressActLink, Person person,
+				Attributes tripAttributes, RouteFactories routeFactories);
 	}
 
 	private final String mode;

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/GenericRouteCreator.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/GenericRouteCreator.java
@@ -22,6 +22,7 @@ package org.matsim.contrib.dvrp.router;
 
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Route;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.path.VrpPaths;
@@ -32,6 +33,7 @@ import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
 import org.matsim.core.router.util.TravelTime;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import com.google.inject.name.Named;
 
@@ -52,7 +54,7 @@ public class GenericRouteCreator implements DefaultMainLegRouter.RouteCreator {
 
 	@Override
 	public Route createRoute(double departureTime, Link accessActLink, Link egressActLink,
-			RouteFactories routeFactories) {
+			Person person, Attributes tripAttributes, RouteFactories routeFactories) {
 		VrpPathWithTravelData unsharedPath = VrpPaths.calcAndCreatePath(accessActLink, egressActLink, departureTime,
 				router, travelTime);
 		double travelTime = unsharedPath.getTravelTime();//includes first & last link


### PR DESCRIPTION
These changes make it possible to implement a custom extension of the `DrtRouteCreator` which bases waiting time on user-specific or even trip-specific requirements.