### PR TITLE
dvrp: add index-based hash table to sparse row to minimise binary search

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpModeRoutingNetworkModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpModeRoutingNetworkModule.java
@@ -73,7 +73,7 @@ public class DvrpModeRoutingNetworkModule extends AbstractDvrpModeModule {
 				return subnetwork;
 			})).asEagerSingleton();
 
-			//lazily initialised: optimisers may do not need it
+			//lazily initialised: optimisers may not need it
 			bindModal(DvrpTravelTimeMatrix.class).toProvider(modalProvider(
 					getter -> new DvrpTravelTimeMatrix(getter.getModal(Network.class),
 							dvrpConfigGroup.getTravelTimeMatrixParams(), globalConfigGroup.getNumberOfThreads(),

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/SparseMatrix.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/SparseMatrix.java
@@ -20,11 +20,11 @@
 
 package org.matsim.contrib.zone.skims;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Node;
@@ -34,7 +34,7 @@ import com.google.common.base.Preconditions;
 /**
  * @author Michal Maciejewski (michalm)
  */
-public class SparseMatrix {
+public final class SparseMatrix {
 	//Range of unsigned short: 0-65535 (18:12:15)
 	//In case 18 hours is not enough, we can reduce the resolution from seconds to tens of seconds
 	private static final int MAX_UNSIGNED_SHORT = Short.MAX_VALUE - Short.MIN_VALUE;
@@ -49,13 +49,11 @@ public class SparseMatrix {
 		}
 	}
 
-	public static class SparseRow {
+	private static final class Bucket {
 		private final int[] nodeIndices; // sorted for binary search
 		private final short[] values; // aligned with nodeIndices (using 'short' as in Matrix)
 
-		private final BitSet presentNodes = new BitSet();
-
-		public SparseRow(List<NodeAndTime> nodeAndTimes) {
+		private Bucket(List<NodeAndTime> nodeAndTimes) {
 			var nodeAndTimeArray = nodeAndTimes.toArray(new NodeAndTime[0]);
 			Arrays.sort(nodeAndTimeArray, Comparator.comparingInt(nodeAndTime -> nodeAndTime.nodeIdx));
 
@@ -67,23 +65,74 @@ public class SparseMatrix {
 				Preconditions.checkArgument(Double.isFinite(e.time) && e.time >= 0 && e.time < MAX_UNSIGNED_SHORT);
 				nodeIndices[i] = e.nodeIdx;
 				values[i] = (short)e.time;
+			}
+		}
+
+		private int get(int toNodeIndex) {
+			return values[Arrays.binarySearch(nodeIndices, toNodeIndex)];
+		}
+	}
+
+	public static final class SparseRow {
+		// 64-128 seemed to work best when micro-benchmarking the berlin network from the robo-taxi papers
+		// for a bigger neighbourhood (maxNeighborDistance = 4000). On average, there is 620 neighbouring nodes
+		// (min 2; max 1941).
+		// Interestingly, the old version (not using buckets) was minimally worse (the tests included all nodes,
+		// so in most of the cases from-to nodes were not neighbours and get filtered out by the bit set)
+		private static final int MAX_AVERAGE_BUCKET_SIZE = 64;
+
+		private final int mask;
+		private final Bucket[] buckets;
+
+		private final BitSet presentNodes = new BitSet();
+
+		public SparseRow(List<NodeAndTime> nodeAndTimes) {
+			if (nodeAndTimes.isEmpty()) {
+				mask = 0;
+				buckets = null;
+				return;
+			}
+
+			int roundedDownBucketCount = nodeAndTimes.size() / MAX_AVERAGE_BUCKET_SIZE;
+			//must be power of 2 due to masking
+			int bucketCount = Math.max(Integer.highestOneBit(2 * roundedDownBucketCount), 1);
+			mask = bucketCount - 1;
+			buckets = new Bucket[bucketCount];
+
+			List<List<NodeAndTime>> nodeAndTimeLists = new ArrayList<>(bucketCount);
+
+			for (int i = 0; i < bucketCount; i++) {
+				nodeAndTimeLists.add(new ArrayList<>());
+			}
+
+			for (NodeAndTime e : nodeAndTimes) {
+				int index = e.nodeIdx & mask;
+				nodeAndTimeLists.get(index).add(e);
 				presentNodes.set(e.nodeIdx);
+			}
+
+			for (int i = 0; i < bucketCount; i++) {
+				buckets[i] = new Bucket(nodeAndTimeLists.get(i));
 			}
 		}
 
 		public int get(int toNodeIndex) {
 			return presentNodes.get(toNodeIndex) ?
-					values[Arrays.binarySearch(nodeIndices, toNodeIndex)] :
+					buckets[toNodeIndex & mask].get(toNodeIndex) :
 					-1; // value not present in the row
 		}
 	}
 
 	private final SparseRow[] rows = new SparseRow[Id.getNumberOfIds(Node.class)];
 
-	public int get(Node fromNode, Node toNode) {
-		var row = rows[fromNode.getId().index()];
-		return row != null ? row.get(toNode.getId().index()) // get the value from the selected row
+	public int get(int fromNode, int toNode) {
+		var row = rows[fromNode];
+		return row != null ? row.get(toNode) // get the value from the selected row
 				: -1; // value not present if no row
+	}
+
+	public int get(Node fromNode, Node toNode) {
+		return get(fromNode.getId().index(), toNode.getId().index());
 	}
 
 	public void setRow(Node fromNode, SparseRow row) {


### PR DESCRIPTION
Java Flight Recorder showed `binarySearch()` in the sparse matrix (extensively used in the selective insertion search) as the main and really huge hotspot. So I decided to add a simple (custom-made) hash table based on node indices to reduce the binary search. Interestingly, it was really hard to be significantly faster than the existing implementation (both when simulating Berlin with 6000 autonomous DRT buses and in micro-benchmarking), which proves that the profiles had some artefacts and the binary search is not the main issue.

BTW. Later on, I ran the same big scenario using a dense node-to-node matrix that reduced speed by less than 5%, which somehow confirmed the issue with profiling.