### PR TITLE
Configurable mode for travel time validation

### DIFF
--- a/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/HereMapsRouteValidator.java
+++ b/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/HereMapsRouteValidator.java
@@ -48,11 +48,12 @@ import org.matsim.core.utils.misc.Time;
  */
 public class HereMapsRouteValidator implements TravelTimeDistanceValidator {
     private static final Logger log = LogManager.getLogger(HereMapsRouteValidator.class);
-    final String apiAccessKey;
-    final String outputPath;
-    final String date;
-    final CoordinateTransformation transformation;
-    boolean writeDetailedFiles = false;
+    private final String mode;
+    private final String apiAccessKey;
+    private final String outputPath;
+    private final String date;
+    private final CoordinateTransformation transformation;
+    private final boolean writeDetailedFiles;
 
     /**
      * @param outputFolder   folder to write gzipped json files
@@ -60,9 +61,10 @@ public class HereMapsRouteValidator implements TravelTimeDistanceValidator {
      * @param date           a date to run the validation for, format: 2017-06-08
      * @param transformation A coordinate transformation to WGS 84
      */
-    public HereMapsRouteValidator(String outputFolder, String apiAccessKey, String date,
+    public HereMapsRouteValidator(String outputFolder, String mode, String apiAccessKey, String date,
                                   CoordinateTransformation transformation, boolean writeDetailedFiles) {
         this.outputPath = outputFolder;
+        this.mode = mode == null ? "car" : mode;
         this.apiAccessKey = apiAccessKey;
         this.date = date;
         this.transformation = transformation;
@@ -82,7 +84,7 @@ public class HereMapsRouteValidator implements TravelTimeDistanceValidator {
      * getTravelTime(org.matsim.contrib.analysis.vsp.traveltimes.CarTrip)
      */
     @Override
-    public Tuple<Double, Double> getTravelTime(CarTrip trip) {
+    public Tuple<Double, Double> getTravelTime(NetworkTrip trip) {
         String tripId = trip.getPersonId().toString() + "_" + trip.getDepartureTime();
         return getTravelTime(trip.getDepartureLocation(), trip.getArrivalLocation(), trip.getDepartureTime(), tripId);
     }
@@ -101,7 +103,7 @@ public class HereMapsRouteValidator implements TravelTimeDistanceValidator {
         DecimalFormat df = (DecimalFormat) NumberFormat.getNumberInstance(locale);
         df.applyPattern(pattern);
 
-        String urlString = "https://router.hereapi.com/v8/routes?" + "&apiKey=" + apiAccessKey + "&transportmode=car&origin="
+        String urlString = "https://router.hereapi.com/v8/routes?" + "&apiKey=" + apiAccessKey + "&transportmode=" + mode + "&origin="
                 + df.format(from.getY()) + "," + df.format(from.getX()) + "&destination=" + df.format(to.getY()) + ","
                 + df.format(to.getX()) + "&departureTime=" + date + "T" + Time.writeTime(departureTime)
                 + "&return=summary";
@@ -138,20 +140,6 @@ public class HereMapsRouteValidator implements TravelTimeDistanceValidator {
             log.error("Cannot read the content on the URL properly. Please manually check the URL", e);
         }
         return new Tuple<Double, Double>((double) travelTime, (double) distance);
-    }
-
-    /**
-     * @return the writeDetailedFiles
-     */
-    public boolean isWriteDetailedFiles() {
-        return writeDetailedFiles;
-    }
-
-    /**
-     * @param writeDetailedFiles the writeDetailedFiles to set
-     */
-    public void setWriteDetailedFiles(boolean writeDetailedFiles) {
-        this.writeDetailedFiles = writeDetailedFiles;
     }
 
 }

--- a/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/NetworkTrip.java
+++ b/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/NetworkTrip.java
@@ -23,7 +23,8 @@ import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.population.Person;
 
-public class CarTrip {
+public class NetworkTrip {
+
 	final private Id<Person> personId;
 	final private double departureTime;
 	final private double arrivalTime;
@@ -35,11 +36,11 @@ public class CarTrip {
 	private Double validatedTravelDistance = null;
 	private double actualTravelTime;
 
-	CarTrip(Id<Person> personId, double departureTime, double arrivaldTime, double distance, Coord departureLocation,
-			Coord arrivalLocation) {
+	NetworkTrip(Id<Person> personId, double departureTime, double arrivalTime, double distance, Coord departureLocation,
+	            Coord arrivalLocation) {
 		this.personId = personId;
 		this.departureTime = departureTime;
-		this.arrivalTime = arrivaldTime;
+		this.arrivalTime = arrivalTime;
 		this.departureLocation = departureLocation;
 		this.arrivalLocation = arrivalLocation;
 		this.travelledDistance = distance;

--- a/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/RunTraveltimeValidationExample.java
+++ b/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/RunTraveltimeValidationExample.java
@@ -24,6 +24,7 @@ package org.matsim.contrib.analysis.vsp.traveltimedistance;
 
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.network.io.MatsimNetworkReader;
@@ -91,7 +92,7 @@ public class RunTraveltimeValidationExample {
 
 
 		CoordinateTransformation transformation = TransformationFactory.getCoordinateTransformation(epsg, TransformationFactory.WGS84);
-		HereMapsRouteValidator validator = new HereMapsRouteValidator(outputfolder, apiKey, date, transformation, false);
+		HereMapsRouteValidator validator = new HereMapsRouteValidator(outputfolder, TransportMode.car, apiKey, date, transformation, false);
         //Setting "writeDetailedFiles" to true will write out the raw JSON files for each calculated route
 		TravelTimeValidationRunner runner;
 		if (tripsToValidate != null){

--- a/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/TravelTimeDistanceValidator.java
+++ b/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/TravelTimeDistanceValidator.java
@@ -25,8 +25,6 @@ package org.matsim.contrib.analysis.vsp.traveltimedistance;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.core.utils.collections.Tuple;
 
-import java.util.Deque;
-
 /**
  * @author  jbischoff, Chengqi Lu
  * An Interface for Traveltime Validation
@@ -41,7 +39,7 @@ public interface TravelTimeDistanceValidator {
 	 * @param trip the trip to validate
 	 * @return a tuple of validated TravelTime and Distance
 	 */
-	Tuple<Double,Double> getTravelTime(CarTrip trip);
+	Tuple<Double,Double> getTravelTime(NetworkTrip trip);
 
 	/**
 	 * A more general form for the trip validation

--- a/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/TravelTimeValidationRunnerPreAnalysis.java
+++ b/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/TravelTimeValidationRunnerPreAnalysis.java
@@ -26,6 +26,7 @@ public class TravelTimeValidationRunnerPreAnalysis {
     private final Network network;
     private final int trips;
     private Geometry keyAreaGeometry;
+    private final String mode;
     private final TravelTimeDistanceValidator validator;
     private final String outputFolder;
 
@@ -40,10 +41,11 @@ public class TravelTimeValidationRunnerPreAnalysis {
 
     private final Random rnd = new Random(1234);
 
-    public TravelTimeValidationRunnerPreAnalysis(Network network, int trips, String outputFolder, TravelTimeDistanceValidator validator, Geometry keyAreaGeometry) {
+    public TravelTimeValidationRunnerPreAnalysis(Network network, int trips, String outputFolder, String mode, TravelTimeDistanceValidator validator, Geometry keyAreaGeometry) {
         this.network = network;
         this.trips = trips;
         this.outputFolder = outputFolder;
+        this.mode = mode;
         this.validator = validator;
         this.keyAreaGeometry = keyAreaGeometry;
     }
@@ -72,7 +74,7 @@ public class TravelTimeValidationRunnerPreAnalysis {
 
     public void run() throws IOException, InterruptedException {
         List<Link> links = network.getLinks().values().stream().
-                filter(l -> l.getAllowedModes().contains(TransportMode.car)).
+                filter(l -> l.getAllowedModes().contains(mode)).
                 collect(Collectors.toList());
         int numOfLinks = links.size();
 

--- a/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/TripsExtractor.java
+++ b/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/traveltimedistance/TripsExtractor.java
@@ -30,7 +30,6 @@ import java.util.Set;
 
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.events.LinkEnterEvent;
 import org.matsim.api.core.v01.events.PersonArrivalEvent;
 import org.matsim.api.core.v01.events.PersonDepartureEvent;
@@ -44,27 +43,26 @@ import org.matsim.api.core.v01.population.Person;
 import org.matsim.vehicles.Vehicle;
 
 /**
+ *
  * @author  jbischoff
- *
  */
-/**
- *
- */
-public class CarTripsExtractor implements PersonDepartureEventHandler, PersonArrivalEventHandler, PersonEntersVehicleEventHandler, LinkEnterEventHandler {
+public class TripsExtractor implements PersonDepartureEventHandler, PersonArrivalEventHandler, PersonEntersVehicleEventHandler, LinkEnterEventHandler {
 
 	
 	private final Set<Id<Person>> personsWithPlan;
 	private final Network network;
+	private final String mode;
 	private final Map<Id<Person>,Double> lastDepartureTime = new HashMap<>();
 	private final Map<Id<Person>,Coord> lastDepartureLocation = new HashMap<>();
 	private final Map<Id<Person>,Id<Vehicle>> vehicle2pax  = new HashMap<>();;
 	private final Map<Id<Vehicle>,Double> distanceTraveled = new HashMap<>();
-	private final List<CarTrip> trips = new ArrayList<>();
+	private final List<NetworkTrip> trips = new ArrayList<>();
 	
 	
-	public CarTripsExtractor(Set<Id<Person>> personsWithPlan, Network network) {
+	public TripsExtractor(Set<Id<Person>> personsWithPlan, Network network, String mode) {
 		this.personsWithPlan = personsWithPlan;
 		this.network = network;
+		this.mode = mode;
 	}
 
 	/* (non-Javadoc)
@@ -84,7 +82,7 @@ public class CarTripsExtractor implements PersonDepartureEventHandler, PersonArr
 	 */
 	@Override
 	public void handleEvent(PersonArrivalEvent event) {
-		if (event.getLegMode().equals(TransportMode.car)){
+		if (event.getLegMode().equals(mode)){
 			if (this.personsWithPlan.contains(event.getPersonId()))
 			{
 				Coord arrivalCoord = network.getLinks().get(event.getLinkId()).getCoord();
@@ -92,7 +90,7 @@ public class CarTripsExtractor implements PersonDepartureEventHandler, PersonArr
 				double departureTime = this.lastDepartureTime.remove(event.getPersonId());
 				Id<Vehicle> vehicleId = vehicle2pax.remove(event.getPersonId());
 				double distance = this.distanceTraveled.remove(vehicleId);
-				CarTrip trip = new CarTrip(event.getPersonId(), departureTime, event.getTime(), distance, departureCoord, arrivalCoord);
+				NetworkTrip trip = new NetworkTrip(event.getPersonId(), departureTime, event.getTime(), distance, departureCoord, arrivalCoord);
 				trip.setActualTravelTime(event.getTime()-departureTime);
 				this.trips.add(trip);
 			}
@@ -104,7 +102,7 @@ public class CarTripsExtractor implements PersonDepartureEventHandler, PersonArr
 	 */
 	@Override
 	public void handleEvent(PersonDepartureEvent event) {
-		if (event.getLegMode().equals(TransportMode.car)){
+		if (event.getLegMode().equals(mode)){
 			if (this.personsWithPlan.contains(event.getPersonId()))
 			{
 				Coord departureCoord = network.getLinks().get(event.getLinkId()).getCoord();
@@ -117,7 +115,7 @@ public class CarTripsExtractor implements PersonDepartureEventHandler, PersonArr
 	/**
 	 * @return the trips
 	 */
-	public List<CarTrip> getTrips() {
+	public List<NetworkTrip> getTrips() {
 		return trips;
 	}
 

--- a/contribs/application/src/main/java/org/matsim/application/analysis/TravelTimeAnalysis.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/TravelTimeAnalysis.java
@@ -21,7 +21,9 @@ import picocli.CommandLine;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 import java.util.Random;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -130,8 +132,10 @@ public class TravelTimeAnalysis implements MATSimAppCommand {
             }
             log.info("Removed {} agents not selecting their best plan", size - populationIds.size());
 
-            if (date == null)
-                date = LocalDate.now();
+            // Set date to next Wednesday if not configured
+            if (date == null) {
+                date = LocalDate.now().with(TemporalAdjusters.next(DayOfWeek.WEDNESDAY));
+            }
 
             log.info("Running analysis for {} trips at {} on file {}", trips, date, events);
 
@@ -171,7 +175,7 @@ public class TravelTimeAnalysis implements MATSimAppCommand {
             CoordinateTransformation transformation = TransformationFactory.getCoordinateTransformation(crs.getInputCRS(), TransformationFactory.WGS84);
             TravelTimeDistanceValidator validator;
             if (api == TravelTimeDistanceValidators.HERE) {
-                validator = new HereMapsRouteValidator(outputFolder, apiMode, appCode, "2021-01-01", transformation, writeDetails);
+                validator = new HereMapsRouteValidator(outputFolder, apiMode, appCode, date.toString(), transformation, writeDetails);
             } else if (api == TravelTimeDistanceValidators.GOOGLE_MAP) {
                 validator = new GoogleMapRouteValidator(outputFolder, apiMode, appCode, date.toString(), transformation);
             } else {

--- a/contribs/application/src/main/java/org/matsim/application/analysis/TravelTimeAnalysis.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/TravelTimeAnalysis.java
@@ -111,6 +111,16 @@ public class TravelTimeAnalysis implements MATSimAppCommand {
             return 2;
         }
 
+        // Set date to next Wednesday if not configured
+        if (date == null) {
+
+            // Google API only allows days in the future
+            if (api == TravelTimeDistanceValidators.GOOGLE_MAP)
+                date = LocalDate.now().with(TemporalAdjusters.next(DayOfWeek.WEDNESDAY));
+            else
+                date = LocalDate.now().with(TemporalAdjusters.previous(DayOfWeek.WEDNESDAY));
+        }
+
         String outputFolder = runDirectory.resolve(output).toString();
         if (type == AnalysisTypes.POST_ANALYSIS) {
             Path events = globFile(runDirectory, runId + ".*events.*");
@@ -131,11 +141,6 @@ public class TravelTimeAnalysis implements MATSimAppCommand {
                     tripFilter = carTrip -> index.contains(carTrip.getArrivalLocation()) || index.contains(carTrip.getDepartureLocation());
             }
             log.info("Removed {} agents not selecting their best plan", size - populationIds.size());
-
-            // Set date to next Wednesday if not configured
-            if (date == null) {
-                date = LocalDate.now().with(TemporalAdjusters.next(DayOfWeek.WEDNESDAY));
-            }
 
             log.info("Running analysis for {} trips at {} on file {}", trips, date, events);
 

--- a/contribs/application/src/main/java/org/matsim/application/analysis/TravelTimeAnalysis.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/TravelTimeAnalysis.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Plan;
@@ -30,7 +31,9 @@ import static org.matsim.application.ApplicationUtils.loadScenario;
 
 @CommandLine.Command(
         name = "travel-time",
-        description = "Run travel time analysis on events file. pre-analysis: analyze the empty network to validate the free flow speed of the network. post-analysis (default): validate the travel time and distance of executed trips"
+        description = "Run travel time analysis on events file. pre-analysis: analyze the empty network to validate the free flow speed of the network." +
+                " post-analysis (default): validate the travel time and distance of executed trips." +
+                " Transit mode of MATSim trips and corresponding mode in API need to be configured separately, due to different naming conventions."
 )
 public class TravelTimeAnalysis implements MATSimAppCommand {
 
@@ -68,6 +71,12 @@ public class TravelTimeAnalysis implements MATSimAppCommand {
 
     @CommandLine.Option(names = "--to", defaultValue = "86400", description = "To time window in seconds")
     private Double timeTo;
+
+    @CommandLine.Option(names = "--trip-mode", defaultValue = TransportMode.car, description = "Transit mode of MATSim trips to validate")
+    private String tripMode;
+
+    @CommandLine.Option(names = "--api-mode", description = "Transit mode to use in api (car if not given). Please refer to API doc for details.", required = false)
+    private String apiMode;
 
     @CommandLine.Option(names = "--write-details", description = "Write JSON file for each calculated route")
     private boolean writeDetails;
@@ -111,7 +120,7 @@ public class TravelTimeAnalysis implements MATSimAppCommand {
                 Person person = scenario.getPopulation().getPersons().get(p);
                 return selector.selectPlan(person) != person.getSelectedPlan();
             });
-            Predicate<CarTrip> tripFilter = carTrip -> true;
+            Predicate<NetworkTrip> tripFilter = carTrip -> true;
             if (shp.getShapeFile() != null) {
                 ShpOptions.Index index = shp.createIndex(crs.getInputCRS(), "__");
                 if (withInShp)
@@ -130,9 +139,9 @@ public class TravelTimeAnalysis implements MATSimAppCommand {
 
             TravelTimeDistanceValidator validator;
             if (api == TravelTimeDistanceValidators.HERE) {
-                validator = new HereMapsRouteValidator(outputFolder, appCode, date.toString(), transformation, writeDetails);
+                validator = new HereMapsRouteValidator(outputFolder, apiMode, appCode, date.toString(), transformation, writeDetails);
             } else if (api == TravelTimeDistanceValidators.GOOGLE_MAP) {
-                validator = new GoogleMapRouteValidator(outputFolder, appCode, date.toString(), transformation, writeDetails);
+                validator = new GoogleMapRouteValidator(outputFolder, apiMode, appCode, date.toString(), transformation);
             } else {
                 throw new RuntimeException("Please enter the api correctly. Please choose from [here, google-map]");
             }
@@ -142,7 +151,7 @@ public class TravelTimeAnalysis implements MATSimAppCommand {
                 timeWindow = new Tuple<>(timeFrom, timeTo);
             }
 
-            TravelTimeValidationRunner runner = new TravelTimeValidationRunner(scenario.getNetwork(), populationIds, events.toString(), outputFolder, validator, trips, timeWindow, tripFilter);
+            TravelTimeValidationRunner runner = new TravelTimeValidationRunner(scenario.getNetwork(), populationIds, events.toString(), outputFolder, tripMode, validator, trips, timeWindow, tripFilter);
             runner.run();
 
             return 0;
@@ -162,14 +171,14 @@ public class TravelTimeAnalysis implements MATSimAppCommand {
             CoordinateTransformation transformation = TransformationFactory.getCoordinateTransformation(crs.getInputCRS(), TransformationFactory.WGS84);
             TravelTimeDistanceValidator validator;
             if (api == TravelTimeDistanceValidators.HERE) {
-                validator = new HereMapsRouteValidator(outputFolder, appCode, "2021-01-01", transformation, writeDetails);
+                validator = new HereMapsRouteValidator(outputFolder, apiMode, appCode, "2021-01-01", transformation, writeDetails);
             } else if (api == TravelTimeDistanceValidators.GOOGLE_MAP) {
-                validator = new GoogleMapRouteValidator(outputFolder, appCode, date.toString(), transformation, writeDetails);
+                validator = new GoogleMapRouteValidator(outputFolder, apiMode, appCode, date.toString(), transformation);
             } else {
                 throw new RuntimeException("Please enter the api correctly. Please choose from [here, google-map]");
             }
 
-            TravelTimeValidationRunnerPreAnalysis preAnalysisRunner = new TravelTimeValidationRunnerPreAnalysis(network, trips, outputFolder, validator, null);
+            TravelTimeValidationRunnerPreAnalysis preAnalysisRunner = new TravelTimeValidationRunnerPreAnalysis(network, trips, outputFolder, tripMode, validator, null);
             if (shp.getShapeFile() != null) {
                 preAnalysisRunner.setKeyAreaGeometry(shp.getGeometry());
             }

--- a/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/BicycleModule.java
+++ b/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/BicycleModule.java
@@ -47,6 +47,10 @@ final class BicycleModule extends AbstractModule {
 
 		addTravelTimeBinding(bicycleConfigGroup.getBicycleMode()).to(BicycleTravelTime.class).in(Singleton.class);
 		addTravelDisutilityFactoryBinding(bicycleConfigGroup.getBicycleMode()).to(BicycleTravelDisutilityFactory.class).in(Singleton.class);
+
+		// TODO: bicycle contrib can not be used with other scoring functions at the moment, as only one can be installed
+		// TODO: scoring should work via a score event so it can be used together with other scoring functions
+
 		bindScoringFunctionFactory().to(BicycleScoringFunctionFactory.class).in(Singleton.class);
 
 		bind( BicycleLinkSpeedCalculator.class ).to( BicycleLinkSpeedCalculatorDefaultImpl.class ) ;


### PR DESCRIPTION
The TravelTimeValidator now accepts two mode options: One for the mode of the MATSim trips to validate and one for the routing mode to be used in the API.
E.g. this allows to also validate bike trips.