### PR TITLE
drt: prevent rejections in selective insertion

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProvider.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProvider.java
@@ -84,7 +84,7 @@ public class SelectiveInsertionProvider implements InsertionProvider {
 						vehicleEntries.parallelStream()
 								//generate feasible insertions (wrt occupancy limits)
 								.flatMap(e -> insertionGenerator.generateInsertions(drtRequest, e).stream())
-								//map them to insertions with admissible detour times
+								//map them to insertions with restrictive detour times
 								.map(restrictiveTimeData::createInsertionWithDetourData))).join();
 
 		return bestInsertion.map(InsertionWithDetourData::getInsertion).stream().collect(toList());

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchQSimModule.java
@@ -27,9 +27,9 @@ import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpModes;
-import org.matsim.core.modal.ModalProviders;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.zone.skims.DvrpTravelTimeMatrix;
+import org.matsim.core.modal.ModalProviders;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
@@ -57,9 +57,15 @@ public class SelectiveInsertionSearchQSimModule extends AbstractDvrpModeQSimModu
 			var provider = SelectiveInsertionProvider.create(drtCfg, insertionCostCalculatorFactory,
 					getter.getModal(DvrpTravelTimeMatrix.class),
 					getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool());
-			var insertionCostCalculator = insertionCostCalculatorFactory.create(PathData::getTravelTime, null);
+			// Use 0 as the cost for the selected insertion:
+			// - In the selective strategy, there is at most 1 insertion pre-selected. So no need to compute as there is
+			//   no other insertion to compare with.
+			// - We assume that the travel times obtained from DvrpTravelTimeMatrix are reasonably well estimated(*),
+			//   so we do not want to check for time window violations
+			//  Re (*) currently, free-speed travel times are quite accurate. We still need to adjust them to different times of day.
+			InsertionCostCalculator<PathData> zeroCostInsertionCostCalculator = (drtRequest, insertion) -> 0;
 			return new DefaultDrtInsertionSearch(provider, getter.getModal(DetourPathCalculator.class),
-					insertionCostCalculator);
+					zeroCostInsertionCostCalculator);
 		})).asEagerSingleton();
 
 		addModalComponent(SingleInsertionDetourPathCalculator.class,


### PR DESCRIPTION
After improving travel time estimation in DVRP (zonal matrix + sparse node-node matrix), we can skip checking TW constraints and blindly accept the pre-selected insertion. Since currently we only estimate free-speed travel times, we need to keep this parameter to make travel times more realistic (for the time being):
https://github.com/matsim-org/matsim-libs/blob/0a8a8472b84bd65e2e93bb1bd0d36be9426eb2c0/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchParams.java#L35
One potential TODO is to adjust travel time estimation for different times of day (so not only free-speed).

I tried this change on the Berlin case with DRT (10% scenario, 270k private car trips converted into DRT, 6k DRT 4-seat buses) and got 0 rejections.