### PR TITLE
prevent potential StackOverflowError in LinkQuadTree with loop-links …

### DIFF
--- a/matsim/src/main/java/org/matsim/core/network/LinkQuadTree.java
+++ b/matsim/src/main/java/org/matsim/core/network/LinkQuadTree.java
@@ -98,7 +98,7 @@ public final class LinkQuadTree {
 //		private final static int CHILD_SE = 2;
 //		private final static int CHILD_SW = 3;
 		
-		private enum ChildPosition {CHILD_NW, CHILD_NE, CHILD_SE, CHILD_SW,NO_CHILD } ;
+		private enum ChildPosition {CHILD_NW, CHILD_NE, CHILD_SE, CHILD_SW,NO_CHILD }
 
 		// I replaced the "int" by an enum since I find it easier to read, and I needed/wanted to understand the code.  If this causes
 		// computational performance losses, we need to change it back.  kai, sep'16
@@ -272,13 +272,13 @@ public final class LinkQuadTree {
 			if (x >= centerX && y >= centerY) {
 				return ChildPosition.CHILD_NE;
 			}
-			if (x >= centerX && y < centerY) {
+			if (x >= centerX/* && y < centerY // this is always true */) {
 				return ChildPosition.CHILD_SE;
 			}
-			if (x < centerX && y < centerY) {
+//			if (x < centerX && y < centerY) { // this should now always be true
 				return ChildPosition.CHILD_SW;
-			}
-			throw new RuntimeException("should never get here since (x,y) has to be _somewhere_ with respect to centerX and centerY") ;
+//			}
+//			throw new RuntimeException("should never get here since (x,y) has to be _somewhere_ with respect to centerX and centerY") ;
 		}
 
 		/**
@@ -361,15 +361,15 @@ public final class LinkQuadTree {
 
 			if (fx == tx) {
 				// enforce minimal extent
-				this.minX = fx - fx*1e-8; // make it adaptive within the number of significant digits
-				this.maxX = fx + fx*1e-8; // make it adaptive within the number of significant digits
+				this.minX = fx - Math.abs(fx)*1e-8; // make it adaptive within the number of significant digits
+				this.maxX = fx + Math.abs(fx)*1e-8; // make it adaptive within the number of significant digits
 			} else {
 				this.minX = Math.min(fx, tx);
 				this.maxX = Math.max(fx, tx);
 			}
 			if (fy == ty) {
-				this.minY = fy - fy*1e-8; // make it adaptive within the number of significant digits
-				this.maxY = fy + fy*1e-8; // make it adaptive within the number of significant digits
+				this.minY = fy - Math.abs(fy)*1e-8; // make it adaptive within the number of significant digits
+				this.maxY = fy + Math.abs(fy)*1e-8; // make it adaptive within the number of significant digits
 			} else {
 				this.minY = Math.min(fy, ty);
 				this.maxY = Math.max(fy, ty);

--- a/matsim/src/test/java/org/matsim/core/network/LinkQuadTreeTest.java
+++ b/matsim/src/test/java/org/matsim/core/network/LinkQuadTreeTest.java
@@ -145,6 +145,31 @@ public class LinkQuadTreeTest {
 	}
 
 	@Test
+	public void testPut_zeroLengthLink_negativeCoords() {
+		/* Same as test above, but with negative coords
+		 */
+
+		Scenario s = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+
+		LinkQuadTree qt = new LinkQuadTree(0, 0, -1000, -1000);
+		Link l13 = createLink(s, 0, -1000, -400, -400);
+		Link l23 = createLink(s, -1000, -1000, -400, -400);
+		Link l53 = createLink(s, 0, 0, -400, -400);
+		Link l63 = createLink(s, -1000, 0, -400, -400);
+		Link l43 = createLink(s, -400, -400, -400, -400);
+		Link l34 = createLink(s, -400, -400, -400, -400);
+		qt.put(l13);
+		qt.put(l23);
+		qt.put(l53);
+		qt.put(l63);
+		qt.put(l43);
+		qt.put(l34);
+
+		// mostly check that there is no exception like StackOverflowError
+		Assert.assertEquals(l13, qt.getNearest(-100, -800));
+	}
+
+	@Test
 	public void testRemove() {
 		Scenario s = ScenarioUtils.createScenario(ConfigUtils.createConfig());
 


### PR DESCRIPTION
…with negative coords

When coordinates used negative values, the calculation of a safe bounding box for loop links was incorrect, resulting to mixed up min and max values. When inserting two loop links on top of each other into the LinkQuadTree with negative coords, those mixed up min/max-boundary values resulted in some checks always failing, resulting in splitting and splitting the region further and further, until the stack was full.