### PR TITLE
bump log4j-1.2-api to 2.16.0

### DIFF
--- a/matsim/pom.xml
+++ b/matsim/pom.xml
@@ -151,7 +151,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-1.2-api</artifactId>
-			<version>2.15.0</version>
+			<version>2.16.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.geotools</groupId>


### PR DESCRIPTION
... dependabot does not care of that.