### PR TITLE
Fix analysis of departure time with prebooked requests

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtLeg.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtLeg.java
@@ -58,7 +58,7 @@ final class DrtLeg {
 		PersonDepartureEvent departedEvent = sequence.getDeparted().get();
 		PassengerPickedUpEvent pickedUpEvent = sequence.getPickedUp().get();
 		this.request = submittedEvent.getRequestId();
-		this.departureTime = submittedEvent.getTime();
+		this.departureTime = departedEvent.getTime();
 		this.person = submittedEvent.getPersonId();
 		this.vehicle = pickedUpEvent.getVehicleId();
 		this.fromLinkId = submittedEvent.getFromLinkId();


### PR DESCRIPTION
Actually, the plots wait time plots were still not displayed properly for prebooked requests. Now they are correct.