### PR TITLE
Dvrp modal vehicle type

### DIFF
--- a/contribs/av/src/main/java/org/matsim/contrib/av/flow/AvIncreasedCapacityModule.java
+++ b/contribs/av/src/main/java/org/matsim/contrib/av/flow/AvIncreasedCapacityModule.java
@@ -20,43 +20,40 @@
 package org.matsim.contrib.av.flow;
 
 import org.matsim.api.core.v01.Id;
-import org.matsim.contrib.dvrp.vrpagent.VrpAgentSourceQSimModule;
-import org.matsim.core.controler.AbstractModule;
+import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.vehicles.VehicleType;
-
-import com.google.inject.name.Names;
 import org.matsim.vehicles.VehicleUtils;
 
 /**
  * This module allows to de- or increase the amount of flow capacity used by a DVRP vehicle,
  * which may be useful for modelling autonomous vehicles within the Queue model.
- * 
- * When using this model in science, please consider citing 
+ * <p>
+ * When using this model in science, please consider citing
  * M. Maciejewski, J. Bischoff; Congestion Effects of Autonomous Taxi Fleets; 16-11;
  * available from <a href="http://www.vsp.tu-berlin.de/publications/vspwp/">http://www.vsp.tu-berlin.de/publications/vspwp/</a>
- *
  */
-public class AvIncreasedCapacityModule extends AbstractModule {
+public class AvIncreasedCapacityModule extends AbstractDvrpModeModule {
 	private final VehicleType vehicleType;
 
 	/**
 	 * @param flowEfficiencyFactor: A factor of 1.0 == same flow for dvrp vehicles as for cars (default),
-	 *                               a factor of > 1: increased efficiency, e.g. a value of 2.0 would mean that two AVs
-	 *                               would need only the flow capacity of 1 ordinary vehicle.
-	 *                               A factor below 1 would mean that more capacity is used.
+	 *                              a factor of > 1: increased efficiency, e.g. a value of 2.0 would mean that two AVs
+	 *                              would need only the flow capacity of 1 ordinary vehicle.
+	 *                              A factor below 1 would mean that more capacity is used.
 	 */
-	public AvIncreasedCapacityModule(double flowEfficiencyFactor) {
-		this(flowEfficiencyFactor, VehicleUtils.createVehicleType(Id.create("autonomousVehicleType", VehicleType.class ) ) );
+	public AvIncreasedCapacityModule(String mode, double flowEfficiencyFactor) {
+		this(mode, flowEfficiencyFactor,
+				VehicleUtils.createVehicleType(Id.create("autonomousVehicleType", VehicleType.class)));
 	}
 
-	public AvIncreasedCapacityModule(double flowEfficiencyFactor, VehicleType vehicleType) {
+	public AvIncreasedCapacityModule(String mode, double flowEfficiencyFactor, VehicleType vehicleType) {
+		super(mode);
 		vehicleType.setFlowEfficiencyFactor(flowEfficiencyFactor);//XXX set the factor here - not settable via XML
 		this.vehicleType = vehicleType;
 	}
 
 	@Override
 	public void install() {
-		bind(VehicleType.class).annotatedWith(Names.named(VrpAgentSourceQSimModule.DVRP_VEHICLE_TYPE))
-				.toInstance(vehicleType);
+		bindModal(VehicleType.class).toInstance(vehicleType);
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/OneTruckModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/examples/onetruck/OneTruckModule.java
@@ -57,9 +57,7 @@ public class OneTruckModule extends AbstractDvrpModeModule {
 		install(new DvrpModeRoutingNetworkModule(getMode(), false));
 		bindModal(TravelTime.class).to(Key.get(TravelTime.class, Names.named(DvrpTravelTimeModule.DVRP_ESTIMATED)));
 
-		bind(VehicleType.class).annotatedWith(Names.named(VrpAgentSourceQSimModule.DVRP_VEHICLE_TYPE))
-				.toInstance(createTruckType());
-		install(new FleetModule(getMode(), fleetSpecificationUrl));
+		install(new FleetModule(getMode(), fleetSpecificationUrl, createTruckType()));
 
 		installQSimModule(new AbstractDvrpModeQSimModule(getMode()) {
 			@Override
@@ -80,5 +78,4 @@ public class OneTruckModule extends AbstractDvrpModeModule {
 		truckType.getCapacity().setSeats(1);
 		return truckType;
 	}
-
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/FleetModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/FleetModule.java
@@ -26,16 +26,14 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.analysis.ExecutedScheduleCollector;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
-import org.matsim.contrib.dvrp.vrpagent.VrpAgentSourceQSimModule;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.vehicles.VehicleType;
+import org.matsim.vehicles.VehicleUtils;
 import org.matsim.vehicles.Vehicles;
 
 import com.google.inject.Inject;
-import com.google.inject.Key;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
-import com.google.inject.name.Names;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -43,6 +41,7 @@ import com.google.inject.name.Names;
 public class FleetModule extends AbstractDvrpModeModule {
 	private final URL fleetSpecificationUrl;
 	private final boolean updateVehicleStartLinkToLastLink;
+	private final VehicleType vehicleType;
 
 	public FleetModule(String mode, URL fleetSpecificationUrl) {
 		this(mode, fleetSpecificationUrl, false);
@@ -52,6 +51,16 @@ public class FleetModule extends AbstractDvrpModeModule {
 		super(mode);
 		this.fleetSpecificationUrl = fleetSpecificationUrl;
 		this.updateVehicleStartLinkToLastLink = updateVehicleStartLinkToLastLink;
+
+		vehicleType = VehicleUtils.getDefaultVehicleType();
+	}
+
+	public FleetModule(String mode, URL fleetSpecificationUrl, VehicleType vehicleType) {
+		super(mode);
+		this.fleetSpecificationUrl = fleetSpecificationUrl;
+		this.vehicleType = vehicleType;
+
+		updateVehicleStartLinkToLastLink = false;
 	}
 
 	@Override
@@ -101,7 +110,6 @@ public class FleetModule extends AbstractDvrpModeModule {
 						getter.getModal(FleetSpecification.class)))).in(Singleton.class);
 		addControlerListenerBinding().to(modalKey(FleetControlerListener.class));
 
-		bindModal(VehicleType.class).to(
-				Key.get(VehicleType.class, Names.named(VrpAgentSourceQSimModule.DVRP_VEHICLE_TYPE)));
+		bindModal(VehicleType.class).toInstance(vehicleType);
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/FleetModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/fleet/FleetModule.java
@@ -26,12 +26,16 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.analysis.ExecutedScheduleCollector;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
+import org.matsim.contrib.dvrp.vrpagent.VrpAgentSourceQSimModule;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
+import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.Vehicles;
 
 import com.google.inject.Inject;
+import com.google.inject.Key;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
+import com.google.inject.name.Names;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -96,5 +100,8 @@ public class FleetModule extends AbstractDvrpModeModule {
 				getter -> new FleetControlerListener(getMode(), getter.get(OutputDirectoryHierarchy.class),
 						getter.getModal(FleetSpecification.class)))).in(Singleton.class);
 		addControlerListenerBinding().to(modalKey(FleetControlerListener.class));
+
+		bindModal(VehicleType.class).to(
+				Key.get(VehicleType.class, Names.named(VrpAgentSourceQSimModule.DVRP_VEHICLE_TYPE)));
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpModule.java
@@ -66,9 +66,6 @@ public final class DvrpModule extends AbstractModule {
 		// Visualisation of schedules for DVRP DynAgents
 		bind(NonPlanAgentQueryHelper.class).to(VrpAgentQueryHelper.class);
 
-		bind(VehicleType.class).annotatedWith(Names.named(VrpAgentSourceQSimModule.DVRP_VEHICLE_TYPE))
-				.toInstance(VehicleUtils.getDefaultVehicleType());
-
 		install(dvrpTravelTimeEstimationModule);
 
 		//lazily initialised:

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpModule.java
@@ -43,8 +43,7 @@ import com.google.inject.name.Names;
 /**
  * This module initialises generic (i.e. not taxi or drt-specific) AND global (not mode-specific) dvrp objects.
  * <p>
- * Some of the initialised objects will become modal at some point in the future. E.g. VehicleType or TravelTime
- * are likely to be provided separately per each mode in the future.
+ * Some of the initialised objects will become modal at some point in the future.
  *
  * @author michalm
  */

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/QSimFreeSpeedTravelTimeWithMaxSpeedLimit.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/QSimFreeSpeedTravelTimeWithMaxSpeedLimit.java
@@ -20,12 +20,8 @@
 
 package org.matsim.contrib.dvrp.trafficmonitoring;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
-import org.matsim.contrib.dvrp.vrpagent.VrpAgentSourceQSimModule;
 import org.matsim.core.config.groups.QSimConfigGroup;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.vehicles.Vehicle;
@@ -41,9 +37,7 @@ public class QSimFreeSpeedTravelTimeWithMaxSpeedLimit implements TravelTime {
 	//FIXME use vehicle max speed (currently impossible, because the vehicle passed to path search is often null)
 	private final double maxSpeed;
 
-	@Inject
-	public QSimFreeSpeedTravelTimeWithMaxSpeedLimit(QSimConfigGroup qsimCfg,
-			@Named(VrpAgentSourceQSimModule.DVRP_VEHICLE_TYPE) VehicleType vehicleType) {
+	public QSimFreeSpeedTravelTimeWithMaxSpeedLimit(QSimConfigGroup qsimCfg, VehicleType vehicleType) {
 		this(qsimCfg.getTimeStepSize(), vehicleType.getMaximumVelocity());
 	}
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/vrpagent/VrpAgentSourceQSimModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/vrpagent/VrpAgentSourceQSimModule.java
@@ -24,16 +24,13 @@ import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpModes;
-import org.matsim.core.modal.ModalProviders;
 import org.matsim.core.mobsim.qsim.QSim;
+import org.matsim.core.modal.ModalProviders;
 import org.matsim.vehicles.VehicleType;
 
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 
 public class VrpAgentSourceQSimModule extends AbstractDvrpModeQSimModule {
-	public static final String DVRP_VEHICLE_TYPE = "dvrp_vehicle_type";
-
 	public VrpAgentSourceQSimModule(String mode) {
 		super(mode);
 	}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/vrpagent/VrpAgentSourceQSimModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/vrpagent/VrpAgentSourceQSimModule.java
@@ -44,15 +44,11 @@ public class VrpAgentSourceQSimModule extends AbstractDvrpModeQSimModule {
 			@Inject
 			private QSim qSim;
 
-			@Inject
-			@Named(DVRP_VEHICLE_TYPE)
-			private VehicleType vehicleType;
-
 			@Override
 			public VrpAgentSource get() {
 				return new VrpAgentSource(getModalInstance(VrpAgentLogic.DynActionCreator.class),
 						getModalInstance(Fleet.class), getModalInstance(VrpOptimizer.class), getMode(), qSim,
-						vehicleType);
+						getModalInstance(VehicleType.class));
 			}
 		});
 	}

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/passenger/DefaultPassengerEngineTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/passenger/DefaultPassengerEngineTest.java
@@ -179,8 +179,7 @@ public class DefaultPassengerEngineTest {
 						//supply
 						addQSimComponentBinding(DynActivityEngine.COMPONENT_NAME).to(DynActivityEngine.class);
 						bindModal(Fleet.class).toInstance(fleet);
-						bind(VehicleType.class).annotatedWith(Names.named(VrpAgentSourceQSimModule.DVRP_VEHICLE_TYPE))
-								.toInstance(VehicleUtils.getDefaultVehicleType());
+						bindModal(VehicleType.class).toInstance(VehicleUtils.getDefaultVehicleType());
 						bindModal(VrpOptimizer.class).to(optimizerClass).asEagerSingleton();
 						bindModal(VrpAgentLogic.DynActionCreator.class).to(OneTaxiActionCreator.class)
 								.asEagerSingleton();

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/router/DiversionTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/router/DiversionTest.java
@@ -62,6 +62,8 @@ import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.vehicles.VehicleType;
+import org.matsim.vehicles.VehicleUtils;
 
 import com.google.inject.Singleton;
 
@@ -290,6 +292,8 @@ public class DiversionTest {
 			bindModal(Fleet.class).toProvider(modalProvider(getter -> {
 				return Fleets.createDefaultFleet(fleetSpecification, getter.getModal(Network.class).getLinks()::get);
 			})).in(Singleton.class);
+
+			bindModal(VehicleType.class).toInstance(VehicleUtils.getDefaultVehicleType());
 
 			install(new VrpAgentSourceQSimModule(getMode()));
 

--- a/contribs/vsp/src/test/java/playground/vsp/flowEfficiency/HierarchicalFLowEfficiencyCalculatorTest.java
+++ b/contribs/vsp/src/test/java/playground/vsp/flowEfficiency/HierarchicalFLowEfficiencyCalculatorTest.java
@@ -156,18 +156,15 @@ public class HierarchicalFLowEfficiencyCalculatorTest {
 							.build());
 				}
 				bindModal(FleetSpecification.class).toInstance(fleet);
+				bindModal(VehicleType.class).toInstance(dvrpVehType);
 			}
 		});
 
 		handler = new FlowEfficiencyHandler();
 
-		//it is important to bind dvrp vehicle type after installing drt modules (since we use overriding)
-		//whenver MATSim does not allow for overriding any more (which is planned for rather far away future), this script will need to get adjusted.
 		controler.addOverridingModule(new AbstractModule() {
 			@Override
 			public void install() {
-				bind(VehicleType.class).annotatedWith(Names.named(VrpAgentSourceQSimModule.DVRP_VEHICLE_TYPE))
-						.toInstance(dvrpVehType);
 				addEventHandlerBinding().toInstance(handler);
 			}
 		});


### PR DESCRIPTION
Based on #1822 (thanks @nkuehnel). Takes a few more steps for a complete transition, otherwise some examples would still try to override the dvrp-global vehicle type, but that binding would be ignored now.

BTW. We want to support more than one vehicle type per mode in the future (e.g. AVs and non-AVs in one DRT fleet). This is something that should work fine with the selective insertion search (DRT), but we need to introduce a few not so big changes to make it possible.