### PR TITLE
reduce file size in accidents analysis

### DIFF
--- a/contribs/accidents/src/main/java/org/matsim/contrib/accidents/AccidentCostComputationBVWP.java
+++ b/contribs/accidents/src/main/java/org/matsim/contrib/accidents/AccidentCostComputationBVWP.java
@@ -17,7 +17,11 @@ class AccidentCostComputationBVWP {
 	/**
 	 * 
 	 * Provides the accident costs in EUR based on a simplified version of Fig. 13 in the German 'BVWP Methodenhandbuch 2030'
-	 * 
+	 *
+	 * BE AWARE THAT THIS DOES NOT DIFFERENTIATE RAILWAYS AND ROADWAYS AT THE MOMENT!
+	 * //TODO incorporate the global average cost rate for railways from the BVWP Methodenhandbuch! But we need a good guess for the distinction of railways and roads (in the pt network) before that!
+	 * tschlenther, sep '21
+	 *
 	 * @param demand
 	 * @param link
 	 * @param roadType

--- a/contribs/accidents/src/main/java/org/matsim/contrib/accidents/AccidentWriter.java
+++ b/contribs/accidents/src/main/java/org/matsim/contrib/accidents/AccidentWriter.java
@@ -23,7 +23,9 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.text.NumberFormat;
 import java.time.LocalTime;
+import java.util.Locale;
 import java.util.Map;
 
 import org.matsim.api.core.v01.Id;
@@ -102,7 +104,11 @@ class AccidentWriter {
 		} catch (IOException e1) {
 			e1.printStackTrace();
 		}
-		
+
+		NumberFormat nf = NumberFormat.getInstance(Locale.US);
+		nf.setMaximumFractionDigits(2);
+		nf.setGroupingUsed(false);
+
 		for (AccidentLinkInfo info : linkId2info.values()) {			
 			double accidentCostsPerDay_BVWP = 0.0;
 			double accidentCostsPerYear_BVWP = 0.0;
@@ -126,7 +132,7 @@ class AccidentWriter {
 				if (linkComputationMethod.toString().equals( AccidentsConfigGroup.AccidentsComputationMethod.BVWP.toString() )){
 					accidentCostsPerDay_BVWP += info.getTimeSpecificInfo().get(timeBinNr).getAccidentCosts();
 					try {
-						accidentCostsBVWP.write(Double.toString(info.getTimeSpecificInfo().get(timeBinNr).getAccidentCosts()));
+						accidentCostsBVWP.write(nf.format(info.getTimeSpecificInfo().get(timeBinNr).getAccidentCosts()));
 						accidentCostsBVWP.write(";");
 					} catch (IOException e) {
 						e.printStackTrace();
@@ -136,9 +142,9 @@ class AccidentWriter {
 			accidentCostsPerYear_BVWP = accidentCostsPerDay_BVWP * 365;
 			try {
 				if (linkComputationMethod.toString().equals( AccidentsConfigGroup.AccidentsComputationMethod.BVWP.toString() )){
-					accidentCostsBVWP.write(Double.toString(accidentCostsPerDay_BVWP));
+					accidentCostsBVWP.write(nf.format(accidentCostsPerDay_BVWP));
 					accidentCostsBVWP.write(";");
-					accidentCostsBVWP.write(Double.toString(accidentCostsPerYear_BVWP));
+					accidentCostsBVWP.write(nf.format(accidentCostsPerYear_BVWP));
 					accidentCostsBVWP.write(";");
 					accidentCostsBVWP.newLine();
 				}

--- a/contribs/accidents/src/test/java/org/matsim/contrib/accidents/RunTest.java
+++ b/contribs/accidents/src/test/java/org/matsim/contrib/accidents/RunTest.java
@@ -86,12 +86,12 @@ public class RunTest {
 					
 					if (lineCounter == 0 && column == 25) {
 						double accidentCosts = Double.valueOf(columns[column]);
-						Assert.assertEquals("wrong accident costs", 10.37988, accidentCosts , MatsimTestUtils.EPSILON);	
+						Assert.assertEquals("wrong accident costs", 10.38, accidentCosts , MatsimTestUtils.EPSILON);
 					}
 					
 					if (lineCounter == 1 && column == 25) {
 						double accidentCosts = Double.valueOf(columns[column]);
-						Assert.assertEquals("wrong accident costs", 16.68195, accidentCosts , MatsimTestUtils.EPSILON);
+						Assert.assertEquals("wrong accident costs", 16.68, accidentCosts , MatsimTestUtils.EPSILON);
 					}
 										
 				}


### PR DESCRIPTION
Cut down the number of decimal digits to 2, as we display Euro per link or per day respectively. This will decrease the output file size remarkably.
I also inserted a comment into `AccidentCostComputationBVWP` that clarifies that the current approach does not distinguish between railways and roes. Thus, in my opinion, we should currently ignore pt links....