### PR TITLE
DVRP: improved last link travel time computation

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourTimeEstimator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourTimeEstimator.java
@@ -24,6 +24,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.common.util.DistanceUtils;
 import org.matsim.contrib.dvrp.path.VrpPaths;
 import org.matsim.contrib.zone.skims.DvrpTravelTimeMatrix;
+import org.matsim.core.router.util.TravelTime;
 
 /**
  * @author michalm
@@ -33,14 +34,15 @@ public interface DetourTimeEstimator {
 		return (from, to) -> DistanceUtils.calculateDistance(from.getToNode(), to.getToNode()) / beelineSpeed;
 	}
 
-	static DetourTimeEstimator createFreeSpeedZonalTimeEstimator(double speedFactor, DvrpTravelTimeMatrix matrix) {
+	static DetourTimeEstimator createFreeSpeedZonalTimeEstimator(double speedFactor, DvrpTravelTimeMatrix matrix,
+			TravelTime travelTime) {
 		return (from, to) -> {
 			if (from == to) {
 				return 0;
 			}
 			double time = FIRST_LINK_TT
 					+ matrix.getFreeSpeedTravelTime(from.getToNode(), to.getFromNode())
-					+ VrpPaths.getLastLinkTT(to, 0);
+					+ VrpPaths.getLastLinkTT(travelTime, to, 0);
 			return time / speedFactor;
 		};
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionProvider.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionProvider.java
@@ -33,6 +33,7 @@ import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.zone.skims.DvrpTravelTimeMatrix;
+import org.matsim.core.router.util.TravelTime;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -42,10 +43,10 @@ import com.google.common.annotations.VisibleForTesting;
 public class ExtensiveInsertionProvider implements InsertionProvider {
 	public static ExtensiveInsertionProvider create(DrtConfigGroup drtCfg,
 			InsertionCostCalculatorFactory insertionCostCalculatorFactory, DvrpTravelTimeMatrix dvrpTravelTimeMatrix,
-			ForkJoinPool forkJoinPool) {
+			TravelTime travelTime, ForkJoinPool forkJoinPool) {
 		var insertionParams = (ExtensiveInsertionSearchParams)drtCfg.getDrtInsertionSearchParams();
 		var admissibleTimeEstimator = DetourTimeEstimator.createFreeSpeedZonalTimeEstimator(
-				insertionParams.getAdmissibleBeelineSpeedFactor(), dvrpTravelTimeMatrix);
+				insertionParams.getAdmissibleBeelineSpeedFactor(), dvrpTravelTimeMatrix, travelTime);
 		var admissibleCostCalculator = insertionCostCalculatorFactory.create(Double::doubleValue,
 				admissibleTimeEstimator);
 		return new ExtensiveInsertionProvider(drtCfg, admissibleTimeEstimator, forkJoinPool, admissibleCostCalculator);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchQSimModule.java
@@ -27,16 +27,13 @@ import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpModes;
-import org.matsim.core.modal.ModalProviders;
-import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.zone.skims.DvrpTravelTimeMatrix;
+import org.matsim.core.modal.ModalProviders;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
 
-import com.google.inject.Inject;
 import com.google.inject.TypeLiteral;
-import com.google.inject.name.Named;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -55,7 +52,7 @@ public class ExtensiveInsertionSearchQSimModule extends AbstractDvrpModeQSimModu
 		}).toProvider(modalProvider(getter -> {
 			var insertionCostCalculatorFactory = getter.getModal(InsertionCostCalculatorFactory.class);
 			var provider = ExtensiveInsertionProvider.create(drtCfg, insertionCostCalculatorFactory,
-					getter.getModal(DvrpTravelTimeMatrix.class),
+					getter.getModal(DvrpTravelTimeMatrix.class), getter.getModal(TravelTime.class),
 					getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool());
 			var insertionCostCalculator = insertionCostCalculatorFactory.create(PathData::getTravelTime, null);
 			return new DefaultDrtInsertionSearch(provider, getter.getModal(DetourPathCalculator.class),

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProvider.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProvider.java
@@ -33,6 +33,7 @@ import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.zone.skims.DvrpTravelTimeMatrix;
+import org.matsim.core.router.util.TravelTime;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -42,10 +43,10 @@ import com.google.common.annotations.VisibleForTesting;
 public class SelectiveInsertionProvider implements InsertionProvider {
 	public static SelectiveInsertionProvider create(DrtConfigGroup drtCfg,
 			InsertionCostCalculatorFactory insertionCostCalculatorFactory, DvrpTravelTimeMatrix dvrpTravelTimeMatrix,
-			ForkJoinPool forkJoinPool) {
+			TravelTime travelTime, ForkJoinPool forkJoinPool) {
 		var insertionParams = (SelectiveInsertionSearchParams)drtCfg.getDrtInsertionSearchParams();
 		var restrictiveDetourTimeEstimator = DetourTimeEstimator.createFreeSpeedZonalTimeEstimator(
-				insertionParams.getRestrictiveBeelineSpeedFactor(), dvrpTravelTimeMatrix);
+				insertionParams.getRestrictiveBeelineSpeedFactor(), dvrpTravelTimeMatrix, travelTime);
 		var restrictiveCostCalculator = insertionCostCalculatorFactory.create(Double::doubleValue,
 				restrictiveDetourTimeEstimator);
 		return new SelectiveInsertionProvider(restrictiveDetourTimeEstimator, forkJoinPool, restrictiveCostCalculator);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchQSimModule.java
@@ -27,16 +27,13 @@ import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpModes;
-import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
 import org.matsim.contrib.zone.skims.DvrpTravelTimeMatrix;
 import org.matsim.core.modal.ModalProviders;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
 
-import com.google.inject.Inject;
 import com.google.inject.TypeLiteral;
-import com.google.inject.name.Named;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -55,7 +52,7 @@ public class SelectiveInsertionSearchQSimModule extends AbstractDvrpModeQSimModu
 		}).toProvider(modalProvider(getter -> {
 			var insertionCostCalculatorFactory = getter.getModal(InsertionCostCalculatorFactory.class);
 			var provider = SelectiveInsertionProvider.create(drtCfg, insertionCostCalculatorFactory,
-					getter.getModal(DvrpTravelTimeMatrix.class),
+					getter.getModal(DvrpTravelTimeMatrix.class), getter.getModal(TravelTime.class),
 					getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool());
 			// Use 0 as the cost for the selected insertion:
 			// - In the selective strategy, there is at most 1 insertion pre-selected. So no need to compute as there is

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SingleInsertionDetourPathCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SingleInsertionDetourPathCalculator.java
@@ -58,6 +58,8 @@ public class SingleInsertionDetourPathCalculator implements DetourPathCalculator
 
 	public static final int MAX_THREADS = 4;
 
+	private final TravelTime travelTime;
+
 	private final LeastCostPathCalculator toPickupPathSearch;
 	private final LeastCostPathCalculator fromPickupPathSearch;
 	private final LeastCostPathCalculator toDropoffPathSearch;
@@ -73,6 +75,8 @@ public class SingleInsertionDetourPathCalculator implements DetourPathCalculator
 	@VisibleForTesting
 	SingleInsertionDetourPathCalculator(Network network, TravelTime travelTime, TravelDisutility travelDisutility,
 			int numberOfThreads, LeastCostPathCalculatorFactory pathCalculatorFactory) {
+		this.travelTime = travelTime;
+
 		toPickupPathSearch = pathCalculatorFactory.createPathCalculator(network, travelDisutility, travelTime);
 		fromPickupPathSearch = pathCalculatorFactory.createPathCalculator(network, travelDisutility, travelTime);
 		toDropoffPathSearch = pathCalculatorFactory.createPathCalculator(network, travelDisutility, travelTime);
@@ -136,7 +140,7 @@ public class SingleInsertionDetourPathCalculator implements DetourPathCalculator
 
 		Path path = router.calcLeastCostPath(fromLink.getToNode(), toLink.getFromNode(), departureTime + FIRST_LINK_TT,
 				null, null);
-		double firstAndLastLinkTT = FIRST_LINK_TT + VrpPaths.getLastLinkTT(toLink,
+		double firstAndLastLinkTT = FIRST_LINK_TT + VrpPaths.getLastLinkTT(travelTime, toLink,
 				departureTime + FIRST_LINK_TT + path.travelTime);
 
 		return new PathData(path, firstAndLastLinkTT);

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DetourTimeEstimatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DetourTimeEstimatorTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.matsim.contrib.zone.skims.DvrpTravelTimeMatrix;
+import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
 import org.matsim.testcases.fakes.FakeLink;
 import org.matsim.testcases.fakes.FakeNode;
 
@@ -38,7 +39,7 @@ public class DetourTimeEstimatorTest {
 	@Test
 	public void freeSpeedZonalTimeEstimator_fromLinkToLinkSame() {
 		var link = new FakeLink(null);
-		var estimator = DetourTimeEstimator.createFreeSpeedZonalTimeEstimator(1, null);
+		var estimator = DetourTimeEstimator.createFreeSpeedZonalTimeEstimator(1, null, null);
 		Assertions.assertThat(estimator.estimateTime(link, link)).isZero();
 	}
 
@@ -50,7 +51,7 @@ public class DetourTimeEstimatorTest {
 		DvrpTravelTimeMatrix ttMatrix = mock(DvrpTravelTimeMatrix.class);
 		when(ttMatrix.getFreeSpeedTravelTime(eq(linkA.getToNode()), eq(linkB.getFromNode()))).thenReturn(1234);
 
-		var estimator = DetourTimeEstimator.createFreeSpeedZonalTimeEstimator(1.5, ttMatrix);
+		var estimator = DetourTimeEstimator.createFreeSpeedZonalTimeEstimator(1.5, ttMatrix, new FreeSpeedTravelTime());
 		double expectedTT = 1 //first link TT
 				+ 1234 // TT between nodes
 				+ linkB.getLength() / linkB.getFreespeed();// last link TT

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DrtPoolingParameterTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DrtPoolingParameterTest.java
@@ -76,13 +76,13 @@ public class DrtPoolingParameterTest {
 	}
 
 	/**
-	 * With a maxWaitTime of 120s, the two closest drt vehicles should be able to reach 2 agents, but be
+	 * With a maxWaitTime of 121s, the two closest drt vehicles should be able to reach 2 agents, but be
 	 * unable to then pickup the other 2 agents without surpassing the maxWaitTime. All other DRT Vehicles
 	 * too far away to reach those agents.
 	 */
 	@Test
 	public void testMaxWaitTimeTwoVehiclesForTwoAgents() {
-		PersonEnterDrtVehicleEventHandler handler = setupAndRunScenario(120,
+		PersonEnterDrtVehicleEventHandler handler = setupAndRunScenario(121,
 			10.0,
 			10000.);
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/SingleInsertionDetourPathCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/SingleInsertionDetourPathCalculatorTest.java
@@ -45,6 +45,7 @@ import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.LeastCostPathCalculator.Path;
+import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
 import org.matsim.testcases.fakes.FakeLink;
 import org.matsim.testcases.fakes.FakeNode;
 
@@ -71,7 +72,7 @@ public class SingleInsertionDetourPathCalculatorTest {
 
 	private final LeastCostPathCalculator pathCalculator = mock(LeastCostPathCalculator.class);
 	private final SingleInsertionDetourPathCalculator detourPathCalculator = new SingleInsertionDetourPathCalculator(
-			null, null, null, 1, (network, travelCosts, travelTimes) -> pathCalculator);
+			null, new FreeSpeedTravelTime(), null, 1, (network, travelCosts, travelTimes) -> pathCalculator);
 
 	@After
 	public void after() {
@@ -146,7 +147,7 @@ public class SingleInsertionDetourPathCalculatorTest {
 
 	private void assertPathData(PathData pathData, Path inputPath, Link toLink) {
 		assertThat(pathData.getTravelTime()).isEqualTo(
-				inputPath.travelTime + FIRST_LINK_TT + getLastLinkTT(toLink, Double.NaN));
+				inputPath.travelTime + FIRST_LINK_TT + getLastLinkTT(new FreeSpeedTravelTime(), toLink, Double.NaN));
 	}
 
 	private Link link(String id) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/run/examples/RunDrtExampleIT.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/run/examples/RunDrtExampleIT.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.assertj.core.data.Percentage;
 import org.junit.Rule;
 import org.junit.Test;
 import org.matsim.api.core.v01.Id;
@@ -45,6 +44,8 @@ import org.matsim.core.utils.io.IOUtils;
 import org.matsim.examples.ExamplesUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vis.otfvis.OTFVisConfigGroup;
+
+import com.google.common.base.MoreObjects;
 
 /**
  * @author jbischoff
@@ -73,9 +74,9 @@ public class RunDrtExampleIT {
 		var expectedStats = Stats.newBuilder()
 				.rejectionRate(0.0)
 				.rejections(0)
-				.waitAverage(300.75)
-				.inVehicleTravelTimeMean(384.59)
-				.totalTravelTimeMean(685.35)
+				.waitAverage(296.95)
+				.inVehicleTravelTimeMean(387.02)
+				.totalTravelTimeMean(683.97)
 				.build();
 
 		verifyDrtCustomerStatsCloseToExpectedStats(utils.getOutputDirectory(), expectedStats);
@@ -106,9 +107,9 @@ public class RunDrtExampleIT {
 		var expectedStats = Stats.newBuilder()
 				.rejectionRate(0.0)
 				.rejections(0)
-				.waitAverage(304.37)
-				.inVehicleTravelTimeMean(387.41)
-				.totalTravelTimeMean(691.78)
+				.waitAverage(293.63)
+				.inVehicleTravelTimeMean(388.85)
+				.totalTravelTimeMean(682.48)
 				.build();
 
 		verifyDrtCustomerStatsCloseToExpectedStats(utils.getOutputDirectory(), expectedStats);
@@ -133,9 +134,9 @@ public class RunDrtExampleIT {
 		var expectedStats = Stats.newBuilder()
 				.rejectionRate(0.0)
 				.rejections(1)
-				.waitAverage(309.1)
-				.inVehicleTravelTimeMean(373.48)
-				.totalTravelTimeMean(682.58)
+				.waitAverage(305.97)
+				.inVehicleTravelTimeMean(378.18)
+				.totalTravelTimeMean(684.16)
 				.build();
 
 		verifyDrtCustomerStatsCloseToExpectedStats(utils.getOutputDirectory(), expectedStats);
@@ -155,10 +156,10 @@ public class RunDrtExampleIT {
 
 		var expectedStats = Stats.newBuilder()
 				.rejectionRate(0.05)
-				.rejections(20)
-				.waitAverage(251.41)
-				.inVehicleTravelTimeMean(377.79)
-				.totalTravelTimeMean(629.21)
+				.rejections(17)
+				.waitAverage(260.41)
+				.inVehicleTravelTimeMean(374.87)
+				.totalTravelTimeMean(635.28)
 				.build();
 
 		verifyDrtCustomerStatsCloseToExpectedStats(utils.getOutputDirectory(), expectedStats);
@@ -178,10 +179,10 @@ public class RunDrtExampleIT {
 
 		var expectedStats = Stats.newBuilder()
 				.rejectionRate(0.03)
-				.rejections(10)
-				.waitAverage(226.37)
-				.inVehicleTravelTimeMean(389.87)
-				.totalTravelTimeMean(616.24)
+				.rejections(11)
+				.waitAverage(223.86)
+				.inVehicleTravelTimeMean(389.57)
+				.totalTravelTimeMean(613.44)
 				.build();
 
 		verifyDrtCustomerStatsCloseToExpectedStats(utils.getOutputDirectory(), expectedStats);
@@ -214,18 +215,15 @@ public class RunDrtExampleIT {
 			params.put(keys.get(i), lastIterationValues.get(i));
 		}
 
-		double inVehicleTravelTimeMean = Double.parseDouble(params.get("inVehicleTravelTime_mean"));
-		double waitAverage = Double.parseDouble(params.get("wait_average"));
-		double rejections = Double.parseDouble(params.get("rejections"));
-		double rejectionRate = Double.parseDouble(params.get("rejectionRate"));
-		double totalTravelTimeMean = Double.parseDouble(params.get("totalTravelTime_mean"));
+		var actualStats = Stats.newBuilder()
+				.rejectionRate(Double.parseDouble(params.get("rejectionRate")))
+				.rejections(Double.parseDouble(params.get("rejections")))
+				.waitAverage(Double.parseDouble(params.get("wait_average")))
+				.inVehicleTravelTimeMean(Double.parseDouble(params.get("inVehicleTravelTime_mean")))
+				.totalTravelTimeMean(Double.parseDouble(params.get("totalTravelTime_mean")))
+				.build();
 
-		var percentage = Percentage.withPercentage(0.00001);
-		assertThat(rejectionRate).isCloseTo(expectedStats.rejectionRate, percentage);
-		assertThat(rejections).isCloseTo(expectedStats.rejections, percentage);
-		assertThat(waitAverage).isCloseTo(expectedStats.waitAverage, percentage);
-		assertThat(inVehicleTravelTimeMean).isCloseTo(expectedStats.inVehicleTravelTimeMean, percentage);
-		assertThat(totalTravelTimeMean).isCloseTo(expectedStats.totalTravelTimeMean, percentage);
+		assertThat(actualStats).usingRecursiveComparison().isEqualTo(expectedStats);
 	}
 
 	private static class Stats {
@@ -241,6 +239,17 @@ public class RunDrtExampleIT {
 			waitAverage = builder.waitAverage;
 			inVehicleTravelTimeMean = builder.inVehicleTravelTimeMean;
 			totalTravelTimeMean = builder.totalTravelTimeMean;
+		}
+
+		@Override
+		public String toString() {
+			return MoreObjects.toStringHelper(this)
+					.add("rejectionRate", rejectionRate)
+					.add("rejections", rejections)
+					.add("waitAverage", waitAverage)
+					.add("inVehicleTravelTimeMean", inVehicleTravelTimeMean)
+					.add("totalTravelTimeMean", totalTravelTimeMean)
+					.toString();
 		}
 
 		public static Builder newBuilder() {

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/OneToManyPathCalculator.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/OneToManyPathCalculator.java
@@ -40,6 +40,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
 import org.matsim.core.router.speedy.LeastCostPathTree;
+import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.utils.misc.OptionalTime;
 
 /**
@@ -48,14 +49,16 @@ import org.matsim.core.utils.misc.OptionalTime;
 class OneToManyPathCalculator {
 	private final IdMap<Node, Node> nodeMap;
 	private final LeastCostPathTree dijkstraTree;
+	private final TravelTime travelTime;
 	private final boolean forwardSearch;
 	private final Link fromLink;
 	private final double startTime;
 
-	OneToManyPathCalculator(IdMap<Node, Node> nodeMap, LeastCostPathTree dijkstraTree, boolean forwardSearch,
-			Link fromLink, double startTime) {
+	OneToManyPathCalculator(IdMap<Node, Node> nodeMap, LeastCostPathTree dijkstraTree, TravelTime travelTime,
+			boolean forwardSearch, Link fromLink, double startTime) {
 		this.nodeMap = nodeMap;
 		this.dijkstraTree = dijkstraTree;
+		this.travelTime = travelTime;
 		this.forwardSearch = forwardSearch;
 		this.fromLink = fromLink;
 		this.startTime = startTime;
@@ -175,8 +178,8 @@ class OneToManyPathCalculator {
 
 	private double getFirstAndLastLinkTT(Link fromLink, Link toLink, double pathTravelTime, double time) {
 		double lastLinkTT = forwardSearch ?
-				VrpPaths.getLastLinkTT(toLink, time + pathTravelTime) :
-				VrpPaths.getLastLinkTT(fromLink, time);
+				VrpPaths.getLastLinkTT(travelTime, toLink, time + pathTravelTime) :
+				VrpPaths.getLastLinkTT(travelTime, fromLink, time);
 		return FIRST_LINK_TT + lastLinkTT;
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/OneToManyPathSearch.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/OneToManyPathSearch.java
@@ -29,19 +29,18 @@ import java.util.function.Supplier;
 import org.matsim.api.core.v01.IdMap;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Node;
+import org.matsim.core.router.speedy.LeastCostPathTree;
+import org.matsim.core.router.speedy.SpeedyGraph;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 
-import org.matsim.core.router.speedy.SpeedyGraph;
-import org.matsim.core.router.speedy.LeastCostPathTree;
-
 public class OneToManyPathSearch {
 	public static OneToManyPathSearch createSearch(SpeedyGraph graph, IdMap<Node, Node> nodeMap, TravelTime travelTime,
 			TravelDisutility travelDisutility, boolean lazyPathCreation) {
-		return new OneToManyPathSearch(nodeMap, new LeastCostPathTree(graph, travelTime, travelDisutility),
+		return new OneToManyPathSearch(nodeMap, new LeastCostPathTree(graph, travelTime, travelDisutility), travelTime,
 				lazyPathCreation);
 	}
 
@@ -86,11 +85,14 @@ public class OneToManyPathSearch {
 
 	private final IdMap<Node, Node> nodeMap;
 	private final LeastCostPathTree dijkstraTree;
+	private final TravelTime travelTime;
 	private final boolean lazyPathCreation;
 
-	private OneToManyPathSearch(IdMap<Node, Node> nodeMap, LeastCostPathTree dijkstraTree, boolean lazyPathCreation) {
+	private OneToManyPathSearch(IdMap<Node, Node> nodeMap, LeastCostPathTree dijkstraTree, TravelTime travelTime,
+			boolean lazyPathCreation) {
 		this.nodeMap = nodeMap;
 		this.dijkstraTree = dijkstraTree;
+		this.travelTime = travelTime;
 		this.lazyPathCreation = lazyPathCreation;
 	}
 
@@ -100,8 +102,8 @@ public class OneToManyPathSearch {
 
 	public PathData[] calcPathDataArray(Link fromLink, List<Link> toLinks, double startTime, boolean forward,
 			double maxTravelTime) {
-		OneToManyPathCalculator pathConstructor = new OneToManyPathCalculator(nodeMap, dijkstraTree, forward, fromLink,
-				startTime);
+		OneToManyPathCalculator pathConstructor = new OneToManyPathCalculator(nodeMap, dijkstraTree, travelTime,
+				forward, fromLink, startTime);
 		pathConstructor.calculateDijkstraTree(toLinks, maxTravelTime);
 		return createPathDataArray(toLinks, pathConstructor);
 	}
@@ -113,8 +115,8 @@ public class OneToManyPathSearch {
 
 	public Map<Link, PathData> calcPathDataMap(Link fromLink, Collection<Link> toLinks, double startTime,
 			boolean forward, double maxTravelTime) {
-		OneToManyPathCalculator pathCalculator = new OneToManyPathCalculator(nodeMap, dijkstraTree, forward, fromLink,
-				startTime);
+		OneToManyPathCalculator pathCalculator = new OneToManyPathCalculator(nodeMap, dijkstraTree, travelTime, forward,
+				fromLink, startTime);
 		pathCalculator.calculateDijkstraTree(toLinks, maxTravelTime);
 		return createPathDataMap(toLinks, pathCalculator);
 	}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/VrpPaths.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/VrpPaths.java
@@ -138,15 +138,6 @@ public class VrpPaths {
 	public static final double FIRST_LINK_TT = 2;
 	public static final double NODE_TRANSITION_TIME = 1;
 
-	/**
-	 * It would make sense to replace these calls with TravelTime.getTravelTime(...) whereever it is used /sh nov 21
-	 */
-	@Deprecated
-	public static double getLastLinkTT(Link lastLink, double time) {
-		// XXX imprecise if qsimCfg.timeStepSize != 1
-		return Math.floor(lastLink.getLength() / lastLink.getFreespeed(time)) - NODE_TRANSITION_TIME;
-	}
-
 	public static double getLastLinkTT(TravelTime travelTime, Link lastLink, double time) {
 		return travelTime.getLinkTravelTime(lastLink, time, null, null) - NODE_TRANSITION_TIME;
 	}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/VrpPaths.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/VrpPaths.java
@@ -39,21 +39,24 @@ public class VrpPaths {
 	 */
 	public static VrpPathWithTravelData calcAndCreatePath(Link fromLink, Link toLink, double departureTime,
 			LeastCostPathCalculator router, TravelTime travelTime) {
-		Path path = fromLink == toLink ? null
-				: router.calcLeastCostPath(fromLink.getToNode(), toLink.getFromNode(), departureTime + FIRST_LINK_TT,
+		Path path = fromLink == toLink ?
+				null :
+				router.calcLeastCostPath(fromLink.getToNode(), toLink.getFromNode(), departureTime + FIRST_LINK_TT,
 						null, null);
 		return VrpPaths.createPath(fromLink, toLink, departureTime, path, travelTime);
 	}
 
 	public static VrpPathWithTravelData calcAndCreatePathForDiversion(LinkTimePair diversionPoint, Link toLink,
 			LeastCostPathCalculator router, TravelTime travelTime) {
-		Path path = diversionPoint.link == toLink ? null
-				: router.calcLeastCostPath(diversionPoint.link.getToNode(), toLink.getFromNode(), diversionPoint.time,
+		Path path = diversionPoint.link == toLink ?
+				null :
+				router.calcLeastCostPath(diversionPoint.link.getToNode(), toLink.getFromNode(), diversionPoint.time,
 						null, null);
 		return VrpPaths.createPathForDiversion(diversionPoint, toLink, path, travelTime);
 	}
 
-	public static VrpPathWithTravelData createZeroLengthPath(Link fromTolink, double departureTime, boolean calculateForDiversion) {
+	public static VrpPathWithTravelData createZeroLengthPath(Link fromTolink, double departureTime,
+			boolean calculateForDiversion) {
 		// To make sure that arrival time stays correct although no special diversion
 		// will be implemented after calling OnlienDriveTaskTracker.divert
 		double travelTime = calculateForDiversion ? -NODE_TRANSITION_TIME : 0.0;
@@ -69,8 +72,8 @@ public class VrpPaths {
 		return createPath(fromLink, toLink, departureTime, pathData.getPath(), travelTime);
 	}
 
-	public static VrpPathWithTravelData createPathForDiversion(LinkTimePair diversionPoint, Link toLink, PathData pathData,
-			TravelTime travelTime) {
+	public static VrpPathWithTravelData createPathForDiversion(LinkTimePair diversionPoint, Link toLink,
+			PathData pathData, TravelTime travelTime) {
 		return createPathForDiversion(diversionPoint, toLink, pathData.getPath(), travelTime);
 	}
 
@@ -128,7 +131,7 @@ public class VrpPaths {
 
 		double totalTT = (!calculateForDiversion ? FIRST_LINK_TT : 0.0) + path.travelTime + linkTT;
 		totalTT -= NODE_TRANSITION_TIME;
-		
+
 		return new VrpPathWithTravelDataImpl(departureTime, totalTT, links, linkTTs);
 	}
 
@@ -142,6 +145,10 @@ public class VrpPaths {
 	public static double getLastLinkTT(Link lastLink, double time) {
 		// XXX imprecise if qsimCfg.timeStepSize != 1
 		return Math.floor(lastLink.getLength() / lastLink.getFreespeed(time)) - NODE_TRANSITION_TIME;
+	}
+
+	public static double getLastLinkTT(TravelTime travelTime, Link lastLink, double time) {
+		return travelTime.getLinkTravelTime(lastLink, time, null, null) - NODE_TRANSITION_TIME;
 	}
 
 	/**

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/path/OneToManyPathCalculatorTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/path/OneToManyPathCalculatorTest.java
@@ -37,13 +37,13 @@ import org.matsim.api.core.v01.network.Node;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
 import org.matsim.contrib.dvrp.router.TimeAsTravelDisutility;
 import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.router.speedy.LeastCostPathTree;
+import org.matsim.core.router.speedy.SpeedyGraph;
 import org.matsim.core.router.util.LeastCostPathCalculator.Path;
+import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
 
 import com.google.common.collect.ImmutableList;
-
-import org.matsim.core.router.speedy.SpeedyGraph;
-import org.matsim.core.router.speedy.LeastCostPathTree;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -64,8 +64,9 @@ public class OneToManyPathCalculatorTest {
 
 	private final IdMap<Node, Node> nodeMap = new IdMap<>(Node.class);
 
-	private final LeastCostPathTree dijkstraTree = new LeastCostPathTree(new SpeedyGraph(network), new FreeSpeedTravelTime(),
-			new TimeAsTravelDisutility(new FreeSpeedTravelTime()));
+	private final TravelTime travelTime = new FreeSpeedTravelTime();
+	private final LeastCostPathTree dijkstraTree = new LeastCostPathTree(new SpeedyGraph(network), travelTime,
+			new TimeAsTravelDisutility(travelTime));
 
 	@Before
 	public void init() {
@@ -77,7 +78,7 @@ public class OneToManyPathCalculatorTest {
 	@Test
 	public void forward_fromNodeB_toNodeB() {
 		//forward search starting from nodeB at time 0
-		var pathCalculator = new OneToManyPathCalculator(nodeMap, dijkstraTree, true, linkAB, 0);
+		var pathCalculator = new OneToManyPathCalculator(nodeMap, dijkstraTree, travelTime, true, linkAB, 0);
 
 		//search until node B is reached
 		pathCalculator.calculateDijkstraTree(List.of(linkBC));
@@ -95,7 +96,7 @@ public class OneToManyPathCalculatorTest {
 	@Test
 	public void forward_fromNodeB_toNodesBD() {
 		//forward search starting from nodeB at time 0
-		var pathCalculator = new OneToManyPathCalculator(nodeMap, dijkstraTree, true, linkAB, 0);
+		var pathCalculator = new OneToManyPathCalculator(nodeMap, dijkstraTree, travelTime, true, linkAB, 0);
 
 		//search until nodes B and D are reached
 		pathCalculator.calculateDijkstraTree(List.of(linkBC, linkDE));
@@ -110,7 +111,7 @@ public class OneToManyPathCalculatorTest {
 	@Test
 	public void forward_fromNodeB_toNodesBD_maxTravelTime() {
 		//forward search starting from nodeB at time 0
-		var pathCalculator = new OneToManyPathCalculator(nodeMap, dijkstraTree, true, linkAB, 0);
+		var pathCalculator = new OneToManyPathCalculator(nodeMap, dijkstraTree, travelTime, true, linkAB, 0);
 
 		//search until nodes B and D are reached with max travel time of 5
 		pathCalculator.calculateDijkstraTree(List.of(linkBC, linkDE), 5);
@@ -125,7 +126,7 @@ public class OneToManyPathCalculatorTest {
 	@Test
 	public void backward_fromNodeD_toNodeD() {
 		//backward search starting from nodeD at time 0
-		var pathCalculator = new OneToManyPathCalculator(nodeMap, dijkstraTree, false, linkDE, 0);
+		var pathCalculator = new OneToManyPathCalculator(nodeMap, dijkstraTree, travelTime, false, linkDE, 0);
 
 		//search until node D is reached
 		pathCalculator.calculateDijkstraTree(List.of(linkCD));
@@ -143,7 +144,7 @@ public class OneToManyPathCalculatorTest {
 	@Test
 	public void backward_fromNodeD_toNodesBD() {
 		//backward search starting from nodeD at time 0
-		var pathCalculator = new OneToManyPathCalculator(nodeMap, dijkstraTree, false, linkDE, 0);
+		var pathCalculator = new OneToManyPathCalculator(nodeMap, dijkstraTree, travelTime, false, linkDE, 0);
 
 		//search until nodes B and D are reached
 		pathCalculator.calculateDijkstraTree(List.of(linkAB, linkCD));
@@ -158,7 +159,7 @@ public class OneToManyPathCalculatorTest {
 	@Test
 	public void backward_fromNodeD_toNodesBD_maxTravelTime() {
 		//backward search starting from nodeD at time 0
-		var pathCalculator = new OneToManyPathCalculator(nodeMap, dijkstraTree, false, linkDE, 0);
+		var pathCalculator = new OneToManyPathCalculator(nodeMap, dijkstraTree, travelTime, false, linkDE, 0);
 
 		//search until nodes B and D are reached with max travel time of 5
 		pathCalculator.calculateDijkstraTree(List.of(linkAB, linkCD), 5);
@@ -175,7 +176,7 @@ public class OneToManyPathCalculatorTest {
 		LeastCostPathTree mockedTree = mock(LeastCostPathTree.class);
 
 		for (boolean forward : List.of(true, false)) {
-			var pathCalculator = new OneToManyPathCalculator(nodeMap, mockedTree, forward, linkAB, 0);
+			var pathCalculator = new OneToManyPathCalculator(nodeMap, mockedTree, travelTime, forward, linkAB, 0);
 
 			//toLink == fromLink, so no search is done
 			pathCalculator.calculateDijkstraTree(List.of(linkAB));
@@ -187,7 +188,7 @@ public class OneToManyPathCalculatorTest {
 	@Test
 	public void pathData_forward() {
 		//forward search starting from linkAB at time 0
-		var pathCalculator = new OneToManyPathCalculator(nodeMap, dijkstraTree, true, linkAB, 0);
+		var pathCalculator = new OneToManyPathCalculator(nodeMap, dijkstraTree, travelTime, true, linkAB, 0);
 
 		pathCalculator.calculateDijkstraTree(List.of(linkDE));
 
@@ -199,7 +200,7 @@ public class OneToManyPathCalculatorTest {
 	@Test
 	public void pathData_backward() {
 		//backward search starting from linkDE at time 0
-		var pathCalculator = new OneToManyPathCalculator(nodeMap, dijkstraTree, false, linkDE, 0);
+		var pathCalculator = new OneToManyPathCalculator(nodeMap, dijkstraTree, travelTime, false, linkDE, 0);
 
 		pathCalculator.calculateDijkstraTree(List.of(linkAB));
 
@@ -211,7 +212,7 @@ public class OneToManyPathCalculatorTest {
 	@Test
 	public void pathData_fromLinkEqualsToLink() {
 		for (boolean forward : List.of(true, false)) {
-			var pathCalculator = new OneToManyPathCalculator(nodeMap, dijkstraTree, forward, linkAB, 0);
+			var pathCalculator = new OneToManyPathCalculator(nodeMap, dijkstraTree, travelTime, forward, linkAB, 0);
 			pathCalculator.calculateDijkstraTree(List.of(linkAB));
 			assertThat(pathCalculator.createPathDataLazily(linkAB)).isEqualTo(PathData.EMPTY);
 		}
@@ -220,7 +221,7 @@ public class OneToManyPathCalculatorTest {
 	@Test
 	public void pathData_nodeNotReached() {
 		for (boolean forward : List.of(true, false)) {
-			var pathCalculator = new OneToManyPathCalculator(nodeMap, dijkstraTree, forward, linkAB, 0);
+			var pathCalculator = new OneToManyPathCalculator(nodeMap, dijkstraTree, travelTime, forward, linkAB, 0);
 			pathCalculator.calculateDijkstraTree(List.of(linkBC));
 			assertThat(pathCalculator.createPathDataLazily(linkDE)).isEqualTo(PathData.INFEASIBLE);
 		}
@@ -238,9 +239,5 @@ public class OneToManyPathCalculatorTest {
 	private Link createAndAddLink(String id, Node fromNode, Node toNode, double length, double freespeed) {
 		return NetworkUtils.createAndAddLink(network, Id.createLinkId(id), fromNode, toNode, length, freespeed,
 				length / 7.5, 1);
-	}
-
-	private double travelTime(Link link) {
-		return link.getLength() / link.getFreespeed();
 	}
 }


### PR DESCRIPTION
This PR replaces the deprecated last link TT calculation with an improved estimation method. This is a follow up to changes made in #1771.