### PR TITLE
MATSimTestUtils: throw exception if file not found

### DIFF
--- a/matsim/src/test/java/org/matsim/testcases/MatsimTestUtils.java
+++ b/matsim/src/test/java/org/matsim/testcases/MatsimTestUtils.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -76,8 +77,8 @@ public final class MatsimTestUtils extends TestWatcher {
 				}
 				assertEquals( "Lines have different content: ", lineInput.trim(), lineOutput.trim() );
 			}
-		} catch ( Exception ee ) {
-			ee.printStackTrace();
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
 		}
 	}
 


### PR DESCRIPTION
... or other IOException.

Before that tests are passing even if the files were not found, because in the `catch` section only the stack trace was printed.
--> This seems to me unexpected, because without files it is not possible to compare and therefore the check should fail.

Now it will throw that IOException.