### PR TITLE
Increase default interval for writing files

### DIFF
--- a/matsim/src/main/java/org/matsim/core/config/groups/ControlerConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/ControlerConfigGroup.java
@@ -85,9 +85,9 @@ public final class ControlerConfigGroup extends ReflectiveConfigGroup {
 
 	private Set<EventsFileFormat> eventsFileFormats = Collections.unmodifiableSet(EnumSet.of(EventsFileFormat.xml));
 
-	private int writeEventsInterval=10;
-	private int writePlansInterval=10;
-	private int writeTripsInterval = 10;
+	private int writeEventsInterval= 50;
+	private int writePlansInterval= 50;
+	private int writeTripsInterval = 50;
 	private String mobsim = MobsimType.qsim.toString();
 	private int writeSnapshotsInterval = 1;
 	private boolean createGraphs = true;

--- a/matsim/src/main/java/org/matsim/core/config/groups/LinkStatsConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/LinkStatsConfigGroup.java
@@ -33,7 +33,7 @@ public final class LinkStatsConfigGroup extends ReflectiveConfigGroup {
 	private static final String WRITELINKSTATSINTERVAL = "writeLinkStatsInterval";
 	private static final String AVERAGELINKSTATSOVERITERATIONS = "averageLinkStatsOverIterations";
 
-	private int writeLinkStatsInterval = 10;
+	private int writeLinkStatsInterval = 50;
 	private int averageLinkStatsOverIterations = 5;
 
 	public LinkStatsConfigGroup() {

--- a/matsim/src/test/java/org/matsim/analysis/LinkStatsControlerListenerTest.java
+++ b/matsim/src/test/java/org/matsim/analysis/LinkStatsControlerListenerTest.java
@@ -75,6 +75,8 @@ public class LinkStatsControlerListenerTest {
 		});
 		LinkStatsControlerListener lscl = injector.getInstance(LinkStatsControlerListener.class);
 
+		config.linkStats().setWriteLinkStatsInterval(5);
+
 		// test defaults
 		Assert.assertEquals(10, config.linkStats().getWriteLinkStatsInterval());
 		Assert.assertEquals(5, config.linkStats().getAverageLinkStatsOverIterations());

--- a/matsim/src/test/java/org/matsim/analysis/LinkStatsControlerListenerTest.java
+++ b/matsim/src/test/java/org/matsim/analysis/LinkStatsControlerListenerTest.java
@@ -75,7 +75,7 @@ public class LinkStatsControlerListenerTest {
 		});
 		LinkStatsControlerListener lscl = injector.getInstance(LinkStatsControlerListener.class);
 
-		config.linkStats().setWriteLinkStatsInterval(5);
+		config.linkStats().setWriteLinkStatsInterval(10);
 
 		// test defaults
 		Assert.assertEquals(10, config.linkStats().getWriteLinkStatsInterval());

--- a/matsim/src/test/java/org/matsim/core/config/groups/ControlerConfigGroupTest.java
+++ b/matsim/src/test/java/org/matsim/core/config/groups/ControlerConfigGroupTest.java
@@ -111,7 +111,7 @@ public class ControlerConfigGroupTest {
 	public void testWritePlansInterval() {
 		ControlerConfigGroup cg = new ControlerConfigGroup();
 		// test initial value
-		Assert.assertEquals(10, cg.getWritePlansInterval());
+		Assert.assertEquals(50, cg.getWritePlansInterval());
 		// test setting with setMobsim
 		cg.setWritePlansInterval(4);
 		Assert.assertEquals(4, cg.getWritePlansInterval());

--- a/matsim/src/test/java/org/matsim/core/config/groups/LinkStatsConfigGroupTest.java
+++ b/matsim/src/test/java/org/matsim/core/config/groups/LinkStatsConfigGroupTest.java
@@ -31,8 +31,8 @@ public class LinkStatsConfigGroupTest {
 	public void testWriteLinkStatsInterval() {
 		LinkStatsConfigGroup cg = new LinkStatsConfigGroup();
 		// test initial value
-		Assert.assertEquals(10, cg.getWriteLinkStatsInterval());
-		Assert.assertEquals("10", cg.getValue("writeLinkStatsInterval"));
+		Assert.assertEquals(50, cg.getWriteLinkStatsInterval());
+		Assert.assertEquals("50", cg.getValue("writeLinkStatsInterval"));
 		// test setting with setMobsim
 		cg.setWriteLinkStatsInterval(4);
 		Assert.assertEquals(4, cg.getWriteLinkStatsInterval());

--- a/matsim/src/test/java/org/matsim/integration/replanning/ResumableRunsIT.java
+++ b/matsim/src/test/java/org/matsim/integration/replanning/ResumableRunsIT.java
@@ -61,6 +61,7 @@ public class ResumableRunsIT {
 		config.controler().setLastIteration(11);
 		config.controler().setWriteEventsInterval(1);
 		config.global().setNumberOfThreads(1); // only use one thread to rule out other disturbances for the test
+		config.controler().setWritePlansInterval(10);
 
 		// run1
 		config.controler().setOutputDirectory(utils.getOutputDirectory() + "/run1/");


### PR DESCRIPTION
By default, event files, link stats and plans are written out every 10th iteration. In our experience, these files are rarely used from individual iterations and use up a lot of space. 

This PR increases the defaults to every 50th iteration.  An even higher value might also be considered.