### PR TITLE
Add empty network validation

### DIFF
--- a/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/HereMapsRouteValidator.java
+++ b/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/HereMapsRouteValidator.java
@@ -131,10 +131,9 @@ public class HereMapsRouteValidator implements TravelTimeDistanceValidator {
 
             in.close();
         } catch (MalformedURLException e) {
-            log.error("URL is not working. Please check your API key");
-            e.printStackTrace();
+            log.error("URL is not working. Please check your API key", e);
         } catch (IOException | ParseException e) {
-            log.error("Cannot read the content on the URL properly. Please manually check the URL");
+            log.error("Cannot read the content on the URL properly. Please manually check the URL", e);
         }
         return new Tuple<Double, Double>((double) travelTime, (double) distance);
     }

--- a/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/HereMapsRouteValidator.java
+++ b/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/HereMapsRouteValidator.java
@@ -41,110 +41,110 @@ import org.matsim.core.utils.misc.Time;
 
 /**
  * @author jbischoff this class requests travel times and distances between two
- *         coordinates from HERE Maps. Please replace the API code with your own
- *         and obey here's usage policy
- *
+ * coordinates from HERE Maps. Please replace the API code with your own
+ * and obey here's usage policy
  */
 public class HereMapsRouteValidator implements TravelTimeDistanceValidator {
 
-	final String apiAcessKey;
-	final String outputPath;
-	final String date;
-	final CoordinateTransformation transformation;
-	boolean writeDetailedFiles = true;
+    final String apiAcessKey;
+    final String outputPath;
+    final String date;
+    final CoordinateTransformation transformation;
+    boolean writeDetailedFiles = false;
 
-	/**
-	 * 
-	 * @param outputFolder   folder to write gzipped json files
-	 * @param apiAccessKey        your API Access Code (to be request on the here.com)
-	 * @param date           a date to run the validation for, format: 2017-06-08
-	 * @param transformation A coordinate transformation to WGS 84
-	 */
-	public HereMapsRouteValidator(String outputFolder, String apiAccessKey, String date,
-			CoordinateTransformation transformation) {
-		this.outputPath = outputFolder;
-		this.apiAcessKey = apiAccessKey;
-		this.date = date;
-		this.transformation = transformation;
-		File outDir = new File(outputFolder);
-		if (!outDir.exists()) {
-			outDir.mkdirs();
-		}
+    /**
+     * @param outputFolder   folder to write gzipped json files
+     * @param apiAccessKey   your API Access Code (to be request on the here.com)
+     * @param date           a date to run the validation for, format: 2017-06-08
+     * @param transformation A coordinate transformation to WGS 84
+     */
+    public HereMapsRouteValidator(String outputFolder, String apiAccessKey, String date,
+                                  CoordinateTransformation transformation) {
+        this.outputPath = outputFolder;
+        this.apiAcessKey = apiAccessKey;
+        this.date = date;
+        this.transformation = transformation;
+        File outDir = new File(outputFolder);
+        if (!outDir.exists()) {
+            outDir.mkdirs();
+        }
 
-	}
+    }
 
-	/*
-	 * (non-Javadoc)
-	 * 
-	 * @see org.matsim.contrib.analysis.vsp.traveltimes.TravelTimeValidator#
-	 * getTravelTime(org.matsim.contrib.analysis.vsp.traveltimes.CarTrip)
-	 */
-	@Override
-	public Tuple<Double, Double> getTravelTime(CarTrip trip) {
-		String filename = outputPath + "/" + trip.getPersonId() + "_" + trip.getDepartureTime() + ".json.gz";
-		return getTravelTime(trip.getDepartureLocation(), trip.getArrivalLocation(), trip.getDepartureTime(), filename);
-	}
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.matsim.contrib.analysis.vsp.traveltimes.TravelTimeValidator#
+     * getTravelTime(org.matsim.contrib.analysis.vsp.traveltimes.CarTrip)
+     */
+    @Override
+    public Tuple<Double, Double> getTravelTime(CarTrip trip) {
+        String tripId = trip.getPersonId().toString() + "_" + trip.getDepartureTime();
+        return getTravelTime(trip.getDepartureLocation(), trip.getArrivalLocation(), trip.getDepartureTime(), tripId);
+    }
 
-	public Tuple<Double, Double> getTravelTime(Coord fromCoord, Coord toCoord, double departureTime, String detailedRecordFileName){
-		long travelTime = 0;
-		long distance = 0;
+    @Override
+    public Tuple<Double, Double> getTravelTime(Coord fromCoord, Coord toCoord, double departureTime, String tripId) {
+        long travelTime = 0;
+        long distance = 0;
 
-		Coord from = transformation.transform(fromCoord);
-		Coord to = transformation.transform(toCoord);
+        Coord from = transformation.transform(fromCoord);
+        Coord to = transformation.transform(toCoord);
 
-		Locale locale = new Locale("en", "UK");
-		String pattern = "###.#####";
+        Locale locale = new Locale("en", "UK");
+        String pattern = "###.#####";
 
-		DecimalFormat df = (DecimalFormat) NumberFormat.getNumberInstance(locale);
-		df.applyPattern(pattern);
+        DecimalFormat df = (DecimalFormat) NumberFormat.getNumberInstance(locale);
+        df.applyPattern(pattern);
 
-		String urlString = "https://router.hereapi.com/v8/routes?" + "&apiKey=" + apiAcessKey + "&transportmode=car&origin="
-				+ df.format(from.getY()) + "," + df.format(from.getX()) + "&destination=" + df.format(to.getY()) + ","
-				+ df.format(to.getX()) + "&departureTime=" + date + "T" + Time.writeTime(departureTime)
-				+ "&return=summary";
+        String urlString = "https://router.hereapi.com/v8/routes?" + "&apiKey=" + apiAcessKey + "&transportmode=car&origin="
+                + df.format(from.getY()) + "," + df.format(from.getX()) + "&destination=" + df.format(to.getY()) + ","
+                + df.format(to.getX()) + "&departureTime=" + date + "T" + Time.writeTime(departureTime)
+                + "&return=summary";
 
-		try {
-			System.out.println(urlString);
-			URL url = new URL(urlString);
-			BufferedReader in = new BufferedReader(new InputStreamReader(url.openStream()));
-			JSONParser jp = new JSONParser();
+        try {
+            System.out.println(urlString);
+            URL url = new URL(urlString);
+            BufferedReader in = new BufferedReader(new InputStreamReader(url.openStream()));
+            JSONParser jp = new JSONParser();
 
-			JSONObject jsonObject = (JSONObject) jp.parse(in);
-			JSONArray routes = (JSONArray) jsonObject.get("routes");
-			if (!routes.isEmpty()) {
-				JSONObject route = (JSONObject) routes.get(0);
-				JSONArray sections = (JSONArray) route.get("sections");
-				JSONObject section = (JSONObject) sections.get(0);
-				JSONObject summary = (JSONObject) section.get("summary");
-				travelTime = (long) summary.get("duration");
-				distance = (long) summary.get("length");
+            JSONObject jsonObject = (JSONObject) jp.parse(in);
+            JSONArray routes = (JSONArray) jsonObject.get("routes");
+            if (!routes.isEmpty()) {
+                JSONObject route = (JSONObject) routes.get(0);
+                JSONArray sections = (JSONArray) route.get("sections");
+                JSONObject section = (JSONObject) sections.get(0);
+                JSONObject summary = (JSONObject) section.get("summary");
+                travelTime = (long) summary.get("duration");
+                distance = (long) summary.get("length");
 
-				if (writeDetailedFiles) {
-					BufferedWriter bw = IOUtils.getBufferedWriter(detailedRecordFileName);
-					bw.write(jsonObject.toString());
-					bw.flush();
-					bw.close();
-				}
-			}
-		} catch (MalformedURLException e) {
-		} catch (IOException e) {
-		} catch (ParseException e) {
-		}
-		return new Tuple<Double, Double>((double) travelTime, (double) distance);
-	}
+                if (writeDetailedFiles) {
+                    String filename = outputPath + "/" + tripId + ".json.gz";
+                    BufferedWriter bw = IOUtils.getBufferedWriter(filename);
+                    bw.write(jsonObject.toString());
+                    bw.flush();
+                    bw.close();
+                }
+            }
+        } catch (MalformedURLException e) {
+        } catch (IOException e) {
+        } catch (ParseException e) {
+        }
+        return new Tuple<Double, Double>((double) travelTime, (double) distance);
+    }
 
-	/**
-	 * @return the writeDetailedFiles
-	 */
-	public boolean isWriteDetailedFiles() {
-		return writeDetailedFiles;
-	}
+    /**
+     * @return the writeDetailedFiles
+     */
+    public boolean isWriteDetailedFiles() {
+        return writeDetailedFiles;
+    }
 
-	/**
-	 * @param writeDetailedFiles the writeDetailedFiles to set
-	 */
-	public void setWriteDetailedFiles(boolean writeDetailedFiles) {
-		this.writeDetailedFiles = writeDetailedFiles;
-	}
+    /**
+     * @param writeDetailedFiles the writeDetailedFiles to set
+     */
+    public void setWriteDetailedFiles(boolean writeDetailedFiles) {
+        this.writeDetailedFiles = writeDetailedFiles;
+    }
 
 }

--- a/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/HereMapsRouteValidator.java
+++ b/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/HereMapsRouteValidator.java
@@ -29,6 +29,8 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.Locale;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -45,7 +47,7 @@ import org.matsim.core.utils.misc.Time;
  * and obey here's usage policy
  */
 public class HereMapsRouteValidator implements TravelTimeDistanceValidator {
-
+    private static final Logger log = LogManager.getLogger(HereMapsRouteValidator.class);
     final String apiAcessKey;
     final String outputPath;
     final String date;
@@ -102,14 +104,15 @@ public class HereMapsRouteValidator implements TravelTimeDistanceValidator {
                 + df.format(to.getX()) + "&departureTime=" + date + "T" + Time.writeTime(departureTime)
                 + "&return=summary";
 
+        log.info(urlString);
+
         try {
-            System.out.println(urlString);
             URL url = new URL(urlString);
             BufferedReader in = new BufferedReader(new InputStreamReader(url.openStream()));
             JSONParser jp = new JSONParser();
-
             JSONObject jsonObject = (JSONObject) jp.parse(in);
             JSONArray routes = (JSONArray) jsonObject.get("routes");
+
             if (!routes.isEmpty()) {
                 JSONObject route = (JSONObject) routes.get(0);
                 JSONArray sections = (JSONArray) route.get("sections");
@@ -117,7 +120,6 @@ public class HereMapsRouteValidator implements TravelTimeDistanceValidator {
                 JSONObject summary = (JSONObject) section.get("summary");
                 travelTime = (long) summary.get("duration");
                 distance = (long) summary.get("length");
-
                 if (writeDetailedFiles) {
                     String filename = outputPath + "/" + tripId + ".json.gz";
                     BufferedWriter bw = IOUtils.getBufferedWriter(filename);
@@ -126,9 +128,13 @@ public class HereMapsRouteValidator implements TravelTimeDistanceValidator {
                     bw.close();
                 }
             }
+
+            in.close();
         } catch (MalformedURLException e) {
-        } catch (IOException e) {
-        } catch (ParseException e) {
+            log.error("URL is not working. Please check your API key");
+            e.printStackTrace();
+        } catch (IOException | ParseException e) {
+            log.error("Cannot read the content on the URL properly. Please manually check the URL");
         }
         return new Tuple<Double, Double>((double) travelTime, (double) distance);
     }

--- a/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/HereMapsRouteValidator.java
+++ b/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/HereMapsRouteValidator.java
@@ -48,7 +48,7 @@ import org.matsim.core.utils.misc.Time;
  */
 public class HereMapsRouteValidator implements TravelTimeDistanceValidator {
     private static final Logger log = LogManager.getLogger(HereMapsRouteValidator.class);
-    final String apiAcessKey;
+    final String apiAccessKey;
     final String outputPath;
     final String date;
     final CoordinateTransformation transformation;
@@ -63,7 +63,7 @@ public class HereMapsRouteValidator implements TravelTimeDistanceValidator {
     public HereMapsRouteValidator(String outputFolder, String apiAccessKey, String date,
                                   CoordinateTransformation transformation) {
         this.outputPath = outputFolder;
-        this.apiAcessKey = apiAccessKey;
+        this.apiAccessKey = apiAccessKey;
         this.date = date;
         this.transformation = transformation;
         File outDir = new File(outputFolder);
@@ -99,7 +99,7 @@ public class HereMapsRouteValidator implements TravelTimeDistanceValidator {
         DecimalFormat df = (DecimalFormat) NumberFormat.getNumberInstance(locale);
         df.applyPattern(pattern);
 
-        String urlString = "https://router.hereapi.com/v8/routes?" + "&apiKey=" + apiAcessKey + "&transportmode=car&origin="
+        String urlString = "https://router.hereapi.com/v8/routes?" + "&apiKey=" + apiAccessKey + "&transportmode=car&origin="
                 + df.format(from.getY()) + "," + df.format(from.getX()) + "&destination=" + df.format(to.getY()) + ","
                 + df.format(to.getX()) + "&departureTime=" + date + "T" + Time.writeTime(departureTime)
                 + "&return=summary";

--- a/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/TravelTimeDistanceValidator.java
+++ b/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/TravelTimeDistanceValidator.java
@@ -22,7 +22,10 @@
  */
 package org.matsim.contrib.analysis.vsp.traveltimedistance;
 
+import org.matsim.api.core.v01.Coord;
 import org.matsim.core.utils.collections.Tuple;
+
+import java.util.Deque;
 
 /**
  * @author  jbischoff
@@ -39,4 +42,6 @@ public interface TravelTimeDistanceValidator {
 	 * @return a tuple of validated TravelTime and Distance
 	 */
 	Tuple<Double,Double> getTravelTime(CarTrip trip);
+
+	Tuple<Double, Double> getTravelTime(Coord fromCorrd, Coord toCoord, double departureTime, String tripId);
 }

--- a/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/TravelTimeDistanceValidator.java
+++ b/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/TravelTimeDistanceValidator.java
@@ -28,7 +28,7 @@ import org.matsim.core.utils.collections.Tuple;
 import java.util.Deque;
 
 /**
- * @author  jbischoff
+ * @author  jbischoff, Chengqi Lu
  * An Interface for Traveltime Validation
  */
 
@@ -43,5 +43,13 @@ public interface TravelTimeDistanceValidator {
 	 */
 	Tuple<Double,Double> getTravelTime(CarTrip trip);
 
+	/**
+	 * A more general form for the trip validation
+	 * @param fromCorrd coordinate of departure location
+	 * @param toCoord coordinate of departure location
+	 * @param departureTime departure time in seconds during the day
+	 * @param tripId id for the trip for detailed record
+	 * @return a tuple of validated TravelTime and Distance
+	 */
 	Tuple<Double, Double> getTravelTime(Coord fromCorrd, Coord toCoord, double departureTime, String tripId);
 }

--- a/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/TravelTimeValidationRunnerPreAnalysis.java
+++ b/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/TravelTimeValidationRunnerPreAnalysis.java
@@ -29,6 +29,10 @@ public class TravelTimeValidationRunnerPreAnalysis {
     private final TravelTimeDistanceValidator validator;
     private final String outputFolder;
 
+    private double insideTripProportion = 0.6;  // Proportion of trips will be chosen within the key area (when key area shape file is provided)
+    private double crossBorderTripProportion = 0.3; // Proportion of trips will be chosen that cross the broader of the key area (when key area shape file is provided)
+    // The rest will be outside trips. Therefore, insideTripProportion+crossBorderTripProportion should be less than or equal to 1
+
     private final Random rnd = new Random(1234);
 
     public TravelTimeValidationRunnerPreAnalysis(Network network, int trips, String outputFolder, TravelTimeDistanceValidator validator, Geometry keyAreaGeometry) {
@@ -41,6 +45,14 @@ public class TravelTimeValidationRunnerPreAnalysis {
 
     public void setKeyAreaGeometry(Geometry keyAreaGeometry) {
         this.keyAreaGeometry = keyAreaGeometry;
+    }
+
+    public void setInsideTripProportion(double insideTripProportion) {
+        this.insideTripProportion = insideTripProportion;
+    }
+
+    public void setCrossBorderTripProportion(double crossBorderTripProportion){
+        this.crossBorderTripProportion = crossBorderTripProportion;
     }
 
     public void run() throws IOException {
@@ -83,11 +95,11 @@ public class TravelTimeValidationRunnerPreAnalysis {
                 int numOfLinksInsideShp = linksInsideShp.size();
                 int numOfOutsideLinks = outsideLinks.size();
 
-                if (counter < 0.6 * trips) {
+                if (counter < insideTripProportion * trips) {
                     fromLink = linksInsideShp.get(rnd.nextInt(numOfLinksInsideShp));
                     toLink = linksInsideShp.get(rnd.nextInt(numOfLinksInsideShp));
                     tripType = "inside";
-                } else if (counter < 0.9 * trips) {
+                } else if (counter < (insideTripProportion + crossBorderTripProportion) * trips) {
                     fromLink = linksInsideShp.get(rnd.nextInt(numOfLinksInsideShp));
                     toLink = outsideLinks.get(rnd.nextInt(numOfOutsideLinks));
                     tripType = "cross-border";

--- a/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/TravelTimeValidationRunnerPreAnalysis.java
+++ b/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/TravelTimeValidationRunnerPreAnalysis.java
@@ -29,9 +29,14 @@ public class TravelTimeValidationRunnerPreAnalysis {
     private final TravelTimeDistanceValidator validator;
     private final String outputFolder;
 
-    private double insideTripProportion = 0.6;  // Proportion of trips will be chosen within the key area (when key area shape file is provided)
-    private double crossBorderTripProportion = 0.3; // Proportion of trips will be chosen that cross the broader of the key area (when key area shape file is provided)
-    // The rest will be outside trips. Therefore, insideTripProportion+crossBorderTripProportion should be less than or equal to 1
+    /**
+     * Proportion of trips will be chosen within the key area (when key area shape file is provided).
+     * */
+    private double insideTripProportion = 0.6;
+    /**
+     * Proportion of trips will be chosen that cross the border of the key area (when key area shape file is provided)
+     * */
+    private double crossBorderTripProportion = 0.3;
 
     private final Random rnd = new Random(1234);
 
@@ -47,10 +52,20 @@ public class TravelTimeValidationRunnerPreAnalysis {
         this.keyAreaGeometry = keyAreaGeometry;
     }
 
+    /**
+     * Set the proportion of the inside trips to analyze.
+     * Note that insideTripProportion + crossBorderTripProportion should be less than or equal to 1
+     * The rest proportion will be outside trips
+     * */
     public void setInsideTripProportion(double insideTripProportion) {
         this.insideTripProportion = insideTripProportion;
     }
 
+    /**
+     * Set the proportion of the cross border trips to analyze.
+     * Note that insideTripProportion + crossBorderTripProportion should be less than or equal to 1
+     * The rest proportion will be outside trips
+     * */
     public void setCrossBorderTripProportion(double crossBorderTripProportion){
         this.crossBorderTripProportion = crossBorderTripProportion;
     }

--- a/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/TravelTimeValidationRunnerPreAnalysis.java
+++ b/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/TravelTimeValidationRunnerPreAnalysis.java
@@ -1,0 +1,126 @@
+package org.matsim.contrib.analysis.vsp.traveltimedistance;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.locationtech.jts.geom.Geometry;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.core.router.costcalculators.OnlyTimeDependentTravelDisutilityFactory;
+import org.matsim.core.router.speedy.SpeedyALTFactory;
+import org.matsim.core.router.util.LeastCostPathCalculator;
+import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
+import org.matsim.core.router.util.TravelDisutility;
+import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
+import org.matsim.core.utils.geometry.geotools.MGC;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+public class TravelTimeValidationRunnerPreAnalysis {
+    private final Network network;
+    private final int trips;
+    private Geometry keyAreaGeometry;
+    private final TravelTimeDistanceValidator validator;
+    private final String outputFolder;
+
+    private final Random rnd = new Random(1234);
+
+    public TravelTimeValidationRunnerPreAnalysis(Network network, int trips, String outputFolder, TravelTimeDistanceValidator validator, Geometry keyAreaGeometry) {
+        this.network = network;
+        this.trips = trips;
+        this.outputFolder = outputFolder;
+        this.validator = validator;
+        this.keyAreaGeometry = keyAreaGeometry;
+    }
+
+    public void setKeyAreaGeometry(Geometry keyAreaGeometry) {
+        this.keyAreaGeometry = keyAreaGeometry;
+    }
+
+    public void run() throws IOException {
+        List<Link> links = network.getLinks().values().stream().
+                filter(l -> l.getAllowedModes().contains(TransportMode.car)).
+                collect(Collectors.toList());
+        int numOfLinks = links.size();
+
+        List<Link> linksInsideShp = new ArrayList<>();
+        List<Link> outsideLinks = new ArrayList<>();
+
+        if (keyAreaGeometry != null) {
+            for (Link link : links) {
+                if (MGC.coord2Point(link.getToNode().getCoord()).within(keyAreaGeometry)) {
+                    linksInsideShp.add(link);
+                }
+            }
+            outsideLinks.addAll(links);
+            outsideLinks.removeAll(linksInsideShp);
+        }
+
+        // Create router
+        FreeSpeedTravelTime travelTime = new FreeSpeedTravelTime();
+        LeastCostPathCalculatorFactory fastAStarLandmarksFactory = new SpeedyALTFactory();
+        OnlyTimeDependentTravelDisutilityFactory disutilityFactory = new OnlyTimeDependentTravelDisutilityFactory();
+        TravelDisutility travelDisutility = disutilityFactory.createTravelDisutility(travelTime);
+        LeastCostPathCalculator router = fastAStarLandmarksFactory.createPathCalculator(network, travelDisutility,
+                travelTime);
+
+        // Choose random trips to validate
+        CSVPrinter csvWriter = new CSVPrinter(new FileWriter(outputFolder + "/pre-analysis-results.csv"), CSVFormat.DEFAULT);
+        csvWriter.printRecord("trip_number", "trip_category", "from_x", "from_y", "to_x", "to_y", "simulated_travel_time", "validated_travel_time");
+        int counter = 0;
+
+        Link fromLink;
+        Link toLink;
+        String tripType;
+        while (counter < trips) {
+            if (!linksInsideShp.isEmpty()) {
+                int numOfLinksInsideShp = linksInsideShp.size();
+                int numOfOutsideLinks = outsideLinks.size();
+
+                if (counter < 0.6 * trips) {
+                    fromLink = linksInsideShp.get(rnd.nextInt(numOfLinksInsideShp));
+                    toLink = linksInsideShp.get(rnd.nextInt(numOfLinksInsideShp));
+                    tripType = "inside";
+                } else if (counter < 0.9 * trips) {
+                    fromLink = linksInsideShp.get(rnd.nextInt(numOfLinksInsideShp));
+                    toLink = outsideLinks.get(rnd.nextInt(numOfOutsideLinks));
+                    tripType = "cross-border";
+                } else {
+                    fromLink = outsideLinks.get(rnd.nextInt(numOfOutsideLinks));
+                    toLink = outsideLinks.get(rnd.nextInt(numOfOutsideLinks));
+                    tripType = "outside";
+                }
+            } else {
+                fromLink = links.get(rnd.nextInt(numOfLinks));
+                toLink = links.get(rnd.nextInt(numOfLinks));
+                tripType = "unknown";
+            }
+
+            if (!fromLink.getToNode().getId().equals(toLink.getToNode().getId())) {
+                String detailedFile = outputFolder + "/detailed-record/trip" + counter + ".json.gz";
+                Coord fromCorrd = fromLink.getToNode().getCoord();
+                Coord toCoord = toLink.getToNode().getCoord();
+                double validatedTravelTime = validator.getTravelTime
+                        (fromCorrd, toCoord, 1, detailedFile).getFirst();
+                if (validatedTravelTime < 60) {
+                    continue;
+                }
+                double simulatedTravelTime = router.calcLeastCostPath
+                        (fromLink.getToNode(), toLink.getToNode(), 0, null, null).travelTime;
+                csvWriter.printRecord(Integer.toString(counter), tripType, Double.toString(fromCorrd.getX()),
+                        Double.toString(fromCorrd.getY()), Double.toString(toCoord.getX()),
+                        Double.toString(toCoord.getY()), Double.toString(simulatedTravelTime),
+                        Double.toString(validatedTravelTime));
+                counter++;
+            }
+        }
+        csvWriter.close();
+
+    }
+}

--- a/contribs/application/src/main/java/org/matsim/application/analysis/TravelTimeAnalysis.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/TravelTimeAnalysis.java
@@ -138,7 +138,11 @@ public class TravelTimeAnalysis implements MATSimAppCommand {
             return 0;
 
         } else if (type.equals("pre-analysis")) {
-            Path networkPath = globFile(runDirectory, ".*network.*");
+            Path networkPath = globFile(runDirectory, "*network*");
+            if (!networkPath.endsWith(".xml") && !networkPath.endsWith(".xml.gz")) {
+                log.error("There are other non-xml file with the name network in the folder. Please consider change the run directory and only keep the correct network xml file in the run directory");
+                return 2;
+            }
             if (!Files.exists(networkPath)) {
                 log.error("Network file does not exist. Please make sure the network file is in the run directory");
                 return 2;

--- a/contribs/application/src/main/java/org/matsim/application/analysis/TravelTimeAnalysis.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/TravelTimeAnalysis.java
@@ -84,7 +84,7 @@ public class TravelTimeAnalysis implements MATSimAppCommand {
         HERE, GOOGLE_MAP
     }
 
-    enum AnalysisTypes{
+    enum AnalysisTypes {
         PRE_ANALYSIS, POST_ANALYSIS
     }
 
@@ -101,7 +101,7 @@ public class TravelTimeAnalysis implements MATSimAppCommand {
         }
 
         String outputFolder = runDirectory.resolve(output).toString();
-        if (type.equals(AnalysisTypes.POST_ANALYSIS)) {
+        if (type == AnalysisTypes.POST_ANALYSIS) {
             Path events = globFile(runDirectory, runId + ".*events.*");
             Scenario scenario = loadScenario(runId, runDirectory, crs);
             Set<Id<Person>> populationIds = scenario.getPopulation().getPersons().keySet();
@@ -141,7 +141,7 @@ public class TravelTimeAnalysis implements MATSimAppCommand {
 
             return 0;
 
-        } else if (type.equals(AnalysisTypes.PRE_ANALYSIS)) {
+        } else if (type == AnalysisTypes.PRE_ANALYSIS) {
             Path networkPath = globFile(runDirectory, "*network*");
             if (!networkPath.toString().endsWith(".xml") && !networkPath.toString().endsWith(".xml.gz")) {
                 log.error("There are other non-xml file with the name network in the folder. Please consider change the run directory and only keep the correct network xml file in the run directory");

--- a/contribs/application/src/main/java/org/matsim/application/analysis/TravelTimeAnalysis.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/TravelTimeAnalysis.java
@@ -1,9 +1,16 @@
 package org.matsim.application.analysis;
 
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.locationtech.jts.geom.Geometry;
+import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Plan;
 import org.matsim.application.MATSimAppCommand;
@@ -15,22 +22,35 @@ import org.matsim.contrib.analysis.vsp.traveltimedistance.TravelTimeValidationRu
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.replanning.selectors.BestPlanSelector;
+import org.matsim.core.router.costcalculators.OnlyTimeDependentTravelDisutilityFactory;
+import org.matsim.core.router.speedy.SpeedyALTFactory;
+import org.matsim.core.router.util.LeastCostPathCalculator;
+import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
+import org.matsim.core.router.util.TravelDisutility;
+import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
 import org.matsim.core.utils.collections.Tuple;
 import org.matsim.core.utils.geometry.CoordinateTransformation;
+import org.matsim.core.utils.geometry.geotools.MGC;
 import org.matsim.core.utils.geometry.transformations.TransformationFactory;
 import picocli.CommandLine;
 
+import java.io.FileWriter;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import static org.matsim.application.ApplicationUtils.globFile;
 import static org.matsim.application.ApplicationUtils.loadScenario;
 
 @CommandLine.Command(
         name = "travel-time",
-        description = "Run travel time analysis on events file."
+        description = "Run travel time analysis on events file. pre-analysis: analyze the empty network to validate the free flow speed of the network. post-analysis (default): validate the travel time and distance of executed trips"
 )
 public class TravelTimeAnalysis implements MATSimAppCommand {
 
@@ -39,13 +59,19 @@ public class TravelTimeAnalysis implements MATSimAppCommand {
     @CommandLine.Parameters(arity = "1", paramLabel = "INPUT", description = "Input run directory")
     private Path runDirectory;
 
+    @CommandLine.Option(names = "--analysis-type", defaultValue = "post-analysis", description = "type of the analysis. Choose from [pre-analysis, post-analysis]", required = true)
+    private String type;
+
     @CommandLine.Option(names = "--run-id", defaultValue = "*", description = "Pattern used to match runId", required = true)
     private String runId;
 
     @CommandLine.Option(names = "--output", defaultValue = "travelTimeResults", description = "Name of output folder", required = true)
     private String output;
 
-    @CommandLine.Option(names = "--api-key", description = "HERE Maps API key, see here.com", required = true)
+    @CommandLine.Option(names = "--api", description = "Online API used. Choose from [here, google-map (todo)]", defaultValue = "here", required = true)
+    private String api;
+
+    @CommandLine.Option(names = "--api-key", description = "API key. You can apply for free API key on their website", required = true)
     private String appCode;
 
     @CommandLine.Option(names = "--date", description = "The date to validate travel times for, format: YYYY-MM-DD")
@@ -72,6 +98,8 @@ public class TravelTimeAnalysis implements MATSimAppCommand {
     @CommandLine.Mixin
     private ShpOptions shp = new ShpOptions();
 
+    private final Random rnd = new Random(1234);
+
     public static void main(String[] args) {
         System.exit(new CommandLine(new TravelTimeAnalysis()).execute(args));
     }
@@ -84,54 +112,142 @@ public class TravelTimeAnalysis implements MATSimAppCommand {
             return 2;
         }
 
-        Path events = globFile(runDirectory, runId + ".*events.*");
-        Scenario scenario = loadScenario(runId, runDirectory, crs);
-
-
-        Set<Id<Person>> populationIds = scenario.getPopulation().getPersons().keySet();
-
-        BestPlanSelector<Plan, Person> selector = new BestPlanSelector<>();
-
-        int size = populationIds.size();
-
-        populationIds.removeIf(p -> {
-            Person person = scenario.getPopulation().getPersons().get(p);
-            return selector.selectPlan(person) != person.getSelectedPlan();
-        });
-
-        Predicate<CarTrip> tripFilter = carTrip -> true;
-        if (shp.getShapeFile() != null) {
-            ShpOptions.Index index = shp.createIndex(crs.getInputCRS(), "__");
-            if (withInShp)
-                tripFilter = carTrip -> index.contains(carTrip.getArrivalLocation()) && index.contains(carTrip.getDepartureLocation());
-            else
-                tripFilter = carTrip -> index.contains(carTrip.getArrivalLocation()) || index.contains(carTrip.getDepartureLocation());
-        }
-
-        log.info("Removed {} agents not selecting their best plan", size - populationIds.size());
-
-        if (date == null)
-            date = LocalDate.now();
-
-        log.info("Running analysis for {} trips at {} on file {}", trips, date, events);
-
-
-        CoordinateTransformation transformation = TransformationFactory.getCoordinateTransformation(crs.getInputCRS(), TransformationFactory.WGS84);
-
         String outputFolder = runDirectory.resolve(output).toString();
-        HereMapsRouteValidator validator = new HereMapsRouteValidator(outputFolder, appCode, date.toString(), transformation);
-        validator.setWriteDetailedFiles(writeDetails);
+        if (type.equals("post-analysis")){
+            Path events = globFile(runDirectory, runId + ".*events.*");
+            Scenario scenario = loadScenario(runId, runDirectory, crs);
+            Set<Id<Person>> populationIds = scenario.getPopulation().getPersons().keySet();
+            BestPlanSelector<Plan, Person> selector = new BestPlanSelector<>();
+            int size = populationIds.size();
+            populationIds.removeIf(p -> {
+                Person person = scenario.getPopulation().getPersons().get(p);
+                return selector.selectPlan(person) != person.getSelectedPlan();
+            });
+            Predicate<CarTrip> tripFilter = carTrip -> true;
+            if (shp.getShapeFile() != null) {
+                ShpOptions.Index index = shp.createIndex(crs.getInputCRS(), "__");
+                if (withInShp)
+                    tripFilter = carTrip -> index.contains(carTrip.getArrivalLocation()) && index.contains(carTrip.getDepartureLocation());
+                else
+                    tripFilter = carTrip -> index.contains(carTrip.getArrivalLocation()) || index.contains(carTrip.getDepartureLocation());
+            }
+            log.info("Removed {} agents not selecting their best plan", size - populationIds.size());
 
-        Tuple<Double, Double> timeWindow = new Tuple<>((double) 0, (double) 3600 * 30);
-        if (timeFrom != null && timeTo != null) {
-            timeWindow = new Tuple<>(timeFrom, timeTo);
+            if (date == null)
+                date = LocalDate.now();
+
+            log.info("Running analysis for {} trips at {} on file {}", trips, date, events);
+
+            CoordinateTransformation transformation = TransformationFactory.getCoordinateTransformation(crs.getInputCRS(), TransformationFactory.WGS84);
+
+
+            HereMapsRouteValidator validator = new HereMapsRouteValidator(outputFolder, appCode, date.toString(), transformation);
+            validator.setWriteDetailedFiles(writeDetails);
+
+            Tuple<Double, Double> timeWindow = new Tuple<>((double) 0, (double) 3600 * 30);
+            if (timeFrom != null && timeTo != null) {
+                timeWindow = new Tuple<>(timeFrom, timeTo);
+            }
+
+            TravelTimeValidationRunner runner = new TravelTimeValidationRunner(scenario.getNetwork(), populationIds, events.toString(), outputFolder, validator, trips, timeWindow, tripFilter);
+
+            runner.run();
+
+            return 0;
+
+        } else if (type.equals("pre-analysis")){
+            Path networkPath = globFile(runDirectory, ".*network.*");
+            if (!Files.exists(networkPath)) {
+                log.error("Network file does not exist. Please make sure the network file is in the run directory");
+                return 2;
+            }
+            Network network = NetworkUtils.readNetwork(networkPath.toString());
+            List<Link> links = network.getLinks().values().stream().
+                    filter(l -> l.getAllowedModes().contains(TransportMode.car)).
+                    collect(Collectors.toList());
+            int numOfLinks = links.size();
+
+            // Create router
+            FreeSpeedTravelTime travelTime = new FreeSpeedTravelTime();
+            LeastCostPathCalculatorFactory fastAStarLandmarksFactory = new SpeedyALTFactory();
+            OnlyTimeDependentTravelDisutilityFactory disutilityFactory = new OnlyTimeDependentTravelDisutilityFactory();
+            TravelDisutility travelDisutility = disutilityFactory.createTravelDisutility(travelTime);
+            LeastCostPathCalculator router = fastAStarLandmarksFactory.createPathCalculator(network, travelDisutility,
+                    travelTime);
+
+            // Read shapefile if presents
+            List<Link> linksInsideShp = new ArrayList<>();
+            List<Link> outsideLinks = new ArrayList<>();
+            if (shp.getShapeFile() != null) {
+                Geometry geometry = shp.getGeometry();
+                for (Link link : links) {
+                    if (MGC.coord2Point(link.getToNode().getCoord()).within(geometry)) {
+                        linksInsideShp.add(link);
+                    }
+                }
+                outsideLinks.addAll(links);
+                outsideLinks.removeAll(linksInsideShp);
+            }
+
+            // Choose random trips to validate
+            CSVPrinter csvWriter = new CSVPrinter(new FileWriter(outputFolder + "/results.csv"), CSVFormat.DEFAULT);
+            csvWriter.printRecord("trip_number", "trip_category", "from_x", "from_y", "to_x", "to_y", "simulated_travel_time", "validated_travel_time");
+            int counter = 0;
+            CoordinateTransformation transformation = TransformationFactory.getCoordinateTransformation(crs.getInputCRS(), TransformationFactory.WGS84);
+            HereMapsRouteValidator validator = new HereMapsRouteValidator(outputFolder.toString(), appCode, "2021-01-01", transformation);
+            validator.setWriteDetailedFiles(writeDetails);
+
+            Link fromLink;
+            Link toLink;
+            String tripType;
+            while (counter < trips) {
+                if (!linksInsideShp.isEmpty()) {
+                    int numOfLinksInsideShp = linksInsideShp.size();
+                    int numOfOutsideLinks = outsideLinks.size();
+
+                    if (counter < 0.6 * trips) {
+                        fromLink = linksInsideShp.get(rnd.nextInt(numOfLinksInsideShp));
+                        toLink = linksInsideShp.get(rnd.nextInt(numOfLinksInsideShp));
+                        tripType = "inside";
+                    } else if (counter < 0.9 * trips) {
+                        fromLink = linksInsideShp.get(rnd.nextInt(numOfLinksInsideShp));
+                        toLink = outsideLinks.get(rnd.nextInt(numOfOutsideLinks));
+                        tripType = "cross-border";
+                    } else {
+                        fromLink = outsideLinks.get(rnd.nextInt(numOfOutsideLinks));
+                        toLink = outsideLinks.get(rnd.nextInt(numOfOutsideLinks));
+                        tripType = "outside";
+                    }
+                } else {
+                    fromLink = links.get(rnd.nextInt(numOfLinks));
+                    toLink = links.get(rnd.nextInt(numOfLinks));
+                    tripType = "unknown";
+                }
+
+                if (!fromLink.getToNode().getId().equals(toLink.getToNode().getId())) {
+                    String detailedFile = outputFolder + "/detailed-record/trip" + counter + ".json.gz";
+                    Coord fromCorrd = fromLink.getToNode().getCoord();
+                    Coord toCoord = toLink.getToNode().getCoord();
+                    double validatedTravelTime = validator.getTravelTime
+                            (fromCorrd, toCoord, 1, detailedFile).getFirst();
+                    if (validatedTravelTime < 60){
+                        continue;
+                    }
+                    double simulatedTravelTime = router.calcLeastCostPath
+                            (fromLink.getToNode(), toLink.getToNode(), 0, null, null).travelTime;
+                    csvWriter.printRecord(Integer.toString(counter), tripType, Double.toString(fromCorrd.getX()),
+                            Double.toString(fromCorrd.getY()), Double.toString(toCoord.getX()),
+                            Double.toString(toCoord.getY()), Double.toString(simulatedTravelTime),
+                            Double.toString(validatedTravelTime));
+                    counter++;
+                }
+            }
+            csvWriter.close();
+            return 0;
         }
 
-        TravelTimeValidationRunner runner = new TravelTimeValidationRunner(scenario.getNetwork(), populationIds, events.toString(), outputFolder, validator, trips, timeWindow, tripFilter);
-
-        runner.run();
-
-        return 0;
+        log.error("Please enter the correct analysis type: [pre-analysis, post-analysis]");
+        return  2;
     }
 
 


### PR DESCRIPTION
The empty network validation (which can be an important process in the pre-analysis) is now moved to the matsim-lib from the matsim kelheim. I will close the PR in the matsim kelheim. 

Once again, this valdiation allow us to validate the free flow speed of the network agianst online API. Small adaptiations are made to the TravelTimeValidation as well as the TravelTimeDistanceValidator interface in order to accommodate the new features. 

Nevertheless, the default values of the newly added parameters are set to the value that the original functionality of the scrpt remain unchanged if you use the original input argument. 

