### PR TITLE
#1751 use simpler interface for networkutils

### DIFF
--- a/contribs/accessibility/src/test/java/org/matsim/contrib/accessibility/run/NetworkUtilTest.java
+++ b/contribs/accessibility/src/test/java/org/matsim/contrib/accessibility/run/NetworkUtilTest.java
@@ -65,7 +65,7 @@ public class NetworkUtilTest {
 		 * why is that a "special case"? in a normal network all sort of slopes are *normally* present. dz, feb'16
 		 */
 		
-		Network network = NetworkUtils.createTimeInvariantNetwork();
+		Network network = NetworkUtils.createNetwork();
 		Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create("2", Node.class), new Coord((double) 0, (double) 1000));
 		Node node3 = NetworkUtils.createAndAddNode(network, Id.create("3", Node.class), new Coord((double) 1000, (double) 2000));

--- a/contribs/accidents/src/test/java/org/matsim/contrib/accidents/BvwpAccidentsCostComputationTest.java
+++ b/contribs/accidents/src/test/java/org/matsim/contrib/accidents/BvwpAccidentsCostComputationTest.java
@@ -23,7 +23,7 @@ public class BvwpAccidentsCostComputationTest {
 		
 	@Test
 	public void test1() {
-		Network network = NetworkUtils.createTimeInvariantNetwork();
+		Network network = NetworkUtils.createNetwork();
 		NetworkFactory factory = network.getFactory();
 		
 		Node n0 = factory.createNode(Id.createNodeId(0), new Coord(0, 1));
@@ -45,7 +45,7 @@ public class BvwpAccidentsCostComputationTest {
 	
 	@Test
 	public void test2() {
-		Network network = NetworkUtils.createTimeInvariantNetwork();
+		Network network = NetworkUtils.createNetwork();
 		NetworkFactory factory = network.getFactory();
 		
 		Node n0 = factory.createNode(Id.createNodeId(0), new Coord(0, 1));
@@ -67,7 +67,7 @@ public class BvwpAccidentsCostComputationTest {
 	
 	@Test
 	public void test3() {
-		Network network = NetworkUtils.createTimeInvariantNetwork();
+		Network network = NetworkUtils.createNetwork();
 		NetworkFactory factory = network.getFactory();
 		
 		Node n0 = factory.createNode(Id.createNodeId(0), new Coord(0, 1));

--- a/contribs/analysis/src/test/java/org/matsim/contrib/analysis/filters/population/PersonIntersectAreaFilterTest.java
+++ b/contribs/analysis/src/test/java/org/matsim/contrib/analysis/filters/population/PersonIntersectAreaFilterTest.java
@@ -49,8 +49,8 @@ public class PersonIntersectAreaFilterTest extends MatsimTestCase {
 	public void testFilter() throws Exception {
 		/* create a simple network where agents can drive from the lower left
 		 * to the upper right */
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node0 = NetworkUtils.createAndAddNode(network, Id.create("0", Node.class), new Coord((double) 0, (double) 0));
+		Network network = NetworkUtils.createNetwork();
+        Node node0 = NetworkUtils.createAndAddNode(network, Id.create("0", Node.class), new Coord((double) 0, (double) 0));
 		Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 10, (double) 10));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create("2", Node.class), new Coord((double) 90, (double) 10));
 		Node node3 = NetworkUtils.createAndAddNode(network, Id.create("3", Node.class), new Coord((double) 10, (double) 90));

--- a/contribs/application/src/main/java/org/matsim/application/analysis/emissions/AirPollutionSpatialAggregation.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/emissions/AirPollutionSpatialAggregation.java
@@ -74,7 +74,7 @@ public class AirPollutionSpatialAggregation implements MATSimAppCommand {
 	@Override
 	public Integer call() throws Exception {
 
-		Network network = NetworkUtils.readTimeInvariantNetwork(this.network.toString());
+		Network network = NetworkUtils.readNetwork(this.network.toString());
 
 		ShpOptions.Index index = shp.getShapeFile() != null ? shp.createIndex(ProjectionUtils.getCRS(network), "_") : null;
 

--- a/contribs/application/src/main/java/org/matsim/application/analysis/emissions/AirPollutionSpatialAggregation.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/emissions/AirPollutionSpatialAggregation.java
@@ -80,7 +80,7 @@ public class AirPollutionSpatialAggregation implements MATSimAppCommand {
 
 		var filteredNetwork = network.getLinks().values().parallelStream()
 				.filter(link -> index == null || index.contains(link.getCoord()))
-				.collect(NetworkUtils.getTimeInvariantCollector());
+				.collect(NetworkUtils.getCollector());
 
 		Map<Pollutant, Raster> rasterMap = FastEmissionGridAnalyzer.processEventsFile(events.toString(), filteredNetwork, gridSize, 20);
 
@@ -96,7 +96,7 @@ public class AirPollutionSpatialAggregation implements MATSimAppCommand {
 			return 2;
 		}
 
-		Raster raster = rasterMap.values().stream().findFirst().get();
+		Raster raster = rasterMap.values().stream().findFirst().orElseThrow();
 
 		try (CSVPrinter printer = csv.createPrinter(output)) {
 

--- a/contribs/application/src/main/java/org/matsim/application/analysis/traffic/LinkStats.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/traffic/LinkStats.java
@@ -74,7 +74,7 @@ public class LinkStats implements MATSimAppCommand {
 
         EventsManager eventsManager = EventsUtils.createEventsManager();
 
-        Network network = NetworkUtils.readTimeInvariantNetwork(this.network.toString());
+        Network network = NetworkUtils.readNetwork(this.network.toString());
 
         TravelTimeCalculator.Builder builder = new TravelTimeCalculator.Builder(network);
         builder.setTimeslice(timeSlice);

--- a/contribs/application/src/main/java/org/matsim/application/analysis/travelTimeValidation/TravelTimeAnalysis.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/travelTimeValidation/TravelTimeAnalysis.java
@@ -215,7 +215,7 @@ public class TravelTimeAnalysis implements MATSimAppCommand {
                 log.error("Network file does not exist. Please make sure the network file is in the run directory");
                 return 2;
             }
-            Network network = NetworkUtils.readTimeInvariantNetwork(networkPath.toString());
+            Network network = NetworkUtils.readNetwork(networkPath.toString());
             CoordinateTransformation transformation = TransformationFactory.getCoordinateTransformation(crs.getInputCRS(), TransformationFactory.WGS84);
             TravelTimeDistanceValidator validator;
             if (api == API.HERE) {

--- a/contribs/application/src/main/java/org/matsim/application/prepare/network/CleanNetwork.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/network/CleanNetwork.java
@@ -28,7 +28,7 @@ public class CleanNetwork implements MATSimAppCommand {
 	@Override
 	public Integer call() throws Exception {
 
-		Network network = NetworkUtils.readTimeInvariantNetwork(input.toString());
+		Network network = NetworkUtils.readNetwork(input.toString());
 
 		var cleaner = new MultimodalNetworkCleaner(network);
 

--- a/contribs/application/src/main/java/org/matsim/application/prepare/network/CreateNetworkFromSumo.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/network/CreateNetworkFromSumo.java
@@ -72,8 +72,8 @@ public final class CreateNetworkFromSumo implements MATSimAppCommand {
 
 		SumoNetworkConverter converter = SumoNetworkConverter.newInstance(input, output, shp.getShapeFile(), crs.getInputCRS(), crs.getTargetCRS());
 
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Lanes lanes = LanesUtils.createLanesContainer();
+		Network network = NetworkUtils.createNetwork();
+        Lanes lanes = LanesUtils.createLanesContainer();
 
 		SumoNetworkHandler handler = converter.convert(network, lanes);
 

--- a/contribs/application/src/main/java/org/matsim/application/prepare/population/ResolveGridCoordinates.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/population/ResolveGridCoordinates.java
@@ -63,7 +63,7 @@ public class ResolveGridCoordinates implements MATSimAppCommand {
 		}
 
 		if (networkPath != null) {
-			network = NetworkUtils.readTimeInvariantNetwork(networkPath.toString());
+			network = NetworkUtils.readNetwork(networkPath.toString());
 		}
 
 

--- a/contribs/application/src/main/java/org/matsim/application/prepare/pt/CreateTransitScheduleFromGtfs.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/pt/CreateTransitScheduleFromGtfs.java
@@ -133,7 +133,7 @@ public class CreateTransitScheduleFromGtfs implements MATSimAppCommand {
 			TransitSchedulePostProcessTools.copyEarlyDeparturesToFollowingNight(scenario.getTransitSchedule(), 6 * 3600, "copied");
 		}
 
-		Network network = Files.exists(networkFile) ? NetworkUtils.readTimeInvariantNetwork(networkFile.toString()) : scenario.getNetwork();
+		Network network = Files.exists(networkFile) ? NetworkUtils.readNetwork(networkFile.toString()) : scenario.getNetwork();
 
 		Scenario ptScenario = getScenarioWithPseudoPtNetworkAndTransitVehicles(network, scenario.getTransitSchedule(), "pt_");
 

--- a/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/network/BicycleOsmNetworkReaderV2.java
+++ b/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/network/BicycleOsmNetworkReaderV2.java
@@ -83,7 +83,7 @@ public final class BicycleOsmNetworkReaderV2 extends OsmNetworkReader {
 //		List<String> bicycleWayTags = Arrays.asList(
 //				new String[]{BicycleUtils.CYCLEWAY, BicycleUtils.SURFACE, BicycleUtils.SMOOTHNESS, TAG_BICYCLE, TAG_ONEWAYBICYCLE});
 
-		Network network = NetworkUtils.createTimeInvariantNetwork();
+		Network network = NetworkUtils.createNetwork();
 		CoordinateTransformation ct = TransformationFactory.getCoordinateTransformation(inputCRS, outputCRS);
 		
 		ElevationDataParser elevationDataParser = new ElevationDataParser(tiffFile, outputCRS);

--- a/contribs/bicycle/src/test/java/org/matsim/contrib/bicycle/BicycleLinkSpeedCalculatorTest.java
+++ b/contribs/bicycle/src/test/java/org/matsim/contrib/bicycle/BicycleLinkSpeedCalculatorTest.java
@@ -24,7 +24,7 @@ public class BicycleLinkSpeedCalculatorTest {
     private static final double MAX_BICYCLE_SPEED = 15;
 
     private final BicycleConfigGroup configGroup = new BicycleConfigGroup();
-    private final Network unusedNetwork = NetworkUtils.createTimeInvariantNetwork();
+    private final Network unusedNetwork = NetworkUtils.createNetwork();
 
     @Before
     public void before() {

--- a/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/runExample/RunCarsharing.java
+++ b/contribs/carsharing/src/main/java/org/matsim/contrib/carsharing/runExample/RunCarsharing.java
@@ -89,7 +89,7 @@ public class RunCarsharing {
 		TransportModeNetworkFilter filter = new TransportModeNetworkFilter(scenario.getNetwork());
 		Set<String> modes = new HashSet<>();
 		modes.add("car");
-		Network networkFF = NetworkUtils.createTimeInvariantNetwork();
+		Network networkFF = NetworkUtils.createNetwork();
 		filter.filter(networkFF, modes);
 		CarsharingXmlReaderNew reader = new CarsharingXmlReaderNew(networkFF);
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/DrtGridUtilsTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/analysis/zonal/DrtGridUtilsTest.java
@@ -44,7 +44,7 @@ public class DrtGridUtilsTest {
 	}
 
 	static Network createNetwork() {
-		Network network = NetworkUtils.createTimeInvariantNetwork();
+		Network network = NetworkUtils.createNetwork();
 		Node a = network.getFactory().createNode(Id.createNodeId("a"), new Coord(0, 0));
 		Node b = network.getFactory().createNode(Id.createNodeId("b"), new Coord(0, 1000));
 		Node c = network.getFactory().createNode(Id.createNodeId("c"), new Coord(1000, 1000));

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehicleDensityTargetCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehicleDensityTargetCalculatorTest.java
@@ -50,7 +50,7 @@ public class EqualVehicleDensityTargetCalculatorTest {
 			IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("dvrp-grid"), "eight_shared_taxi_config.xml"),
 			new MultiModeDrtConfigGroup());
 
-	private final Network network = NetworkUtils.readTimeInvariantNetwork(
+	private final Network network = NetworkUtils.readNetwork(
 			config.network().getInputFileURL(config.getContext()).toString());
 
 	private final DrtZonalSystem zonalSystem = DrtZonalSystem.createFromPreparedGeometries(network,

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehiclesToPopulationRatioTargetCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/targetcalculator/EqualVehiclesToPopulationRatioTargetCalculatorTest.java
@@ -56,7 +56,7 @@ public class EqualVehiclesToPopulationRatioTargetCalculatorTest {
 			IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("dvrp-grid"), "eight_shared_taxi_config.xml"),
 			new MultiModeDrtConfigGroup());
 
-	private final Network network = NetworkUtils.readTimeInvariantNetwork(
+	private final Network network = NetworkUtils.readNetwork(
 			config.network().getInputFileURL(config.getContext()).toString());
 
 	private final DrtZonalSystem zonalSystem = DrtZonalSystem.createFromPreparedGeometries(network,

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/path/OneToManyPathCalculatorTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/path/OneToManyPathCalculatorTest.java
@@ -49,7 +49,7 @@ import com.google.common.collect.ImmutableList;
  * @author Michal Maciejewski (michalm)
  */
 public class OneToManyPathCalculatorTest {
-	private final Network network = NetworkUtils.createTimeInvariantNetwork();
+	private final Network network = NetworkUtils.createNetwork();
 
 	private final Node nodeA = createAndAddNode("A", new Coord(0, 0));
 	private final Node nodeB = createAndAddNode("B", new Coord(150, 0));

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOfflineTravelTimeEstimatorTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/trafficmonitoring/DvrpOfflineTravelTimeEstimatorTest.java
@@ -40,8 +40,8 @@ import com.google.common.base.Preconditions;
  * @author Michal Maciejewski (michalm)
  */
 public class DvrpOfflineTravelTimeEstimatorTest {
-	private final Network network = NetworkUtils.createTimeInvariantNetwork();
-	private final Node nodeA = NetworkUtils.createAndAddNode(network, Id.createNodeId("A"), new Coord());
+	private final Network network = NetworkUtils.createNetwork();
+    private final Node nodeA = NetworkUtils.createAndAddNode(network, Id.createNodeId("A"), new Coord());
 	private final Node nodeB = NetworkUtils.createAndAddNode(network, Id.createNodeId("B"), new Coord());
 	private final Link linkAB = NetworkUtils.createAndAddLink(network, Id.createLinkId("A_B"), nodeA, nodeB, 100, 10,
 			10, 1);

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrixTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrixTest.java
@@ -34,8 +34,8 @@ import org.matsim.core.network.NetworkUtils;
  */
 public class DvrpTravelTimeMatrixTest {
 
-	private final Network network = NetworkUtils.createTimeInvariantNetwork();
-	private final Node nodeA = NetworkUtils.createAndAddNode(network, Id.createNodeId("A"), new Coord(0, 0));
+	private final Network network = NetworkUtils.createNetwork();
+    private final Node nodeA = NetworkUtils.createAndAddNode(network, Id.createNodeId("A"), new Coord(0, 0));
 	private final Node nodeB = NetworkUtils.createAndAddNode(network, Id.createNodeId("B"), new Coord(150, 150));
 	private final Node nodeC = NetworkUtils.createAndAddNode(network, Id.createNodeId("C"), new Coord(-10, -10));
 

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/zone/skims/TravelTimeMatricesTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/zone/skims/TravelTimeMatricesTest.java
@@ -40,8 +40,8 @@ import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
 public class TravelTimeMatricesTest {
 	@Test
 	public void travelTimeMatrix() {
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node nodeA = NetworkUtils.createAndAddNode(network, Id.createNodeId("A"), new Coord(0, 0));
+		Network network = NetworkUtils.createNetwork();
+        Node nodeA = NetworkUtils.createAndAddNode(network, Id.createNodeId("A"), new Coord(0, 0));
 		Node nodeB = NetworkUtils.createAndAddNode(network, Id.createNodeId("B"), new Coord(150, 150));
 		NetworkUtils.createAndAddLink(network, Id.createLinkId("AB"), nodeA, nodeB, 150, 15, 20, 1);
 		NetworkUtils.createAndAddLink(network, Id.createLinkId("BA"), nodeB, nodeA, 300, 15, 40, 1);
@@ -60,8 +60,8 @@ public class TravelTimeMatricesTest {
 
 	@Test
 	public void travelTimeSparseMatrix() {
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node nodeA = NetworkUtils.createAndAddNode(network, Id.createNodeId("A"), new Coord(0, 0));
+        Network network = NetworkUtils.createNetwork();
+        Node nodeA = NetworkUtils.createAndAddNode(network, Id.createNodeId("A"), new Coord(0, 0));
 		Node nodeB = NetworkUtils.createAndAddNode(network, Id.createNodeId("B"), new Coord(150, 150));
 		Node nodeC = NetworkUtils.createAndAddNode(network, Id.createNodeId("C"), new Coord(-150, -150));
 		NetworkUtils.createAndAddLink(network, Id.createLinkId("AB"), nodeA, nodeB, 150, 15, 20, 1);

--- a/contribs/dvrp/src/test/java/org/matsim/core/router/speedy/SpeedyMultiSourceALTBackwardTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/core/router/speedy/SpeedyMultiSourceALTBackwardTest.java
@@ -43,7 +43,7 @@ import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
  * @author Michal Maciejewski (michalm)
  */
 public class SpeedyMultiSourceALTBackwardTest {
-	private final Network network = NetworkUtils.createTimeInvariantNetwork();
+	private final Network network = NetworkUtils.createNetwork();
 
 	// single-direction links (from right to left, e.g. B->A, but not A->B)
 	//

--- a/contribs/dvrp/src/test/java/org/matsim/core/router/speedy/SpeedyMultiSourceALTForwardTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/core/router/speedy/SpeedyMultiSourceALTForwardTest.java
@@ -41,7 +41,7 @@ import org.matsim.core.trafficmonitoring.FreeSpeedTravelTime;
  * @author Michal Maciejewski (michalm)
  */
 public class SpeedyMultiSourceALTForwardTest {
-	private final Network network = NetworkUtils.createTimeInvariantNetwork();
+	private final Network network = NetworkUtils.createNetwork();
 
 	// single-direction links (from left to right, e.g. A->B, but not B->A)
 	//

--- a/contribs/emissions/src/test/java/org/matsim/contrib/emissions/analysis/EmissionGridAnalyzerTest.java
+++ b/contribs/emissions/src/test/java/org/matsim/contrib/emissions/analysis/EmissionGridAnalyzerTest.java
@@ -55,7 +55,7 @@ public class EmissionGridAnalyzerTest {
         new EmissionGridAnalyzer.Builder()
                 .withSmoothingRadius(1)
                 .withGridSize(1000)
-                .withNetwork(NetworkUtils.createTimeInvariantNetwork())
+                .withNetwork(NetworkUtils.createNetwork())
                 .withTimeBinSize(1)
                 .build();
 
@@ -94,7 +94,7 @@ public class EmissionGridAnalyzerTest {
         final double pollutionPerEvent = 1000;
         final int time = 1;
         final Path eventsFile = Paths.get(testUtils.getOutputDirectory()).resolve(UUID.randomUUID().toString() + ".xml");
-        final Network network = NetworkUtils.createTimeInvariantNetwork();
+        final Network network = NetworkUtils.createNetwork();
         Node from = network.getFactory().createNode(Id.createNodeId("from"), new Coord(5, 5));
         network.addNode(from);
         Node to = network.getFactory().createNode(Id.createNodeId("to"), new Coord(6, 6));
@@ -133,7 +133,7 @@ public class EmissionGridAnalyzerTest {
         final double pollutionPerEvent = 1000;
         final int time = 1;
         final Path eventsFile = Paths.get(testUtils.getOutputDirectory()).resolve(UUID.randomUUID().toString() + ".xml");
-        final Network network = NetworkUtils.createTimeInvariantNetwork();
+        final Network network = NetworkUtils.createNetwork();
         Node from = network.getFactory().createNode(Id.createNodeId("from"), new Coord(5, 5));
         network.addNode(from);
         Node to = network.getFactory().createNode(Id.createNodeId("to"), new Coord(6, 6));
@@ -172,7 +172,7 @@ public class EmissionGridAnalyzerTest {
         final double pollutionPerEvent = 1000;
         final int time = 1;
         final Path eventsFile = Paths.get(testUtils.getOutputDirectory()).resolve(UUID.randomUUID().toString() + ".xml");
-        final Network network = NetworkUtils.createTimeInvariantNetwork();
+        final Network network = NetworkUtils.createNetwork();
         Node from = network.getFactory().createNode(Id.createNodeId("from"), new Coord(5, 5));
         network.addNode(from);
         Node to = network.getFactory().createNode(Id.createNodeId("to"), new Coord(6, 6));
@@ -214,7 +214,7 @@ public class EmissionGridAnalyzerTest {
         final double pollutionPerEvent = 1000;
         final int time = 1;
         final Path eventsFile = Paths.get(testUtils.getOutputDirectory()).resolve(UUID.randomUUID().toString() + ".xml");
-        final Network network = NetworkUtils.createTimeInvariantNetwork();
+        final Network network = NetworkUtils.createNetwork();
         Node from = network.getFactory().createNode(Id.createNodeId("from"), new Coord(5, 5));
         network.addNode(from);
         Node to = network.getFactory().createNode(Id.createNodeId("to"), new Coord(6, 6));

--- a/contribs/emissions/src/test/java/org/matsim/contrib/emissions/analysis/FastEmissionGridAnalyzerTest.java
+++ b/contribs/emissions/src/test/java/org/matsim/contrib/emissions/analysis/FastEmissionGridAnalyzerTest.java
@@ -189,7 +189,7 @@ public class FastEmissionGridAnalyzerTest {
         final var emissionEvents = Paths.get(utils.getOutputDirectory()).resolve("emission.events.xml.gz");
         final var biggestExpectedValue = 6.056547619047618E-6;
 
-        var network = NetworkUtils.readTimeInvariantNetwork(networkUrl.toString());
+        var network = NetworkUtils.readNetwork(networkUrl.toString());
         TestUtils.writeWarmEventsToFile(emissionEvents, network, Pollutant.NOx, 10, 1, 1);
 
         var rasterMap = FastEmissionGridAnalyzer.processEventsFile(emissionEvents.toString(), network, 1000, 1);

--- a/contribs/freight/src/test/java/org/matsim/contrib/freight/jsprit/FixedCostsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/contrib/freight/jsprit/FixedCostsTest.java
@@ -145,8 +145,8 @@ public class FixedCostsTest extends MatsimTestCase {
 		//load Network and build netbasedCosts for jsprit
 
 		URL context = org.matsim.examples.ExamplesUtils.getTestScenarioURL( "freight-chessboard-9x9" );
-		URL networkURL = IOUtils.extendUrl( context, "grid9x9.xml" );
-		Network network = NetworkUtils.createTimeInvariantNetwork();
+		URL networkURL = IOUtils.extendUrl(context, "grid9x9.xml");
+        Network network = NetworkUtils.createNetwork();
 		new MatsimNetworkReader(network).readURL(networkURL);
 
 		NetworkBasedTransportCosts.Builder netBuilder = NetworkBasedTransportCosts.Builder.newInstance( network, vehicleTypes.getVehicleTypes().values() );

--- a/contribs/freight/src/test/java/org/matsim/contrib/freight/jsprit/MatsimTransformerTest.java
+++ b/contribs/freight/src/test/java/org/matsim/contrib/freight/jsprit/MatsimTransformerTest.java
@@ -394,7 +394,7 @@ public class MatsimTransformerTest {
 	@Test
 	public void createVehicleRoutingProblemBuilderWithServices_isMadeCorrectly() {
 		Carrier carrier = createCarrierWithServices();
-		Network network = NetworkUtils.createTimeInvariantNetwork();
+        Network network = NetworkUtils.createNetwork();
 		new MatsimNetworkReader(network).readFile(testUtils.getClassInputDirectory() + "grid-network.xml");
 		VehicleRoutingProblem.Builder vrpBuilder = MatsimJspritFactory.createRoutingProblemBuilder(carrier, network);
 		VehicleRoutingProblem vrp = vrpBuilder.build();
@@ -446,8 +446,8 @@ public class MatsimTransformerTest {
 	@Test
 //	@Ignore		//Set to ignore due to not implemented functionality of Shipments in MatsimJspritFactory
 	public void createVehicleRoutingProblemBuilderWithShipments_isMadeCorrectly() {
-		Carrier carrier = createCarrierWithShipments();
-		Network network = NetworkUtils.createTimeInvariantNetwork();
+        Carrier carrier = createCarrierWithShipments();
+        Network network = NetworkUtils.createNetwork();
 		new MatsimNetworkReader(network).readFile(testUtils.getClassInputDirectory() + "grid-network.xml");
 		VehicleRoutingProblem.Builder vrpBuilder = MatsimJspritFactory.createRoutingProblemBuilder(carrier, network);
 		VehicleRoutingProblem vrp = vrpBuilder.build();

--- a/contribs/freight/src/test/java/org/matsim/contrib/freight/utils/FreightUtilsIT.java
+++ b/contribs/freight/src/test/java/org/matsim/contrib/freight/utils/FreightUtilsIT.java
@@ -118,7 +118,7 @@ public class FreightUtilsIT {
 		new CarrierVehicleTypeLoader(carriersWithServicesAndShpiments).loadVehicleTypes(vehicleTypes) ;
 
 		//load Network and build netbasedCosts for jsprit
-		Network network = NetworkUtils.createTimeInvariantNetwork();
+		Network network = NetworkUtils.createNetwork();
 		new MatsimNetworkReader(network).readFile(testUtils.getPackageInputDirectory() + "grid-network.xml");
 		Builder netBuilder = NetworkBasedTransportCosts.Builder.newInstance( network, vehicleTypes.getVehicleTypes().values() );
 		final NetworkBasedTransportCosts netBasedCosts = netBuilder.build() ;

--- a/contribs/freight/src/test/java/org/matsim/contrib/freight/utils/FreightUtilsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/contrib/freight/utils/FreightUtilsTest.java
@@ -126,7 +126,7 @@ public class FreightUtilsTest {
 		new CarrierVehicleTypeLoader(carriersWithServicesAndShpiments).loadVehicleTypes(vehicleTypes) ;
 
 		//load Network and build netbasedCosts for jsprit
-		Network network = NetworkUtils.createTimeInvariantNetwork();
+		Network network = NetworkUtils.createNetwork();
 		new MatsimNetworkReader(network).readFile(testUtils.getPackageInputDirectory() + "grid-network.xml");
 		Builder netBuilder = NetworkBasedTransportCosts.Builder.newInstance( network, vehicleTypes.getVehicleTypes().values() );
 		final NetworkBasedTransportCosts netBasedCosts = netBuilder.build() ;
@@ -324,7 +324,7 @@ public class FreightUtilsTest {
 		CarrierShipment shipment1 = createMatsimShipment("shipment1", "i(1,0)", "i(7,6)R", 1);
 		CarrierUtils.addShipment(carrierMixedWServicesAndShipments, shipment1);
 
-		Network network = NetworkUtils.createTimeInvariantNetwork();
+        Network network = NetworkUtils.createNetwork();
 		new MatsimNetworkReader(network).readFile(testUtils.getPackageInputDirectory() + "grid-network.xml");
 
 		MatsimJspritFactory.createRoutingProblemBuilder(carrierMixedWServicesAndShipments, network);

--- a/contribs/minibus/src/test/java/org/matsim/contrib/minibus/schedule/CreatePStopsOnJunctionApproachesAndBetweenJunctionsTest.java
+++ b/contribs/minibus/src/test/java/org/matsim/contrib/minibus/schedule/CreatePStopsOnJunctionApproachesAndBetweenJunctionsTest.java
@@ -222,7 +222,7 @@ public class CreatePStopsOnJunctionApproachesAndBetweenJunctionsTest {
 	 *                                                        26
 	 */
 	private Network buildComplexIntersection() {
-		Network network = NetworkUtils.createTimeInvariantNetwork();
+		Network network = NetworkUtils.createNetwork();
 
 		/* Left cluster */
 		Node n01 = NetworkUtils.createAndAddNode(network, Id.createNodeId( 1), CoordUtils.createCoord(  0.0,  85.0));

--- a/contribs/noise/src/main/java/org/matsim/contrib/noise/OSM2Intersection.java
+++ b/contribs/noise/src/main/java/org/matsim/contrib/noise/OSM2Intersection.java
@@ -85,7 +85,7 @@ public class OSM2Intersection {
 
         @Override
         public void complete() {
-            Network network = NetworkUtils.createTimeInvariantNetwork();
+            Network network = NetworkUtils.createNetwork();
             new MatsimNetworkReader(network).readFile("D:\\resultStorage\\moia-msm\\realisticModeChoice\\outputMixedCarOnly126\\croppedDenseNetwork_surface.xml.gz");
 
             TLongObjectMap<List<Link>> id2Link = new TLongObjectHashMap<>();

--- a/contribs/noise/src/main/java/org/matsim/contrib/noise/OSM2Surface.java
+++ b/contribs/noise/src/main/java/org/matsim/contrib/noise/OSM2Surface.java
@@ -77,7 +77,7 @@ public class OSM2Surface {
 
         @Override
         public void complete() {
-            Network network = NetworkUtils.createTimeInvariantNetwork();
+            Network network = NetworkUtils.createNetwork();
             new MatsimNetworkReader(network).readFile("D:\\resultStorage\\moia-msm\\realisticModeChoice\\outputMixedCarOnly126\\croppedDenseNetwork.xml.gz");
 
             TLongObjectMap<List<Link>> id2Link = new TLongObjectHashMap<>();

--- a/contribs/noise/src/test/java/org/matsim/contrib/noise/NoiseRLS19IT.java
+++ b/contribs/noise/src/test/java/org/matsim/contrib/noise/NoiseRLS19IT.java
@@ -80,9 +80,9 @@ public class NoiseRLS19IT {
         ShieldingContext context = new ShieldingContext(config, shieldingCorrection, barrierContext);
 
 
-        ReceiverPoint rp = new NoiseReceiverPoint(Id.create("a", ReceiverPoint.class), new Coord(0,0));
-        Network network = NetworkUtils.createTimeInvariantNetwork();
-        Node from = NetworkUtils.createNode(Id.createNodeId("node1"), new Coord(6,7));
+        ReceiverPoint rp = new NoiseReceiverPoint(Id.create("a", ReceiverPoint.class), new Coord(0, 0));
+        Network network = NetworkUtils.createNetwork();
+        Node from = NetworkUtils.createNode(Id.createNodeId("node1"), new Coord(6, 7));
         Node to = NetworkUtils.createNode(Id.createNodeId("node1"), new Coord(7,6));
         Link link = NetworkUtils.createLink(Id.createLinkId("link"), from, to, network, 10, 0,0,0);
         final Coord coord = CoordUtils.orthogonalProjectionOnLineSegment(

--- a/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/SupersonicOsmNetworkReader.java
+++ b/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/SupersonicOsmNetworkReader.java
@@ -98,7 +98,7 @@ public class SupersonicOsmNetworkReader {
         parser.parse(inputFile);
 
         // set up state for convertion of parsed osm data
-        this.network = NetworkUtils.createTimeInvariantNetwork();
+        this.network = NetworkUtils.createNetwork();
         this.ways = parser.getWays();
         this.nodes = parser.getNodes();
 

--- a/contribs/osm/src/test/java/org/matsim/contrib/osm/networkReader/OsmBicycleReaderIT.java
+++ b/contribs/osm/src/test/java/org/matsim/contrib/osm/networkReader/OsmBicycleReaderIT.java
@@ -28,7 +28,7 @@ public class OsmBicycleReaderIT {
 				.build()
 				.read(inputFile);
 
-		Network expectedResult = NetworkUtils.readTimeInvariantNetwork(Paths.get(matsimTestUtils.getInputDirectory()).resolve("expected-result.xml.gz").toString());
+		Network expectedResult = NetworkUtils.readNetwork(Paths.get(matsimTestUtils.getInputDirectory()).resolve("expected-result.xml.gz").toString());
 
 		Utils.assertEquals(expectedResult, network);
 	}

--- a/contribs/osm/src/test/java/org/matsim/contrib/osm/networkReader/SupersonicOsmNetworkReaderIT.java
+++ b/contribs/osm/src/test/java/org/matsim/contrib/osm/networkReader/SupersonicOsmNetworkReaderIT.java
@@ -28,7 +28,7 @@ public class SupersonicOsmNetworkReaderIT {
 				.build()
 				.read(Paths.get(utils.getPackageInputDirectory()).resolve("andorra-latest.osm.pbf"));
 
-		Network expectedResult = NetworkUtils.readTimeInvariantNetwork(Paths.get(utils.getInputDirectory()).resolve("expected-result.xml.gz").toString());
+		Network expectedResult = NetworkUtils.readNetwork(Paths.get(utils.getInputDirectory()).resolve("expected-result.xml.gz").toString());
 
 		log.info("expected result contains: " + expectedResult.getLinks().size() + " links and " + expectedResult.getNodes().size() + " nodes");
 		log.info("result contains: " + network.getLinks().size() + " links and " + network.getNodes().size() + " nodes");

--- a/contribs/sharing/src/main/java/org/matsim/contrib/sharing/utils/ReadGBFS.java
+++ b/contribs/sharing/src/main/java/org/matsim/contrib/sharing/utils/ReadGBFS.java
@@ -52,13 +52,13 @@ public class ReadGBFS {
 
 		// Filter network according to modes
 
-		Network fullNetwork = NetworkUtils.createTimeInvariantNetwork();
+		Network fullNetwork = NetworkUtils.createNetwork();
 		new MatsimNetworkReader(fullNetwork).readFile(cmd.getOptionStrict("network-path"));
 
 		Set<String> modes = Arrays.asList(cmd.getOptionStrict("network-modes").split(",")).stream().map(String::trim)
 				.collect(Collectors.toSet());
 
-		Network network = NetworkUtils.createTimeInvariantNetwork();
+        Network network = NetworkUtils.createNetwork();
 		new TransportModeNetworkFilter(fullNetwork).filter(network, modes);
 
 		// Load main feed

--- a/contribs/sharing/src/main/java/org/matsim/contrib/sharing/utils/WriteStationShapefile.java
+++ b/contribs/sharing/src/main/java/org/matsim/contrib/sharing/utils/WriteStationShapefile.java
@@ -30,7 +30,7 @@ public class WriteStationShapefile {
 		SharingServiceSpecification service = new DefaultSharingServiceSpecification();
 		new SharingServiceReader(service).readFile(cmd.getOptionStrict("service-path"));
 
-		Network network = NetworkUtils.createTimeInvariantNetwork();
+		Network network = NetworkUtils.createNetwork();
 		new MatsimNetworkReader(network).readFile(cmd.getOptionStrict("network-path"));
 
 		CoordinateReferenceSystem crs = MGC.getCRS(cmd.getOptionStrict("crs"));

--- a/contribs/sumo/src/main/java/org/matsim/contrib/sumo/SumoNetworkConverter.java
+++ b/contribs/sumo/src/main/java/org/matsim/contrib/sumo/SumoNetworkConverter.java
@@ -120,7 +120,7 @@ public class SumoNetworkConverter implements Callable<Integer> {
     public Integer call() throws Exception {
 
 
-        Network network = NetworkUtils.createTimeInvariantNetwork();
+        Network network = NetworkUtils.createNetwork();
         Lanes lanes = LanesUtils.createLanesContainer();
 
         SumoNetworkHandler handler = convert(network, lanes);

--- a/contribs/sumo/src/test/java/org/matsim/contrib/sumo/SumoNetworkConverterTest.java
+++ b/contribs/sumo/src/test/java/org/matsim/contrib/sumo/SumoNetworkConverterTest.java
@@ -6,22 +6,18 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.api.core.v01.network.Node;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.lanes.LanesReader;
 import org.matsim.lanes.LanesToLinkAssignment;
-import org.matsim.lanes.LanesUtils;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.SortedMap;
-import java.util.stream.Collectors;
 
 public class SumoNetworkConverterTest {
 
@@ -38,7 +34,7 @@ public class SumoNetworkConverterTest {
 
         converter.call();
 
-        Network network = NetworkUtils.readTimeInvariantNetwork(output.toString());
+        Network network = NetworkUtils.readNetwork(output.toString());
 
         assert network.getNodes().size() == 21 : "Must contain 21 nodes";
         assert network.getNodes().containsKey(Id.createNodeId("251106770")) : "Must contain specific id";

--- a/contribs/taxi/src/test/java/org/matsim/contrib/taxi/fare/TaxiFareHandlerTest.java
+++ b/contribs/taxi/src/test/java/org/matsim/contrib/taxi/fare/TaxiFareHandlerTest.java
@@ -105,8 +105,8 @@ public class TaxiFareHandlerTest {
 	}
 
 	private Network createNetwork() {
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node n1 = NetworkUtils.createNode(Id.createNodeId(1), new Coord(0, 0));
+		Network network = NetworkUtils.createNetwork();
+        Node n1 = NetworkUtils.createNode(Id.createNodeId(1), new Coord(0, 0));
 		Node n2 = NetworkUtils.createNode(Id.createNodeId(2), new Coord(2000, 0));
 		Node n3 = NetworkUtils.createNode(Id.createNodeId(3), new Coord(2000, 2000));
 		Node n4 = NetworkUtils.createNode(Id.createNodeId(4), new Coord(2100, 2000));

--- a/contribs/vsp/src/main/java/org/matsim/contrib/freight/analysis/RunFreightAnalysis.java
+++ b/contribs/vsp/src/main/java/org/matsim/contrib/freight/analysis/RunFreightAnalysis.java
@@ -54,7 +54,7 @@ public class RunFreightAnalysis {
        File vehiclesFile = new File(inputPath + "/output_allVehicles.xml.gz");
        File eventsFile = new File(inputPath + "/output_events.xml.gz");
 
-       Network network = NetworkUtils.readTimeInvariantNetwork(networkFile.getAbsolutePath());
+       Network network = NetworkUtils.readNetwork(networkFile.getAbsolutePath());
 
        Carriers carriers = new Carriers();
        new CarrierPlanXmlReader(carriers).readFile(carrierFile.getAbsolutePath());

--- a/contribs/vsp/src/main/java/playground/vsp/andreas/fcd/Fcd.java
+++ b/contribs/vsp/src/main/java/playground/vsp/andreas/fcd/Fcd.java
@@ -246,7 +246,7 @@ public class Fcd {
 	
 	private void writeNetworkFromEvents(String netOutFile) {
 		log.info("Creating network from fcd events...");
-		Network net = NetworkUtils.createTimeInvariantNetwork();
+		Network net = NetworkUtils.createNetwork();
 		
 		FcdEvent lastEvent = null;
 		for (Iterator<FcdEvent> iterator = this.fcdEventsList.iterator(); iterator.hasNext();) {

--- a/contribs/vsp/src/main/java/playground/vsp/andreas/mzilske/bvg09/DataPrepare.java
+++ b/contribs/vsp/src/main/java/playground/vsp/andreas/mzilske/bvg09/DataPrepare.java
@@ -135,8 +135,8 @@ public class DataPrepare {
 	}
 
 	protected void createNetworkFromSchedule() {
-		this.pseudoNetwork = NetworkUtils.createTimeInvariantNetwork();
-		new CreatePseudoNetwork(this.scenario.getTransitSchedule(), this.pseudoNetwork, "tr_").createNetwork();
+		this.pseudoNetwork = NetworkUtils.createNetwork();
+        new CreatePseudoNetwork(this.scenario.getTransitSchedule(), this.pseudoNetwork, "tr_").createNetwork();
 	}
 
 	protected void mergeNetworks() {

--- a/contribs/vsp/src/main/java/playground/vsp/andreas/mzilske/osm/Stitcher.java
+++ b/contribs/vsp/src/main/java/playground/vsp/andreas/mzilske/osm/Stitcher.java
@@ -44,7 +44,7 @@ public class Stitcher {
 
 	private Network network;
 
-	private Network networkForThisRoute = NetworkUtils.createTimeInvariantNetwork();
+	private Network networkForThisRoute = NetworkUtils.createNetwork();
 
 	private LinkedList<Id<Node>> forwardStops = new LinkedList<>();
 

--- a/contribs/vsp/src/main/java/playground/vsp/andreas/utils/net/OSM2MATSim.java
+++ b/contribs/vsp/src/main/java/playground/vsp/andreas/utils/net/OSM2MATSim.java
@@ -24,7 +24,7 @@ public class OSM2MATSim {
 
 	public static void main(final String[] args) {
 
-		Network network = NetworkUtils.createTimeInvariantNetwork();
+		Network network = NetworkUtils.createNetwork();
 //		OsmNetworkReader osmReader = new OsmNetworkReader(network, new WGS84toCH1903LV03());
 		OsmNetworkReader osmReader = new OsmNetworkReader(network,
 				TransformationFactory.getCoordinateTransformation(TransformationFactory.WGS84,

--- a/contribs/vsp/src/main/java/playground/vsp/flowEfficiency/LinkTurnDirectionAttributesFromGraphHopper.java
+++ b/contribs/vsp/src/main/java/playground/vsp/flowEfficiency/LinkTurnDirectionAttributesFromGraphHopper.java
@@ -36,7 +36,6 @@ import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.contrib.accessibility.utils.NetworkUtil;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.utils.geometry.CoordinateTransformation;
 import org.matsim.core.utils.geometry.transformations.GeotoolsTransformation;
@@ -96,7 +95,7 @@ public class LinkTurnDirectionAttributesFromGraphHopper implements Callable<Inte
 
     public LinkTurnDirectionAttributesFromGraphHopper(String osmFilePath) {
         this.osm = Path.of(osmFilePath);
-    };
+    }
 
     private LinkTurnDirectionAttributesFromGraphHopper(String osmFilePath, String matsimNetworkFilePath, String networkCrs) {
         this.osm = Path.of(osmFilePath);
@@ -121,7 +120,7 @@ public class LinkTurnDirectionAttributesFromGraphHopper implements Callable<Inte
 
 
     public Network assignLinkTurnAttributes(Path input, String networkCrs){
-        Network network = NetworkUtils.readTimeInvariantNetwork(input.toString());
+        Network network = NetworkUtils.readNetwork(input.toString());
         return assignLinkTurnAttributes(network, networkCrs);
     }
 

--- a/matsim/src/main/java/org/matsim/core/network/NetworkUtils.java
+++ b/matsim/src/main/java/org/matsim/core/network/NetworkUtils.java
@@ -32,6 +32,7 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.NetworkWriter;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.groups.NetworkConfigGroup;
 import org.matsim.core.gbl.Gbl;
 import org.matsim.core.network.algorithms.NetworkSimplifier;
@@ -49,23 +50,38 @@ import org.matsim.core.utils.misc.OptionalTime;
 public final class NetworkUtils {
 
 	private static final Logger log = Logger.getLogger(NetworkUtils.class);
-	
+
+	/**
+	 * This will create a time invariant network.
+	 *
+	 * @return Empty time invariant MATSim network
+	 */
+	public static Network createNetwork() {
+		return createNetwork(ConfigUtils.createConfig());
+	}
+
+	/**
+	 * Override for {@link NetworkUtils#createNetwork(NetworkConfigGroup)}
+	 */
 	public static Network createNetwork(Config config) {
 		return createNetwork(config.network());
 	}
 
+	/**
+	 * Creates a network based on the properties found in network config group. Either returns a default network or
+	 * a time variable network
+	 *
+	 * @param networkConfigGroup the 'isTimeVariantNetwork' property is read
+	 * @return Empty MATSim network
+	 */
 	public static Network createNetwork(NetworkConfigGroup networkConfigGroup) {
 		LinkFactory linkFactory = new LinkFactoryImpl();
-		
+
 		if (networkConfigGroup.isTimeVariantNetwork()) {
 			linkFactory = new VariableIntervalTimeVariantLinkFactory();
 		}
-		
-		return new NetworkImpl(linkFactory);
-	}
 
-	public static Network createNetwork() {
-		return new NetworkImpl(new LinkFactoryImpl());
+		return new NetworkImpl(linkFactory);
 	}
 
 	/**
@@ -99,7 +115,7 @@ public final class NetworkUtils {
 	 * @return array containing the nodes, sorted ascending by id.
 	 */
 	public static Node[] getSortedNodes(final Network network) {
-		Node[] nodes = network.getNodes().values().toArray(new Node[network.getNodes().size()]);
+		Node[] nodes = network.getNodes().values().toArray(Node[]::new);
 		Arrays.sort(nodes, Comparator.comparing(Identifiable::getId));
 		return nodes;
 	}
@@ -134,7 +150,7 @@ public final class NetworkUtils {
 	 * @return array containing the links, sorted ascending by id.
 	 */
 	public static Link[] getSortedLinks(final Network network) {
-		Link[] links = network.getLinks().values().toArray(new Link[network.getLinks().size()]);
+		Link[] links = network.getLinks().values().toArray(Link[]::new);
 		Arrays.sort(links, Comparator.comparing(Identifiable::getId));
 		return links;
 	}
@@ -414,19 +430,19 @@ public final class NetworkUtils {
         if (nearestRightLink == null) {
             return nearestOverallLink;
         }
-        return nearestRightLink;
-    }
+		return nearestRightLink;
+	}
 
-    /**
-     * Finds the (approx.) nearest link to a given point on the map.
-     * It searches first for the nearest node, and then for the nearest link
-     * originating or ending at that node.
-     *
-     * @param coord
-     *          the coordinate for which the closest link should be found
-     * @return the link found closest to coord
-     * 
-     * @see {@link NetworkUtils#getNearestLinkExactly(Network, Coord)}
+	/**
+	 * Finds the (approx.) nearest link to a given point on the map.
+	 * It searches first for the nearest node, and then for the nearest link
+	 * originating or ending at that node.
+	 *
+	 * @param coord
+	 *          the coordinate for which the closest link should be found
+	 * @return the link found closest to coord
+	 *
+	 * @see NetworkUtils#getNearestLinkExactly(Network, Coord)
      */
     public static Link getNearestLink(Network network, final Coord coord) {
         Link nearestLink = null;
@@ -887,17 +903,17 @@ public final class NetworkUtils {
 		return true;
 	}
 
-	public static NetworkCollector getCollector(NetworkConfigGroup networkConfigGroup) {
-		return new NetworkCollector(networkConfigGroup);
+	public static NetworkCollector getCollector() {
+		NetworkConfigGroup networkConfigGroup = new NetworkConfigGroup();
+		networkConfigGroup.setTimeVariantNetwork(false);
+		return getCollector(networkConfigGroup);
 	}
 
 	public static NetworkCollector getCollector(Config config) {
-		return new NetworkCollector(config.network());
+		return getCollector(config.network());
 	}
-	
-	public static NetworkCollector getTimeInvariantCollector() {
-		NetworkConfigGroup networkConfigGroup = new NetworkConfigGroup();
-		networkConfigGroup.setTimeVariantNetwork(false);
+
+	public static NetworkCollector getCollector(NetworkConfigGroup networkConfigGroup) {
 		return new NetworkCollector(networkConfigGroup);
 	}
 

--- a/matsim/src/main/java/org/matsim/core/network/NetworkUtils.java
+++ b/matsim/src/main/java/org/matsim/core/network/NetworkUtils.java
@@ -803,10 +803,6 @@ public final class NetworkUtils {
 		return null;
 	}
 
-	public static void readNetwork(Network network, String string) {
-		new MatsimNetworkReader(network).readFile(string);
-	}
-
 	public static OptionalTime getLinkAccessTime(Link link, String routingMode){
 		String attribute = NetworkRoutingInclAccessEgressModule.ACCESSTIMELINKATTRIBUTEPREFIX+routingMode;
 		Object o = link.getAttributes().getAttribute(attribute);
@@ -821,44 +817,33 @@ public final class NetworkUtils {
 		link.getAttributes().putAttribute(attribute,accessTime);
 	}
 
-	public static OptionalTime getLinkEgressTime(Link link, String routingMode){
-		String attribute = NetworkRoutingInclAccessEgressModule.EGRESSTIMELINKATTRIBUTEPREFIX+routingMode;
+	public static OptionalTime getLinkEgressTime(Link link, String routingMode) {
+		String attribute = NetworkRoutingInclAccessEgressModule.EGRESSTIMELINKATTRIBUTEPREFIX + routingMode;
 		Object o = link.getAttributes().getAttribute(attribute);
-		if (o!=null){
+		if (o != null) {
 			return OptionalTime.defined((double) o);
-		}
-		else return OptionalTime.undefined();
+		} else return OptionalTime.undefined();
 	}
 
-	public static void setLinkEgressTime(Link link, String routingMode, double egressTime){
-		String attribute = NetworkRoutingInclAccessEgressModule.EGRESSTIMELINKATTRIBUTEPREFIX+routingMode;
-		link.getAttributes().putAttribute(attribute,egressTime);
+	public static void setLinkEgressTime(Link link, String routingMode, double egressTime) {
+		String attribute = NetworkRoutingInclAccessEgressModule.EGRESSTIMELINKATTRIBUTEPREFIX + routingMode;
+		link.getAttributes().putAttribute(attribute, egressTime);
 	}
 
-
-	public static Network readNetwork(String string, Config config) {
-		return readNetwork(string, config.network());
+	public static Network readNetwork(String filename) {
+		return readNetwork(filename, ConfigUtils.createConfig());
 	}
 
-	public static Network readNetwork(String string, NetworkConfigGroup networkConfigGroup) {
+	public static Network readNetwork(String filename, Config config) {
+		return readNetwork(filename, config.network());
+	}
+
+	public static Network readNetwork(String filename, NetworkConfigGroup networkConfigGroup) {
 		Network network = createNetwork(networkConfigGroup);
-		new MatsimNetworkReader(network).readFile(string);
+		new MatsimNetworkReader(network).readFile(filename);
 		return network;
-	}
-	
-	public static Network readTimeInvariantNetwork(String string) {
-		Network network = createNetwork();
-		new MatsimNetworkReader(network).readFile(string);
-		return network;
-	}
-	
-	@Deprecated
-	public static Network readNetwork(String string) {
-		log.warn("Using NetworkUtils.readNetwork() is deprecated. Use readNetwork(Path, Config) or readTimeInvariantNetwork(Path) and see createNetwork() for further information.");
-		return readTimeInvariantNetwork(string);
 	}
 
-	
 	/**
 	 * reads network form file and applies a coordinate transformation.
 	 * @param filename network file name
@@ -873,6 +858,10 @@ public final class NetworkUtils {
 					node.setCoord(transformedCoord);
 				});
 		return network;
+	}
+
+	public static void readNetwork(Network network, String string) {
+		new MatsimNetworkReader(network).readFile(string);
 	}
 
 	public static boolean compare(Network expected, Network actual) {

--- a/matsim/src/main/java/org/matsim/core/network/NetworkUtils.java
+++ b/matsim/src/main/java/org/matsim/core/network/NetworkUtils.java
@@ -63,28 +63,8 @@ public final class NetworkUtils {
 		
 		return new NetworkImpl(linkFactory);
 	}
-	
-	public static Network createTimeInvariantNetwork() {
-		return new NetworkImpl(new LinkFactoryImpl());
-	}
-	
-	/**
-	 * This function is deprecated as it creates by default a non-time-varying
-	 * network. This poses problems where, for instance, you have a time-varying
-	 * network and want to use a TransportModeNetworkFilter to extract a specific
-	 * model network. Before, the time-varying information would have been lost,
-	 * because the present method was used to create the new network to which the
-	 * filtered links were added. Hence, make use of createNetwork(Config) or
-	 * createNetwork(NetworkConfigGroup) to avoid these errors.
-	 * 
-	 * If you're sure that your network will remain time invariant, use
-	 * NetworkUtils.createTimeInvariantNetwork().
-	 * 
-	 * @return
-	 */
-	@Deprecated
+
 	public static Network createNetwork() {
-		log.warn("Using NetworkUtils.createNetwork() is deprecated. Use createNetwork(Config).");
 		return new NetworkImpl(new LinkFactoryImpl());
 	}
 
@@ -851,7 +831,7 @@ public final class NetworkUtils {
 	}
 	
 	public static Network readTimeInvariantNetwork(String string) {
-		Network network = createTimeInvariantNetwork();
+		Network network = createNetwork();
 		new MatsimNetworkReader(network).readFile(string);
 		return network;
 	}

--- a/matsim/src/main/java/org/matsim/core/network/algorithms/NetworkInverter.java
+++ b/matsim/src/main/java/org/matsim/core/network/algorithms/NetworkInverter.java
@@ -67,7 +67,7 @@ public final class NetworkInverter {
 	}
 
 	private void invertNetwork(){
-		this.invertedNetwork = NetworkUtils.createTimeInvariantNetwork();
+		this.invertedNetwork = NetworkUtils.createNetwork();
 		int numberOfNodesGenerated = 0;
 		int numberOfLinksGenerated = 0;
 

--- a/matsim/src/main/java/org/matsim/core/network/algorithms/intersectionSimplifier/IntersectionSimplifier.java
+++ b/matsim/src/main/java/org/matsim/core/network/algorithms/intersectionSimplifier/IntersectionSimplifier.java
@@ -71,7 +71,7 @@ public class IntersectionSimplifier {
 
 		LOG.info("Simplifying the intersections...");
 		reportNetworkStatistics(network);
-		Network newNetwork = NetworkUtils.createTimeInvariantNetwork();
+		Network newNetwork = NetworkUtils.createNetwork();
 
 		/* Get all the network's node coordinates that must be clustered. */
 		List<Node> nodes = new ArrayList<>();

--- a/matsim/src/main/java/org/matsim/core/network/algorithms/intersectionSimplifier/RunIntersectionSimplifier.java
+++ b/matsim/src/main/java/org/matsim/core/network/algorithms/intersectionSimplifier/RunIntersectionSimplifier.java
@@ -52,7 +52,7 @@ public class RunIntersectionSimplifier {
 		String input = args[0];
 		String output = args[1];
 		
-		Network network = NetworkUtils.createTimeInvariantNetwork();
+		Network network = NetworkUtils.createNetwork();
 		new MatsimNetworkReader(network).readFile(input);
 		
 		IntersectionSimplifier ns = new IntersectionSimplifier(30.0, 2);

--- a/matsim/src/main/java/org/matsim/run/TeleAtlas2Network.java
+++ b/matsim/src/main/java/org/matsim/run/TeleAtlas2Network.java
@@ -305,8 +305,8 @@ public class TeleAtlas2Network {
 //		str = str.trim();
 //		args = str.split(" ");
 
-		network = NetworkUtils.createTimeInvariantNetwork();
-		parseArguments(args);
+		network = NetworkUtils.createNetwork();
+        parseArguments(args);
 		convert();
 		// TODO balmermi: more options
 		// transform // -t WGS84toCH1903LV03

--- a/matsim/src/test/java/org/matsim/analysis/LegHistogramTest.java
+++ b/matsim/src/test/java/org/matsim/analysis/LegHistogramTest.java
@@ -47,8 +47,8 @@ public class LegHistogramTest extends MatsimTestCase {
 	 * handled correctly.
 	 */
 	public void testDeparturesMiscModes() {
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node1 = NetworkUtils.createAndAddNode(network, Id.create(1, Node.class), new Coord((double) 0, (double) 0));
+		Network network = NetworkUtils.createNetwork();
+        Node node1 = NetworkUtils.createAndAddNode(network, Id.create(1, Node.class), new Coord((double) 0, (double) 0));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create(2, Node.class), new Coord((double) 1000, (double) 0));
 		final Node fromNode = node1;
 		final Node toNode = node2;
@@ -100,8 +100,8 @@ public class LegHistogramTest extends MatsimTestCase {
 	 * do not lead to an exception.
 	 */
 	public void testNofBins() {
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node1 = NetworkUtils.createAndAddNode(network, Id.create(1, Node.class), new Coord((double) 0, (double) 0));
+        Network network = NetworkUtils.createNetwork();
+        Node node1 = NetworkUtils.createAndAddNode(network, Id.create(1, Node.class), new Coord((double) 0, (double) 0));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create(2, Node.class), new Coord((double) 1000, (double) 0));
 		final Node fromNode = node1;
 		final Node toNode = node2;
@@ -140,8 +140,8 @@ public class LegHistogramTest extends MatsimTestCase {
 	}
 
 	public void testReset() {
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node1 = NetworkUtils.createAndAddNode(network, Id.create(1, Node.class), new Coord((double) 0, (double) 0));
+        Network network = NetworkUtils.createNetwork();
+        Node node1 = NetworkUtils.createAndAddNode(network, Id.create(1, Node.class), new Coord((double) 0, (double) 0));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create(2, Node.class), new Coord((double) 1000, (double) 0));
 		final Node fromNode = node1;
 		final Node toNode = node2;

--- a/matsim/src/test/java/org/matsim/analysis/TripsAndLegsCSVWriterTest.java
+++ b/matsim/src/test/java/org/matsim/analysis/TripsAndLegsCSVWriterTest.java
@@ -659,7 +659,7 @@ public class TripsAndLegsCSVWriterTest {
 	/**************************Creating a network*********************************/
 	private void createNetwork() {
 
-		Network network = NetworkUtils.createTimeInvariantNetwork();
+		Network network = NetworkUtils.createNetwork();
 		NetworkFactory factory = network.getFactory();
 		
 		Node n0, n1, n2, n3;

--- a/matsim/src/test/java/org/matsim/core/events/BasicEventsHandlerTest.java
+++ b/matsim/src/test/java/org/matsim/core/events/BasicEventsHandlerTest.java
@@ -41,8 +41,8 @@ public class BasicEventsHandlerTest extends MatsimTestCase {
 		events.addHandler(handler);
 		events.initProcessing();
 
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node1 = network.getFactory().createNode(Id.create(1, Node.class), new Coord((double) 0, (double) 0));
+		Network network = NetworkUtils.createNetwork();
+        Node node1 = network.getFactory().createNode(Id.create(1, Node.class), new Coord((double) 0, (double) 0));
 		Node node2 = network.getFactory().createNode(Id.create(2, Node.class), new Coord((double) 1000, (double) 0));
 		final Node from = node1;
 		final Node to = node2;

--- a/matsim/src/test/java/org/matsim/core/mobsim/qsim/pt/UmlaufDriverTest.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/qsim/pt/UmlaufDriverTest.java
@@ -81,8 +81,8 @@ public class UmlaufDriverTest extends MatsimTestCase {
 		TransitLine tLine = builder.createTransitLine(Id.create("L", TransitLine.class));
 		ArrayList<Id<Link>> linkIds = new ArrayList<Id<Link>>();
 
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
+		Network network = NetworkUtils.createNetwork();
+        Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create("2", Node.class), new Coord((double) 1000, (double) 0));
 		Node node3 = NetworkUtils.createAndAddNode(network, Id.create("3", Node.class), new Coord((double) 2000, (double) 0));
 		Node node4 = NetworkUtils.createAndAddNode(network, Id.create("4", Node.class), new Coord((double) 3000, (double) 0));

--- a/matsim/src/test/java/org/matsim/core/mobsim/qsim/qnetsimengine/EquiDistAgentSnapshotInfoBuilderTest.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/qsim/qnetsimengine/EquiDistAgentSnapshotInfoBuilderTest.java
@@ -118,7 +118,7 @@ public class EquiDistAgentSnapshotInfoBuilderTest {
                 Id.createLinkId(1),
                 NetworkUtils.createNode(Id.createNodeId(1), fromCoord),
                 NetworkUtils.createNode(Id.createNodeId(2), toCoord),
-                NetworkUtils.createTimeInvariantNetwork(),
+                NetworkUtils.createNetwork(),
                 linkLength,
                 freespeed,
                 linkCapacity,

--- a/matsim/src/test/java/org/matsim/core/mobsim/qsim/qnetsimengine/QueueAgentSnapshotInfoBuilderTest.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/qsim/qnetsimengine/QueueAgentSnapshotInfoBuilderTest.java
@@ -255,7 +255,7 @@ public class QueueAgentSnapshotInfoBuilderTest {
                 Id.createLinkId(1),
                 NetworkUtils.createNode(Id.createNodeId(1), fromCoord),
                 NetworkUtils.createNode(Id.createNodeId(2), toCoord),
-                NetworkUtils.createTimeInvariantNetwork(),
+                NetworkUtils.createNetwork(),
                 linkLength,
                 freespeed,
                 linkCapacity,

--- a/matsim/src/test/java/org/matsim/core/network/AbstractNetworkWriterReaderTest.java
+++ b/matsim/src/test/java/org/matsim/core/network/AbstractNetworkWriterReaderTest.java
@@ -137,7 +137,7 @@ public abstract class AbstractNetworkWriterReaderTest extends MatsimTestCase {
 	}
 
 	public void testNodes_IdSpecialCharacters() {
-		Network network1 = NetworkUtils.createTimeInvariantNetwork();
+		Network network1 = NetworkUtils.createNetwork();
 		NetworkFactory nf = network1.getFactory();
 		Node nodeA1 = nf.createNode(Id.create("A & 1 <a>\"'aa", Node.class), new Coord(100, 200));
 		Node nodeB1 = nf.createNode(Id.create("B & 1 <b>\"'bb", Node.class), new Coord(100, 200));
@@ -155,7 +155,7 @@ public abstract class AbstractNetworkWriterReaderTest extends MatsimTestCase {
 	}
 
 	public void testLinks_IdSpecialCharacters() {
-		Network network1 = NetworkUtils.createTimeInvariantNetwork();
+		Network network1 = NetworkUtils.createNetwork();
 		NetworkFactory nf = network1.getFactory();
 		Node nodeA1 = nf.createNode(Id.create("A & 1 <a>\"'aa", Node.class), new Coord(100, 200));
 		Node nodeB1 = nf.createNode(Id.create("B & 1 <b>\"'bb", Node.class), new Coord(100, 200));
@@ -183,7 +183,7 @@ public abstract class AbstractNetworkWriterReaderTest extends MatsimTestCase {
 	}
 
 	public void testNetwork_NameSpecialCharacters() {
-		Network network1 = NetworkUtils.createTimeInvariantNetwork();
+		Network network1 = NetworkUtils.createNetwork();
 		network1.setName("Special & characters < are > in \" this ' name.");
 		NetworkFactory nf = network1.getFactory();
 		Node nodeA1 = nf.createNode(Id.create("1", Node.class), new Coord(100, 200));
@@ -204,7 +204,7 @@ public abstract class AbstractNetworkWriterReaderTest extends MatsimTestCase {
 	}
 
 	private void doTestAllowedModes(final Set<String> modes, final String filename) {
-		Network network1 = NetworkUtils.createTimeInvariantNetwork();
+		Network network1 = NetworkUtils.createNetwork();
 		Node n1 = NetworkUtils.createAndAddNode(network1, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
 		Node n2 = NetworkUtils.createAndAddNode(network1, Id.create("2", Node.class), new Coord((double) 1000, (double) 0));
 		final Node fromNode = n1;
@@ -237,7 +237,7 @@ public abstract class AbstractNetworkWriterReaderTest extends MatsimTestCase {
 	}
 
 	private void doTestNodes(List<Node> nodes, final String filename) {
-		Network network1 = NetworkUtils.createTimeInvariantNetwork();
+		Network network1 = NetworkUtils.createNetwork();
 		for(Node n : nodes){
 			network1.addNode(n);
 		}

--- a/matsim/src/test/java/org/matsim/core/network/NetworkChangeEventsParserWriterTest.java
+++ b/matsim/src/test/java/org/matsim/core/network/NetworkChangeEventsParserWriterTest.java
@@ -82,8 +82,8 @@ public class NetworkChangeEventsParserWriterTest {
 	public void testWriteChangeEventWithSmallValueAndReadBack() {
 		final String fileName = utils.getOutputDirectory() + "wurst.xml";
 
-		final Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
+		final Network network = NetworkUtils.createNetwork();
+        Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create("2", Node.class), new Coord((double) 0, (double) 1000));
 		final Link link = NetworkUtils.createAndAddLink(network, Id.create("2", Link.class), node1, node2, (double) 1500, 1.667, (double) 3600, (double) 1);
 
@@ -107,8 +107,8 @@ public class NetworkChangeEventsParserWriterTest {
 		List<NetworkChangeEvent> changeEvents = new ArrayList<>();
 		new NetworkChangeEventsWriter().write(fileName, changeEvents);
 
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		List<NetworkChangeEvent> changeEvents2 = new ArrayList<>();
+        Network network = NetworkUtils.createNetwork();
+        List<NetworkChangeEvent> changeEvents2 = new ArrayList<>();
 		new NetworkChangeEventsParser(network, changeEvents2).readFile(fileName);
 
 		// the main test is that there is no exception
@@ -117,8 +117,8 @@ public class NetworkChangeEventsParserWriterTest {
 
 	@Test
 	public void testAbsoluteChangeEvents() {
-		final Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
+        final Network network = NetworkUtils.createNetwork();
+        Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create("2", Node.class), new Coord((double) 0, (double) 1000));
 		final Link link = NetworkUtils.createAndAddLink(network, Id.create("2", Link.class), node1, node2, (double) 1500, 1.667, (double) 3600, (double) 1);
 
@@ -145,8 +145,8 @@ public class NetworkChangeEventsParserWriterTest {
 
 	@Test
 	public void testScaleFactorChangeEvents() {
-		final Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
+        final Network network = NetworkUtils.createNetwork();
+        Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create("2", Node.class), new Coord((double) 0, (double) 1000));
 		final Link link = NetworkUtils.createAndAddLink(network, Id.create("2", Link.class), node1, node2, (double) 1500, 1.667, (double) 3600, (double) 1);
 
@@ -173,8 +173,8 @@ public class NetworkChangeEventsParserWriterTest {
 
 	@Test
 	public void testPositiveOffsetChangeEvents() {
-		final Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
+        final Network network = NetworkUtils.createNetwork();
+        Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create("2", Node.class), new Coord((double) 0, (double) 1000));
 		final Link link = NetworkUtils.createAndAddLink(network, Id.create("2", Link.class), node1, node2, (double) 1500, 1.667, (double) 3600, (double) 1);
 
@@ -201,8 +201,8 @@ public class NetworkChangeEventsParserWriterTest {
 
 	@Test
 	public void testNegativeOffsetChangeEvents() {
-		final Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
+        final Network network = NetworkUtils.createNetwork();
+        Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create("2", Node.class), new Coord((double) 0, (double) 1000));
 		final Link link = NetworkUtils.createAndAddLink(network, Id.create("2", Link.class), node1, node2, (double) 1500, 1.667, (double) 3600, (double) 1);
 

--- a/matsim/src/test/java/org/matsim/core/network/NetworkCollectorTest.java
+++ b/matsim/src/test/java/org/matsim/core/network/NetworkCollectorTest.java
@@ -17,7 +17,7 @@ public class NetworkCollectorTest {
     private static Network getNetworkFromExample() {
 
         var networkUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("berlin"), "network.xml.gz");
-        var network = NetworkUtils.createTimeInvariantNetwork();
+        var network = NetworkUtils.createNetwork();
         new MatsimNetworkReader(network).readURL(networkUrl);
         return network;
     }

--- a/matsim/src/test/java/org/matsim/core/network/NetworkCollectorTest.java
+++ b/matsim/src/test/java/org/matsim/core/network/NetworkCollectorTest.java
@@ -4,7 +4,6 @@ import org.junit.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
-import org.matsim.core.config.groups.NetworkConfigGroup;
 import org.matsim.core.network.io.MatsimNetworkReader;
 import org.matsim.core.utils.io.IOUtils;
 import org.matsim.examples.ExamplesUtils;
@@ -28,7 +27,7 @@ public class NetworkCollectorTest {
         var network = getNetworkFromExample();
 
         var collectedNetwork = network.getLinks().values().stream()
-                .collect(NetworkUtils.getTimeInvariantCollector());
+                .collect(NetworkUtils.getCollector());
 
         assertTrue(NetworkUtils.compare(network, collectedNetwork));
     }
@@ -39,7 +38,7 @@ public class NetworkCollectorTest {
         var network = getNetworkFromExample();
 
         var collectedNetwork = network.getLinks().values().parallelStream()
-                .collect(NetworkUtils.getTimeInvariantCollector());
+                .collect(NetworkUtils.getCollector());
 
         assertTrue(NetworkUtils.compare(network, collectedNetwork));
     }
@@ -53,7 +52,7 @@ public class NetworkCollectorTest {
 
         var collectedNetwork = network.getLinks().values().stream()
                 .filter(link -> !link.getId().equals(filterId))
-                .collect(NetworkUtils.getTimeInvariantCollector());
+                .collect(NetworkUtils.getCollector());
 
         // make sure the link is not in filtered network
         assertFalse(collectedNetwork.getLinks().containsKey(filterId));

--- a/matsim/src/test/java/org/matsim/core/network/NetworkImplTest.java
+++ b/matsim/src/test/java/org/matsim/core/network/NetworkImplTest.java
@@ -109,8 +109,8 @@ public class NetworkImplTest extends AbstractNetworkTest {
 	 */
 	@Test
 	public void testAddLink_noNodes(){
-		Network n = NetworkUtils.createTimeInvariantNetwork();
-		Node a = n.getFactory().createNode(Id.create("a", Node.class), new Coord(0.0, 0.0));
+		Network n = NetworkUtils.createNetwork();
+        Node a = n.getFactory().createNode(Id.create("a", Node.class), new Coord(0.0, 0.0));
 		Node b = n.getFactory().createNode(Id.create("b", Node.class), new Coord(1000.0, 0.0));
 		Node c = n.getFactory().createNode(Id.create("c", Node.class), new Coord(0.0, 1000.0));
 		

--- a/matsim/src/test/java/org/matsim/core/network/NetworkUtilsTest.java
+++ b/matsim/src/test/java/org/matsim/core/network/NetworkUtilsTest.java
@@ -146,8 +146,8 @@ public class NetworkUtilsTest {
 
 	@Test
 	public void testfindNearestPointOnLink(){
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Coord n1 = new Coord(1,1);
+		Network network = NetworkUtils.createNetwork();
+        Coord n1 = new Coord(1, 1);
 		Coord n2 = new Coord(100,100);
 		Coord plainX = new Coord(1,100);
 		Coord plainY = new Coord(100,1);
@@ -205,8 +205,8 @@ public class NetworkUtilsTest {
 	@Test
 	public void getOriginalGeometry() {
 
-		var network = NetworkUtils.createTimeInvariantNetwork();
-		var fromNode  = NetworkUtils.createAndAddNode(network, Id.createNodeId("from"), new Coord(0,0));
+        var network = NetworkUtils.createNetwork();
+        var fromNode = NetworkUtils.createAndAddNode(network, Id.createNodeId("from"), new Coord(0, 0));
 		var toNode = NetworkUtils.createAndAddNode(network, Id.createNodeId("to"), new Coord(100, 100));
 		var link = network.getFactory().createLink(Id.createLinkId("link"), fromNode, toNode);
 		network.addLink(link);
@@ -236,8 +236,8 @@ public class NetworkUtilsTest {
 	@Test
 	public void getOriginalGeometry_noGeometryStored() {
 
-		var network = NetworkUtils.createTimeInvariantNetwork();
-		var fromNode  = NetworkUtils.createAndAddNode(network, Id.createNodeId("from"), new Coord(0,0));
+        var network = NetworkUtils.createNetwork();
+        var fromNode = NetworkUtils.createAndAddNode(network, Id.createNodeId("from"), new Coord(0, 0));
 		var toNode = NetworkUtils.createAndAddNode(network, Id.createNodeId("to"), new Coord(100, 100));
 		var link = network.getFactory().createLink(Id.createLinkId("link"), fromNode, toNode);
 		network.addLink(link);
@@ -264,8 +264,8 @@ public class NetworkUtilsTest {
 	@Test
 	public void getOriginalGeometry_emptyGeometryStored() {
 
-		var network = NetworkUtils.createTimeInvariantNetwork();
-		var fromNode  = NetworkUtils.createAndAddNode(network, Id.createNodeId("from"), new Coord(0,0));
+        var network = NetworkUtils.createNetwork();
+        var fromNode = NetworkUtils.createAndAddNode(network, Id.createNodeId("from"), new Coord(0, 0));
 		var toNode = NetworkUtils.createAndAddNode(network, Id.createNodeId("to"), new Coord(100, 100));
 		var link = network.getFactory().createLink(Id.createLinkId("link"), fromNode, toNode);
 		link.getAttributes().putAttribute(NetworkUtils.ORIG_GEOM, "");

--- a/matsim/src/test/java/org/matsim/core/network/algorithms/CalcBoundingBoxTest.java
+++ b/matsim/src/test/java/org/matsim/core/network/algorithms/CalcBoundingBoxTest.java
@@ -37,8 +37,8 @@ public class CalcBoundingBoxTest {
 
 	@Test
 	public void testRun() {
-		Network net = NetworkUtils.createTimeInvariantNetwork();
-		NetworkFactory nf = net.getFactory();
+		Network net = NetworkUtils.createNetwork();
+        NetworkFactory nf = net.getFactory();
 
 		Node n0 = nf.createNode(Id.create(0, Node.class), new Coord((double) 100, (double) 500));
 		Node n1 = nf.createNode(Id.create(1, Node.class), new Coord((double) 300, (double) 400));
@@ -73,8 +73,8 @@ public class CalcBoundingBoxTest {
 
 	@Test
 	public void testRun_allNegative() {
-		Network net = NetworkUtils.createTimeInvariantNetwork();
-		NetworkFactory nf = net.getFactory();
+        Network net = NetworkUtils.createNetwork();
+        NetworkFactory nf = net.getFactory();
 
 		final double x4 = -100;
 		final double y4 = -500;

--- a/matsim/src/test/java/org/matsim/core/network/algorithms/NetworkCleanerTest.java
+++ b/matsim/src/test/java/org/matsim/core/network/algorithms/NetworkCleanerTest.java
@@ -40,8 +40,8 @@ public class NetworkCleanerTest extends TestCase {
 
 	public void testSink() {
 		// create a simple network
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
+		Network network = NetworkUtils.createNetwork();
+        Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create("2", Node.class), new Coord((double) 100, (double) 0));
 		Node node3 = NetworkUtils.createAndAddNode(network, Id.create("3", Node.class), new Coord((double) 100, (double) 100));
 		Node node4 = NetworkUtils.createAndAddNode(network, Id.create("4", Node.class), new Coord((double) 0, (double) 100));
@@ -75,8 +75,8 @@ public class NetworkCleanerTest extends TestCase {
 
 	public void testDoubleSink() {
 		// create a simple network
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
+        Network network = NetworkUtils.createNetwork();
+        Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create("2", Node.class), new Coord((double) 100, (double) 0));
 		Node node3 = NetworkUtils.createAndAddNode(network, Id.create("3", Node.class), new Coord((double) 100, (double) 100));
 		Node node4 = NetworkUtils.createAndAddNode(network, Id.create("4", Node.class), new Coord((double) 0, (double) 100));
@@ -113,8 +113,8 @@ public class NetworkCleanerTest extends TestCase {
 
 	public void testSource() {
 		// create a simple network
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
+        Network network = NetworkUtils.createNetwork();
+        Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create("2", Node.class), new Coord((double) 100, (double) 0));
 		Node node3 = NetworkUtils.createAndAddNode(network, Id.create("3", Node.class), new Coord((double) 100, (double) 100));
 		Node node4 = NetworkUtils.createAndAddNode(network, Id.create("4", Node.class), new Coord((double) 0, (double) 100));
@@ -148,8 +148,8 @@ public class NetworkCleanerTest extends TestCase {
 
 	public void testDoubleSource() {
 		// create a simple network
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
+        Network network = NetworkUtils.createNetwork();
+        Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create("2", Node.class), new Coord((double) 100, (double) 0));
 		Node node3 = NetworkUtils.createAndAddNode(network, Id.create("3", Node.class), new Coord((double) 100, (double) 100));
 		Node node4 = NetworkUtils.createAndAddNode(network, Id.create("4", Node.class), new Coord((double) 0, (double) 100));

--- a/matsim/src/test/java/org/matsim/core/network/algorithms/NetworkSimplifierPass2WayTest.java
+++ b/matsim/src/test/java/org/matsim/core/network/algorithms/NetworkSimplifierPass2WayTest.java
@@ -132,7 +132,7 @@ public class NetworkSimplifierPass2WayTest {
     }
 
     private Network reshuffleNodesAndReturnNetwork(List<Node> nodes) {
-        Network network = NetworkUtils.createTimeInvariantNetwork();
+        Network network = NetworkUtils.createNetwork();
         Collections.shuffle(nodes);
         for (Node n : nodes) {
             System.out.println("Adding node "+ n.getId());

--- a/matsim/src/test/java/org/matsim/core/network/algorithms/NetworkSimplifierTest.java
+++ b/matsim/src/test/java/org/matsim/core/network/algorithms/NetworkSimplifierTest.java
@@ -102,8 +102,8 @@ public class NetworkSimplifierTest {
 		 originally, the algorithm had a problem and corrupted the network, resulting in a non-routable network
 		 */
 
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node a = NetworkUtils.createAndAddNode(network, Id.create("A", Node.class), new Coord(0.0, 10.0));
+		Network network = NetworkUtils.createNetwork();
+        Node a = NetworkUtils.createAndAddNode(network, Id.create("A", Node.class), new Coord(0.0, 10.0));
 		Node b = NetworkUtils.createAndAddNode(network, Id.create("B", Node.class), new Coord(0.0, -10.0));
 		Node c = NetworkUtils.createAndAddNode(network, Id.create("C", Node.class), new Coord(0.0, 0.0));
 		Node d = NetworkUtils.createAndAddNode(network, Id.create("D", Node.class), new Coord(10.0, 0.0));
@@ -211,8 +211,8 @@ public class NetworkSimplifierTest {
 	 * @return
 	 */
 	private Network buildNetwork(){
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node a = NetworkUtils.createAndAddNode(network, Id.createNodeId("A"), CoordUtils.createCoord(0.0,  0.0));
+        Network network = NetworkUtils.createNetwork();
+        Node a = NetworkUtils.createAndAddNode(network, Id.createNodeId("A"), CoordUtils.createCoord(0.0, 0.0));
 		Node b = NetworkUtils.createAndAddNode(network, Id.createNodeId("B"), CoordUtils.createCoord(10.0,  0.0));
 		Node c = NetworkUtils.createAndAddNode(network, Id.createNodeId("C"), CoordUtils.createCoord(20.0,  0.0));
 		Node d = NetworkUtils.createAndAddNode(network, Id.createNodeId("D"), CoordUtils.createCoord(30.0,  0.0));

--- a/matsim/src/test/java/org/matsim/core/network/algorithms/intersectionSimplifier/IntersectionSimplifierTest.java
+++ b/matsim/src/test/java/org/matsim/core/network/algorithms/intersectionSimplifier/IntersectionSimplifierTest.java
@@ -260,7 +260,7 @@ public class IntersectionSimplifierTest {
 	 *                                                                         26
 	 */
 	private Network buildComplexIntersection() {
-		Network network = NetworkUtils.createTimeInvariantNetwork();
+		Network network = NetworkUtils.createNetwork();
 
 		/* Left cluster */
 		Node n01 = NetworkUtils.createAndAddNode(network, Id.createNodeId( 1), CoordUtils.createCoord(  0.0,  85.0));

--- a/matsim/src/test/java/org/matsim/core/network/io/NetworkReprojectionIOTest.java
+++ b/matsim/src/test/java/org/matsim/core/network/io/NetworkReprojectionIOTest.java
@@ -62,7 +62,7 @@ public class NetworkReprojectionIOTest {
 
 		new NetworkWriter( initialNetwork ).write( networkFile );
 
-		final Network readNetwork = NetworkUtils.createTimeInvariantNetwork();
+		final Network readNetwork = NetworkUtils.createNetwork();
 		new MatsimNetworkReader(
 				INITIAL_CRS, TARGET_CRS,
 				readNetwork ).readFile( networkFile );
@@ -91,7 +91,7 @@ public class NetworkReprojectionIOTest {
 				transformation,
 				initialNetwork ).write( networkFile );
 
-		final Network readNetwork = NetworkUtils.createTimeInvariantNetwork();
+        final Network readNetwork = NetworkUtils.createNetwork();
 		new MatsimNetworkReader(
 				readNetwork ).readFile( networkFile );
 
@@ -149,7 +149,7 @@ public class NetworkReprojectionIOTest {
 		final Controler controler = new Controler( scenario );
 		controler.run();
 
-		final Network dumpedNetwork = NetworkUtils.createTimeInvariantNetwork();
+        final Network dumpedNetwork = NetworkUtils.createNetwork();
 		new MatsimNetworkReader( dumpedNetwork ).readFile( outputDirectory+"/output_network.xml.gz" );
 
 		for ( Id<Node> id : scenario.getNetwork().getNodes().keySet() ) {
@@ -203,7 +203,7 @@ public class NetworkReprojectionIOTest {
 		final Controler controler = new Controler( scenario );
 		controler.run();
 
-		final Network dumpedNetwork = NetworkUtils.createTimeInvariantNetwork();
+        final Network dumpedNetwork = NetworkUtils.createNetwork();
 		new MatsimNetworkReader( dumpedNetwork ).readFile( outputDirectory+"/output_network.xml.gz" );
 
 		for ( Id<Node> id : initialNetwork.getNodes().keySet() ) {
@@ -224,7 +224,7 @@ public class NetworkReprojectionIOTest {
 	}
 
 	private Network createInitialNetwork() {
-		final Network network = NetworkUtils.createTimeInvariantNetwork();
+        final Network network = NetworkUtils.createNetwork();
 
 		final Node node1 =
 				network.getFactory().createNode(

--- a/matsim/src/test/java/org/matsim/core/population/PlanImplTest.java
+++ b/matsim/src/test/java/org/matsim/core/population/PlanImplTest.java
@@ -212,8 +212,8 @@ public class PlanImplTest {
 
 	@Test
 	public void testCopyPlan_NetworkRoute() {
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node1 = NetworkUtils.createAndAddNode(network, Id.create(1, Node.class), new Coord(0, 0));
+		Network network = NetworkUtils.createNetwork();
+        Node node1 = NetworkUtils.createAndAddNode(network, Id.create(1, Node.class), new Coord(0, 0));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create(2, Node.class), new Coord(1000, 0));
 		Node node3 = NetworkUtils.createAndAddNode(network, Id.create(3, Node.class), new Coord(2000, 0));
 		final Node fromNode = node1;
@@ -243,8 +243,8 @@ public class PlanImplTest {
 
 	@Test
 	public void testCopyPlan_GenericRoute() {
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node1 = NetworkUtils.createAndAddNode(network, Id.create(1, Node.class), new Coord(0, 0));
+        Network network = NetworkUtils.createNetwork();
+        Node node1 = NetworkUtils.createAndAddNode(network, Id.create(1, Node.class), new Coord(0, 0));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create(2, Node.class), new Coord(1000, 0));
 		Node node3 = NetworkUtils.createAndAddNode(network, Id.create(3, Node.class), new Coord(2000, 0));
 		final Node fromNode = node1;

--- a/matsim/src/test/java/org/matsim/core/population/routes/AbstractNetworkRouteTest.java
+++ b/matsim/src/test/java/org/matsim/core/population/routes/AbstractNetworkRouteTest.java
@@ -455,7 +455,7 @@ public abstract class AbstractNetworkRouteTest {
 		 *    v             v|             v|             v|
 		 *  ( 1)-----1---->( 2)-----2---->( 3)-----3---->( 4)-----4---->( 5)
 		 */
-		Network network = NetworkUtils.createTimeInvariantNetwork();
+		Network network = NetworkUtils.createNetwork();
 		Node node0 = NetworkUtils.createAndAddNode(network, Id.create("0", Node.class), new Coord((double) 0, (double) 500));
 		Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create("2", Node.class), new Coord((double) 1000, (double) 0));

--- a/matsim/src/test/java/org/matsim/core/population/routes/CompressedNetworkRouteTest.java
+++ b/matsim/src/test/java/org/matsim/core/population/routes/CompressedNetworkRouteTest.java
@@ -132,8 +132,8 @@ public class CompressedNetworkRouteTest extends AbstractNetworkRouteTest {
 
 	@Test
 	public void testClone() {
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		NetworkFactory builder = network.getFactory();
+		Network network = NetworkUtils.createNetwork();
+        NetworkFactory builder = network.getFactory();
 
 		Node node1 = builder.createNode(Id.create(1, Node.class), new Coord((double) 0, (double) 1000));
 		Node node2 = builder.createNode(Id.create(2, Node.class), new Coord((double) 0, (double) 2000));

--- a/matsim/src/test/java/org/matsim/core/replanning/selectors/PathSizeLogitSelectorTest.java
+++ b/matsim/src/test/java/org/matsim/core/replanning/selectors/PathSizeLogitSelectorTest.java
@@ -330,8 +330,8 @@ public class PathSizeLogitSelectorTest extends AbstractPlanSelectorTest {
 		//              |7
 		//             (5)
 
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node n1 = NetworkUtils.createAndAddNode(network, Id.create(1, Node.class), new Coord((double) 0, (double) 10));
+		Network network = NetworkUtils.createNetwork();
+        Node n1 = NetworkUtils.createAndAddNode(network, Id.create(1, Node.class), new Coord((double) 0, (double) 10));
 		Node n2 = NetworkUtils.createAndAddNode(network, Id.create(2, Node.class), new Coord((double) 3, (double) 2));
 		Node n3 = NetworkUtils.createAndAddNode(network, Id.create(3, Node.class), new Coord((double) 0, (double) 0));
 		Node n4 = NetworkUtils.createAndAddNode(network, Id.create(4, Node.class), new Coord((double) 4, (double) 1));

--- a/matsim/src/test/java/org/matsim/core/replanning/strategies/TimeAllocationMutatorModuleTest.java
+++ b/matsim/src/test/java/org/matsim/core/replanning/strategies/TimeAllocationMutatorModuleTest.java
@@ -125,7 +125,7 @@ public class TimeAllocationMutatorModuleTest extends MatsimTestCase {
 	 */
 	private static void runMutationRangeTest( final PlanAlgorithm tripPlanMutateTimeAllocation, final int expectedMutationRange ) {
 		// setup network
-		Network network = NetworkUtils.createTimeInvariantNetwork();
+		Network network = NetworkUtils.createNetwork();
 		network.setCapacityPeriod(Time.parseTime("01:00:00"));
 		Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create("2", Node.class), new Coord((double) 100, (double) 0));
@@ -206,7 +206,7 @@ public class TimeAllocationMutatorModuleTest extends MatsimTestCase {
 	 */
 	private void runSimplifiedMutationRangeTest(final PlanAlgorithm tripPlanMutateTimeAllocation, final int expectedMutationRange) {
 		// setup network
-		Network network = NetworkUtils.createTimeInvariantNetwork();
+        Network network = NetworkUtils.createNetwork();
 		network.setCapacityPeriod(Time.parseTime("01:00:00"));
 		Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create("2", Node.class), new Coord((double) 100, (double) 0));

--- a/matsim/src/test/java/org/matsim/core/router/MultiNodeDijkstraTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/MultiNodeDijkstraTest.java
@@ -627,7 +627,7 @@ public class MultiNodeDijkstraTest {
 		/*package*/ Network network;
 
 		public Fixture() {
-			this.network = (Network) NetworkUtils.createTimeInvariantNetwork();
+			this.network = (Network) NetworkUtils.createNetwork();
 			Node node1 = NetworkUtils.createAndAddNode(this.network, Id.create(1, Node.class), new Coord((double) 1000, (double) 0));
 			Node node2 = NetworkUtils.createAndAddNode(this.network, Id.create(2, Node.class), new Coord((double) 500, (double) 0));
 			Node node3 = NetworkUtils.createAndAddNode(this.network, Id.create(3, Node.class), new Coord((double) 0, (double) 0));

--- a/matsim/src/test/java/org/matsim/core/router/speedy/SpeedyGraphTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/speedy/SpeedyGraphTest.java
@@ -187,7 +187,7 @@ public class SpeedyGraphTest {
              *   (5)==================(6)
              */
 
-            this.network = NetworkUtils.createTimeInvariantNetwork();
+            this.network = NetworkUtils.createNetwork();
             NetworkFactory nf = this.network.getFactory();
 
             this.node1 = nf.createNode(Id.create("1", Node.class), new Coord(0, 1000));

--- a/matsim/src/test/java/org/matsim/core/trafficmonitoring/TravelTimeCalculatorTest.java
+++ b/matsim/src/test/java/org/matsim/core/trafficmonitoring/TravelTimeCalculatorTest.java
@@ -366,8 +366,8 @@ public class TravelTimeCalculatorTest extends MatsimTestCase {
 	 * @author mrieser / senozon
 	 */
 	public void testGetLinkTravelTime_ignorePtVehiclesAtStop() {
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		TravelTimeCalculatorConfigGroup config = new TravelTimeCalculatorConfigGroup();
+		Network network = NetworkUtils.createNetwork();
+        TravelTimeCalculatorConfigGroup config = new TravelTimeCalculatorConfigGroup();
 		config.setTraveltimeBinSize(900);
 		TravelTimeCalculator ttc = new TravelTimeCalculator(network, config);
 
@@ -394,8 +394,8 @@ public class TravelTimeCalculatorTest extends MatsimTestCase {
 	 * @author mrieser / senozon
 	 */
 	public void testGetLinkTravelTime_usePtVehiclesWithoutStop() {
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		TravelTimeCalculatorConfigGroup config = new TravelTimeCalculatorConfigGroup();
+        Network network = NetworkUtils.createNetwork();
+        TravelTimeCalculatorConfigGroup config = new TravelTimeCalculatorConfigGroup();
 		config.setTraveltimeBinSize(900);
 		TravelTimeCalculator ttc = new TravelTimeCalculator(network, config);
 
@@ -424,8 +424,8 @@ public class TravelTimeCalculatorTest extends MatsimTestCase {
 	 * @author cdobler
 	 */
 	public void testGetLinkTravelTime_NoAnalyzedModes() {
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		TravelTimeCalculatorConfigGroup config = new TravelTimeCalculatorConfigGroup();
+        Network network = NetworkUtils.createNetwork();
+        TravelTimeCalculatorConfigGroup config = new TravelTimeCalculatorConfigGroup();
 		config.setTraveltimeBinSize(900);
 		config.setAnalyzedModesAsString("" );
 		config.setFilterModes(true);
@@ -460,8 +460,8 @@ public class TravelTimeCalculatorTest extends MatsimTestCase {
 	 * @author cdobler
 	 */
 	public void testGetLinkTravelTime_CarAnalyzedModes() {
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		TravelTimeCalculatorConfigGroup config = new TravelTimeCalculatorConfigGroup();
+        Network network = NetworkUtils.createNetwork();
+        TravelTimeCalculatorConfigGroup config = new TravelTimeCalculatorConfigGroup();
 		config.setTraveltimeBinSize(900);
 		config.setAnalyzedModesAsString(TransportMode.car );
 		config.setFilterModes(true);
@@ -501,8 +501,8 @@ public class TravelTimeCalculatorTest extends MatsimTestCase {
 	 * @author cdobler
 	 */
 	public void testGetLinkTravelTime_NoFilterModes() {
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		TravelTimeCalculatorConfigGroup config = new TravelTimeCalculatorConfigGroup();
+        Network network = NetworkUtils.createNetwork();
+        TravelTimeCalculatorConfigGroup config = new TravelTimeCalculatorConfigGroup();
 		config.setTraveltimeBinSize(900);
 		config.setAnalyzedModesAsString("" );
 		config.setFilterModes(false);
@@ -542,8 +542,8 @@ public class TravelTimeCalculatorTest extends MatsimTestCase {
 	 * @author cdobler
 	 */
 	public void testGetLinkTravelTime_FilterDefaultModes() {
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		TravelTimeCalculatorConfigGroup config = new TravelTimeCalculatorConfigGroup();
+        Network network = NetworkUtils.createNetwork();
+        TravelTimeCalculatorConfigGroup config = new TravelTimeCalculatorConfigGroup();
 		config.setTraveltimeBinSize(900);
 		config.setFilterModes(true);
 		TravelTimeCalculator ttc = new TravelTimeCalculator(network, config);

--- a/matsim/src/test/java/org/matsim/core/trafficmonitoring/TravelTimeDataArrayTest.java
+++ b/matsim/src/test/java/org/matsim/core/trafficmonitoring/TravelTimeDataArrayTest.java
@@ -16,8 +16,8 @@ public class TravelTimeDataArrayTest{
 
 	@Test
 	public void test() {
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node from = NetworkUtils.createNode( Id.createNodeId( "1" ) );
+		Network network = NetworkUtils.createNetwork();
+        Node from = NetworkUtils.createNode(Id.createNodeId("1"));
 		Node to = NetworkUtils.createNode( Id.createNodeId( "2" ) );
 		Link link = NetworkUtils.createLink( Id.createLinkId( "1-2" ), from, to, network, 10, 10, 10, 1 );
 		final int numSlots = 24;

--- a/matsim/src/test/java/org/matsim/core/utils/misc/NetworkUtilsTest.java
+++ b/matsim/src/test/java/org/matsim/core/utils/misc/NetworkUtilsTest.java
@@ -331,8 +331,8 @@ public class NetworkUtilsTest {
 	private Network getTestNetwork() {
 		int numOfLinks = 5;
 
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node[] nodes = new Node[numOfLinks+1];
+		Network network = NetworkUtils.createNetwork();
+        Node[] nodes = new Node[numOfLinks + 1];
 		for (int i = 0; i <= numOfLinks; i++) {
 			nodes[i] = NetworkUtils.createAndAddNode(network, Id.create(i, Node.class), new Coord((double) (1000 * i), (double) 0));
 		}
@@ -343,8 +343,8 @@ public class NetworkUtilsTest {
 	}
 
 	private static class MultimodalFixture {
-		/*package*/ final Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node[] nodes = new Node[6];
+        /*package*/ final Network network = NetworkUtils.createNetwork();
+        Node[] nodes = new Node[6];
 		Link[] links = new Link[this.nodes.length - 1];
 
 		public MultimodalFixture() {

--- a/matsim/src/test/java/org/matsim/pt/router/MultiNodeDijkstraTest.java
+++ b/matsim/src/test/java/org/matsim/pt/router/MultiNodeDijkstraTest.java
@@ -420,7 +420,7 @@ public class MultiNodeDijkstraTest extends TestCase {
 		/*package*/ Network network;
 
 		public Fixture() {
-			this.network = NetworkUtils.createTimeInvariantNetwork();
+			this.network = NetworkUtils.createNetwork();
 			Node node1 = NetworkUtils.createAndAddNode(this.network, Id.create(1, Node.class), new Coord((double) 1000, (double) 0));
 			Node node2 = NetworkUtils.createAndAddNode(this.network, Id.create(2, Node.class), new Coord((double) 500, (double) 0));
 			Node node3 = NetworkUtils.createAndAddNode(this.network, Id.create(3, Node.class), new Coord((double) 0, (double) 0));

--- a/matsim/src/test/java/org/matsim/pt/router/TransitLeastCostPathTreeTest.java
+++ b/matsim/src/test/java/org/matsim/pt/router/TransitLeastCostPathTreeTest.java
@@ -193,7 +193,7 @@ public class TransitLeastCostPathTreeTest {
         int count = 10000;
 
         public Fixture() {
-            this.network = NetworkUtils.createTimeInvariantNetwork();
+            this.network = NetworkUtils.createNetwork();
             Node linkStartNode = NetworkUtils.createAndAddNode(this.network, Id.create(0, Node.class), new Coord((double) 0, (double) 0));
             for (int i = 1; i < count; i++) {
                 Node linkEndNode = NetworkUtils.createAndAddNode(this.network, Id.create(i, Node.class), new Coord((double) i, (double) 0));

--- a/matsim/src/test/java/org/matsim/pt/transitSchedule/TransitScheduleFormatV1Test.java
+++ b/matsim/src/test/java/org/matsim/pt/transitSchedule/TransitScheduleFormatV1Test.java
@@ -59,8 +59,8 @@ public class TransitScheduleFormatV1Test extends MatsimTestCase {
 
 	public void testWriteRead() throws IOException, SAXException, ParserConfigurationException {
 		// prepare required data
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node n1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
+		Network network = NetworkUtils.createNetwork();
+        Node n1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord((double) 0, (double) 0));
 		Node n2 = NetworkUtils.createAndAddNode(network, Id.create("2", Node.class), new Coord((double) 0, (double) 0));
 		Node n3 = NetworkUtils.createAndAddNode(network, Id.create("3", Node.class), new Coord((double) 0, (double) 0));
 		Node n4 = NetworkUtils.createAndAddNode(network, Id.create("4", Node.class), new Coord((double) 0, (double) 0));

--- a/matsim/src/test/java/org/matsim/pt/transitSchedule/TransitScheduleReaderV1Test.java
+++ b/matsim/src/test/java/org/matsim/pt/transitSchedule/TransitScheduleReaderV1Test.java
@@ -85,8 +85,8 @@ public class TransitScheduleReaderV1Test {
 	@Test
 	public void testStopFacility_withLink() {
 		TransitSchedule schedule = new TransitScheduleFactoryImpl().createTransitSchedule();
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node1 = NetworkUtils.createAndAddNode(network, Id.create(1, Node.class), new Coord((double) 10, (double) 5));
+        Network network = NetworkUtils.createNetwork();
+        Node node1 = NetworkUtils.createAndAddNode(network, Id.create(1, Node.class), new Coord((double) 10, (double) 5));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create(2, Node.class), new Coord((double) 5, (double) 11));
 		final Node fromNode = node1;
 		final Node toNode = node2;
@@ -116,9 +116,9 @@ public class TransitScheduleReaderV1Test {
 
 	@Test
 	public void testStopFacility_withBadLink() {
-		TransitSchedule schedule = new TransitScheduleFactoryImpl().createTransitSchedule();
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node1 = NetworkUtils.createAndAddNode(network, Id.create(1, Node.class), new Coord((double) 10, (double) 5));
+        TransitSchedule schedule = new TransitScheduleFactoryImpl().createTransitSchedule();
+        Network network = NetworkUtils.createNetwork();
+        Node node1 = NetworkUtils.createAndAddNode(network, Id.create(1, Node.class), new Coord((double) 10, (double) 5));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create(2, Node.class), new Coord((double) 5, (double) 11));
 		final Node fromNode = node1;
 		final Node toNode = node2;
@@ -738,8 +738,8 @@ public class TransitScheduleReaderV1Test {
 	public void testRouteProfileRoute_OneLink() {
 		TransitSchedule schedule = new TransitScheduleFactoryImpl().createTransitSchedule();
 
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node1 = NetworkUtils.createAndAddNode(network, Id.create(1, Node.class), new Coord((double) 10, (double) 5));
+        Network network = NetworkUtils.createNetwork();
+        Node node1 = NetworkUtils.createAndAddNode(network, Id.create(1, Node.class), new Coord((double) 10, (double) 5));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create(2, Node.class), new Coord((double) 5, (double) 11));
 		Node node3 = NetworkUtils.createAndAddNode(network, Id.create(3, Node.class), new Coord((double) 5, (double) 11));
 		Node node4 = NetworkUtils.createAndAddNode(network, Id.create(4, Node.class), new Coord((double) 5, (double) 11));
@@ -805,8 +805,8 @@ public class TransitScheduleReaderV1Test {
 	public void testRouteProfileRoute_TwoLinks() {
 		TransitSchedule schedule = new TransitScheduleFactoryImpl().createTransitSchedule();
 
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node1 = NetworkUtils.createAndAddNode(network, Id.create(1, Node.class), new Coord((double) 10, (double) 5));
+        Network network = NetworkUtils.createNetwork();
+        Node node1 = NetworkUtils.createAndAddNode(network, Id.create(1, Node.class), new Coord((double) 10, (double) 5));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create(2, Node.class), new Coord((double) 5, (double) 11));
 		Node node3 = NetworkUtils.createAndAddNode(network, Id.create(3, Node.class), new Coord((double) 5, (double) 11));
 		Node node4 = NetworkUtils.createAndAddNode(network, Id.create(4, Node.class), new Coord((double) 5, (double) 11));
@@ -874,8 +874,8 @@ public class TransitScheduleReaderV1Test {
 	public void testRouteProfileRoute_MoreLinks() {
 		TransitSchedule schedule = new TransitScheduleFactoryImpl().createTransitSchedule();
 
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node1 = NetworkUtils.createAndAddNode(network, Id.create(1, Node.class), new Coord((double) 10, (double) 5));
+        Network network = NetworkUtils.createNetwork();
+        Node node1 = NetworkUtils.createAndAddNode(network, Id.create(1, Node.class), new Coord((double) 10, (double) 5));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create(2, Node.class), new Coord((double) 5, (double) 11));
 		Node node3 = NetworkUtils.createAndAddNode(network, Id.create(3, Node.class), new Coord((double) 5, (double) 11));
 		Node node4 = NetworkUtils.createAndAddNode(network, Id.create(4, Node.class), new Coord((double) 5, (double) 11));

--- a/matsim/src/test/java/org/matsim/utils/gis/matsim2esri/network/LanesBasedWidthCalculatorTest.java
+++ b/matsim/src/test/java/org/matsim/utils/gis/matsim2esri/network/LanesBasedWidthCalculatorTest.java
@@ -35,8 +35,8 @@ public class LanesBasedWidthCalculatorTest {
 
 	@Test
 	public void testGetWidth_laneWidthNaN() {
-		Network net = NetworkUtils.createTimeInvariantNetwork();
-		Node n1 = net.getFactory().createNode(Id.create("1", Node.class), new Coord((double) 0, (double) 0));
+		Network net = NetworkUtils.createNetwork();
+        Node n1 = net.getFactory().createNode(Id.create("1", Node.class), new Coord((double) 0, (double) 0));
 		Node n2 = net.getFactory().createNode(Id.create("2", Node.class), new Coord((double) 1000, (double) 0));
 		net.addNode(n1);
 		net.addNode(n2);

--- a/matsim/src/test/java/org/matsim/vis/snapshotwriters/PositionInfoTest.java
+++ b/matsim/src/test/java/org/matsim/vis/snapshotwriters/PositionInfoTest.java
@@ -40,8 +40,8 @@ public class PositionInfoTest extends MatsimTestCase {
 	 */
 	public void testDistanceOnLink_shortLink() {
 
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord(0, 0));
+		Network network = NetworkUtils.createNetwork();
+        Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord(0, 0));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create("2", Node.class), new Coord(1000, 1000));
 		Link link1 = NetworkUtils.createAndAddLink(network, Id.create("1", Link.class), node1, node2, 1000, 10, 9999, 1);
 
@@ -76,8 +76,8 @@ public class PositionInfoTest extends MatsimTestCase {
 	 */
 	public void testDistanceOnLink_longLink() {
 
-		Network network = NetworkUtils.createTimeInvariantNetwork();
-		Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord(0, 0));
+        Network network = NetworkUtils.createNetwork();
+        Node node1 = NetworkUtils.createAndAddNode(network, Id.create("1", Node.class), new Coord(0, 0));
 		Node node2 = NetworkUtils.createAndAddNode(network, Id.create("2", Node.class), new Coord(1000, 1000));
 		Link link1 = NetworkUtils.createAndAddLink(network, Id.create("1", Link.class), node1, node2, 2000, 10, 9999, 1);
 


### PR DESCRIPTION
Undo some changes made to ```NetworkUtils``` where the default methods had longer names than the ones for more specialized use cases. This was discussed in #1751 