### PR TITLE
upgrade bean validation to 7.0.x

### DIFF
--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/JointDemandConfigGroup.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/JointDemandConfigGroup.java
@@ -24,8 +24,8 @@ package org.matsim.contrib.commercialTrafficApplications.jointDemand;/*
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ReflectiveConfigGroup;
 
-import javax.validation.constraints.Positive;
-import javax.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 
 import java.util.Map;
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystemParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalSystemParams.java
@@ -24,8 +24,8 @@ import java.net.URL;
 import java.util.Map;
 
 import javax.annotation.Nullable;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigGroup;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/fare/DrtFareParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/fare/DrtFareParams.java
@@ -22,7 +22,7 @@ package org.matsim.contrib.drt.fare;
 
 import java.util.Map;
 
-import javax.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.PositiveOrZero;
 
 import org.matsim.core.config.ReflectiveConfigGroup;
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DrtRequestInsertionRetryParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DrtRequestInsertionRetryParams.java
@@ -22,8 +22,8 @@ package org.matsim.contrib.drt.optimizer.insertion;
 
 import java.util.Map;
 
-import javax.validation.constraints.Positive;
-import javax.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 
 import org.matsim.core.config.ReflectiveConfigGroup;
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchParams.java
@@ -20,8 +20,8 @@
 
 package org.matsim.contrib.drt.optimizer.insertion;
 
-import javax.validation.constraints.DecimalMin;
-import javax.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.PositiveOrZero;
 
 /**
  * @author Michal Maciejewski (michalm)

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchParams.java
@@ -20,7 +20,7 @@
 
 package org.matsim.contrib.drt.optimizer.insertion;
 
-import javax.validation.constraints.Positive;
+import jakarta.validation.constraints.Positive;
 
 /**
  * @author Michal Maciejewski (michalm)

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/Feedforward/FeedforwardRebalancingStrategyParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/Feedforward/FeedforwardRebalancingStrategyParams.java
@@ -20,8 +20,8 @@ package org.matsim.contrib.drt.optimizer.rebalancing.Feedforward;
 
 import java.util.Map;
 
-import javax.validation.constraints.Positive;
-import javax.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingParams;
 import org.matsim.core.config.ReflectiveConfigGroup;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/RebalancingParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/RebalancingParams.java
@@ -20,9 +20,9 @@ package org.matsim.contrib.drt.optimizer.rebalancing;
 
 import java.util.Map;
 
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
-import javax.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 
 import org.matsim.contrib.drt.optimizer.rebalancing.Feedforward.FeedforwardRebalancingStrategyParams;
 import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingStrategyParams;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategyParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategyParams.java
@@ -20,8 +20,8 @@ package org.matsim.contrib.drt.optimizer.rebalancing.mincostflow;
 
 import java.util.Map;
 
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingParams;
 import org.matsim.core.config.ReflectiveConfigGroup;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/plusOne/PlusOneRebalancingStrategyParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/plusOne/PlusOneRebalancingStrategyParams.java
@@ -20,7 +20,7 @@ package org.matsim.contrib.drt.optimizer.rebalancing.plusOne;
 
 import java.util.Map;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingParams;
 import org.matsim.core.config.ReflectiveConfigGroup;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehicleDensityTargetCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehicleDensityTargetCalculator.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.ToDoubleFunction;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 import org.matsim.contrib.drt.analysis.zonal.DrtZonalSystem;
 import org.matsim.contrib.drt.analysis.zonal.DrtZone;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehiclesToPopulationRatioTargetCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehiclesToPopulationRatioTargetCalculator.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 import java.util.function.ToDoubleFunction;
 import java.util.stream.Collectors;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.population.Activity;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -27,11 +27,11 @@ import java.util.Map;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
-import javax.validation.constraints.DecimalMin;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
-import javax.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.TransportMode;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtTaskType.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtTaskType.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 import org.matsim.contrib.dvrp.schedule.Task;
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/speedup/DrtSpeedUpParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/speedup/DrtSpeedUpParams.java
@@ -20,11 +20,11 @@
 
 package org.matsim.contrib.drt.speedup;
 
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.DecimalMin;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
-import javax.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ReflectiveConfigGroup;

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigGroup.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigGroup.java
@@ -23,11 +23,11 @@ import java.net.URL;
 import java.util.Map;
 
 import javax.annotation.Nullable;
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
-import javax.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.TransportMode;

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/ZonalSystemParams.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/ZonalSystemParams.java
@@ -23,8 +23,8 @@ package org.matsim.contrib.zone;
 import java.net.URL;
 import java.util.Map;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
 
 import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ReflectiveConfigGroup;

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrixParams.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrixParams.java
@@ -22,7 +22,7 @@ package org.matsim.contrib.zone.skims;
 
 import java.util.Map;
 
-import javax.validation.constraints.Positive;
+import jakarta.validation.constraints.Positive;
 
 import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ReflectiveConfigGroup;

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/EvConfigGroup.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/EvConfigGroup.java
@@ -22,8 +22,8 @@ package org.matsim.contrib.ev;
 import java.util.Map;
 
 import javax.annotation.Nullable;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ReflectiveConfigGroup;

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/temperature/TemperatureChangeConfigGroup.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/temperature/TemperatureChangeConfigGroup.java
@@ -24,8 +24,8 @@ package org.matsim.contrib.ev.temperature;/*
 import java.net.URL;
 import java.util.Map;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ReflectiveConfigGroup;

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/FreightConfigGroup.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/FreightConfigGroup.java
@@ -22,7 +22,7 @@ import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ReflectiveConfigGroup;
 import org.matsim.core.utils.io.IOUtils;
 
-import javax.validation.constraints.Positive;
+import jakarta.validation.constraints.Positive;
 import java.net.URL;
 import java.util.Map;
 

--- a/contribs/sharing/src/main/java/org/matsim/contrib/sharing/run/SharingServiceConfigGroup.java
+++ b/contribs/sharing/src/main/java/org/matsim/contrib/sharing/run/SharingServiceConfigGroup.java
@@ -5,8 +5,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnegative;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ReflectiveConfigGroup;

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/assignment/AssignmentETaxiOptimizerParams.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/assignment/AssignmentETaxiOptimizerParams.java
@@ -19,8 +19,8 @@
 
 package org.matsim.contrib.etaxi.optimizer.assignment;
 
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.Positive;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.Positive;
 
 import org.matsim.contrib.taxi.optimizer.AbstractTaxiOptimizerParams;
 import org.matsim.contrib.taxi.optimizer.assignment.AssignmentTaxiOptimizerParams;

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/rules/RuleBasedETaxiOptimizerParams.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/rules/RuleBasedETaxiOptimizerParams.java
@@ -19,8 +19,8 @@
 
 package org.matsim.contrib.etaxi.optimizer.rules;
 
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.Positive;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.Positive;
 
 import org.matsim.contrib.taxi.optimizer.AbstractTaxiOptimizerParams;
 import org.matsim.contrib.taxi.optimizer.rules.RuleBasedTaxiOptimizerParams;

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/fare/TaxiFareParams.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/fare/TaxiFareParams.java
@@ -22,7 +22,7 @@ package org.matsim.contrib.taxi.fare;
 
 import java.util.Map;
 
-import javax.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.PositiveOrZero;
 
 import org.matsim.core.config.ReflectiveConfigGroup;
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/AbstractTaxiOptimizerParams.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/AbstractTaxiOptimizerParams.java
@@ -21,7 +21,7 @@ package org.matsim.contrib.taxi.optimizer;
 
 import java.util.Map;
 
-import javax.validation.constraints.Positive;
+import jakarta.validation.constraints.Positive;
 
 import org.matsim.core.config.ReflectiveConfigGroup;
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/assignment/AssignmentTaxiOptimizerParams.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/assignment/AssignmentTaxiOptimizerParams.java
@@ -21,8 +21,8 @@ package org.matsim.contrib.taxi.optimizer.assignment;
 
 import java.util.Map;
 
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 import org.matsim.contrib.taxi.optimizer.AbstractTaxiOptimizerParams;
 import org.matsim.contrib.taxi.optimizer.assignment.TaxiToRequestAssignmentCostProvider.Mode;

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/fifo/FifoTaxiOptimizerParams.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/fifo/FifoTaxiOptimizerParams.java
@@ -19,7 +19,7 @@
 
 package org.matsim.contrib.taxi.optimizer.fifo;
 
-import javax.validation.constraints.Positive;
+import jakarta.validation.constraints.Positive;
 
 import org.matsim.contrib.taxi.optimizer.AbstractTaxiOptimizerParams;
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/rules/RuleBasedTaxiOptimizerParams.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/rules/RuleBasedTaxiOptimizerParams.java
@@ -21,8 +21,8 @@ package org.matsim.contrib.taxi.optimizer.rules;
 
 import java.util.Map;
 
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 import org.matsim.contrib.taxi.optimizer.AbstractTaxiOptimizerParams;
 import org.matsim.contrib.taxi.optimizer.rules.RuleBasedRequestInserter.Goal;

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiConfigGroup.java
@@ -26,9 +26,9 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.TransportMode;

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiTaskType.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiTaskType.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 import org.matsim.contrib.dvrp.schedule.Task;
 

--- a/contribs/vsp/src/main/java/playground/vsp/pt/fare/DistanceBasedPtFareParams.java
+++ b/contribs/vsp/src/main/java/playground/vsp/pt/fare/DistanceBasedPtFareParams.java
@@ -4,7 +4,7 @@ import org.matsim.api.core.v01.TransportMode;
 import org.matsim.core.config.ReflectiveConfigGroup;
 import org.matsim.pt.PtConstants;
 
-import javax.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.util.Map;
 
 /**

--- a/contribs/vsp/src/main/java/playground/vsp/pt/fare/PtFareConfigGroup.java
+++ b/contribs/vsp/src/main/java/playground/vsp/pt/fare/PtFareConfigGroup.java
@@ -2,7 +2,7 @@ package playground.vsp.pt.fare;
 
 import org.matsim.core.config.ReflectiveConfigGroup;
 
-import javax.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.util.Map;
 
 public class PtFareConfigGroup extends ReflectiveConfigGroup {

--- a/matsim/pom.xml
+++ b/matsim/pom.xml
@@ -262,22 +262,22 @@
 		<dependency>
 			<groupId>jakarta.validation</groupId>
 			<artifactId>jakarta.validation-api</artifactId>
-			<version>2.0.2</version>
+			<version>3.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator</artifactId>
-			<version>6.1.7.Final</version>
+			<version>7.0.1.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator-annotation-processor</artifactId>
-			<version>6.1.7.Final</version>
+			<version>7.0.1.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish</groupId>
-			<artifactId>javax.el</artifactId>
-			<version>3.0.1-b12</version>
+			<artifactId>jakarta.el</artifactId>
+			<version>4.0.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/matsim/src/main/java/org/matsim/core/config/ConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/ConfigGroup.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 import org.apache.log4j.Logger;
 import org.matsim.core.api.internal.MatsimExtensionPoint;

--- a/matsim/src/main/java/org/matsim/core/config/consistency/BeanValidationConfigConsistencyChecker.java
+++ b/matsim/src/main/java/org/matsim/core/config/consistency/BeanValidationConfigConsistencyChecker.java
@@ -26,10 +26,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-import javax.validation.Validation;
-import javax.validation.Validator;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigGroup;

--- a/matsim/src/main/java/org/matsim/core/config/groups/GlobalConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/GlobalConfigGroup.java
@@ -21,8 +21,8 @@
 package org.matsim.core.config.groups;
 
 import java.util.Map;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
 import org.apache.log4j.Logger;
 import org.matsim.core.config.ReflectiveConfigGroup;
 

--- a/matsim/src/main/java/org/matsim/core/config/groups/QSimConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/QSimConfigGroup.java
@@ -28,8 +28,8 @@ import org.matsim.core.utils.misc.OptionalTime;
 import org.matsim.core.utils.misc.Time;
 import org.matsim.vis.snapshotwriters.SnapshotWritersModule;
 
-import javax.validation.constraints.Positive;
-import javax.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.util.*;
 
 /**

--- a/matsim/src/main/java/org/matsim/core/mobsim/hermes/HermesConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/hermes/HermesConfigGroup.java
@@ -20,7 +20,7 @@ package org.matsim.core.mobsim.hermes;
 
 import java.util.Map;
 import java.util.Set;
-import javax.validation.constraints.Positive;
+import jakarta.validation.constraints.Positive;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ReflectiveConfigGroup;

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/agents/BasicPlanAgentImpl.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/agents/BasicPlanAgentImpl.java
@@ -23,7 +23,7 @@
 
 import java.util.List;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;

--- a/matsim/src/test/java/org/matsim/core/config/consistency/BeanValidationConfigConsistencyCheckerTest.java
+++ b/matsim/src/test/java/org/matsim/core/config/consistency/BeanValidationConfigConsistencyCheckerTest.java
@@ -27,9 +27,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import javax.validation.ConstraintViolationException;
-import javax.validation.constraints.Positive;
-import javax.validation.constraints.PositiveOrZero;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Test;


### PR DESCRIPTION
Started using Java 17 in my playground project and ran into the following issue:

Validation 6.1.x does not handle Java 17 properly (e.g. cannot recognise records). This issue does not affect matsim (yet) as we are at Java 11. Currently, it affects projects that use Java 17 and depend on matsim.