### PR TITLE
Customise travel time by dvrp mode

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/run/ShiftEDrtModeOptimizerQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/run/ShiftEDrtModeOptimizerQSimModule.java
@@ -1,8 +1,5 @@
 package org.matsim.contrib.drt.extension.eshifts.run;
 
-import com.google.inject.Inject;
-import com.google.inject.TypeLiteral;
-import com.google.inject.name.Named;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.extension.edrt.optimizer.depot.NearestChargerAsDepot;
@@ -24,9 +21,19 @@ import org.matsim.contrib.drt.extension.shifts.schedule.ShiftDrtStayTaskEndTimeC
 import org.matsim.contrib.drt.extension.shifts.schedule.ShiftDrtTaskFactory;
 import org.matsim.contrib.drt.extension.shifts.scheduler.ShiftDrtScheduleInquiry;
 import org.matsim.contrib.drt.extension.shifts.shift.DrtShifts;
-import org.matsim.contrib.drt.optimizer.*;
+import org.matsim.contrib.drt.optimizer.DefaultDrtOptimizer;
+import org.matsim.contrib.drt.optimizer.DrtModeOptimizerQSimModule;
+import org.matsim.contrib.drt.optimizer.DrtOptimizer;
+import org.matsim.contrib.drt.optimizer.QSimScopeForkJoinPoolHolder;
+import org.matsim.contrib.drt.optimizer.VehicleEntry;
 import org.matsim.contrib.drt.optimizer.depot.DepotFinder;
-import org.matsim.contrib.drt.optimizer.insertion.*;
+import org.matsim.contrib.drt.optimizer.insertion.CostCalculationStrategy;
+import org.matsim.contrib.drt.optimizer.insertion.DefaultUnplannedRequestInserter;
+import org.matsim.contrib.drt.optimizer.insertion.DrtInsertionSearch;
+import org.matsim.contrib.drt.optimizer.insertion.DrtRequestInsertionRetryParams;
+import org.matsim.contrib.drt.optimizer.insertion.DrtRequestInsertionRetryQueue;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator;
+import org.matsim.contrib.drt.optimizer.insertion.UnplannedRequestInserter;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtStayTaskEndTimeCalculator;
@@ -43,7 +50,6 @@ import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpMode;
 import org.matsim.contrib.dvrp.run.DvrpModes;
 import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
-import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
 import org.matsim.contrib.ev.infrastructure.ChargingInfrastructure;
 import org.matsim.contrib.ev.infrastructure.ChargingInfrastructures;
@@ -53,6 +59,9 @@ import org.matsim.core.modal.ModalProviders;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
+
+import com.google.inject.Inject;
+import com.google.inject.TypeLiteral;
 
 /**
  * @author nkuehnel / MOIA
@@ -152,13 +161,11 @@ public class ShiftEDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule
 		bindModal(EmptyVehicleRelocator.class).toProvider(
 				new ModalProviders.AbstractProvider<DvrpMode, EmptyVehicleRelocator>(drtCfg.getMode(), DvrpModes::mode ) {
 					@Inject
-					@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
-					private TravelTime travelTime;
-					@Inject
 					private MobsimTimer timer;
 
 					@Override
 					public EmptyVehicleRelocator get() {
+						var travelTime = getModalInstance(TravelTime.class);
 						Network network = getModalInstance(Network.class);
 						DrtTaskFactory taskFactory = getModalInstance(DrtTaskFactory.class);
 						TravelDisutility travelDisutility = getModalInstance(
@@ -170,13 +177,11 @@ public class ShiftEDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule
 		bindModal(EShiftTaskScheduler.class).toProvider(
 				new ModalProviders.AbstractProvider<DvrpMode, EShiftTaskScheduler>(drtCfg.getMode(), DvrpModes::mode) {
 					@Inject
-					@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
-					private TravelTime travelTime;
-					@Inject
 					private MobsimTimer timer;
 
 					@Override
 					public EShiftTaskScheduler get() {
+						var travelTime = getModalInstance(TravelTime.class);
 						var chargingInfrastructure = getModalInstance(ChargingInfrastructure.class);
 						Network network = getModalInstance(Network.class);
 						ShiftDrtTaskFactory taskFactory = getModalInstance(ShiftDrtTaskFactory.class);
@@ -190,8 +195,7 @@ public class ShiftEDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule
 		bindModal(DrtScheduleInquiry.class).to(ShiftDrtScheduleInquiry.class).asEagerSingleton();
 		bindModal(RequestInsertionScheduler.class).toProvider(modalProvider(
 				getter -> new ShiftRequestInsertionScheduler(drtCfg, getter.getModal(Fleet.class),
-						getter.get(MobsimTimer.class),
-						getter.getNamed(TravelTime.class, DvrpTravelTimeModule.DVRP_ESTIMATED),
+						getter.get(MobsimTimer.class), getter.getModal(TravelTime.class),
 						getter.getModal(ScheduleTimingUpdater.class), getter.getModal(ShiftDrtTaskFactory.class),
 						getter.getModal(OperationFacilities.class)))).asEagerSingleton();
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/scheduler/EShiftTaskScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/scheduler/EShiftTaskScheduler.java
@@ -1,6 +1,12 @@
 package org.matsim.contrib.drt.extension.eshifts.scheduler;
 
-import com.google.inject.name.Named;
+import static org.matsim.contrib.drt.extension.shifts.scheduler.ShiftTaskScheduler.RELOCATE_VEHICLE_SHIFT_BREAK_TASK_TYPE;
+import static org.matsim.contrib.drt.extension.shifts.scheduler.ShiftTaskScheduler.RELOCATE_VEHICLE_SHIFT_CHANGEOVER_TASK_TYPE;
+import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.DRIVE;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
@@ -24,7 +30,6 @@ import org.matsim.contrib.dvrp.schedule.Schedule;
 import org.matsim.contrib.dvrp.schedule.StayTask;
 import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.contrib.dvrp.tracker.OnlineDriveTaskTracker;
-import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.dvrp.util.LinkTimePair;
 import org.matsim.contrib.ev.charging.BatteryCharging;
 import org.matsim.contrib.ev.charging.ChargingEstimations;
@@ -39,13 +44,6 @@ import org.matsim.core.router.speedy.SpeedyALTFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.matsim.contrib.drt.extension.shifts.scheduler.ShiftTaskScheduler.RELOCATE_VEHICLE_SHIFT_BREAK_TASK_TYPE;
-import static org.matsim.contrib.drt.extension.shifts.scheduler.ShiftTaskScheduler.RELOCATE_VEHICLE_SHIFT_CHANGEOVER_TASK_TYPE;
-import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.DRIVE;
 
 /**
  * @author nkuehnel / MOIA
@@ -64,17 +62,17 @@ public class EShiftTaskScheduler {
     private final Network network;
     private final ChargingInfrastructure chargingInfrastructure;
 
-    public EShiftTaskScheduler(Network network, @Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
-							   TravelDisutility travelDisutility, MobsimTimer timer, ShiftDrtTaskFactory taskFactory,
-							   ShiftDrtConfigGroup shiftConfig, ChargingInfrastructure chargingInfrastructure) {
-        this.travelTime = travelTime;
-        this.timer = timer;
-        this.taskFactory = taskFactory;
-        this.network = network;
-        this.shiftConfig = shiftConfig;
-        this.router = new SpeedyALTFactory().createPathCalculator(network, travelDisutility, travelTime);
-        this.chargingInfrastructure = chargingInfrastructure;
-    }
+	public EShiftTaskScheduler(Network network, TravelTime travelTime, TravelDisutility travelDisutility,
+			MobsimTimer timer, ShiftDrtTaskFactory taskFactory, ShiftDrtConfigGroup shiftConfig,
+			ChargingInfrastructure chargingInfrastructure) {
+		this.travelTime = travelTime;
+		this.timer = timer;
+		this.taskFactory = taskFactory;
+		this.network = network;
+		this.shiftConfig = shiftConfig;
+		this.router = new SpeedyALTFactory().createPathCalculator(network, travelDisutility, travelTime);
+		this.chargingInfrastructure = chargingInfrastructure;
+	}
 
     public void relocateForBreak(ShiftDvrpVehicle vehicle, OperationFacility breakFacility, DrtShift shift) {
         final Schedule schedule = vehicle.getSchedule();

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/optimizer/ShiftRequestInsertionScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/optimizer/ShiftRequestInsertionScheduler.java
@@ -1,6 +1,14 @@
 package org.matsim.contrib.drt.extension.shifts.optimizer;
 
-import com.google.inject.name.Named;
+import static org.matsim.contrib.drt.extension.shifts.scheduler.ShiftTaskScheduler.RELOCATE_VEHICLE_SHIFT_CHANGEOVER_TASK_TYPE;
+import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.DRIVE;
+import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.STAY;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.extension.shifts.fleet.ShiftDvrpVehicle;
@@ -28,20 +36,10 @@ import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
 import org.matsim.contrib.dvrp.schedule.StayTask;
 import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.contrib.dvrp.tracker.OnlineDriveTaskTracker;
-import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.dvrp.util.LinkTimePair;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.facilities.Facility;
-
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-
-import static org.matsim.contrib.drt.extension.shifts.scheduler.ShiftTaskScheduler.RELOCATE_VEHICLE_SHIFT_CHANGEOVER_TASK_TYPE;
-import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.DRIVE;
-import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.STAY;
 
 /**
  * @author nkuehnel / MOIA
@@ -57,18 +55,18 @@ public class ShiftRequestInsertionScheduler implements RequestInsertionScheduler
     private final OperationFacilities shiftBreakNetwork;
 
 
-    public ShiftRequestInsertionScheduler(DrtConfigGroup drtCfg, Fleet fleet, MobsimTimer timer,
-                                          @Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
-                                          ScheduleTimingUpdater scheduleTimingUpdater, ShiftDrtTaskFactory taskFactory, OperationFacilities shiftBreakNetwork) {
-        this.fleet = fleet;
-        this.stopDuration = drtCfg.getStopDuration();
-        this.timer = timer;
-        this.travelTime = travelTime;
-        this.scheduleTimingUpdater = scheduleTimingUpdater;
-        this.taskFactory = taskFactory;
-        this.shiftBreakNetwork = shiftBreakNetwork;
-        initSchedules();
-    }
+    public ShiftRequestInsertionScheduler(DrtConfigGroup drtCfg, Fleet fleet, MobsimTimer timer, TravelTime travelTime,
+			ScheduleTimingUpdater scheduleTimingUpdater, ShiftDrtTaskFactory taskFactory,
+			OperationFacilities shiftBreakNetwork) {
+		this.fleet = fleet;
+		this.stopDuration = drtCfg.getStopDuration();
+		this.timer = timer;
+		this.travelTime = travelTime;
+		this.scheduleTimingUpdater = scheduleTimingUpdater;
+		this.taskFactory = taskFactory;
+		this.shiftBreakNetwork = shiftBreakNetwork;
+		initSchedules();
+	}
 
     public void initSchedules() {
         final Map<Id<Link>, List<OperationFacility>> facilitiesByLink = shiftBreakNetwork.getDrtOperationFacilities().values().stream().collect(Collectors.groupingBy(Facility::getLinkId));

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/run/ShiftDrtModeOptimizerQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/run/ShiftDrtModeOptimizerQSimModule.java
@@ -1,8 +1,5 @@
 package org.matsim.contrib.drt.extension.shifts.run;
 
-import com.google.inject.Inject;
-import com.google.inject.TypeLiteral;
-import com.google.inject.name.Named;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.extension.shifts.config.ShiftDrtConfigGroup;
@@ -22,10 +19,20 @@ import org.matsim.contrib.drt.extension.shifts.schedule.ShiftDrtTaskFactoryImpl;
 import org.matsim.contrib.drt.extension.shifts.scheduler.ShiftDrtScheduleInquiry;
 import org.matsim.contrib.drt.extension.shifts.scheduler.ShiftTaskScheduler;
 import org.matsim.contrib.drt.extension.shifts.shift.DrtShifts;
-import org.matsim.contrib.drt.optimizer.*;
+import org.matsim.contrib.drt.optimizer.DefaultDrtOptimizer;
+import org.matsim.contrib.drt.optimizer.DrtModeOptimizerQSimModule;
+import org.matsim.contrib.drt.optimizer.DrtOptimizer;
+import org.matsim.contrib.drt.optimizer.QSimScopeForkJoinPoolHolder;
+import org.matsim.contrib.drt.optimizer.VehicleEntry;
 import org.matsim.contrib.drt.optimizer.depot.DepotFinder;
 import org.matsim.contrib.drt.optimizer.depot.NearestStartLinkAsDepot;
-import org.matsim.contrib.drt.optimizer.insertion.*;
+import org.matsim.contrib.drt.optimizer.insertion.CostCalculationStrategy;
+import org.matsim.contrib.drt.optimizer.insertion.DefaultUnplannedRequestInserter;
+import org.matsim.contrib.drt.optimizer.insertion.DrtInsertionSearch;
+import org.matsim.contrib.drt.optimizer.insertion.DrtRequestInsertionRetryParams;
+import org.matsim.contrib.drt.optimizer.insertion.DrtRequestInsertionRetryQueue;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator;
+import org.matsim.contrib.drt.optimizer.insertion.UnplannedRequestInserter;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtStayTaskEndTimeCalculator;
@@ -44,7 +51,6 @@ import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpMode;
 import org.matsim.contrib.dvrp.run.DvrpModes;
 import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
-import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.framework.MobsimTimer;
@@ -52,6 +58,9 @@ import org.matsim.core.modal.ModalProviders;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
+
+import com.google.inject.Inject;
+import com.google.inject.TypeLiteral;
 
 /**
  * @author nkuehnel, fzwick / MOIA
@@ -141,14 +150,11 @@ public class ShiftDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule 
 		bindModal(ShiftDrtTaskFactory.class).toInstance(taskFactory);
 		bindModal(EmptyVehicleRelocator.class).toProvider(new ModalProviders.AbstractProvider<>(drtCfg.getMode(), DvrpModes::mode) {
 			@Inject
-			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
-			private TravelTime travelTime;
-
-			@Inject
 			private MobsimTimer timer;
 
 			@Override
 			public EmptyVehicleRelocator get() {
+				var travelTime = getModalInstance(TravelTime.class);
 				Network network = getModalInstance(Network.class);
 				DrtTaskFactory taskFactory = getModalInstance(DrtTaskFactory.class);
 				TravelDisutility travelDisutility = getModalInstance(
@@ -160,13 +166,11 @@ public class ShiftDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule 
 		bindModal(ShiftTaskScheduler.class).toProvider(
 				new ModalProviders.AbstractProvider<DvrpMode, ShiftTaskScheduler>(drtCfg.getMode(), DvrpModes::mode) {
 					@Inject
-					@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
-					private TravelTime travelTime;
-					@Inject
 					private MobsimTimer timer;
 
 					@Override
 					public ShiftTaskScheduler get() {
+						var travelTime = getModalInstance(TravelTime.class);
 						Network network = getModalInstance(Network.class);
 						ShiftDrtTaskFactory taskFactory = getModalInstance(ShiftDrtTaskFactory.class);
 						TravelDisutility travelDisutility = getModalInstance(
@@ -179,8 +183,7 @@ public class ShiftDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule 
 		bindModal(DrtScheduleInquiry.class).to(ShiftDrtScheduleInquiry.class).asEagerSingleton();
 		bindModal(RequestInsertionScheduler.class).toProvider(modalProvider(
 				getter -> new ShiftRequestInsertionScheduler(drtCfg, getter.getModal(Fleet.class),
-						getter.get(MobsimTimer.class),
-						getter.getNamed(TravelTime.class, DvrpTravelTimeModule.DVRP_ESTIMATED),
+						getter.get(MobsimTimer.class), getter.getModal(TravelTime.class),
 						getter.getModal(ScheduleTimingUpdater.class), getter.getModal(ShiftDrtTaskFactory.class),
 						getter.getModal(OperationFacilities.class)))).asEagerSingleton();
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/scheduler/ShiftTaskScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/scheduler/ShiftTaskScheduler.java
@@ -1,9 +1,21 @@
 package org.matsim.contrib.drt.extension.shifts.scheduler;
 
-import com.google.inject.name.Named;
+import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.DRIVE;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.drt.extension.shifts.config.ShiftDrtConfigGroup;
+import org.matsim.contrib.drt.extension.shifts.fleet.ShiftDvrpVehicle;
+import org.matsim.contrib.drt.extension.shifts.operationFacilities.OperationFacility;
+import org.matsim.contrib.drt.extension.shifts.schedule.ShiftBreakTask;
+import org.matsim.contrib.drt.extension.shifts.schedule.ShiftChangeOverTask;
+import org.matsim.contrib.drt.extension.shifts.schedule.ShiftDrtTaskFactory;
+import org.matsim.contrib.drt.extension.shifts.schedule.WaitForShiftStayTask;
+import org.matsim.contrib.drt.extension.shifts.shift.DrtShift;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
 import org.matsim.contrib.drt.schedule.DrtTaskBaseType;
 import org.matsim.contrib.drt.schedule.DrtTaskType;
@@ -16,26 +28,12 @@ import org.matsim.contrib.dvrp.schedule.Schedule;
 import org.matsim.contrib.dvrp.schedule.StayTask;
 import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.contrib.dvrp.tracker.OnlineDriveTaskTracker;
-import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.dvrp.util.LinkTimePair;
-import org.matsim.contrib.drt.extension.shifts.config.ShiftDrtConfigGroup;
-import org.matsim.contrib.drt.extension.shifts.fleet.ShiftDvrpVehicle;
-import org.matsim.contrib.drt.extension.shifts.operationFacilities.OperationFacility;
-import org.matsim.contrib.drt.extension.shifts.schedule.ShiftBreakTask;
-import org.matsim.contrib.drt.extension.shifts.schedule.ShiftChangeOverTask;
-import org.matsim.contrib.drt.extension.shifts.schedule.ShiftDrtTaskFactory;
-import org.matsim.contrib.drt.extension.shifts.schedule.WaitForShiftStayTask;
-import org.matsim.contrib.drt.extension.shifts.shift.DrtShift;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.router.FastAStarEuclideanFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.DRIVE;
 
 /**
  * @author nkuehnel / MOIA
@@ -56,16 +54,15 @@ public class ShiftTaskScheduler {
 
     private final Network network;
 
-    public ShiftTaskScheduler(Network network, @Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
-							  TravelDisutility travelDisutility, MobsimTimer timer, ShiftDrtTaskFactory taskFactory,
-							  ShiftDrtConfigGroup shiftConfig) {
-        this.travelTime = travelTime;
-        this.timer = timer;
-        this.taskFactory = taskFactory;
-        this.network = network;
-        this.shiftConfig = shiftConfig;
-        this.router = new FastAStarEuclideanFactory().createPathCalculator(network, travelDisutility, travelTime);
-    }
+	public ShiftTaskScheduler(Network network, TravelTime travelTime, TravelDisutility travelDisutility,
+			MobsimTimer timer, ShiftDrtTaskFactory taskFactory, ShiftDrtConfigGroup shiftConfig) {
+		this.travelTime = travelTime;
+		this.timer = timer;
+		this.taskFactory = taskFactory;
+		this.network = network;
+		this.shiftConfig = shiftConfig;
+		this.router = new FastAStarEuclideanFactory().createPathCalculator(network, travelDisutility, travelTime);
+	}
 
     public void relocateForBreak(ShiftDvrpVehicle vehicle, OperationFacility breakFacility, DrtShift shift) {
         final Schedule schedule = vehicle.getSchedule();

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtModeOptimizerQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtModeOptimizerQSimModule.java
@@ -121,14 +121,11 @@ public class DrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 		bindModal(EmptyVehicleRelocator.class).toProvider(
 				new ModalProviders.AbstractProvider<>(drtCfg.getMode(), DvrpModes::mode) {
 					@Inject
-					@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
-					private TravelTime travelTime;
-
-					@Inject
 					private MobsimTimer timer;
 
 					@Override
 					public EmptyVehicleRelocator get() {
+						var travelTime = getModalInstance(TravelTime.class);
 						Network network = getModalInstance(Network.class);
 						DrtTaskFactory taskFactory = getModalInstance(DrtTaskFactory.class);
 						TravelDisutility travelDisutility = getModalInstance(
@@ -142,7 +139,7 @@ public class DrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 		bindModal(RequestInsertionScheduler.class).toProvider(modalProvider(
 						getter -> new DefaultRequestInsertionScheduler(drtCfg, getter.getModal(Fleet.class),
 								getter.get(MobsimTimer.class),
-								getter.getNamed(TravelTime.class, DvrpTravelTimeModule.DVRP_ESTIMATED),
+								getter.getModal(TravelTime.class),
 								getter.getModal(ScheduleTimingUpdater.class), getter.getModal(DrtTaskFactory.class))))
 				.asEagerSingleton();
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchQSimModule.java
@@ -64,12 +64,9 @@ public class ExtensiveInsertionSearchQSimModule extends AbstractDvrpModeQSimModu
 
 		addModalComponent(MultiInsertionDetourPathCalculator.class,
 				new ModalProviders.AbstractProvider<>(getMode(), DvrpModes::mode) {
-					@Inject
-					@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
-					private TravelTime travelTime;
-
 					@Override
 					public MultiInsertionDetourPathCalculator get() {
+						var travelTime = getModalInstance(TravelTime.class);
 						Network network = getModalInstance(Network.class);
 						TravelDisutility travelDisutility = getModalInstance(
 								TravelDisutilityFactory.class).createTravelDisutility(travelTime);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/MultiInsertionDetourPathCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/MultiInsertionDetourPathCalculator.java
@@ -29,8 +29,6 @@ import java.util.concurrent.Executors;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import javax.inject.Named;
-
 import org.matsim.api.core.v01.IdMap;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
@@ -40,7 +38,6 @@ import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
-import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.core.mobsim.framework.events.MobsimBeforeCleanupEvent;
 import org.matsim.core.mobsim.framework.listeners.MobsimBeforeCleanupListener;
 import org.matsim.core.router.speedy.SpeedyGraph;
@@ -62,8 +59,7 @@ public class MultiInsertionDetourPathCalculator implements DetourPathCalculator,
 
 	private final ExecutorService executorService;
 
-	public MultiInsertionDetourPathCalculator(Network network,
-			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, TravelDisutility travelDisutility,
+	public MultiInsertionDetourPathCalculator(Network network, TravelTime travelTime, TravelDisutility travelDisutility,
 			DrtConfigGroup drtCfg) {
 		SpeedyGraph graph = new SpeedyGraph(network);
 		IdMap<Node, Node> nodeMap = new IdMap<>(Node.class);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchQSimModule.java
@@ -70,12 +70,9 @@ public class SelectiveInsertionSearchQSimModule extends AbstractDvrpModeQSimModu
 
 		addModalComponent(SingleInsertionDetourPathCalculator.class,
 				new ModalProviders.AbstractProvider<>(getMode(), DvrpModes::mode) {
-					@Inject
-					@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
-					private TravelTime travelTime;
-
 					@Override
 					public SingleInsertionDetourPathCalculator get() {
+						var travelTime = getModalInstance(TravelTime.class);
 						Network network = getModalInstance(Network.class);
 						TravelDisutility travelDisutility = getModalInstance(
 								TravelDisutilityFactory.class).createTravelDisutility(travelTime);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SingleInsertionDetourPathCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SingleInsertionDetourPathCalculator.java
@@ -31,15 +31,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import javax.inject.Named;
-
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.optimizer.Waypoint;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.path.VrpPaths;
-import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.core.mobsim.framework.events.MobsimBeforeCleanupEvent;
 import org.matsim.core.mobsim.framework.listeners.MobsimBeforeCleanupListener;
 import org.matsim.core.router.speedy.SpeedyALTFactory;
@@ -68,11 +65,9 @@ public class SingleInsertionDetourPathCalculator implements DetourPathCalculator
 
 	private final ExecutorService executorService;
 
-	public SingleInsertionDetourPathCalculator(Network network,
-			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, TravelDisutility travelDisutility,
-			DrtConfigGroup drtCfg) {
-		this(network, travelTime, travelDisutility, drtCfg.getNumberOfThreads(),
-				new SpeedyALTFactory());
+	public SingleInsertionDetourPathCalculator(Network network, TravelTime travelTime,
+			TravelDisutility travelDisutility, DrtConfigGroup drtCfg) {
+		this(network, travelTime, travelDisutility, drtCfg.getNumberOfThreads(), new SpeedyALTFactory());
 	}
 
 	@VisibleForTesting

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRouteCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRouteCreator.java
@@ -27,16 +27,12 @@ import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.path.VrpPaths;
 import org.matsim.contrib.dvrp.router.DefaultMainLegRouter;
-import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.core.population.routes.RouteFactories;
-import org.matsim.core.router.RoutingRequest;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.utils.objectattributes.attributable.Attributes;
-
-import com.google.inject.name.Named;
 
 /**
  * @author jbischoff
@@ -49,8 +45,7 @@ public class DrtRouteCreator implements DefaultMainLegRouter.RouteCreator {
 	private final LeastCostPathCalculator router;
 
 	public DrtRouteCreator(DrtConfigGroup drtCfg, Network modalNetwork,
-			LeastCostPathCalculatorFactory leastCostPathCalculatorFactory,
-			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
+			LeastCostPathCalculatorFactory leastCostPathCalculatorFactory, TravelTime travelTime,
 			TravelDisutilityFactory travelDisutilityFactory) {
 		this.drtCfg = drtCfg;
 		this.travelTime = travelTime;
@@ -69,8 +64,8 @@ public class DrtRouteCreator implements DefaultMainLegRouter.RouteCreator {
 		return drtCfg.getMaxTravelTimeAlpha() * unsharedRideTime + drtCfg.getMaxTravelTimeBeta();
 	}
 
-	public Route createRoute(double departureTime, Link accessActLink, Link egressActLink,
-			Person person, Attributes tripAttributes, RouteFactories routeFactories) {
+	public Route createRoute(double departureTime, Link accessActLink, Link egressActLink, Person person,
+			Attributes tripAttributes, RouteFactories routeFactories) {
 		VrpPathWithTravelData unsharedPath = VrpPaths.calcAndCreatePath(accessActLink, egressActLink, departureTime,
 				router, travelTime);
 		double unsharedRideTime = unsharedPath.getTravelTime();//includes first & last link
@@ -83,8 +78,7 @@ public class DrtRouteCreator implements DefaultMainLegRouter.RouteCreator {
 		route.setDirectRideTime(unsharedRideTime);
 		route.setMaxWaitTime(drtCfg.getMaxWaitTime());
 
-		if(this.drtCfg.getStoreUnsharedPath())
-		{
+		if (this.drtCfg.getStoreUnsharedPath()) {
 			route.setUnsharedPath(unsharedPath);
 		}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
@@ -45,12 +45,9 @@ import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
 import org.matsim.contrib.dvrp.schedule.StayTask;
 import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.contrib.dvrp.tracker.OnlineDriveTaskTracker;
-import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.dvrp.util.LinkTimePair;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.router.util.TravelTime;
-
-import com.google.inject.name.Named;
 
 /**
  * @author michalm
@@ -65,8 +62,7 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 	private final DrtTaskFactory taskFactory;
 
 	public DefaultRequestInsertionScheduler(DrtConfigGroup drtCfg, Fleet fleet, MobsimTimer timer,
-			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
-			ScheduleTimingUpdater scheduleTimingUpdater, DrtTaskFactory taskFactory) {
+			TravelTime travelTime, ScheduleTimingUpdater scheduleTimingUpdater, DrtTaskFactory taskFactory) {
 		this.fleet = fleet;
 		this.stopDuration = drtCfg.getStopDuration();
 		this.timer = timer;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/EmptyVehicleRelocator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/EmptyVehicleRelocator.java
@@ -30,14 +30,11 @@ import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.path.VrpPaths;
 import org.matsim.contrib.dvrp.schedule.Schedule;
-import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.router.speedy.SpeedyALTFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
-
-import com.google.inject.name.Named;
 
 /**
  * @author michalm
@@ -50,8 +47,8 @@ public class EmptyVehicleRelocator {
 	private final DrtTaskFactory taskFactory;
 	private final LeastCostPathCalculator router;
 
-	public EmptyVehicleRelocator(Network network, @Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
-			TravelDisutility travelDisutility, MobsimTimer timer, DrtTaskFactory taskFactory) {
+	public EmptyVehicleRelocator(Network network, TravelTime travelTime, TravelDisutility travelDisutility,
+			MobsimTimer timer, DrtTaskFactory taskFactory) {
 		this.travelTime = travelTime;
 		this.timer = timer;
 		this.taskFactory = taskFactory;

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxi/OneTaxiModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxi/OneTaxiModule.java
@@ -36,12 +36,16 @@ import org.matsim.contrib.dvrp.router.TimeAsTravelDisutility;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpModes;
+import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentSourceQSimModule;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
 import org.matsim.core.router.speedy.SpeedyDijkstraFactory;
+import org.matsim.core.router.util.TravelTime;
 
+import com.google.inject.Key;
 import com.google.inject.Singleton;
+import com.google.inject.name.Names;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -62,6 +66,7 @@ public class OneTaxiModule extends AbstractDvrpModeModule {
 		install(new DvrpModeRoutingNetworkModule(getMode(), false));
 
 		install(new DvrpModeRoutingModule(getMode(), new SpeedyDijkstraFactory()));
+		bindModal(TravelTime.class).to(Key.get(TravelTime.class, Names.named(DvrpTravelTimeModule.DVRP_ESTIMATED)));
 		bindModal(TravelDisutilityFactory.class).toInstance(TimeAsTravelDisutility::new);
 
 		install(new FleetModule(getMode(), fleetSpecificationUrl));

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/OneTruckModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/OneTruckModule.java
@@ -30,11 +30,14 @@ import org.matsim.contrib.dvrp.router.DvrpModeRoutingNetworkModule;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpModes;
+import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentSourceQSimModule;
+import org.matsim.core.router.util.TravelTime;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehicleUtils;
 
+import com.google.inject.Key;
 import com.google.inject.name.Names;
 
 /**
@@ -52,6 +55,7 @@ public class OneTruckModule extends AbstractDvrpModeModule {
 	public void install() {
 		DvrpModes.registerDvrpMode(binder(), getMode());
 		install(new DvrpModeRoutingNetworkModule(getMode(), false));
+		bindModal(TravelTime.class).to(Key.get(TravelTime.class, Names.named(DvrpTravelTimeModule.DVRP_ESTIMATED)));
 
 		bind(VehicleType.class).annotatedWith(Names.named(VrpAgentSourceQSimModule.DVRP_VEHICLE_TYPE))
 				.toInstance(createTruckType());

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpModeRoutingModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpModeRoutingModule.java
@@ -26,14 +26,12 @@ import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.DvrpMode;
 import org.matsim.contrib.dvrp.run.DvrpModes;
 import org.matsim.core.modal.ModalProviders;
-import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.core.router.RoutingModule;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
 import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
 import org.matsim.core.router.util.TravelTime;
 
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -64,10 +62,6 @@ public class DvrpModeRoutingModule extends AbstractDvrpModeModule {
 
 	public static class DefaultMainLegRouterProvider extends ModalProviders.AbstractProvider<DvrpMode, RoutingModule> {
 		@Inject
-		@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
-		private TravelTime travelTime;
-
-		@Inject
 		private Scenario scenario;
 
 		public DefaultMainLegRouterProvider(String mode) {
@@ -83,10 +77,6 @@ public class DvrpModeRoutingModule extends AbstractDvrpModeModule {
 
 	private static class GenericRouteCreatorProvider
 			extends ModalProviders.AbstractProvider<DvrpMode, GenericRouteCreator> {
-		@Inject
-		@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
-		private TravelTime travelTime;
-
 		private final LeastCostPathCalculatorFactory leastCostPathCalculatorFactory;
 
 		private GenericRouteCreatorProvider(String mode,
@@ -97,6 +87,7 @@ public class DvrpModeRoutingModule extends AbstractDvrpModeModule {
 
 		@Override
 		public GenericRouteCreator get() {
+			var travelTime = getModalInstance(TravelTime.class);
 			return new GenericRouteCreator(leastCostPathCalculatorFactory, getModalInstance(Network.class), travelTime,
 					getModalInstance(TravelDisutilityFactory.class));
 		}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/GenericRouteCreator.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/GenericRouteCreator.java
@@ -45,7 +45,7 @@ public class GenericRouteCreator implements DefaultMainLegRouter.RouteCreator {
 	private final LeastCostPathCalculator router;
 
 	public GenericRouteCreator(LeastCostPathCalculatorFactory leastCostPathCalculatorFactory, Network modalNetwork,
-			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
+			TravelTime travelTime,
 			TravelDisutilityFactory travelDisutilityFactory) {
 		this.travelTime = travelTime;
 		router = leastCostPathCalculatorFactory.createPathCalculator(modalNetwork,

--- a/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingsearch/routing/WithinDayParkingRouter.java
+++ b/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingsearch/routing/WithinDayParkingRouter.java
@@ -32,36 +32,29 @@ import org.matsim.core.population.routes.RouteUtils;
 import org.matsim.core.router.DijkstraFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.LeastCostPathCalculator.Path;
-import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
 
 import com.google.inject.name.Named;
 
 /**
  * @author jbischoff
- *
  */
 public class WithinDayParkingRouter implements ParkingRouter {
 
-	private Network network;
-
-	private TravelTime travelTime;
-	private TravelDisutility travelDisutility;
-	private LeastCostPathCalculator pathCalculator;
+	private final Network network;
+	private final LeastCostPathCalculator pathCalculator;
 
 	@Inject
 	WithinDayParkingRouter(@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime, Network network) {
-		this.travelTime = travelTime;
-		travelDisutility = new TimeAsTravelDisutility(this.travelTime);
 		this.network = network;
-		pathCalculator = new DijkstraFactory().createPathCalculator(network, travelDisutility, this.travelTime);
+		pathCalculator = new DijkstraFactory().createPathCalculator(network, new TimeAsTravelDisutility(travelTime),
+				travelTime);
 	}
 
 	@Override
 	public NetworkRoute getRouteFromParkingToDestination(Id<Link> destinationLinkId, double departureTime,
 			Id<Link> startLinkId) {
 
-		
 		Link startLink = this.network.getLinks().get(startLinkId);
 		Link endLink = this.network.getLinks().get(destinationLinkId);
 

--- a/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingsearch/sim/SetupParking.java
+++ b/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingsearch/sim/SetupParking.java
@@ -44,6 +44,7 @@ import org.matsim.core.mobsim.qsim.components.QSimComponentsConfig;
 import org.matsim.core.mobsim.qsim.components.StandardQSimComponentConfigurator;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
 import org.matsim.core.router.speedy.SpeedyALTFactory;
+import org.matsim.core.router.util.TravelTime;
 
 import com.google.inject.Key;
 import com.google.inject.name.Names;
@@ -66,6 +67,8 @@ public class SetupParking {
 		controler.addOverridingModule(new AbstractModule() {
 			@Override
 			public void install() {
+				bind(TravelTime.class).annotatedWith(DvrpModes.mode(TransportMode.car))
+						.to(Key.get(TravelTime.class, Names.named(DvrpTravelTimeModule.DVRP_ESTIMATED)));
 				bind(TravelDisutilityFactory.class).annotatedWith(DvrpModes.mode(TransportMode.car))
 						.toInstance(TimeAsTravelDisutility::new);
 				bind(Network.class).annotatedWith(DvrpModes.mode(TransportMode.car))

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/ETaxiScheduler.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/ETaxiScheduler.java
@@ -33,7 +33,6 @@ import org.matsim.contrib.dvrp.schedule.Schedule;
 import org.matsim.contrib.dvrp.schedule.Schedule.ScheduleStatus;
 import org.matsim.contrib.dvrp.schedule.Schedules;
 import org.matsim.contrib.dvrp.schedule.Task;
-import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.ev.charging.ChargingEstimations;
 import org.matsim.contrib.ev.charging.ChargingWithAssignmentLogic;
 import org.matsim.contrib.ev.fleet.ElectricVehicle;
@@ -48,14 +47,12 @@ import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelTime;
 
-import com.google.inject.name.Named;
-
 public class ETaxiScheduler extends TaxiScheduler {
 	public static final TaxiTaskType DRIVE_TO_CHARGER = new TaxiTaskType("DRIVE_TO_CHARGER", EMPTY_DRIVE);
 
 	public ETaxiScheduler(TaxiConfigGroup taxiCfg, Fleet fleet, TaxiScheduleInquiry taxiScheduleInquiry,
-			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
-			Supplier<LeastCostPathCalculator> routerCreator, EventsManager eventsManager, MobsimTimer mobsimTimer) {
+			TravelTime travelTime, Supplier<LeastCostPathCalculator> routerCreator, EventsManager eventsManager,
+			MobsimTimer mobsimTimer) {
 		super(taxiCfg, fleet, taxiScheduleInquiry, travelTime, routerCreator, eventsManager, mobsimTimer);
 	}
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/ETaxiOptimizerProvider.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/ETaxiOptimizerProvider.java
@@ -22,7 +22,6 @@ package org.matsim.contrib.etaxi.optimizer;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
-import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.etaxi.ETaxiScheduler;
 import org.matsim.contrib.etaxi.optimizer.assignment.AssignmentETaxiOptimizer;
 import org.matsim.contrib.etaxi.optimizer.assignment.AssignmentETaxiOptimizerParams;
@@ -47,7 +46,6 @@ import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
 
 import com.google.inject.Provider;
-import com.google.inject.name.Named;
 
 public class ETaxiOptimizerProvider implements Provider<TaxiOptimizer> {
 	private final EventsManager eventsManager;
@@ -62,9 +60,8 @@ public class ETaxiOptimizerProvider implements Provider<TaxiOptimizer> {
 	private final ScheduleTimingUpdater scheduleTimingUpdater;
 
 	public ETaxiOptimizerProvider(EventsManager eventsManager, TaxiConfigGroup taxiCfg, Fleet fleet, Network network,
-			MobsimTimer timer, @Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
-			TravelDisutility travelDisutility, ETaxiScheduler eScheduler, ScheduleTimingUpdater scheduleTimingUpdater,
-			ChargingInfrastructure chargingInfrastructure) {
+			MobsimTimer timer, TravelTime travelTime, TravelDisutility travelDisutility, ETaxiScheduler eScheduler,
+			ScheduleTimingUpdater scheduleTimingUpdater, ChargingInfrastructure chargingInfrastructure) {
 		this.eventsManager = eventsManager;
 		this.taxiCfg = taxiCfg;
 		this.fleet = fleet;
@@ -97,8 +94,8 @@ public class ETaxiOptimizerProvider implements Provider<TaxiOptimizer> {
 			return new AssignmentETaxiOptimizer(eventsManager, taxiCfg, fleet, timer, network, travelTime,
 					travelDisutility, eScheduler, scheduleTimingUpdater, chargingInfrastructure, router);
 		} else {
-			throw new RuntimeException("Unsupported taxi optimizer type: " + taxiCfg.getTaxiOptimizerParams().
-					getName());
+			throw new RuntimeException(
+					"Unsupported taxi optimizer type: " + taxiCfg.getTaxiOptimizerParams().getName());
 		}
 	}
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/ETaxiModeQSimModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/ETaxiModeQSimModule.java
@@ -81,14 +81,11 @@ public class ETaxiModeQSimModule extends AbstractDvrpModeQSimModule {
 					private MobsimTimer timer;
 
 					@Inject
-					@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
-					private TravelTime travelTime;
-
-					@Inject
 					private EventsManager events;
 
 					@Override
 					public TaxiOptimizer get() {
+						var travelTime = getModalInstance(TravelTime.class);
 						var fleet = getModalInstance(Fleet.class);
 						var network = getModalInstance(Network.class);
 						var eTaxiScheduler = getModalInstance(ETaxiScheduler.class);
@@ -111,14 +108,11 @@ public class ETaxiModeQSimModule extends AbstractDvrpModeQSimModule {
 					private MobsimTimer timer;
 
 					@Inject
-					@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
-					private TravelTime travelTime;
-
-					@Inject
 					private EventsManager events;
 
 					@Override
 					public ETaxiScheduler get() {
+						var travelTime = getModalInstance(TravelTime.class);
 						Fleet fleet = getModalInstance(Fleet.class);
 						TaxiScheduleInquiry taxiScheduleInquiry = new TaxiScheduleInquiry(taxiCfg, timer);
 						Network network = getModalInstance(Network.class);

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/DefaultTaxiOptimizerProvider.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/DefaultTaxiOptimizerProvider.java
@@ -24,7 +24,6 @@ import java.net.URL;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
-import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.taxi.optimizer.assignment.AssignmentRequestInserter;
 import org.matsim.contrib.taxi.optimizer.assignment.AssignmentTaxiOptimizerParams;
 import org.matsim.contrib.taxi.optimizer.fifo.FifoRequestInserter;
@@ -47,7 +46,6 @@ import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
 
 import com.google.inject.Provider;
-import com.google.inject.name.Named;
 
 public class DefaultTaxiOptimizerProvider implements Provider<TaxiOptimizer> {
 	private final EventsManager eventsManager;
@@ -62,9 +60,8 @@ public class DefaultTaxiOptimizerProvider implements Provider<TaxiOptimizer> {
 	private final ScheduleTimingUpdater scheduleTimingUpdater;
 
 	public DefaultTaxiOptimizerProvider(EventsManager eventsManager, TaxiConfigGroup taxiCfg, Fleet fleet,
-			Network network, MobsimTimer timer, @Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
-			TravelDisutility travelDisutility, TaxiScheduler scheduler, ScheduleTimingUpdater scheduleTimingUpdater,
-			URL context) {
+			Network network, MobsimTimer timer, TravelTime travelTime, TravelDisutility travelDisutility,
+			TaxiScheduler scheduler, ScheduleTimingUpdater scheduleTimingUpdater, URL context) {
 		this.eventsManager = eventsManager;
 		this.taxiCfg = taxiCfg;
 		this.fleet = fleet;

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeModule.java
@@ -27,6 +27,7 @@ import org.matsim.contrib.dvrp.router.DvrpModeRoutingNetworkModule;
 import org.matsim.contrib.dvrp.router.TimeAsTravelDisutility;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.DvrpModes;
+import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.taxi.analysis.TaxiEventSequenceCollector;
 import org.matsim.contrib.taxi.fare.TaxiFareHandler;
 import org.matsim.contrib.taxi.util.stats.TaxiStatsDumper;
@@ -34,6 +35,10 @@ import org.matsim.core.controler.IterationCounter;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
 import org.matsim.core.router.speedy.SpeedyALTFactory;
+import org.matsim.core.router.util.TravelTime;
+
+import com.google.inject.Key;
+import com.google.inject.name.Names;
 
 /**
  * @author michalm
@@ -51,6 +56,7 @@ public final class TaxiModeModule extends AbstractDvrpModeModule {
 		DvrpModes.registerDvrpMode(binder(), getMode());
 
 		install(new DvrpModeRoutingNetworkModule(getMode(), taxiCfg.isUseModeFilteredSubnetwork()));
+		bindModal(TravelTime.class).to(Key.get(TravelTime.class, Names.named(DvrpTravelTimeModule.DVRP_ESTIMATED)));
 		bindModal(TravelDisutilityFactory.class).toInstance(TimeAsTravelDisutility::new);
 
 		install(new DvrpModeRoutingModule(getMode(), new SpeedyALTFactory()));

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeQSimModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/run/TaxiModeQSimModule.java
@@ -80,14 +80,11 @@ public class TaxiModeQSimModule extends AbstractDvrpModeQSimModule {
 					private MobsimTimer timer;
 
 					@Inject
-					@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
-					private TravelTime travelTime;
-
-					@Inject
 					private EventsManager events;
 
 					@Override
 					public TaxiOptimizer get() {
+						var travelTime = getModalInstance(TravelTime.class);
 						Fleet fleet = getModalInstance(Fleet.class);
 						Network network = getModalInstance(Network.class);
 						TaxiScheduler taxiScheduler = getModalInstance(TaxiScheduler.class);
@@ -106,14 +103,11 @@ public class TaxiModeQSimModule extends AbstractDvrpModeQSimModule {
 					private MobsimTimer timer;
 
 					@Inject
-					@Named(DvrpTravelTimeModule.DVRP_ESTIMATED)
-					private TravelTime travelTime;
-
-					@Inject
 					private EventsManager events;
 
 					@Override
 					public TaxiScheduler get() {
+						var travelTime = getModalInstance(TravelTime.class);
 						Fleet fleet = getModalInstance(Fleet.class);
 						TaxiScheduleInquiry taxiScheduleInquiry = new TaxiScheduleInquiry(taxiCfg, timer);
 						Network network = getModalInstance(Network.class);

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/scheduler/TaxiScheduler.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/scheduler/TaxiScheduler.java
@@ -44,7 +44,6 @@ import org.matsim.contrib.dvrp.schedule.Schedule.ScheduleStatus;
 import org.matsim.contrib.dvrp.schedule.Schedules;
 import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.contrib.dvrp.tracker.OnlineDriveTaskTracker;
-import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.dvrp.util.LinkTimePair;
 import org.matsim.contrib.taxi.passenger.TaxiRequest;
 import org.matsim.contrib.taxi.passenger.TaxiRequest.TaxiRequestStatus;
@@ -65,7 +64,6 @@ import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelTime;
 
 import com.google.common.util.concurrent.Futures;
-import com.google.inject.name.Named;
 
 public class TaxiScheduler implements MobsimBeforeCleanupListener {
 	protected final TaxiConfigGroup taxiCfg;
@@ -85,8 +83,8 @@ public class TaxiScheduler implements MobsimBeforeCleanupListener {
 	private final ExecutorServiceWithResource<LeastCostPathCalculator> executorService;
 
 	public TaxiScheduler(TaxiConfigGroup taxiCfg, Fleet fleet, TaxiScheduleInquiry taxiScheduleInquiry,
-			@Named(DvrpTravelTimeModule.DVRP_ESTIMATED) TravelTime travelTime,
-			Supplier<LeastCostPathCalculator> routerCreator, EventsManager eventsManager, MobsimTimer mobsimTimer) {
+			TravelTime travelTime, Supplier<LeastCostPathCalculator> routerCreator, EventsManager eventsManager,
+			MobsimTimer mobsimTimer) {
 		this.taxiCfg = taxiCfg;
 		this.fleet = fleet;
 		this.taxiScheduleInquiry = taxiScheduleInquiry;


### PR DESCRIPTION
Currently the `DVRP_ESTIMATED` travel times are based on the "collected" travel times for car **qsim mode** and used for all vehicles across all **dvrp modes**. This is one of a few obstacles preventing us from simulating heterogenous fleets.

As a first step, let's focus on a simplified use case: being able to customise travel times per dvrp mode. This PR introduces modal binding for TravelTime for each dvrp mode, where `DVRP_ESTIMATED` travel time is used by default, i.e.
```
bindModal(TravelTime.class).to(Key.get(TravelTime.class, Names.named(DvrpTravelTimeModule.DVRP_ESTIMATED)));
```
This default binding needs to be overridden to provide different travel times.