### PR TITLE
Make use of interfaces for NetworkBasedTransportCosts

### DIFF
--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/TourPlanning.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/TourPlanning.java
@@ -25,7 +25,6 @@ import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem;
 import com.graphhopper.jsprit.core.problem.constraint.ConstraintManager;
 import com.graphhopper.jsprit.core.problem.constraint.ServiceDeliveriesFirstConstraint;
 import com.graphhopper.jsprit.core.problem.constraint.VehicleDependentTimeWindowConstraints;
-import com.graphhopper.jsprit.core.problem.cost.VehicleRoutingTransportCosts;
 import com.graphhopper.jsprit.core.problem.solution.VehicleRoutingProblemSolution;
 import com.graphhopper.jsprit.core.util.Solutions;
 import org.apache.log4j.Logger;
@@ -37,7 +36,7 @@ import org.matsim.contrib.freight.carrier.CarrierUtils;
 import org.matsim.contrib.freight.carrier.Carriers;
 import org.matsim.contrib.freight.jsprit.MatsimJspritFactory;
 import org.matsim.contrib.freight.jsprit.NetworkBasedTransportCosts;
-//import commercialtraffic.vwUserCode.NetworkBasedTransportCosts;
+import org.matsim.contrib.freight.jsprit.TransportCosts;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.vehicles.VehicleType;
 
@@ -78,10 +77,7 @@ class TourPlanning {
 		runTourPlanningForCarriers(carriers, scenario, netBasedCosts);
 	}
 
-	static void runTourPlanningForCarriers(Carriers carriers, Scenario scenario, VehicleRoutingTransportCosts transportCosts) throws InterruptedException, ExecutionException {
-
-		if(! (transportCosts instanceof NetworkBasedTransportCosts)) throw new IllegalArgumentException("currently, carrier plans can only be routed with " + NetworkBasedTransportCosts.class +
-				". Sorry! We aim to provide another solution. Please refer to tschlenther or kmt...");
+	static void runTourPlanningForCarriers(Carriers carriers, Scenario scenario, TransportCosts transportCosts) throws InterruptedException, ExecutionException {
 
 		HashMap<Id<Carrier>, Integer> carrierServiceCounterMap = new HashMap<>();
 

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/jsprit/NetworkBasedTransportCosts.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/jsprit/NetworkBasedTransportCosts.java
@@ -72,7 +72,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author stefan schröder
  *
  */
-public class NetworkBasedTransportCosts implements VehicleRoutingTransportCosts {
+public class NetworkBasedTransportCosts implements TransportCosts {
 
 	public interface InternalLeastCostPathCalculatorListener {
 
@@ -853,7 +853,7 @@ public class NetworkBasedTransportCosts implements VehicleRoutingTransportCosts 
 		return new TransportDataKey(fromId, toId, time, vehicleType);
 	}
 
-	LeastCostPathCalculator getRouter() {
+	public LeastCostPathCalculator getRouter() {
 		return createLeastCostPathCalculator();
 	}
 

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/jsprit/NetworkRouter.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/jsprit/NetworkRouter.java
@@ -31,8 +31,8 @@ public class NetworkRouter {
 	 * @param {@link CarrierPlan}
 	 * @param {@link NetworkBasedTransportCosts}
 	 */
-	public static void routePlan(CarrierPlan plan, NetworkBasedTransportCosts netbasedTransportCosts){
-		new TimeAndSpacePlanRouter(netbasedTransportCosts.getRouter(), netbasedTransportCosts.getNetwork(), netbasedTransportCosts.getTravelTime()).run(plan);
+	public static void routePlan(CarrierPlan plan, TransportCosts freightTransportCosts){
+		new TimeAndSpacePlanRouter(freightTransportCosts.getRouter(), freightTransportCosts.getNetwork(), freightTransportCosts.getTravelTime()).run(plan);
 	}
 
 }

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/jsprit/TransportCosts.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/jsprit/TransportCosts.java
@@ -1,0 +1,15 @@
+package org.matsim.contrib.freight.jsprit;
+
+import com.graphhopper.jsprit.core.problem.cost.VehicleRoutingTransportCosts;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.core.router.util.LeastCostPathCalculator;
+import org.matsim.core.router.util.TravelTime;
+
+/**
+ * @author: Steffen Axer
+ */
+public interface TransportCosts extends VehicleRoutingTransportCosts {
+    LeastCostPathCalculator getRouter();
+    Network getNetwork();
+    TravelTime getTravelTime();
+}


### PR DESCRIPTION
This PR allows to replace NetworkBasedTransportCosts with custom implementations as they are now using an interface named `TransportCosts` which extends previous `VehicleRoutingTransportCosts` and provides three additional methods. Those three additional methods have been unsed internally in the previous NetworkBasedTransportCosts, but their implementation have neven been enforced by an interface.