### PR TITLE
Fix check in SharingRoutingModule

### DIFF
--- a/contribs/sharing/src/main/java/org/matsim/contrib/sharing/routing/InteractionPoint.java
+++ b/contribs/sharing/src/main/java/org/matsim/contrib/sharing/routing/InteractionPoint.java
@@ -43,4 +43,8 @@ public class InteractionPoint {
 	static public InteractionPoint of(SharingStation station) {
 		return new InteractionPoint(station.getLink().getId(), Optional.of(station.getId()));
 	}
+
+	public boolean equals(InteractionPoint interactionPoint) {
+		return interactionPoint.getLinkId().equals(this.getLinkId());
+	}
 }

--- a/contribs/sharing/src/main/java/org/matsim/contrib/sharing/routing/SharingRoutingModule.java
+++ b/contribs/sharing/src/main/java/org/matsim/contrib/sharing/routing/SharingRoutingModule.java
@@ -61,7 +61,9 @@ public class SharingRoutingModule implements RoutingModule {
 			return null;
 		}
 
-		if (pickupInteraction.get().equals(dropoffInteraction.get())) {
+		InteractionPoint a = pickupInteraction.get();
+		InteractionPoint b = dropoffInteraction.get();
+		if (a.equals(b)) {
 			return null;
 		}
 

--- a/contribs/sharing/src/main/java/org/matsim/contrib/sharing/service/SharingUtils.java
+++ b/contribs/sharing/src/main/java/org/matsim/contrib/sharing/service/SharingUtils.java
@@ -23,7 +23,7 @@ public class SharingUtils {
 	static public final String STATION_ID_ATTRIBUTE = "sharing:stationId";
 	static public final String SERVICE_ID_ATTRIBUTE = "sharing:service";
 
-	static public final String MODE_PREFIX = "sharing:";
+	static public final String MODE_PREFIX = "sharing_";
 
 	static public final double INTERACTION_DURATION = 60.0;
 

--- a/contribs/sharing/src/test/java/org/matsim/contrib/sharing/RunIT.java
+++ b/contribs/sharing/src/test/java/org/matsim/contrib/sharing/RunIT.java
@@ -154,22 +154,22 @@ public class RunIT {
 
 		OutputData data = countLegs(controller.getControlerIO().getOutputPath() + "/output_events.xml.gz");
 
-		Assert.assertEquals(83271, (long) data.counts.get("car"));
-		Assert.assertEquals(31125, (long) data.counts.get("walk"));
-		Assert.assertEquals(86, (long) data.counts.get("bike"));
-		Assert.assertEquals(19086, (long) data.counts.get("pt"));
+		Assert.assertEquals(83845, (long) data.counts.get("car"));
+		Assert.assertEquals(32063, (long) data.counts.get("walk"));
+		Assert.assertEquals(77, (long) data.counts.get("bike"));
+		Assert.assertEquals(19154, (long) data.counts.get("pt"));
 
 		Assert.assertEquals(62, (long) data.pickupCounts.get("wheels"));
 		Assert.assertEquals(2, (long) data.pickupCounts.get("mobility"));
-		Assert.assertEquals(24, (long) data.pickupCounts.get("velib"));
+		Assert.assertEquals(15, (long) data.pickupCounts.get("velib"));
 
 		Assert.assertEquals(62, (long) data.dropoffCounts.get("wheels"));
 		Assert.assertEquals(0, (long) data.dropoffCounts.getOrDefault("mobility", 0L));
-		Assert.assertEquals(24, (long) data.dropoffCounts.get("velib"));
+		Assert.assertEquals(15, (long) data.dropoffCounts.get("velib"));
 
-		Assert.assertEquals(1537, (long) data.failedPickupCounts.get("wheels"));
+		Assert.assertEquals(1536, (long) data.failedPickupCounts.get("wheels"));
 		Assert.assertEquals(1, (long) data.failedPickupCounts.get("mobility"));
-		Assert.assertEquals(50, (long) data.failedPickupCounts.get("velib"));
+		Assert.assertEquals(13, (long) data.failedPickupCounts.get("velib"));
 
 		Assert.assertEquals(0, (long) data.failedDropoffCounts.getOrDefault("wheels", 0L));
 		Assert.assertEquals(0, (long) data.failedDropoffCounts.getOrDefault("mobility", 0L));


### PR DESCRIPTION
This PR ensures that routes that starts and ends at the same InteractionPoint are returned as null. It make no sense to use a sharing mode, insteade agent should walk.