### PR TITLE
Run appveyor when merging to 13.x; use jdk 16

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,13 +4,13 @@ version: '{build}'
 
 branches:
   only:
-    - master
+    - 13.x
 skip_tags: true
 clone_depth: 5
 
 environment:
   matrix:
-    - JAVA_HOME: C:\Program Files\Java\jdk11
+    - JAVA_HOME: C:\Program Files\Java\jdk16
   fast_finish: true
 
 image: Visual Studio 2019


### PR DESCRIPTION
- we should also test pushes to 13.x on the windows platform
- use the latest JDK available (17 not yet there)