### PR TITLE
CI: switch to JDK 17 (zulu distro)

### DIFF
--- a/.github/workflows/verify-push.yaml
+++ b/.github/workflows/verify-push.yaml
@@ -88,8 +88,8 @@ jobs:
         if: ${{matrix.module != 'matsim' || steps.detect-changes.outputs.outside-contribs == 'true'}}
         uses: actions/setup-java@v2
         with:
-          java-version: 16
-          distribution: 'adopt'
+          java-version: 17
+          distribution: 'zulu'
 
       - name: Build module (with dependencies)
         if: ${{matrix.module != 'matsim' || steps.detect-changes.outputs.outside-contribs == 'true'}}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/RandomDrtZoneTargetLinkSelector.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/RandomDrtZoneTargetLinkSelector.java
@@ -20,7 +20,7 @@
 
 package org.matsim.contrib.drt.analysis.zonal;
 
-import java.util.Random;
+import java.util.function.IntUnaryOperator;
 
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.core.gbl.MatsimRandom;
@@ -29,18 +29,18 @@ import org.matsim.core.gbl.MatsimRandom;
  * @author tschlenther
  */
 public class RandomDrtZoneTargetLinkSelector implements DrtZoneTargetLinkSelector {
-	private final Random random;
+	private final IntUnaryOperator random;
 
 	public RandomDrtZoneTargetLinkSelector() {
-		this(MatsimRandom.getLocalInstance());
+		this(MatsimRandom.getLocalInstance()::nextInt);
 	}
 
-	public RandomDrtZoneTargetLinkSelector(Random random) {
+	public RandomDrtZoneTargetLinkSelector(IntUnaryOperator random) {
 		this.random = random;
 	}
 
 	@Override
 	public Link selectTargetLink(DrtZone zone) {
-		return zone.getLinks().get(random.nextInt(zone.getLinks().size()));
+		return zone.getLinks().get(random.applyAsInt(zone.getLinks().size()));
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/RandomDrtZoneTargetLinkSelectorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/RandomDrtZoneTargetLinkSelectorTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
-import java.util.Random;
+import java.util.function.IntUnaryOperator;
 
 import org.junit.Test;
 import org.matsim.api.core.v01.Id;
@@ -48,9 +48,9 @@ public class RandomDrtZoneTargetLinkSelectorTest {
 		DrtZone zone = DrtZone.createDummyZone("zone", List.of(link0, link1, link2, link3), null);
 
 		//fake random sequence
-		Random random = mock(Random.class);
+		IntUnaryOperator random = mock(IntUnaryOperator.class);
 		ArgumentCaptor<Integer> boundCaptor = ArgumentCaptor.forClass(int.class);
-		when(random.nextInt(boundCaptor.capture())).thenReturn(0, 3, 1, 2);
+		when(random.applyAsInt(boundCaptor.capture())).thenReturn(0, 3, 1, 2);
 
 		//test selected target links
 		RandomDrtZoneTargetLinkSelector selector = new RandomDrtZoneTargetLinkSelector(random);


### PR DESCRIPTION
Changing to `zulu` as `adopt` is not yet available. Let's see if we are (almost) ready for JDK 17.