### PR TITLE
Make the DRT request submitted events compatible with previous runs (output events)

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/events/DrtRequestSubmittedEvent.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/events/DrtRequestSubmittedEvent.java
@@ -105,14 +105,14 @@ public class DrtRequestSubmittedEvent extends PassengerRequestSubmittedEvent {
 		double unsharedRideTime = Double.parseDouble(attributes.get(ATTRIBUTE_UNSHARED_RIDE_TIME));
 		double unsharedRideDistance = Double.parseDouble(attributes.get(ATTRIBUTE_UNSHARED_RIDE_DISTANCE));
 		double latestPickupTime = Double.parseDouble(attributes.getOrDefault(ATTRIBUTE_LATEST_PICKUP_TIME, "-1"));
-		double latestDropOffTime = Double.parseDouble(attributes.getOrDefault(ATTRIBUTE_LATEST_DROPOFF_TIME, "-1"));
+		double latestDropoffTime = Double.parseDouble(attributes.getOrDefault(ATTRIBUTE_LATEST_DROPOFF_TIME, "-1"));
 		if (latestPickupTime == -1) {
-			latestDropOffTime = Double.NaN;
+			latestDropoffTime = Double.NaN;
 		}
-		if (latestDropOffTime == -1) {
-			latestDropOffTime = Double.NaN;
+		if (latestDropoffTime == -1) {
+			latestDropoffTime = Double.NaN;
 		}
 		return new DrtRequestSubmittedEvent(time, mode, requestId, personId, fromLinkId, toLinkId, unsharedRideTime,
-				unsharedRideDistance, latestPickupTime, latestDropOffTime);
+				unsharedRideDistance, latestPickupTime, latestDropoffTime);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/events/DrtRequestSubmittedEvent.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/events/DrtRequestSubmittedEvent.java
@@ -37,7 +37,7 @@ public class DrtRequestSubmittedEvent extends PassengerRequestSubmittedEvent {
 
 	public static final String ATTRIBUTE_UNSHARED_RIDE_TIME = "unsharedRideTime";
 	public static final String ATTRIBUTE_UNSHARED_RIDE_DISTANCE = "unsharedRideDistance";
-	
+
 	public static final String ATTRIBUTE_LATEST_PICKUP_TIME = "latestPickupTime";
 	public static final String ATTRIBUTE_LATEST_DROPOFF_TIME = "latestDropoffTime";
 
@@ -75,11 +75,11 @@ public class DrtRequestSubmittedEvent extends PassengerRequestSubmittedEvent {
 	public final double getUnsharedRideDistance() {
 		return unsharedRideDistance;
 	}
-	
+
 	public final double getLatestPickupTime() {
 		return latestPickupTime;
 	}
-	
+
 	public final double getLatestDropoffTime() {
 		return latestDropoffTime;
 	}
@@ -104,8 +104,14 @@ public class DrtRequestSubmittedEvent extends PassengerRequestSubmittedEvent {
 		Id<Link> toLinkId = Id.createLinkId(attributes.get(ATTRIBUTE_TO_LINK));
 		double unsharedRideTime = Double.parseDouble(attributes.get(ATTRIBUTE_UNSHARED_RIDE_TIME));
 		double unsharedRideDistance = Double.parseDouble(attributes.get(ATTRIBUTE_UNSHARED_RIDE_DISTANCE));
-		double latestPickupTime = Double.parseDouble(attributes.get(ATTRIBUTE_LATEST_PICKUP_TIME));
-		double latestDropoffTime = Double.parseDouble(attributes.get(ATTRIBUTE_LATEST_DROPOFF_TIME));
+		double latestPickupTime = Double.parseDouble(attributes.getOrDefault(ATTRIBUTE_LATEST_PICKUP_TIME, "-1"));
+		double latestDropoffTime = Double.parseDouble(attributes.getOrDefault(ATTRIBUTE_LATEST_DROPOFF_TIME, "-1"));
+		if (latestPickupTime == -1) {
+			latestDropoffTime = Double.NaN;
+		}
+		if (latestDropoffTime == -1) {
+			latestDropoffTime = Double.NaN;
+		}
 		return new DrtRequestSubmittedEvent(time, mode, requestId, personId, fromLinkId, toLinkId, unsharedRideTime,
 				unsharedRideDistance, latestPickupTime, latestDropoffTime);
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/events/DrtRequestSubmittedEvent.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/events/DrtRequestSubmittedEvent.java
@@ -104,14 +104,8 @@ public class DrtRequestSubmittedEvent extends PassengerRequestSubmittedEvent {
 		Id<Link> toLinkId = Id.createLinkId(attributes.get(ATTRIBUTE_TO_LINK));
 		double unsharedRideTime = Double.parseDouble(attributes.get(ATTRIBUTE_UNSHARED_RIDE_TIME));
 		double unsharedRideDistance = Double.parseDouble(attributes.get(ATTRIBUTE_UNSHARED_RIDE_DISTANCE));
-		double latestPickupTime = Double.parseDouble(attributes.getOrDefault(ATTRIBUTE_LATEST_PICKUP_TIME, "-1"));
-		double latestDropoffTime = Double.parseDouble(attributes.getOrDefault(ATTRIBUTE_LATEST_DROPOFF_TIME, "-1"));
-		if (latestPickupTime == -1) {
-			latestDropoffTime = Double.NaN;
-		}
-		if (latestDropoffTime == -1) {
-			latestDropoffTime = Double.NaN;
-		}
+		double latestPickupTime = Double.parseDouble(attributes.getOrDefault(ATTRIBUTE_LATEST_PICKUP_TIME, "NaN"));
+		double latestDropoffTime = Double.parseDouble(attributes.getOrDefault(ATTRIBUTE_LATEST_DROPOFF_TIME, "NaN"));
 		return new DrtRequestSubmittedEvent(time, mode, requestId, personId, fromLinkId, toLinkId, unsharedRideTime,
 				unsharedRideDistance, latestPickupTime, latestDropoffTime);
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/events/DrtRequestSubmittedEvent.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/events/DrtRequestSubmittedEvent.java
@@ -105,14 +105,14 @@ public class DrtRequestSubmittedEvent extends PassengerRequestSubmittedEvent {
 		double unsharedRideTime = Double.parseDouble(attributes.get(ATTRIBUTE_UNSHARED_RIDE_TIME));
 		double unsharedRideDistance = Double.parseDouble(attributes.get(ATTRIBUTE_UNSHARED_RIDE_DISTANCE));
 		double latestPickupTime = Double.parseDouble(attributes.getOrDefault(ATTRIBUTE_LATEST_PICKUP_TIME, "-1"));
-		double latestDropoffTime = Double.parseDouble(attributes.getOrDefault(ATTRIBUTE_LATEST_DROPOFF_TIME, "-1"));
+		double latestDropOffTime = Double.parseDouble(attributes.getOrDefault(ATTRIBUTE_LATEST_DROPOFF_TIME, "-1"));
 		if (latestPickupTime == -1) {
-			latestDropoffTime = Double.NaN;
+			latestDropOffTime = Double.NaN;
 		}
-		if (latestDropoffTime == -1) {
-			latestDropoffTime = Double.NaN;
+		if (latestDropOffTime == -1) {
+			latestDropOffTime = Double.NaN;
 		}
 		return new DrtRequestSubmittedEvent(time, mode, requestId, personId, fromLinkId, toLinkId, unsharedRideTime,
-				unsharedRideDistance, latestPickupTime, latestDropoffTime);
+				unsharedRideDistance, latestPickupTime, latestDropOffTime);
 	}
 }


### PR DESCRIPTION
The newly added attribute (latestPickupTime and latestDropOffTime) will become "NaN" if it doesnt appear in the events file (i.e. for previous runs). Before this PR, reading events from previous runs will fail because of the missing attribute in the DRT Request submitted event.