### PR TITLE
Allow overriding QSimModule bindings multiple times

### DIFF
--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSimProvider.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSimProvider.java
@@ -87,7 +87,7 @@ public class QSimProvider implements Provider<QSim> {
 		AbstractQSimModule qsimModule = AbstractQSimModule.overrideQSimModules(modules, Collections.emptyList());
 		
 		for (AbstractQSimModule override : overridingModules) {
-			qsimModule = AbstractQSimModule.overrideQSimModules(modules, Collections.singletonList(override));
+			qsimModule = AbstractQSimModule.overrideQSimModules(Collections.singleton(qsimModule), Collections.singletonList(override));
 		}
 		
 		final AbstractQSimModule finalQsimModule = qsimModule;

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSimProvider.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSimProvider.java
@@ -24,6 +24,7 @@ package org.matsim.core.mobsim.qsim;
 
 import java.lang.annotation.Annotation;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.log4j.Logger;
@@ -83,12 +84,18 @@ public class QSimProvider implements Provider<QSim> {
 		modules.forEach(m -> m.setIterationNumber(iterationNumber));
 		overridingModules.forEach(m -> m.setIterationNumber(iterationNumber));
 
-		AbstractQSimModule qsimModule = AbstractQSimModule.overrideQSimModules(modules, overridingModules);
-
+		AbstractQSimModule qsimModule = AbstractQSimModule.overrideQSimModules(modules, Collections.emptyList());
+		
+		for (AbstractQSimModule override : overridingModules) {
+			qsimModule = AbstractQSimModule.overrideQSimModules(modules, Collections.singletonList(override));
+		}
+		
+		final AbstractQSimModule finalQsimModule = qsimModule;
+		
 		AbstractModule module = new AbstractModule() {
 			@Override
 			protected void configure() {
-				install(qsimModule);
+				install(finalQsimModule);
 				bind(QSim.class).asEagerSingleton();
 				bind(Netsim.class).to(QSim.class);
 			}

--- a/matsim/src/test/java/org/matsim/core/mobsim/qsim/AbstractQSimModuleTest.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/qsim/AbstractQSimModuleTest.java
@@ -103,6 +103,33 @@ public class AbstractQSimModuleTest {
 
 		Assert.assertTrue(value.get() > 0);
 	}
+	
+	@Test
+	public void testOverrideAgentFactoryTwice() {
+		Config config = ConfigUtils.createConfig();
+		config.controler().setOverwriteFileSetting(OverwriteFileSetting.deleteDirectoryIfExists);
+		config.controler().setLastIteration(0);
+
+		Scenario scenario = ScenarioUtils.loadScenario(config);
+
+		PopulationFactory populationFactory = scenario.getPopulation().getFactory();
+		Person person = populationFactory.createPerson(Id.createPersonId("person"));
+		Plan plan =  populationFactory.createPlan();
+		plan.addActivity( populationFactory.createActivityFromLinkId("type", Id.createLinkId("0")));
+		person.addPlan(plan);
+		scenario.getPopulation().addPerson(person);
+
+		AtomicLong value1 = new AtomicLong(0);
+		AtomicLong value2 = new AtomicLong(0);
+
+		Controler controler = new Controler(scenario);
+		controler.addOverridingQSimModule(new TestQSimModule(value1));
+		controler.addOverridingQSimModule(new TestQSimModule(value2));
+		controler.run();
+
+		Assert.assertTrue(value1.get() == 0);
+		Assert.assertTrue(value2.get() > 0);
+	}
 
 	private class TestQSimModule extends AbstractQSimModule {
 		private final AtomicLong value;


### PR DESCRIPTION
Calls to `Controler.addOverridingModule` currently allow multiple overrides, i.e. I can override a certain binding, e.g. `@Named("car") TravelTime` with one overriding module, and then with another one:

```
controler.addOverridingModule(new FirstModule());
controler.addOverridingModule(new SecondModule());
```

For `Controler.addOverridingQSimModule` currently only the first override works. The second one will complain that a binding is already defined. 

This PR adds the same functionality for QSimModules, they can now be overridden multple times. This is useful, e.g. when overriding a DrtOptimizer with a ShiftDrtOptimizer and then with a AlgorithmXYZOptimizer and similar cases.