### PR TITLE
Simplify insertion generation

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourData.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourData.java
@@ -39,17 +39,6 @@ import org.matsim.contrib.drt.passenger.DrtRequest;
  * On the other hand, detour data (D) could itself provide time-dependent information.
  */
 public class DetourData<D> {
-	static DetourData<Double> create(DetourTimeEstimator detourTimeEstimator, DrtRequest drtRequest) {
-		//TODO add departure/arrival times to improve estimation
-		Function<Link, Double> timesToPickup = link -> detourTimeEstimator.estimateTime(link, drtRequest.getFromLink());
-		Function<Link, Double> timesFromPickup = link -> detourTimeEstimator.estimateTime(drtRequest.getFromLink(),
-				link);
-		Function<Link, Double> timesToDropoff = link -> detourTimeEstimator.estimateTime(link, drtRequest.getToLink());
-		Function<Link, Double> timesFromDropoff = link -> detourTimeEstimator.estimateTime(drtRequest.getToLink(),
-				link);
-		return new DetourData<>(timesToPickup, timesFromPickup, timesToDropoff, timesFromDropoff, 0.);
-	}
-
 	private final Function<Link, D> detourToPickup;
 	private final Function<Link, D> detourFromPickup;
 	private final Function<Link, D> detourToDropoff;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourTime.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourTime.java
@@ -35,15 +35,6 @@ public class DetourTime {
 		this.detourTimeEstimator = detourTimeEstimator;
 	}
 
-	public InsertionWithDetourData<Double> createInsertionWithDetourData(InsertionGenerator.Insertion insertion,
-			DrtRequest request) {
-		double toPickup = calcToPickupTime(insertion, request);
-		double fromPickup = calcFromPickupTime(insertion, request);
-		double toDropoff = calcToDropoffTime(insertion, request);
-		double fromDropoff = calcFromDropoffTime(insertion, request);
-		return new InsertionWithDetourData<>(insertion, toPickup, fromPickup, toDropoff, fromDropoff);
-	}
-
 	public double calcToPickupTime(InsertionGenerator.Insertion insertion, DrtRequest drtRequest) {
 		return detourTimeEstimator.estimateTime(insertion.pickup.previousWaypoint.getLink(), drtRequest.getFromLink());
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourTime.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourTime.java
@@ -1,0 +1,66 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2020 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.optimizer.insertion;
+
+import org.matsim.contrib.drt.optimizer.Waypoint;
+import org.matsim.contrib.drt.passenger.DrtRequest;
+
+/**
+ * The current implementation assumes the DetourData functions are time independent. This may be changed in the future (esp.
+ * for pre-booking or to enhance TT estimation) to BiFunctions: (Link, time) -> data.
+ */
+public class DetourTime {
+	//TODO add departure/arrival times to improve estimation
+	private final DetourTimeEstimator detourTimeEstimator;
+
+	DetourTime(DetourTimeEstimator detourTimeEstimator) {
+		this.detourTimeEstimator = detourTimeEstimator;
+	}
+
+	public InsertionWithDetourData<Double> createInsertionWithDetourData(InsertionGenerator.Insertion insertion,
+			DrtRequest request) {
+		double toPickup = calcToPickupTime(insertion, request);
+		double fromPickup = calcFromPickupTime(insertion, request);
+		double toDropoff = calcToDropoffTime(insertion, request);
+		double fromDropoff = calcFromDropoffTime(insertion, request);
+		return new InsertionWithDetourData<>(insertion, toPickup, fromPickup, toDropoff, fromDropoff);
+	}
+
+	public double calcToPickupTime(InsertionGenerator.Insertion insertion, DrtRequest drtRequest) {
+		return detourTimeEstimator.estimateTime(insertion.pickup.previousWaypoint.getLink(), drtRequest.getFromLink());
+	}
+
+	public double calcFromPickupTime(InsertionGenerator.Insertion insertion, DrtRequest drtRequest) {
+		return detourTimeEstimator.estimateTime(drtRequest.getFromLink(), insertion.pickup.nextWaypoint.getLink());
+	}
+
+	public double calcToDropoffTime(InsertionGenerator.Insertion insertion, DrtRequest drtRequest) {
+		return insertion.dropoff.previousWaypoint instanceof Waypoint.Pickup ?
+				Double.POSITIVE_INFINITY :
+				detourTimeEstimator.estimateTime(insertion.dropoff.previousWaypoint.getLink(), drtRequest.getToLink());
+	}
+
+	public double calcFromDropoffTime(InsertionGenerator.Insertion insertion, DrtRequest drtRequest) {
+		return insertion.dropoff.nextWaypoint instanceof Waypoint.End ?
+				0 :
+				detourTimeEstimator.estimateTime(drtRequest.getToLink(), insertion.dropoff.nextWaypoint.getLink());
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionProvider.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionProvider.java
@@ -81,10 +81,8 @@ public class ExtensiveInsertionProvider implements InsertionProvider {
 		// Parallel outer stream over vehicle entries. The inner stream (flatmap) is sequential.
 		List<InsertionWithDetourData<Double>> preFilteredInsertions = forkJoinPool.submit(
 				() -> vehicleEntries.parallelStream()
-						//generate feasible insertions (wrt occupancy limits)
-						.flatMap(e -> insertionGenerator.generateInsertions(drtRequest, e).stream())
-						//map insertions to insertions with admissible detour times (i.e. admissible beeline speed factor)
-						.map(admissibleTimeData::createInsertionWithDetourData)
+						//generate feasible insertions (wrt occupancy limits) with admissible detour times
+						.flatMap(e -> insertionGenerator.generateInsertions(drtRequest, e, admissibleTimeData).stream())
 						//optimistic pre-filtering wrt admissible cost function
 						.filter(insertion -> admissibleCostCalculator.calculate(drtRequest, insertion)
 								< INFEASIBLE_SOLUTION_COST)

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionProvider.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionProvider.java
@@ -76,13 +76,14 @@ public class ExtensiveInsertionProvider implements InsertionProvider {
 
 	@Override
 	public List<Insertion> getInsertions(DrtRequest drtRequest, Collection<VehicleEntry> vehicleEntries) {
-		DetourData<Double> admissibleTimeData = DetourData.create(admissibleTimeEstimator, drtRequest);
+		DetourTime admissibleDetourTime = new DetourTime(admissibleTimeEstimator);
 
 		// Parallel outer stream over vehicle entries. The inner stream (flatmap) is sequential.
 		List<InsertionWithDetourData<Double>> preFilteredInsertions = forkJoinPool.submit(
 				() -> vehicleEntries.parallelStream()
 						//generate feasible insertions (wrt occupancy limits) with admissible detour times
-						.flatMap(e -> insertionGenerator.generateInsertions(drtRequest, e, admissibleTimeData).stream())
+						.flatMap(e -> insertionGenerator.generateInsertions(drtRequest, e, admissibleDetourTime)
+								.stream())
 						//optimistic pre-filtering wrt admissible cost function
 						.filter(insertion -> admissibleCostCalculator.calculate(drtRequest, insertion)
 								< INFEASIBLE_SOLUTION_COST)

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProvider.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProvider.java
@@ -51,22 +51,19 @@ public class SelectiveInsertionProvider implements InsertionProvider {
 		return new SelectiveInsertionProvider(restrictiveDetourTimeEstimator, forkJoinPool, restrictiveCostCalculator);
 	}
 
-	private final DetourTimeEstimator restrictiveTimeEstimator;
 	private final BestInsertionFinder<Double> initialInsertionFinder;
 	private final InsertionGenerator insertionGenerator;
 	private final ForkJoinPool forkJoinPool;
 
 	public SelectiveInsertionProvider(DetourTimeEstimator restrictiveTimeEstimator, ForkJoinPool forkJoinPool,
 			InsertionCostCalculator<Double> restrictiveCostCalculator) {
-		this(restrictiveTimeEstimator, new BestInsertionFinder<>(restrictiveCostCalculator), new InsertionGenerator(),
+		this(new BestInsertionFinder<>(restrictiveCostCalculator), new InsertionGenerator(restrictiveTimeEstimator),
 				forkJoinPool);
 	}
 
 	@VisibleForTesting
-	SelectiveInsertionProvider(DetourTimeEstimator restrictiveTimeEstimator,
-			BestInsertionFinder<Double> initialInsertionFinder, InsertionGenerator insertionGenerator,
-			ForkJoinPool forkJoinPool) {
-		this.restrictiveTimeEstimator = restrictiveTimeEstimator;
+	SelectiveInsertionProvider(BestInsertionFinder<Double> initialInsertionFinder,
+			InsertionGenerator insertionGenerator, ForkJoinPool forkJoinPool) {
 		this.initialInsertionFinder = initialInsertionFinder;
 		this.insertionGenerator = insertionGenerator;
 		this.forkJoinPool = forkJoinPool;
@@ -74,8 +71,6 @@ public class SelectiveInsertionProvider implements InsertionProvider {
 
 	@Override
 	public List<Insertion> getInsertions(DrtRequest drtRequest, Collection<VehicleEntry> vehicleEntries) {
-		DetourTime restrictiveDetourTime = new DetourTime(restrictiveTimeEstimator);
-
 		// Parallel outer stream over vehicle entries. The inner stream (flatmap) is sequential.
 		Optional<InsertionWithDetourData<Double>> bestInsertion = forkJoinPool.submit(
 				// find best insertion given a stream of insertion with time data
@@ -83,8 +78,7 @@ public class SelectiveInsertionProvider implements InsertionProvider {
 						//for each vehicle entry
 						vehicleEntries.parallelStream()
 								//generate feasible insertions (wrt occupancy limits) with restrictive detour times
-								.flatMap(e -> insertionGenerator.generateInsertions(drtRequest, e,
-										restrictiveDetourTime).stream()))).join();
+								.flatMap(e -> insertionGenerator.generateInsertions(drtRequest, e).stream()))).join();
 
 		return bestInsertion.map(InsertionWithDetourData::getInsertion).stream().collect(toList());
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProvider.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProvider.java
@@ -82,10 +82,9 @@ public class SelectiveInsertionProvider implements InsertionProvider {
 				() -> initialInsertionFinder.findBestInsertion(drtRequest,
 						//for each vehicle entry
 						vehicleEntries.parallelStream()
-								//generate feasible insertions (wrt occupancy limits)
-								.flatMap(e -> insertionGenerator.generateInsertions(drtRequest, e).stream())
-								//map them to insertions with restrictive detour times
-								.map(restrictiveTimeData::createInsertionWithDetourData))).join();
+								//generate feasible insertions (wrt occupancy limits) with restrictive detour times
+								.flatMap(e -> insertionGenerator.generateInsertions(drtRequest, e, restrictiveTimeData)
+										.stream()))).join();
 
 		return bestInsertion.map(InsertionWithDetourData::getInsertion).stream().collect(toList());
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProvider.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProvider.java
@@ -74,7 +74,7 @@ public class SelectiveInsertionProvider implements InsertionProvider {
 
 	@Override
 	public List<Insertion> getInsertions(DrtRequest drtRequest, Collection<VehicleEntry> vehicleEntries) {
-		DetourData<Double> restrictiveTimeData = DetourData.create(restrictiveTimeEstimator, drtRequest);
+		DetourTime restrictiveDetourTime = new DetourTime(restrictiveTimeEstimator);
 
 		// Parallel outer stream over vehicle entries. The inner stream (flatmap) is sequential.
 		Optional<InsertionWithDetourData<Double>> bestInsertion = forkJoinPool.submit(
@@ -83,8 +83,8 @@ public class SelectiveInsertionProvider implements InsertionProvider {
 						//for each vehicle entry
 						vehicleEntries.parallelStream()
 								//generate feasible insertions (wrt occupancy limits) with restrictive detour times
-								.flatMap(e -> insertionGenerator.generateInsertions(drtRequest, e, restrictiveTimeData)
-										.stream()))).join();
+								.flatMap(e -> insertionGenerator.generateInsertions(drtRequest, e,
+										restrictiveDetourTime).stream()))).join();
 
 		return bestInsertion.map(InsertionWithDetourData::getInsertion).stream().collect(toList());
 	}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DetourDataTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DetourDataTest.java
@@ -133,19 +133,4 @@ public class DetourDataTest {
 	private Waypoint.Stop stop(Link link) {
 		return new Waypoint.Stop(new DrtStopTask(0, 60, link), 0);
 	}
-
-	@Test
-	public void testCreate() {
-		Insertion insertion = new Insertion(request, entry, 0, 1);
-		var timeEstimates = ImmutableTable.<Link, Link, Double>builder()//
-				.put(startLink, pickupLink, 12.)
-				.put(pickupLink, stop0Link, 34.)
-				.put(stop0Link, dropoffLink, 56.)
-				.put(dropoffLink, stop1Link, 78.)
-				.build();
-		var detourData = DetourData.create(timeEstimates::get, request).createInsertionWithDetourData(insertion);
-
-		var expectedDetourData = new InsertionWithDetourData<>(insertion, 12., 34., 56., 78.);
-		assertThat(detourData).isEqualToComparingFieldByField(expectedDetourData);
-	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionProviderTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionProviderTest.java
@@ -70,8 +70,9 @@ public class ExtensiveInsertionProviderTest {
 		var feasibleInsertion = new Insertion(vehicleEntry, insertionPoint(), insertionPoint());
 		var infeasibleInsertion = new Insertion(vehicleEntry, insertionPoint(), insertionPoint());
 		var insertionGenerator = mock(InsertionGenerator.class);
-		when(insertionGenerator.generateInsertions(eq(request), eq(vehicleEntry)))//
-				.thenReturn(List.of(feasibleInsertion, infeasibleInsertion));
+		when(insertionGenerator.generateInsertions(eq(request), eq(vehicleEntry), any()))//
+				.thenReturn(List.of(insertionWithDetourData(feasibleInsertion),
+						insertionWithDetourData(infeasibleInsertion)));
 
 		//mock admissibleCostCalculator
 		@SuppressWarnings("unchecked")
@@ -94,5 +95,9 @@ public class ExtensiveInsertionProviderTest {
 
 	private InsertionGenerator.InsertionPoint insertionPoint() {
 		return new InsertionGenerator.InsertionPoint(-1, mock(Waypoint.class), null, mock(Waypoint.class));
+	}
+
+	private InsertionWithDetourData<Double> insertionWithDetourData(Insertion insertion) {
+		return new InsertionWithDetourData<>(insertion, Double.NaN, Double.NaN, Double.NaN, Double.NaN);
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionProviderTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionProviderTest.java
@@ -43,7 +43,7 @@ public class ExtensiveInsertionProviderTest {
 
 	@Test
 	public void getInsertions_noInsertionsGenerated() {
-		var insertionProvider = new ExtensiveInsertionProvider(null, null, null, new InsertionGenerator(),
+		var insertionProvider = new ExtensiveInsertionProvider(null, null, new InsertionGenerator(null),
 				rule.forkJoinPool);
 		assertThat(insertionProvider.getInsertions(null, List.of())).isEmpty();
 	}
@@ -70,7 +70,7 @@ public class ExtensiveInsertionProviderTest {
 		var feasibleInsertion = new Insertion(vehicleEntry, insertionPoint(), insertionPoint());
 		var infeasibleInsertion = new Insertion(vehicleEntry, insertionPoint(), insertionPoint());
 		var insertionGenerator = mock(InsertionGenerator.class);
-		when(insertionGenerator.generateInsertions(eq(request), eq(vehicleEntry), any()))//
+		when(insertionGenerator.generateInsertions(eq(request), eq(vehicleEntry)))//
 				.thenReturn(List.of(insertionWithDetourData(feasibleInsertion),
 						insertionWithDetourData(infeasibleInsertion)));
 
@@ -87,8 +87,8 @@ public class ExtensiveInsertionProviderTest {
 		var params = new ExtensiveInsertionSearchParams().setNearestInsertionsAtEndLimit(nearestInsertionsAtEndLimit);
 		//pretend all insertions are at end to check KNearestInsertionsAtEndFilter
 		when(vehicleEntry.isAfterLastStop(anyInt())).thenReturn(true);
-		var insertionProvider = new ExtensiveInsertionProvider(params, admissibleCostCalculator, (from, to) -> 978.,
-				insertionGenerator, rule.forkJoinPool);
+		var insertionProvider = new ExtensiveInsertionProvider(params, admissibleCostCalculator, insertionGenerator,
+				rule.forkJoinPool);
 		assertThat(insertionProvider.getInsertions(request, List.of(vehicleEntry))).isEqualTo(
 				nearestInsertionsAtEndLimit == 0 ? List.of() : List.of(feasibleInsertion));
 	}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
@@ -64,9 +64,9 @@ public class InsertionGeneratorTest {
 	public void generateInsertions_startEmpty_noStops() {
 		Waypoint.Start start = new Waypoint.Start(null, link("0"), 0, 0); //no stops => must be empty
 		VehicleEntry entry = entry(start);
-		assertThatInsertions(drtRequest, entry).usingRecursiveFieldByFieldElementComparator().containsExactly(
+		assertInsertions(drtRequest, entry,
 				//pickup after start
-				insertion(entry, 0, 0));
+				insertion(entry, 0, 0, 1, 2, null, 0));
 	}
 
 	@Test
@@ -74,11 +74,12 @@ public class InsertionGeneratorTest {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, 1); // 1 pax aboard
 		Waypoint.Stop stop0 = stop(link("stop0"), 0);//drop off 1 pax
 		VehicleEntry entry = entry(start, stop0);
-		assertThatInsertions(drtRequest, entry).usingRecursiveFieldByFieldElementComparator().containsExactly(
+		assertInsertions(drtRequest, entry,
 				//pickup after start
-				insertion(entry, 0, 0), insertion(entry, 0, 1),
-				//picup after stop 0
-				insertion(entry, 1, 1));
+				insertion(entry, 0, 0, 1, 2, null, 4),//
+				insertion(entry, 0, 1, 1, 2, 3., 0),
+				//pickup after stop 0
+				insertion(entry, 1, 1, 1, 2, null, 0));
 	}
 
 	@Test
@@ -86,10 +87,10 @@ public class InsertionGeneratorTest {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, CAPACITY); //full
 		Waypoint.Stop stop0 = stop(link("stop0"), 0);//drop off 4 pax
 		VehicleEntry entry = entry(start, stop0);
-		assertThatInsertions(drtRequest, entry).usingRecursiveFieldByFieldElementComparator().containsExactly(
+		assertInsertions(drtRequest, entry,
 				//no pickup after stop
 				//pickup after stop 0
-				insertion(entry, 1, 1));
+				insertion(entry, 1, 1, 1, 2, null, 0));
 	}
 
 	@Test
@@ -98,13 +99,16 @@ public class InsertionGeneratorTest {
 		Waypoint.Stop stop0 = stop(link("stop0"), 1);//pick up 1 pax
 		Waypoint.Stop stop1 = stop(link("stop1"), 0);//drop off 1 pax
 		VehicleEntry entry = entry(start, stop0, stop1);
-		assertThatInsertions(drtRequest, entry).usingRecursiveFieldByFieldElementComparator().containsExactly(
+		assertInsertions(drtRequest, entry,
 				//pickup after start
-				insertion(entry, 0, 0), insertion(entry, 0, 1), insertion(entry, 0, 2),
+				insertion(entry, 0, 0, 1, 2, null, 4),//
+				insertion(entry, 0, 1, 1, 2, 3., 4),//
+				insertion(entry, 0, 2, 1, 2, 3., 0),
 				//pickup after stop 0
-				insertion(entry, 1, 1), insertion(entry, 1, 2),
+				insertion(entry, 1, 1, 1, 2, null, 4),//
+				insertion(entry, 1, 2, 1, 2, 3., 0),
 				//pickup after stop 1
-				insertion(entry, 2, 2));
+				insertion(entry, 2, 2, 1, 2, null, 0));
 	}
 
 	@Test
@@ -113,12 +117,12 @@ public class InsertionGeneratorTest {
 		Waypoint.Stop stop0 = stop(link("stop0"), CAPACITY);//pick up 4 pax (full)
 		Waypoint.Stop stop1 = stop(link("stop1"), 0);//drop off 4 pax
 		VehicleEntry entry = entry(start, stop0, stop1);
-		assertThatInsertions(drtRequest, entry).usingRecursiveFieldByFieldElementComparator().containsExactly(
+		assertInsertions(drtRequest, entry,
 				//pickup after start
-				insertion(entry, 0, 0),
+				insertion(entry, 0, 0, 1, 2, null, 4),
 				//no pickup after stop 0
 				//pickup after stop 1
-				insertion(entry, 2, 2));
+				insertion(entry, 2, 2, 1, 2, null, 0));
 	}
 
 	@Test
@@ -127,12 +131,13 @@ public class InsertionGeneratorTest {
 		Waypoint.Stop stop0 = stop(link("stop0"), 2);//drop off 2 pax
 		Waypoint.Stop stop1 = stop(link("stop1"), 0);//drop off 2 pax
 		VehicleEntry entry = entry(start, stop0, stop1);
-		assertThatInsertions(drtRequest, entry).usingRecursiveFieldByFieldElementComparator().containsExactly(
+		assertInsertions(drtRequest, entry,
 				//no pickup after start
 				//pickup after stop 0
-				insertion(entry, 1, 1), insertion(entry, 1, 2),
+				insertion(entry, 1, 1, 1, 2, null, 4),//
+				insertion(entry, 1, 2, 1, 2, 3., 0),
 				//pickup after stop 1
-				insertion(entry, 2, 2));
+				insertion(entry, 2, 2, 1, 2, null, 0));
 	}
 
 	@Test
@@ -141,11 +146,11 @@ public class InsertionGeneratorTest {
 		Waypoint.Stop stop0 = stop(link("stop0"), CAPACITY);//drop off 1 pax, pickup 1 pax (full)
 		Waypoint.Stop stop1 = stop(link("stop1"), 0);//drop off 4 pax
 		VehicleEntry entry = entry(start, stop0, stop1);
-		assertThatInsertions(drtRequest, entry).usingRecursiveFieldByFieldElementComparator().containsExactly(
+		assertInsertions(drtRequest, entry,
 				//no pickup after start
 				//no pickup after stop 0
 				//pickup after stop 1
-				insertion(entry, 2, 2));
+				insertion(entry, 2, 2, 1, 2, null, 0));
 	}
 
 	@Test
@@ -155,14 +160,15 @@ public class InsertionGeneratorTest {
 		Waypoint.Stop stop1 = stop(link("stop1"), CAPACITY);// pickup 4 pax
 		Waypoint.Stop stop2 = stop(link("stop2"), 0);// dropoff 4 pax
 		VehicleEntry entry = entry(start, stop0, stop1, stop2);
-		assertThatInsertions(drtRequest, entry).usingRecursiveFieldByFieldElementComparator().containsExactly(
+		assertInsertions(drtRequest, entry,
 				//pickup after start
-				insertion(entry, 0, 0), insertion(entry, 0, 1),
+				insertion(entry, 0, 0, 1, 2, null, 4),//
+				insertion(entry, 0, 1, 1, 2, 3., 4),
 				//pickup after stop 0
-				insertion(entry, 1, 1),
+				insertion(entry, 1, 1, 1, 2, null, 4),
 				//pickup after stop 1
 				//pickup after stop 2
-				insertion(entry, 3, 3));
+				insertion(entry, 3, 3, 1, 2, null, 0));
 	}
 
 	@Test
@@ -172,13 +178,13 @@ public class InsertionGeneratorTest {
 		Waypoint.Stop stop1 = stop(link("stop1"), CAPACITY);// pickup 4 pax
 		Waypoint.Stop stop2 = stop(link("stop2"), 0);// dropoff 4 pax
 		VehicleEntry entry = entry(start, stop0, stop1, stop2);
-		assertThatInsertions(drtRequest, entry).usingRecursiveFieldByFieldElementComparator().containsExactly(
+		assertInsertions(drtRequest, entry,
 				//no pickup after start
 				//pickup after stop 0
-				insertion(entry, 1, 1),
+				insertion(entry, 1, 1, 1, 2, null, 4),
 				//pickup after stop 1
 				//pickup after stop 2
-				insertion(entry, 3, 3));
+				insertion(entry, 3, 3, 1, 2, null, 0));
 	}
 
 	@Test
@@ -186,10 +192,10 @@ public class InsertionGeneratorTest {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, 1); // 1 pax
 		Waypoint.Stop stop0 = stop(fromLink, 0);//dropoff 1 pax
 		VehicleEntry entry = entry(start, stop0);
-		assertThatInsertions(drtRequest, entry).usingRecursiveFieldByFieldElementComparator().containsExactly(
+		assertInsertions(drtRequest, entry,
 				//no pickup after start (pickup is exactly at stop0)
 				//pickup after stop 0
-				insertion(entry, 1, 1));
+				insertion(entry, 1, 1, 1, 2, null, 0));
 	}
 
 	@Test
@@ -197,11 +203,11 @@ public class InsertionGeneratorTest {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, 1); // 1 pax
 		Waypoint.Stop stop0 = stop(toLink, 0);//dropoff 1 pax
 		VehicleEntry entry = entry(start, stop0);
-		assertThatInsertions(drtRequest, entry).usingRecursiveFieldByFieldElementComparator().containsExactly(
+		assertInsertions(drtRequest, entry,
 				//pickup after start: insertion(0, 0) is a duplicate of insertion(0, 1)
-				insertion(entry, 0, 1),
+				insertion(entry, 0, 1, 1, 2, 3., 0),
 				//pickup after stop 0
-				insertion(entry, 1, 1));
+				insertion(entry, 1, 1, 1, 2, null, 0));
 	}
 
 	@Test
@@ -212,27 +218,32 @@ public class InsertionGeneratorTest {
 		Waypoint.Stop stop0 = stop(toLink, CAPACITY);//dropoff 1 pax
 		Waypoint.Stop stop1 = stop(link("stop1"), 0);//dropoff 1 pax
 		VehicleEntry entry = entry(start, stop0, stop1);
-		assertThatInsertions(drtRequest, entry).usingRecursiveFieldByFieldElementComparator().containsExactly(
+		assertInsertions(drtRequest, entry,
 				//pickup after start: insertion(0, 0) is a duplicate of insertion(0, 1)
-				insertion(entry, 0, 1),
+				insertion(entry, 0, 1, 1, 2, 3., 4),
 				//pickup after stop 0
-				insertion(entry, 2, 2));
+				insertion(entry, 2, 2, 1, 2, null, 0));
 	}
 
 	private Link link(String id) {
 		return new FakeLink(Id.createLinkId(id));
 	}
 
-	private ListAssert<Insertion> assertThatInsertions(DrtRequest drtRequest, VehicleEntry entry) {
+	private void assertInsertions(DrtRequest drtRequest, VehicleEntry entry,
+			InsertionWithDetourData<Double>... expectedInsertions) {
 		int stopCount = entry.stops.size();
 		int endOccupancy = stopCount > 0 ? entry.stops.get(stopCount - 1).outgoingOccupancy : entry.start.occupancy;
 		Preconditions.checkArgument(endOccupancy == 0);//make sure the input is valid
 
-		return assertThat(new InsertionGenerator().generateInsertions(drtRequest, entry));
+		assertThat(new InsertionGenerator().generateInsertions(drtRequest, entry,
+				new DetourData<>(l -> 1., l -> 2., l -> 3., l -> 4., 0.))).usingRecursiveFieldByFieldElementComparator()
+				.containsExactly(expectedInsertions);
 	}
 
-	private Insertion insertion(VehicleEntry entry, int pickupIdx, int dropoffIdx) {
-		return new Insertion(drtRequest, entry, pickupIdx, dropoffIdx);
+	private InsertionWithDetourData<Double> insertion(VehicleEntry entry, int pickupIdx, int dropoffIdx,
+			double timeToPickup, double timeFromPickup, Double timeToDropoff, double timeFromDropoff) {
+		return new InsertionWithDetourData<>(new Insertion(drtRequest, entry, pickupIdx, dropoffIdx), timeToPickup,
+				timeFromPickup, timeToDropoff, timeFromDropoff);
 	}
 
 	private Waypoint.Stop stop(Link link, int outgoingOccupancy) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
@@ -249,9 +249,8 @@ public class InsertionGeneratorTest {
 			throw new IllegalArgumentException();
 		};
 
-		assertThat(new InsertionGenerator().generateInsertions(drtRequest, entry,
-				new DetourTime(timeEstimator))).usingRecursiveFieldByFieldElementComparator()
-				.containsExactly(expectedInsertions);
+		assertThat(new InsertionGenerator(timeEstimator).generateInsertions(drtRequest,
+				entry)).usingRecursiveFieldByFieldElementComparator().containsExactly(expectedInsertions);
 	}
 
 	private InsertionWithDetourData<Double> insertion(VehicleEntry entry, int pickupIdx, int dropoffIdx,

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
@@ -22,7 +22,6 @@ package org.matsim.contrib.drt.optimizer.insertion;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.assertj.core.api.ListAssert;
 import org.junit.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
@@ -66,7 +65,7 @@ public class InsertionGeneratorTest {
 		VehicleEntry entry = entry(start);
 		assertInsertions(drtRequest, entry,
 				//pickup after start
-				insertion(entry, 0, 0, 1, 2, null, 0));
+				insertion(entry, 0, 0, 1, 2, Double.POSITIVE_INFINITY, 0));
 	}
 
 	@Test
@@ -76,10 +75,10 @@ public class InsertionGeneratorTest {
 		VehicleEntry entry = entry(start, stop0);
 		assertInsertions(drtRequest, entry,
 				//pickup after start
-				insertion(entry, 0, 0, 1, 2, null, 4),//
-				insertion(entry, 0, 1, 1, 2, 3., 0),
+				insertion(entry, 0, 0, 1, 2, Double.POSITIVE_INFINITY, 4),//
+				insertion(entry, 0, 1, 1, 2, 3, 0),
 				//pickup after stop 0
-				insertion(entry, 1, 1, 1, 2, null, 0));
+				insertion(entry, 1, 1, 1, 2, Double.POSITIVE_INFINITY, 0));
 	}
 
 	@Test
@@ -90,7 +89,7 @@ public class InsertionGeneratorTest {
 		assertInsertions(drtRequest, entry,
 				//no pickup after stop
 				//pickup after stop 0
-				insertion(entry, 1, 1, 1, 2, null, 0));
+				insertion(entry, 1, 1, 1, 2, Double.POSITIVE_INFINITY, 0));
 	}
 
 	@Test
@@ -101,14 +100,14 @@ public class InsertionGeneratorTest {
 		VehicleEntry entry = entry(start, stop0, stop1);
 		assertInsertions(drtRequest, entry,
 				//pickup after start
-				insertion(entry, 0, 0, 1, 2, null, 4),//
-				insertion(entry, 0, 1, 1, 2, 3., 4),//
-				insertion(entry, 0, 2, 1, 2, 3., 0),
+				insertion(entry, 0, 0, 1, 2, Double.POSITIVE_INFINITY, 4),//
+				insertion(entry, 0, 1, 1, 2, 3, 4),//
+				insertion(entry, 0, 2, 1, 2, 3, 0),
 				//pickup after stop 0
-				insertion(entry, 1, 1, 1, 2, null, 4),//
-				insertion(entry, 1, 2, 1, 2, 3., 0),
+				insertion(entry, 1, 1, 1, 2, Double.POSITIVE_INFINITY, 4),//
+				insertion(entry, 1, 2, 1, 2, 3, 0),
 				//pickup after stop 1
-				insertion(entry, 2, 2, 1, 2, null, 0));
+				insertion(entry, 2, 2, 1, 2, Double.POSITIVE_INFINITY, 0));
 	}
 
 	@Test
@@ -119,10 +118,10 @@ public class InsertionGeneratorTest {
 		VehicleEntry entry = entry(start, stop0, stop1);
 		assertInsertions(drtRequest, entry,
 				//pickup after start
-				insertion(entry, 0, 0, 1, 2, null, 4),
+				insertion(entry, 0, 0, 1, 2, Double.POSITIVE_INFINITY, 4),
 				//no pickup after stop 0
 				//pickup after stop 1
-				insertion(entry, 2, 2, 1, 2, null, 0));
+				insertion(entry, 2, 2, 1, 2, Double.POSITIVE_INFINITY, 0));
 	}
 
 	@Test
@@ -134,10 +133,10 @@ public class InsertionGeneratorTest {
 		assertInsertions(drtRequest, entry,
 				//no pickup after start
 				//pickup after stop 0
-				insertion(entry, 1, 1, 1, 2, null, 4),//
-				insertion(entry, 1, 2, 1, 2, 3., 0),
+				insertion(entry, 1, 1, 1, 2, Double.POSITIVE_INFINITY, 4),//
+				insertion(entry, 1, 2, 1, 2, 3, 0),
 				//pickup after stop 1
-				insertion(entry, 2, 2, 1, 2, null, 0));
+				insertion(entry, 2, 2, 1, 2, Double.POSITIVE_INFINITY, 0));
 	}
 
 	@Test
@@ -150,7 +149,7 @@ public class InsertionGeneratorTest {
 				//no pickup after start
 				//no pickup after stop 0
 				//pickup after stop 1
-				insertion(entry, 2, 2, 1, 2, null, 0));
+				insertion(entry, 2, 2, 1, 2, Double.POSITIVE_INFINITY, 0));
 	}
 
 	@Test
@@ -162,13 +161,13 @@ public class InsertionGeneratorTest {
 		VehicleEntry entry = entry(start, stop0, stop1, stop2);
 		assertInsertions(drtRequest, entry,
 				//pickup after start
-				insertion(entry, 0, 0, 1, 2, null, 4),//
-				insertion(entry, 0, 1, 1, 2, 3., 4),
+				insertion(entry, 0, 0, 1, 2, Double.POSITIVE_INFINITY, 4),//
+				insertion(entry, 0, 1, 1, 2, 3, 4),
 				//pickup after stop 0
-				insertion(entry, 1, 1, 1, 2, null, 4),
+				insertion(entry, 1, 1, 1, 2, Double.POSITIVE_INFINITY, 4),
 				//pickup after stop 1
 				//pickup after stop 2
-				insertion(entry, 3, 3, 1, 2, null, 0));
+				insertion(entry, 3, 3, 1, 2, Double.POSITIVE_INFINITY, 0));
 	}
 
 	@Test
@@ -181,10 +180,10 @@ public class InsertionGeneratorTest {
 		assertInsertions(drtRequest, entry,
 				//no pickup after start
 				//pickup after stop 0
-				insertion(entry, 1, 1, 1, 2, null, 4),
+				insertion(entry, 1, 1, 1, 2, Double.POSITIVE_INFINITY, 4),
 				//pickup after stop 1
 				//pickup after stop 2
-				insertion(entry, 3, 3, 1, 2, null, 0));
+				insertion(entry, 3, 3, 1, 2, Double.POSITIVE_INFINITY, 0));
 	}
 
 	@Test
@@ -195,7 +194,7 @@ public class InsertionGeneratorTest {
 		assertInsertions(drtRequest, entry,
 				//no pickup after start (pickup is exactly at stop0)
 				//pickup after stop 0
-				insertion(entry, 1, 1, 1, 2, null, 0));
+				insertion(entry, 1, 1, 0, 2, Double.POSITIVE_INFINITY, 0));
 	}
 
 	@Test
@@ -205,9 +204,9 @@ public class InsertionGeneratorTest {
 		VehicleEntry entry = entry(start, stop0);
 		assertInsertions(drtRequest, entry,
 				//pickup after start: insertion(0, 0) is a duplicate of insertion(0, 1)
-				insertion(entry, 0, 1, 1, 2, 3., 0),
+				insertion(entry, 0, 1, 1, 2, 0, 0),
 				//pickup after stop 0
-				insertion(entry, 1, 1, 1, 2, null, 0));
+				insertion(entry, 1, 1, 1, 2, Double.POSITIVE_INFINITY, 0));
 	}
 
 	@Test
@@ -220,9 +219,9 @@ public class InsertionGeneratorTest {
 		VehicleEntry entry = entry(start, stop0, stop1);
 		assertInsertions(drtRequest, entry,
 				//pickup after start: insertion(0, 0) is a duplicate of insertion(0, 1)
-				insertion(entry, 0, 1, 1, 2, 3., 4),
+				insertion(entry, 0, 1, 1, 2, 0, 4),
 				//pickup after stop 0
-				insertion(entry, 2, 2, 1, 2, null, 0));
+				insertion(entry, 2, 2, 1, 2, Double.POSITIVE_INFINITY, 0));
 	}
 
 	private Link link(String id) {
@@ -235,13 +234,28 @@ public class InsertionGeneratorTest {
 		int endOccupancy = stopCount > 0 ? entry.stops.get(stopCount - 1).outgoingOccupancy : entry.start.occupancy;
 		Preconditions.checkArgument(endOccupancy == 0);//make sure the input is valid
 
+		DetourTimeEstimator timeEstimator = (from, to) -> {
+			if (from == to) {
+				return 0;
+			} else if (to.equals(drtRequest.getFromLink())) {
+				return 1;//to pickup
+			} else if (from.equals(drtRequest.getFromLink())) {
+				return 2;//from pickup
+			} else if (to.equals(drtRequest.getToLink())) {
+				return 3;//to dropoff
+			} else if (from.equals(drtRequest.getToLink())) {
+				return 4;//from dropoff
+			}
+			throw new IllegalArgumentException();
+		};
+
 		assertThat(new InsertionGenerator().generateInsertions(drtRequest, entry,
-				new DetourData<>(l -> 1., l -> 2., l -> 3., l -> 4., 0.))).usingRecursiveFieldByFieldElementComparator()
+				new DetourTime(timeEstimator))).usingRecursiveFieldByFieldElementComparator()
 				.containsExactly(expectedInsertions);
 	}
 
 	private InsertionWithDetourData<Double> insertion(VehicleEntry entry, int pickupIdx, int dropoffIdx,
-			double timeToPickup, double timeFromPickup, Double timeToDropoff, double timeFromDropoff) {
+			double timeToPickup, double timeFromPickup, double timeToDropoff, double timeFromDropoff) {
 		return new InsertionWithDetourData<>(new Insertion(drtRequest, entry, pickupIdx, dropoffIdx), timeToPickup,
 				timeFromPickup, timeToDropoff, timeFromDropoff);
 	}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProviderTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProviderTest.java
@@ -51,7 +51,7 @@ public class SelectiveInsertionProviderTest {
 
 	@Test
 	public void getInsertions_noInsertionsGenerated() {
-		var insertionProvider = new SelectiveInsertionProvider(null, initialInsertionFinder, new InsertionGenerator(),
+		var insertionProvider = new SelectiveInsertionProvider(initialInsertionFinder, new InsertionGenerator(null),
 				rule.forkJoinPool);
 		assertThat(insertionProvider.getInsertions(null, List.of())).isEmpty();
 	}
@@ -74,7 +74,7 @@ public class SelectiveInsertionProviderTest {
 		var insertion1 = new Insertion(vehicleEntry, insertionPoint(), insertionPoint());
 		var insertion2 = new Insertion(vehicleEntry, insertionPoint(), insertionPoint());
 		var insertionGenerator = mock(InsertionGenerator.class);
-		when(insertionGenerator.generateInsertions(eq(request), eq(vehicleEntry), any())).thenReturn(
+		when(insertionGenerator.generateInsertions(eq(request), eq(vehicleEntry))).thenReturn(
 				List.of(insertionWithDetourData(insertion1), insertionWithDetourData(insertion2)));
 
 		//init restrictiveDetourTimeEstimator
@@ -91,8 +91,8 @@ public class SelectiveInsertionProviderTest {
 				.thenReturn(selectedInsertionWithDetourData);
 
 		//test insertionProvider
-		var insertionProvider = new SelectiveInsertionProvider(restrictiveDetourTimeEstimator, initialInsertionFinder,
-				insertionGenerator, rule.forkJoinPool);
+		var insertionProvider = new SelectiveInsertionProvider(initialInsertionFinder, insertionGenerator,
+				rule.forkJoinPool);
 		assertThat(insertionProvider.getInsertions(request, List.of(vehicleEntry))).isEqualTo(
 				selectedInsertion.stream().collect(toList()));
 	}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProviderTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProviderTest.java
@@ -23,8 +23,7 @@ package org.matsim.contrib.drt.optimizer.insertion;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -75,8 +74,8 @@ public class SelectiveInsertionProviderTest {
 		var insertion1 = new Insertion(vehicleEntry, insertionPoint(), insertionPoint());
 		var insertion2 = new Insertion(vehicleEntry, insertionPoint(), insertionPoint());
 		var insertionGenerator = mock(InsertionGenerator.class);
-		when(insertionGenerator.generateInsertions(eq(request), eq(vehicleEntry))).thenReturn(
-				List.of(insertion1, insertion2));
+		when(insertionGenerator.generateInsertions(eq(request), eq(vehicleEntry), any())).thenReturn(
+				List.of(insertionWithDetourData(insertion1), insertionWithDetourData(insertion2)));
 
 		//init restrictiveDetourTimeEstimator
 		DetourTimeEstimator restrictiveDetourTimeEstimator = (from, to) -> 987.;
@@ -100,5 +99,9 @@ public class SelectiveInsertionProviderTest {
 
 	private InsertionGenerator.InsertionPoint insertionPoint() {
 		return new InsertionGenerator.InsertionPoint(-1, mock(Waypoint.class), null, mock(Waypoint.class));
+	}
+
+	private InsertionWithDetourData<Double> insertionWithDetourData(Insertion insertion) {
+		return new InsertionWithDetourData<>(insertion, Double.NaN, Double.NaN, Double.NaN, Double.NaN);
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProviderTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProviderTest.java
@@ -83,7 +83,7 @@ public class SelectiveInsertionProviderTest {
 		//mock initialInsertionFinder
 		var selectedInsertion = oneSelected ? Optional.of(insertion1) : Optional.<Insertion>empty();
 		var selectedInsertionWithDetourData = selectedInsertion.map(
-				DetourData.create(restrictiveDetourTimeEstimator, request)::createInsertionWithDetourData);
+				new DetourData<>(l -> 987., l -> 987., l -> 987., l -> 987., 0.)::createInsertionWithDetourData);
 		when(initialInsertionFinder.findBestInsertion(eq(request),
 				argThat(argument -> argument.map(InsertionWithDetourData::getInsertion)
 						.collect(toSet())


### PR DESCRIPTION
As a preparation step for computing detour times already during insertion generation. That should allow early pruning of generated insertions based on available time slack. These changes will be handled in the upcoming series of PRs.

**Motivation**
When running big DRT scenarios (e.g. Berlin scenario with 6 000 vehicles, 270 000 requests) with the selective insertion search, most of the time is actually spent on generating and evaluating insertions using travel-time matrices. At the same time, computing the actual paths for the finally selected insertion has a relatively small impact on the total computation time. Therefore, earlier pruning of infeasible insertions should bring a substantial speedup for the selective insertion search.