### PR TITLE
drt: pre-calculate and cache vehicle/stop slack times

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/edrt/optimizer/EDrtVehicleDataEntryFactory.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/edrt/optimizer/EDrtVehicleDataEntryFactory.java
@@ -44,7 +44,7 @@ public class EDrtVehicleDataEntryFactory implements VehicleEntry.EntryFactory {
 		public final double socBeforeFinalStay;
 
 		public EVehicleEntry(VehicleEntry entry, double socBeforeFinalStay) {
-			super(entry.vehicle, entry.start, entry.stops);
+			super(entry);
 			this.socBeforeFinalStay = socBeforeFinalStay;
 		}
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/edrt/optimizer/EDrtVehicleDataEntryFactory.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/edrt/optimizer/EDrtVehicleDataEntryFactory.java
@@ -59,7 +59,7 @@ public class EDrtVehicleDataEntryFactory implements VehicleEntry.EntryFactory {
 
 	@Override
 	public VehicleEntry create(DvrpVehicle vehicle, double currentTime) {
-		if (!entryFactory.isEligibleForRequestInsertion(vehicle, currentTime)) {
+		if (entryFactory.isNotEligibleForRequestInsertion(vehicle, currentTime)) {
 			return null;
 		}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/optimizer/insertion/ShiftInsertionCostCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/optimizer/insertion/ShiftInsertionCostCalculator.java
@@ -46,7 +46,7 @@ public class ShiftInsertionCostCalculator<D> implements InsertionCostCalculator<
 			CostCalculationStrategy costCalculationStrategy, ToDoubleFunction<D> detourTime,
 			DetourTimeEstimator replacedDriveTimeEstimator) {
 		this.timer = timer;
-		defaultInsertionCostCalculator = new DefaultInsertionCostCalculator<>(drtConfig, timer, costCalculationStrategy,
+		defaultInsertionCostCalculator = new DefaultInsertionCostCalculator<>(drtConfig, costCalculationStrategy,
 				detourTime, replacedDriveTimeEstimator);
 		detourTimeCalculator = new InsertionDetourTimeCalculator<>(drtConfig.getStopDuration(), detourTime,
 				replacedDriveTimeEstimator);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/VehicleDataEntryFactoryImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/VehicleDataEntryFactoryImpl.java
@@ -31,6 +31,7 @@ import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.schedule.Schedule;
 import org.matsim.contrib.dvrp.schedule.Schedule.ScheduleStatus;
+import org.matsim.contrib.dvrp.schedule.Schedules;
 import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.contrib.dvrp.tracker.OnlineDriveTaskTracker;
 import org.matsim.contrib.dvrp.util.LinkTimePair;
@@ -107,11 +108,38 @@ public class VehicleDataEntryFactoryImpl implements VehicleEntry.EntryFactory {
 			outgoingOccupancy -= s.getOccupancyChange();
 		}
 
+		var slackTimes = computeSlackTimes(vehicle, currentTime, stops);
+
 		return new VehicleEntry(vehicle, new Waypoint.Start(startTask, start.link, start.time, outgoingOccupancy),
-				ImmutableList.copyOf(stops));
+				ImmutableList.copyOf(stops), slackTimes);
 	}
 
 	public boolean isNotEligibleForRequestInsertion(DvrpVehicle vehicle, double currentTime) {
 		return currentTime + lookAhead < vehicle.getServiceBeginTime() || currentTime >= vehicle.getServiceEndTime();
+	}
+
+	static double[] computeSlackTimes(DvrpVehicle vehicle, double now, Waypoint.Stop[] stops) {
+		double[] slackTimes = new double[stops.length + 1];
+
+		//vehicle
+		double slackTime = calcVehicleSlackTime(vehicle, now);
+		slackTimes[stops.length] = slackTime;
+
+		//stops
+		for (int i = stops.length - 1; i >= 0; i--) {
+			var stop = stops[i];
+			slackTime = Math.min(stop.latestArrivalTime - stop.task.getBeginTime(), slackTime);
+			slackTime = Math.min(stop.latestDepartureTime - stop.task.getEndTime(), slackTime);
+			slackTimes[i] = slackTime;
+		}
+		return slackTimes;
+	}
+
+	static double calcVehicleSlackTime(DvrpVehicle vehicle, double now) {
+		DrtStayTask lastTask = (DrtStayTask)Schedules.getLastTask(vehicle.getSchedule());
+		//if the last task is started, take 'now', otherwise take the planned begin time
+		double availableFromTime = Math.max(lastTask.getBeginTime(), now);
+		//for an already delayed vehicle, assume slack is 0 (instead of a negative number)
+		return Math.max(0, vehicle.getServiceEndTime() - availableFromTime);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/VehicleDataEntryFactoryImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/VehicleDataEntryFactoryImpl.java
@@ -52,7 +52,7 @@ public class VehicleDataEntryFactoryImpl implements VehicleEntry.EntryFactory {
 	}
 
 	public VehicleEntry create(DvrpVehicle vehicle, double currentTime) {
-		if (!isEligibleForRequestInsertion(vehicle, currentTime)) {
+		if (isNotEligibleForRequestInsertion(vehicle, currentTime)) {
 			return null;
 		}
 
@@ -111,7 +111,7 @@ public class VehicleDataEntryFactoryImpl implements VehicleEntry.EntryFactory {
 				ImmutableList.copyOf(stops));
 	}
 
-	public boolean isEligibleForRequestInsertion(DvrpVehicle vehicle, double currentTime) {
-		return !(currentTime + lookAhead < vehicle.getServiceBeginTime() || currentTime >= vehicle.getServiceEndTime());
+	public boolean isNotEligibleForRequestInsertion(DvrpVehicle vehicle, double currentTime) {
+		return currentTime + lookAhead < vehicle.getServiceBeginTime() || currentTime >= vehicle.getServiceEndTime();
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/VehicleEntry.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/VehicleEntry.java
@@ -36,12 +36,23 @@ public class VehicleEntry {
 	public final Waypoint.Start start;
 	public final ImmutableList<Waypoint.Stop> stops;
 	public final Waypoint.End end;
+	private final double[] slackTimes;// for all insertion points
 
-	public VehicleEntry(DvrpVehicle vehicle, Waypoint.Start start, ImmutableList<Waypoint.Stop> stops) {
+	public VehicleEntry(DvrpVehicle vehicle, Waypoint.Start start, ImmutableList<Waypoint.Stop> stops,
+			double[] slackTimes) {
 		this.vehicle = vehicle;
 		this.start = start;
 		this.stops = stops;
 		this.end = Waypoint.End.OPEN_END;
+		this.slackTimes = slackTimes;
+	}
+
+	protected VehicleEntry(VehicleEntry that) {
+		this.vehicle = that.vehicle;
+		this.start = that.start;
+		this.stops = that.stops;
+		this.end = that.end;
+		this.slackTimes = that.slackTimes;
 	}
 
 	public Waypoint getWaypoint(int index) {
@@ -50,5 +61,9 @@ public class VehicleEntry {
 
 	public boolean isAfterLastStop(int index) {
 		return index == stops.size();
+	}
+
+	public double getSlackTime(int index) {
+		return slackTimes[index];
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategy.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategy.java
@@ -29,20 +29,18 @@ public interface CostCalculationStrategy {
 	/**
 	 * @param request
 	 * @param insertion
-	 * @param vehicleSlackTime
 	 * @param detourTimeInfo
 	 * @return the cost of insertion, INFEASIBLE_SOLUTION_COST if insertion is not feasible
 	 */
-	double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion, double vehicleSlackTime,
+	double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion,
 			InsertionDetourTimeCalculator.DetourTimeInfo detourTimeInfo);
 
 	class RejectSoftConstraintViolations implements CostCalculationStrategy {
 		@Override
-		public double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion, double vehicleSlackTime,
+		public double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion,
 				InsertionDetourTimeCalculator.DetourTimeInfo detourTimeInfo) {
 			double totalTimeLoss = detourTimeInfo.getTotalTimeLoss();
-			if (totalTimeLoss > vehicleSlackTime
-					|| detourTimeInfo.departureTime > request.getLatestStartTime()
+			if (detourTimeInfo.departureTime > request.getLatestStartTime()
 					|| detourTimeInfo.arrivalTime > request.getLatestArrivalTime()) {
 				//no extra time is lost => do not check if the current slack time is long enough (can be even negative)
 				return InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
@@ -59,14 +57,9 @@ public interface CostCalculationStrategy {
 		static final double MAX_TRAVEL_TIME_VIOLATION_PENALTY = 10;// 10 seconds of penalty per 1 second of late arrival
 
 		@Override
-		public double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion, double vehicleSlackTime,
+		public double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion,
 				InsertionDetourTimeCalculator.DetourTimeInfo detourTimeInfo) {
 			double totalTimeLoss = detourTimeInfo.getTotalTimeLoss();
-			if (totalTimeLoss > vehicleSlackTime) {
-				//no extra time is lost => do not check if the current slack time is long enough (can be even negative)
-				return InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
-			}
-
 			double waitTimeViolation = Math.max(0, detourTimeInfo.departureTime - request.getLatestStartTime());
 			double travelTimeViolation = Math.max(0, detourTimeInfo.arrivalTime - request.getLatestArrivalTime());
 			return MAX_WAIT_TIME_VIOLATION_PENALTY * waitTimeViolation

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategy.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategy.java
@@ -41,7 +41,7 @@ public interface CostCalculationStrategy {
 		public double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion, double vehicleSlackTime,
 				InsertionDetourTimeCalculator.DetourTimeInfo detourTimeInfo) {
 			double totalTimeLoss = detourTimeInfo.getTotalTimeLoss();
-			if ((totalTimeLoss > 0 && totalTimeLoss > vehicleSlackTime)
+			if (totalTimeLoss > vehicleSlackTime
 					|| detourTimeInfo.departureTime > request.getLatestStartTime()
 					|| detourTimeInfo.arrivalTime > request.getLatestArrivalTime()) {
 				//no extra time is lost => do not check if the current slack time is long enough (can be even negative)
@@ -62,7 +62,7 @@ public interface CostCalculationStrategy {
 		public double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion, double vehicleSlackTime,
 				InsertionDetourTimeCalculator.DetourTimeInfo detourTimeInfo) {
 			double totalTimeLoss = detourTimeInfo.getTotalTimeLoss();
-			if (totalTimeLoss > 0 && totalTimeLoss > vehicleSlackTime) {
+			if (totalTimeLoss > vehicleSlackTime) {
 				//no extra time is lost => do not check if the current slack time is long enough (can be even negative)
 				return InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
 			}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultInsertionCostCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultInsertionCostCalculator.java
@@ -130,8 +130,12 @@ public class DefaultInsertionCostCalculator<D> implements InsertionCostCalculato
 		return true; //all time constraints of all stops are satisfied
 	}
 
+	//we assume slack time is never negative
 	static double calcVehicleSlackTime(VehicleEntry vEntry, double now) {
 		DrtStayTask lastTask = (DrtStayTask)Schedules.getLastTask(vEntry.vehicle.getSchedule());
-		return vEntry.vehicle.getServiceEndTime() - Math.max(lastTask.getBeginTime(), now);
+		//if the last task is started, take 'now', otherwise take the planned begin time
+		double availableFromTime = Math.max(lastTask.getBeginTime(), now);
+		//for an already delayed vehicle, assume slack is 0 (instead of a negative number)
+		return Math.max(0, vEntry.vehicle.getServiceEndTime() - availableFromTime);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultInsertionCostCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultInsertionCostCalculator.java
@@ -24,12 +24,8 @@ import java.util.function.ToDoubleFunction;
 
 import javax.annotation.Nullable;
 
-import org.matsim.contrib.drt.optimizer.VehicleEntry;
-import org.matsim.contrib.drt.optimizer.Waypoint;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
-import org.matsim.contrib.drt.schedule.DrtStayTask;
-import org.matsim.contrib.dvrp.schedule.Schedules;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -45,28 +41,24 @@ public class DefaultInsertionCostCalculator<D> implements InsertionCostCalculato
 			@Override
 			public <D> InsertionCostCalculator<D> create(ToDoubleFunction<D> detourTime,
 					DetourTimeEstimator replacedDriveTimeEstimator) {
-				return new DefaultInsertionCostCalculator<>(drtCfg, timer, costCalculationStrategy, detourTime,
+				return new DefaultInsertionCostCalculator<>(drtCfg, costCalculationStrategy, detourTime,
 						replacedDriveTimeEstimator);
 			}
 		};
 	}
 
-	private final DoubleSupplier timeOfDay;
 	private final CostCalculationStrategy costCalculationStrategy;
 	private final InsertionDetourTimeCalculator<D> detourTimeCalculator;
 
-	public DefaultInsertionCostCalculator(DrtConfigGroup drtConfig, MobsimTimer timer,
-			CostCalculationStrategy costCalculationStrategy, ToDoubleFunction<D> detourTime,
-			@Nullable DetourTimeEstimator replacedDriveTimeEstimator) {
-		this(timer::getTimeOfDay, costCalculationStrategy,
-				new InsertionDetourTimeCalculator<>(drtConfig.getStopDuration(), detourTime,
-						replacedDriveTimeEstimator));
+	public DefaultInsertionCostCalculator(DrtConfigGroup drtConfig, CostCalculationStrategy costCalculationStrategy,
+			ToDoubleFunction<D> detourTime, @Nullable DetourTimeEstimator replacedDriveTimeEstimator) {
+		this(costCalculationStrategy, new InsertionDetourTimeCalculator<>(drtConfig.getStopDuration(), detourTime,
+				replacedDriveTimeEstimator));
 	}
 
 	@VisibleForTesting
-	DefaultInsertionCostCalculator(DoubleSupplier timeOfDay, CostCalculationStrategy costCalculationStrategy,
+	DefaultInsertionCostCalculator(CostCalculationStrategy costCalculationStrategy,
 			InsertionDetourTimeCalculator<D> detourTimeCalculator) {
-		this.timeOfDay = timeOfDay;
 		this.costCalculationStrategy = costCalculationStrategy;
 		this.detourTimeCalculator = detourTimeCalculator;
 	}
@@ -89,53 +81,14 @@ public class DefaultInsertionCostCalculator<D> implements InsertionCostCalculato
 
 		var detourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion);
 
-		if (!checkTimeConstraintsForScheduledRequests(insertion.getInsertion(), detourTimeInfo.pickupTimeLoss,
-				detourTimeInfo.getTotalTimeLoss())) {
+		var insertion1 = insertion.getInsertion();
+		var vEntry = insertion1.vehicleEntry;
+
+		if (vEntry.getSlackTime(insertion1.pickup.index) < detourTimeInfo.pickupTimeLoss
+				|| vEntry.getSlackTime(insertion1.dropoff.index) < detourTimeInfo.getTotalTimeLoss()) {
 			return INFEASIBLE_SOLUTION_COST;
 		}
 
-		double vehicleSlackTime = calcVehicleSlackTime(insertion.getVehicleEntry(), timeOfDay.getAsDouble());
-		return costCalculationStrategy.calcCost(drtRequest, insertion.getInsertion(), vehicleSlackTime, detourTimeInfo);
-	}
-
-	static boolean checkTimeConstraintsForScheduledRequests(InsertionGenerator.Insertion insertion,
-			double pickupDetourTimeLoss, double totalTimeLoss) {
-		VehicleEntry vEntry = insertion.vehicleEntry;
-		final int pickupIdx = insertion.pickup.index;
-		final int dropoffIdx = insertion.dropoff.index;
-
-		// each existing stop has 2 time constraints: latestArrivalTime and latestDepartureTime (see: Waypoint.Stop)
-		// we are looking only at the time constraints of the scheduled requests (the new request is checked separately)
-
-		// all stops after the new (potential) pickup but before the new dropoff are delayed by pickupDetourTimeLoss
-		// check if this delay satisfies the time constraints at these stops
-		for (int s = pickupIdx; s < dropoffIdx; s++) {
-			Waypoint.Stop stop = vEntry.stops.get(s);
-			if (stop.task.getBeginTime() + pickupDetourTimeLoss > stop.latestArrivalTime
-					|| stop.task.getEndTime() + pickupDetourTimeLoss > stop.latestDepartureTime) {
-				return false;
-			}
-		}
-
-		// all stops after the new (potential) dropoff are delayed by totalTimeLoss
-		// check if this delay satisfies the time constraints at these stops
-		for (int s = dropoffIdx; s < vEntry.stops.size(); s++) {
-			Waypoint.Stop stop = vEntry.stops.get(s);
-			if (stop.task.getBeginTime() + totalTimeLoss > stop.latestArrivalTime
-					|| stop.task.getEndTime() + totalTimeLoss > stop.latestDepartureTime) {
-				return false;
-			}
-		}
-
-		return true; //all time constraints of all stops are satisfied
-	}
-
-	//we assume slack time is never negative
-	static double calcVehicleSlackTime(VehicleEntry vEntry, double now) {
-		DrtStayTask lastTask = (DrtStayTask)Schedules.getLastTask(vEntry.vehicle.getSchedule());
-		//if the last task is started, take 'now', otherwise take the planned begin time
-		double availableFromTime = Math.max(lastTask.getBeginTime(), now);
-		//for an already delayed vehicle, assume slack is 0 (instead of a negative number)
-		return Math.max(0, vEntry.vehicle.getServiceEndTime() - availableFromTime);
+		return costCalculationStrategy.calcCost(drtRequest, insertion1, detourTimeInfo);
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/VehicleDataEntryFactoryImplTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/VehicleDataEntryFactoryImplTest.java
@@ -1,0 +1,99 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2021 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.optimizer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.matsim.contrib.drt.optimizer.VehicleDataEntryFactoryImpl.computeSlackTimes;
+import static org.matsim.contrib.drt.optimizer.Waypoint.Stop;
+
+import org.junit.Test;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.contrib.drt.schedule.DrtStayTask;
+import org.matsim.contrib.drt.schedule.DrtStopTask;
+import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
+import org.matsim.contrib.dvrp.fleet.DvrpVehicleImpl;
+import org.matsim.contrib.dvrp.fleet.ImmutableDvrpVehicleSpecification;
+import org.matsim.testcases.fakes.FakeLink;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class VehicleDataEntryFactoryImplTest {
+	private final Link depot = new FakeLink(Id.createLinkId("depot"));
+
+	//time slack: 20 (arrival is the constraint)
+	private final Stop stop0 = stop(100, 120, 200, 230);
+
+	//time slack: 30 (departure is the constraint)
+	private final Stop stop1 = stop(300, 340, 400, 430);
+
+	@Test
+	public void computeSlackTimes_withStops() {
+		//final stay task not started - vehicle slack time is 50
+		assertThat(computeSlackTimes(vehicle(500, 450), 100, new Stop[] { stop0, stop1 })).containsExactly(20, 30, 50);
+
+		//final stay task not started - vehicle slack time is 25 and limits the slack times at stop1
+		assertThat(computeSlackTimes(vehicle(500, 475), 100, new Stop[] { stop0, stop1 })).containsExactly(20, 25, 25);
+
+		//final stay task not started - vehicle slack time is 10 and limits the slack times at all stops
+		assertThat(computeSlackTimes(vehicle(500, 490), 100, new Stop[] { stop0, stop1 })).containsExactly(10, 10, 10);
+	}
+
+	@Test
+	public void computeSlackTimes_withoutStops() {
+		//final stay task not started yet - vehicle slack time is 10
+		assertThat(computeSlackTimes(vehicle(500, 490), 485, new Stop[] {})).containsExactly(10);
+
+		//final stay task just started - vehicle slack time is 10
+		assertThat(computeSlackTimes(vehicle(500, 490), 490, new Stop[] {})).containsExactly(10);
+
+		//final stay task half completed - vehicle slack time is 5
+		assertThat(computeSlackTimes(vehicle(500, 490), 495, new Stop[] {})).containsExactly(5);
+
+		//final stay task just completed - vehicle slack time is 0
+		assertThat(computeSlackTimes(vehicle(500, 490), 500, new Stop[] {})).containsExactly(0);
+
+		//final stay task started, but delayed - vehicle slack time is 0
+		assertThat(computeSlackTimes(vehicle(500, 510), 510, new Stop[] {})).containsExactly(0);
+
+		//final stay task planned after vehicle end time - vehicle slack time is 0s
+		assertThat(computeSlackTimes(vehicle(500, 510), 300, new Stop[] {})).containsExactly(0);
+	}
+
+	private Stop stop(double beginTime, double latestArrivalTime, double endTime, double latestDepartureTime) {
+		return new Stop(new DrtStopTask(beginTime, endTime, null), latestArrivalTime, latestDepartureTime, 0);
+	}
+
+	private DvrpVehicle vehicle(double vehicleEndTime, double lastStayTaskBeginTime) {
+		var vehicle = new DvrpVehicleImpl(ImmutableDvrpVehicleSpecification.newBuilder()
+				.id(Id.create("a", DvrpVehicle.class))
+				.startLinkId(depot.getId())
+				.capacity(0)
+				.serviceBeginTime(0)
+				.serviceEndTime(vehicleEndTime)
+				.build(), depot);
+		vehicle.getSchedule()
+				.addTask(
+						new DrtStayTask(lastStayTaskBeginTime, Math.max(lastStayTaskBeginTime, vehicleEndTime), depot));
+		return vehicle;
+	}
+}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/BestInsertionFinderTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/BestInsertionFinderTest.java
@@ -137,7 +137,7 @@ public class BestInsertionFinderTest {
 	private InsertionWithDetourData<Double> insertion(String vehicleId, int pickupIdx, int dropoffIdx) {
 		var vehicle = mock(DvrpVehicle.class);
 		when(vehicle.getId()).thenReturn(Id.create(vehicleId, DvrpVehicle.class));
-		var vehicleEntry = new VehicleEntry(vehicle, null, null);
+		var vehicleEntry = new VehicleEntry(vehicle, null, null, null);
 
 		var pickupInsertion = new InsertionGenerator.InsertionPoint(pickupIdx, null, null, null);
 		var dropoffInsertion = new InsertionGenerator.InsertionPoint(dropoffIdx, null, null, null);

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategyTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategyTest.java
@@ -39,12 +39,6 @@ public class CostCalculationStrategyTest {
 	}
 
 	@Test
-	public void RejectSoftConstraintViolations_negativeSlackTime_butNoTimeLoss() {
-		assertRejectSoftConstraintViolations(9999, 9999, -10,
-				new InsertionDetourTimeCalculator.DetourTimeInfo(0, 0, 0, 0), 0);
-	}
-
-	@Test
 	public void RejectSoftConstraintViolations_tooLongWaitTime() {
 		assertRejectSoftConstraintViolations(10, 9999, 9999,
 				new InsertionDetourTimeCalculator.DetourTimeInfo(11, 22, 0, 0), INFEASIBLE_SOLUTION_COST);
@@ -76,12 +70,6 @@ public class CostCalculationStrategyTest {
 	public void DiscourageSoftConstraintViolations_tooLittleSlackTime() {
 		assertDiscourageSoftConstraintViolations(9999, 9999, 10,
 				new InsertionDetourTimeCalculator.DetourTimeInfo(0, 0, 5, 5.01), INFEASIBLE_SOLUTION_COST);
-	}
-
-	@Test
-	public void DiscourageSoftConstraintViolations_negativeSlackTime_butNoTimeLoss() {
-		assertDiscourageSoftConstraintViolations(9999, 9999, -10,
-				new InsertionDetourTimeCalculator.DetourTimeInfo(0, 0, 0, 0), 0);
 	}
 
 	@Test

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategyTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategyTest.java
@@ -26,6 +26,7 @@ import static org.matsim.contrib.drt.optimizer.insertion.CostCalculationStrategy
 import static org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
 
 import org.junit.Test;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionDetourTimeCalculator.DetourTimeInfo;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 
 /**
@@ -33,70 +34,54 @@ import org.matsim.contrib.drt.passenger.DrtRequest;
  */
 public class CostCalculationStrategyTest {
 	@Test
-	public void RejectSoftConstraintViolations_tooLittleSlackTime() {
-		assertRejectSoftConstraintViolations(9999, 9999, 10,
-				new InsertionDetourTimeCalculator.DetourTimeInfo(0, 0, 5, 5.01), INFEASIBLE_SOLUTION_COST);
-	}
-
-	@Test
 	public void RejectSoftConstraintViolations_tooLongWaitTime() {
-		assertRejectSoftConstraintViolations(10, 9999, 9999,
-				new InsertionDetourTimeCalculator.DetourTimeInfo(11, 22, 0, 0), INFEASIBLE_SOLUTION_COST);
+		assertRejectSoftConstraintViolations(10, 9999, new DetourTimeInfo(11, 22, 0, 0), INFEASIBLE_SOLUTION_COST);
 	}
 
 	@Test
 	public void RejectSoftConstraintViolations_tooLongTravelTime() {
-		assertRejectSoftConstraintViolations(9999, 10, 9999,
-				new InsertionDetourTimeCalculator.DetourTimeInfo(0, 11, 0, 0), INFEASIBLE_SOLUTION_COST);
+		assertRejectSoftConstraintViolations(9999, 10, new DetourTimeInfo(0, 11, 0, 0), INFEASIBLE_SOLUTION_COST);
 	}
 
 	@Test
 	public void RejectSoftConstraintViolations_allConstraintSatisfied() {
-		assertRejectSoftConstraintViolations(9999, 9999, 9999,
-				new InsertionDetourTimeCalculator.DetourTimeInfo(11, 22, 33, 44), 33 + 44);
+		assertRejectSoftConstraintViolations(9999, 9999, new DetourTimeInfo(11, 22, 33, 44), 33 + 44);
 	}
 
 	private void assertRejectSoftConstraintViolations(double latestStartTime, double latestArrivalTime,
-			double vehicleSlackTime, InsertionDetourTimeCalculator.DetourTimeInfo detourTimeInfo, double expectedCost) {
+			DetourTimeInfo detourTimeInfo, double expectedCost) {
 		var drtRequest = DrtRequest.newBuilder()
 				.latestStartTime(latestStartTime)
 				.latestArrivalTime(latestArrivalTime)
 				.build();
 		assertThat(new CostCalculationStrategy.RejectSoftConstraintViolations().calcCost(drtRequest, null,
-				vehicleSlackTime, detourTimeInfo)).isEqualTo(expectedCost);
-	}
-
-	@Test
-	public void DiscourageSoftConstraintViolations_tooLittleSlackTime() {
-		assertDiscourageSoftConstraintViolations(9999, 9999, 10,
-				new InsertionDetourTimeCalculator.DetourTimeInfo(0, 0, 5, 5.01), INFEASIBLE_SOLUTION_COST);
+				detourTimeInfo)).isEqualTo(expectedCost);
 	}
 
 	@Test
 	public void DiscourageSoftConstraintViolations_tooLongWaitTime() {
-		assertDiscourageSoftConstraintViolations(10, 9999, 9999,
-				new InsertionDetourTimeCalculator.DetourTimeInfo(11, 22, 0, 0), MAX_WAIT_TIME_VIOLATION_PENALTY);
+		assertDiscourageSoftConstraintViolations(10, 9999, new DetourTimeInfo(11, 22, 0, 0),
+				MAX_WAIT_TIME_VIOLATION_PENALTY);
 	}
 
 	@Test
 	public void DiscourageSoftConstraintViolations_tooLongTravelTime() {
-		assertDiscourageSoftConstraintViolations(9999, 10, 9999,
-				new InsertionDetourTimeCalculator.DetourTimeInfo(0, 11, 0, 0), MAX_TRAVEL_TIME_VIOLATION_PENALTY);
+		assertDiscourageSoftConstraintViolations(9999, 10, new DetourTimeInfo(0, 11, 0, 0),
+				MAX_TRAVEL_TIME_VIOLATION_PENALTY);
 	}
 
 	@Test
 	public void DiscourageSoftConstraintViolations_allConstraintSatisfied() {
-		assertDiscourageSoftConstraintViolations(9999, 9999, 9999,
-				new InsertionDetourTimeCalculator.DetourTimeInfo(11, 22, 33, 44), 33 + 44);
+		assertDiscourageSoftConstraintViolations(9999, 9999, new DetourTimeInfo(11, 22, 33, 44), 33 + 44);
 	}
 
 	private void assertDiscourageSoftConstraintViolations(double latestStartTime, double latestArrivalTime,
-			double vehicleSlackTime, InsertionDetourTimeCalculator.DetourTimeInfo detourTimeInfo, double expectedCost) {
+			DetourTimeInfo detourTimeInfo, double expectedCost) {
 		var drtRequest = DrtRequest.newBuilder()
 				.latestStartTime(latestStartTime)
 				.latestArrivalTime(latestArrivalTime)
 				.build();
 		assertThat(new CostCalculationStrategy.DiscourageSoftConstraintViolations().calcCost(drtRequest, null,
-				vehicleSlackTime, detourTimeInfo)).isEqualTo(expectedCost);
+				detourTimeInfo)).isEqualTo(expectedCost);
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearchTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearchTest.java
@@ -50,8 +50,8 @@ import org.matsim.core.mobsim.framework.MobsimTimer;
 public class DefaultDrtInsertionSearchTest {
 	@Test
 	public void findBestInsertion_noInsertionsProvided() {
-		var insertionCostCalculator = new DefaultInsertionCostCalculator<>(new DrtConfigGroup(), new MobsimTimer(),
-				null, PathData::getTravelTime, null);
+		var insertionCostCalculator = new DefaultInsertionCostCalculator<>(new DrtConfigGroup(), null,
+				PathData::getTravelTime, null);
 		var insertionSearch = new DefaultDrtInsertionSearch(mock(InsertionProvider.class), null,
 				insertionCostCalculator);
 		assertThat(insertionSearch.findBestInsertion(null, List.of())).isEmpty();

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserterTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserterTest.java
@@ -189,7 +189,7 @@ public class DefaultUnplannedRequestInserterTest {
 		var unplannedRequests = requests(request1);
 		double now = 15;
 
-		var vehicle1Entry = new VehicleEntry(vehicle1, null, null);
+		var vehicle1Entry = new VehicleEntry(vehicle1, null, null, null);
 		var createEntryCounter = new MutableInt();
 		VehicleEntry.EntryFactory entryFactory = (vehicle, currentTime) -> {
 			//make sure the right arguments are passed

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DetourDataTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DetourDataTest.java
@@ -36,7 +36,6 @@ import org.matsim.testcases.fakes.FakeLink;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableTable;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -127,7 +126,7 @@ public class DetourDataTest {
 
 	private VehicleEntry entry(Link startLink, Link... stopLinks) {
 		return new VehicleEntry(null, new Waypoint.Start(null, startLink, 0, 0),
-				Arrays.stream(stopLinks).map(this::stop).collect(ImmutableList.toImmutableList()));
+				Arrays.stream(stopLinks).map(this::stop).collect(ImmutableList.toImmutableList()), null);
 	}
 
 	private Waypoint.Stop stop(Link link) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
@@ -21,9 +21,8 @@
 package org.matsim.contrib.drt.optimizer.insertion;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.matsim.contrib.drt.optimizer.insertion.DefaultInsertionCostCalculator.calcVehicleSlackTime;
-import static org.matsim.contrib.drt.optimizer.insertion.DefaultInsertionCostCalculator.checkTimeConstraintsForScheduledRequests;
 import static org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
+import static org.matsim.contrib.drt.optimizer.insertion.InsertionDetourTimeCalculator.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -51,127 +50,45 @@ public class InsertionCostCalculatorTest {
 	private final Link toLink = link("to");
 	private final DrtRequest drtRequest = DrtRequest.newBuilder().fromLink(fromLink).toLink(toLink).build();
 
-	private final Waypoint.Start start = start(null, 0, link("start"));
-
-	//time slack: 20 (arrival is the constraint)
-	private final Waypoint.Stop stop0 = stop(100, 120, 200, 230);
-
-	//time slack: 30 (departure is the constraint)
-	private final Waypoint.Stop stop1 = stop(300, 340, 400, 430);
-
 	@Test
-	public void testCalculate() throws NoSuchFieldException {
-		VehicleEntry entry = entry(500, 450, stop0);
+	public void testCalculate() {
+		VehicleEntry entry = entry(new double[] { 20, 50 });
 		var insertion = new InsertionWithDetourData<>(insertion(entry, 0, 1), null, null, null, null);
 
 		//feasible solution
-		assertCalculate(0, insertion, new InsertionDetourTimeCalculator.DetourTimeInfo(0, 0, 11, 22), 11 + 22);
+		assertCalculate(insertion, new DetourTimeInfo(0, 0, 11, 22), 11 + 22);
+
+		//feasible solution - longest possible pickup and dropoff time losses
+		assertCalculate(insertion, new DetourTimeInfo(0, 0, 20, 30), 20 + 30);
 
 		//infeasible solution - time constraints at stop 0
-		assertCalculate(0, insertion, new InsertionDetourTimeCalculator.DetourTimeInfo(0, 0, 999, 999),
-				INFEASIBLE_SOLUTION_COST);
+		assertCalculate(insertion, new DetourTimeInfo(0, 0, 21, 29), INFEASIBLE_SOLUTION_COST);
 
-		//infeasible solution - too little vehicle time slack
-		assertCalculate(499, insertion, new InsertionDetourTimeCalculator.DetourTimeInfo(0, 0, 1, 1),
-				INFEASIBLE_SOLUTION_COST);
+		//infeasible solution - vehicle time constraints
+		assertCalculate(insertion, new DetourTimeInfo(0, 0, 20, 31), INFEASIBLE_SOLUTION_COST);
 	}
 
-	private <D> void assertCalculate(double now, InsertionWithDetourData<D> insertion,
-			InsertionDetourTimeCalculator.DetourTimeInfo detourTimeInfo, double expectedCost) {
+	private <D> void assertCalculate(InsertionWithDetourData<D> insertion, DetourTimeInfo detourTimeInfo,
+			double expectedCost) {
 		@SuppressWarnings("unchecked")
 		var detourTimeCalculator = (InsertionDetourTimeCalculator<D>)mock(InsertionDetourTimeCalculator.class);
-		var insertionCostCalculator = new DefaultInsertionCostCalculator<>(() -> now,
+		var insertionCostCalculator = new DefaultInsertionCostCalculator<>(
 				new CostCalculationStrategy.RejectSoftConstraintViolations(), detourTimeCalculator);
 		when(detourTimeCalculator.calculateDetourTimeInfo(insertion)).thenReturn(detourTimeInfo);
 		assertThat(insertionCostCalculator.calculate(drtRequest, insertion)).isEqualTo(expectedCost);
 	}
 
-	@Test
-	public void checkTimeConstraintsForScheduledRequests_start_pickup_stop_dropoff_stop() {
-		VehicleEntry entry = entry(stop0, stop1);
-		var insertion = insertion(entry, 0, 1);
-
-		//almost too late
-		assertThat(checkTimeConstraintsForScheduledRequests(insertion, 20, 30)).isTrue();
-
-		//pickup too late
-		assertThat(checkTimeConstraintsForScheduledRequests(insertion, 21, 30)).isFalse();
-
-		//dropoff too late
-		assertThat(checkTimeConstraintsForScheduledRequests(insertion, 20, 31)).isFalse();
-	}
-
-	@Test
-	public void checkTimeConstraintsForScheduledRequests_start_pickup_dropoff_stop_stop() {
-		VehicleEntry entry = entry(stop0, stop1);
-		var insertion = insertion(entry, 0, 0);
-
-		//almost too late
-		assertThat(checkTimeConstraintsForScheduledRequests(insertion, 19, 20)).isTrue();
-
-		//pickup & dropoff too late
-		assertThat(checkTimeConstraintsForScheduledRequests(insertion, 21, 22)).isFalse();
-
-		//dropoff too late
-		assertThat(checkTimeConstraintsForScheduledRequests(insertion, 20, 21)).isFalse();
-	}
-
-	@Test
-	public void checkTimeConstraintsForScheduledRequests_start_stop_stop_pickup_dropoff() {
-		VehicleEntry entry = entry(stop0, stop1);
-		var insertion = insertion(entry, 2, 2);
-
-		//appended at the end -> never too late
-		assertThat(checkTimeConstraintsForScheduledRequests(insertion, 9999, 9999)).isTrue();
-	}
-
-	@Test
-	public void calcVehicleSlackTime_all_cases() {
-		//we are ahead of time
-		assertThat(calcVehicleSlackTime(entry(1000, 600), 0)).isEqualTo(400);
-
-		//at least 150 s of delay, optimistically 250 s of slack
-		assertThat(calcVehicleSlackTime(entry(1000, 600), 750)).isEqualTo(250);
-
-		//behind the vehicle end time - due to current time
-		assertThat(calcVehicleSlackTime(entry(1000, 990), 1111)).isEqualTo(-111);
-
-		//behind the vehicle end time - due to predicted last task end time
-		assertThat(calcVehicleSlackTime(entry(1000, 1234), 888)).isEqualTo(-234);
-
-	}
-
-	private VehicleEntry entry(double vehicleEndTime, double lastStayTaskBeginTime, Waypoint.Stop... stops) {
-		var vehicle = new DvrpVehicleImpl(ImmutableDvrpVehicleSpecification.newBuilder()
-				.id(Id.create("a", DvrpVehicle.class))
-				.startLinkId(Id.createLinkId("depot"))
-				.capacity(0)
-				.serviceBeginTime(0)
-				.serviceEndTime(vehicleEndTime)
-				.build(), link("depot"));
-		vehicle.getSchedule()
-				.addTask(new DrtStayTask(lastStayTaskBeginTime, Math.max(lastStayTaskBeginTime, vehicleEndTime),
-						link("depot")));
-		return new VehicleEntry(vehicle, start, ImmutableList.copyOf(stops));
+	private VehicleEntry entry(double[] slackTimes) {
+		return new VehicleEntry(null, null, null, slackTimes);
 	}
 
 	private Link link(String id) {
 		return new FakeLink(Id.createLinkId(id));
 	}
 
-	private Waypoint.Start start(Task task, double time, Link link) {
-		return new Waypoint.Start(task, link, time, 0);
-	}
-
-	private Waypoint.Stop stop(double beginTime, double latestArrivalTime, double endTime, double latestDepartureTime) {
-		return new Waypoint.Stop(new DrtStopTask(beginTime, endTime, null), latestArrivalTime, latestDepartureTime, 0);
-	}
-
-	private VehicleEntry entry(Waypoint.Stop... stops) {
-		return new VehicleEntry(null, start, ImmutableList.copyOf(stops));
-	}
-
 	private InsertionGenerator.Insertion insertion(VehicleEntry entry, int pickupIdx, int dropoffIdx) {
-		return new InsertionGenerator.Insertion(drtRequest, entry, pickupIdx, dropoffIdx);
+		return new InsertionGenerator.Insertion(entry,
+				new InsertionGenerator.InsertionPoint(pickupIdx, null, null, null),
+				new InsertionGenerator.InsertionPoint(dropoffIdx, null, null, null));
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
@@ -209,7 +209,7 @@ public class InsertionDetourTimeCalculatorTest {
 	}
 
 	private VehicleEntry entry(Waypoint.Start start, Waypoint.Stop... stops) {
-		return new VehicleEntry(null, start, ImmutableList.copyOf(stops));
+		return new VehicleEntry(null, start, ImmutableList.copyOf(stops), null);
 	}
 
 	private InsertionWithDetourData<Double> insertion(VehicleEntry entry, int pickupIdx, int dropoffIdx,

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
@@ -264,6 +264,6 @@ public class InsertionGeneratorTest {
 	}
 
 	private VehicleEntry entry(Waypoint.Start start, Waypoint.Stop... stops) {
-		return new VehicleEntry(vehicle, start, ImmutableList.copyOf(stops));
+		return new VehicleEntry(vehicle, start, ImmutableList.copyOf(stops), null);
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/KNearestInsertionsAtEndFilterTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/KNearestInsertionsAtEndFilterTest.java
@@ -123,7 +123,7 @@ public class KNearestInsertionsAtEndFilterTest {
 	private VehicleEntry vehicleEntry(String id, Waypoint.Start start, Waypoint.Stop... stops) {
 		var vehicle = mock(DvrpVehicle.class);
 		when(vehicle.getId()).thenReturn(Id.create(id, DvrpVehicle.class));
-		return new VehicleEntry(vehicle, start, ImmutableList.copyOf(stops));
+		return new VehicleEntry(vehicle, start, ImmutableList.copyOf(stops), null);
 	}
 
 	@SafeVarargs


### PR DESCRIPTION
As pointed out in #1758, in large scenarios the slowest part of the the selective search is evaluating all possible insertion points using matrix-based travel times (contrary to the extensive search where the actual path search takes more time). This PR focuses on faster evaluation of insertion points by using pre-computed slack times.

This reduces the QSim duration by ~10% (Berlin scenario with 6 000 vehicles, 270 000 requests) given the selective search is used. For the extensive search, some speedup should be also observed (but has not been measured).

