### PR TITLE
config: accept only "true"/"false" strings as boolean values

### DIFF
--- a/contribs/parking/src/main/resources/parkingsearch/config.xml
+++ b/contribs/parking/src/main/resources/parkingsearch/config.xml
@@ -31,7 +31,7 @@
 		<param name="flowCapacityFactor" value="1.0"/>
 		<param name="storageCapacityFactor" value="1.0"/>
 		<param name="stuckTime" value="10"/>
-		<param name="removeStuckVehicles" value="yes"/>
+		<param name="removeStuckVehicles" value="false"/>
 		<param name="simStarttimeInterpretation" value="onlyUseStarttime"/>
 	</module>
 	<module name="strategy">

--- a/matsim/src/main/java/org/matsim/core/config/ReflectiveConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/ReflectiveConfigGroup.java
@@ -33,6 +33,8 @@ import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.core.api.internal.MatsimExtensionPoint;
 
+import com.google.common.base.Preconditions;
+
 /**
  * A module using reflection for easy implementation of config groups.
  * <br>
@@ -289,6 +291,8 @@ public abstract class ReflectiveConfigGroup extends ConfigGroup implements Matsi
 			setter.invoke( this , Long.parseLong( value ) );
 		}
 		else if ( type.equals( Boolean.class ) || type.equals( Boolean.TYPE ) ) {
+			Preconditions.checkArgument(value.equals("true") || value.equals("false"),
+					"Incorrect value of the boolean parameter: %s", value);
 			setter.invoke( this , Boolean.parseBoolean( value ) );
 		}
 		else if ( type.equals( Character.class ) || type.equals( Character.TYPE ) ) {


### PR DESCRIPTION
Otherwise all non-"true" values are considered "false".

Like here: https://github.com/matsim-scenarios/matsim-berlin/blob/5.5.x/scenarios/berlin-v5.5-1pct/input/drt/berlin-drt-v5.5-1pct.config.xml#L195. The intention was to actually apply the filtering to the "drt" mode (so the value was meant to be "true", but currently no filtering is done).
