### PR TITLE
dvrp: support creating non-free-speed travel time matrices

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpModeRoutingNetworkModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpModeRoutingNetworkModule.java
@@ -75,7 +75,7 @@ public class DvrpModeRoutingNetworkModule extends AbstractDvrpModeModule {
 
 			//lazily initialised: optimisers may not need it
 			bindModal(DvrpTravelTimeMatrix.class).toProvider(modalProvider(
-					getter -> new DvrpTravelTimeMatrix(getter.getModal(Network.class),
+					getter -> DvrpTravelTimeMatrix.createFreeSpeedMatrix(getter.getModal(Network.class),
 							dvrpConfigGroup.getTravelTimeMatrixParams(), globalConfigGroup.getNumberOfThreads(),
 							qSimConfigGroup.getTimeStepSize()))).in(Singleton.class);
 		} else {

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpGlobalTravelTimesMatrixProvider.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpGlobalTravelTimesMatrixProvider.java
@@ -51,6 +51,7 @@ public class DvrpGlobalTravelTimesMatrixProvider implements Provider<DvrpTravelT
 
 	@Override
 	public DvrpTravelTimeMatrix get() {
-		return new DvrpTravelTimeMatrix(network, params, numberOfThreads, qSimConfigGroup.getTimeStepSize());
+		return DvrpTravelTimeMatrix.createFreeSpeedMatrix(network, params, numberOfThreads,
+				qSimConfigGroup.getTimeStepSize());
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrix.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrix.java
@@ -26,20 +26,26 @@ import org.matsim.contrib.dvrp.router.TimeAsTravelDisutility;
 import org.matsim.contrib.dvrp.trafficmonitoring.QSimFreeSpeedTravelTime;
 import org.matsim.contrib.zone.SquareGridSystem;
 import org.matsim.contrib.zone.ZonalSystems;
+import org.matsim.core.router.util.TravelTime;
 
 /**
  * @author Michal Maciejewski (michalm)
  */
 public class DvrpTravelTimeMatrix {
+	public static DvrpTravelTimeMatrix createFreeSpeedMatrix(Network dvrpNetwork,
+			DvrpTravelTimeMatrixParams params, int numberOfThreads, double qSimTimeStepSize) {
+		return new DvrpTravelTimeMatrix(dvrpNetwork, params, numberOfThreads,
+				new QSimFreeSpeedTravelTime(qSimTimeStepSize));
+	}
+
 	private final SquareGridSystem gridSystem;
 	private final Matrix freeSpeedTravelTimeMatrix;
 	private final SparseMatrix freeSpeedTravelTimeSparseMatrix;
 
 	public DvrpTravelTimeMatrix(Network dvrpNetwork, DvrpTravelTimeMatrixParams params, int numberOfThreads,
-			double qSimTimeStepSize) {
+			TravelTime travelTime) {
 		gridSystem = new SquareGridSystem(dvrpNetwork.getNodes().values(), params.getCellSize());
 		var centralNodes = ZonalSystems.computeMostCentralNodes(dvrpNetwork.getNodes().values(), gridSystem);
-		var travelTime = new QSimFreeSpeedTravelTime(qSimTimeStepSize);
 		var travelDisutility = new TimeAsTravelDisutility(travelTime);
 		freeSpeedTravelTimeMatrix = TravelTimeMatrices.calculateTravelTimeMatrix(dvrpNetwork, centralNodes, 0,
 				travelTime, travelDisutility, numberOfThreads);

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrixTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrixTest.java
@@ -49,7 +49,7 @@ public class DvrpTravelTimeMatrixTest {
 	@Test
 	public void matrix() {
 		DvrpTravelTimeMatrixParams params = new DvrpTravelTimeMatrixParams().setCellSize(100).setMaxNeighborDistance(0);
-		var matrix = new DvrpTravelTimeMatrix(network, params, 1, 1);
+		var matrix = DvrpTravelTimeMatrix.createFreeSpeedMatrix(network, params, 1, 1);
 
 		// distances between central nodes: A and B
 		assertThat(matrix.getFreeSpeedTravelTime(nodeA, nodeA)).isEqualTo(0);
@@ -68,7 +68,7 @@ public class DvrpTravelTimeMatrixTest {
 	public void sparseMatrix() {
 		DvrpTravelTimeMatrixParams params = new DvrpTravelTimeMatrixParams().setCellSize(100)
 				.setMaxNeighborDistance(9999);
-		var matrix = new DvrpTravelTimeMatrix(network, params, 1, 1);
+		var matrix = DvrpTravelTimeMatrix.createFreeSpeedMatrix(network, params, 1, 1);
 
 		// distances between central nodes: A and B
 		assertThat(matrix.getFreeSpeedTravelTime(nodeA, nodeA)).isEqualTo(0);


### PR DESCRIPTION
Next step after #1775: In DRT we also use free-speed travel time matrices. However, if some vehicles move slower (e.g. AVs with some max speed imposed), we should be able to build such matrices with a custom travel time (e.g. with `QSimFreeSpeedTravelTimeWithMaxSpeedLimit`).