### PR TITLE
Allowed speed tag

### DIFF
--- a/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/SupersonicOsmNetworkReader.java
+++ b/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/SupersonicOsmNetworkReader.java
@@ -256,6 +256,7 @@ public class SupersonicOsmNetworkReader {
         link.setCapacity(LinkProperties.getLaneCapacity(link.getLength(), properties, adjustCapacityLength) * link.getNumberOfLanes());
         link.getAttributes().putAttribute(NetworkUtils.ORIGID, segment.getOriginalWayId());
         link.getAttributes().putAttribute(NetworkUtils.TYPE, highwayType);
+        link.getAttributes().putAttribute(NetworkUtils.ALLOWED_SPEED, getMaxSpeed(segment.getTags(), link.getLength(), properties));
         if (storeOriginalGeometry && segment.getNodesForSegment().size() > 2)
             // this is optional functionality. Also, the first and last nodeforsegment are the from and to node of the simplified link
             // it makes only sense to store more geometry information if there are intermediate nodes.
@@ -294,6 +295,14 @@ public class SupersonicOsmNetworkReader {
         if (tags.containsKey(OsmTags.MAXSPEED)) {
             double maxSpeed = parseSpeedTag(tags.get(OsmTags.MAXSPEED), properties);
             return LinkProperties.calculateSpeedIfSpeedTag(maxSpeed, freeSpeedFactor);
+        } else {
+            return LinkProperties.calculateSpeedIfNoSpeedTag(linkLength, properties);
+        }
+    }
+
+    private double getMaxSpeed(Map<String, String> tags, double linkLength, LinkProperties properties) {
+        if (tags.containsKey(OsmTags.MAXSPEED)) {
+            return parseSpeedTag(tags.get(OsmTags.MAXSPEED), properties);
         } else {
             return LinkProperties.calculateSpeedIfNoSpeedTag(linkLength, properties);
         }

--- a/contribs/osm/src/test/java/org/matsim/contrib/osm/networkReader/SupersonicOsmNetworkReaderTest.java
+++ b/contribs/osm/src/test/java/org/matsim/contrib/osm/networkReader/SupersonicOsmNetworkReaderTest.java
@@ -165,6 +165,7 @@ public class SupersonicOsmNetworkReaderTest {
 
 		Link link = network.getLinks().get(Id.createLinkId("10000f"));
 		assertEquals(60 / 3.6, link.getFreespeed(), 0);
+		assertEquals(link.getFreespeed(), (double) link.getAttributes().getAttribute(NetworkUtils.ALLOWED_SPEED), 0);
 	}
 
 	@Test
@@ -188,6 +189,7 @@ public class SupersonicOsmNetworkReaderTest {
 
 		Link link = network.getLinks().get(Id.createLinkId("10000f"));
 		assertEquals(60 * 1.609344 / 3.6, link.getFreespeed(), 0);
+		assertEquals(link.getFreespeed(), (double) link.getAttributes().getAttribute(NetworkUtils.ALLOWED_SPEED), 0);
 	}
 
 	@Test
@@ -211,7 +213,10 @@ public class SupersonicOsmNetworkReaderTest {
 		assertEquals(2, network.getNodes().size());
 
 		Link link = network.getLinks().get(Id.createLinkId("10000f"));
+		// the freespeed of the link should be reduced by the speed factor
 		assertEquals(50 / 3.6 * LinkProperties.DEFAULT_FREESPEED_FACTOR, link.getFreespeed(), 0);
+		// the original max speed should be stored as is
+		assertEquals(50 / 3.6, (double) link.getAttributes().getAttribute(NetworkUtils.ALLOWED_SPEED), 0);
 	}
 
 	@Test
@@ -236,6 +241,7 @@ public class SupersonicOsmNetworkReaderTest {
 
 		Link link = network.getLinks().get(Id.createLinkId("10000f"));
 		assertEquals(LinkProperties.createMotorway().freespeed, link.getFreespeed(), 0);
+		assertEquals(link.getFreespeed(), (double) link.getAttributes().getAttribute(NetworkUtils.ALLOWED_SPEED), 0);
 	}
 
 	@Test
@@ -261,6 +267,7 @@ public class SupersonicOsmNetworkReaderTest {
 
 		Link link = network.getLinks().get(Id.createLinkId("10000f"));
 		assertEquals(LinkProperties.createTertiary().freespeed, link.getFreespeed(), 0);
+		assertEquals(link.getFreespeed(), (double) link.getAttributes().getAttribute(NetworkUtils.ALLOWED_SPEED), 0);
 	}
 
 	@Test
@@ -288,6 +295,7 @@ public class SupersonicOsmNetworkReaderTest {
 
 		// the freespeed for 'urban' links (links without a speed tag and shorter than 300m) freespeed is reduced depending on the length of the link
 		assertTrue(LinkProperties.createTertiary().freespeed > link.getFreespeed());
+		assertEquals(link.getFreespeed(), (double) link.getAttributes().getAttribute(NetworkUtils.ALLOWED_SPEED), 0);
 	}
 
 	@Test

--- a/contribs/sumo/src/main/java/org/matsim/contrib/sumo/SumoNetworkConverter.java
+++ b/contribs/sumo/src/main/java/org/matsim/contrib/sumo/SumoNetworkConverter.java
@@ -232,7 +232,7 @@ public class SumoNetworkConverter implements Callable<Integer> {
             if (edge.name != null)
                 link.getAttributes().putAttribute("name", edge.name);
 
-            link.getAttributes().putAttribute("type", edge.type);
+            link.getAttributes().putAttribute(NetworkUtils.TYPE, edge.type);
 
             link.setNumberOfLanes(edge.lanes.size());
             Set<String> modes = Sets.newHashSet(TransportMode.car, TransportMode.ride);
@@ -274,7 +274,7 @@ public class SumoNetworkConverter implements Callable<Integer> {
                 }
             }
 
-            link.getAttributes().putAttribute("allowed_speed", speed);
+            link.getAttributes().putAttribute(NetworkUtils.ALLOWED_SPEED, speed);
 
             if (prop == null) {
                 log.warn("Skipping unknown link type: {}", type.highway);

--- a/matsim/src/main/java/org/matsim/core/network/NetworkUtils.java
+++ b/matsim/src/main/java/org/matsim/core/network/NetworkUtils.java
@@ -643,6 +643,7 @@ public final class NetworkUtils {
 		return link.getLength() / link.getFreespeed(time) ;
 	}
 
+	public static final String ALLOWED_SPEED = "allowed_speed";
 	public static final String TYPE="type" ;
 	public static void setType( Link link , String type ) {
 //		if ( link instanceof LinkImpl ) {


### PR DESCRIPTION
this handles the osm-parser part of #1823 

To figure out HBEFA road types in the emission contrib we want the original max speed tag from osm in the network.