### PR TITLE
Construct executed tasks for analysis

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/analysis/ExecutedScheduleCollector.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/analysis/ExecutedScheduleCollector.java
@@ -1,0 +1,110 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2021 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.dvrp.analysis;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
+import org.matsim.contrib.dvrp.vrpagent.TaskEndedEvent;
+import org.matsim.contrib.dvrp.vrpagent.TaskEndedEventHandler;
+import org.matsim.contrib.dvrp.vrpagent.TaskStartedEvent;
+import org.matsim.contrib.dvrp.vrpagent.TaskStartedEventHandler;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class ExecutedScheduleCollector implements TaskStartedEventHandler, TaskEndedEventHandler {
+	public static class ExecutedSchedule {
+		public final Id<DvrpVehicle> vehicleId;
+		private final List<ExecutedTask> executedTasks = new ArrayList<>();
+
+		public ExecutedSchedule(Id<DvrpVehicle> vehicleId) {
+			this.vehicleId = vehicleId;
+		}
+
+		public List<ExecutedTask> getExecutedTasks() {
+			// so we can safely share the task list without worrying about external changes to the list
+			return Collections.unmodifiableList(executedTasks);
+		}
+	}
+
+	public static ExecutedScheduleCollector createWithDefaultTaskCreator(String mode) {
+		return new ExecutedScheduleCollector(mode,
+				(taskStarted, taskEnded) -> new ExecutedTask(taskStarted.getTaskType(), taskStarted.getTime(),
+						taskEnded.getTime(), taskStarted.getLinkId(), taskEnded.getLinkId()));
+	}
+
+	private final String mode;
+	private final BiFunction<TaskStartedEvent, TaskEndedEvent, ExecutedTask> executedTaskCreator;
+
+	private final Map<Id<DvrpVehicle>, TaskStartedEvent> taskStartedEvents = new HashMap<>();
+	private final Map<Id<DvrpVehicle>, ExecutedSchedule> executedSchedules = new HashMap<>();
+
+	public ExecutedScheduleCollector(String mode,
+			BiFunction<TaskStartedEvent, TaskEndedEvent, ExecutedTask> executedTaskCreator) {
+		this.mode = mode;
+		this.executedTaskCreator = executedTaskCreator;
+	}
+
+	public Collection<ExecutedSchedule> getExecutedSchedules() {
+		return executedSchedules.values();
+	}
+
+	@Override
+	public void handleEvent(TaskStartedEvent startEvent) {
+		if (!startEvent.getDvrpMode().equals(mode)) {
+			return;
+		}
+
+		var previousEvent = taskStartedEvents.put(startEvent.getDvrpVehicleId(), startEvent);
+		Preconditions.checkState(previousEvent == null, "No end event reported for previous task start event: (%s).",
+				previousEvent);
+	}
+
+	@Override
+	public void handleEvent(TaskEndedEvent endEvent) {
+		if (!endEvent.getDvrpMode().equals(mode)) {
+			return;
+		}
+
+		var startEvent = taskStartedEvents.remove(endEvent.getDvrpVehicleId());
+		Preconditions.checkNotNull(startEvent, "No start event reported for task end event: (%s).", startEvent);
+		Preconditions.checkArgument(startEvent.getTaskType().equals(endEvent.getTaskType()),
+				"Start event (%s) and end event (%s) refer to tasks of different types", startEvent, endEvent);
+
+		executedSchedules.computeIfAbsent(endEvent.getDvrpVehicleId(), ExecutedSchedule::new) //
+				.executedTasks.add(executedTaskCreator.apply(startEvent, endEvent));
+	}
+
+	@Override
+	public void reset(int iteration) {
+		executedSchedules.clear();
+	}
+}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/analysis/ExecutedTask.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/analysis/ExecutedTask.java
@@ -1,0 +1,62 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2021 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.dvrp.analysis;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.contrib.dvrp.schedule.Task;
+import org.matsim.contrib.dvrp.schedule.Tasks;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Immutable
+ *
+ * @author Michal Maciejewski (michalm)
+ */
+public class ExecutedTask {
+	/**
+	 * ExecutedTasks should be created from events rather than Tasks
+	 */
+	public static ExecutedTask createFromTask(Task task) {
+		// just some sanity check. However, even already PERFORMED tasks can be still modified (the class has setters),
+		// so no guarantee if the created ExecutedTask really represents its actual execution.
+		Preconditions.checkArgument(task.getStatus() == Task.TaskStatus.PERFORMED);
+		return new ExecutedTask(task.getTaskType(), task.getBeginTime(), task.getEndTime(),
+				Tasks.getBeginLink(task).getId(), Tasks.getEndLink(task).getId());
+	}
+
+	public final Task.TaskType taskType;
+	public final double beginTime;
+	public final double endTime;
+	public final Id<Link> startLinkId;
+	public final Id<Link> endLinkId;
+
+	public ExecutedTask(Task.TaskType taskType, double beginTime, double endTime, Id<Link> startLinkId,
+			Id<Link> endLinkId) {
+		Preconditions.checkArgument(beginTime <= endTime);
+		this.taskType = Preconditions.checkNotNull(taskType);
+		this.beginTime = beginTime;
+		this.endTime = endTime;
+		this.startLinkId = Preconditions.checkNotNull(startLinkId);
+		this.endLinkId = Preconditions.checkNotNull(endLinkId);
+	}
+}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/schedule/Task.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/schedule/Task.java
@@ -36,6 +36,9 @@ import org.matsim.contrib.dvrp.tracker.TaskTracker;
  * @author (of documentation) nagel
  */
 public interface Task {
+	/**
+	 * TaskType implementations should be immutable.
+	 */
 	interface TaskType {
 		String name();
 	}

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/analysis/TaxiModeAnalysisModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/analysis/TaxiModeAnalysisModule.java
@@ -23,6 +23,7 @@
  */
 package org.matsim.contrib.taxi.analysis;
 
+import org.matsim.contrib.dvrp.analysis.ExecutedScheduleCollector;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.taxi.run.TaxiConfigGroup;
 
@@ -42,5 +43,9 @@ public class TaxiModeAnalysisModule extends AbstractDvrpModeModule {
 		bindModal(TaxiEventSequenceCollector.class).toProvider(
 				modalProvider(getter -> new TaxiEventSequenceCollector(taxiCfg.getMode()))).asEagerSingleton();
 		addEventHandlerBinding().to(modalKey(TaxiEventSequenceCollector.class));
+
+		bindModal(ExecutedScheduleCollector.class).toProvider(
+				modalProvider(getter -> ExecutedScheduleCollector.createWithDefaultTaskCreator(taxiCfg.getMode())));
+		addEventHandlerBinding().to(modalKey(ExecutedScheduleCollector.class));
 	}
 }


### PR DESCRIPTION
To (later) replace the use of actual tasks/schedule objects in analysis (e.g. in taxi).