### PR TITLE
dvrp: always try to read dvrp vehicles from matsim vehicles if dvrp-specific vehicle input is not provided

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/FleetModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/FleetModule.java
@@ -26,7 +26,6 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.analysis.ExecutedScheduleCollector;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
-import org.matsim.core.config.groups.QSimConfigGroup;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.vehicles.Vehicles;
 
@@ -64,7 +63,7 @@ public class FleetModule extends AbstractDvrpModeModule {
 				new FleetReader(fleetSpecification).parse(fleetSpecificationUrl);
 				return fleetSpecification;
 			}).asEagerSingleton();
-		} else if (getConfig().qsim().getVehiclesSource() == QSimConfigGroup.VehiclesSource.fromVehiclesData) {
+		} else {
 			bindModal(FleetSpecification.class).toProvider(new Provider<>() {
 				@Inject
 				private Vehicles vehicles;

--- a/examples/scenarios/dvrp-grid/multi_mode_one_shared_taxi_config.xml
+++ b/examples/scenarios/dvrp-grid/multi_mode_one_shared_taxi_config.xml
@@ -57,7 +57,6 @@
 		<param name="simStarttimeInterpretation" value="onlyUseStarttime"/>
 		<param name="insertingWaitingVehiclesBeforeDrivingVehicles" value="true"/>
 		<param name="snapshotStyle" value="queue"/>
-		<param name="vehiclesSource" value="fromVehiclesData"/>
 	</module>
 
 	<module name="otfvis">


### PR DESCRIPTION
It is always possible to override the `FleetSpecification` modal binding to change the way vehicles are created (so-called "option 3") regardless of whether option 1 or 2 is selected inside `FleetModule`.