### PR TITLE
dvrp: use matsim vehicle from dvrp vehicle specification to create mobsim vehicle

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/fleet/DefaultShiftDvrpVehicle.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/fleet/DefaultShiftDvrpVehicle.java
@@ -1,14 +1,15 @@
 package org.matsim.contrib.drt.extension.shifts.fleet;
 
-import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.network.Link;
-import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
-import org.matsim.contrib.dvrp.schedule.Schedule;
-import org.matsim.contrib.drt.extension.shifts.shift.DrtShift;
-
 import java.util.Comparator;
 import java.util.PriorityQueue;
 import java.util.Queue;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.contrib.drt.extension.shifts.shift.DrtShift;
+import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
+import org.matsim.contrib.dvrp.fleet.DvrpVehicleSpecification;
+import org.matsim.contrib.dvrp.schedule.Schedule;
 
 /**
  * @author nkuehnel, fzwick / MOIA
@@ -52,6 +53,11 @@ public class DefaultShiftDvrpVehicle implements ShiftDvrpVehicle {
 	@Override
 	public Schedule getSchedule() {
 		return vehicle.getSchedule();
+	}
+
+	@Override
+	public DvrpVehicleSpecification getSpecification() {
+		return vehicle.getSpecification();
 	}
 
 	@Override

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/DvrpVehicle.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/DvrpVehicle.java
@@ -62,4 +62,7 @@ public interface DvrpVehicle extends Identifiable<DvrpVehicle> {
 	 * </ul>
 	 */
 	Schedule getSchedule();
+
+
+	DvrpVehicleSpecification getSpecification();
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/DvrpVehicleImpl.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/DvrpVehicleImpl.java
@@ -81,6 +81,10 @@ public class DvrpVehicleImpl implements DvrpVehicle {
 		return schedule;
 	}
 
+	public DvrpVehicleSpecification getSpecification() {
+		return specification;
+	}
+
 	@Override
 	public String toString() {
 		return MoreObjects.toStringHelper(this)

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/vrpagent/VrpAgentSource.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/vrpagent/VrpAgentSource.java
@@ -30,6 +30,7 @@ import org.matsim.core.mobsim.framework.AgentSource;
 import org.matsim.core.mobsim.qsim.QSim;
 import org.matsim.core.mobsim.qsim.qnetsimengine.QVehicle;
 import org.matsim.core.mobsim.qsim.qnetsimengine.QVehicleImpl;
+import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehiclesFactory;
 
@@ -63,8 +64,10 @@ public class VrpAgentSource implements AgentSource {
 					qSim.getEventsManager());
 			DynAgent vrpAgent = new DynAgent(Id.createPersonId(id), startLinkId, qSim.getEventsManager(),
 					vrpAgentLogic);
-			QVehicle mobsimVehicle = new QVehicleImpl(
-					vehicleFactory.createVehicle(Id.create(id, org.matsim.vehicles.Vehicle.class), vehicleType));
+			Vehicle matsimVehicle = dvrpVehicle.getSpecification()
+					.getMatsimVehicle()
+					.orElse(vehicleFactory.createVehicle(Id.create(id, Vehicle.class), vehicleType));
+			QVehicle mobsimVehicle = new QVehicleImpl(matsimVehicle);
 			vrpAgent.setVehicle(mobsimVehicle);
 			mobsimVehicle.setDriver(vrpAgent);
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/evrp/EvDvrpVehicle.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/evrp/EvDvrpVehicle.java
@@ -23,6 +23,7 @@ package org.matsim.contrib.evrp;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
+import org.matsim.contrib.dvrp.fleet.DvrpVehicleSpecification;
 import org.matsim.contrib.dvrp.schedule.Schedule;
 import org.matsim.contrib.ev.fleet.ElectricFleet;
 import org.matsim.contrib.ev.fleet.ElectricVehicle;
@@ -76,5 +77,10 @@ public class EvDvrpVehicle implements DvrpVehicle {
 	@Override
 	public Schedule getSchedule() {
 		return vehicle.getSchedule();
+	}
+
+	@Override
+	public DvrpVehicleSpecification getSpecification() {
+		return vehicle.getSpecification();
 	}
 }


### PR DESCRIPTION
If a dvrp vehicle has a reference to a matsim vehicle (e.g. when dvrp vehicles are created from the standard matsim vehicle input), the type of that matsim vehicle will be used to create a mobsim vehicle for the corresponding dvrp agent. Otherwise, the default vehicle type (annotated with `@Named(DVRP_VEHICLE_TYPE)`) will be used (current approach).