### PR TITLE
Extract StayTask and DrtStopTask interfaces

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtModeAnalysisModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtModeAnalysisModule.java
@@ -23,13 +23,13 @@
  */
 package org.matsim.contrib.drt.analysis;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+import java.awt.Color;
+import java.util.Comparator;
+
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 import org.matsim.contrib.drt.schedule.DrtDriveTask;
-import org.matsim.contrib.drt.schedule.DrtStayTask;
-import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.drt.util.stats.DrtVehicleOccupancyProfiles;
 import org.matsim.contrib.dvrp.analysis.ExecutedScheduleCollector;
 import org.matsim.contrib.dvrp.fleet.FleetSpecification;
@@ -42,8 +42,8 @@ import org.matsim.core.config.Config;
 import org.matsim.core.config.groups.QSimConfigGroup;
 import org.matsim.core.controler.MatsimServices;
 
-import java.awt.*;
-import java.util.Comparator;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * @author michalm (Michal Maciejewski)
@@ -51,7 +51,7 @@ import java.util.Comparator;
 public class DrtModeAnalysisModule extends AbstractDvrpModeModule {
 	private final DrtConfigGroup drtCfg;
 	private ImmutableSet<Task.TaskType> passengerServingTaskTypes = ImmutableSet.of(DrtDriveTask.TYPE,
-			DrtStopTask.TYPE);
+			DefaultDrtStopTask.TYPE);
 
 	public DrtModeAnalysisModule(DrtConfigGroup drtCfg) {
 		super(drtCfg.getMode());
@@ -90,15 +90,15 @@ public class DrtModeAnalysisModule extends AbstractDvrpModeModule {
 						drtCfg.getMode(), getter.getModal(VehicleOccupancyProfileCalculator.class))));
 
 		bindModal(VehicleTaskProfileCalculator.class).toProvider(modalProvider(
-				getter -> new VehicleTaskProfileCalculator(getMode(), getter.getModal(FleetSpecification.class),
-						300, getter.get(QSimConfigGroup.class)))).asEagerSingleton();
+				getter -> new VehicleTaskProfileCalculator(getMode(), getter.getModal(FleetSpecification.class), 300,
+						getter.get(QSimConfigGroup.class)))).asEagerSingleton();
 		addEventHandlerBinding().to(modalKey(VehicleTaskProfileCalculator.class));
 		addControlerListenerBinding().to(modalKey(VehicleTaskProfileCalculator.class));
 
 		addControlerListenerBinding().toProvider(modalProvider(
-				getter -> new VehicleTaskProfileWriter(getter.get(MatsimServices.class),
-						drtCfg.getMode(), getter.getModal(VehicleTaskProfileCalculator.class),
-						Comparator.comparing(Task.TaskType::name), ImmutableMap.of(DrtStayTask.TYPE, Color.LIGHT_GRAY))));
+				getter -> new VehicleTaskProfileWriter(getter.get(MatsimServices.class), drtCfg.getMode(),
+						getter.getModal(VehicleTaskProfileCalculator.class), Comparator.comparing(Task.TaskType::name),
+						ImmutableMap.of(DefaultDrtStopTask.TYPE, Color.LIGHT_GRAY))));
 
 		addControlerListenerBinding().toProvider(modalProvider(
 				getter -> new DrtAnalysisControlerListener(getter.get(Config.class), drtCfg,

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/edrt/schedule/EDrtStopTask.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/edrt/schedule/EDrtStopTask.java
@@ -20,13 +20,13 @@
 package org.matsim.contrib.drt.extension.edrt.schedule;
 
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.contrib.drt.schedule.DrtStopTask;
+import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 import org.matsim.contrib.evrp.ETask;
 
 /**
  * @author michalm
  */
-public class EDrtStopTask extends DrtStopTask implements ETask {
+public class EDrtStopTask extends DefaultDrtStopTask implements ETask {
 	private final double consumedEnergy;
 
 	public EDrtStopTask(double beginTime, double endTime, Link link, double consumedEnergy) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/run/EvShiftDrtControlerCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/run/EvShiftDrtControlerCreator.java
@@ -13,7 +13,7 @@ import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.run.DrtModeQSimModule;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtDriveTask;
-import org.matsim.contrib.drt.schedule.DrtStopTask;
+import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 import org.matsim.contrib.ev.discharging.AuxDischargingHandler;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
@@ -37,7 +37,7 @@ public class EvShiftDrtControlerCreator {
 			controler.addOverridingQSimModule(new DrtModeQSimModule(drtCfg, new ShiftDrtModeOptimizerQSimModule(drtCfg, shiftDrtConfigGroup)));
 			controler.addOverridingQSimModule(new DrtModeQSimModule(drtCfg, new ShiftEDrtModeOptimizerQSimModule(drtCfg, shiftDrtConfigGroup)));
 			controler.addOverridingModule(new DrtModeAnalysisModule(drtCfg, ImmutableSet.of(DrtDriveTask.TYPE,
-					DrtStopTask.TYPE, ShiftTaskScheduler.RELOCATE_VEHICLE_SHIFT_BREAK_TASK_TYPE,
+					DefaultDrtStopTask.TYPE, ShiftTaskScheduler.RELOCATE_VEHICLE_SHIFT_BREAK_TASK_TYPE,
 					ShiftTaskScheduler.RELOCATE_VEHICLE_SHIFT_CHANGEOVER_TASK_TYPE)));
 			controler.addOverridingQSimModule(new EvShiftDvrpFleetQSimModule(drtCfg.getMode()));
 		}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/schedule/EDrtShiftChangeoverTaskImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/schedule/EDrtShiftChangeoverTaskImpl.java
@@ -1,7 +1,7 @@
 package org.matsim.contrib.drt.extension.eshifts.schedule;
 
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.contrib.drt.schedule.DrtStopTask;
+import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 import org.matsim.contrib.evrp.ChargingTask;
 import org.matsim.contrib.evrp.ETask;
 import org.matsim.contrib.drt.extension.shifts.operationFacilities.OperationFacility;
@@ -10,7 +10,7 @@ import org.matsim.contrib.drt.extension.shifts.schedule.ShiftChangeOverTask;
 /**
  * @author nkuehnel / MOIA
  */
-public class EDrtShiftChangeoverTaskImpl extends DrtStopTask implements ShiftChangeOverTask, ETask {
+public class EDrtShiftChangeoverTaskImpl extends DefaultDrtStopTask implements ShiftChangeOverTask, ETask {
 
     private final double shiftEndTime;
     private final double consumedEnergy;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/run/ShiftDrtControlerCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/run/ShiftDrtControlerCreator.java
@@ -1,22 +1,17 @@
 package org.matsim.contrib.drt.extension.shifts.run;
 
 import com.google.common.collect.ImmutableSet;
-import org.matsim.api.core.v01.Scenario;
+
 import org.matsim.contrib.drt.analysis.DrtModeAnalysisModule;
 import org.matsim.contrib.drt.extension.shifts.config.ShiftDrtConfigGroup;
 import org.matsim.contrib.drt.extension.shifts.scheduler.ShiftTaskScheduler;
-import org.matsim.contrib.drt.routing.DrtRoute;
-import org.matsim.contrib.drt.routing.DrtRouteFactory;
 import org.matsim.contrib.drt.run.*;
 import org.matsim.contrib.drt.schedule.DrtDriveTask;
-import org.matsim.contrib.drt.schedule.DrtStopTask;
-import org.matsim.contrib.dvrp.run.DvrpModule;
+import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
-import org.matsim.contrib.otfvis.OTFVisLiveModule;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.Controler;
-import org.matsim.core.scenario.ScenarioUtils;
 
 /**
  * @author nkuehnel, fzwick / MOIA
@@ -40,7 +35,7 @@ public class ShiftDrtControlerCreator {
 			controler.addOverridingModule(new ShiftDrtModeModule(drtCfg, shiftDrtConfigGroup));
 			controler.addOverridingQSimModule(new DrtModeQSimModule(drtCfg, new ShiftDrtModeOptimizerQSimModule(drtCfg, shiftDrtConfigGroup)));
 			controler.addOverridingModule(new DrtModeAnalysisModule(drtCfg, ImmutableSet.of(DrtDriveTask.TYPE,
-					DrtStopTask.TYPE, ShiftTaskScheduler.RELOCATE_VEHICLE_SHIFT_BREAK_TASK_TYPE,
+					DefaultDrtStopTask.TYPE, ShiftTaskScheduler.RELOCATE_VEHICLE_SHIFT_BREAK_TASK_TYPE,
 					ShiftTaskScheduler.RELOCATE_VEHICLE_SHIFT_CHANGEOVER_TASK_TYPE)));
 			controler.addOverridingQSimModule(new ShiftDvrpFleetQsimModule(drtCfg.getMode()));
 		}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/schedule/ShiftBreakTaskImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/schedule/ShiftBreakTaskImpl.java
@@ -1,14 +1,14 @@
 package org.matsim.contrib.drt.extension.shifts.schedule;
 
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.drt.extension.shifts.operationFacilities.OperationFacility;
 import org.matsim.contrib.drt.extension.shifts.shift.DrtShiftBreak;
+import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 
 /**
  * @author nkuehnel / MOIA
  */
-public class ShiftBreakTaskImpl extends DrtStopTask implements ShiftBreakTask {
+public class ShiftBreakTaskImpl extends DefaultDrtStopTask implements ShiftBreakTask {
 
     private final DrtShiftBreak shiftBreak;
     private final OperationFacility facility;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/schedule/ShiftChangeoverTaskImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/schedule/ShiftChangeoverTaskImpl.java
@@ -1,14 +1,14 @@
 package org.matsim.contrib.drt.extension.shifts.schedule;
 
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.drt.extension.shifts.operationFacilities.OperationFacility;
+import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 
 /**
  * A task representing stopping and waiting for a new shift.
  * @author nkuehnel / MOIA
  */
-public class ShiftChangeoverTaskImpl extends DrtStopTask implements ShiftChangeOverTask {
+public class ShiftChangeoverTaskImpl extends DefaultDrtStopTask implements ShiftChangeOverTask {
 
 	private final double shiftEndTime;
 	private final OperationFacility facility;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DefaultDrtStopTask.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DefaultDrtStopTask.java
@@ -1,0 +1,87 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2017 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.drt.schedule;
+
+import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.STOP;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.contrib.drt.passenger.DrtRequest;
+import org.matsim.contrib.dvrp.optimizer.Request;
+import org.matsim.contrib.dvrp.schedule.DefaultStayTask;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * A task representing stopping at a bus stop with at least one or more passengers being picked up or dropped off.
+ * <p>
+ * Note that we can have both dropoff requests and pickup requests for the same stop.  kai, nov'18
+ *
+ * @author michalm
+ */
+public class DefaultDrtStopTask extends DefaultStayTask implements DrtStopTask {
+	public static final DrtTaskType TYPE = new DrtTaskType(STOP);
+
+	private final Map<Id<Request>, DrtRequest> dropoffRequests = new LinkedHashMap<>();
+	private final Map<Id<Request>, DrtRequest> pickupRequests = new LinkedHashMap<>();
+
+	public DefaultDrtStopTask(double beginTime, double endTime, Link link) {
+		super(TYPE, beginTime, endTime, link);
+	}
+
+	/**
+	 * @return requests associated with passengers being dropped off at this stop
+	 */
+	@Override
+	public Map<Id<Request>, DrtRequest> getDropoffRequests() {
+		return Collections.unmodifiableMap(dropoffRequests);
+	}
+
+	/**
+	 * @return requests associated with passengers being picked up at this stop
+	 */
+	@Override
+	public Map<Id<Request>, DrtRequest> getPickupRequests() {
+		return Collections.unmodifiableMap(pickupRequests);
+	}
+
+	@Override
+	public void addDropoffRequest(DrtRequest request) {
+		dropoffRequests.put(request.getId(), request);
+	}
+
+	@Override
+	public void addPickupRequest(DrtRequest request) {
+		pickupRequests.put(request.getId(), request);
+	}
+
+	@Override
+	public String toString() {
+		return MoreObjects.toStringHelper(this)
+				.add("dropoffRequests", dropoffRequests)
+				.add("pickupRequests", pickupRequests)
+				.add("super", super.toString())
+				.toString();
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtStayTask.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtStayTask.java
@@ -22,12 +22,12 @@ package org.matsim.contrib.drt.schedule;
 import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.STAY;
 
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.contrib.dvrp.schedule.StayTask;
+import org.matsim.contrib.dvrp.schedule.DefaultStayTask;
 
 /**
  * @author michalm
  */
-public class DrtStayTask extends StayTask {
+public class DrtStayTask extends DefaultStayTask {
 	public static final DrtTaskType TYPE = new DrtTaskType(STAY);
 
 	public DrtStayTask(double beginTime, double endTime, Link link) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtStopTask.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtStopTask.java
@@ -29,7 +29,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.dvrp.optimizer.Request;
-import org.matsim.contrib.dvrp.schedule.StayTask;
+import org.matsim.contrib.dvrp.schedule.DefaultStayTask;
 
 import com.google.common.base.MoreObjects;
 
@@ -40,7 +40,7 @@ import com.google.common.base.MoreObjects;
  *
  * @author michalm
  */
-public class DrtStopTask extends StayTask {
+public class DrtStopTask extends DefaultStayTask {
 	public static final DrtTaskType TYPE = new DrtTaskType(STOP);
 
 	private final Map<Id<Request>, DrtRequest> dropoffRequests = new LinkedHashMap<>();

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtStopTask.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtStopTask.java
@@ -1,9 +1,9 @@
-/* *********************************************************************** *
+/*
+ * *********************************************************************** *
  * project: org.matsim.*
- *                                                                         *
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2017 by the members listed in the COPYING,        *
+ * copyright       : (C) 2021 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -15,69 +15,31 @@
  *   (at your option) any later version.                                   *
  *   See also COPYING, LICENSE and WARRANTY file                           *
  *                                                                         *
- * *********************************************************************** */
+ * *********************************************************************** *
+ */
 
 package org.matsim.contrib.drt.schedule;
 
-import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.STOP;
-
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.dvrp.optimizer.Request;
-import org.matsim.contrib.dvrp.schedule.DefaultStayTask;
-
-import com.google.common.base.MoreObjects;
+import org.matsim.contrib.dvrp.schedule.StayTask;
 
 /**
  * A task representing stopping at a bus stop with at least one or more passengers being picked up or dropped off.
  * <p>
  * Note that we can have both dropoff requests and pickup requests for the same stop.  kai, nov'18
  *
- * @author michalm
+ * @author Michal Maciejewski (michalm)
  */
-public class DrtStopTask extends DefaultStayTask {
-	public static final DrtTaskType TYPE = new DrtTaskType(STOP);
+public interface DrtStopTask extends StayTask {
+	Map<Id<Request>, DrtRequest> getDropoffRequests();
 
-	private final Map<Id<Request>, DrtRequest> dropoffRequests = new LinkedHashMap<>();
-	private final Map<Id<Request>, DrtRequest> pickupRequests = new LinkedHashMap<>();
+	Map<Id<Request>, DrtRequest> getPickupRequests();
 
-	public DrtStopTask(double beginTime, double endTime, Link link) {
-		super(TYPE, beginTime, endTime, link);
-	}
+	void addDropoffRequest(DrtRequest request);
 
-	/**
-	 * @return requests associated with passengers being dropped off at this stop
-	 */
-	public Map<Id<Request>, DrtRequest> getDropoffRequests() {
-		return Collections.unmodifiableMap(dropoffRequests);
-	}
-
-	/**
-	 * @return requests associated with passengers being picked up at this stop
-	 */
-	public Map<Id<Request>, DrtRequest> getPickupRequests() {
-		return Collections.unmodifiableMap(pickupRequests);
-	}
-
-	public void addDropoffRequest(DrtRequest request) {
-		dropoffRequests.put(request.getId(), request);
-	}
-
-	public void addPickupRequest(DrtRequest request) {
-		pickupRequests.put(request.getId(), request);
-	}
-
-	@Override
-	public String toString() {
-		return MoreObjects.toStringHelper(this)
-				.add("dropoffRequests", dropoffRequests)
-				.add("pickupRequests", pickupRequests)
-				.add("super", super.toString())
-				.toString();
-	}
+	void addPickupRequest(DrtRequest request);
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtTaskFactoryImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtTaskFactoryImpl.java
@@ -33,7 +33,7 @@ public class DrtTaskFactoryImpl implements DrtTaskFactory {
 
 	@Override
 	public DrtStopTask createStopTask(DvrpVehicle vehicle, double beginTime, double endTime, Link link) {
-		return new DrtStopTask(beginTime, endTime, link);
+		return new DefaultDrtStopTask(beginTime, endTime, link);
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/util/DrtEventsReaders.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/util/DrtEventsReaders.java
@@ -25,14 +25,14 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import java.util.List;
 import java.util.Map;
 
+import org.matsim.contrib.drt.extension.edrt.schedule.EDrtChargingTask;
 import org.matsim.contrib.drt.passenger.events.DrtRequestSubmittedEvent;
+import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 import org.matsim.contrib.drt.schedule.DrtDriveTask;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
-import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.drt.schedule.DrtTaskType;
 import org.matsim.contrib.drt.scheduler.EmptyVehicleRelocator;
 import org.matsim.contrib.dvrp.util.DvrpEventsReaders;
-import org.matsim.contrib.drt.extension.edrt.schedule.EDrtChargingTask;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.events.MatsimEventsReader;
 import org.matsim.core.events.MatsimEventsReader.CustomEventMapper;
@@ -40,8 +40,8 @@ import org.matsim.core.events.MatsimEventsReader.CustomEventMapper;
 import com.google.common.collect.ImmutableMap;
 
 public final class DrtEventsReaders {
-	public static final Map<String, DrtTaskType> TASK_TYPE_MAP = List.of(DrtDriveTask.TYPE, DrtStopTask.TYPE,
-			DrtStayTask.TYPE, EmptyVehicleRelocator.RELOCATE_VEHICLE_TASK_TYPE, EDrtChargingTask.TYPE)
+	public static final Map<String, DrtTaskType> TASK_TYPE_MAP = List.of(DrtDriveTask.TYPE, DefaultDrtStopTask.TYPE,
+					DrtStayTask.TYPE, EmptyVehicleRelocator.RELOCATE_VEHICLE_TASK_TYPE, EDrtChargingTask.TYPE)
 			.stream()
 			.collect(toImmutableMap(DrtTaskType::name, type -> type));
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/VehicleDataEntryFactoryImplTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/VehicleDataEntryFactoryImplTest.java
@@ -27,8 +27,8 @@ import static org.matsim.contrib.drt.optimizer.Waypoint.Stop;
 import org.junit.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
+import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
-import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicleImpl;
 import org.matsim.contrib.dvrp.fleet.ImmutableDvrpVehicleSpecification;
@@ -80,7 +80,7 @@ public class VehicleDataEntryFactoryImplTest {
 	}
 
 	private Stop stop(double beginTime, double latestArrivalTime, double endTime, double latestDepartureTime) {
-		return new Stop(new DrtStopTask(beginTime, endTime, null), latestArrivalTime, latestDepartureTime, 0);
+		return new Stop(new DefaultDrtStopTask(beginTime, endTime, null), latestArrivalTime, latestDepartureTime, 0);
 	}
 
 	private DvrpVehicle vehicle(double vehicleEndTime, double lastStayTaskBeginTime) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserterTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserterTest.java
@@ -38,7 +38,7 @@ import org.matsim.api.core.v01.Identifiable;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
 import org.matsim.contrib.drt.passenger.DrtRequest;
-import org.matsim.contrib.drt.schedule.DrtStopTask;
+import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 import org.matsim.contrib.drt.scheduler.RequestInsertionScheduler;
 import org.matsim.contrib.drt.scheduler.RequestInsertionScheduler.PickupDropoffTaskPair;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
@@ -211,9 +211,9 @@ public class DefaultUnplannedRequestInserterTest {
 		double pickupEndTime = now + 20;
 		double dropoffBeginTime = now + 40;
 		RequestInsertionScheduler insertionScheduler = (request, insertion) -> {
-			var pickupTask = new DrtStopTask(pickupEndTime - 10, pickupEndTime, request1.getFromLink());
+			var pickupTask = new DefaultDrtStopTask(pickupEndTime - 10, pickupEndTime, request1.getFromLink());
 			pickupTask.addPickupRequest(request1);
-			var dropoffTask = new DrtStopTask(dropoffBeginTime, dropoffBeginTime + 10, request1.getToLink());
+			var dropoffTask = new DefaultDrtStopTask(dropoffBeginTime, dropoffBeginTime + 10, request1.getToLink());
 			dropoffTask.addPickupRequest(request1);
 			return new PickupDropoffTaskPair(pickupTask, dropoffTask);
 		};

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DetourDataTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DetourDataTest.java
@@ -31,7 +31,7 @@ import org.matsim.contrib.drt.optimizer.VehicleEntry;
 import org.matsim.contrib.drt.optimizer.Waypoint;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
 import org.matsim.contrib.drt.passenger.DrtRequest;
-import org.matsim.contrib.drt.schedule.DrtStopTask;
+import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 import org.matsim.testcases.fakes.FakeLink;
 
 import com.google.common.collect.ImmutableList;
@@ -130,6 +130,6 @@ public class DetourDataTest {
 	}
 
 	private Waypoint.Stop stop(Link link) {
-		return new Waypoint.Stop(new DrtStopTask(0, 60, link), 0);
+		return new Waypoint.Stop(new DefaultDrtStopTask(0, 60, link), 0);
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
@@ -30,7 +30,7 @@ import org.matsim.contrib.drt.optimizer.Waypoint;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionDetourTimeCalculator.DetourTimeInfo;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
 import org.matsim.contrib.drt.passenger.DrtRequest;
-import org.matsim.contrib.drt.schedule.DrtStopTask;
+import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.testcases.fakes.FakeLink;
 
@@ -65,7 +65,7 @@ public class InsertionDetourTimeCalculatorTest {
 	@Test
 	public void detourTimeLoss_ongoingStopAsStart_pickup_dropoff() {
 		//similar to detourTmeLoss_start_pickup_dropoff(), but the pickup is appended to the ongoing STOP task
-		Waypoint.Start start = start(new DrtStopTask(20, 20 + STOP_DURATION, fromLink), STOP_DURATION, fromLink);
+		Waypoint.Start start = start(new DefaultDrtStopTask(20, 20 + STOP_DURATION, fromLink), STOP_DURATION, fromLink);
 		VehicleEntry entry = entry(start);
 		var detour = new Detour(null, 15., null, 0.);//toPickup/Dropoff unused
 		var insertion = insertion(entry, 0, 0, detour);
@@ -205,7 +205,7 @@ public class InsertionDetourTimeCalculatorTest {
 	}
 
 	private Waypoint.Stop stop(double beginTime, Link link) {
-		return new Waypoint.Stop(new DrtStopTask(beginTime, beginTime + STOP_DURATION, link), 0);
+		return new Waypoint.Stop(new DefaultDrtStopTask(beginTime, beginTime + STOP_DURATION, link), 0);
 	}
 
 	private VehicleEntry entry(Waypoint.Start start, Waypoint.Stop... stops) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
@@ -29,7 +29,7 @@ import org.matsim.contrib.drt.optimizer.VehicleEntry;
 import org.matsim.contrib.drt.optimizer.Waypoint;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
 import org.matsim.contrib.drt.passenger.DrtRequest;
-import org.matsim.contrib.drt.schedule.DrtStopTask;
+import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicleImpl;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicleSpecification;
@@ -260,7 +260,7 @@ public class InsertionGeneratorTest {
 	}
 
 	private Waypoint.Stop stop(Link link, int outgoingOccupancy) {
-		return new Waypoint.Stop(new DrtStopTask(0, 0, link), outgoingOccupancy);
+		return new Waypoint.Stop(new DefaultDrtStopTask(0, 0, link), outgoingOccupancy);
 	}
 
 	private VehicleEntry entry(Waypoint.Start start, Waypoint.Stop... stops) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/KNearestInsertionsAtEndFilterTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/KNearestInsertionsAtEndFilterTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
 import org.matsim.contrib.drt.optimizer.Waypoint;
-import org.matsim.contrib.drt.schedule.DrtStopTask;
+import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 
 import com.google.common.collect.ImmutableList;
@@ -117,7 +117,7 @@ public class KNearestInsertionsAtEndFilterTest {
 	}
 
 	private Waypoint.Stop stop(double endTime) {
-		return new Waypoint.Stop(new DrtStopTask(endTime - 10, endTime, null), 0);
+		return new Waypoint.Stop(new DefaultDrtStopTask(endTime - 10, endTime, null), 0);
 	}
 
 	private VehicleEntry vehicleEntry(String id, Waypoint.Start start, Waypoint.Stop... stops) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/util/DrtEventsReadersTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/util/DrtEventsReadersTest.java
@@ -32,11 +32,12 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.events.Event;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
+import org.matsim.contrib.drt.extension.edrt.schedule.EDrtChargingTask;
 import org.matsim.contrib.drt.passenger.events.DrtRequestSubmittedEvent;
 import org.matsim.contrib.drt.passenger.events.DrtRequestSubmittedEventHandler;
+import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 import org.matsim.contrib.drt.schedule.DrtDriveTask;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
-import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.drt.schedule.DrtTaskType;
 import org.matsim.contrib.drt.scheduler.EmptyVehicleRelocator;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
@@ -45,7 +46,6 @@ import org.matsim.contrib.dvrp.vrpagent.TaskEndedEvent;
 import org.matsim.contrib.dvrp.vrpagent.TaskEndedEventHandler;
 import org.matsim.contrib.dvrp.vrpagent.TaskStartedEvent;
 import org.matsim.contrib.dvrp.vrpagent.TaskStartedEventHandler;
-import org.matsim.contrib.drt.extension.edrt.schedule.EDrtChargingTask;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.groups.ControlerConfigGroup;
 import org.matsim.core.events.EventsUtils;
@@ -67,7 +67,7 @@ public class DrtEventsReadersTest {
 	private final List<Event> drtEvents = List.of(
 			new DrtRequestSubmittedEvent(0, mode, request, person, link1, link2, 111, 222, 412.0, 512.0),//
 			taskStarted(10, DrtDriveTask.TYPE, 0, link1),//
-			taskEnded(30, DrtStopTask.TYPE, 1, link2), //
+			taskEnded(30, DefaultDrtStopTask.TYPE, 1, link2), //
 			taskStarted(50, DrtStayTask.TYPE, 2, link1),//
 			taskEnded(70, EmptyVehicleRelocator.RELOCATE_VEHICLE_TASK_TYPE, 3, link2),//
 			taskStarted(90, EDrtChargingTask.TYPE, 4, link2)//

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxi/OneTaxiOptimizer.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxi/OneTaxiOptimizer.java
@@ -38,6 +38,7 @@ import org.matsim.contrib.dvrp.schedule.Schedule;
 import org.matsim.contrib.dvrp.schedule.Schedule.ScheduleStatus;
 import org.matsim.contrib.dvrp.schedule.Schedules;
 import org.matsim.contrib.dvrp.schedule.StayTask;
+import org.matsim.contrib.dvrp.schedule.DefaultStayTask;
 import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.framework.MobsimTimer;
@@ -78,7 +79,7 @@ public final class OneTaxiOptimizer implements VrpOptimizer {
 
 		vehicle = fleet.getVehicles().values().iterator().next();
 		vehicle.getSchedule()
-				.addTask(new StayTask(OneTaxiTaskType.WAIT, vehicle.getServiceBeginTime(), vehicle.getServiceEndTime(),
+				.addTask(new DefaultStayTask(OneTaxiTaskType.WAIT, vehicle.getServiceBeginTime(), vehicle.getServiceEndTime(),
 						vehicle.getStartLink()));
 	}
 
@@ -128,7 +129,7 @@ public final class OneTaxiOptimizer implements VrpOptimizer {
 
 		// just wait (and be ready) till the end of the vehicle's time window (T1)
 		double tEnd = Math.max(t4, vehicle.getServiceEndTime());
-		schedule.addTask(new StayTask(OneTaxiTaskType.WAIT, t4, tEnd, toLink));
+		schedule.addTask(new DefaultStayTask(OneTaxiTaskType.WAIT, t4, tEnd, toLink));
 
 		eventsManager.processEvent(
 				new PassengerRequestScheduledEvent(timer.getTimeOfDay(), TransportMode.taxi, request.getId(),

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxi/OneTaxiServeTask.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetaxi/OneTaxiServeTask.java
@@ -22,12 +22,12 @@ package org.matsim.contrib.dvrp.examples.onetaxi;
 import static org.matsim.contrib.dvrp.examples.onetaxi.OneTaxiOptimizer.OneTaxiTaskType;
 
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.contrib.dvrp.schedule.StayTask;
+import org.matsim.contrib.dvrp.schedule.DefaultStayTask;
 
 /**
  * @author michalm
  */
-public class OneTaxiServeTask extends StayTask {
+public class OneTaxiServeTask extends DefaultStayTask {
 	private final OneTaxiRequest request;
 
 	public OneTaxiServeTask(OneTaxiTaskType taskType, double beginTime, double endTime, Link link,

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/OneTruckOptimizer.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/OneTruckOptimizer.java
@@ -37,6 +37,7 @@ import org.matsim.contrib.dvrp.schedule.Schedule;
 import org.matsim.contrib.dvrp.schedule.Schedule.ScheduleStatus;
 import org.matsim.contrib.dvrp.schedule.Schedules;
 import org.matsim.contrib.dvrp.schedule.StayTask;
+import org.matsim.contrib.dvrp.schedule.DefaultStayTask;
 import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.router.speedy.SpeedyDijkstraFactory;
@@ -74,7 +75,7 @@ final class OneTruckOptimizer implements VrpOptimizer {
 
 		vehicle = fleet.getVehicles().values().iterator().next();
 		vehicle.getSchedule()
-				.addTask(new StayTask(OneTruckTaskType.WAIT, vehicle.getServiceBeginTime(), vehicle.getServiceEndTime(),
+				.addTask(new DefaultStayTask(OneTruckTaskType.WAIT, vehicle.getServiceBeginTime(), vehicle.getServiceEndTime(),
 						vehicle.getStartLink()));
 	}
 
@@ -123,7 +124,7 @@ final class OneTruckOptimizer implements VrpOptimizer {
 
 		// just wait (and be ready) till the end of the vehicle's time window (T1)
 		double tEnd = Math.max(t4, vehicle.getServiceEndTime());
-		schedule.addTask(new StayTask(OneTruckTaskType.WAIT, t4, tEnd, toLink));
+		schedule.addTask(new DefaultStayTask(OneTruckTaskType.WAIT, t4, tEnd, toLink));
 	}
 
 	@Override

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/OneTruckServeTask.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/OneTruckServeTask.java
@@ -22,12 +22,12 @@ package org.matsim.contrib.dvrp.examples.onetruck;
 import static org.matsim.contrib.dvrp.examples.onetruck.OneTruckOptimizer.OneTruckTaskType;
 
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.contrib.dvrp.schedule.StayTask;
+import org.matsim.contrib.dvrp.schedule.DefaultStayTask;
 
 /**
  * @author michalm
  */
-public class OneTruckServeTask extends StayTask {
+public class OneTruckServeTask extends DefaultStayTask {
 	private final OneTruckRequest request;
 
 	public OneTruckServeTask(OneTruckTaskType taskType, double beginTime, double endTime, Link link,

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/schedule/AbstractTask.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/schedule/AbstractTask.java
@@ -27,7 +27,7 @@ import com.google.common.base.Preconditions;
 /**
  * @author michalm
  */
-abstract class AbstractTask implements Task {
+public abstract class AbstractTask implements Task {
 	// ==== BEGIN: fields managed by ScheduleImpl
 	int taskIdx;
 	TaskStatus status;

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/schedule/DefaultStayTask.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/schedule/DefaultStayTask.java
@@ -17,32 +17,30 @@
  *                                                                         *
  * *********************************************************************** */
 
-package org.matsim.contrib.taxi.schedule;
+package org.matsim.contrib.dvrp.schedule;
 
-import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.DROPOFF;
-
-import org.matsim.contrib.dvrp.schedule.DefaultStayTask;
-import org.matsim.contrib.taxi.passenger.TaxiRequest;
+import org.matsim.api.core.v01.network.Link;
 
 import com.google.common.base.MoreObjects;
 
-public class TaxiDropoffTask extends DefaultStayTask {
-	public static final TaxiTaskType TYPE = new TaxiTaskType(DROPOFF);
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class DefaultStayTask extends AbstractTask implements StayTask {
+	private final Link link;
 
-	private final TaxiRequest request;
-
-	public TaxiDropoffTask(double beginTime, double endTime, TaxiRequest request) {
-		super(TYPE, beginTime, endTime, request.getToLink());
-		this.request = request;
-		request.setDropoffTask(this);
+	public DefaultStayTask(TaskType taskType, double beginTime, double endTime, Link link) {
+		super(taskType, beginTime, endTime);
+		this.link = link;
 	}
 
-	public TaxiRequest getRequest() {
-		return request;
+	@Override
+	public final Link getLink() {
+		return link;
 	}
 
 	@Override
 	public String toString() {
-		return MoreObjects.toStringHelper(this).add("request", request).add("super", super.toString()).toString();
+		return MoreObjects.toStringHelper(this).add("super", super.toString()).add("link", link).toString();
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/schedule/StayTask.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/schedule/StayTask.java
@@ -1,9 +1,9 @@
-/* *********************************************************************** *
+/*
+ * *********************************************************************** *
  * project: org.matsim.*
- *                                                                         *
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2013 by the members listed in the COPYING,        *
+ * copyright       : (C) 2021 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -15,28 +15,16 @@
  *   (at your option) any later version.                                   *
  *   See also COPYING, LICENSE and WARRANTY file                           *
  *                                                                         *
- * *********************************************************************** */
+ * *********************************************************************** *
+ */
 
 package org.matsim.contrib.dvrp.schedule;
 
 import org.matsim.api.core.v01.network.Link;
 
-import com.google.common.base.MoreObjects;
-
-public class StayTask extends AbstractTask {
-	private final Link link;
-
-	public StayTask(TaskType taskType, double beginTime, double endTime, Link link) {
-		super(taskType, beginTime, endTime);
-		this.link = link;
-	}
-
-	public final Link getLink() {
-		return link;
-	}
-
-	@Override
-	public String toString() {
-		return MoreObjects.toStringHelper(this).add("super", super.toString()).add("link", link).toString();
-	}
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public interface StayTask extends Task {
+	Link getLink();
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/evrp/ChargingTaskImpl.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/evrp/ChargingTaskImpl.java
@@ -22,7 +22,8 @@ package org.matsim.contrib.evrp;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
-import org.matsim.contrib.dvrp.schedule.StayTask;
+
+import org.matsim.contrib.dvrp.schedule.DefaultStayTask;
 import org.matsim.contrib.ev.charging.ChargingWithAssignmentLogic;
 import org.matsim.contrib.ev.fleet.ElectricVehicle;
 import org.matsim.contrib.ev.infrastructure.Charger;
@@ -30,7 +31,7 @@ import org.matsim.contrib.ev.infrastructure.Charger;
 /**
  * @author michalm
  */
-public class ChargingTaskImpl extends StayTask implements ChargingTask {
+public class ChargingTaskImpl extends DefaultStayTask implements ChargingTask {
 	private final ChargingWithAssignmentLogic chargingLogic;
 	private final ElectricVehicle ev;
 	private Double chargingStartedTime;

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/vrpagent/VrpAgentLogicTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/vrpagent/VrpAgentLogicTest.java
@@ -35,6 +35,7 @@ import org.matsim.contrib.dvrp.fleet.ImmutableDvrpVehicleSpecification;
 import org.matsim.contrib.dvrp.optimizer.Request;
 import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
 import org.matsim.contrib.dvrp.schedule.StayTask;
+import org.matsim.contrib.dvrp.schedule.DefaultStayTask;
 import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.contrib.dvrp.schedule.Task.TaskType;
 import org.matsim.contrib.dynagent.DynAction;
@@ -97,7 +98,7 @@ public class VrpAgentLogicTest {
 	public void testInitialActivity_planned() {
 		DynActivity initialActivity = dynAgentLogic.computeInitialActivity(dynAgent);
 
-		StayTask task0 = new StayTask(TestTaskType.TYPE, 10, 90, startLink);
+		StayTask task0 = new DefaultStayTask(TestTaskType.TYPE, 10, 90, startLink);
 		vehicle.getSchedule().addTask(task0);
 
 		assertThat(initialActivity.getActivityType()).isEqualTo(BEFORE_SCHEDULE_ACTIVITY_TYPE);
@@ -109,7 +110,7 @@ public class VrpAgentLogicTest {
 	public void testInitialActivity_started_failure() {
 		DynActivity initialActivity = dynAgentLogic.computeInitialActivity(dynAgent);
 
-		StayTask task0 = new StayTask(TestTaskType.TYPE, 10, 90, startLink);
+		StayTask task0 = new DefaultStayTask(TestTaskType.TYPE, 10, 90, startLink);
 		vehicle.getSchedule().addTask(task0);
 		vehicle.getSchedule().nextTask();
 
@@ -132,7 +133,7 @@ public class VrpAgentLogicTest {
 	@Test
 	public void testNextAction_planned_started() {
 		double time = 10;
-		StayTask task0 = new StayTask(TestTaskType.TYPE, time, 90, startLink);
+		StayTask task0 = new DefaultStayTask(TestTaskType.TYPE, time, 90, startLink);
 		vehicle.getSchedule().addTask(task0);
 
 		DynActivity nextActivity = (DynActivity)dynAgentLogic.computeNextAction(null, time);
@@ -143,9 +144,9 @@ public class VrpAgentLogicTest {
 	@Test
 	public void testNextAction_started_started() {
 		double time = 50;
-		StayTask task0 = new StayTask(TestTaskType.TYPE, 10, time, startLink);
+		StayTask task0 = new DefaultStayTask(TestTaskType.TYPE, 10, time, startLink);
 		vehicle.getSchedule().addTask(task0);
-		StayTask task1 = new StayTask(TestTaskType.TYPE, time, 90, startLink);
+		StayTask task1 = new DefaultStayTask(TestTaskType.TYPE, time, 90, startLink);
 		vehicle.getSchedule().addTask(task1);
 		vehicle.getSchedule().nextTask();//current: task0
 
@@ -157,7 +158,7 @@ public class VrpAgentLogicTest {
 	@Test
 	public void testNextAction_started_completed() {
 		double time = 90;
-		StayTask task0 = new StayTask(TestTaskType.TYPE, 10, time, startLink);
+		StayTask task0 = new DefaultStayTask(TestTaskType.TYPE, 10, time, startLink);
 		vehicle.getSchedule().addTask(task0);
 		vehicle.getSchedule().nextTask();//current: task0
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiPickupTask.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiPickupTask.java
@@ -21,12 +21,12 @@ package org.matsim.contrib.taxi.schedule;
 
 import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.PICKUP;
 
-import org.matsim.contrib.dvrp.schedule.StayTask;
+import org.matsim.contrib.dvrp.schedule.DefaultStayTask;
 import org.matsim.contrib.taxi.passenger.TaxiRequest;
 
 import com.google.common.base.MoreObjects;
 
-public class TaxiPickupTask extends StayTask {
+public class TaxiPickupTask extends DefaultStayTask {
 	public static final TaxiTaskType TYPE = new TaxiTaskType(PICKUP);
 
 	private final TaxiRequest request;

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiStayTask.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/schedule/TaxiStayTask.java
@@ -22,9 +22,9 @@ package org.matsim.contrib.taxi.schedule;
 import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.STAY;
 
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.contrib.dvrp.schedule.StayTask;
+import org.matsim.contrib.dvrp.schedule.DefaultStayTask;
 
-public class TaxiStayTask extends StayTask {
+public class TaxiStayTask extends DefaultStayTask {
 	public static final TaxiTaskType TYPE = new TaxiTaskType(STAY);
 
 	public TaxiStayTask(double beginTime, double endTime, Link link) {


### PR DESCRIPTION
To allow more flexibility when implementing custom tasks (incl. mixing two different task types into one). See: https://github.com/matsim-org/matsim-libs/pull/1788#issuecomment-991355810