### PR TITLE
DRT: calc detour info inside insertion generator

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/optimizer/ShiftRequestInsertionScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/optimizer/ShiftRequestInsertionScheduler.java
@@ -91,13 +91,13 @@ public class ShiftRequestInsertionScheduler implements RequestInsertionScheduler
     }
 
     private DrtStopTask insertPickup(DrtRequest request, InsertionWithDetourData<OneToManyPathSearch.PathData> insertionWithDetourData) {
-		var insertion = insertionWithDetourData.getInsertion();
+		var insertion = insertionWithDetourData.insertion;
         VehicleEntry vehicleEntry = insertion.vehicleEntry;
         Schedule schedule = vehicleEntry.vehicle.getSchedule();
         List<Waypoint.Stop> stops = vehicleEntry.stops;
         int pickupIdx = insertion.pickup.index;
         int dropoffIdx = insertion.dropoff.index;
-		var detourData = insertionWithDetourData.getDetourData();
+		var detourData = insertionWithDetourData.detourData;
 
         Schedule.ScheduleStatus scheduleStatus = schedule.getStatus();
         Task currentTask = scheduleStatus == Schedule.ScheduleStatus.PLANNED ? null : schedule.getCurrentTask();
@@ -269,13 +269,13 @@ public class ShiftRequestInsertionScheduler implements RequestInsertionScheduler
 
     private DrtStopTask insertDropoff(DrtRequest request, InsertionWithDetourData<OneToManyPathSearch.PathData> insertionWithDetourData,
                                       DrtStopTask pickupTask) {
-		var insertion = insertionWithDetourData.getInsertion();
+		var insertion = insertionWithDetourData.insertion;
         VehicleEntry vehicleEntry = insertion.vehicleEntry;
         Schedule schedule = vehicleEntry.vehicle.getSchedule();
         List<Waypoint.Stop> stops = vehicleEntry.stops;
         int pickupIdx = insertion.pickup.index;
         int dropoffIdx = insertion.dropoff.index;
-		var detourData = insertionWithDetourData.getDetourData();
+		var detourData = insertionWithDetourData.detourData;
 
         Task driveToDropoffTask;
         if (pickupIdx == dropoffIdx) { // no drive to dropoff

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/optimizer/insertion/ShiftInsertionCostCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/optimizer/insertion/ShiftInsertionCostCalculator.java
@@ -55,9 +55,9 @@ public class ShiftInsertionCostCalculator<D> implements InsertionCostCalculator<
 	@Override
 	public double calculate(DrtRequest drtRequest, InsertionWithDetourData<D> insertion) {
 		//TODO precompute time slacks for each stop to filter out even more infeasible insertions ???????????
-		var detourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion.getInsertion(),
-				insertion.getDetourData());
-		if (!checkShiftTimeConstraintsForScheduledRequests(insertion.getInsertion(),
+		var detourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion.insertion,
+				insertion.detourData);
+		if (!checkShiftTimeConstraintsForScheduledRequests(insertion.insertion,
 				detourTimeInfo.pickupDetourInfo.pickupTimeLoss, detourTimeInfo.getTotalTimeLoss())) {
 			return INFEASIBLE_SOLUTION_COST;
 		}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/optimizer/insertion/ShiftInsertionCostCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/optimizer/insertion/ShiftInsertionCostCalculator.java
@@ -55,7 +55,8 @@ public class ShiftInsertionCostCalculator<D> implements InsertionCostCalculator<
 	@Override
 	public double calculate(DrtRequest drtRequest, InsertionWithDetourData<D> insertion) {
 		//TODO precompute time slacks for each stop to filter out even more infeasible insertions ???????????
-		var detourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion);
+		var detourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion.getInsertion(),
+				insertion.getDetourData());
 		if (!checkShiftTimeConstraintsForScheduledRequests(insertion.getInsertion(),
 				detourTimeInfo.pickupDetourInfo.pickupTimeLoss, detourTimeInfo.getTotalTimeLoss())) {
 			return INFEASIBLE_SOLUTION_COST;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/Waypoint.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/Waypoint.java
@@ -32,6 +32,8 @@ import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.core.utils.misc.OptionalTime;
 
+import com.google.common.base.MoreObjects;
+
 /**
  * @author Michal Maciejewski (michalm)
  */
@@ -76,6 +78,16 @@ public interface Waypoint {
 		public int getOutgoingOccupancy() {
 			return occupancy;
 		}
+
+		@Override
+		public String toString() {
+			return MoreObjects.toStringHelper(this)
+					.add("task", task)
+					.add("link", link)
+					.add("time", time)
+					.add("occupancy", occupancy)
+					.toString();
+		}
 	}
 
 	class End implements Waypoint {
@@ -116,6 +128,11 @@ public interface Waypoint {
 		@Override
 		public int getOutgoingOccupancy() {
 			throw new UnsupportedOperationException("End is the terminal waypoint");
+		}
+
+		@Override
+		public String toString() {
+			return MoreObjects.toStringHelper(this).add("link", link).add("arrivalTime", arrivalTime).toString();
 		}
 	}
 
@@ -218,6 +235,11 @@ public interface Waypoint {
 		public int getOutgoingOccupancy() {
 			throw new UnsupportedOperationException();
 		}
+
+		@Override
+		public String toString() {
+			return MoreObjects.toStringHelper(this).add("request", request).toString();
+		}
 	}
 
 	class Dropoff implements Waypoint {
@@ -245,6 +267,11 @@ public interface Waypoint {
 		@Override
 		public int getOutgoingOccupancy() {
 			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public String toString() {
+			return MoreObjects.toStringHelper(this).add("request", request).toString();
 		}
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/BestInsertionFinder.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/BestInsertionFinder.java
@@ -51,7 +51,7 @@ public class BestInsertionFinder<D> {
 
 	static <D> Comparator<InsertionWithCost<D>> createInsertionWithCostComparator() {
 		return Comparator.<InsertionWithCost<D>>comparingDouble(insertionWithCost -> insertionWithCost.cost)
-				.thenComparing(insertion -> insertion.insertionWithDetourData.getInsertion(), INSERTION_COMPARATOR);
+				.thenComparing(insertion -> insertion.insertionWithDetourData.insertion, INSERTION_COMPARATOR);
 	}
 
 	private final Comparator<InsertionWithCost<D>> comparator = createInsertionWithCostComparator();

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearch.java
@@ -40,18 +40,22 @@ public final class DefaultDrtInsertionSearch implements DrtInsertionSearch<PathD
 
 	private final InsertionProvider insertionProvider;
 	private final DetourPathCalculator detourPathCalculator;
+	private final InsertionDetourTimeCalculator<PathData> detourTimeCalculator;
 	private final BestInsertionFinder<PathData> bestInsertionFinder;
 
 	public DefaultDrtInsertionSearch(InsertionProvider insertionProvider, DetourPathCalculator detourPathCalculator,
-			InsertionCostCalculator<PathData> insertionCostCalculator) {
-		this(insertionProvider, detourPathCalculator, new BestInsertionFinder<>(insertionCostCalculator));
+			InsertionCostCalculator<PathData> insertionCostCalculator, double stopDuration) {
+		this(insertionProvider, detourPathCalculator, new BestInsertionFinder<>(insertionCostCalculator),
+				new InsertionDetourTimeCalculator<>(stopDuration, PathData::getTravelTime, null));
 	}
 
 	@VisibleForTesting
 	DefaultDrtInsertionSearch(InsertionProvider insertionProvider, DetourPathCalculator detourPathCalculator,
-			BestInsertionFinder<PathData> bestInsertionFinder) {
+			BestInsertionFinder<PathData> bestInsertionFinder,
+			InsertionDetourTimeCalculator<PathData> detourTimeCalculator) {
 		this.insertionProvider = insertionProvider;
 		this.detourPathCalculator = detourPathCalculator;
+		this.detourTimeCalculator = detourTimeCalculator;
 		this.bestInsertionFinder = bestInsertionFinder;
 	}
 
@@ -64,7 +68,10 @@ public final class DefaultDrtInsertionSearch implements DrtInsertionSearch<PathD
 		}
 
 		DetourPathDataCache pathData = detourPathCalculator.calculatePaths(drtRequest, insertions);
-		return bestInsertionFinder.findBestInsertion(drtRequest,
-				insertions.stream().map(i -> new InsertionWithDetourData<>(i, pathData.createInsertionDetourData(i))));
+		return bestInsertionFinder.findBestInsertion(drtRequest, insertions.stream().map(i -> {
+			var insertionDetourData = pathData.createInsertionDetourData(i);
+			return new InsertionWithDetourData<>(i, insertionDetourData,
+					detourTimeCalculator.calculateDetourTimeInfo(i, insertionDetourData));
+		}));
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultInsertionCostCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultInsertionCostCalculator.java
@@ -77,10 +77,9 @@ public class DefaultInsertionCostCalculator<D> implements InsertionCostCalculato
 	@Override
 	public double calculate(DrtRequest drtRequest, InsertionWithDetourData<D> insertion) {
 		//TODO precompute time slacks for each stop to filter out even more infeasible insertions ???????????
-		var detourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion.getInsertion(),
-				insertion.getDetourData());
+		var detourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion.insertion, insertion.detourData);
 
-		var insertion1 = insertion.getInsertion();
+		var insertion1 = insertion.insertion;
 		var vEntry = insertion1.vehicleEntry;
 
 		if (vEntry.getSlackTime(insertion1.pickup.index) < detourTimeInfo.pickupDetourInfo.pickupTimeLoss

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultInsertionCostCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultInsertionCostCalculator.java
@@ -77,8 +77,8 @@ public class DefaultInsertionCostCalculator<D> implements InsertionCostCalculato
 	@Override
 	public double calculate(DrtRequest drtRequest, InsertionWithDetourData<D> insertion) {
 		//TODO precompute time slacks for each stop to filter out even more infeasible insertions ???????????
-
-		var detourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion);
+		var detourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion.getInsertion(),
+				insertion.getDetourData());
 
 		var insertion1 = insertion.getInsertion();
 		var vEntry = insertion1.vehicleEntry;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
@@ -131,7 +131,7 @@ public class DefaultUnplannedRequestInserter implements UnplannedRequestInserter
 			}
 		} else {
 			InsertionWithDetourData<PathData> insertion = best.get();
-			var vehicle = insertion.getInsertion().vehicleEntry.vehicle;
+			var vehicle = insertion.insertion.vehicleEntry.vehicle;
 			var pickupDropoffTaskPair = insertionScheduler.scheduleRequest(req, insertion);
 
 			VehicleEntry newVehicleEntry = vehicleEntryFactory.create(vehicle, now);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionProvider.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionProvider.java
@@ -60,7 +60,7 @@ public class ExtensiveInsertionProvider implements InsertionProvider {
 	public ExtensiveInsertionProvider(DrtConfigGroup drtCfg, DetourTimeEstimator admissibleTimeEstimator,
 			ForkJoinPool forkJoinPool, InsertionCostCalculator<Double> admissibleCostCalculator) {
 		this((ExtensiveInsertionSearchParams)drtCfg.getDrtInsertionSearchParams(), admissibleCostCalculator,
-				new InsertionGenerator(admissibleTimeEstimator), forkJoinPool);
+				new InsertionGenerator(drtCfg.getStopDuration(), admissibleTimeEstimator), forkJoinPool);
 	}
 
 	@VisibleForTesting

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionSearchQSimModule.java
@@ -56,7 +56,7 @@ public class ExtensiveInsertionSearchQSimModule extends AbstractDvrpModeQSimModu
 					getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool());
 			var insertionCostCalculator = insertionCostCalculatorFactory.create(PathData::getTravelTime, null);
 			return new DefaultDrtInsertionSearch(provider, getter.getModal(DetourPathCalculator.class),
-					insertionCostCalculator);
+					insertionCostCalculator, drtCfg.getStopDuration());
 		})).asEagerSingleton();
 
 		addModalComponent(MultiInsertionDetourPathCalculator.class,

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculator.java
@@ -73,7 +73,8 @@ public class InsertionDetourTimeCalculator<D> {
 			arrivalTime = dropoff.previousWaypoint.getDepartureTime() + pickupTimeLoss + toDropoffTT;
 		}
 
-		return new DetourTimeInfo(departureTime, arrivalTime, pickupTimeLoss, dropoffTimeLoss);
+		return new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
+							new DropoffDetourInfo(arrivalTime, dropoffTimeLoss));
 	}
 
 	private DetourTimeInfo calculateDetourTimeInfoForIfPickupToDropoffDetour(Insertion insertion,
@@ -101,7 +102,8 @@ public class InsertionDetourTimeCalculator<D> {
 		double departureTime = pickup.previousWaypoint.getDepartureTime() + toPickupTT + additionalPickupStopDuration;
 		double arrivalTime = departureTime + fromPickupToDropoffTT;
 
-		return new DetourTimeInfo(departureTime, arrivalTime, pickupTimeLoss, dropoffTimeLoss);
+		return new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
+							new DropoffDetourInfo(arrivalTime, dropoffTimeLoss));
 	}
 
 	private double calcAdditionalPickupStopDurationIfSameLinkAsPrevious(VehicleEntry vEntry, int pickupIdx) {
@@ -176,11 +178,6 @@ public class InsertionDetourTimeCalculator<D> {
 		public DetourTimeInfo(PickupDetourInfo pickupDetourInfo, DropoffDetourInfo dropoffDetourInfo) {
 			this.pickupDetourInfo = pickupDetourInfo;
 			this.dropoffDetourInfo = dropoffDetourInfo;
-		}
-
-		public DetourTimeInfo(double departureTime, double arrivalTime, double pickupTimeLoss, double dropoffTimeLoss) {
-			this(new PickupDetourInfo(departureTime, pickupTimeLoss),
-					new DropoffDetourInfo(arrivalTime, dropoffTimeLoss));
 		}
 
 		// TOTAL time delay of each stop placed after the dropoff insertion point

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculator.java
@@ -7,7 +7,11 @@ import java.util.function.ToDoubleFunction;
 import javax.annotation.Nullable;
 
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.InsertionPoint;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionWithDetourData.InsertionDetourData;
+
+import com.google.common.base.MoreObjects;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -29,17 +33,15 @@ public class InsertionDetourTimeCalculator<D> {
 		this.replacedDriveTimeEstimator = replacedDriveTimeEstimator;
 	}
 
-	public DetourTimeInfo calculateDetourTimeInfo(InsertionWithDetourData<D> insertionWithDetourData) {
-		var insertion = insertionWithDetourData.getInsertion();
+	public DetourTimeInfo calculateDetourTimeInfo(Insertion insertion, InsertionDetourData<D> detourData) {
 		InsertionPoint pickup = insertion.pickup;
 		InsertionPoint dropoff = insertion.dropoff;
 		if (pickup.index == dropoff.index) {
 			//handle the pickup->dropoff case separately
-			return calculateDetourTimeInfoForIfPickupToDropoffDetour(insertionWithDetourData);
+			return calculateDetourTimeInfoForIfPickupToDropoffDetour(insertion, detourData);
 		}
 
 		VehicleEntry vEntry = insertion.vehicleEntry;
-		var detourData = insertionWithDetourData.getDetourData();
 
 		final double departureTime;
 		final double pickupTimeLoss;
@@ -74,12 +76,10 @@ public class InsertionDetourTimeCalculator<D> {
 		return new DetourTimeInfo(departureTime, arrivalTime, pickupTimeLoss, dropoffTimeLoss);
 	}
 
-	private DetourTimeInfo calculateDetourTimeInfoForIfPickupToDropoffDetour(
-			InsertionWithDetourData<D> insertionWithDetourData) {
-		var insertion = insertionWithDetourData.getInsertion();
+	private DetourTimeInfo calculateDetourTimeInfoForIfPickupToDropoffDetour(Insertion insertion,
+			InsertionDetourData<D> detourData) {
 		VehicleEntry vEntry = insertion.vehicleEntry;
 		InsertionPoint pickup = insertion.pickup;
-		var detourData = insertionWithDetourData.getDetourData();
 
 		final double toPickupTT;
 		final double additionalPickupStopDuration;
@@ -138,6 +138,14 @@ public class InsertionDetourTimeCalculator<D> {
 			this.departureTime = departureTime;
 			this.pickupTimeLoss = pickupTimeLoss;
 		}
+
+		@Override
+		public String toString() {
+			return MoreObjects.toStringHelper(this)
+					.add("departureTime", departureTime)
+					.add("pickupTimeLoss", pickupTimeLoss)
+					.toString();
+		}
 	}
 
 	public static class DropoffDetourInfo {
@@ -149,6 +157,14 @@ public class InsertionDetourTimeCalculator<D> {
 		public DropoffDetourInfo(double arrivalTime, double dropoffTimeLoss) {
 			this.arrivalTime = arrivalTime;
 			this.dropoffTimeLoss = dropoffTimeLoss;
+		}
+
+		@Override
+		public String toString() {
+			return MoreObjects.toStringHelper(this)
+					.add("arrivalTime", arrivalTime)
+					.add("dropoffTimeLoss", dropoffTimeLoss)
+					.toString();
 		}
 	}
 
@@ -171,6 +187,14 @@ public class InsertionDetourTimeCalculator<D> {
 		// (this is the amount of extra time the vehicle will operate if this insertion is applied)
 		public double getTotalTimeLoss() {
 			return pickupDetourInfo.pickupTimeLoss + dropoffDetourInfo.dropoffTimeLoss;
+		}
+
+		@Override
+		public String toString() {
+			return MoreObjects.toStringHelper(this)
+					.add("pickupDetourInfo", pickupDetourInfo)
+					.add("dropoffDetourInfo", dropoffDetourInfo)
+					.toString();
 		}
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGenerator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGenerator.java
@@ -125,9 +125,12 @@ public class InsertionGenerator {
 	}
 
 	private final DetourTime detourTime;
+	private final InsertionDetourTimeCalculator<Double> detourTimeCalculator;
 
-	public InsertionGenerator(DetourTimeEstimator detourTimeEstimator) {
+	public InsertionGenerator(double stopDuration, DetourTimeEstimator detourTimeEstimator) {
 		detourTime = new DetourTime(detourTimeEstimator);
+		detourTimeCalculator = new InsertionDetourTimeCalculator<>(stopDuration, Double::doubleValue,
+				detourTimeEstimator);
 	}
 
 	public List<InsertionWithDetourData<Double>> generateInsertions(DrtRequest drtRequest, VehicleEntry vEntry) {
@@ -196,6 +199,8 @@ public class InsertionGenerator {
 		double toDropoff = detourTime.calcToDropoffTime(insertion, request);
 		double fromDropoff = detourTime.calcFromDropoffTime(insertion, request);
 		var insertionDetourData = new InsertionDetourData<>(toPickup, fromPickup, toDropoff, fromDropoff);
-		return new InsertionWithDetourData<>(insertion, insertionDetourData);
+
+		var detourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion, insertionDetourData);
+		return new InsertionWithDetourData<>(insertion, insertionDetourData, detourTimeInfo);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionWithDetourData.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionWithDetourData.java
@@ -76,34 +76,21 @@ public class InsertionWithDetourData<D> {
 		}
 	}
 
-	private final Insertion insertion;
-	private final InsertionDetourData<D> insertionDetourData;
-	private final DetourTimeInfo detourTimeInfo;
+	public final Insertion insertion;
+	public final InsertionDetourData<D> detourData;
+	public final DetourTimeInfo detourTimeInfo;
 
-	InsertionWithDetourData(Insertion insertion, InsertionDetourData<D> insertionDetourData,
-			DetourTimeInfo detourTimeInfo) {
+	InsertionWithDetourData(Insertion insertion, InsertionDetourData<D> detourData, DetourTimeInfo detourTimeInfo) {
 		this.insertion = insertion;
-		this.insertionDetourData = insertionDetourData;
+		this.detourData = detourData;
 		this.detourTimeInfo = detourTimeInfo;
-	}
-
-	public Insertion getInsertion() {
-		return insertion;
-	}
-
-	public InsertionDetourData<D> getDetourData() {
-		return insertionDetourData;
-	}
-
-	public DetourTimeInfo getDetourTimeInfo() {
-		return detourTimeInfo;
 	}
 
 	@Override
 	public String toString() {
 		return MoreObjects.toStringHelper(this)
 				.add("insertion", insertion)
-				.add("insertionDetourData", insertionDetourData)
+				.add("insertionDetourData", detourData)
 				.add("detourTimeInfo", detourTimeInfo)
 				.toString();
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionWithDetourData.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionWithDetourData.java
@@ -20,9 +20,9 @@
 
 package org.matsim.contrib.drt.optimizer.insertion;
 
-import org.matsim.contrib.drt.optimizer.VehicleEntry;
+import static org.matsim.contrib.drt.optimizer.insertion.InsertionDetourTimeCalculator.DetourTimeInfo;
+
 import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
-import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.InsertionPoint;
 
 import com.google.common.base.MoreObjects;
 
@@ -78,10 +78,13 @@ public class InsertionWithDetourData<D> {
 
 	private final Insertion insertion;
 	private final InsertionDetourData<D> insertionDetourData;
+	private final DetourTimeInfo detourTimeInfo;
 
-	InsertionWithDetourData(Insertion insertion, InsertionDetourData<D> insertionDetourData) {
+	InsertionWithDetourData(Insertion insertion, InsertionDetourData<D> insertionDetourData,
+			DetourTimeInfo detourTimeInfo) {
 		this.insertion = insertion;
 		this.insertionDetourData = insertionDetourData;
+		this.detourTimeInfo = detourTimeInfo;
 	}
 
 	public Insertion getInsertion() {
@@ -92,11 +95,16 @@ public class InsertionWithDetourData<D> {
 		return insertionDetourData;
 	}
 
+	public DetourTimeInfo getDetourTimeInfo() {
+		return detourTimeInfo;
+	}
+
 	@Override
 	public String toString() {
 		return MoreObjects.toStringHelper(this)
 				.add("insertion", insertion)
 				.add("insertionDetourData", insertionDetourData)
+				.add("detourTimeInfo", detourTimeInfo)
 				.toString();
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/KNearestInsertionsAtEndFilter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/KNearestInsertionsAtEndFilter.java
@@ -40,7 +40,7 @@ class KNearestInsertionsAtEndFilter {
 		var filteredInsertions = new ArrayList<InsertionGenerator.Insertion>(insertions.size());
 
 		for (var insertionWithDetourData : insertions) {
-			var insertion = insertionWithDetourData.getInsertion();
+			var insertion = insertionWithDetourData.insertion;
 			VehicleEntry vEntry = insertion.vehicleEntry;
 			var pickup = insertion.pickup;
 			if (!vEntry.isAfterLastStop(pickup.index)) {
@@ -51,13 +51,13 @@ class KNearestInsertionsAtEndFilter {
 				// x ADMISSIBLE_BEELINE_SPEED_FACTOR to remove bias towards near but still busy vehicles
 				// (timeToPickup is underestimated by this factor)
 				double timeDistance = departureTime
-						+ admissibleBeelineSpeedFactor * insertionWithDetourData.getDetourData().detourToPickup;
+						+ admissibleBeelineSpeedFactor * insertionWithDetourData.detourData.detourToPickup;
 				nearestInsertionsAtEnd.add(new InsertionWithCost<>(insertionWithDetourData, timeDistance));
 			}
 		}
 
 		nearestInsertionsAtEnd.kSmallestElements()
-				.forEach(i -> filteredInsertions.add(i.insertionWithDetourData.getInsertion()));
+				.forEach(i -> filteredInsertions.add(i.insertionWithDetourData.insertion));
 
 		return filteredInsertions;
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProvider.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProvider.java
@@ -82,6 +82,8 @@ public class SelectiveInsertionProvider implements InsertionProvider {
 								//generate feasible insertions (wrt occupancy limits) with restrictive detour times
 								.flatMap(e -> insertionGenerator.generateInsertions(drtRequest, e).stream()))).join();
 
-		return bestInsertion.map(InsertionWithDetourData::getInsertion).stream().collect(toList());
+		return bestInsertion.map(doubleInsertionWithDetourData -> doubleInsertionWithDetourData.insertion)
+				.stream()
+				.collect(toList());
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProvider.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProvider.java
@@ -49,17 +49,18 @@ public class SelectiveInsertionProvider implements InsertionProvider {
 				insertionParams.getRestrictiveBeelineSpeedFactor(), dvrpTravelTimeMatrix, travelTime);
 		var restrictiveCostCalculator = insertionCostCalculatorFactory.create(Double::doubleValue,
 				restrictiveDetourTimeEstimator);
-		return new SelectiveInsertionProvider(restrictiveDetourTimeEstimator, forkJoinPool, restrictiveCostCalculator);
+		return new SelectiveInsertionProvider(drtCfg, restrictiveDetourTimeEstimator, forkJoinPool,
+				restrictiveCostCalculator);
 	}
 
 	private final BestInsertionFinder<Double> initialInsertionFinder;
 	private final InsertionGenerator insertionGenerator;
 	private final ForkJoinPool forkJoinPool;
 
-	public SelectiveInsertionProvider(DetourTimeEstimator restrictiveTimeEstimator, ForkJoinPool forkJoinPool,
-			InsertionCostCalculator<Double> restrictiveCostCalculator) {
-		this(new BestInsertionFinder<>(restrictiveCostCalculator), new InsertionGenerator(restrictiveTimeEstimator),
-				forkJoinPool);
+	public SelectiveInsertionProvider(DrtConfigGroup drtCfg, DetourTimeEstimator restrictiveTimeEstimator,
+			ForkJoinPool forkJoinPool, InsertionCostCalculator<Double> restrictiveCostCalculator) {
+		this(new BestInsertionFinder<>(restrictiveCostCalculator),
+				new InsertionGenerator(drtCfg.getStopDuration(), restrictiveTimeEstimator), forkJoinPool);
 	}
 
 	@VisibleForTesting

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionSearchQSimModule.java
@@ -62,7 +62,7 @@ public class SelectiveInsertionSearchQSimModule extends AbstractDvrpModeQSimModu
 			//  Re (*) currently, free-speed travel times are quite accurate. We still need to adjust them to different times of day.
 			InsertionCostCalculator<PathData> zeroCostInsertionCostCalculator = (drtRequest, insertion) -> 0;
 			return new DefaultDrtInsertionSearch(provider, getter.getModal(DetourPathCalculator.class),
-					zeroCostInsertionCostCalculator);
+					zeroCostInsertionCostCalculator, drtCfg.getStopDuration());
 		})).asEagerSingleton();
 
 		addModalComponent(SingleInsertionDetourPathCalculator.class,

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
@@ -88,13 +88,13 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 	}
 
 	private DrtStopTask insertPickup(DrtRequest request, InsertionWithDetourData<PathData> insertionWithDetourData) {
-		var insertion = insertionWithDetourData.getInsertion();
+		var insertion = insertionWithDetourData.insertion;
 		VehicleEntry vehicleEntry = insertion.vehicleEntry;
 		Schedule schedule = vehicleEntry.vehicle.getSchedule();
 		List<Waypoint.Stop> stops = vehicleEntry.stops;
 		int pickupIdx = insertion.pickup.index;
 		int dropoffIdx = insertion.dropoff.index;
-		var detourData = insertionWithDetourData.getDetourData();
+		var detourData = insertionWithDetourData.detourData;
 
 		ScheduleStatus scheduleStatus = schedule.getStatus();
 		Task currentTask = scheduleStatus == ScheduleStatus.PLANNED ? null : schedule.getCurrentTask();
@@ -234,13 +234,13 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 
 	private DrtStopTask insertDropoff(DrtRequest request, InsertionWithDetourData<PathData> insertionWithDetourData,
 			DrtStopTask pickupTask) {
-		var insertion = insertionWithDetourData.getInsertion();
+		var insertion = insertionWithDetourData.insertion;
 		VehicleEntry vehicleEntry = insertion.vehicleEntry;
 		Schedule schedule = vehicleEntry.vehicle.getSchedule();
 		List<Waypoint.Stop> stops = vehicleEntry.stops;
 		int pickupIdx = insertion.pickup.index;
 		int dropoffIdx = insertion.dropoff.index;
-		var detourData = insertionWithDetourData.getDetourData();
+		var detourData = insertionWithDetourData.detourData;
 
 		Task driveToDropoffTask;
 		if (pickupIdx == dropoffIdx) { // no drive to dropoff

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/BestInsertionFinderTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/BestInsertionFinderTest.java
@@ -143,6 +143,6 @@ public class BestInsertionFinderTest {
 		var dropoffInsertion = new InsertionGenerator.InsertionPoint(dropoffIdx, null, null, null);
 
 		return new InsertionWithDetourData<>(
-				new InsertionGenerator.Insertion(vehicleEntry, pickupInsertion, dropoffInsertion), null);
+				new InsertionGenerator.Insertion(vehicleEntry, pickupInsertion, dropoffInsertion), null, null);
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategyTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategyTest.java
@@ -24,6 +24,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.matsim.contrib.drt.optimizer.insertion.CostCalculationStrategy.DiscourageSoftConstraintViolations.MAX_TRAVEL_TIME_VIOLATION_PENALTY;
 import static org.matsim.contrib.drt.optimizer.insertion.CostCalculationStrategy.DiscourageSoftConstraintViolations.MAX_WAIT_TIME_VIOLATION_PENALTY;
 import static org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
+import static org.matsim.contrib.drt.optimizer.insertion.InsertionDetourTimeCalculator.DropoffDetourInfo;
+import static org.matsim.contrib.drt.optimizer.insertion.InsertionDetourTimeCalculator.PickupDetourInfo;
 
 import org.junit.Test;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionDetourTimeCalculator.DetourTimeInfo;
@@ -35,17 +37,21 @@ import org.matsim.contrib.drt.passenger.DrtRequest;
 public class CostCalculationStrategyTest {
 	@Test
 	public void RejectSoftConstraintViolations_tooLongWaitTime() {
-		assertRejectSoftConstraintViolations(10, 9999, new DetourTimeInfo(11, 22, 0, 0), INFEASIBLE_SOLUTION_COST);
+		assertRejectSoftConstraintViolations(10, 9999,
+				new DetourTimeInfo(new PickupDetourInfo(11, 0), new DropoffDetourInfo(22, 0)),
+				INFEASIBLE_SOLUTION_COST);
 	}
 
 	@Test
 	public void RejectSoftConstraintViolations_tooLongTravelTime() {
-		assertRejectSoftConstraintViolations(9999, 10, new DetourTimeInfo(0, 11, 0, 0), INFEASIBLE_SOLUTION_COST);
+		assertRejectSoftConstraintViolations(9999, 10,
+				new DetourTimeInfo(new PickupDetourInfo(0, 0), new DropoffDetourInfo(11, 0)), INFEASIBLE_SOLUTION_COST);
 	}
 
 	@Test
 	public void RejectSoftConstraintViolations_allConstraintSatisfied() {
-		assertRejectSoftConstraintViolations(9999, 9999, new DetourTimeInfo(11, 22, 33, 44), 33 + 44);
+		assertRejectSoftConstraintViolations(9999, 9999,
+				new DetourTimeInfo(new PickupDetourInfo(11, 33), new DropoffDetourInfo(22, 44)), 33 + 44);
 	}
 
 	private void assertRejectSoftConstraintViolations(double latestStartTime, double latestArrivalTime,
@@ -60,19 +66,22 @@ public class CostCalculationStrategyTest {
 
 	@Test
 	public void DiscourageSoftConstraintViolations_tooLongWaitTime() {
-		assertDiscourageSoftConstraintViolations(10, 9999, new DetourTimeInfo(11, 22, 0, 0),
+		assertDiscourageSoftConstraintViolations(10, 9999,
+				new DetourTimeInfo(new PickupDetourInfo(11, 0), new DropoffDetourInfo(22, 0)),
 				MAX_WAIT_TIME_VIOLATION_PENALTY);
 	}
 
 	@Test
 	public void DiscourageSoftConstraintViolations_tooLongTravelTime() {
-		assertDiscourageSoftConstraintViolations(9999, 10, new DetourTimeInfo(0, 11, 0, 0),
+		assertDiscourageSoftConstraintViolations(9999, 10,
+				new DetourTimeInfo(new PickupDetourInfo(0, 0), new DropoffDetourInfo(11, 0)),
 				MAX_TRAVEL_TIME_VIOLATION_PENALTY);
 	}
 
 	@Test
 	public void DiscourageSoftConstraintViolations_allConstraintSatisfied() {
-		assertDiscourageSoftConstraintViolations(9999, 9999, new DetourTimeInfo(11, 22, 33, 44), 33 + 44);
+		assertDiscourageSoftConstraintViolations(9999, 9999,
+				new DetourTimeInfo(new PickupDetourInfo(11, 33), new DropoffDetourInfo(22, 44)), 33 + 44);
 	}
 
 	private void assertDiscourageSoftConstraintViolations(double latestStartTime, double latestArrivalTime,

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearchTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearchTest.java
@@ -77,7 +77,7 @@ public class DefaultDrtInsertionSearchTest {
 		var bestInsertionFinder = (BestInsertionFinder<PathData>)mock(BestInsertionFinder.class);
 		var insertionWithPathData = new InsertionWithDetourData<>(insertion, insertionPathData, detourTimeInfo);
 		when(bestInsertionFinder.findBestInsertion(eq(request),
-				argThat(argument -> argument.map(InsertionWithDetourData::getInsertion)
+				argThat(argument -> argument.map(insertionWithDetourData -> insertionWithDetourData.insertion)
 						.collect(toSet())
 						.equals(Set.of(insertion))))).thenReturn(Optional.of(insertionWithPathData));
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearchTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultDrtInsertionSearchTest.java
@@ -28,19 +28,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
 import org.junit.Test;
-import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
-import org.matsim.contrib.drt.optimizer.Waypoint;
 import org.matsim.contrib.drt.optimizer.insertion.DefaultDrtInsertionSearch.InsertionProvider;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
-import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.InsertionPoint;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionWithDetourData.InsertionDetourData;
 import org.matsim.contrib.drt.passenger.DrtRequest;
-import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
 
 /**
@@ -49,62 +45,45 @@ import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
 public class DefaultDrtInsertionSearchTest {
 	@Test
 	public void findBestInsertion_noInsertionsProvided() {
-		var insertionCostCalculator = new DefaultInsertionCostCalculator<>(new DrtConfigGroup(), null,
-				PathData::getTravelTime, null);
-		var insertionSearch = new DefaultDrtInsertionSearch(mock(InsertionProvider.class), null,
-				insertionCostCalculator);
+		var insertionSearch = new DefaultDrtInsertionSearch(mock(InsertionProvider.class), null, null, null);
 		assertThat(insertionSearch.findBestInsertion(null, List.of())).isEmpty();
 	}
 
 	@Test
-	public void findBestInsertion_twoInsertionsProvided() {
-		var beforePickupLink = mock(Link.class);
-		var afterPickupLink = mock(Link.class);
-		var beforeDropoffLink = mock(Link.class);
-		var afterDropoffLink = mock(Link.class);
-
+	public void findBestInsertion_oneInsertionsProvided() {
 		var request = DrtRequest.newBuilder().build();
 		var vehicleEntry = mock(VehicleEntry.class);
 
 		//mock insertionProvider
-		var selectedInsertion = new Insertion(vehicleEntry, insertionPoint(beforePickupLink, afterPickupLink),
-				insertionPoint(beforeDropoffLink, afterDropoffLink));
-		var discardedInsertion = new Insertion(vehicleEntry, insertionPoint(beforePickupLink, afterPickupLink),
-				insertionPoint(beforeDropoffLink, afterDropoffLink));
-		var filteredInsertions = List.of(selectedInsertion, discardedInsertion);
+		var insertion = mock(Insertion.class);
+		var allInsertions = List.of(insertion);
 		var insertionProvider = mock(InsertionProvider.class);
-		when(insertionProvider.getInsertions(eq(request), eq(List.of(vehicleEntry)))).thenReturn(filteredInsertions);
+		when(insertionProvider.getInsertions(eq(request), eq(List.of(vehicleEntry)))).thenReturn(allInsertions);
 
 		//mock detourPathCalculator
-		var detourData = new DetourPathDataCache(Map.of(beforePickupLink, mock(PathData.class)),
-				Map.of(afterPickupLink, mock(PathData.class)), Map.of(beforeDropoffLink, mock(PathData.class)),
-				Map.of(afterDropoffLink, mock(PathData.class)), PathData.EMPTY);
+		var pathData = mock(DetourPathDataCache.class);
 		var detourPathCalculator = mock(DetourPathCalculator.class);
-		when(detourPathCalculator.calculatePaths(eq(request), eq(filteredInsertions))).thenReturn(detourData);
+		when(detourPathCalculator.calculatePaths(eq(request), eq(allInsertions))).thenReturn(pathData);
+		var insertionPathData = new InsertionDetourData<PathData>(null, null, null, null);
+		when(pathData.createInsertionDetourData(eq(insertion))).thenReturn(insertionPathData);
+
+		//mock detourTimeCalculator
+		var detourTimeCalculator = (InsertionDetourTimeCalculator<PathData>)mock(InsertionDetourTimeCalculator.class);
+		var detourTimeInfo = new InsertionDetourTimeCalculator.DetourTimeInfo(null, null);
+		when(detourTimeCalculator.calculateDetourTimeInfo(eq(insertion), eq(insertionPathData))).thenReturn(
+				detourTimeInfo);
 
 		//mock bestInsertionFinder
-		var selectedInsertionWithPathData = new InsertionWithDetourData<>(selectedInsertion,
-				detourData.createInsertionDetourData(selectedInsertion));
-		@SuppressWarnings("unchecked")
 		var bestInsertionFinder = (BestInsertionFinder<PathData>)mock(BestInsertionFinder.class);
+		var insertionWithPathData = new InsertionWithDetourData<>(insertion, insertionPathData, detourTimeInfo);
 		when(bestInsertionFinder.findBestInsertion(eq(request),
 				argThat(argument -> argument.map(InsertionWithDetourData::getInsertion)
 						.collect(toSet())
-						.equals(Set.of(selectedInsertion, discardedInsertion))))).thenReturn(
-				Optional.of(selectedInsertionWithPathData));
+						.equals(Set.of(insertion))))).thenReturn(Optional.of(insertionWithPathData));
 
 		//test insertion search
 		var insertionSearch = new DefaultDrtInsertionSearch(insertionProvider, detourPathCalculator,
-				bestInsertionFinder);
-		assertThat(insertionSearch.findBestInsertion(request, List.of(vehicleEntry))).hasValue(
-				selectedInsertionWithPathData);
-	}
-
-	private InsertionPoint insertionPoint(Link previousLink, Link nextLink) {
-		var previousWaypoint = mock(Waypoint.class);
-		when(previousWaypoint.getLink()).thenReturn(previousLink);
-		var nextWaypoint = mock(Waypoint.class);
-		when(nextWaypoint.getLink()).thenReturn(nextLink);
-		return new InsertionPoint(-1, previousWaypoint, null, nextWaypoint);
+				bestInsertionFinder, detourTimeCalculator);
+		assertThat(insertionSearch.findBestInsertion(request, List.of(vehicleEntry))).hasValue(insertionWithPathData);
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserterTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserterTest.java
@@ -204,7 +204,7 @@ public class DefaultUnplannedRequestInserterTest {
 
 		DrtInsertionSearch<PathData> insertionSearch = (drtRequest, vEntries) -> drtRequest == request1 ?
 				Optional.of(new InsertionWithDetourData<PathData>(
-						new InsertionGenerator.Insertion(vEntries.iterator().next(), null, null), null)) :
+						new InsertionGenerator.Insertion(vEntries.iterator().next(), null, null), null, null)) :
 				fail("request1 expected");
 
 		double pickupEndTime = now + 20;

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionProviderTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionProviderTest.java
@@ -44,7 +44,7 @@ public class ExtensiveInsertionProviderTest {
 
 	@Test
 	public void getInsertions_noInsertionsGenerated() {
-		var insertionProvider = new ExtensiveInsertionProvider(null, null, new InsertionGenerator(null),
+		var insertionProvider = new ExtensiveInsertionProvider(null, null, new InsertionGenerator(120, null),
 				rule.forkJoinPool);
 		assertThat(insertionProvider.getInsertions(null, List.of())).isEmpty();
 	}
@@ -100,6 +100,6 @@ public class ExtensiveInsertionProviderTest {
 
 	private InsertionWithDetourData<Double> insertionWithDetourData(Insertion insertion) {
 		return new InsertionWithDetourData<>(insertion,
-				new InsertionDetourData<>(Double.NaN, Double.NaN, Double.NaN, Double.NaN));
+				new InsertionDetourData<>(Double.NaN, Double.NaN, Double.NaN, Double.NaN), null);
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionProviderTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/ExtensiveInsertionProviderTest.java
@@ -79,9 +79,9 @@ public class ExtensiveInsertionProviderTest {
 		@SuppressWarnings("unchecked")
 		var admissibleCostCalculator = (InsertionCostCalculator<Double>)mock(InsertionCostCalculator.class);
 		when(admissibleCostCalculator.calculate(eq(request),
-				argThat(argument -> argument.getInsertion() == feasibleInsertion))).thenReturn(1.);
+				argThat(argument -> argument.insertion == feasibleInsertion))).thenReturn(1.);
 		when(admissibleCostCalculator.calculate(eq(request),
-				argThat(argument -> argument.getInsertion() == infeasibleInsertion)))//
+				argThat(argument -> argument.insertion == infeasibleInsertion)))//
 				.thenReturn(InsertionCostCalculator.INFEASIBLE_SOLUTION_COST);
 
 		//test insertionProvider

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
@@ -22,7 +22,7 @@ package org.matsim.contrib.drt.optimizer.insertion;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
-import static org.matsim.contrib.drt.optimizer.insertion.InsertionDetourTimeCalculator.DetourTimeInfo;
+import static org.matsim.contrib.drt.optimizer.insertion.InsertionDetourTimeCalculator.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -48,16 +48,20 @@ public class InsertionCostCalculatorTest {
 		var insertion = insertion(entry, 0, 1);
 
 		//feasible solution
-		assertCalculate(insertion, new DetourTimeInfo(0, 0, 11, 22), 11 + 22);
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(0, 11), new DropoffDetourInfo(0, 22)),
+				11 + 22);
 
 		//feasible solution - longest possible pickup and dropoff time losses
-		assertCalculate(insertion, new DetourTimeInfo(0, 0, 20, 30), 20 + 30);
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(0, 20), new DropoffDetourInfo(0, 30)),
+				20 + 30);
 
 		//infeasible solution - time constraints at stop 0
-		assertCalculate(insertion, new DetourTimeInfo(0, 0, 21, 29), INFEASIBLE_SOLUTION_COST);
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(0, 21), new DropoffDetourInfo(0, 29)),
+				INFEASIBLE_SOLUTION_COST);
 
 		//infeasible solution - vehicle time constraints
-		assertCalculate(insertion, new DetourTimeInfo(0, 0, 20, 31), INFEASIBLE_SOLUTION_COST);
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(0, 20), new DropoffDetourInfo(0, 31)),
+				INFEASIBLE_SOLUTION_COST);
 	}
 
 	private <D> void assertCalculate(Insertion insertion, DetourTimeInfo detourTimeInfo, double expectedCost) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
@@ -45,7 +45,7 @@ public class InsertionCostCalculatorTest {
 	@Test
 	public void testCalculate() {
 		VehicleEntry entry = entry(new double[] { 20, 50 });
-		var insertion = new InsertionWithDetourData<>(insertion(entry, 0, 1), null);
+		var insertion = insertion(entry, 0, 1);
 
 		//feasible solution
 		assertCalculate(insertion, new DetourTimeInfo(0, 0, 11, 22), 11 + 22);
@@ -60,14 +60,15 @@ public class InsertionCostCalculatorTest {
 		assertCalculate(insertion, new DetourTimeInfo(0, 0, 20, 31), INFEASIBLE_SOLUTION_COST);
 	}
 
-	private <D> void assertCalculate(InsertionWithDetourData<D> insertion, DetourTimeInfo detourTimeInfo,
-			double expectedCost) {
+	private <D> void assertCalculate(Insertion insertion, DetourTimeInfo detourTimeInfo, double expectedCost) {
 		@SuppressWarnings("unchecked")
 		var detourTimeCalculator = (InsertionDetourTimeCalculator<D>)mock(InsertionDetourTimeCalculator.class);
-		var insertionCostCalculator = new DefaultInsertionCostCalculator<>(
+		var insertionCostCalculator = new DefaultInsertionCostCalculator<D>(
 				new CostCalculationStrategy.RejectSoftConstraintViolations(), detourTimeCalculator);
-		when(detourTimeCalculator.calculateDetourTimeInfo(insertion)).thenReturn(detourTimeInfo);
-		assertThat(insertionCostCalculator.calculate(drtRequest, insertion)).isEqualTo(expectedCost);
+		var insertionWithDetourData = new InsertionWithDetourData<D>(insertion, null, detourTimeInfo);
+		when(detourTimeCalculator.calculateDetourTimeInfo(insertionWithDetourData.getInsertion(),
+				insertionWithDetourData.getDetourData())).thenReturn(detourTimeInfo);
+		assertThat(insertionCostCalculator.calculate(drtRequest, insertionWithDetourData)).isEqualTo(expectedCost);
 	}
 
 	private VehicleEntry entry(double[] slackTimes) {
@@ -79,8 +80,7 @@ public class InsertionCostCalculatorTest {
 	}
 
 	private Insertion insertion(VehicleEntry entry, int pickupIdx, int dropoffIdx) {
-		return new Insertion(entry,
-				new InsertionGenerator.InsertionPoint(pickupIdx, null, null, null),
+		return new Insertion(entry, new InsertionGenerator.InsertionPoint(pickupIdx, null, null, null),
 				new InsertionGenerator.InsertionPoint(dropoffIdx, null, null, null));
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
@@ -66,8 +66,8 @@ public class InsertionCostCalculatorTest {
 		var insertionCostCalculator = new DefaultInsertionCostCalculator<D>(
 				new CostCalculationStrategy.RejectSoftConstraintViolations(), detourTimeCalculator);
 		var insertionWithDetourData = new InsertionWithDetourData<D>(insertion, null, detourTimeInfo);
-		when(detourTimeCalculator.calculateDetourTimeInfo(insertionWithDetourData.getInsertion(),
-				insertionWithDetourData.getDetourData())).thenReturn(detourTimeInfo);
+		when(detourTimeCalculator.calculateDetourTimeInfo(insertionWithDetourData.insertion,
+				insertionWithDetourData.detourData)).thenReturn(detourTimeInfo);
 		assertThat(insertionCostCalculator.calculate(drtRequest, insertionWithDetourData)).isEqualTo(expectedCost);
 	}
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
@@ -184,7 +184,8 @@ public class InsertionDetourTimeCalculatorTest {
 
 		var detourTimeCalculator = new InsertionDetourTimeCalculator<>(STOP_DURATION, Double::doubleValue,
 				replacedDriveTimeEstimates::get);
-		var actualDetourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion);
+		var actualDetourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion.getInsertion(),
+				insertion.getDetourData());
 
 		double departureTime = start.getDepartureTime() + detour.detourToPickup + STOP_DURATION;
 		double pickupTimeLoss = detour.detourToPickup + STOP_DURATION + detour.detourFromPickup
@@ -198,7 +199,8 @@ public class InsertionDetourTimeCalculatorTest {
 
 	private void assertDetourTimeInfo(InsertionWithDetourData<Double> insertion, DetourTimeInfo expected) {
 		var detourTimeCalculator = new InsertionDetourTimeCalculator<>(STOP_DURATION, Double::doubleValue, null);
-		var detourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion);
+		var detourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion.getInsertion(),
+				insertion.getDetourData());
 		assertThat(detourTimeInfo).usingRecursiveComparison().isEqualTo(expected);
 	}
 
@@ -220,7 +222,8 @@ public class InsertionDetourTimeCalculatorTest {
 
 	private InsertionWithDetourData<Double> insertion(VehicleEntry entry, int pickupIdx, int dropoffIdx,
 			InsertionDetourData<Double> detour) {
-		return new InsertionWithDetourData<Double>(new Insertion(drtRequest, entry, pickupIdx, dropoffIdx), detour);
+		return new InsertionWithDetourData<Double>(new Insertion(drtRequest, entry, pickupIdx, dropoffIdx), detour,
+				null);
 	}
 
 	private double timeBetween(Waypoint from, Waypoint to) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
@@ -21,6 +21,8 @@
 package org.matsim.contrib.drt.optimizer.insertion;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.matsim.contrib.drt.optimizer.insertion.InsertionDetourTimeCalculator.DropoffDetourInfo;
+import static org.matsim.contrib.drt.optimizer.insertion.InsertionDetourTimeCalculator.PickupDetourInfo;
 
 import org.junit.Test;
 import org.matsim.api.core.v01.Id;
@@ -59,8 +61,8 @@ public class InsertionDetourTimeCalculatorTest {
 		double pickupTimeLoss = detour.detourToPickup + STOP_DURATION + detour.detourFromPickup;
 		double arrivalTime = departureTime + detour.detourFromPickup;
 		double dropoffTimeLoss = STOP_DURATION;
-		assertDetourTimeInfo(insertion,
-				new DetourTimeInfo(departureTime, arrivalTime, pickupTimeLoss, dropoffTimeLoss));
+		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
+				new DropoffDetourInfo(arrivalTime, dropoffTimeLoss)));
 	}
 
 	@Test
@@ -75,8 +77,8 @@ public class InsertionDetourTimeCalculatorTest {
 		double pickupTimeLoss = detour.detourFromPickup;
 		double arrivalTime = departureTime + detour.detourFromPickup;
 		double dropoffTimeLoss = STOP_DURATION;
-		assertDetourTimeInfo(insertion,
-				new DetourTimeInfo(departureTime, arrivalTime, pickupTimeLoss, dropoffTimeLoss));
+		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
+				new DropoffDetourInfo(arrivalTime, dropoffTimeLoss)));
 	}
 
 	@Test
@@ -92,8 +94,8 @@ public class InsertionDetourTimeCalculatorTest {
 				stop0);
 		double arrivalTime = departureTime + detour.detourFromPickup;
 		double dropoffTimeLoss = STOP_DURATION + detour.detourFromDropoff;
-		assertDetourTimeInfo(insertion,
-				new DetourTimeInfo(departureTime, arrivalTime, pickupTimeLoss, dropoffTimeLoss));
+		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
+				new DropoffDetourInfo(arrivalTime, dropoffTimeLoss)));
 	}
 
 	@Test
@@ -109,8 +111,8 @@ public class InsertionDetourTimeCalculatorTest {
 				stop0);
 		double arrivalTime = stop0.getDepartureTime() + pickupTimeLoss + detour.detourToDropoff;
 		double dropoffTimeLoss = detour.detourToDropoff + STOP_DURATION;
-		assertDetourTimeInfo(insertion,
-				new DetourTimeInfo(departureTime, arrivalTime, pickupTimeLoss, dropoffTimeLoss));
+		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
+				new DropoffDetourInfo(arrivalTime, dropoffTimeLoss)));
 	}
 
 	@Test
@@ -128,8 +130,8 @@ public class InsertionDetourTimeCalculatorTest {
 		double arrivalTime = stop0.getDepartureTime() + pickupTimeLoss + detour.detourToDropoff;
 		double dropoffTimeLoss = detour.detourToDropoff + STOP_DURATION + detour.detourFromDropoff - timeBetween(stop0,
 				stop1);
-		assertDetourTimeInfo(insertion,
-				new DetourTimeInfo(departureTime, arrivalTime, pickupTimeLoss, dropoffTimeLoss));
+		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
+				new DropoffDetourInfo(arrivalTime, dropoffTimeLoss)));
 	}
 
 	@Test
@@ -145,8 +147,8 @@ public class InsertionDetourTimeCalculatorTest {
 		double pickupTimeLoss = STOP_DURATION;
 		double arrivalTime = stop0.getArrivalTime() + pickupTimeLoss;
 		double dropoffTimeLoss = 0;
-		assertDetourTimeInfo(insertion,
-				new DetourTimeInfo(departureTime, arrivalTime, pickupTimeLoss, dropoffTimeLoss));
+		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
+				new DropoffDetourInfo(arrivalTime, dropoffTimeLoss)));
 	}
 
 	@Test
@@ -162,8 +164,8 @@ public class InsertionDetourTimeCalculatorTest {
 		double pickupTimeLoss = 0;
 		double arrivalTime = stop1.getArrivalTime();
 		double dropoffTimeLoss = 0;
-		assertDetourTimeInfo(insertion,
-				new DetourTimeInfo(departureTime, arrivalTime, pickupTimeLoss, dropoffTimeLoss));
+		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
+				new DropoffDetourInfo(arrivalTime, dropoffTimeLoss)));
 	}
 
 	@Test
@@ -194,7 +196,8 @@ public class InsertionDetourTimeCalculatorTest {
 		double dropoffTimeLoss = detour.detourToDropoff + STOP_DURATION + detour.detourFromDropoff
 				- dropoffDetourReplacedDriveEstimate;
 		assertThat(actualDetourTimeInfo).usingRecursiveComparison()
-				.isEqualTo(new DetourTimeInfo(departureTime, arrivalTime, pickupTimeLoss, dropoffTimeLoss));
+				.isEqualTo(new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
+						new DropoffDetourInfo(arrivalTime, dropoffTimeLoss)));
 	}
 
 	private void assertDetourTimeInfo(InsertionWithDetourData<Double> insertion, DetourTimeInfo expected) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
@@ -184,8 +184,8 @@ public class InsertionDetourTimeCalculatorTest {
 
 		var detourTimeCalculator = new InsertionDetourTimeCalculator<>(STOP_DURATION, Double::doubleValue,
 				replacedDriveTimeEstimates::get);
-		var actualDetourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion.getInsertion(),
-				insertion.getDetourData());
+		var actualDetourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion.insertion,
+				insertion.detourData);
 
 		double departureTime = start.getDepartureTime() + detour.detourToPickup + STOP_DURATION;
 		double pickupTimeLoss = detour.detourToPickup + STOP_DURATION + detour.detourFromPickup
@@ -199,8 +199,7 @@ public class InsertionDetourTimeCalculatorTest {
 
 	private void assertDetourTimeInfo(InsertionWithDetourData<Double> insertion, DetourTimeInfo expected) {
 		var detourTimeCalculator = new InsertionDetourTimeCalculator<>(STOP_DURATION, Double::doubleValue, null);
-		var detourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion.getInsertion(),
-				insertion.getDetourData());
+		var detourTimeInfo = detourTimeCalculator.calculateDetourTimeInfo(insertion.insertion, insertion.detourData);
 		assertThat(detourTimeInfo).usingRecursiveComparison().isEqualTo(expected);
 	}
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
@@ -313,10 +313,10 @@ public class InsertionGeneratorTest {
 
 		for (int i = 0; i < expectedInsertions.length; i++) {
 			//TODO we do not compare insertion.detourTimeInfo
-			assertThat(actualInsertions.get(i).getInsertion()).usingRecursiveComparison()
-					.isEqualTo(expectedInsertions[i].getInsertion());
-			assertThat(actualInsertions.get(i).getDetourData()).usingRecursiveComparison()
-					.isEqualTo(expectedInsertions[i].getDetourData());
+			assertThat(actualInsertions.get(i).insertion).usingRecursiveComparison()
+					.isEqualTo(expectedInsertions[i].insertion);
+			assertThat(actualInsertions.get(i).detourData).usingRecursiveComparison()
+					.isEqualTo(expectedInsertions[i].detourData);
 		}
 	}
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
@@ -27,6 +27,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
 import org.matsim.contrib.drt.optimizer.Waypoint;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionDetourTimeCalculator.DetourTimeInfo;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionWithDetourData.InsertionDetourData;
 import org.matsim.contrib.drt.passenger.DrtRequest;
@@ -46,6 +47,13 @@ import com.google.common.collect.ImmutableList;
 public class InsertionGeneratorTest {
 	private static final int CAPACITY = 4;
 
+	private static final int STOP_DURATION = 10;
+
+	private static final double TIME_TO_PICKUP = 100;
+	private static final double TIME_FROM_PICKUP = 200;
+	private static final double TIME_TO_DROPOFF = 300;
+	private static final double TIME_FROM_DROPOFF = 400;
+
 	private final Link fromLink = link("from");
 	private final Link toLink = link("to");
 	private final DrtRequest drtRequest = DrtRequest.newBuilder().fromLink(fromLink).toLink(toLink).build();
@@ -62,152 +70,198 @@ public class InsertionGeneratorTest {
 
 	@Test
 	public void generateInsertions_startEmpty_noStops() {
-		Waypoint.Start start = new Waypoint.Start(null, link("0"), 0, 0); //no stops => must be empty
+		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, 0); //no stops => must be empty
 		VehicleEntry entry = entry(start);
 		assertInsertions(drtRequest, entry,
 				//pickup after start
-				insertion(entry, 0, 0, 1, 2, Double.POSITIVE_INFINITY, 0));
+				insertion(new Insertion(drtRequest, entry, 0, 0),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, Double.POSITIVE_INFINITY, 0.),
+						null));
 	}
 
 	@Test
 	public void generateInsertions_startNotFull_oneStop() {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, 1); // 1 pax aboard
-		Waypoint.Stop stop0 = stop(link("stop0"), 0);//drop off 1 pax
+		Waypoint.Stop stop0 = stop(99, link("stop0"), 0);//drop off 1 pax
 		VehicleEntry entry = entry(start, stop0);
 		assertInsertions(drtRequest, entry,
 				//pickup after start
-				insertion(entry, 0, 0, 1, 2, Double.POSITIVE_INFINITY, 4),//
-				insertion(entry, 0, 1, 1, 2, 3, 0),
+				insertion(new Insertion(drtRequest, entry, 0, 0),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, Double.POSITIVE_INFINITY,
+								TIME_FROM_DROPOFF), null),//
+				insertion(new Insertion(drtRequest, entry, 0, 1),//
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, TIME_TO_DROPOFF, 0.), null),
 				//pickup after stop 0
-				insertion(entry, 1, 1, 1, 2, Double.POSITIVE_INFINITY, 0));
+				insertion(new Insertion(drtRequest, entry, 1, 1),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, Double.POSITIVE_INFINITY, 0.),
+						null));
 	}
 
 	@Test
 	public void generateInsertions_startFull_oneStop() {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, CAPACITY); //full
-		Waypoint.Stop stop0 = stop(link("stop0"), 0);//drop off 4 pax
+		Waypoint.Stop stop0 = stop(0, link("stop0"), 0);//drop off 4 pax
 		VehicleEntry entry = entry(start, stop0);
 		assertInsertions(drtRequest, entry,
 				//no pickup after stop
 				//pickup after stop 0
-				insertion(entry, 1, 1, 1, 2, Double.POSITIVE_INFINITY, 0));
+				insertion(new Insertion(drtRequest, entry, 1, 1),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, Double.POSITIVE_INFINITY, 0.),
+						null));
 	}
 
 	@Test
 	public void generateInsertions_startEmpty_twoStops_notFullBetweenStops() {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, 0); //empty
-		Waypoint.Stop stop0 = stop(link("stop0"), 1);//pick up 1 pax
-		Waypoint.Stop stop1 = stop(link("stop1"), 0);//drop off 1 pax
+		Waypoint.Stop stop0 = stop(0, link("stop0"), 1);//pick up 1 pax
+		Waypoint.Stop stop1 = stop(0, link("stop1"), 0);//drop off 1 pax
 		VehicleEntry entry = entry(start, stop0, stop1);
 		assertInsertions(drtRequest, entry,
 				//pickup after start
-				insertion(entry, 0, 0, 1, 2, Double.POSITIVE_INFINITY, 4),//
-				insertion(entry, 0, 1, 1, 2, 3, 4),//
-				insertion(entry, 0, 2, 1, 2, 3, 0),
+				insertion(new Insertion(drtRequest, entry, 0, 0),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, Double.POSITIVE_INFINITY,
+								TIME_FROM_DROPOFF), null),//
+				insertion(new Insertion(drtRequest, entry, 0, 1),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, TIME_TO_DROPOFF, TIME_FROM_DROPOFF),
+						null),//
+				insertion(new Insertion(drtRequest, entry, 0, 2),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, TIME_TO_DROPOFF, 0.), null),
 				//pickup after stop 0
-				insertion(entry, 1, 1, 1, 2, Double.POSITIVE_INFINITY, 4),//
-				insertion(entry, 1, 2, 1, 2, 3, 0),
+				insertion(new Insertion(drtRequest, entry, 1, 1),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, Double.POSITIVE_INFINITY,
+								TIME_FROM_DROPOFF), null),//
+				insertion(new Insertion(drtRequest, entry, 1, 2),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, TIME_TO_DROPOFF, 0.), null),
 				//pickup after stop 1
-				insertion(entry, 2, 2, 1, 2, Double.POSITIVE_INFINITY, 0));
+				insertion(new Insertion(drtRequest, entry, 2, 2),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, Double.POSITIVE_INFINITY, 0.),
+						null));
 	}
 
 	@Test
 	public void generateInsertions_startEmpty_twoStops_fullBetweenStops() {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, 0); //empty
-		Waypoint.Stop stop0 = stop(link("stop0"), CAPACITY);//pick up 4 pax (full)
-		Waypoint.Stop stop1 = stop(link("stop1"), 0);//drop off 4 pax
+		Waypoint.Stop stop0 = stop(0, link("stop0"), CAPACITY);//pick up 4 pax (full)
+		Waypoint.Stop stop1 = stop(0, link("stop1"), 0);//drop off 4 pax
 		VehicleEntry entry = entry(start, stop0, stop1);
 		assertInsertions(drtRequest, entry,
 				//pickup after start
-				insertion(entry, 0, 0, 1, 2, Double.POSITIVE_INFINITY, 4),
+				insertion(new Insertion(drtRequest, entry, 0, 0),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, Double.POSITIVE_INFINITY,
+								TIME_FROM_DROPOFF), null),
 				//no pickup after stop 0
 				//pickup after stop 1
-				insertion(entry, 2, 2, 1, 2, Double.POSITIVE_INFINITY, 0));
+				insertion(new Insertion(drtRequest, entry, 2, 2),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, Double.POSITIVE_INFINITY, 0.),
+						null));
 	}
 
 	@Test
 	public void generateInsertions_startFull_twoStops_notFullBetweenStops() {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, CAPACITY); //full
-		Waypoint.Stop stop0 = stop(link("stop0"), 2);//drop off 2 pax
-		Waypoint.Stop stop1 = stop(link("stop1"), 0);//drop off 2 pax
+		Waypoint.Stop stop0 = stop(0, link("stop0"), 2);//drop off 2 pax
+		Waypoint.Stop stop1 = stop(0, link("stop1"), 0);//drop off 2 pax
 		VehicleEntry entry = entry(start, stop0, stop1);
 		assertInsertions(drtRequest, entry,
 				//no pickup after start
 				//pickup after stop 0
-				insertion(entry, 1, 1, 1, 2, Double.POSITIVE_INFINITY, 4),//
-				insertion(entry, 1, 2, 1, 2, 3, 0),
+				insertion(new Insertion(drtRequest, entry, 1, 1),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, Double.POSITIVE_INFINITY,
+								TIME_FROM_DROPOFF), null),//
+				insertion(new Insertion(drtRequest, entry, 1, 2),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, TIME_TO_DROPOFF, 0.), null),
 				//pickup after stop 1
-				insertion(entry, 2, 2, 1, 2, Double.POSITIVE_INFINITY, 0));
+				insertion(new Insertion(drtRequest, entry, 2, 2),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, Double.POSITIVE_INFINITY, 0.),
+						null));
 	}
 
 	@Test
 	public void generateInsertions_startFull_twoStops_fullBetweenStops() {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, CAPACITY); //full
-		Waypoint.Stop stop0 = stop(link("stop0"), CAPACITY);//drop off 1 pax, pickup 1 pax (full)
-		Waypoint.Stop stop1 = stop(link("stop1"), 0);//drop off 4 pax
+		Waypoint.Stop stop0 = stop(0, link("stop0"), CAPACITY);//drop off 1 pax, pickup 1 pax (full)
+		Waypoint.Stop stop1 = stop(0, link("stop1"), 0);//drop off 4 pax
 		VehicleEntry entry = entry(start, stop0, stop1);
 		assertInsertions(drtRequest, entry,
 				//no pickup after start
 				//no pickup after stop 0
 				//pickup after stop 1
-				insertion(entry, 2, 2, 1, 2, Double.POSITIVE_INFINITY, 0));
+				insertion(new Insertion(drtRequest, entry, 2, 2),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, Double.POSITIVE_INFINITY, 0.),
+						null));
 	}
 
 	@Test
 	public void generateInsertions_startNotFull_threeStops_emptyBetweenStops01_fullBetweenStops12() {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, 1); //empty
-		Waypoint.Stop stop0 = stop(link("stop0"), 0);// dropoff 1 pax
-		Waypoint.Stop stop1 = stop(link("stop1"), CAPACITY);// pickup 4 pax
-		Waypoint.Stop stop2 = stop(link("stop2"), 0);// dropoff 4 pax
+		Waypoint.Stop stop0 = stop(0, link("stop0"), 0);// dropoff 1 pax
+		Waypoint.Stop stop1 = stop(0, link("stop1"), CAPACITY);// pickup 4 pax
+		Waypoint.Stop stop2 = stop(0, link("stop2"), 0);// dropoff 4 pax
 		VehicleEntry entry = entry(start, stop0, stop1, stop2);
 		assertInsertions(drtRequest, entry,
 				//pickup after start
-				insertion(entry, 0, 0, 1, 2, Double.POSITIVE_INFINITY, 4),//
-				insertion(entry, 0, 1, 1, 2, 3, 4),
+				insertion(new Insertion(drtRequest, entry, 0, 0),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, Double.POSITIVE_INFINITY,
+								TIME_FROM_DROPOFF), null),//
+				insertion(new Insertion(drtRequest, entry, 0, 1),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, TIME_TO_DROPOFF, TIME_FROM_DROPOFF),
+						null),
 				//pickup after stop 0
-				insertion(entry, 1, 1, 1, 2, Double.POSITIVE_INFINITY, 4),
+				insertion(new Insertion(drtRequest, entry, 1, 1),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, Double.POSITIVE_INFINITY,
+								TIME_FROM_DROPOFF), null),
 				//pickup after stop 1
 				//pickup after stop 2
-				insertion(entry, 3, 3, 1, 2, Double.POSITIVE_INFINITY, 0));
+				insertion(new Insertion(drtRequest, entry, 3, 3),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, Double.POSITIVE_INFINITY, 0.),
+						null));
 	}
 
 	@Test
 	public void generateInsertions_startFull_threeStops_emptyBetweenStops01_fullBetweenStops12() {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, CAPACITY); //full
-		Waypoint.Stop stop0 = stop(link("stop0"), 0);// dropoff 4 pax
-		Waypoint.Stop stop1 = stop(link("stop1"), CAPACITY);// pickup 4 pax
-		Waypoint.Stop stop2 = stop(link("stop2"), 0);// dropoff 4 pax
+		Waypoint.Stop stop0 = stop(0, link("stop0"), 0);// dropoff 4 pax
+		Waypoint.Stop stop1 = stop(0, link("stop1"), CAPACITY);// pickup 4 pax
+		Waypoint.Stop stop2 = stop(0, link("stop2"), 0);// dropoff 4 pax
 		VehicleEntry entry = entry(start, stop0, stop1, stop2);
 		assertInsertions(drtRequest, entry,
 				//no pickup after start
 				//pickup after stop 0
-				insertion(entry, 1, 1, 1, 2, Double.POSITIVE_INFINITY, 4),
+				insertion(new Insertion(drtRequest, entry, 1, 1),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, Double.POSITIVE_INFINITY,
+								TIME_FROM_DROPOFF), null),
 				//pickup after stop 1
 				//pickup after stop 2
-				insertion(entry, 3, 3, 1, 2, Double.POSITIVE_INFINITY, 0));
+				insertion(new Insertion(drtRequest, entry, 3, 3),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, Double.POSITIVE_INFINITY, 0.),
+						null));
 	}
 
 	@Test
 	public void generateInsertions_noDetourForPickup_noDuplicatedInsertions() {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, 1); // 1 pax
-		Waypoint.Stop stop0 = stop(fromLink, 0);//dropoff 1 pax
+		Waypoint.Stop stop0 = stop(0, fromLink, 0);//dropoff 1 pax
 		VehicleEntry entry = entry(start, stop0);
 		assertInsertions(drtRequest, entry,
 				//no pickup after start (pickup is exactly at stop0)
 				//pickup after stop 0
-				insertion(entry, 1, 1, 0, 2, Double.POSITIVE_INFINITY, 0));
+				insertion(new Insertion(drtRequest, entry, 1, 1),
+						new InsertionDetourData<>(0., TIME_FROM_PICKUP, Double.POSITIVE_INFINITY, 0.), null));
 	}
 
 	@Test
 	public void generateInsertions_noDetourForDropoff_noDuplicatedInsertions() {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, 1); // 1 pax
-		Waypoint.Stop stop0 = stop(toLink, 0);//dropoff 1 pax
+		Waypoint.Stop stop0 = stop(0, toLink, 0);//dropoff 1 pax
 		VehicleEntry entry = entry(start, stop0);
 		assertInsertions(drtRequest, entry,
 				//pickup after start: insertion(0, 0) is a duplicate of insertion(0, 1)
-				insertion(entry, 0, 1, 1, 2, 0, 0),
+				insertion(new Insertion(drtRequest, entry, 0, 1),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, 0., 0.), null),
 				//pickup after stop 0
-				insertion(entry, 1, 1, 1, 2, Double.POSITIVE_INFINITY, 0));
+				insertion(new Insertion(drtRequest, entry, 1, 1),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, Double.POSITIVE_INFINITY, 0.),
+						null));
 	}
 
 	@Test
@@ -215,14 +269,17 @@ public class InsertionGeneratorTest {
 		// a special case where we allow inserting the dropoff after a stop despite outgoingOccupancy == maxCapacity
 		// this is only because the the dropoff happens exactly at (not after) the stop
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, 1); // 1 pax
-		Waypoint.Stop stop0 = stop(toLink, CAPACITY);//dropoff 1 pax
-		Waypoint.Stop stop1 = stop(link("stop1"), 0);//dropoff 1 pax
+		Waypoint.Stop stop0 = stop(0, toLink, CAPACITY);//dropoff 1 pax
+		Waypoint.Stop stop1 = stop(0, link("stop1"), 0);//dropoff 1 pax
 		VehicleEntry entry = entry(start, stop0, stop1);
 		assertInsertions(drtRequest, entry,
 				//pickup after start: insertion(0, 0) is a duplicate of insertion(0, 1)
-				insertion(entry, 0, 1, 1, 2, 0, 4),
+				insertion(new Insertion(drtRequest, entry, 0, 1),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, 0., TIME_FROM_DROPOFF), null),
 				//pickup after stop 0
-				insertion(entry, 2, 2, 1, 2, Double.POSITIVE_INFINITY, 0));
+				insertion(new Insertion(drtRequest, entry, 2, 2),
+						new InsertionDetourData<>(TIME_TO_PICKUP, TIME_FROM_PICKUP, Double.POSITIVE_INFINITY, 0.),
+						null));
 	}
 
 	private Link link(String id) {
@@ -239,29 +296,37 @@ public class InsertionGeneratorTest {
 			if (from == to) {
 				return 0;
 			} else if (to.equals(drtRequest.getFromLink())) {
-				return 1;//to pickup
+				return TIME_TO_PICKUP;
 			} else if (from.equals(drtRequest.getFromLink())) {
-				return 2;//from pickup
+				return TIME_FROM_PICKUP;
 			} else if (to.equals(drtRequest.getToLink())) {
-				return 3;//to dropoff
+				return TIME_TO_DROPOFF;
 			} else if (from.equals(drtRequest.getToLink())) {
-				return 4;//from dropoff
+				return TIME_FROM_DROPOFF;
 			}
-			throw new IllegalArgumentException();
+			return 100;
 		};
 
-		assertThat(new InsertionGenerator(timeEstimator).generateInsertions(drtRequest,
-				entry)).usingRecursiveFieldByFieldElementComparator().containsExactly(expectedInsertions);
+		var actualInsertions = new InsertionGenerator(STOP_DURATION, timeEstimator).generateInsertions(drtRequest,
+				entry);
+		assertThat(actualInsertions).hasSize(expectedInsertions.length);
+
+		for (int i = 0; i < expectedInsertions.length; i++) {
+			//TODO we do not compare insertion.detourTimeInfo
+			assertThat(actualInsertions.get(i).getInsertion()).usingRecursiveComparison()
+					.isEqualTo(expectedInsertions[i].getInsertion());
+			assertThat(actualInsertions.get(i).getDetourData()).usingRecursiveComparison()
+					.isEqualTo(expectedInsertions[i].getDetourData());
+		}
 	}
 
-	private InsertionWithDetourData<Double> insertion(VehicleEntry entry, int pickupIdx, int dropoffIdx,
-			double timeToPickup, double timeFromPickup, double timeToDropoff, double timeFromDropoff) {
-		return new InsertionWithDetourData<>(new Insertion(drtRequest, entry, pickupIdx, dropoffIdx),
-				new InsertionDetourData<>(timeToPickup, timeFromPickup, timeToDropoff, timeFromDropoff));
+	private InsertionWithDetourData<Double> insertion(Insertion insertion, InsertionDetourData<Double> detourData,
+			DetourTimeInfo detourTimeInfo) {
+		return new InsertionWithDetourData<>(insertion, detourData, detourTimeInfo);
 	}
 
-	private Waypoint.Stop stop(Link link, int outgoingOccupancy) {
-		return new Waypoint.Stop(new DefaultDrtStopTask(0, 0, link), outgoingOccupancy);
+	private Waypoint.Stop stop(double beginTime, Link link, int outgoingOccupancy) {
+		return new Waypoint.Stop(new DefaultDrtStopTask(beginTime, beginTime + STOP_DURATION, link), outgoingOccupancy);
 	}
 
 	private VehicleEntry entry(Waypoint.Start start, Waypoint.Stop... stops) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/KNearestInsertionsAtEndFilterTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/KNearestInsertionsAtEndFilterTest.java
@@ -113,7 +113,7 @@ public class KNearestInsertionsAtEndFilterTest {
 		return new InsertionWithDetourData<>(new Insertion(vehicleEntry,
 				new InsertionPoint(pickupIdx, vehicleEntry.getWaypoint(pickupIdx), null,
 						vehicleEntry.getWaypoint(pickupIdx + 1)), null),
-				new InsertionDetourData<>(toPickupDetourTime, null, null, null));
+				new InsertionDetourData<>(toPickupDetourTime, null, null, null), null);
 	}
 
 	private Waypoint.Start start(double endTime) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/KNearestInsertionsAtEndFilterTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/KNearestInsertionsAtEndFilterTest.java
@@ -63,8 +63,8 @@ public class KNearestInsertionsAtEndFilterTest {
 		var insertion1 = insertion(vehicleEntry, 0, 11);
 		var insertion2 = insertion(vehicleEntry, 0, 22);
 
-		assertThat(filterOneInsertionAtEnd(insertion1, insertion2)).containsExactlyInAnyOrder(insertion1.getInsertion(),
-				insertion2.getInsertion());
+		assertThat(filterOneInsertionAtEnd(insertion1, insertion2)).containsExactlyInAnyOrder(insertion1.insertion,
+				insertion2.insertion);
 	}
 
 	@Test
@@ -78,8 +78,8 @@ public class KNearestInsertionsAtEndFilterTest {
 		var insertion2 = insertion(vehicleEntry2, 0, 61);
 
 		//insertion1 is better
-		assertThat(filterOneInsertionAtEnd(insertion1, insertion2)).containsExactly(insertion1.getInsertion());
-		assertThat(filterOneInsertionAtEnd(insertion2, insertion1)).containsExactly(insertion1.getInsertion());
+		assertThat(filterOneInsertionAtEnd(insertion1, insertion2)).containsExactly(insertion1.insertion);
+		assertThat(filterOneInsertionAtEnd(insertion2, insertion1)).containsExactly(insertion1.insertion);
 	}
 
 	@Test
@@ -93,8 +93,8 @@ public class KNearestInsertionsAtEndFilterTest {
 		var insertion2 = insertion(vehicleEntry2, 0, 60);
 
 		//take the first
-		assertThat(filterOneInsertionAtEnd(insertion1, insertion2)).containsExactly(insertion1.getInsertion());
-		assertThat(filterOneInsertionAtEnd(insertion2, insertion1)).containsExactly(insertion1.getInsertion());
+		assertThat(filterOneInsertionAtEnd(insertion1, insertion2)).containsExactly(insertion1.insertion);
+		assertThat(filterOneInsertionAtEnd(insertion2, insertion1)).containsExactly(insertion1.insertion);
 	}
 
 	@Test
@@ -105,7 +105,7 @@ public class KNearestInsertionsAtEndFilterTest {
 
 		//insertionAtEnd always returned last
 		assertThat(filterOneInsertionAtEnd(insertionAfterStart, insertionAtEnd)).containsExactlyInAnyOrder(
-				insertionAfterStart.getInsertion(), insertionAtEnd.getInsertion());
+				insertionAfterStart.insertion, insertionAtEnd.insertion);
 	}
 
 	private InsertionWithDetourData<Double> insertion(VehicleEntry vehicleEntry, int pickupIdx,

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProviderTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProviderTest.java
@@ -89,7 +89,8 @@ public class SelectiveInsertionProviderTest {
 		//test insertionProvider
 		var insertionProvider = new SelectiveInsertionProvider(initialInsertionFinder, insertionGenerator,
 				rule.forkJoinPool);
-		assertThat(insertionProvider.getInsertions(request, List.of(vehicleEntry))).isEqualTo(
-				selectedInsertion.stream().map(InsertionWithDetourData::getInsertion).collect(toList()));
+		assertThat(insertionProvider.getInsertions(request, List.of(vehicleEntry))).isEqualTo(selectedInsertion.stream()
+				.map(doubleInsertionWithDetourData -> doubleInsertionWithDetourData.insertion)
+				.collect(toList()));
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProviderTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/SelectiveInsertionProviderTest.java
@@ -52,8 +52,8 @@ public class SelectiveInsertionProviderTest {
 
 	@Test
 	public void getInsertions_noInsertionsGenerated() {
-		var insertionProvider = new SelectiveInsertionProvider(initialInsertionFinder, new InsertionGenerator(null),
-				rule.forkJoinPool);
+		var insertionProvider = new SelectiveInsertionProvider(initialInsertionFinder,
+				new InsertionGenerator(120, null), rule.forkJoinPool);
 		assertThat(insertionProvider.getInsertions(null, List.of())).isEmpty();
 	}
 
@@ -73,7 +73,7 @@ public class SelectiveInsertionProviderTest {
 
 		// mock insertionGenerator
 		var insertionWithDetourData = new InsertionWithDetourData<>(new Insertion(vehicleEntry, null, null),
-				new InsertionDetourData<>(Double.NaN, Double.NaN, Double.NaN, Double.NaN));
+				new InsertionDetourData<>(Double.NaN, Double.NaN, Double.NaN, Double.NaN), null);
 		var insertionGenerator = mock(InsertionGenerator.class);
 		when(insertionGenerator.generateInsertions(eq(request), eq(vehicleEntry))).thenReturn(
 				List.of(insertionWithDetourData));


### PR DESCRIPTION
A next step after #1819: detour time info is now computed inside insertion generator. The next step will be speeding up the insertion generation and evaluation (including early pruning of insertions and reusing computed data mentioned in #1819).