### PR TITLE
dvrp: remove warnings about running drt/taxi with multi-threaded QSim

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -271,10 +271,6 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 					+ "attempting to travel without vehicles being available.");
 		}
 
-		if (config.qsim().getNumberOfThreads() > 1) {
-			log.warn("EXPERIMENTAL FEATURE: Running DRT with a multi-threaded QSim");
-		}
-
 		Verify.verify(getMaxWaitTime() >= getStopDuration(),
 				MAX_WAIT_TIME + " must not be smaller than " + STOP_DURATION);
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
@@ -183,10 +183,6 @@ public final class TaxiConfigGroup extends ReflectiveConfigGroupWithConfigurable
 	protected void checkConsistency(Config config) {
 		super.checkConsistency(config);
 
-		if (config.qsim().getNumberOfThreads() > 1) {
-			log.warn("EXPERIMENTAL FEATURE: Running taxi with a multi-threaded QSim");
-		}
-
 		Verify.verify(!isVehicleDiversion() || isOnlineVehicleTracker(),
 				TaxiConfigGroup.VEHICLE_DIVERSION + " requires " + TaxiConfigGroup.ONLINE_VEHICLE_TRACKER);
 


### PR DESCRIPTION
No longer an experimental feature. AFAIK no issues reported so far.