### PR TITLE
drt: collect multiple fare-related events for one request

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtLeg.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtLeg.java
@@ -25,6 +25,7 @@ import java.util.function.Function;
 
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.events.PersonMoneyEvent;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.drt.passenger.events.DrtRequestSubmittedEvent;
@@ -66,6 +67,6 @@ final class DrtLeg {
 		this.unsharedTimeEstimate_m = submittedEvent.getUnsharedRideTime();
 		this.arrivalTime = sequence.getDroppedOff().get().getTime();
 		// PersonMoneyEvent has negative amount because the agent's money is reduced -> for the operator that is a positive amount
-		this.fare = sequence.getDrtFare().isPresent() ? -sequence.getDrtFare().get().getAmount() : 0.0;
+		this.fare = sequence.getDrtFares().stream().mapToDouble(PersonMoneyEvent::getAmount).sum();
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtLegsAnalyser.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtLegsAnalyser.java
@@ -37,11 +37,11 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.events.PersonMoneyEvent;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.common.util.ChartSaveUtils;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicleSpecification;
 import org.matsim.contrib.dvrp.fleet.FleetSpecification;
 import org.matsim.contrib.dvrp.optimizer.Request;
-import org.matsim.contrib.common.util.ChartSaveUtils;
 import org.matsim.core.utils.io.IOUtils;
 import org.matsim.core.utils.misc.Time;
 import org.matsim.vehicles.Vehicle;
@@ -49,7 +49,7 @@ import org.matsim.vehicles.Vehicle;
 public class DrtLegsAnalyser {
 
 	public static Map<Double, List<DrtLeg>> splitLegsIntoBins(Collection<DrtLeg> legs, int startTime, int endTime,
-															  int binSize_s) {
+			int binSize_s) {
 		LinkedList<DrtLeg> allLegs = new LinkedList<>(legs);
 		DrtLeg currentLeg = allLegs.pollFirst();
 		if (currentLeg.departureTime > endTime) {
@@ -72,7 +72,7 @@ public class DrtLegsAnalyser {
 	}
 
 	public static void analyzeBoardingsAndDeboardings(List<DrtLeg> legs, String delimiter, double startTime,
-													  double endTime, double timeBinSize, String boardingsFile, String deboardingsFile, Network network) {
+			double endTime, double timeBinSize, String boardingsFile, String deboardingsFile, Network network) {
 		if (endTime < startTime) {
 			throw new IllegalArgumentException("endTime < startTime");
 		}
@@ -122,14 +122,13 @@ public class DrtLegsAnalyser {
 	}
 
 	public static String summarizeLegs(List<DrtLeg> legs, Map<Id<Request>, Double> travelDistances,
-									   List<PersonMoneyEvent> drtFarePersonMoneyEvents, String delimiter) {
+			List<PersonMoneyEvent> drtFarePersonMoneyEvents, String delimiter) {
 		DescriptiveStatistics waitStats = new DescriptiveStatistics();
 		DescriptiveStatistics rideStats = new DescriptiveStatistics();
 		DescriptiveStatistics distanceStats = new DescriptiveStatistics();
 		DescriptiveStatistics directDistanceStats = new DescriptiveStatistics();
 
 		DescriptiveStatistics traveltimes = new DescriptiveStatistics();
-		DescriptiveStatistics fares = new DescriptiveStatistics();
 
 		DecimalFormat format = new DecimalFormat();
 		format.setDecimalFormatSymbols(new DecimalFormatSymbols(Locale.US));
@@ -162,8 +161,8 @@ public class DrtLegsAnalyser {
 				format.format(traveltimes.getMean()) + "",//
 				// all fares referencing this drt operator. Including daily fares independent from the legs.
 				// PersonMoneyEvent has negative amount because the agent's money is reduced -> for the operator that is a positive amount
-				format.format(- drtFarePersonMoneyEvents.stream().mapToDouble(PersonMoneyEvent::getAmount).sum() /
-						(waitStats.getValues().length == 0 ? 1 : waitStats.getValues().length)));
+				format.format(-drtFarePersonMoneyEvents.stream().mapToDouble(PersonMoneyEvent::getAmount).sum()
+						/ (waitStats.getValues().length == 0 ? 1 : waitStats.getValues().length)));
 	}
 
 	public static double getDirectDistanceMean(List<DrtLeg> legs) {
@@ -181,7 +180,7 @@ public class DrtLegsAnalyser {
 	}
 
 	public static void analyseDetours(Network network, List<DrtLeg> legs, Map<Id<Request>, Double> travelDistances,
-									  DrtConfigGroup drtCfg, String fileName, boolean createGraphs) {
+			DrtConfigGroup drtCfg, String fileName, boolean createGraphs) {
 		if (legs == null)
 			return;
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/speedup/DrtSpeedUpTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/speedup/DrtSpeedUpTest.java
@@ -279,7 +279,7 @@ public class DrtSpeedUpTest {
 		var drtFare = new PersonMoneyEvent(submittedTime, null, 5.5, DrtFareHandler.PERSON_MONEY_EVENT_PURPOSE_DRT_FARE,
 				MODE, requestId.toString());
 		return new PerformedRequestEventSequence(submittedEvent, mock(PassengerRequestScheduledEvent.class),
-				pickupEvent, dropoffEvent, drtFare);
+				pickupEvent, dropoffEvent, List.of(drtFare));
 	}
 
 	DvrpVehicleSpecification vehicleSpecification(String id) {


### PR DESCRIPTION
Currently, we can collect only one event. However, nothing block us from setting up more than one fare handler per mode. If that is the case, there may be more than one fare-related event associated directly with a given request.
@vsp-gleich 