### PR TITLE
Taxi: pre-compute origin-destination paths

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/VrpPathWithTravelData.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/VrpPathWithTravelData.java
@@ -25,4 +25,6 @@ public interface VrpPathWithTravelData extends VrpPath {
 	double getTravelTime();
 
 	double getArrivalTime();
+
+	VrpPathWithTravelData withDepartureTime(double timeShift);
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/VrpPathWithTravelDataImpl.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/VrpPathWithTravelDataImpl.java
@@ -91,4 +91,9 @@ public class VrpPathWithTravelDataImpl implements VrpPathWithTravelData {
 	public Iterator<Link> iterator() {
 		return Iterators.forArray(links);
 	}
+
+	@Override
+	public VrpPathWithTravelData withDepartureTime(double newDepartureTime) {
+		return new VrpPathWithTravelDataImpl(newDepartureTime, travelTime, links, linkTTs);
+	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/ETaxiScheduler.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/ETaxiScheduler.java
@@ -19,7 +19,12 @@
 
 package org.matsim.contrib.etaxi;
 
-import com.google.inject.name.Named;
+import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.EMPTY_DRIVE;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.Fleet;
@@ -41,17 +46,15 @@ import org.matsim.contrib.taxi.scheduler.TaxiScheduler;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelTime;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.EMPTY_DRIVE;
+import com.google.inject.name.Named;
 
 public class ETaxiScheduler extends TaxiScheduler {
 	public static final TaxiTaskType DRIVE_TO_CHARGER = new TaxiTaskType("DRIVE_TO_CHARGER", EMPTY_DRIVE);
 
 	public ETaxiScheduler(TaxiConfigGroup taxiCfg, Fleet fleet, TaxiScheduleInquiry taxiScheduleInquiry,
-			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, LeastCostPathCalculator router) {
-		super(taxiCfg, fleet, taxiScheduleInquiry, travelTime, router);
+			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
+			Supplier<LeastCostPathCalculator> routerCreator) {
+		super(taxiCfg, fleet, taxiScheduleInquiry, travelTime, routerCreator);
 	}
 
 	// FIXME underestimated due to the ongoing AUX/drive consumption

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/ETaxiModeQSimModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/ETaxiModeQSimModule.java
@@ -105,7 +105,7 @@ public class ETaxiModeQSimModule extends AbstractDvrpModeQSimModule {
 				getter -> ChargingInfrastructures.createModalNetworkChargers(getter.get(ChargingInfrastructure.class),
 						getter.getModal(Network.class), getMode()))).asEagerSingleton();
 
-		bindModal(ETaxiScheduler.class).toProvider(new ModalProviders.AbstractProvider<>(taxiCfg.getMode()) {
+		addModalComponent(ETaxiScheduler.class, new ModalProviders.AbstractProvider<>(taxiCfg.getMode()) {
 			@Inject
 			private MobsimTimer timer;
 
@@ -125,7 +125,7 @@ public class ETaxiModeQSimModule extends AbstractDvrpModeQSimModule {
 						travelDisutility, travelTime);
 				return new ETaxiScheduler(taxiCfg, fleet, taxiScheduleInquiry, travelTime, routerCreator);
 			}
-		}).asEagerSingleton();
+		});
 
 		bindModal(ScheduleTimingUpdater.class).toProvider(modalProvider(
 				getter -> new ScheduleTimingUpdater(getter.get(MobsimTimer.class),

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/ETaxiModeQSimModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/ETaxiModeQSimModule.java
@@ -19,6 +19,8 @@
 
 package org.matsim.contrib.etaxi.run;
 
+import java.util.function.Supplier;
+
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
@@ -118,9 +120,10 @@ public class ETaxiModeQSimModule extends AbstractDvrpModeQSimModule {
 				Network network = getModalInstance(Network.class);
 				TravelDisutility travelDisutility = getModalInstance(
 						TravelDisutilityFactory.class).createTravelDisutility(travelTime);
-				LeastCostPathCalculator router = new SpeedyALTFactory().createPathCalculator(network, travelDisutility,
-						travelTime);
-				return new ETaxiScheduler(taxiCfg, fleet, taxiScheduleInquiry, travelTime, router);
+				var speedyALTFactory = new SpeedyALTFactory();
+				Supplier<LeastCostPathCalculator> routerCreator = () -> speedyALTFactory.createPathCalculator(network,
+						travelDisutility, travelTime);
+				return new ETaxiScheduler(taxiCfg, fleet, taxiScheduleInquiry, travelTime, routerCreator);
 			}
 		}).asEagerSingleton();
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
@@ -109,7 +109,6 @@ public final class TaxiConfigGroup extends ReflectiveConfigGroupWithConfigurable
 			+ " If not provided, the vehicle specifications will be created from matsim vehicle file or provided via a custom binding."
 			+ " See FleetModule.";
 
-
 	// output
 	public static final String TIME_PROFILES = "timeProfiles";
 	static final String TIME_PROFILES_EXP =
@@ -125,6 +124,11 @@ public final class TaxiConfigGroup extends ReflectiveConfigGroupWithConfigurable
 	static final String BREAK_IF_NOT_ALL_REQUESTS_SERVED_EXP =
 			"Specifies whether the simulation should interrupt if not all requests were performed when"
 					+ " an interation ends. Otherwise, a warning is given. True by default.";
+
+	public static final String NUMBER_OF_THREADS = "numberOfThreads";
+	static final String NUMBER_OF_THREADS_EXP =
+			"Number of threads used for parallel computation of paths (occupied drive tasks)."
+					+ " Default value is the number of cores available to JVM";
 
 	@NotBlank
 	private String mode = TransportMode.taxi; // travel mode (passengers'/customers' perspective)
@@ -150,6 +154,9 @@ public final class TaxiConfigGroup extends ReflectiveConfigGroupWithConfigurable
 	private boolean detailedStats = false;
 
 	private boolean breakSimulationIfNotAllRequestsServed = true;
+
+	@Positive
+	private int numberOfThreads = Runtime.getRuntime().availableProcessors();
 
 	@NotNull
 	private AbstractTaxiOptimizerParams taxiOptimizerParams;
@@ -206,6 +213,7 @@ public final class TaxiConfigGroup extends ReflectiveConfigGroupWithConfigurable
 		map.put(TIME_PROFILES, TIME_PROFILES_EXP);
 		map.put(DETAILED_STATS, DETAILED_STATS_EXP);
 		map.put(BREAK_IF_NOT_ALL_REQUESTS_SERVED, BREAK_IF_NOT_ALL_REQUESTS_SERVED_EXP);
+		map.put(NUMBER_OF_THREADS, NUMBER_OF_THREADS_EXP);
 		return map;
 	}
 
@@ -412,6 +420,23 @@ public final class TaxiConfigGroup extends ReflectiveConfigGroupWithConfigurable
 	@StringSetter(BREAK_IF_NOT_ALL_REQUESTS_SERVED)
 	public TaxiConfigGroup setBreakSimulationIfNotAllRequestsServed(boolean breakSimulationIfNotAllRequestsServed) {
 		this.breakSimulationIfNotAllRequestsServed = breakSimulationIfNotAllRequestsServed;
+		return this;
+	}
+
+	/**
+	 * @return {@value #NUMBER_OF_THREADS_EXP}
+	 */
+	@StringGetter(NUMBER_OF_THREADS)
+	public int getNumberOfThreads() {
+		return numberOfThreads;
+	}
+
+	/**
+	 * @param numberOfThreads {@value #NUMBER_OF_THREADS_EXP}
+	 */
+	@StringSetter(NUMBER_OF_THREADS)
+	public TaxiConfigGroup setNumberOfThreads(int numberOfThreads) {
+		this.numberOfThreads = numberOfThreads;
 		return this;
 	}
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
@@ -128,6 +128,8 @@ public final class TaxiConfigGroup extends ReflectiveConfigGroupWithConfigurable
 	public static final String NUMBER_OF_THREADS = "numberOfThreads";
 	static final String NUMBER_OF_THREADS_EXP =
 			"Number of threads used for parallel computation of paths (occupied drive tasks)."
+					+ " 4-6 threads is usually enough. It's recommended to specify a higher number than that if possible"
+					+ " - of course, threads will probably be not 100% busy."
 					+ " Default value is the number of cores available to JVM";
 
 	@NotBlank

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeQSimModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeQSimModule.java
@@ -20,6 +20,8 @@
 
 package org.matsim.contrib.taxi.run;
 
+import java.util.function.Supplier;
+
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
@@ -113,9 +115,10 @@ public class TaxiModeQSimModule extends AbstractDvrpModeQSimModule {
 				Network network = getModalInstance(Network.class);
 				TravelDisutility travelDisutility = getModalInstance(
 						TravelDisutilityFactory.class).createTravelDisutility(travelTime);
-				LeastCostPathCalculator router = new SpeedyALTFactory().createPathCalculator(network, travelDisutility,
-						travelTime);
-				return new TaxiScheduler(taxiCfg, fleet, taxiScheduleInquiry, travelTime, router);
+				var speedyALTFactory = new SpeedyALTFactory();
+				Supplier<LeastCostPathCalculator> routerCreator = () -> speedyALTFactory.createPathCalculator(network,
+						travelDisutility, travelTime);
+				return new TaxiScheduler(taxiCfg, fleet, taxiScheduleInquiry, travelTime, routerCreator);
 			}
 		}).asEagerSingleton();
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeQSimModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeQSimModule.java
@@ -100,7 +100,7 @@ public class TaxiModeQSimModule extends AbstractDvrpModeQSimModule {
 			}
 		});
 
-		bindModal(TaxiScheduler.class).toProvider(new ModalProviders.AbstractProvider<>(taxiCfg.getMode()) {
+		addModalComponent(TaxiScheduler.class, new ModalProviders.AbstractProvider<>(taxiCfg.getMode()) {
 			@Inject
 			private MobsimTimer timer;
 
@@ -120,7 +120,7 @@ public class TaxiModeQSimModule extends AbstractDvrpModeQSimModule {
 						travelDisutility, travelTime);
 				return new TaxiScheduler(taxiCfg, fleet, taxiScheduleInquiry, travelTime, routerCreator);
 			}
-		}).asEagerSingleton();
+		});
 
 		bindModal(ScheduleTimingUpdater.class).toProvider(modalProvider(
 				getter -> new ScheduleTimingUpdater(getter.get(MobsimTimer.class),

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/scheduler/TaxiScheduler.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/scheduler/TaxiScheduler.java
@@ -19,15 +19,22 @@
 
 package org.matsim.contrib.taxi.scheduler;
 
+import static java.util.stream.Collectors.toList;
 import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Future;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.Fleet;
+import org.matsim.contrib.dvrp.optimizer.Request;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelDataImpl;
 import org.matsim.contrib.dvrp.path.VrpPaths;
@@ -48,26 +55,45 @@ import org.matsim.contrib.taxi.schedule.TaxiPickupTask;
 import org.matsim.contrib.taxi.schedule.TaxiStayTask;
 import org.matsim.contrib.taxi.schedule.TaxiTaskBaseType;
 import org.matsim.contrib.taxi.schedule.TaxiTaskType;
+import org.matsim.contrib.util.ExecutorServiceWithResource;
+import org.matsim.core.mobsim.framework.events.MobsimBeforeCleanupEvent;
+import org.matsim.core.mobsim.framework.listeners.MobsimBeforeCleanupListener;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelTime;
 
+import com.google.common.util.concurrent.Futures;
 import com.google.inject.name.Named;
 
-public class TaxiScheduler {
+public class TaxiScheduler implements MobsimBeforeCleanupListener {
 	protected final TaxiConfigGroup taxiCfg;
 	private final Fleet fleet;
 	private final TravelTime travelTime;
 	private final LeastCostPathCalculator router;
 	private final TaxiScheduleInquiry taxiScheduleInquiry;
 
+	// Pre-computing paths (occupied drive tasks) when they are not needed immediately (destinationKnown is false):
+	// In some configurations, the taxi optimiser may not know the destination until the passenger is picked up.
+	// But we can obtain this information already on request submission and use it to pre-compute the origin-destination path in the background.
+	// If sufficiently many threads are used, all such paths are found before the pickup simulation ends.
+	// Consequently, QSim is not (directly) slowed down by computing these paths.
+	private final ConcurrentMap<Id<Request>, Future<VrpPathWithTravelData>> pathFutures = new ConcurrentHashMap<>();
+	private final ExecutorServiceWithResource<LeastCostPathCalculator> executorService;
+
 	public TaxiScheduler(TaxiConfigGroup taxiCfg, Fleet fleet, TaxiScheduleInquiry taxiScheduleInquiry,
 			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
-			Supplier<LeastCostPathCalculator> routerSupplier) {
+			Supplier<LeastCostPathCalculator> routerCreator) {
 		this.taxiCfg = taxiCfg;
 		this.fleet = fleet;
 		this.taxiScheduleInquiry = taxiScheduleInquiry;
 		this.travelTime = travelTime;
-		this.router = routerSupplier.get();
+
+		router = routerCreator.get();
+
+		executorService = taxiCfg.isDestinationKnown() ?
+				null :
+				new ExecutorServiceWithResource<>(IntStream.range(0, taxiCfg.getNumberOfThreads())
+						.mapToObj(i -> routerCreator.get())
+						.collect(toList()));
 
 		initFleet();
 	}
@@ -97,9 +123,18 @@ public class TaxiScheduler {
 				+ taxiCfg.getPickupDuration();
 		schedule.addTask(new TaxiPickupTask(vrpPath.getArrivalTime(), pickupEndTime, request));
 
+		Link reqFromLink = request.getFromLink();
+		Link reqToLink = request.getToLink();
 		if (taxiCfg.isDestinationKnown()) {
-			appendOccupiedDriveAndDropoff(schedule);
+			// TODO use an estimate to set up the occupied drive task and then start computing the actual path in the background
+			VrpPathWithTravelData path = calcPath(reqFromLink, reqToLink, pickupEndTime);
+			appendOccupiedDriveAndDropoff(schedule, request, path);
 			appendTasksAfterDropoff(vehicle);
+		} else {
+			// pre-compute path for occupied drive; the occupied drive and subsequent tasks will be added after the pickup
+			var pathFuture = executorService.submitCallable(
+					router -> VrpPaths.calcAndCreatePath(reqFromLink, reqToLink, pickupEndTime, router, travelTime));
+			pathFutures.put(request.getId(), pathFuture);
 		}
 	}
 
@@ -199,27 +234,22 @@ public class TaxiScheduler {
 		if (!taxiCfg.isDestinationKnown()) {
 			Task currentTask = schedule.getCurrentTask();
 			if (PICKUP.isBaseTypeOf(currentTask)) {
-				appendOccupiedDriveAndDropoff(schedule);
+				// use pre-computed path (occupied drive)
+				var req = ((TaxiPickupTask)currentTask).getRequest();
+				var path = Futures.getUnchecked(pathFutures.remove(req.getId()))
+						.withDepartureTime(currentTask.getEndTime());
+				appendOccupiedDriveAndDropoff(schedule, req, path);
 				appendTasksAfterDropoff(vehicle);
 			}
 		}
 	}
 
-	protected void appendOccupiedDriveAndDropoff(Schedule schedule) {
-		TaxiPickupTask pickupStayTask = (TaxiPickupTask)Schedules.getLastTask(schedule);
-
-		// add DELIVERY after SERVE
-		TaxiRequest req = pickupStayTask.getRequest();
-		Link reqFromLink = req.getFromLink();
-		Link reqToLink = req.getToLink();
-		double t3 = pickupStayTask.getEndTime();
-
-		VrpPathWithTravelData path = calcPath(reqFromLink, reqToLink, t3);
+	protected void appendOccupiedDriveAndDropoff(Schedule schedule, TaxiRequest req, VrpPathWithTravelData path) {
 		schedule.addTask(new TaxiOccupiedDriveTask(path, req));
 
-		double t4 = path.getArrivalTime();
-		double t5 = t4 + taxiCfg.getDropoffDuration();
-		schedule.addTask(new TaxiDropoffTask(t4, t5, req));
+		double arrivalTime = path.getArrivalTime();
+		double departureTime = arrivalTime + taxiCfg.getDropoffDuration();
+		schedule.addTask(new TaxiDropoffTask(arrivalTime, departureTime, req));
 	}
 
 	protected VrpPathWithTravelData calcPath(Link fromLink, Link toLink, double departureTime) {
@@ -374,6 +404,13 @@ public class TaxiScheduler {
 
 			default:
 				throw new RuntimeException();
+		}
+	}
+
+	@Override
+	public void notifyMobsimBeforeCleanup(MobsimBeforeCleanupEvent e) {
+		if (executorService != null) {
+			executorService.shutdown();
 		}
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/scheduler/TaxiScheduler.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/scheduler/TaxiScheduler.java
@@ -23,6 +23,7 @@ import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
@@ -60,12 +61,13 @@ public class TaxiScheduler {
 	private final TaxiScheduleInquiry taxiScheduleInquiry;
 
 	public TaxiScheduler(TaxiConfigGroup taxiCfg, Fleet fleet, TaxiScheduleInquiry taxiScheduleInquiry,
-			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, LeastCostPathCalculator router) {
+			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
+			Supplier<LeastCostPathCalculator> routerSupplier) {
 		this.taxiCfg = taxiCfg;
 		this.fleet = fleet;
 		this.taxiScheduleInquiry = taxiScheduleInquiry;
 		this.travelTime = travelTime;
-		this.router = router;
+		this.router = routerSupplier.get();
 
 		initFleet();
 	}


### PR DESCRIPTION
In some configurations, the taxi optimiser may not know the destination until the passenger is picked up. But we can obtain this information already on request submission and use it to pre-compute the origin-destination path in the background.

If sufficiently many threads are used, all such paths are found before the pickup simulation ends. Consequently, QSim is not (directly) slowed down by computing these paths.

4-6 threads is usually enough. It's recommended to specify a higher number than that if possible (see the new param in the taxi config) - of course, threads will probably be not 100% busy. By default, it is set to the number of available cores.