### PR TITLE
Change visibility to allow code reusage instead of code copy

### DIFF
--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/ChangeCommercialJobOperator.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/ChangeCommercialJobOperator.java
@@ -45,7 +45,7 @@ public final class ChangeCommercialJobOperator extends AbstractMultithreadedModu
 
     private final Carriers carriers;
 
-	ChangeCommercialJobOperator(GlobalConfigGroup globalConfigGroup, Carriers carriers) {
+	public ChangeCommercialJobOperator(GlobalConfigGroup globalConfigGroup, Carriers carriers) {
         super(globalConfigGroup);
         this.carriers = carriers;
     }

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/CommercialJobScoreCalculator.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/CommercialJobScoreCalculator.java
@@ -1,6 +1,6 @@
 package org.matsim.contrib.commercialTrafficApplications.jointDemand.commercialJob;
 
-interface CommercialJobScoreCalculator {
+public interface CommercialJobScoreCalculator {
 
     /**
      * @param timeDifference

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/CommercialTrafficAnalysisListener.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/CommercialTrafficAnalysisListener.java
@@ -42,7 +42,7 @@ import java.text.DecimalFormatSymbols;
 import java.util.*;
 
 
-class CommercialTrafficAnalysisListener implements IterationEndsListener {
+public class CommercialTrafficAnalysisListener implements IterationEndsListener {
 
     @Inject
     private

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/CommercialTrafficChecker.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/CommercialTrafficChecker.java
@@ -30,13 +30,12 @@ import org.matsim.contrib.freight.carrier.Carrier;
 import org.matsim.contrib.freight.carrier.Carriers;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
-class CommercialTrafficChecker {
+public class CommercialTrafficChecker {
     private static final Logger log = Logger.getLogger(CommercialTrafficChecker.class);
 
-    static void run(Population population, Carriers carriers){
+    public static void run(Population population, Carriers carriers){
         boolean fail = checkPopulationAttributesConsistency(population);
         if(checkCarrierConsistency(carriers)) fail = true;
         if(fail) throw new RuntimeException("there is a problem with consistency for commercial traffic either in the plans or in the carriers. Please check the log for details.");

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/DefaultCommercialJobGenerator.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/DefaultCommercialJobGenerator.java
@@ -64,7 +64,7 @@ import static org.matsim.contrib.commercialTrafficApplications.jointDemand.comme
 /**
  * Generates carriers and tours depending on next iteration's freight demand
  */
-class DefaultCommercialJobGenerator implements CommercialJobGenerator {
+public class DefaultCommercialJobGenerator implements CommercialJobGenerator {
 
 
 	private final double firsttourTraveltimeBuffer;

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/DefaultCommercialServiceScore.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/DefaultCommercialServiceScore.java
@@ -21,13 +21,13 @@ package org.matsim.contrib.commercialTrafficApplications.jointDemand.commercialJ
  * created by jbischoff, 18.06.2019
  */
 
-class DefaultCommercialServiceScore implements CommercialJobScoreCalculator {
+public class DefaultCommercialServiceScore implements CommercialJobScoreCalculator {
 
     final double maxPerformedScore;
     final double minPerformedScore;
     final double negativeScoreThreshold;
 
-	DefaultCommercialServiceScore(double maxPerformedScore, double minPerformedScore, double negativeScoreThreshold) {
+    public DefaultCommercialServiceScore(double maxPerformedScore, double minPerformedScore, double negativeScoreThreshold) {
         this.maxPerformedScore = maxPerformedScore;
         this.minPerformedScore = minPerformedScore;
         this.negativeScoreThreshold = negativeScoreThreshold;

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/JointDemandConfigGroup.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/JointDemandConfigGroup.java
@@ -64,7 +64,7 @@ public class JointDemandConfigGroup extends ReflectiveConfigGroup {
     /**
      * @return -- {@value #FIRSTLEGBUFFERDESC}
      */
-//    @StringGetter(FIRSTLEGBUFFER)
+public //    @StringGetter(FIRSTLEGBUFFER)
     double getFirstLegTraveltimeBufferFactor() {
         return firstLegTraveltimeBufferFactor;
     }

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/ScoreCommercialJobs.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/ScoreCommercialJobs.java
@@ -39,7 +39,7 @@ import org.matsim.core.api.experimental.events.EventsManager;
 import java.util.*;
 import java.util.stream.Collectors;
 
-class ScoreCommercialJobs implements ActivityStartEventHandler, ActivityEndEventHandler {
+public class ScoreCommercialJobs implements ActivityStartEventHandler, ActivityEndEventHandler {
 
     private final Population population;
 
@@ -68,7 +68,7 @@ class ScoreCommercialJobs implements ActivityStartEventHandler, ActivityEndEvent
     }
 
 
-    void prepareTourArrivalsForDay() {
+    public void prepareTourArrivalsForDay() {
         freightAgent2Jobs.clear();
 
         Set<Plan> freightPlans = population.getPersons().values().stream()

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/TourLengthAnalyzer.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/TourLengthAnalyzer.java
@@ -42,7 +42,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-class TourLengthAnalyzer implements ActivityEndEventHandler, LinkEnterEventHandler, PersonEntersVehicleEventHandler, PersonLeavesVehicleEventHandler {
+public class TourLengthAnalyzer implements ActivityEndEventHandler, LinkEnterEventHandler, PersonEntersVehicleEventHandler, PersonLeavesVehicleEventHandler {
 
     private final Map<Id<Vehicle>, Set<Id<Person>>> currentFreightVehicleForDelivery = new HashMap<>();
     private final Map<Id<Person>, Double> deliveryAgentDistances = new HashMap<>();

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/TourPlanning.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/commercialJob/TourPlanning.java
@@ -55,11 +55,11 @@ import java.util.stream.Collectors;
 
 //import org.matsim.contrib.freight.jsprit.NetworkRouter;
 
-class TourPlanning {
+public class TourPlanning {
 
 	private static final Logger log = Logger.getLogger(TourPlanning.class);
 
-	static void runTourPlanningForCarriersWithNetBasedCosts(Carriers carriers, Scenario scenario, int jSpritTimeSliceWidth,
+	public static void runTourPlanningForCarriersWithNetBasedCosts(Carriers carriers, Scenario scenario, int jSpritTimeSliceWidth,
 															TravelTime travelTime) throws ExecutionException, InterruptedException {
 
 		Set<VehicleType> vehicleTypes = new HashSet<>();
@@ -78,7 +78,7 @@ class TourPlanning {
 		runTourPlanningForCarriers(carriers, scenario, netBasedCosts);
 	}
 
-	static void runTourPlanningForCarriers(Carriers carriers, Scenario scenario, VehicleRoutingTransportCosts transportCosts) throws InterruptedException, ExecutionException {
+	public static void runTourPlanningForCarriers(Carriers carriers, Scenario scenario, VehicleRoutingTransportCosts transportCosts) throws InterruptedException, ExecutionException {
 
 		if(! (transportCosts instanceof NetworkBasedTransportCosts)) throw new IllegalArgumentException("currently, carrier plans can only be routed with " + NetworkBasedTransportCosts.class +
 				". Sorry! We aim to provide another solution. Please refer to tschlenther or kmt...");


### PR DESCRIPTION
This PR enables users to create custom JointDemandModule by reusing existing code instead of copying code. Switched some classes and static methods from package exclusive visibility to public. (@tschlenther, @mrieser, @kt86) 