### PR TITLE
Some DRT analysis improvements

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
@@ -40,13 +40,13 @@ import org.jfree.chart.JFreeChart;
 import org.jfree.data.xy.XYSeries;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.contrib.drt.analysis.DrtEventSequenceCollector.PerformedRequestEventSequence;
+import org.matsim.contrib.drt.analysis.DrtEventSequenceCollector.EventSequence;
 import org.matsim.contrib.drt.passenger.events.DrtRequestSubmittedEvent;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtTaskBaseType;
 import org.matsim.contrib.drt.schedule.DrtTaskType;
-import org.matsim.contrib.util.stats.VehicleOccupancyProfileCalculator;
 import org.matsim.contrib.dvrp.fleet.FleetSpecification;
+import org.matsim.contrib.util.stats.VehicleOccupancyProfileCalculator;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.groups.QSimConfigGroup;
 import org.matsim.core.controler.MatsimServices;
@@ -106,7 +106,7 @@ public class DrtAnalysisControlerListener implements IterationEndsListener {
 		List<DrtLeg> legs = drtEventSequenceCollector.getPerformedRequestSequences()
 				.values()
 				.stream()
-				.filter(PerformedRequestEventSequence::isCompleted)
+				.filter(EventSequence::isCompleted)
 				.map(sequence -> new DrtLeg(sequence, network.getLinks()::get))
 				.sorted(Comparator.comparing(leg -> leg.departureTime))
 				.collect(toList());
@@ -169,7 +169,9 @@ public class DrtAnalysisControlerListener implements IterationEndsListener {
 					"travelTime",//
 					"travelDistance_m",//
 					"directTravelDistance_m",//
-					"fareForLeg");
+					"fareForLeg", //
+					"latestDepartureTime", //
+					"latestArrivalTime");
 
 			DrtLegsAnalyser.collection2Text(legs, filename(event, "drt_legs", ".csv"), header, leg -> String.join(";",//
 					(Double)leg.departureTime + "",//
@@ -186,14 +188,17 @@ public class DrtAnalysisControlerListener implements IterationEndsListener {
 					(leg.arrivalTime - leg.departureTime - leg.waitTime) + "",//
 					format.format(drtVehicleStats.getTravelDistances().get(leg.request)),//
 					format.format(leg.unsharedDistanceEstimate_m),//
-					format.format(leg.fare)));
+					format.format(leg.fare), //
+					format.format(leg.latestDepartureTime), //
+					format.format(leg.latestArrivalTime)));
 		}
 		DrtLegsAnalyser.writeVehicleDistances(drtVehicleStats.getVehicleStates(),
 				filename(event, "vehicleDistanceStats", ".csv"));
 		DrtLegsAnalyser.analyseDetours(network, legs, drtVehicleStats.getTravelDistances(), drtCfg,
 				filename(event, "drt_detours"), createGraphs);
 		DrtLegsAnalyser.analyseWaitTimes(filename(event, "waitStats"), legs, 1800, createGraphs);
-
+		DrtLegsAnalyser.analyseConstraints(filename(event, "constraints"), legs, createGraphs);
+		
 		double endTime = qSimCfg.getEndTime()
 				.orElseGet(() -> legs.isEmpty() ?
 						qSimCfg.getStartTime().orElse(0) :
@@ -265,13 +270,13 @@ public class DrtAnalysisControlerListener implements IterationEndsListener {
 	}
 
 	public void writeAndPlotWaitTimeEstimateComparison(
-			Collection<PerformedRequestEventSequence> performedRequestEventSequences, String plotFileName,
+			Collection<EventSequence> performedRequestEventSequences, String plotFileName,
 			String textFileName, boolean createChart) {
 		try (var bw = IOUtils.getBufferedWriter(textFileName)) {
 			XYSeries times = new XYSeries("waittimes", true, true);
 
 			bw.append(line("RequestId", "actualWaitTime", "estimatedWaitTime", "deviate"));
-			for (PerformedRequestEventSequence seq : performedRequestEventSequences) {
+			for (EventSequence seq : performedRequestEventSequences) {
 				if (seq.getPickedUp().isPresent()) {
 					double actualWaitTime = seq.getPickedUp().get().getTime() - seq.getSubmitted().getTime();
 					double estimatedWaitTime = seq.getScheduled().getPickupTime() - seq.getSubmitted().getTime();

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
@@ -279,7 +279,7 @@ public class DrtAnalysisControlerListener implements IterationEndsListener {
 			for (EventSequence seq : performedRequestEventSequences) {
 				if (seq.getPickedUp().isPresent()) {
 					double actualWaitTime = seq.getPickedUp().get().getTime() - seq.getSubmitted().getTime();
-					double estimatedWaitTime = seq.getScheduled().getPickupTime() - seq.getSubmitted().getTime();
+					double estimatedWaitTime = seq.getScheduled().get().getPickupTime() - seq.getSubmitted().getTime();
 					bw.append(line(seq.getSubmitted().getRequestId(), actualWaitTime, estimatedWaitTime,
 							actualWaitTime - estimatedWaitTime));
 					times.add(actualWaitTime, estimatedWaitTime);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtEventSequenceCollector.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtEventSequenceCollector.java
@@ -76,7 +76,7 @@ public class DrtEventSequenceCollector
 		private PassengerRequestRejectedEvent rejected;
 		
 		@Nullable
-		private PersonDepartureEvent departed;
+		private PersonDepartureEvent departure;
 		@Nullable
 		private PassengerPickedUpEvent pickedUp;
 		@Nullable
@@ -93,7 +93,7 @@ public class DrtEventSequenceCollector
 				PassengerDroppedOffEvent droppedOff, List<PersonMoneyEvent> drtFares) {
 			this.submitted = Objects.requireNonNull(submitted);
 			this.scheduled = Objects.requireNonNull(scheduled);
-			this.departed = departed;
+			this.departure = departed;
 			this.pickedUp = pickedUp;
 			this.droppedOff = droppedOff;
 			this.drtFares = new ArrayList<>(drtFares);
@@ -112,7 +112,7 @@ public class DrtEventSequenceCollector
 		}
 		
 		public Optional<PersonDepartureEvent> getDeparted() {
-			return Optional.ofNullable(departed);
+			return Optional.ofNullable(departure);
 		}
 
 		public Optional<PassengerPickedUpEvent> getPickedUp() {
@@ -186,7 +186,7 @@ public class DrtEventSequenceCollector
 				// sequence and note down the person id to fill in the departure event later on.
 				sequencesWithoutDeparture.computeIfAbsent(event.getPersonId(), id -> new LinkedList<>()).add(sequence);
 			} else {
-				sequence.departed = departureEvent.get();
+				sequence.departure = departureEvent.get();
 			}
 		}
 	}
@@ -202,7 +202,7 @@ public class DrtEventSequenceCollector
 				// is down (usually right after).
 				departuresWithoutSequence.computeIfAbsent(event.getPersonId(), id -> new LinkedList<>()).add(event);
 			} else {
-				sequence.get().departed = event;
+				sequence.get().departure = event;
 			}
 		}
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtEventSequenceCollector.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtEventSequenceCollector.java
@@ -85,14 +85,14 @@ public class DrtEventSequenceCollector
 		private List<PersonMoneyEvent> drtFares = new LinkedList<>();
 
 		EventSequence(DrtRequestSubmittedEvent submitted) {
-			this.submitted = submitted;
+			this.submitted = Objects.requireNonNull(submitted);
 		}
 		
 		public EventSequence(PersonDepartureEvent departed, DrtRequestSubmittedEvent submitted,
 				PassengerRequestScheduledEvent scheduled, PassengerPickedUpEvent pickedUp,
 				PassengerDroppedOffEvent droppedOff, List<PersonMoneyEvent> drtFares) {
 			this.submitted = Objects.requireNonNull(submitted);
-			this.scheduled = Objects.requireNonNull(scheduled);
+			this.scheduled = scheduled;
 			this.departure = departed;
 			this.pickedUp = pickedUp;
 			this.droppedOff = droppedOff;
@@ -103,12 +103,12 @@ public class DrtEventSequenceCollector
 			return submitted;
 		}
 
-		public PassengerRequestScheduledEvent getScheduled() {
-			return scheduled;
+		public Optional<PassengerRequestScheduledEvent> getScheduled() {
+			return Optional.ofNullable(scheduled);
 		}
 		
-		public PassengerRequestRejectedEvent getRejected() {
-			return rejected;
+		public Optional<PassengerRequestRejectedEvent> getRejected() {
+			return Optional.ofNullable(rejected);
 		}
 		
 		public Optional<PersonDepartureEvent> getDeparted() {
@@ -151,13 +151,13 @@ public class DrtEventSequenceCollector
 
 	public Map<Id<Request>, EventSequence> getRejectedRequestSequences() {
 		return sequences.entrySet().stream() //
-				.filter(e -> e.getValue().getRejected() != null) //
+				.filter(e -> e.getValue().getRejected().isPresent()) //
 				.collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
 	}
 
 	public Map<Id<Request>, EventSequence> getPerformedRequestSequences() {
 		return sequences.entrySet().stream() //
-				.filter(e -> e.getValue().getRejected() == null) //
+				.filter(e -> e.getValue().getRejected().isEmpty()) //
 				.collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
 	}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtEventSequenceCollector.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtEventSequenceCollector.java
@@ -24,17 +24,22 @@ import static org.matsim.contrib.drt.fare.DrtFareHandler.PERSON_MONEY_EVENT_REFE
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
-import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.events.PersonDepartureEvent;
 import org.matsim.api.core.v01.events.PersonMoneyEvent;
+import org.matsim.api.core.v01.events.handler.PersonDepartureEventHandler;
 import org.matsim.api.core.v01.events.handler.PersonMoneyEventHandler;
+import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.drt.fare.DrtFareHandler;
 import org.matsim.contrib.drt.passenger.events.DrtRequestSubmittedEvent;
 import org.matsim.contrib.drt.passenger.events.DrtRequestSubmittedEventHandler;
@@ -60,31 +65,35 @@ import com.google.common.base.Preconditions;
 public class DrtEventSequenceCollector
 		implements PassengerRequestRejectedEventHandler, PassengerRequestScheduledEventHandler,
 		DrtRequestSubmittedEventHandler, PassengerPickedUpEventHandler, PassengerDroppedOffEventHandler,
-		PersonMoneyEventHandler {
+		PersonMoneyEventHandler, PersonDepartureEventHandler {
 
-	private static final Logger log = Logger.getLogger(DrtEventSequenceCollector.class);
-
-	public static class PerformedRequestEventSequence {
+	public static class EventSequence {
 		private final DrtRequestSubmittedEvent submitted;
-		private final PassengerRequestScheduledEvent scheduled;
-		//pickedUp and droppedOff may be null if QSim ends before the request is actually handled
+		
+		@Nullable
+		private PassengerRequestScheduledEvent scheduled;
+		@Nullable
+		private PassengerRequestRejectedEvent rejected;
+		
+		@Nullable
+		private PersonDepartureEvent departed;
 		@Nullable
 		private PassengerPickedUpEvent pickedUp;
 		@Nullable
 		private PassengerDroppedOffEvent droppedOff;
 		@Nullable
-		private List<PersonMoneyEvent> drtFares;
+		private List<PersonMoneyEvent> drtFares = new LinkedList<>();
 
-		public PerformedRequestEventSequence(DrtRequestSubmittedEvent submitted,
-				PassengerRequestScheduledEvent scheduled) {
-			this(submitted, scheduled, null, null, List.of());
+		EventSequence(DrtRequestSubmittedEvent submitted) {
+			this.submitted = submitted;
 		}
-
-		public PerformedRequestEventSequence(DrtRequestSubmittedEvent submitted,
+		
+		public EventSequence(PersonDepartureEvent departed, DrtRequestSubmittedEvent submitted,
 				PassengerRequestScheduledEvent scheduled, PassengerPickedUpEvent pickedUp,
 				PassengerDroppedOffEvent droppedOff, List<PersonMoneyEvent> drtFares) {
 			this.submitted = Objects.requireNonNull(submitted);
 			this.scheduled = Objects.requireNonNull(scheduled);
+			this.departed = departed;
 			this.pickedUp = pickedUp;
 			this.droppedOff = droppedOff;
 			this.drtFares = new ArrayList<>(drtFares);
@@ -96,6 +105,14 @@ public class DrtEventSequenceCollector
 
 		public PassengerRequestScheduledEvent getScheduled() {
 			return scheduled;
+		}
+		
+		public PassengerRequestRejectedEvent getRejected() {
+			return rejected;
+		}
+		
+		public Optional<PersonDepartureEvent> getDeparted() {
+			return Optional.ofNullable(departed);
 		}
 
 		public Optional<PassengerPickedUpEvent> getPickedUp() {
@@ -115,45 +132,33 @@ public class DrtEventSequenceCollector
 		}
 	}
 
-	public static class RejectedRequestEventSequence {
-		private final DrtRequestSubmittedEvent submitted;
-		private final PassengerRequestRejectedEvent rejected;
-
-		public RejectedRequestEventSequence(DrtRequestSubmittedEvent submitted,
-				PassengerRequestRejectedEvent rejected) {
-			this.submitted = submitted;
-			this.rejected = rejected;
-		}
-
-		public DrtRequestSubmittedEvent getSubmitted() {
-			return submitted;
-		}
-
-		public PassengerRequestRejectedEvent getRejected() {
-			return rejected;
-		}
-	}
-
 	private final String mode;
-	private final Map<Id<Request>, DrtRequestSubmittedEvent> requestSubmissions = new HashMap<>();
-	private final Map<Id<Request>, RejectedRequestEventSequence> rejectedRequestSequences = new HashMap<>();
-	private final Map<Id<Request>, PerformedRequestEventSequence> performedRequestSequences = new HashMap<>();
+	
+	private final Map<Id<Request>, EventSequence> sequences = new HashMap<>();
 	private final List<PersonMoneyEvent> drtFarePersonMoneyEvents = new ArrayList<>();
+	
+	private final Map<Id<Person>, List<EventSequence>> sequencesWithoutDeparture = new HashMap<>();
+	private final Map<Id<Person>, List<PersonDepartureEvent>> departuresWithoutSequence = new HashMap<>();
 
 	public DrtEventSequenceCollector(String mode) {
 		this.mode = mode;
 	}
 
 	public Map<Id<Request>, DrtRequestSubmittedEvent> getRequestSubmissions() {
-		return requestSubmissions;
+		return sequences.entrySet().stream() //
+				.collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().submitted));
 	}
 
-	public Map<Id<Request>, RejectedRequestEventSequence> getRejectedRequestSequences() {
-		return rejectedRequestSequences;
+	public Map<Id<Request>, EventSequence> getRejectedRequestSequences() {
+		return sequences.entrySet().stream() //
+				.filter(e -> e.getValue().getRejected() != null) //
+				.collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
 	}
 
-	public Map<Id<Request>, PerformedRequestEventSequence> getPerformedRequestSequences() {
-		return performedRequestSequences;
+	public Map<Id<Request>, EventSequence> getPerformedRequestSequences() {
+		return sequences.entrySet().stream() //
+				.filter(e -> e.getValue().getRejected() == null) //
+				.collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
 	}
 
 	public List<PersonMoneyEvent> getDrtFarePersonMoneyEvents() {
@@ -162,46 +167,71 @@ public class DrtEventSequenceCollector
 
 	@Override
 	public void reset(int iteration) {
-		requestSubmissions.clear();
-		rejectedRequestSequences.clear();
-		performedRequestSequences.clear();
+		sequences.clear();
 		drtFarePersonMoneyEvents.clear();
+		sequencesWithoutDeparture.clear();
+		departuresWithoutSequence.clear();
 	}
 
 	@Override
 	public void handleEvent(DrtRequestSubmittedEvent event) {
 		if (event.getMode().equals(mode)) {
-			requestSubmissions.put(event.getRequestId(), event);
+			EventSequence sequence = new EventSequence(event);
+			sequences.put(event.getRequestId(), sequence);
+			
+			Optional<PersonDepartureEvent> departureEvent = popDepartureForSubmission(event);
+			
+			if (departureEvent.isEmpty()) {
+				// We have a submitted request, but no departure event yet (i.e. a prebooking). We start the
+				// sequence and note down the person id to fill in the departure event later on.
+				sequencesWithoutDeparture.computeIfAbsent(event.getPersonId(), id -> new LinkedList<>()).add(sequence);
+			} else {
+				sequence.departed = departureEvent.get();
+			}
+		}
+	}
+	
+	@Override
+	public void handleEvent(PersonDepartureEvent event) {
+		if (event.getLegMode().equals(mode)) {
+			Optional<EventSequence> sequence = popSequenceForDeparture(event);
+			
+			if (sequence.isEmpty()) {
+				// We have a departure event, but no submission yet (i.e. and instant booking).
+				// We note down the departure event here to recover it later when the submission
+				// is down (usually right after).
+				departuresWithoutSequence.computeIfAbsent(event.getPersonId(), id -> new LinkedList<>()).add(event);
+			} else {
+				sequence.get().departed = event;
+			}
 		}
 	}
 
 	@Override
 	public void handleEvent(PassengerRequestScheduledEvent event) {
 		if (event.getMode().equals(mode)) {
-			performedRequestSequences.put(event.getRequestId(),
-					new PerformedRequestEventSequence(requestSubmissions.get(event.getRequestId()), event));
+			sequences.get(event.getRequestId()).scheduled = event;
 		}
 	}
 
 	@Override
 	public void handleEvent(PassengerRequestRejectedEvent event) {
 		if (event.getMode().equals(mode)) {
-			rejectedRequestSequences.put(event.getRequestId(),
-					new RejectedRequestEventSequence(requestSubmissions.get(event.getRequestId()), event));
+			sequences.get(event.getRequestId()).rejected = event;
 		}
 	}
 
 	@Override
 	public void handleEvent(PassengerPickedUpEvent event) {
 		if (event.getMode().equals(mode)) {
-			performedRequestSequences.get(event.getRequestId()).pickedUp = event;
+			sequences.get(event.getRequestId()).pickedUp = event;
 		}
 	}
 
 	@Override
 	public void handleEvent(PassengerDroppedOffEvent event) {
 		if (event.getMode().equals(mode)) {
-			performedRequestSequences.get(event.getRequestId()).droppedOff = event;
+			sequences.get(event.getRequestId()).droppedOff = event;
 		}
 	}
 
@@ -217,11 +247,85 @@ public class DrtEventSequenceCollector
 							+ " or similar. Terminating.", event.getPurpose(), event.getTransactionPartner());
 
 			drtFarePersonMoneyEvents.add(event);
-			PerformedRequestEventSequence sequence = performedRequestSequences.get(
+			EventSequence sequence = sequences.get(
 					Id.create(event.getReference(), Request.class));
 			if (sequence != null) {
 				sequence.drtFares.add(event);
 			}
 		}
+	}
+
+	/*
+	 * This function is helper that finds a PersonDepartureEvent for a given
+	 * DrtRequestSubmittedEvent. This means that the departure has happened before
+	 * submission, which is the usually case for instant requests.
+	 */
+	private Optional<PersonDepartureEvent> popDepartureForSubmission(DrtRequestSubmittedEvent event) {
+		List<PersonDepartureEvent> potentialDepartures = departuresWithoutSequence.get(event.getPersonId());
+		Optional<PersonDepartureEvent> result = Optional.empty();
+
+		boolean foundDeparture = false;
+
+		if (potentialDepartures != null) {
+			Iterator<PersonDepartureEvent> iterator = potentialDepartures.iterator();
+
+			while (iterator.hasNext()) {
+				PersonDepartureEvent departedEvent = iterator.next();
+
+				if (event.getFromLinkId().equals(departedEvent.getLinkId())) {
+					if (foundDeparture) {
+						throw new IllegalStateException(
+								"Ambiguous matching between submission and departure - not sure how to solve this");
+					}
+
+					iterator.remove();
+					result = Optional.of(departedEvent);
+					foundDeparture = true;
+				}
+			}
+
+			if (potentialDepartures.size() == 0) {
+				departuresWithoutSequence.remove(event.getPersonId());
+			}
+		}
+
+		return result;
+	}
+	
+	/*
+	 * This function is helper that finds a sequence given a PersonDepartureEvent.
+	 * This means that a sequence has started (the request has been submitted)
+	 * before the agent has departed, i.e. this is a pre-booking of some sort.
+	 */
+	private Optional<EventSequence> popSequenceForDeparture(PersonDepartureEvent event) {
+		Optional<EventSequence> result = Optional.empty();
+
+		List<EventSequence> potentialSequences = sequencesWithoutDeparture.get(event.getPersonId());
+		boolean foundSequence = false;
+
+		if (potentialSequences != null) {
+			Iterator<EventSequence> iterator = potentialSequences.iterator();
+
+			while (iterator.hasNext()) {
+				EventSequence sequence = iterator.next();
+
+				if (sequence.submitted.getFromLinkId().equals(event.getLinkId())) {
+					if (foundSequence) {
+						throw new IllegalStateException(
+								"Ambiguous matching between submission and departure - not sure how to solve this");
+					}
+
+					iterator.remove();
+					result = Optional.of(sequence);
+					foundSequence = true;
+				}
+			}
+
+			if (potentialSequences.size() == 0) {
+				sequencesWithoutDeparture.remove(event.getPersonId());
+			}
+		}
+		
+		return result;
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtLegsAnalyser.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtLegsAnalyser.java
@@ -491,4 +491,35 @@ public class DrtLegsAnalyser {
 		double count = (double)Arrays.stream(waitingTimes).filter(t -> t < timeCriteria).count();
 		return count * 100 / waitingTimes.length;
 	}
+	
+	public static void analyseConstraints(String fileName, List<DrtLeg> legs, boolean createGraphs) {
+		if (legs == null)
+			return;
+
+		if (!createGraphs)
+			return;
+
+		XYSeries waitingTimes = new XYSeries("max_wait_times");
+		XYSeries travelTimes = new XYSeries("max_travel_times");
+
+		for (DrtLeg leg : legs) {
+			double waitingTime = leg.waitTime;
+			double maximumWaitingTime = leg.latestDepartureTime - leg.departureTime;
+			waitingTimes.add(maximumWaitingTime, waitingTime);
+
+			if (leg.toLink != null) {
+				double travelTime = leg.arrivalTime - leg.departureTime;
+				double maximumTravelTime = leg.latestArrivalTime - leg.departureTime;
+				travelTimes.add(maximumTravelTime, travelTime);
+			}
+		}
+
+		final JFreeChart chart = DensityScatterPlots.createPlot("Maximum wait time", "Maximum wait time [s]",
+				"Actual wait time [s]", waitingTimes);
+		ChartSaveUtils.saveAsPNG(chart, fileName + "_waiting_time", 1500, 1500);
+
+		final JFreeChart chart2 = DensityScatterPlots.createPlot("Maximum travel time", "Maximum travel time [s]",
+				"Actual travel time [s]", travelTimes);
+		ChartSaveUtils.saveAsPNG(chart2, fileName + "_travel_time", 1500, 1500);
+	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalWaitTimesAnalyzer.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/zonal/DrtZonalWaitTimesAnalyzer.java
@@ -39,7 +39,7 @@ import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Polygon;
 import org.matsim.contrib.drt.analysis.DrtEventSequenceCollector;
-import org.matsim.contrib.drt.analysis.DrtEventSequenceCollector.PerformedRequestEventSequence;
+import org.matsim.contrib.drt.analysis.DrtEventSequenceCollector.EventSequence;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.core.controler.events.IterationEndsEvent;
 import org.matsim.core.controler.events.ShutdownEvent;
@@ -136,7 +136,7 @@ public final class DrtZonalWaitTimesAnalyzer implements IterationEndsListener, S
 		}
 		zoneStats.put(zoneIdForOutsideOfZonalSystem, new DescriptiveStatistics());
 
-		for (PerformedRequestEventSequence seq : requestAnalyzer.getPerformedRequestSequences().values()) {
+		for (EventSequence seq : requestAnalyzer.getPerformedRequestSequences().values()) {
 			if (seq.getPickedUp().isPresent()) {
 				DrtZone zone = zones.getZoneForLinkId(seq.getSubmitted().getFromLinkId());
 				final String zoneStr = zone != null ? zone.getId() : zoneIdForOutsideOfZonalSystem;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DrtRequestCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DrtRequestCreator.java
@@ -52,7 +52,7 @@ public class DrtRequestCreator implements PassengerRequestCreator {
 
 		eventsManager.processEvent(
 				new DrtRequestSubmittedEvent(submissionTime, mode, id, passengerId, fromLink.getId(), toLink.getId(),
-						drtRoute.getDirectRideTime(), drtRoute.getDistance()));
+						drtRoute.getDirectRideTime(), drtRoute.getDistance(), latestDepartureTime, latestArrivalTime));
 
 		DrtRequest request = DrtRequest.newBuilder()
 				.id(id)

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/events/DrtRequestSubmittedEvent.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/events/DrtRequestSubmittedEvent.java
@@ -37,15 +37,24 @@ public class DrtRequestSubmittedEvent extends PassengerRequestSubmittedEvent {
 
 	public static final String ATTRIBUTE_UNSHARED_RIDE_TIME = "unsharedRideTime";
 	public static final String ATTRIBUTE_UNSHARED_RIDE_DISTANCE = "unsharedRideDistance";
+	
+	public static final String ATTRIBUTE_LATEST_PICKUP_TIME = "latestPickupTime";
+	public static final String ATTRIBUTE_LATEST_DROPOFF_TIME = "latestDropoffTime";
 
 	private final double unsharedRideTime;
 	private final double unsharedRideDistance;
 
+	private final double latestPickupTime;
+	private final double latestDropoffTime;
+
 	public DrtRequestSubmittedEvent(double time, String mode, Id<Request> requestId, Id<Person> personId,
-			Id<Link> fromLinkId, Id<Link> toLinkId, double unsharedRideTime, double unsharedRideDistance) {
+			Id<Link> fromLinkId, Id<Link> toLinkId, double unsharedRideTime, double unsharedRideDistance,
+			double latestPickupTime, double latestDropoffTime) {
 		super(time, mode, requestId, personId, fromLinkId, toLinkId);
 		this.unsharedRideTime = unsharedRideTime;
 		this.unsharedRideDistance = unsharedRideDistance;
+		this.latestPickupTime = latestPickupTime;
+		this.latestDropoffTime = latestDropoffTime;
 	}
 
 	@Override
@@ -66,12 +75,22 @@ public class DrtRequestSubmittedEvent extends PassengerRequestSubmittedEvent {
 	public final double getUnsharedRideDistance() {
 		return unsharedRideDistance;
 	}
+	
+	public final double getLatestPickupTime() {
+		return latestPickupTime;
+	}
+	
+	public final double getLatestDropoffTime() {
+		return latestDropoffTime;
+	}
 
 	@Override
 	public Map<String, String> getAttributes() {
 		Map<String, String> attr = super.getAttributes();
 		attr.put(ATTRIBUTE_UNSHARED_RIDE_TIME, unsharedRideTime + "");
 		attr.put(ATTRIBUTE_UNSHARED_RIDE_DISTANCE, unsharedRideDistance + "");
+		attr.put(ATTRIBUTE_LATEST_PICKUP_TIME, latestPickupTime + "");
+		attr.put(ATTRIBUTE_LATEST_DROPOFF_TIME, latestDropoffTime + "");
 		return attr;
 	}
 
@@ -85,7 +104,9 @@ public class DrtRequestSubmittedEvent extends PassengerRequestSubmittedEvent {
 		Id<Link> toLinkId = Id.createLinkId(attributes.get(ATTRIBUTE_TO_LINK));
 		double unsharedRideTime = Double.parseDouble(attributes.get(ATTRIBUTE_UNSHARED_RIDE_TIME));
 		double unsharedRideDistance = Double.parseDouble(attributes.get(ATTRIBUTE_UNSHARED_RIDE_DISTANCE));
+		double latestPickupTime = Double.parseDouble(attributes.get(ATTRIBUTE_LATEST_PICKUP_TIME));
+		double latestDropoffTime = Double.parseDouble(attributes.get(ATTRIBUTE_LATEST_DROPOFF_TIME));
 		return new DrtRequestSubmittedEvent(time, mode, requestId, personId, fromLinkId, toLinkId, unsharedRideTime,
-				unsharedRideDistance);
+				unsharedRideDistance, latestPickupTime, latestDropoffTime);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/speedup/DrtSpeedUp.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/speedup/DrtSpeedUp.java
@@ -135,7 +135,7 @@ public final class DrtSpeedUp implements IterationStartsListener, IterationEndsL
 		return (int)drtEventSequenceCollector.getPerformedRequestSequences()
 				.values()
 				.stream()
-				.filter(DrtEventSequenceCollector.PerformedRequestEventSequence::isCompleted)
+				.filter(DrtEventSequenceCollector.EventSequence::isCompleted)
 				.count();
 	}
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/fare/DrtFareHandlerTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/fare/DrtFareHandlerTest.java
@@ -70,7 +70,7 @@ public class DrtFareHandlerTest {
 		{
 			var requestId = Id.create(0, Request.class);
 			events.processEvent(new DrtRequestSubmittedEvent(0.0, mode, requestId, personId, Id.createLinkId("12"),
-					Id.createLinkId("23"), 240, 1000));
+					Id.createLinkId("23"), 240, 1000, 0.0, 0.0));
 			events.processEvent(new PassengerDroppedOffEvent(300.0, mode, requestId, personId, null));
 			events.flush();
 
@@ -81,7 +81,7 @@ public class DrtFareHandlerTest {
 			// test minFarePerTrip
 			var requestId = Id.create(1, Request.class);
 			events.processEvent(new DrtRequestSubmittedEvent(0.0, mode, requestId, personId, Id.createLinkId("45"),
-					Id.createLinkId("56"), 24, 100));
+					Id.createLinkId("56"), 24, 100, 0.0, 0.0));
 			events.processEvent(new PassengerDroppedOffEvent(300.0, mode, requestId, personId, null));
 			events.finishProcessing();
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/util/DrtEventsReadersTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/util/DrtEventsReadersTest.java
@@ -65,7 +65,7 @@ public class DrtEventsReadersTest {
 
 	//standard dvrp events are tested in DvrpEventsReadersTest
 	private final List<Event> drtEvents = List.of(
-			new DrtRequestSubmittedEvent(0, mode, request, person, link1, link2, 111, 222),//
+			new DrtRequestSubmittedEvent(0, mode, request, person, link1, link2, 111, 222, Double.NaN, Double.NaN),//
 			taskStarted(10, DrtDriveTask.TYPE, 0, link1),//
 			taskEnded(30, DrtStopTask.TYPE, 1, link2), //
 			taskStarted(50, DrtStayTask.TYPE, 2, link1),//

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/util/DrtEventsReadersTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/util/DrtEventsReadersTest.java
@@ -65,7 +65,7 @@ public class DrtEventsReadersTest {
 
 	//standard dvrp events are tested in DvrpEventsReadersTest
 	private final List<Event> drtEvents = List.of(
-			new DrtRequestSubmittedEvent(0, mode, request, person, link1, link2, 111, 222, Double.NaN, Double.NaN),//
+			new DrtRequestSubmittedEvent(0, mode, request, person, link1, link2, 111, 222, 412.0, 512.0),//
 			taskStarted(10, DrtDriveTask.TYPE, 0, link1),//
 			taskEnded(30, DrtStopTask.TYPE, 1, link2), //
 			taskStarted(50, DrtStayTask.TYPE, 2, link1),//


### PR DESCRIPTION
This PR modifies some DRT analysis functionality:

- Analysis is corrected for prebooking cases (before waiting time was calculated from the DrtRequestSubmissionEvent to the PassengerPickupEvent, now it is calculated from the PersonDepartureEvent to the PassengerPickupEvent). The PersonDepartureEvent can either come after the DrtRequestSubmissionEvent (= prebooking) or before (= instant).
- Currently, analysis assumes that requests are either rejected or scheduled. Other optimizers may reject requests after they have initially been scheduled (which also happens in reality with ridesharing operators). This is now taken into account, a request that is rejected at any time is regarded as "rejected".
- So far, analysis plots only show the unsharedRideTime vs. actualRideTime with constraint boundaries, but no similar analysis for waiting times (except in an aggregated way) exist to check whether the waiting time constraint is fulfilled. The PR adds two new plots (constraints_drt_travel_time, constrains_drt_waiting_time), which allow for this analysis and also in the case where an implementation of `DrtRequestCreator` makes use of *individual* contraints per request.

@michalmac Let me know which parts are interesting to be commited. I think the prebooking / rejection analysis is quite important, the plots may be bonus.

![0 constraints_drt_waiting_time](https://user-images.githubusercontent.com/647500/144883693-59efc88f-b9ff-4beb-a2c2-a16e207ac613.png)
![0 constraints_drt_travel_time](https://user-images.githubusercontent.com/647500/144883694-55f6a74f-1ba6-4f62-8ad8-c2115f8adb16.png)