### PR TITLE
Variable stop durations for DRT

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/edrt/run/EDrtModeOptimizerQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/edrt/run/EDrtModeOptimizerQSimModule.java
@@ -45,6 +45,7 @@ import org.matsim.contrib.drt.optimizer.insertion.UnplannedRequestInserter;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtTaskFactory;
+import org.matsim.contrib.drt.schedule.DrtStopTask.StopDuration;
 import org.matsim.contrib.drt.scheduler.DefaultRequestInsertionScheduler;
 import org.matsim.contrib.drt.scheduler.DrtScheduleInquiry;
 import org.matsim.contrib.drt.scheduler.EmptyVehicleRelocator;
@@ -133,7 +134,7 @@ public class EDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 						getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool()))).asEagerSingleton();
 
 		bindModal(InsertionCostCalculator.InsertionCostCalculatorFactory.class).toProvider(modalProvider(
-				getter -> DefaultInsertionCostCalculator.createFactory(drtCfg, getter.get(MobsimTimer.class),
+				getter -> DefaultInsertionCostCalculator.createFactory(getter.getModal(StopDuration.class), getter.get(MobsimTimer.class),
 						getter.getModal(CostCalculationStrategy.class))));
 
 		install(DrtModeOptimizerQSimModule.getInsertionSearchQSimModule(drtCfg));
@@ -166,14 +167,14 @@ public class EDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 		bindModal(DrtScheduleInquiry.class).to(DrtScheduleInquiry.class).asEagerSingleton();
 
 		bindModal(RequestInsertionScheduler.class).toProvider(modalProvider(
-						getter -> new DefaultRequestInsertionScheduler(drtCfg, getter.getModal(Fleet.class),
+						getter -> new DefaultRequestInsertionScheduler(getter.getModal(StopDuration.class), getter.getModal(Fleet.class),
 								getter.get(MobsimTimer.class), getter.getModal(TravelTime.class),
 								getter.getModal(ScheduleTimingUpdater.class), getter.getModal(DrtTaskFactory.class))))
 				.asEagerSingleton();
 
 		bindModal(ScheduleTimingUpdater.class).toProvider(modalProvider(
 				getter -> new ScheduleTimingUpdater(getter.get(MobsimTimer.class),
-						new EDrtStayTaskEndTimeCalculator(drtCfg)))).asEagerSingleton();
+						new EDrtStayTaskEndTimeCalculator(getter.getModal(StopDuration.class))))).asEagerSingleton();
 
 		bindModal(VrpAgentLogic.DynActionCreator.class).toProvider(modalProvider(
 				getter -> new EDrtActionCreator(getter.getModal(PassengerHandler.class), getter.get(MobsimTimer.class),

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/edrt/schedule/EDrtStayTaskEndTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/edrt/schedule/EDrtStayTaskEndTimeCalculator.java
@@ -18,14 +18,14 @@
 
 package org.matsim.contrib.drt.extension.edrt.schedule;
 
-import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtStayTaskEndTimeCalculator;
+import org.matsim.contrib.drt.schedule.DrtStopTask.StopDuration;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.schedule.StayTask;
 
 public class EDrtStayTaskEndTimeCalculator extends DrtStayTaskEndTimeCalculator {
-	public EDrtStayTaskEndTimeCalculator(DrtConfigGroup drtConfigGroup) {
-		super(drtConfigGroup);
+	public EDrtStayTaskEndTimeCalculator(StopDuration stopDuration) {
+		super(stopDuration);
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/optimizer/ShiftRequestInsertionScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/optimizer/ShiftRequestInsertionScheduler.java
@@ -148,7 +148,8 @@ public class ShiftRequestInsertionScheduler implements RequestInsertionScheduler
                         throw new RuntimeException("Cannot serve request!");
                     }
                 } else {
-                	double duration = stopDuration.calculateStopDuration(stopTask.getDropoffRequests().values(), stopTask.getPickupRequests().values());
+					double duration = stopDuration.calculateStopDuration(vehicleEntry.vehicle,
+							stopTask.getDropoffRequests().values(), stopTask.getPickupRequests().values());
     				stopTask.setEndTime(Math.max(Math.max(stopTask.getBeginTime() + duration, stopTask.getEndTime()), request.getEarliestStartTime()));
                 }
 
@@ -247,7 +248,8 @@ public class ShiftRequestInsertionScheduler implements RequestInsertionScheduler
         // insert pickup stop task
         double startTime = beforePickupTask.getEndTime();
         int taskIdx = beforePickupTask.getTaskIdx() + 1;
-        double duration = stopDuration.calculateStopDuration(Collections.emptySet(), Collections.singleton(request));
+		double duration = stopDuration.calculateStopDuration(vehicleEntry.vehicle, Collections.emptySet(),
+				Collections.singleton(request));
 		DrtStopTask pickupStopTask = taskFactory.createStopTask(vehicleEntry.vehicle, startTime,
                 Math.max(startTime + duration, request.getEarliestStartTime()), request.getFromLink());
         schedule.addTask(taskIdx, pickupStopTask);
@@ -287,7 +289,8 @@ public class ShiftRequestInsertionScheduler implements RequestInsertionScheduler
             if (request.getToLink() == stopTask.getLink()) { // no detour; no new stop task
                 // add dropoff request to stop task
                 stopTask.addDropoffRequest(request);
-                double duration = stopDuration.calculateStopDuration(Collections.singleton(request), Collections.emptySet());
+				double duration = stopDuration.calculateStopDuration(vehicleEntry.vehicle,
+						Collections.singleton(request), Collections.emptySet());
 				stopTask.setEndTime(Math.max(stopTask.getBeginTime() + duration, stopTask.getEndTime()));
                 return stopTask;
             } else { // add drive task to dropoff location
@@ -328,7 +331,8 @@ public class ShiftRequestInsertionScheduler implements RequestInsertionScheduler
         // insert dropoff stop task
         double startTime = driveToDropoffTask.getEndTime();
         int taskIdx = driveToDropoffTask.getTaskIdx() + 1;
-        double duration = stopDuration.calculateStopDuration(Collections.singleton(request), Collections.emptySet());
+		double duration = stopDuration.calculateStopDuration(vehicleEntry.vehicle, Collections.singleton(request),
+				Collections.emptySet());
 		DrtStopTask dropoffStopTask = taskFactory.createStopTask(vehicleEntry.vehicle, startTime,
                 startTime + duration, request.getToLink());
         schedule.addTask(taskIdx, dropoffStopTask);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/run/ShiftDrtModeOptimizerQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/run/ShiftDrtModeOptimizerQSimModule.java
@@ -38,6 +38,7 @@ import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtStayTaskEndTimeCalculator;
 import org.matsim.contrib.drt.schedule.DrtTaskFactory;
 import org.matsim.contrib.drt.schedule.DrtTaskFactoryImpl;
+import org.matsim.contrib.drt.schedule.DrtStopTask.StopDuration;
 import org.matsim.contrib.drt.scheduler.DrtScheduleInquiry;
 import org.matsim.contrib.drt.scheduler.EmptyVehicleRelocator;
 import org.matsim.contrib.drt.scheduler.RequestInsertionScheduler;
@@ -101,7 +102,7 @@ public class ShiftDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule 
 		).asEagerSingleton();
 
 		bindModal(InsertionCostCalculator.InsertionCostCalculatorFactory.class).toProvider(modalProvider(
-				getter -> ShiftInsertionCostCalculator.createFactory(drtCfg, getter.get(MobsimTimer.class),
+				getter -> ShiftInsertionCostCalculator.createFactory(getter.getModal(StopDuration.class), getter.get(MobsimTimer.class),
 						getter.getModal(CostCalculationStrategy.class))));
 
 		bindModal(VehicleEntry.EntryFactory.class).toInstance(new ShiftVehicleDataEntryFactory(drtCfg));
@@ -119,7 +120,7 @@ public class ShiftDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule 
 
 		bindModal(DrtScheduleInquiry.class).to(ShiftDrtScheduleInquiry.class).asEagerSingleton();
 		bindModal(RequestInsertionScheduler.class).toProvider(modalProvider(
-				getter -> new ShiftRequestInsertionScheduler(drtCfg, getter.getModal(Fleet.class),
+				getter -> new ShiftRequestInsertionScheduler(getter.getModal(StopDuration.class), getter.getModal(Fleet.class),
 						getter.get(MobsimTimer.class), getter.getModal(TravelTime.class),
 						getter.getModal(ScheduleTimingUpdater.class), getter.getModal(ShiftDrtTaskFactory.class),
 						getter.getModal(OperationFacilities.class)))
@@ -128,7 +129,7 @@ public class ShiftDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule 
 		bindModal(ScheduleTimingUpdater.class).toProvider(modalProvider(
 				getter -> new ScheduleTimingUpdater(getter.get(MobsimTimer.class),
 						new ShiftDrtStayTaskEndTimeCalculator(shiftConfigGroup,
-								new DrtStayTaskEndTimeCalculator(drtCfg))))
+								new DrtStayTaskEndTimeCalculator(getter.getModal(StopDuration.class)))))
 		).asEagerSingleton();
 
 		bindModal(VrpAgentLogic.DynActionCreator.class).toProvider(modalProvider(

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtModeOptimizerQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtModeOptimizerQSimModule.java
@@ -40,6 +40,7 @@ import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtStayTaskEndTimeCalculator;
 import org.matsim.contrib.drt.schedule.DrtTaskFactory;
 import org.matsim.contrib.drt.schedule.DrtTaskFactoryImpl;
+import org.matsim.contrib.drt.schedule.DrtStopTask.StopDuration;
 import org.matsim.contrib.drt.scheduler.DefaultRequestInsertionScheduler;
 import org.matsim.contrib.drt.scheduler.DrtScheduleInquiry;
 import org.matsim.contrib.drt.scheduler.EmptyVehicleRelocator;
@@ -105,8 +106,8 @@ public class DrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 						getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool()))).asEagerSingleton();
 
 		bindModal(InsertionCostCalculatorFactory.class).toProvider(modalProvider(
-				getter -> DefaultInsertionCostCalculator.createFactory(drtCfg, getter.get(MobsimTimer.class),
-						getter.getModal(CostCalculationStrategy.class))));
+				getter -> DefaultInsertionCostCalculator.createFactory(getter.getModal(StopDuration.class),
+						getter.get(MobsimTimer.class), getter.getModal(CostCalculationStrategy.class))));
 
 		install(getInsertionSearchQSimModule(drtCfg));
 
@@ -137,7 +138,7 @@ public class DrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 		bindModal(DrtScheduleInquiry.class).to(DrtScheduleInquiry.class).asEagerSingleton();
 
 		bindModal(RequestInsertionScheduler.class).toProvider(modalProvider(
-						getter -> new DefaultRequestInsertionScheduler(drtCfg, getter.getModal(Fleet.class),
+						getter -> new DefaultRequestInsertionScheduler(getter.getModal(StopDuration.class), getter.getModal(Fleet.class),
 								getter.get(MobsimTimer.class),
 								getter.getModal(TravelTime.class),
 								getter.getModal(ScheduleTimingUpdater.class), getter.getModal(DrtTaskFactory.class))))
@@ -145,7 +146,7 @@ public class DrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 
 		bindModal(ScheduleTimingUpdater.class).toProvider(modalProvider(
 				getter -> new ScheduleTimingUpdater(getter.get(MobsimTimer.class),
-						new DrtStayTaskEndTimeCalculator(drtCfg)))).asEagerSingleton();
+						new DrtStayTaskEndTimeCalculator(getter.getModal(StopDuration.class))))).asEagerSingleton();
 
 		bindModal(VrpAgentLogic.DynActionCreator.class).toProvider(modalProvider(
 				getter -> new DrtActionCreator(getter.getModal(PassengerHandler.class), getter.get(MobsimTimer.class),

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultInsertionCostCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultInsertionCostCalculator.java
@@ -19,13 +19,11 @@
 
 package org.matsim.contrib.drt.optimizer.insertion;
 
-import java.util.function.DoubleSupplier;
 import java.util.function.ToDoubleFunction;
 
 import javax.annotation.Nullable;
 
 import org.matsim.contrib.drt.passenger.DrtRequest;
-import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtStopTask.StopDuration;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultInsertionCostCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultInsertionCostCalculator.java
@@ -26,6 +26,7 @@ import javax.annotation.Nullable;
 
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.drt.schedule.DrtStopTask.StopDuration;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -35,13 +36,13 @@ import com.google.common.annotations.VisibleForTesting;
  */
 public class DefaultInsertionCostCalculator<D> implements InsertionCostCalculator<D> {
 
-	public static InsertionCostCalculatorFactory createFactory(DrtConfigGroup drtCfg, MobsimTimer timer,
+	public static InsertionCostCalculatorFactory createFactory(StopDuration stopDuration, MobsimTimer timer,
 			CostCalculationStrategy costCalculationStrategy) {
 		return new InsertionCostCalculatorFactory() {
 			@Override
 			public <D> InsertionCostCalculator<D> create(ToDoubleFunction<D> detourTime,
 					DetourTimeEstimator replacedDriveTimeEstimator) {
-				return new DefaultInsertionCostCalculator<>(drtCfg, costCalculationStrategy, detourTime,
+				return new DefaultInsertionCostCalculator<>(stopDuration, costCalculationStrategy, detourTime,
 						replacedDriveTimeEstimator);
 			}
 		};
@@ -50,9 +51,9 @@ public class DefaultInsertionCostCalculator<D> implements InsertionCostCalculato
 	private final CostCalculationStrategy costCalculationStrategy;
 	private final InsertionDetourTimeCalculator<D> detourTimeCalculator;
 
-	public DefaultInsertionCostCalculator(DrtConfigGroup drtConfig, CostCalculationStrategy costCalculationStrategy,
+	public DefaultInsertionCostCalculator(StopDuration stopDuration, CostCalculationStrategy costCalculationStrategy,
 			ToDoubleFunction<D> detourTime, @Nullable DetourTimeEstimator replacedDriveTimeEstimator) {
-		this(costCalculationStrategy, new InsertionDetourTimeCalculator<>(drtConfig.getStopDuration(), detourTime,
+		this(costCalculationStrategy, new InsertionDetourTimeCalculator<>(stopDuration, detourTime,
 				replacedDriveTimeEstimator));
 	}
 
@@ -79,7 +80,7 @@ public class DefaultInsertionCostCalculator<D> implements InsertionCostCalculato
 	public double calculate(DrtRequest drtRequest, InsertionWithDetourData<D> insertion) {
 		//TODO precompute time slacks for each stop to filter out even more infeasible insertions ???????????
 
-		var detourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion);
+		var detourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion, drtRequest);
 
 		var insertion1 = insertion.getInsertion();
 		var vEntry = insertion1.vehicleEntry;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculator.java
@@ -102,14 +102,8 @@ public class InsertionDetourTimeCalculator<D> {
 		double fromDropoffTT = detourTime.applyAsDouble(insertion.getDetourFromDropoff());
 		double replacedDriveTT = calculateReplacedDriveDuration(vEntry, pickup.index);
 		double pickupTimeLoss = toPickupTT + additionalPickupStopDuration + fromPickupToDropoffTT - replacedDriveTT;
-
-		final double dropoffTimeLoss;
-		if (dropoff.newWaypoint.getLink() == dropoff.nextWaypoint.getLink()) {
-			dropoffTimeLoss = calcAdditionalDropoffStopDurationIfSameLinkAsPrevious(vEntry, dropoff.index, request);
-		} else {
-			double dropoffStopDuration = stopDuration.calculateStopDuration(Collections.singleton(request), Collections.emptySet());
-			dropoffTimeLoss = dropoffStopDuration + fromDropoffTT;
-		}
+		double dropoffStopDuration = stopDuration.calculateStopDuration(Collections.singleton(request), Collections.emptySet());
+		double dropoffTimeLoss = dropoffStopDuration + fromDropoffTT;
 
 		double departureTime = pickup.previousWaypoint.getDepartureTime() + toPickupTT + additionalPickupStopDuration;
 		double arrivalTime = departureTime + fromPickupToDropoffTT;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculator.java
@@ -59,7 +59,7 @@ public class InsertionDetourTimeCalculator<D> {
 			double fromPickupTT = detourTime.applyAsDouble(insertion.getDetourFromPickup());
 			double replacedDriveTT = calculateReplacedDriveDuration(vEntry, pickup.index);
 			
-			double pickupStopDuration = stopDuration.calculateStopDuration(Collections.emptySet(), Collections.singleton(request));
+			double pickupStopDuration = stopDuration.calculateStopDuration(vEntry.vehicle, Collections.emptySet(), Collections.singleton(request));
 			pickupTimeLoss = toPickupTT + pickupStopDuration + fromPickupTT - replacedDriveTT;
 			departureTime = toPickupDepartureTime + toPickupTT + pickupStopDuration;
 		}
@@ -74,7 +74,7 @@ public class InsertionDetourTimeCalculator<D> {
 			double toDropoffTT = detourTime.applyAsDouble(insertion.getDetourToDropoff());
 			double fromDropoffTT = detourTime.applyAsDouble(insertion.getDetourFromDropoff());
 			double replacedDriveTT = calculateReplacedDriveDuration(insertion.getVehicleEntry(), dropoff.index);
-			double dropoffStopDuration = stopDuration.calculateStopDuration(Collections.singleton(request), Collections.emptySet());
+			double dropoffStopDuration = stopDuration.calculateStopDuration(vEntry.vehicle, Collections.singleton(request), Collections.emptySet());
 			dropoffTimeLoss = toDropoffTT + dropoffStopDuration + fromDropoffTT - replacedDriveTT;
 			arrivalTime = dropoff.previousWaypoint.getDepartureTime() + pickupTimeLoss + toDropoffTT;
 		}
@@ -94,14 +94,14 @@ public class InsertionDetourTimeCalculator<D> {
 			additionalPickupStopDuration = calcAdditionalStopDurationIfSameLinkAsPrevious(vEntry, pickup.index, request);
 		} else {
 			toPickupTT = detourTime.applyAsDouble(insertion.getDetourToPickup());
-			additionalPickupStopDuration = stopDuration.calculateStopDuration(Collections.emptySet(), Collections.singleton(request));
+			additionalPickupStopDuration = stopDuration.calculateStopDuration(vEntry.vehicle, Collections.emptySet(), Collections.singleton(request));
 		}
 
 		double fromPickupToDropoffTT = detourTime.applyAsDouble(insertion.getDetourFromPickup());
 		double fromDropoffTT = detourTime.applyAsDouble(insertion.getDetourFromDropoff());
 		double replacedDriveTT = calculateReplacedDriveDuration(vEntry, pickup.index);
 		double pickupTimeLoss = toPickupTT + additionalPickupStopDuration + fromPickupToDropoffTT - replacedDriveTT;
-		double dropoffStopDuration = stopDuration.calculateStopDuration(Collections.singleton(request), Collections.emptySet());
+		double dropoffStopDuration = stopDuration.calculateStopDuration(vEntry.vehicle, Collections.singleton(request), Collections.emptySet());
 		double dropoffTimeLoss = dropoffStopDuration + fromDropoffTT;
 
 		double departureTime = pickup.previousWaypoint.getDepartureTime() + toPickupTT + additionalPickupStopDuration;
@@ -119,14 +119,14 @@ public class InsertionDetourTimeCalculator<D> {
 			if (startTask.isPresent() && STOP.isBaseTypeOf(startTask.get())) {
 				stopTask = (DrtStopTask) startTask.get();
 			} else {
-				return stopDuration.calculateStopDuration(Collections.emptySet(), Collections.singleton(request));
+				return stopDuration.calculateStopDuration(vEntry.vehicle, Collections.emptySet(), Collections.singleton(request));
 			}
 		} else {
 			stopTask = vEntry.stops.get(insertionIdx - 1).task;
 		}
 		
-		double intialDuration = stopDuration.calculateStopDuration(stopTask.getDropoffRequests().values(), stopTask.getPickupRequests().values());
-		double updatedDuration = stopDuration.calculateStopDuration(stopTask.getDropoffRequests().values(), CollectionUtils.union(stopTask.getPickupRequests().values(), Collections.singleton(request)));
+		double intialDuration = stopDuration.calculateStopDuration(vEntry.vehicle, stopTask.getDropoffRequests().values(), stopTask.getPickupRequests().values());
+		double updatedDuration = stopDuration.calculateStopDuration(vEntry.vehicle, stopTask.getDropoffRequests().values(), CollectionUtils.union(stopTask.getPickupRequests().values(), Collections.singleton(request)));
 		double timeLoss = updatedDuration - intialDuration;
 		
 		if (insertionIdx == 0 && timeLoss > 0.0) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -46,6 +46,7 @@ import org.matsim.contrib.drt.routing.DrtRouteUpdater;
 import org.matsim.contrib.drt.routing.DrtStopFacility;
 import org.matsim.contrib.drt.routing.DrtStopFacilityImpl;
 import org.matsim.contrib.drt.routing.DrtStopNetwork;
+import org.matsim.contrib.drt.schedule.DrtStopTask.StopDuration;
 import org.matsim.contrib.drt.speedup.DrtSpeedUp;
 import org.matsim.contrib.dvrp.fleet.FleetModule;
 import org.matsim.contrib.dvrp.fleet.FleetSpecification;
@@ -169,6 +170,8 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 							getter.getModal(DrtEventSequenceCollector.class)))).asEagerSingleton();
 			addControlerListenerBinding().to(modalKey(DrtSpeedUp.class));
 		});
+		
+		bindModal(StopDuration.class).toInstance((d, p) -> drtCfg.getStopDuration());
 	}
 
 	private static class DrtRouteCreatorProvider extends ModalProviders.AbstractProvider<DvrpMode, DrtRouteCreator> {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -171,7 +171,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 			addControlerListenerBinding().to(modalKey(DrtSpeedUp.class));
 		});
 		
-		bindModal(StopDuration.class).toInstance((d, p) -> drtCfg.getStopDuration());
+		bindModal(StopDuration.class).toInstance((vehicle, dropoffs, pickups) -> drtCfg.getStopDuration());
 	}
 
 	private static class DrtRouteCreatorProvider extends ModalProviders.AbstractProvider<DvrpMode, DrtRouteCreator> {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtStayTaskEndTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtStayTaskEndTimeCalculator.java
@@ -65,7 +65,7 @@ public class DrtStayTaskEndTimeCalculator implements ScheduleTimingUpdater.StayT
 						.max()
 						.orElse(Double.NEGATIVE_INFINITY); //TODO REMOVE_STAY_TASK ?? @michal
 				
-				double duration = stopDuration.calculateStopDuration(stopTask.getDropoffRequests().values(), stopTask.getPickupRequests().values());
+				double duration = stopDuration.calculateStopDuration(vehicle, stopTask.getDropoffRequests().values(), stopTask.getPickupRequests().values());
 				return Math.max(newBeginTime + duration, maxEarliestPickupTime);
 			}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtStopTask.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtStopTask.java
@@ -21,6 +21,7 @@ package org.matsim.contrib.drt.schedule;
 
 import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.STOP;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -79,5 +80,9 @@ public class DrtStopTask extends StayTask {
 				.add("pickupRequests", pickupRequests)
 				.add("super", super.toString())
 				.toString();
+	}
+	
+	public interface StopDuration {
+		double calculateStopDuration(Collection<DrtRequest> dropoffRequests, Collection<DrtRequest> pickupRequests);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtStopTask.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtStopTask.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.passenger.DrtRequest;
+import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.optimizer.Request;
 import org.matsim.contrib.dvrp.schedule.StayTask;
 
@@ -83,6 +84,7 @@ public class DrtStopTask extends StayTask {
 	}
 	
 	public interface StopDuration {
-		double calculateStopDuration(Collection<DrtRequest> dropoffRequests, Collection<DrtRequest> pickupRequests);
+		double calculateStopDuration(DvrpVehicle vehicle, Collection<DrtRequest> dropoffRequests,
+				Collection<DrtRequest> pickupRequests);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
@@ -140,7 +140,8 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 				// add pickup request to stop task
 				stopTask.addPickupRequest(request);
 				
-				double duration = stopDuration.calculateStopDuration(stopTask.getDropoffRequests().values(), stopTask.getPickupRequests().values());
+				double duration = stopDuration.calculateStopDuration(vehicleEntry.vehicle,
+						stopTask.getDropoffRequests().values(), stopTask.getPickupRequests().values());
 				stopTask.setEndTime(Math.max(Math.max(stopTask.getBeginTime() + duration, stopTask.getEndTime()), request.getEarliestStartTime()));
 
 				/// ADDED
@@ -212,7 +213,8 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 		// insert pickup stop task
 		double startTime = beforePickupTask.getEndTime();
 		int taskIdx = beforePickupTask.getTaskIdx() + 1;
-		double duration = stopDuration.calculateStopDuration(Collections.emptySet(), Collections.singleton(request));
+		double duration = stopDuration.calculateStopDuration(vehicleEntry.vehicle, Collections.emptySet(),
+				Collections.singleton(request));
 		DrtStopTask pickupStopTask = taskFactory.createStopTask(vehicleEntry.vehicle, startTime,
 				Math.max(startTime + duration, request.getEarliestStartTime()), request.getFromLink());
 		schedule.addTask(taskIdx, pickupStopTask);
@@ -251,7 +253,8 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 			if (request.getToLink() == stopTask.getLink()) { // no detour; no new stop task
 				// add dropoff request to stop task
 				stopTask.addDropoffRequest(request);
-				double duration = stopDuration.calculateStopDuration(Collections.singleton(request), Collections.emptySet());
+				double duration = stopDuration.calculateStopDuration(vehicleEntry.vehicle,
+						Collections.singleton(request), Collections.emptySet());
 				stopTask.setEndTime(Math.max(stopTask.getBeginTime() + duration, stopTask.getEndTime()));
 				return stopTask;
 			} else { // add drive task to dropoff location
@@ -277,7 +280,8 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 		// insert dropoff stop task
 		double startTime = driveToDropoffTask.getEndTime();
 		int taskIdx = driveToDropoffTask.getTaskIdx() + 1;
-		double duration = stopDuration.calculateStopDuration(Collections.singleton(request), Collections.emptySet());
+		double duration = stopDuration.calculateStopDuration(vehicleEntry.vehicle, Collections.singleton(request),
+				Collections.emptySet());
 		DrtStopTask dropoffStopTask = taskFactory.createStopTask(vehicleEntry.vehicle, startTime,
 				startTime + duration, request.getToLink());
 		schedule.addTask(taskIdx, dropoffStopTask);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
@@ -141,7 +141,7 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 				stopTask.addPickupRequest(request);
 				
 				double duration = stopDuration.calculateStopDuration(stopTask.getDropoffRequests().values(), stopTask.getPickupRequests().values());
-				stopTask.setEndTime(Math.max(stopTask.getBeginTime() + duration, request.getEarliestStartTime()));
+				stopTask.setEndTime(Math.max(Math.max(stopTask.getBeginTime() + duration, stopTask.getEndTime()), request.getEarliestStartTime()));
 
 				/// ADDED
 				//// TODO this is copied, but has not been updated !!!!!!!!!!!!!!!
@@ -251,6 +251,8 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 			if (request.getToLink() == stopTask.getLink()) { // no detour; no new stop task
 				// add dropoff request to stop task
 				stopTask.addDropoffRequest(request);
+				double duration = stopDuration.calculateStopDuration(Collections.singleton(request), Collections.emptySet());
+				stopTask.setEndTime(Math.max(stopTask.getBeginTime() + duration, stopTask.getEndTime()));
 				return stopTask;
 			} else { // add drive task to dropoff location
 
@@ -298,10 +300,7 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 		} else {
 			Link toLink = stops.get(dropoffIdx).task.getLink(); // dropoff->j+1
 
-			double taskDuration = stopDuration.calculateStopDuration(
-					stops.get(dropoffIdx).task.getDropoffRequests().values(),
-					stops.get(dropoffIdx).task.getDropoffRequests().values());
-			VrpPathWithTravelData vrpPath = VrpPaths.createPath(request.getToLink(), toLink, startTime + taskDuration,
+			VrpPathWithTravelData vrpPath = VrpPaths.createPath(request.getToLink(), toLink, startTime + duration,
 					insertion.getDetourFromDropoff(), travelTime);
 			Task driveFromDropoffTask = taskFactory.createDriveTask(vehicleEntry.vehicle, vrpPath, DrtDriveTask.TYPE);
 			schedule.addTask(taskIdx + 1, driveFromDropoffTask);

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearchTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearchTest.java
@@ -50,7 +50,7 @@ import org.matsim.core.mobsim.framework.MobsimTimer;
 public class DefaultDrtInsertionSearchTest {
 	@Test
 	public void findBestInsertion_noInsertionsProvided() {
-		var insertionCostCalculator = new DefaultInsertionCostCalculator<>(new DrtConfigGroup(), null,
+		var insertionCostCalculator = new DefaultInsertionCostCalculator<>((d, p) -> Double.NaN, null,
 				PathData::getTravelTime, null);
 		var insertionSearch = new DefaultDrtInsertionSearch(mock(InsertionProvider.class), null,
 				insertionCostCalculator);

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearchTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearchTest.java
@@ -50,7 +50,7 @@ import org.matsim.core.mobsim.framework.MobsimTimer;
 public class DefaultDrtInsertionSearchTest {
 	@Test
 	public void findBestInsertion_noInsertionsProvided() {
-		var insertionCostCalculator = new DefaultInsertionCostCalculator<>((d, p) -> Double.NaN, null,
+		var insertionCostCalculator = new DefaultInsertionCostCalculator<>((v, d, p) -> Double.NaN, null,
 				PathData::getTravelTime, null);
 		var insertionSearch = new DefaultDrtInsertionSearch(mock(InsertionProvider.class), null,
 				insertionCostCalculator);

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
@@ -74,7 +74,7 @@ public class InsertionCostCalculatorTest {
 		var detourTimeCalculator = (InsertionDetourTimeCalculator<D>)mock(InsertionDetourTimeCalculator.class);
 		var insertionCostCalculator = new DefaultInsertionCostCalculator<>(
 				new CostCalculationStrategy.RejectSoftConstraintViolations(), detourTimeCalculator);
-		when(detourTimeCalculator.calculateDetourTimeInfo(insertion)).thenReturn(detourTimeInfo);
+		when(detourTimeCalculator.calculateDetourTimeInfo(insertion, drtRequest)).thenReturn(detourTimeInfo);
 		assertThat(insertionCostCalculator.calculate(drtRequest, insertion)).isEqualTo(expectedCost);
 	}
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
@@ -177,7 +177,7 @@ public class InsertionDetourTimeCalculatorTest {
 				.put(stop0.getLink(), stop1.getLink(), dropoffDetourReplacedDriveEstimate)
 				.build();
 
-		var detourTimeCalculator = new InsertionDetourTimeCalculator<>((d, p) -> STOP_DURATION, Double::doubleValue,
+		var detourTimeCalculator = new InsertionDetourTimeCalculator<>((v, d, p) -> STOP_DURATION, Double::doubleValue,
 				replacedDriveTimeEstimates::get);
 		var actualDetourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion, drtRequest);
 
@@ -191,7 +191,7 @@ public class InsertionDetourTimeCalculatorTest {
 	}
 
 	private void assertDetourTimeInfo(InsertionWithDetourData<Double> insertion, DetourTimeInfo expected) {
-		var detourTimeCalculator = new InsertionDetourTimeCalculator<>((d, p) -> STOP_DURATION, Double::doubleValue, null);
+		var detourTimeCalculator = new InsertionDetourTimeCalculator<>((v, d, p) -> STOP_DURATION, Double::doubleValue, null);
 		var detourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion, drtRequest);
 		assertThat(detourTimeInfo).isEqualToComparingFieldByField(expected);
 	}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorWithVariableDurationTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorWithVariableDurationTest.java
@@ -52,7 +52,7 @@ public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 	private static final int STOP_DURATION_INITIAL = 10;
 	private static final int STOP_DURATION_ADDED = 5;
 	
-	private static final StopDuration stopDuration = (d, p) -> {
+	private static final StopDuration stopDuration = (v, d, p) -> {
 		return 0.0
 				+ (d.contains(drtRequestInitial) || p.contains(drtRequestInitial) ? STOP_DURATION_INITIAL : 0.0)
 				+ (d.contains(drtRequestAdded) || p.contains(drtRequestAdded) ? STOP_DURATION_ADDED : 0.0);						

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorWithVariableDurationTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorWithVariableDurationTest.java
@@ -40,6 +40,7 @@ import com.google.common.collect.ImmutableTable;
 
 /**
  * @author Michal Maciejewski (michalm)
+ * @author Sebastian Hörl (sebhoerl)
  */
 public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 	private final static Link fromLink = link("from");

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorWithVariableDurationTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorWithVariableDurationTest.java
@@ -151,7 +151,7 @@ public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 		double departureTime = start.getDepartureTime() + STOP_DURATION_ADDED;
 		double pickupTimeLoss = STOP_DURATION_ADDED;
 		double arrivalTime = stop0.getArrivalTime() + pickupTimeLoss;
-		double dropoffTimeLoss = 0;
+		double dropoffTimeLoss = STOP_DURATION_ADDED;
 		assertDetourTimeInfo(insertion,
 				new DetourTimeInfo(departureTime, arrivalTime, pickupTimeLoss, dropoffTimeLoss));
 	}


### PR DESCRIPTION
Currently, the stop duration in DRT is defined via configuration, and it is a constant value per stop. This PR introduces a StopDuration interface, which is inspired by the TravelTime interface. Based on the vehicle (e.g., special type) or the pickup and dropoff requests (which may have specific needs), the interface decides how long the stop will take. The default implementation is based on the configuration:

```bindModal(StopDuration.class).toInstance((vehicle, dropoffs, pickups) -> drtCfg.getStopDuration());```

There is one caveat: Sometimes, DRT will add new requests to *ongoing* stops. In that case, a custom implementation of `StopDuration` may modify the duration of the `DrtStopTask`, but this information would not be passed down to the active `BusStopActivity`. For now, a warning is produced if such a case happens.