### PR TITLE
Refactor insertion detour data

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/optimizer/ShiftRequestInsertionScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/optimizer/ShiftRequestInsertionScheduler.java
@@ -90,12 +90,14 @@ public class ShiftRequestInsertionScheduler implements RequestInsertionScheduler
         return new PickupDropoffTaskPair(pickupTask, dropoffTask);
     }
 
-    private DrtStopTask insertPickup(DrtRequest request, InsertionWithDetourData<OneToManyPathSearch.PathData> insertion) {
-        VehicleEntry vehicleEntry = insertion.getVehicleEntry();
+    private DrtStopTask insertPickup(DrtRequest request, InsertionWithDetourData<OneToManyPathSearch.PathData> insertionWithDetourData) {
+		var insertion = insertionWithDetourData.getInsertion();
+        VehicleEntry vehicleEntry = insertion.vehicleEntry;
         Schedule schedule = vehicleEntry.vehicle.getSchedule();
         List<Waypoint.Stop> stops = vehicleEntry.stops;
-        int pickupIdx = insertion.getPickup().index;
-        int dropoffIdx = insertion.getDropoff().index;
+        int pickupIdx = insertion.pickup.index;
+        int dropoffIdx = insertion.dropoff.index;
+		var detourData = insertionWithDetourData.getDetourData();
 
         Schedule.ScheduleStatus scheduleStatus = schedule.getStatus();
         Task currentTask = scheduleStatus == Schedule.ScheduleStatus.PLANNED ? null : schedule.getCurrentTask();
@@ -106,12 +108,12 @@ public class ShiftRequestInsertionScheduler implements RequestInsertionScheduler
             if (diversion != null) { // divert vehicle
                 beforePickupTask = currentTask;
                 VrpPathWithTravelData vrpPath = VrpPaths.createPath(vehicleEntry.start.link, request.getFromLink(),
-                        vehicleEntry.start.time, insertion.getDetourToPickup(), travelTime);
+                        vehicleEntry.start.time, detourData.detourToPickup, travelTime);
                 ((OnlineDriveTaskTracker) beforePickupTask.getTaskTracker()).divertPath(vrpPath);
             } else { // too late for diversion
                 if (request.getFromLink() != vehicleEntry.start.link) { // add a new drive task
                     VrpPathWithTravelData vrpPath = VrpPaths.createPath(vehicleEntry.start.link, request.getFromLink(),
-                            vehicleEntry.start.time, insertion.getDetourToPickup(), travelTime);
+                            vehicleEntry.start.time, detourData.detourToPickup, travelTime);
                     beforePickupTask = taskFactory.createDriveTask(vehicleEntry.vehicle, vrpPath, DrtDriveTask.TYPE);
                     schedule.addTask(currentTask.getTaskIdx() + 1, beforePickupTask);
                 } else { // no need for a new drive task
@@ -185,7 +187,7 @@ public class ShiftRequestInsertionScheduler implements RequestInsertionScheduler
                     Link toLink = request.getToLink(); // pickup->dropoff
 
                     VrpPathWithTravelData vrpPath = VrpPaths.createPath(request.getFromLink(), toLink,
-                            stopTask.getEndTime(), insertion.getDetourFromPickup(), travelTime);
+                            stopTask.getEndTime(), detourData.detourFromPickup, travelTime);
                     Task driveFromPickupTask = taskFactory.createDriveTask(vehicleEntry.vehicle, vrpPath,
                             DrtDriveTask.TYPE);
                     schedule.addTask(stopTask.getTaskIdx() + 1, driveFromPickupTask);
@@ -234,7 +236,7 @@ public class ShiftRequestInsertionScheduler implements RequestInsertionScheduler
                 } else {// add drive task to pickup location
                     // insert drive i->pickup
                     VrpPathWithTravelData vrpPath = VrpPaths.createPath(stayOrStopTask.getLink(), request.getFromLink(),
-                            stayOrStopTask.getEndTime(), insertion.getDetourToPickup(), travelTime);
+                            stayOrStopTask.getEndTime(), detourData.detourToPickup, travelTime);
                     beforePickupTask = taskFactory.createDriveTask(vehicleEntry.vehicle, vrpPath, DrtDriveTask.TYPE);
                     schedule.addTask(stayOrStopTask.getTaskIdx() + 1, beforePickupTask);
                 }
@@ -254,7 +256,7 @@ public class ShiftRequestInsertionScheduler implements RequestInsertionScheduler
                 : stops.get(pickupIdx).task.getLink(); // pickup->i+1
 
         VrpPathWithTravelData vrpPath = VrpPaths.createPath(request.getFromLink(), toLink, pickupStopTask.getEndTime(),
-                insertion.getDetourFromPickup(), travelTime);
+                detourData.detourFromPickup, travelTime);
         Task driveFromPickupTask = taskFactory.createDriveTask(vehicleEntry.vehicle, vrpPath, DrtDriveTask.TYPE);
         schedule.addTask(taskIdx + 1, driveFromPickupTask);
 
@@ -265,14 +267,15 @@ public class ShiftRequestInsertionScheduler implements RequestInsertionScheduler
         return pickupStopTask;
     }
 
-    private DrtStopTask insertDropoff(DrtRequest request, InsertionWithDetourData<OneToManyPathSearch.PathData> insertion,
+    private DrtStopTask insertDropoff(DrtRequest request, InsertionWithDetourData<OneToManyPathSearch.PathData> insertionWithDetourData,
                                       DrtStopTask pickupTask) {
-        VehicleEntry vehicleEntry = insertion.getVehicleEntry();
+		var insertion = insertionWithDetourData.getInsertion();
+        VehicleEntry vehicleEntry = insertion.vehicleEntry;
         Schedule schedule = vehicleEntry.vehicle.getSchedule();
         List<Waypoint.Stop> stops = vehicleEntry.stops;
-        int pickupIdx = insertion.getPickup().index;
-        int dropoffIdx = insertion.getDropoff().index;
-
+        int pickupIdx = insertion.pickup.index;
+        int dropoffIdx = insertion.dropoff.index;
+		var detourData = insertionWithDetourData.getDetourData();
 
         Task driveToDropoffTask;
         if (pickupIdx == dropoffIdx) { // no drive to dropoff
@@ -313,7 +316,7 @@ public class ShiftRequestInsertionScheduler implements RequestInsertionScheduler
 
                 // insert drive i->dropoff
                 VrpPathWithTravelData vrpPath = VrpPaths.createPath(stopTask.getLink(), request.getToLink(),
-                        stopTask.getEndTime(), insertion.getDetourToDropoff(), travelTime);
+                        stopTask.getEndTime(), detourData.detourToDropoff, travelTime);
                 driveToDropoffTask = taskFactory.createDriveTask(vehicleEntry.vehicle, vrpPath, DrtDriveTask.TYPE);
                 schedule.addTask(stopTask.getTaskIdx() + 1, driveToDropoffTask);
             }
@@ -347,7 +350,7 @@ public class ShiftRequestInsertionScheduler implements RequestInsertionScheduler
             Link toLink = nextStopTask.getLink(); // dropoff->j+1
 
             VrpPathWithTravelData vrpPath = VrpPaths.createPath(request.getToLink(), toLink, startTime + stopDuration,
-                    insertion.getDetourFromDropoff(), travelTime);
+                    detourData.detourFromDropoff, travelTime);
 
 
             Task driveFromDropoffTask;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/optimizer/insertion/ShiftInsertionCostCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/optimizer/insertion/ShiftInsertionCostCalculator.java
@@ -3,6 +3,9 @@ package org.matsim.contrib.drt.extension.shifts.optimizer.insertion;
 import java.util.List;
 import java.util.function.ToDoubleFunction;
 
+import org.matsim.contrib.drt.extension.shifts.schedule.ShiftBreakTask;
+import org.matsim.contrib.drt.extension.shifts.schedule.ShiftChangeOverTask;
+import org.matsim.contrib.drt.extension.shifts.shift.DrtShiftBreak;
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
 import org.matsim.contrib.drt.optimizer.Waypoint;
 import org.matsim.contrib.drt.optimizer.insertion.CostCalculationStrategy;
@@ -16,9 +19,6 @@ import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
 import org.matsim.contrib.dvrp.schedule.Task;
-import org.matsim.contrib.drt.extension.shifts.schedule.ShiftBreakTask;
-import org.matsim.contrib.drt.extension.shifts.schedule.ShiftChangeOverTask;
-import org.matsim.contrib.drt.extension.shifts.shift.DrtShiftBreak;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 
 /**
@@ -56,8 +56,8 @@ public class ShiftInsertionCostCalculator<D> implements InsertionCostCalculator<
 	public double calculate(DrtRequest drtRequest, InsertionWithDetourData<D> insertion) {
 		//TODO precompute time slacks for each stop to filter out even more infeasible insertions ???????????
 		var detourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion);
-		if (!checkShiftTimeConstraintsForScheduledRequests(insertion.getInsertion(), detourTimeInfo.pickupTimeLoss,
-				detourTimeInfo.getTotalTimeLoss())) {
+		if (!checkShiftTimeConstraintsForScheduledRequests(insertion.getInsertion(),
+				detourTimeInfo.pickupDetourInfo.pickupTimeLoss, detourTimeInfo.getTotalTimeLoss())) {
 			return INFEASIBLE_SOLUTION_COST;
 		}
 		return defaultInsertionCostCalculator.calculate(drtRequest, insertion);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategy.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategy.java
@@ -40,8 +40,8 @@ public interface CostCalculationStrategy {
 		public double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion,
 				InsertionDetourTimeCalculator.DetourTimeInfo detourTimeInfo) {
 			double totalTimeLoss = detourTimeInfo.getTotalTimeLoss();
-			if (detourTimeInfo.departureTime > request.getLatestStartTime()
-					|| detourTimeInfo.arrivalTime > request.getLatestArrivalTime()) {
+			if (detourTimeInfo.pickupDetourInfo.departureTime > request.getLatestStartTime()
+					|| detourTimeInfo.dropoffDetourInfo.arrivalTime > request.getLatestArrivalTime()) {
 				//no extra time is lost => do not check if the current slack time is long enough (can be even negative)
 				return InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
 			}
@@ -60,8 +60,10 @@ public interface CostCalculationStrategy {
 		public double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion,
 				InsertionDetourTimeCalculator.DetourTimeInfo detourTimeInfo) {
 			double totalTimeLoss = detourTimeInfo.getTotalTimeLoss();
-			double waitTimeViolation = Math.max(0, detourTimeInfo.departureTime - request.getLatestStartTime());
-			double travelTimeViolation = Math.max(0, detourTimeInfo.arrivalTime - request.getLatestArrivalTime());
+			double waitTimeViolation = Math.max(0,
+					detourTimeInfo.pickupDetourInfo.departureTime - request.getLatestStartTime());
+			double travelTimeViolation = Math.max(0,
+					detourTimeInfo.dropoffDetourInfo.arrivalTime - request.getLatestArrivalTime());
 			return MAX_WAIT_TIME_VIOLATION_PENALTY * waitTimeViolation
 					+ MAX_TRAVEL_TIME_VIOLATION_PENALTY * travelTimeViolation
 					+ totalTimeLoss;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearch.java
@@ -63,7 +63,7 @@ public final class DefaultDrtInsertionSearch implements DrtInsertionSearch<PathD
 			return Optional.empty();
 		}
 
-		DetourPathData pathData = detourPathCalculator.calculatePaths(drtRequest, insertions);
+		DetourPathDataCache pathData = detourPathCalculator.calculatePaths(drtRequest, insertions);
 		return bestInsertionFinder.findBestInsertion(drtRequest,
 				insertions.stream().map(i -> new InsertionWithDetourData<>(i, pathData.createInsertionDetourData(i))));
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearch.java
@@ -63,7 +63,7 @@ public final class DefaultDrtInsertionSearch implements DrtInsertionSearch<PathD
 			return Optional.empty();
 		}
 
-		DetourData<PathData> pathData = detourPathCalculator.calculatePaths(drtRequest, insertions);
+		DetourPathData pathData = detourPathCalculator.calculatePaths(drtRequest, insertions);
 		return bestInsertionFinder.findBestInsertion(drtRequest,
 				insertions.stream().map(pathData::createInsertionWithDetourData));
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearch.java
@@ -65,6 +65,6 @@ public final class DefaultDrtInsertionSearch implements DrtInsertionSearch<PathD
 
 		DetourPathData pathData = detourPathCalculator.calculatePaths(drtRequest, insertions);
 		return bestInsertionFinder.findBestInsertion(drtRequest,
-				insertions.stream().map(pathData::createInsertionWithDetourData));
+				insertions.stream().map(i -> new InsertionWithDetourData<>(i, pathData.createInsertionDetourData(i))));
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultInsertionCostCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultInsertionCostCalculator.java
@@ -19,7 +19,6 @@
 
 package org.matsim.contrib.drt.optimizer.insertion;
 
-import java.util.function.DoubleSupplier;
 import java.util.function.ToDoubleFunction;
 
 import javax.annotation.Nullable;
@@ -84,7 +83,7 @@ public class DefaultInsertionCostCalculator<D> implements InsertionCostCalculato
 		var insertion1 = insertion.getInsertion();
 		var vEntry = insertion1.vehicleEntry;
 
-		if (vEntry.getSlackTime(insertion1.pickup.index) < detourTimeInfo.pickupTimeLoss
+		if (vEntry.getSlackTime(insertion1.pickup.index) < detourTimeInfo.pickupDetourInfo.pickupTimeLoss
 				|| vEntry.getSlackTime(insertion1.dropoff.index) < detourTimeInfo.getTotalTimeLoss()) {
 			return INFEASIBLE_SOLUTION_COST;
 		}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
@@ -131,7 +131,7 @@ public class DefaultUnplannedRequestInserter implements UnplannedRequestInserter
 			}
 		} else {
 			InsertionWithDetourData<PathData> insertion = best.get();
-			var vehicle = insertion.getVehicleEntry().vehicle;
+			var vehicle = insertion.getInsertion().vehicleEntry.vehicle;
 			var pickupDropoffTaskPair = insertionScheduler.scheduleRequest(req, insertion);
 
 			VehicleEntry newVehicleEntry = vehicleEntryFactory.create(vehicle, now);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourDataLogging.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourDataLogging.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import org.apache.log4j.Logger;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionWithDetourData.InsertionDetourData;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -33,18 +34,18 @@ import org.apache.log4j.Logger;
 public final class DetourDataLogging {
 	private static final Logger log = Logger.getLogger(DetourDataLogging.class);
 
-	public static void printoutEstimatedTimes(InsertionWithDetourData<Double> data) {
+	public static void printoutEstimatedTimes(InsertionDetourData<Double> data) {
 		printoutDetour(data, Objects::toString);
 	}
 
-	public static void printoutPathTimes(InsertionWithDetourData<PathData> data) {
+	public static void printoutPathTimes(InsertionDetourData<PathData> data) {
 		printoutDetour(data, pd -> String.valueOf(pd == null ? null : pd.getTravelTime()));
 	}
 
-	public static <D> void printoutDetour(InsertionWithDetourData<D> data, Function<D, String> toString) {
-		log.info("toPickup=" + toString.apply(data.getDetourToPickup()));
-		log.info("fromPickup=" + toString.apply(data.getDetourFromPickup()));
-		log.info("toDropoff=" + toString.apply(data.getDetourToDropoff()));
-		log.info("fromDropoff=" + toString.apply(data.getDetourFromDropoff()));
+	public static <D> void printoutDetour(InsertionDetourData<D> data, Function<D, String> toString) {
+		log.info("toPickup=" + toString.apply(data.detourToPickup));
+		log.info("fromPickup=" + toString.apply(data.detourFromPickup));
+		log.info("toDropoff=" + toString.apply(data.detourToDropoff));
+		log.info("fromDropoff=" + toString.apply(data.detourFromDropoff));
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourPathCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourPathCalculator.java
@@ -27,5 +27,5 @@ import org.matsim.contrib.drt.passenger.DrtRequest;
  * @author michalm
  */
 public interface DetourPathCalculator {
-	DetourPathData calculatePaths(DrtRequest drtRequest, List<Insertion> filteredInsertions);
+	DetourPathDataCache calculatePaths(DrtRequest drtRequest, List<Insertion> filteredInsertions);
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourPathCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourPathCalculator.java
@@ -22,11 +22,10 @@ import java.util.List;
 
 import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
 import org.matsim.contrib.drt.passenger.DrtRequest;
-import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
 
 /**
  * @author michalm
  */
 public interface DetourPathCalculator {
-	DetourData<PathData> calculatePaths(DrtRequest drtRequest, List<Insertion> filteredInsertions);
+	DetourPathData calculatePaths(DrtRequest drtRequest, List<Insertion> filteredInsertions);
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourPathData.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourPathData.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
 
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.optimizer.Waypoint;
-import org.matsim.contrib.drt.passenger.DrtRequest;
+import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
 
 /**
  * Contains detour data for all potential insertions (i.e. pickup and dropoff indices)
@@ -38,20 +38,20 @@ import org.matsim.contrib.drt.passenger.DrtRequest;
  * <p>
  * On the other hand, detour data (D) could itself provide time-dependent information.
  */
-public class DetourData<D> {
-	private final Function<Link, D> detourToPickup;
-	private final Function<Link, D> detourFromPickup;
-	private final Function<Link, D> detourToDropoff;
-	private final Function<Link, D> detourFromDropoff;
-	private final D zeroDetour;
+public class DetourPathData {
+	private final Function<Link, PathData> detourToPickup;
+	private final Function<Link, PathData> detourFromPickup;
+	private final Function<Link, PathData> detourToDropoff;
+	private final Function<Link, PathData> detourFromDropoff;
+	private final PathData zeroDetour;
 
-	DetourData(Map<Link, D> detourToPickup, Map<Link, D> detourFromPickup, Map<Link, D> detourToDropoff,
-			Map<Link, D> detourFromDropoff, D zeroDetour) {
+	DetourPathData(Map<Link, PathData> detourToPickup, Map<Link, PathData> detourFromPickup,
+			Map<Link, PathData> detourToDropoff, Map<Link, PathData> detourFromDropoff, PathData zeroDetour) {
 		this(detourToPickup::get, detourFromPickup::get, detourToDropoff::get, detourFromDropoff::get, zeroDetour);
 	}
 
-	DetourData(Function<Link, D> detourToPickup, Function<Link, D> detourFromPickup, Function<Link, D> detourToDropoff,
-			Function<Link, D> detourFromDropoff, D zeroDetour) {
+	DetourPathData(Function<Link, PathData> detourToPickup, Function<Link, PathData> detourFromPickup,
+			Function<Link, PathData> detourToDropoff, Function<Link, PathData> detourFromDropoff, PathData zeroDetour) {
 		this.detourToPickup = detourToPickup;
 		this.detourFromPickup = detourFromPickup;
 		this.detourToDropoff = detourToDropoff;
@@ -59,13 +59,13 @@ public class DetourData<D> {
 		this.zeroDetour = zeroDetour;
 	}
 
-	public InsertionWithDetourData<D> createInsertionWithDetourData(InsertionGenerator.Insertion insertion) {
-		D toPickup = detourToPickup.apply(insertion.pickup.previousWaypoint.getLink());
-		D fromPickup = detourFromPickup.apply(insertion.pickup.nextWaypoint.getLink());
-		D toDropoff = insertion.dropoff.previousWaypoint instanceof Waypoint.Pickup ?
+	public InsertionWithDetourData<PathData> createInsertionWithDetourData(InsertionGenerator.Insertion insertion) {
+		PathData toPickup = detourToPickup.apply(insertion.pickup.previousWaypoint.getLink());
+		PathData fromPickup = detourFromPickup.apply(insertion.pickup.nextWaypoint.getLink());
+		PathData toDropoff = insertion.dropoff.previousWaypoint instanceof Waypoint.Pickup ?
 				null :
 				detourToDropoff.apply(insertion.dropoff.previousWaypoint.getLink());
-		D fromDropoff = insertion.dropoff.nextWaypoint instanceof Waypoint.End ?
+		PathData fromDropoff = insertion.dropoff.nextWaypoint instanceof Waypoint.End ?
 				zeroDetour :
 				detourFromDropoff.apply(insertion.dropoff.nextWaypoint.getLink());
 		return new InsertionWithDetourData<>(insertion, toPickup, fromPickup, toDropoff, fromDropoff);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourPathData.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourPathData.java
@@ -21,7 +21,6 @@
 package org.matsim.contrib.drt.optimizer.insertion;
 
 import java.util.Map;
-import java.util.function.Function;
 
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.optimizer.Waypoint;
@@ -39,19 +38,14 @@ import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
  * On the other hand, detour data (D) could itself provide time-dependent information.
  */
 public class DetourPathData {
-	private final Function<Link, PathData> detourToPickup;
-	private final Function<Link, PathData> detourFromPickup;
-	private final Function<Link, PathData> detourToDropoff;
-	private final Function<Link, PathData> detourFromDropoff;
+	private final Map<Link, PathData> detourToPickup;
+	private final Map<Link, PathData> detourFromPickup;
+	private final Map<Link, PathData> detourToDropoff;
+	private final Map<Link, PathData> detourFromDropoff;
 	private final PathData zeroDetour;
 
 	DetourPathData(Map<Link, PathData> detourToPickup, Map<Link, PathData> detourFromPickup,
 			Map<Link, PathData> detourToDropoff, Map<Link, PathData> detourFromDropoff, PathData zeroDetour) {
-		this(detourToPickup::get, detourFromPickup::get, detourToDropoff::get, detourFromDropoff::get, zeroDetour);
-	}
-
-	DetourPathData(Function<Link, PathData> detourToPickup, Function<Link, PathData> detourFromPickup,
-			Function<Link, PathData> detourToDropoff, Function<Link, PathData> detourFromDropoff, PathData zeroDetour) {
 		this.detourToPickup = detourToPickup;
 		this.detourFromPickup = detourFromPickup;
 		this.detourToDropoff = detourToDropoff;
@@ -60,14 +54,14 @@ public class DetourPathData {
 	}
 
 	public InsertionWithDetourData<PathData> createInsertionWithDetourData(InsertionGenerator.Insertion insertion) {
-		PathData toPickup = detourToPickup.apply(insertion.pickup.previousWaypoint.getLink());
-		PathData fromPickup = detourFromPickup.apply(insertion.pickup.nextWaypoint.getLink());
+		PathData toPickup = detourToPickup.get(insertion.pickup.previousWaypoint.getLink());
+		PathData fromPickup = detourFromPickup.get(insertion.pickup.nextWaypoint.getLink());
 		PathData toDropoff = insertion.dropoff.previousWaypoint instanceof Waypoint.Pickup ?
 				null :
-				detourToDropoff.apply(insertion.dropoff.previousWaypoint.getLink());
+				detourToDropoff.get(insertion.dropoff.previousWaypoint.getLink());
 		PathData fromDropoff = insertion.dropoff.nextWaypoint instanceof Waypoint.End ?
 				zeroDetour :
-				detourFromDropoff.apply(insertion.dropoff.nextWaypoint.getLink());
+				detourFromDropoff.get(insertion.dropoff.nextWaypoint.getLink());
 		return new InsertionWithDetourData<>(insertion, toPickup, fromPickup, toDropoff, fromDropoff);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourPathData.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourPathData.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.optimizer.Waypoint;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionWithDetourData.InsertionDetourData;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
 
 /**
@@ -53,7 +54,7 @@ public class DetourPathData {
 		this.zeroDetour = zeroDetour;
 	}
 
-	public InsertionWithDetourData<PathData> createInsertionWithDetourData(InsertionGenerator.Insertion insertion) {
+	public InsertionDetourData<PathData> createInsertionDetourData(InsertionGenerator.Insertion insertion) {
 		PathData toPickup = detourToPickup.get(insertion.pickup.previousWaypoint.getLink());
 		PathData fromPickup = detourFromPickup.get(insertion.pickup.nextWaypoint.getLink());
 		PathData toDropoff = insertion.dropoff.previousWaypoint instanceof Waypoint.Pickup ?
@@ -62,6 +63,6 @@ public class DetourPathData {
 		PathData fromDropoff = insertion.dropoff.nextWaypoint instanceof Waypoint.End ?
 				zeroDetour :
 				detourFromDropoff.get(insertion.dropoff.nextWaypoint.getLink());
-		return new InsertionWithDetourData<>(insertion, toPickup, fromPickup, toDropoff, fromDropoff);
+		return new InsertionDetourData<>(toPickup, fromPickup, toDropoff, fromDropoff);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourPathDataCache.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourPathDataCache.java
@@ -24,28 +24,22 @@ import java.util.Map;
 
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.optimizer.Waypoint;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionWithDetourData.InsertionDetourData;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
 
 /**
- * Contains detour data for all potential insertions (i.e. pickup and dropoff indices)
- * <p>
- * Having them collected in one set allows the typical use case where all paths are precomputed in one go
- * and then provided via InsertionWithPathData for a specific Insertion.
- * <p>
- * The current implementation assumes the DetourData functions are time independent. This may be changed in the future (esp.
- * for pre-booking or to enhance simple beeline TT estimation) to BiFunctions: (Link, time) -> data.
- * <p>
- * On the other hand, detour data (D) could itself provide time-dependent information.
+ * Contains detour data for all potential insertions (i.e. pickup and dropoff indices).
+ * Typically, all path data of a given type (i.e. to/from pickup/delivery) are precomputed in one go and then cached.
  */
-public class DetourPathData {
+public class DetourPathDataCache {
 	private final Map<Link, PathData> detourToPickup;
 	private final Map<Link, PathData> detourFromPickup;
 	private final Map<Link, PathData> detourToDropoff;
 	private final Map<Link, PathData> detourFromDropoff;
 	private final PathData zeroDetour;
 
-	DetourPathData(Map<Link, PathData> detourToPickup, Map<Link, PathData> detourFromPickup,
+	DetourPathDataCache(Map<Link, PathData> detourToPickup, Map<Link, PathData> detourFromPickup,
 			Map<Link, PathData> detourToDropoff, Map<Link, PathData> detourFromDropoff, PathData zeroDetour) {
 		this.detourToPickup = detourToPickup;
 		this.detourFromPickup = detourFromPickup;
@@ -54,7 +48,7 @@ public class DetourPathData {
 		this.zeroDetour = zeroDetour;
 	}
 
-	public InsertionDetourData<PathData> createInsertionDetourData(InsertionGenerator.Insertion insertion) {
+	public InsertionDetourData<PathData> createInsertionDetourData(Insertion insertion) {
 		PathData toPickup = detourToPickup.get(insertion.pickup.previousWaypoint.getLink());
 		PathData fromPickup = detourFromPickup.get(insertion.pickup.nextWaypoint.getLink());
 		PathData toDropoff = insertion.dropoff.previousWaypoint instanceof Waypoint.Pickup ?

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculator.java
@@ -122,28 +122,49 @@ public class InsertionDetourTimeCalculator<D> {
 		return replacedDriveEndTime - replacedDriveStartTime;
 	}
 
-	//move to InsertionDetourTimeCalculator; make InsertionDetourTimeCalculator an interface?
-	public static class DetourTimeInfo {
+	public static class PickupDetourInfo {
 		// expected departure time for the new request
 		public final double departureTime;
-		// expected arrival time for the new request
-		public final double arrivalTime;
 		// time delay of each stop placed after the pickup insertion point
 		public final double pickupTimeLoss;
+
+		public PickupDetourInfo(double departureTime, double pickupTimeLoss) {
+			this.departureTime = departureTime;
+			this.pickupTimeLoss = pickupTimeLoss;
+		}
+	}
+
+	public static class DropoffDetourInfo {
+		// expected arrival time for the new request
+		public final double arrivalTime;
 		// ADDITIONAL time delay of each stop placed after the dropoff insertion point
 		public final double dropoffTimeLoss;
 
-		public DetourTimeInfo(double departureTime, double arrivalTime, double pickupTimeLoss, double dropoffTimeLoss) {
-			this.departureTime = departureTime;
+		public DropoffDetourInfo(double arrivalTime, double dropoffTimeLoss) {
 			this.arrivalTime = arrivalTime;
-			this.pickupTimeLoss = pickupTimeLoss;
 			this.dropoffTimeLoss = dropoffTimeLoss;
+		}
+	}
+
+	//move to InsertionDetourTimeCalculator; make InsertionDetourTimeCalculator an interface?
+	public static class DetourTimeInfo {
+		public final PickupDetourInfo pickupDetourInfo;
+		public final DropoffDetourInfo dropoffDetourInfo;
+
+		public DetourTimeInfo(PickupDetourInfo pickupDetourInfo, DropoffDetourInfo dropoffDetourInfo) {
+			this.pickupDetourInfo = pickupDetourInfo;
+			this.dropoffDetourInfo = dropoffDetourInfo;
+		}
+
+		public DetourTimeInfo(double departureTime, double arrivalTime, double pickupTimeLoss, double dropoffTimeLoss) {
+			this(new PickupDetourInfo(departureTime, pickupTimeLoss),
+					new DropoffDetourInfo(arrivalTime, dropoffTimeLoss));
 		}
 
 		// TOTAL time delay of each stop placed after the dropoff insertion point
 		// (this is the amount of extra time the vehicle will operate if this insertion is applied)
 		public double getTotalTimeLoss() {
-			return pickupTimeLoss + dropoffTimeLoss;
+			return pickupDetourInfo.pickupTimeLoss + dropoffDetourInfo.dropoffTimeLoss;
 		}
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculator.java
@@ -7,6 +7,7 @@ import java.util.function.ToDoubleFunction;
 import javax.annotation.Nullable;
 
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.InsertionPoint;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -29,8 +30,8 @@ public class InsertionDetourTimeCalculator<D> {
 	}
 
 	public DetourTimeInfo calculateDetourTimeInfo(InsertionWithDetourData<D> insertion) {
-		InsertionGenerator.InsertionPoint pickup = insertion.getPickup();
-		InsertionGenerator.InsertionPoint dropoff = insertion.getDropoff();
+		InsertionPoint pickup = insertion.getPickup();
+		InsertionPoint dropoff = insertion.getDropoff();
 		if (pickup.index == dropoff.index) {
 			//handle the pickup->dropoff case separately
 			return calculateDetourTimeInfoForIfPickupToDropoffDetour(insertion);
@@ -73,7 +74,7 @@ public class InsertionDetourTimeCalculator<D> {
 
 	private DetourTimeInfo calculateDetourTimeInfoForIfPickupToDropoffDetour(InsertionWithDetourData<D> insertion) {
 		VehicleEntry vEntry = insertion.getVehicleEntry();
-		InsertionGenerator.InsertionPoint pickup = insertion.getPickup();
+		InsertionPoint pickup = insertion.getPickup();
 
 		final double toPickupTT;
 		final double additionalPickupStopDuration;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGenerator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGenerator.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
 import org.matsim.contrib.drt.optimizer.Waypoint;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionWithDetourData.InsertionDetourData;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 
 import com.google.common.base.MoreObjects;
@@ -194,6 +195,7 @@ public class InsertionGenerator {
 		double fromPickup = detourTime.calcFromPickupTime(insertion, request);
 		double toDropoff = detourTime.calcToDropoffTime(insertion, request);
 		double fromDropoff = detourTime.calcFromDropoffTime(insertion, request);
-		return new InsertionWithDetourData<>(insertion, toPickup, fromPickup, toDropoff, fromDropoff);
+		var insertionDetourData = new InsertionDetourData<>(toPickup, fromPickup, toDropoff, fromDropoff);
+		return new InsertionWithDetourData<>(insertion, insertionDetourData);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionWithDetourData.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionWithDetourData.java
@@ -31,10 +31,32 @@ import com.google.common.base.MoreObjects;
  */
 public class InsertionWithDetourData<D> {
 	public static class InsertionDetourData<D> {
+		/**
+		 * Detour necessary to get from start or the preceding stop to pickup.
+		 * <p>
+		 * If pickup is inserted at the (existing) previous stop -> no detour.
+		 */
 		public final D detourToPickup;
-		public final D detourFromPickup; // "zero" detour if pickup inserted at the end of schedule !!!
-		public final D detourToDropoff; // detour from pickup if dropoff inserted directly after pickup
-		public final D detourFromDropoff; // "zero" detour if dropoff inserted at the end of schedule
+		/**
+		 * Detour necessary to get from pickup to the next stop or 0 if appended at the end.
+		 * <p>
+		 * IMPORTANT: At this point the dropoff location is not taken into account !!!
+		 * "zero" detour if pickup inserted at the end of schedule !!!
+		 */
+		public final D detourFromPickup;
+		/**
+		 * Detour necessary to get from the preceding stop (could be a stop of the corresponding pickup) to dropoff.
+		 * <p>
+		 * If dropoff is inserted at the (existing) previous stop -> no detour.
+		 * If dropoff inserted directly after pickup -> detour from pickup
+		 */
+		public final D detourToDropoff;
+		/**
+		 * Detour necessary to get from dropoff to the next stop or no detour if appended at the end.
+		 * <p>
+		 * "zero" detour if dropoff inserted at the end of schedule
+		 */
+		public final D detourFromDropoff;
 
 		public InsertionDetourData(D detourToPickup, D detourFromPickup, D detourToDropoff, D detourFromDropoff) {
 			this.detourToPickup = detourToPickup;
@@ -66,58 +88,8 @@ public class InsertionWithDetourData<D> {
 		return insertion;
 	}
 
-	public VehicleEntry getVehicleEntry() {
-		return insertion.vehicleEntry;
-	}
-
-	public InsertionPoint getPickup() {
-		return insertion.pickup;
-	}
-
-	public InsertionPoint getDropoff() {
-		return insertion.dropoff;
-	}
-
-	/**
-	 * Detour necessary to get from start or the preceding stop to pickup.
-	 * <p>
-	 * If pickup is inserted at the (existing) previous stop -> no detour.
-	 *
-	 * @return
-	 */
-	public D getDetourToPickup() {
-		return insertionDetourData.detourToPickup;
-	}
-
-	/**
-	 * Detour necessary to get from pickup to the next stop or 0 if appended at the end.
-	 * <p>
-	 * IMPORTANT: At this point the dropoff location is not taken into account !!!
-	 *
-	 * @return
-	 */
-	public D getDetourFromPickup() {
-		return insertionDetourData.detourFromPickup;
-	}
-
-	/**
-	 * Detour necessary to get from the preceding stop (could be a stop of the corresponding pickup) to dropoff.
-	 * <p>
-	 * If dropoff is inserted at the (existing) previous stop -> no detour.
-	 *
-	 * @return
-	 */
-	public D getDetourToDropoff() {
-		return insertionDetourData.detourToDropoff;
-	}
-
-	/**
-	 * Detour necessary to get from dropoff to the next stop or no detour if appended at the end.
-	 *
-	 * @return
-	 */
-	public D getDetourFromDropoff() {
-		return insertionDetourData.detourFromDropoff;
+	public InsertionDetourData<D> getDetourData() {
+		return insertionDetourData;
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionWithDetourData.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionWithDetourData.java
@@ -30,20 +30,36 @@ import com.google.common.base.MoreObjects;
  * @author michalm
  */
 public class InsertionWithDetourData<D> {
+	public static class InsertionDetourData<D> {
+		public final D detourToPickup;
+		public final D detourFromPickup; // "zero" detour if pickup inserted at the end of schedule !!!
+		public final D detourToDropoff; // detour from pickup if dropoff inserted directly after pickup
+		public final D detourFromDropoff; // "zero" detour if dropoff inserted at the end of schedule
+
+		public InsertionDetourData(D detourToPickup, D detourFromPickup, D detourToDropoff, D detourFromDropoff) {
+			this.detourToPickup = detourToPickup;
+			this.detourFromPickup = detourFromPickup;
+			this.detourToDropoff = detourToDropoff;
+			this.detourFromDropoff = detourFromDropoff;
+		}
+
+		@Override
+		public String toString() {
+			return MoreObjects.toStringHelper(this)
+					.add("detourToPickup", detourToPickup)
+					.add("detourFromPickup", detourFromPickup)
+					.add("detourToDropoff", detourToDropoff)
+					.add("detourFromDropoff", detourFromDropoff)
+					.toString();
+		}
+	}
+
 	private final Insertion insertion;
+	private final InsertionDetourData<D> insertionDetourData;
 
-	private final D detourToPickup;
-	private final D detourFromPickup; // "zero" detour if pickup inserted at the end of schedule !!!
-	private final D detourToDropoff; // detour from pickup if dropoff inserted directly after pickup
-	private final D detourFromDropoff; // "zero" detour if dropoff inserted at the end of schedule
-
-	InsertionWithDetourData(Insertion insertion, D detourToPickup, D detourFromPickup, D detourToDropoff,
-			D detourFromDropoff) {
+	InsertionWithDetourData(Insertion insertion, InsertionDetourData<D> insertionDetourData) {
 		this.insertion = insertion;
-		this.detourToPickup = detourToPickup;
-		this.detourFromPickup = detourFromPickup;
-		this.detourToDropoff = detourToDropoff;
-		this.detourFromDropoff = detourFromDropoff;
+		this.insertionDetourData = insertionDetourData;
 	}
 
 	public Insertion getInsertion() {
@@ -70,7 +86,7 @@ public class InsertionWithDetourData<D> {
 	 * @return
 	 */
 	public D getDetourToPickup() {
-		return detourToPickup;
+		return insertionDetourData.detourToPickup;
 	}
 
 	/**
@@ -81,7 +97,7 @@ public class InsertionWithDetourData<D> {
 	 * @return
 	 */
 	public D getDetourFromPickup() {
-		return detourFromPickup;
+		return insertionDetourData.detourFromPickup;
 	}
 
 	/**
@@ -92,7 +108,7 @@ public class InsertionWithDetourData<D> {
 	 * @return
 	 */
 	public D getDetourToDropoff() {
-		return detourToDropoff;
+		return insertionDetourData.detourToDropoff;
 	}
 
 	/**
@@ -101,17 +117,14 @@ public class InsertionWithDetourData<D> {
 	 * @return
 	 */
 	public D getDetourFromDropoff() {
-		return detourFromDropoff;
+		return insertionDetourData.detourFromDropoff;
 	}
 
 	@Override
 	public String toString() {
 		return MoreObjects.toStringHelper(this)
 				.add("insertion", insertion)
-				.add("detourToPickup", detourToPickup)
-				.add("detourFromPickup", detourFromPickup)
-				.add("detourToDropoff", detourToDropoff)
-				.add("detourFromDropoff", detourFromDropoff)
+				.add("insertionDetourData", insertionDetourData)
 				.toString();
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/KNearestInsertionsAtEndFilter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/KNearestInsertionsAtEndFilter.java
@@ -21,9 +21,9 @@ package org.matsim.contrib.drt.optimizer.insertion;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.matsim.contrib.common.collections.PartialSort;
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
 import org.matsim.contrib.drt.optimizer.insertion.BestInsertionFinder.InsertionWithCost;
-import org.matsim.contrib.common.collections.PartialSort;
 
 /**
  * "Insertion at end" means appending both pickup and dropoff at the end of the schedule, which means the ride
@@ -39,18 +39,20 @@ class KNearestInsertionsAtEndFilter {
 				BestInsertionFinder.createInsertionWithCostComparator());
 		var filteredInsertions = new ArrayList<InsertionGenerator.Insertion>(insertions.size());
 
-		for (var insertion : insertions) {
-			VehicleEntry vEntry = insertion.getVehicleEntry();
-			var pickup = insertion.getPickup();
+		for (var insertionWithDetourData : insertions) {
+			var insertion = insertionWithDetourData.getInsertion();
+			VehicleEntry vEntry = insertion.vehicleEntry;
+			var pickup = insertion.pickup;
 			if (!vEntry.isAfterLastStop(pickup.index)) {
-				filteredInsertions.add(insertion.getInsertion());
+				filteredInsertions.add(insertion);
 			} else if (k > 0) {
 				double departureTime = pickup.previousWaypoint.getDepartureTime();
 
 				// x ADMISSIBLE_BEELINE_SPEED_FACTOR to remove bias towards near but still busy vehicles
 				// (timeToPickup is underestimated by this factor)
-				double timeDistance = departureTime + admissibleBeelineSpeedFactor * insertion.getDetourToPickup();
-				nearestInsertionsAtEnd.add(new InsertionWithCost<>(insertion, timeDistance));
+				double timeDistance = departureTime
+						+ admissibleBeelineSpeedFactor * insertionWithDetourData.getDetourData().detourToPickup;
+				nearestInsertionsAtEnd.add(new InsertionWithCost<>(insertionWithDetourData, timeDistance));
 			}
 		}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/MultiInsertionDetourPathCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/MultiInsertionDetourPathCalculator.java
@@ -83,7 +83,7 @@ public class MultiInsertionDetourPathCalculator implements DetourPathCalculator,
 	}
 
 	@Override
-	public DetourPathData calculatePaths(DrtRequest drtRequest, List<Insertion> filteredInsertions) {
+	public DetourPathDataCache calculatePaths(DrtRequest drtRequest, List<Insertion> filteredInsertions) {
 		// with vehicle insertion filtering -- pathsToPickup is the most computationally demanding task, while
 		// pathsFromDropoff is the least demanding one
 		var pathsToPickupFuture = executorService.submit(() -> calcPathsToPickup(drtRequest, filteredInsertions));
@@ -92,7 +92,7 @@ public class MultiInsertionDetourPathCalculator implements DetourPathCalculator,
 		var pathsFromDropoffFuture = executorService.submit(() -> calcPathsFromDropoff(drtRequest, filteredInsertions));
 
 		try {
-			return new DetourPathData(pathsToPickupFuture.get(), pathsFromPickupFuture.get(),
+			return new DetourPathDataCache(pathsToPickupFuture.get(), pathsFromPickupFuture.get(),
 					pathsToDropoffFuture.get(), pathsFromDropoffFuture.get(), PathData.EMPTY);
 		} catch (InterruptedException | ExecutionException e) {
 			throw new RuntimeException(e);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/MultiInsertionDetourPathCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/MultiInsertionDetourPathCalculator.java
@@ -83,7 +83,7 @@ public class MultiInsertionDetourPathCalculator implements DetourPathCalculator,
 	}
 
 	@Override
-	public DetourData<PathData> calculatePaths(DrtRequest drtRequest, List<Insertion> filteredInsertions) {
+	public DetourPathData calculatePaths(DrtRequest drtRequest, List<Insertion> filteredInsertions) {
 		// with vehicle insertion filtering -- pathsToPickup is the most computationally demanding task, while
 		// pathsFromDropoff is the least demanding one
 		var pathsToPickupFuture = executorService.submit(() -> calcPathsToPickup(drtRequest, filteredInsertions));
@@ -92,8 +92,8 @@ public class MultiInsertionDetourPathCalculator implements DetourPathCalculator,
 		var pathsFromDropoffFuture = executorService.submit(() -> calcPathsFromDropoff(drtRequest, filteredInsertions));
 
 		try {
-			return new DetourData<>(pathsToPickupFuture.get(), pathsFromPickupFuture.get(), pathsToDropoffFuture.get(),
-					pathsFromDropoffFuture.get(), PathData.EMPTY);
+			return new DetourPathData(pathsToPickupFuture.get(), pathsFromPickupFuture.get(),
+					pathsToDropoffFuture.get(), pathsFromDropoffFuture.get(), PathData.EMPTY);
 		} catch (InterruptedException | ExecutionException e) {
 			throw new RuntimeException(e);
 		}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SingleInsertionDetourPathCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SingleInsertionDetourPathCalculator.java
@@ -85,7 +85,7 @@ public class SingleInsertionDetourPathCalculator implements DetourPathCalculator
 	}
 
 	@Override
-	public DetourData<PathData> calculatePaths(DrtRequest drtRequest, List<Insertion> filteredInsertions) {
+	public DetourPathData calculatePaths(DrtRequest drtRequest, List<Insertion> filteredInsertions) {
 		Link pickup = drtRequest.getFromLink();
 		Link dropoff = drtRequest.getToLink();
 
@@ -121,8 +121,8 @@ public class SingleInsertionDetourPathCalculator implements DetourPathCalculator
 								latestDropoffTime)));
 
 		try {
-			return new DetourData<>(pathsToPickupFuture.get(), pathsFromPickupFuture.get(), pathsToDropoffFuture.get(),
-					pathsFromDropoffFuture.get(), PathData.EMPTY);
+			return new DetourPathData(pathsToPickupFuture.get(), pathsFromPickupFuture.get(),
+					pathsToDropoffFuture.get(), pathsFromDropoffFuture.get(), PathData.EMPTY);
 		} catch (InterruptedException | ExecutionException e) {
 			throw new RuntimeException(e);
 		}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SingleInsertionDetourPathCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SingleInsertionDetourPathCalculator.java
@@ -85,7 +85,7 @@ public class SingleInsertionDetourPathCalculator implements DetourPathCalculator
 	}
 
 	@Override
-	public DetourPathData calculatePaths(DrtRequest drtRequest, List<Insertion> filteredInsertions) {
+	public DetourPathDataCache calculatePaths(DrtRequest drtRequest, List<Insertion> filteredInsertions) {
 		Link pickup = drtRequest.getFromLink();
 		Link dropoff = drtRequest.getToLink();
 
@@ -121,7 +121,7 @@ public class SingleInsertionDetourPathCalculator implements DetourPathCalculator
 								latestDropoffTime)));
 
 		try {
-			return new DetourPathData(pathsToPickupFuture.get(), pathsFromPickupFuture.get(),
+			return new DetourPathDataCache(pathsToPickupFuture.get(), pathsFromPickupFuture.get(),
 					pathsToDropoffFuture.get(), pathsFromDropoffFuture.get(), PathData.EMPTY);
 		} catch (InterruptedException | ExecutionException e) {
 			throw new RuntimeException(e);

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/BestInsertionFinderTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/BestInsertionFinderTest.java
@@ -142,8 +142,7 @@ public class BestInsertionFinderTest {
 		var pickupInsertion = new InsertionGenerator.InsertionPoint(pickupIdx, null, null, null);
 		var dropoffInsertion = new InsertionGenerator.InsertionPoint(dropoffIdx, null, null, null);
 
-		return new InsertionWithDetourData<Double>(
-				new InsertionGenerator.Insertion(vehicleEntry, pickupInsertion, dropoffInsertion), null, null, null,
-				null);
+		return new InsertionWithDetourData<>(
+				new InsertionGenerator.Insertion(vehicleEntry, pickupInsertion, dropoffInsertion), null);
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearchTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearchTest.java
@@ -76,7 +76,7 @@ public class DefaultDrtInsertionSearchTest {
 		when(insertionProvider.getInsertions(eq(request), eq(List.of(vehicleEntry)))).thenReturn(filteredInsertions);
 
 		//mock detourPathCalculator
-		var detourData = new DetourPathData(Map.of(beforePickupLink, mock(PathData.class)),
+		var detourData = new DetourPathDataCache(Map.of(beforePickupLink, mock(PathData.class)),
 				Map.of(afterPickupLink, mock(PathData.class)), Map.of(beforeDropoffLink, mock(PathData.class)),
 				Map.of(afterDropoffLink, mock(PathData.class)), PathData.EMPTY);
 		var detourPathCalculator = mock(DetourPathCalculator.class);

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearchTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearchTest.java
@@ -42,7 +42,6 @@ import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.InsertionPo
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
-import org.matsim.core.mobsim.framework.MobsimTimer;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -77,7 +76,7 @@ public class DefaultDrtInsertionSearchTest {
 		when(insertionProvider.getInsertions(eq(request), eq(List.of(vehicleEntry)))).thenReturn(filteredInsertions);
 
 		//mock detourPathCalculator
-		var detourData = new DetourData<>(Map.of(beforePickupLink, mock(PathData.class)),
+		var detourData = new DetourPathData(Map.of(beforePickupLink, mock(PathData.class)),
 				Map.of(afterPickupLink, mock(PathData.class)), Map.of(beforeDropoffLink, mock(PathData.class)),
 				Map.of(afterDropoffLink, mock(PathData.class)), PathData.EMPTY);
 		var detourPathCalculator = mock(DetourPathCalculator.class);

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearchTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearchTest.java
@@ -83,7 +83,8 @@ public class DefaultDrtInsertionSearchTest {
 		when(detourPathCalculator.calculatePaths(eq(request), eq(filteredInsertions))).thenReturn(detourData);
 
 		//mock bestInsertionFinder
-		var selectedInsertionWithPathData = detourData.createInsertionWithDetourData(selectedInsertion);
+		var selectedInsertionWithPathData = new InsertionWithDetourData<>(selectedInsertion,
+				detourData.createInsertionDetourData(selectedInsertion));
 		@SuppressWarnings("unchecked")
 		var bestInsertionFinder = (BestInsertionFinder<PathData>)mock(BestInsertionFinder.class);
 		when(bestInsertionFinder.findBestInsertion(eq(request),

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserterTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserterTest.java
@@ -204,8 +204,7 @@ public class DefaultUnplannedRequestInserterTest {
 
 		DrtInsertionSearch<PathData> insertionSearch = (drtRequest, vEntries) -> drtRequest == request1 ?
 				Optional.of(new InsertionWithDetourData<PathData>(
-						new InsertionGenerator.Insertion(vEntries.iterator().next(), null, null), null, null, null,
-						null)) :
+						new InsertionGenerator.Insertion(vEntries.iterator().next(), null, null), null)) :
 				fail("request1 expected");
 
 		double pickupEndTime = now + 20;

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DetourPathDataCacheTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DetourPathDataCacheTest.java
@@ -43,7 +43,7 @@ import com.google.common.collect.ImmutableMap;
 /**
  * @author Michal Maciejewski (michalm)
  */
-public class DetourPathDataTest {
+public class DetourPathDataCacheTest {
 	private final Link pickupLink = link("pickupLink");
 	private final Link dropoffLink = link("dropoffLink");
 	private final Link startLink = link("startLink");
@@ -81,7 +81,7 @@ public class DetourPathDataTest {
 			dropoff_stop1);
 
 	private static final PathData ZERO_DETOUR = mock(PathData.class);
-	private final DetourPathData detourPathData = new DetourPathData(pathToPickupMap, pathFromPickupMap,
+	private final DetourPathDataCache detourPathDataCache = new DetourPathDataCache(pathToPickupMap, pathFromPickupMap,
 			pathToDropoffMap, pathFromDropoffMap, ZERO_DETOUR);
 
 	@Test
@@ -117,7 +117,7 @@ public class DetourPathDataTest {
 	private void assertInsertion(int pickupIdx, int dropoffIdx, PathData detourToPickup, PathData detourFromPickup,
 			PathData detourToDropoff, PathData detourFromDropoff) {
 		Insertion insertion = new Insertion(request, entry, pickupIdx, dropoffIdx);
-		var actual = detourPathData.createInsertionDetourData(insertion);
+		var actual = detourPathDataCache.createInsertionDetourData(insertion);
 
 		var expectedInsertionDetourData = new InsertionDetourData<>(detourToPickup, detourFromPickup, detourToDropoff,
 				detourFromDropoff);

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DetourPathDataTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DetourPathDataTest.java
@@ -31,6 +31,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
 import org.matsim.contrib.drt.optimizer.Waypoint;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionWithDetourData.InsertionDetourData;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
@@ -116,10 +117,12 @@ public class DetourPathDataTest {
 	private void assertInsertion(int pickupIdx, int dropoffIdx, PathData detourToPickup, PathData detourFromPickup,
 			PathData detourToDropoff, PathData detourFromDropoff) {
 		Insertion insertion = new Insertion(request, entry, pickupIdx, dropoffIdx);
-		var actual = detourPathData.createInsertionWithDetourData(insertion);
-		var expected = new InsertionWithDetourData<>(insertion, detourToPickup, detourFromPickup, detourToDropoff,
+		var actual = detourPathData.createInsertionDetourData(insertion);
+
+		var expectedInsertionDetourData = new InsertionDetourData<>(detourToPickup, detourFromPickup, detourToDropoff,
 				detourFromDropoff);
-		assertThat(actual).isEqualToComparingFieldByField(expected);
+
+		assertThat(actual).usingRecursiveComparison().isEqualTo(expectedInsertionDetourData);
 	}
 
 	private Link link(String id) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DetourPathDataTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DetourPathDataTest.java
@@ -21,6 +21,7 @@
 package org.matsim.contrib.drt.optimizer.insertion;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
 
@@ -32,6 +33,7 @@ import org.matsim.contrib.drt.optimizer.Waypoint;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
+import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
 import org.matsim.testcases.fakes.FakeLink;
 
 import com.google.common.collect.ImmutableList;
@@ -40,46 +42,46 @@ import com.google.common.collect.ImmutableMap;
 /**
  * @author Michal Maciejewski (michalm)
  */
-public class DetourDataTest {
+public class DetourPathDataTest {
 	private final Link pickupLink = link("pickupLink");
 	private final Link dropoffLink = link("dropoffLink");
 	private final Link startLink = link("startLink");
 	private final Link stop0Link = link("stop0Link");
 	private final Link stop1Link = link("stop1Link");
 
-	private final String start_pickup = "start_pickup";
-	private final String stop0_pickup = "stop0_pickup";
-	private final String stop1_pickup = "stop1_pickup";
+	private final PathData start_pickup = mock(PathData.class);
+	private final PathData stop0_pickup = mock(PathData.class);
+	private final PathData stop1_pickup = mock(PathData.class);
 
-	private final String pickup_stop0 = "pickup_stop0";
-	private final String pickup_stop1 = "pickup_stop1";
+	private final PathData pickup_stop0 = mock(PathData.class);
+	private final PathData pickup_stop1 = mock(PathData.class);
 
-	private final String pickup_dropoff = "pickup_dropoff";
+	private final PathData pickup_dropoff = mock(PathData.class);
 
-	private final String stop0_dropoff = "stop0_dropoff";
-	private final String stop1_dropoff = "stop1_dropoff";
+	private final PathData stop0_dropoff = mock(PathData.class);
+	private final PathData stop1_dropoff = mock(PathData.class);
 
-	private final String dropoff_stop0 = "dropoff_stop0";
-	private final String dropoff_stop1 = "dropoff_stop1";
+	private final PathData dropoff_stop0 = mock(PathData.class);
+	private final PathData dropoff_stop1 = mock(PathData.class);
 
 	private final DrtRequest request = DrtRequest.newBuilder().fromLink(pickupLink).toLink(dropoffLink).build();
 	private final VehicleEntry entry = entry(startLink, stop0Link, stop1Link);
 
-	private final ImmutableMap<Link, String> pathToPickupMap = ImmutableMap.of(startLink, start_pickup, stop0Link,
+	private final ImmutableMap<Link, PathData> pathToPickupMap = ImmutableMap.of(startLink, start_pickup, stop0Link,
 			stop0_pickup, stop1Link, stop1_pickup);
 
-	private final ImmutableMap<Link, String> pathFromPickupMap = ImmutableMap.of(stop0Link, pickup_stop0, stop1Link,
+	private final ImmutableMap<Link, PathData> pathFromPickupMap = ImmutableMap.of(stop0Link, pickup_stop0, stop1Link,
 			pickup_stop1, dropoffLink, pickup_dropoff);
 
-	private final ImmutableMap<Link, String> pathToDropoffMap = ImmutableMap.of(pickupLink, pickup_dropoff, stop0Link,
+	private final ImmutableMap<Link, PathData> pathToDropoffMap = ImmutableMap.of(pickupLink, pickup_dropoff, stop0Link,
 			stop0_dropoff, stop1Link, stop1_dropoff);
 
-	private final ImmutableMap<Link, String> pathFromDropoffMap = ImmutableMap.of(stop0Link, dropoff_stop0, stop1Link,
+	private final ImmutableMap<Link, PathData> pathFromDropoffMap = ImmutableMap.of(stop0Link, dropoff_stop0, stop1Link,
 			dropoff_stop1);
 
-	private static final String ZERO_DETOUR = "zero_detour";
-	private final DetourData<String> detourData = new DetourData<>(pathToPickupMap, pathFromPickupMap, pathToDropoffMap,
-			pathFromDropoffMap, ZERO_DETOUR);
+	private static final PathData ZERO_DETOUR = mock(PathData.class);
+	private final DetourPathData detourPathData = new DetourPathData(pathToPickupMap, pathFromPickupMap,
+			pathToDropoffMap, pathFromDropoffMap, ZERO_DETOUR);
 
 	@Test
 	public void insertion_0_0() {
@@ -111,10 +113,10 @@ public class DetourDataTest {
 		assertInsertion(2, 2, stop1_pickup, pickup_dropoff, null, ZERO_DETOUR);
 	}
 
-	private void assertInsertion(int pickupIdx, int dropoffIdx, String detourToPickup, String detourFromPickup,
-			String detourToDropoff, String detourFromDropoff) {
+	private void assertInsertion(int pickupIdx, int dropoffIdx, PathData detourToPickup, PathData detourFromPickup,
+			PathData detourToDropoff, PathData detourFromDropoff) {
 		Insertion insertion = new Insertion(request, entry, pickupIdx, dropoffIdx);
-		var actual = detourData.createInsertionWithDetourData(insertion);
+		var actual = detourPathData.createInsertionWithDetourData(insertion);
 		var expected = new InsertionWithDetourData<>(insertion, detourToPickup, detourFromPickup, detourToDropoff,
 				detourFromDropoff);
 		assertThat(actual).isEqualToComparingFieldByField(expected);

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionProviderTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionProviderTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
 import org.matsim.contrib.drt.optimizer.Waypoint;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionWithDetourData.InsertionDetourData;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 
 /**
@@ -98,6 +99,7 @@ public class ExtensiveInsertionProviderTest {
 	}
 
 	private InsertionWithDetourData<Double> insertionWithDetourData(Insertion insertion) {
-		return new InsertionWithDetourData<>(insertion, Double.NaN, Double.NaN, Double.NaN, Double.NaN);
+		return new InsertionWithDetourData<>(insertion,
+				new InsertionDetourData<>(Double.NaN, Double.NaN, Double.NaN, Double.NaN));
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
@@ -22,7 +22,7 @@ package org.matsim.contrib.drt.optimizer.insertion;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
-import static org.matsim.contrib.drt.optimizer.insertion.InsertionDetourTimeCalculator.*;
+import static org.matsim.contrib.drt.optimizer.insertion.InsertionDetourTimeCalculator.DetourTimeInfo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -30,17 +30,9 @@ import org.junit.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
-import org.matsim.contrib.drt.optimizer.Waypoint;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
 import org.matsim.contrib.drt.passenger.DrtRequest;
-import org.matsim.contrib.drt.schedule.DrtStayTask;
-import org.matsim.contrib.drt.schedule.DrtStopTask;
-import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
-import org.matsim.contrib.dvrp.fleet.DvrpVehicleImpl;
-import org.matsim.contrib.dvrp.fleet.ImmutableDvrpVehicleSpecification;
-import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.testcases.fakes.FakeLink;
-
-import com.google.common.collect.ImmutableList;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -53,7 +45,7 @@ public class InsertionCostCalculatorTest {
 	@Test
 	public void testCalculate() {
 		VehicleEntry entry = entry(new double[] { 20, 50 });
-		var insertion = new InsertionWithDetourData<>(insertion(entry, 0, 1), null, null, null, null);
+		var insertion = new InsertionWithDetourData<>(insertion(entry, 0, 1), null);
 
 		//feasible solution
 		assertCalculate(insertion, new DetourTimeInfo(0, 0, 11, 22), 11 + 22);
@@ -86,8 +78,8 @@ public class InsertionCostCalculatorTest {
 		return new FakeLink(Id.createLinkId(id));
 	}
 
-	private InsertionGenerator.Insertion insertion(VehicleEntry entry, int pickupIdx, int dropoffIdx) {
-		return new InsertionGenerator.Insertion(entry,
+	private Insertion insertion(VehicleEntry entry, int pickupIdx, int dropoffIdx) {
+		return new Insertion(entry,
 				new InsertionGenerator.InsertionPoint(pickupIdx, null, null, null),
 				new InsertionGenerator.InsertionPoint(dropoffIdx, null, null, null));
 	}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
@@ -186,14 +186,14 @@ public class InsertionDetourTimeCalculatorTest {
 		double arrivalTime = stop0.getDepartureTime() + pickupTimeLoss + detour.toDropoff;
 		double dropoffTimeLoss = detour.toDropoff + STOP_DURATION + detour.fromDropoff
 				- dropoffDetourReplacedDriveEstimate;
-		assertThat(actualDetourTimeInfo).isEqualToComparingFieldByField(
-				new DetourTimeInfo(departureTime, arrivalTime, pickupTimeLoss, dropoffTimeLoss));
+		assertThat(actualDetourTimeInfo).usingRecursiveComparison()
+				.isEqualTo(new DetourTimeInfo(departureTime, arrivalTime, pickupTimeLoss, dropoffTimeLoss));
 	}
 
 	private void assertDetourTimeInfo(InsertionWithDetourData<Double> insertion, DetourTimeInfo expected) {
 		var detourTimeCalculator = new InsertionDetourTimeCalculator<>(STOP_DURATION, Double::doubleValue, null);
 		var detourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion);
-		assertThat(detourTimeInfo).isEqualToComparingFieldByField(expected);
+		assertThat(detourTimeInfo).usingRecursiveComparison().isEqualTo(expected);
 	}
 
 	private Link link(String id) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
@@ -28,6 +28,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
 import org.matsim.contrib.drt.optimizer.Waypoint;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionWithDetourData.InsertionDetourData;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
@@ -255,8 +256,8 @@ public class InsertionGeneratorTest {
 
 	private InsertionWithDetourData<Double> insertion(VehicleEntry entry, int pickupIdx, int dropoffIdx,
 			double timeToPickup, double timeFromPickup, double timeToDropoff, double timeFromDropoff) {
-		return new InsertionWithDetourData<>(new Insertion(drtRequest, entry, pickupIdx, dropoffIdx), timeToPickup,
-				timeFromPickup, timeToDropoff, timeFromDropoff);
+		return new InsertionWithDetourData<>(new Insertion(drtRequest, entry, pickupIdx, dropoffIdx),
+				new InsertionDetourData<>(timeToPickup, timeFromPickup, timeToDropoff, timeFromDropoff));
 	}
 
 	private Waypoint.Stop stop(Link link, int outgoingOccupancy) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/KNearestInsertionsAtEndFilterTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/KNearestInsertionsAtEndFilterTest.java
@@ -30,6 +30,9 @@ import org.junit.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
 import org.matsim.contrib.drt.optimizer.Waypoint;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.InsertionPoint;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionWithDetourData.InsertionDetourData;
 import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 
@@ -107,9 +110,10 @@ public class KNearestInsertionsAtEndFilterTest {
 
 	private InsertionWithDetourData<Double> insertion(VehicleEntry vehicleEntry, int pickupIdx,
 			double toPickupDetourTime) {
-		return new InsertionWithDetourData<>(new InsertionGenerator.Insertion(vehicleEntry,
-				new InsertionGenerator.InsertionPoint(pickupIdx, vehicleEntry.getWaypoint(pickupIdx), null,
-						vehicleEntry.getWaypoint(pickupIdx + 1)), null), toPickupDetourTime, null, null, null);
+		return new InsertionWithDetourData<>(new Insertion(vehicleEntry,
+				new InsertionPoint(pickupIdx, vehicleEntry.getWaypoint(pickupIdx), null,
+						vehicleEntry.getWaypoint(pickupIdx + 1)), null),
+				new InsertionDetourData<>(toPickupDetourTime, null, null, null));
 	}
 
 	private Waypoint.Start start(double endTime) {
@@ -127,7 +131,7 @@ public class KNearestInsertionsAtEndFilterTest {
 	}
 
 	@SafeVarargs
-	private List<InsertionGenerator.Insertion> filterOneInsertionAtEnd(InsertionWithDetourData<Double>... insertions) {
+	private List<Insertion> filterOneInsertionAtEnd(InsertionWithDetourData<Double>... insertions) {
 		return KNearestInsertionsAtEndFilter.filterInsertionsAtEnd(1, 1, List.of(insertions));
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/MultiInsertionDetourPathCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/MultiInsertionDetourPathCalculatorTest.java
@@ -86,12 +86,12 @@ public class MultiInsertionDetourPathCalculatorTest {
 		var insertion = new InsertionGenerator.Insertion(null, pickup, dropoff);
 
 		var detourData = detourPathCalculator.calculatePaths(request, List.of(insertion));
-		var insertionWithDetourData = detourData.createInsertionWithDetourData(insertion);
+		var insertionWithDetourData = detourData.createInsertionDetourData(insertion);
 
-		assertThat(insertionWithDetourData.getDetourToPickup()).isEqualTo(pathToPickup);
-		assertThat(insertionWithDetourData.getDetourFromPickup()).isEqualTo(pathFromPickup);
-		assertThat(insertionWithDetourData.getDetourToDropoff()).isEqualTo(pathToDropoff);
-		assertThat(insertionWithDetourData.getDetourFromDropoff()).isEqualTo(pathFromDropoff);
+		assertThat(insertionWithDetourData.detourToPickup).isEqualTo(pathToPickup);
+		assertThat(insertionWithDetourData.detourFromPickup).isEqualTo(pathFromPickup);
+		assertThat(insertionWithDetourData.detourToDropoff).isEqualTo(pathToDropoff);
+		assertThat(insertionWithDetourData.detourFromDropoff).isEqualTo(pathFromDropoff);
 	}
 
 	@Test
@@ -107,12 +107,12 @@ public class MultiInsertionDetourPathCalculatorTest {
 		var insertion = new InsertionGenerator.Insertion(null, pickup, dropoff);
 
 		var detourData = detourPathCalculator.calculatePaths(request, List.of(insertion));
-		var insertionWithDetourData = detourData.createInsertionWithDetourData(insertion);
+		var insertionWithDetourData = detourData.createInsertionDetourData(insertion);
 
-		assertThat(insertionWithDetourData.getDetourToPickup()).isEqualTo(pathToPickup);
-		assertThat(insertionWithDetourData.getDetourFromPickup()).isEqualTo(pathFromPickup);
-		assertThat(insertionWithDetourData.getDetourToDropoff()).isNull();
-		assertThat(insertionWithDetourData.getDetourFromDropoff().getTravelTime()).isZero();
+		assertThat(insertionWithDetourData.detourToPickup).isEqualTo(pathToPickup);
+		assertThat(insertionWithDetourData.detourFromPickup).isEqualTo(pathFromPickup);
+		assertThat(insertionWithDetourData.detourToDropoff).isNull();
+		assertThat(insertionWithDetourData.detourFromDropoff.getTravelTime()).isZero();
 	}
 
 	@Test
@@ -130,12 +130,12 @@ public class MultiInsertionDetourPathCalculatorTest {
 		var insertion = new InsertionGenerator.Insertion(null, pickup, dropoff);
 
 		var detourData = detourPathCalculator.calculatePaths(request, List.of(insertion));
-		var insertionWithDetourData = detourData.createInsertionWithDetourData(insertion);
+		var insertionWithDetourData = detourData.createInsertionDetourData(insertion);
 
-		assertThat(insertionWithDetourData.getDetourToPickup()).isEqualTo(PathData.EMPTY);
-		assertThat(insertionWithDetourData.getDetourFromPickup()).isEqualTo(PathData.EMPTY);
-		assertThat(insertionWithDetourData.getDetourToDropoff()).isEqualTo(PathData.EMPTY);
-		assertThat(insertionWithDetourData.getDetourFromDropoff()).isEqualTo(PathData.EMPTY);
+		assertThat(insertionWithDetourData.detourToPickup).isEqualTo(PathData.EMPTY);
+		assertThat(insertionWithDetourData.detourFromPickup).isEqualTo(PathData.EMPTY);
+		assertThat(insertionWithDetourData.detourToDropoff).isEqualTo(PathData.EMPTY);
+		assertThat(insertionWithDetourData.detourFromDropoff).isEqualTo(PathData.EMPTY);
 	}
 
 	private PathData mockCalcPathData(Link fromLink, Link toLink, double startTimeArg, boolean forward,

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProviderTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProviderTest.java
@@ -36,6 +36,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionWithDetourData.InsertionDetourData;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 
 /**
@@ -71,8 +72,8 @@ public class SelectiveInsertionProviderTest {
 		var vehicleEntry = mock(VehicleEntry.class);
 
 		// mock insertionGenerator
-		var insertionWithDetourData = new InsertionWithDetourData<>(new Insertion(vehicleEntry, null, null), Double.NaN,
-				Double.NaN, Double.NaN, Double.NaN);
+		var insertionWithDetourData = new InsertionWithDetourData<>(new Insertion(vehicleEntry, null, null),
+				new InsertionDetourData<>(Double.NaN, Double.NaN, Double.NaN, Double.NaN));
 		var insertionGenerator = mock(InsertionGenerator.class);
 		when(insertionGenerator.generateInsertions(eq(request), eq(vehicleEntry))).thenReturn(
 				List.of(insertionWithDetourData));

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProviderTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProviderTest.java
@@ -23,7 +23,8 @@ package org.matsim.contrib.drt.optimizer.insertion;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -34,7 +35,6 @@ import java.util.Set;
 import org.junit.Rule;
 import org.junit.Test;
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
-import org.matsim.contrib.drt.optimizer.Waypoint;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 
@@ -71,37 +71,24 @@ public class SelectiveInsertionProviderTest {
 		var vehicleEntry = mock(VehicleEntry.class);
 
 		// mock insertionGenerator
-		var insertion1 = new Insertion(vehicleEntry, insertionPoint(), insertionPoint());
-		var insertion2 = new Insertion(vehicleEntry, insertionPoint(), insertionPoint());
+		var insertionWithDetourData = new InsertionWithDetourData<>(new Insertion(vehicleEntry, null, null), Double.NaN,
+				Double.NaN, Double.NaN, Double.NaN);
 		var insertionGenerator = mock(InsertionGenerator.class);
 		when(insertionGenerator.generateInsertions(eq(request), eq(vehicleEntry))).thenReturn(
-				List.of(insertionWithDetourData(insertion1), insertionWithDetourData(insertion2)));
-
-		//init restrictiveDetourTimeEstimator
-		DetourTimeEstimator restrictiveDetourTimeEstimator = (from, to) -> 987.;
+				List.of(insertionWithDetourData));
 
 		//mock initialInsertionFinder
-		var selectedInsertion = oneSelected ? Optional.of(insertion1) : Optional.<Insertion>empty();
-		var selectedInsertionWithDetourData = selectedInsertion.map(
-				new DetourData<>(l -> 987., l -> 987., l -> 987., l -> 987., 0.)::createInsertionWithDetourData);
+		var selectedInsertion = oneSelected ?
+				Optional.of(insertionWithDetourData) :
+				Optional.<InsertionWithDetourData<Double>>empty();
 		when(initialInsertionFinder.findBestInsertion(eq(request),
-				argThat(argument -> argument.map(InsertionWithDetourData::getInsertion)
-						.collect(toSet())
-						.equals(Set.of(insertion1, insertion2)))))//
-				.thenReturn(selectedInsertionWithDetourData);
+				argThat(argument -> argument.collect(toSet()).equals(Set.of(insertionWithDetourData)))))//
+				.thenReturn(selectedInsertion);
 
 		//test insertionProvider
 		var insertionProvider = new SelectiveInsertionProvider(initialInsertionFinder, insertionGenerator,
 				rule.forkJoinPool);
 		assertThat(insertionProvider.getInsertions(request, List.of(vehicleEntry))).isEqualTo(
-				selectedInsertion.stream().collect(toList()));
-	}
-
-	private InsertionGenerator.InsertionPoint insertionPoint() {
-		return new InsertionGenerator.InsertionPoint(-1, mock(Waypoint.class), null, mock(Waypoint.class));
-	}
-
-	private InsertionWithDetourData<Double> insertionWithDetourData(Insertion insertion) {
-		return new InsertionWithDetourData<>(insertion, Double.NaN, Double.NaN, Double.NaN, Double.NaN);
+				selectedInsertion.stream().map(InsertionWithDetourData::getInsertion).collect(toList()));
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/SingleInsertionDetourPathCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/SingleInsertionDetourPathCalculatorTest.java
@@ -91,12 +91,12 @@ public class SingleInsertionDetourPathCalculatorTest {
 		var insertion = new Insertion(null, pickup, dropoff);
 
 		var detourData = detourPathCalculator.calculatePaths(request, List.of(insertion));
-		var insertionWithDetourData = detourData.createInsertionWithDetourData(insertion);
+		var insertionWithDetourData = detourData.createInsertionDetourData(insertion);
 
-		assertPathData(insertionWithDetourData.getDetourToPickup(), pathToPickup, pickupLink);
-		assertPathData(insertionWithDetourData.getDetourFromPickup(), pathFromPickup, afterPickupLink);
-		assertPathData(insertionWithDetourData.getDetourToDropoff(), pathToDropoff, dropoffLink);
-		assertPathData(insertionWithDetourData.getDetourFromDropoff(), pathFromDropoff, afterDropoffLink);
+		assertPathData(insertionWithDetourData.detourToPickup, pathToPickup, pickupLink);
+		assertPathData(insertionWithDetourData.detourFromPickup, pathFromPickup, afterPickupLink);
+		assertPathData(insertionWithDetourData.detourToDropoff, pathToDropoff, dropoffLink);
+		assertPathData(insertionWithDetourData.detourFromDropoff, pathFromDropoff, afterDropoffLink);
 	}
 
 	@Test
@@ -111,14 +111,14 @@ public class SingleInsertionDetourPathCalculatorTest {
 		var insertion = new Insertion(null, pickup, dropoff);
 
 		var detourData = detourPathCalculator.calculatePaths(request, List.of(insertion));
-		var insertionWithDetourData = detourData.createInsertionWithDetourData(insertion);
+		var insertionWithDetourData = detourData.createInsertionDetourData(insertion);
 
-		assertPathData(insertionWithDetourData.getDetourToPickup(), pathToPickup, pickupLink);
-		assertPathData(insertionWithDetourData.getDetourFromPickup(), pathFromPickup, afterPickupLink);
+		assertPathData(insertionWithDetourData.detourToPickup, pathToPickup, pickupLink);
+		assertPathData(insertionWithDetourData.detourFromPickup, pathFromPickup, afterPickupLink);
 		//this path data should not be used and is null
-		assertThat(insertionWithDetourData.getDetourToDropoff()).isNull();
+		assertThat(insertionWithDetourData.detourToDropoff).isNull();
 		//this path data is of zero duration
-		assertThat(insertionWithDetourData.getDetourFromDropoff().getTravelTime()).isZero();
+		assertThat(insertionWithDetourData.detourFromDropoff.getTravelTime()).isZero();
 	}
 
 	@Test
@@ -128,12 +128,12 @@ public class SingleInsertionDetourPathCalculatorTest {
 		var insertion = new Insertion(null, pickup, dropoff);
 
 		var detourData = detourPathCalculator.calculatePaths(request, List.of(insertion));
-		var insertionWithDetourData = detourData.createInsertionWithDetourData(insertion);
+		var insertionWithDetourData = detourData.createInsertionDetourData(insertion);
 
-		assertThat(insertionWithDetourData.getDetourToPickup().getTravelTime()).isZero();
-		assertThat(insertionWithDetourData.getDetourFromPickup().getTravelTime()).isZero();
-		assertThat(insertionWithDetourData.getDetourToDropoff().getTravelTime()).isZero();
-		assertThat(insertionWithDetourData.getDetourFromDropoff().getTravelTime()).isZero();
+		assertThat(insertionWithDetourData.detourToPickup.getTravelTime()).isZero();
+		assertThat(insertionWithDetourData.detourFromPickup.getTravelTime()).isZero();
+		assertThat(insertionWithDetourData.detourToDropoff.getTravelTime()).isZero();
+		assertThat(insertionWithDetourData.detourFromDropoff.getTravelTime()).isZero();
 	}
 
 	private Path mockCalcLeastCostPath(Link fromLink, Link toLink, double startTimeArg, double pathTravelTime) {


### PR DESCRIPTION
A round of refactoring around making insertion generation and evaluation simpler and faster (see #1758 for some background).

The next steps will be about moving `DetourTimeInfo` computation to insertion generation, which will enable different speedups like:
- early pruning on violated time constraint
- re-use of pickup detour time info while iterating through dropoff insertion points.