### PR TITLE
Make drt shift breaks optional

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/dispatcher/EDrtShiftDispatcherImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/dispatcher/EDrtShiftDispatcherImpl.java
@@ -100,7 +100,7 @@ public class EDrtShiftDispatcherImpl implements DrtShiftDispatcher {
         if (chargingInfrastructure != null) {
             resetCharger();
         }
-
+		shiftTaskScheduler.initSchedules();
         createQueues();
     }
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/dispatcher/EDrtShiftDispatcherImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/dispatcher/EDrtShiftDispatcherImpl.java
@@ -192,7 +192,7 @@ public class EDrtShiftDispatcherImpl implements DrtShiftDispatcher {
                     shiftTaskScheduler.relocateForBreak(activeShift.vehicle, breakFacility, shift);
                     eventsManager.processEvent(new DrtShiftBreakScheduledEvent(timer.getTimeOfDay(), shift.getId(),
                             activeShift.vehicle.getId(), breakFacility.getLinkId(),
-                            shift.getBreak().getScheduledLatestArrival()));
+                            shift.getBreak().orElseThrow().getScheduledLatestArrival()));
                 }
             }
         }
@@ -625,7 +625,7 @@ public class EDrtShiftDispatcherImpl implements DrtShiftDispatcher {
     }
 
     private boolean shiftNeedsBreak(DrtShift shift, double timeStep) {
-        return shift.getBreak() != null && shift.getBreak().getEarliestBreakStartTime() == timeStep
-                && !shift.getBreak().isScheduled();
+        return shift.getBreak().isPresent() && shift.getBreak().get().getEarliestBreakStartTime() == timeStep
+                && !shift.getBreak().get().isScheduled();
     }
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/run/ShiftEDrtModeOptimizerQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/run/ShiftEDrtModeOptimizerQSimModule.java
@@ -66,7 +66,8 @@ public class ShiftEDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule
 		bindModal(EShiftTaskScheduler.class).toProvider(modalProvider(
 				getter -> new EShiftTaskScheduler(getter.getModal(Network.class), getter.getModal(TravelTime.class),
 						getter.getModal(TravelDisutilityFactory.class).createTravelDisutility(getter.getModal(TravelTime.class)),
-						getter.get(MobsimTimer.class), taskFactory,	shiftConfigGroup, getter.getModal(ChargingInfrastructure.class))
+						getter.get(MobsimTimer.class), taskFactory,	shiftConfigGroup, getter.getModal(ChargingInfrastructure.class),
+						getter.getModal(OperationFacilities.class), getter.getModal(Fleet.class))
 		)).asEagerSingleton();
 
 		bindModal(VrpAgentLogic.DynActionCreator.class).toProvider(modalProvider(

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/analysis/BreakCorridorXY.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/analysis/BreakCorridorXY.java
@@ -44,14 +44,14 @@ public class BreakCorridorXY implements DrtShiftBreakStartedEventHandler, DrtShi
 
     @Override
     public void handleEvent(DrtShiftBreakStartedEvent event) {
-        final DrtShiftBreakSpecification drtShiftBreak = shifts.getShiftSpecifications().get(event.getShiftId()).getBreak();
+        final DrtShiftBreakSpecification drtShiftBreak = shifts.getShiftSpecifications().get(event.getShiftId()).getBreak().orElseThrow();
         final double earliestBreakStartTime = drtShiftBreak.getEarliestBreakStartTime();
         shift2plannedVsActualBreakStart.put(event.getShiftId(), new Tuple<>(earliestBreakStartTime, event.getTime()));
     }
 
     @Override
     public void handleEvent(DrtShiftBreakEndedEvent event) {
-        final DrtShiftBreakSpecification drtShiftBreak = shifts.getShiftSpecifications().get(event.getShiftId()).getBreak();
+        final DrtShiftBreakSpecification drtShiftBreak = shifts.getShiftSpecifications().get(event.getShiftId()).getBreak().orElseThrow();
         final double latestBreakEndTime = drtShiftBreak.getLatestBreakEndTime();
         shift2plannedVsActualBreakEnd.put(event.getShiftId(), new Tuple<>(latestBreakEndTime, event.getTime()));
     }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/analysis/ShiftDurationXY.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/analysis/ShiftDurationXY.java
@@ -68,7 +68,7 @@ public class ShiftDurationXY implements DrtShiftStartedEventHandler, DrtShiftEnd
     public void handleEvent(DrtShiftBreakEndedEvent event) {
         final Double start = shift2BreakStartTime.get(event.getShiftId());
         double duration = event.getTime() - start;
-        final DrtShiftBreakSpecification drtShift = shifts.getShiftSpecifications().get(event.getShiftId()).getBreak();
+        final DrtShiftBreakSpecification drtShift = shifts.getShiftSpecifications().get(event.getShiftId()).getBreak().orElseThrow();
         double plannedDuration = drtShift.getDuration();
         shift2plannedVsActualBreakDuration.put(event.getShiftId(), new Tuple<>(plannedDuration, duration));
     }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/dispatcher/DrtShiftDispatcherImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/dispatcher/DrtShiftDispatcherImpl.java
@@ -84,6 +84,7 @@ public class DrtShiftDispatcherImpl implements DrtShiftDispatcher {
         this.eventsManager = eventsManager;
         this.configGroup = configGroup;
 
+		shiftTaskScheduler.initSchedules();
         createQueues();
     }
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/dispatcher/DrtShiftDispatcherImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/dispatcher/DrtShiftDispatcherImpl.java
@@ -127,7 +127,7 @@ public class DrtShiftDispatcherImpl implements DrtShiftDispatcher {
                     shiftTaskScheduler.relocateForBreak(activeShift.vehicle, breakFacility, shift);
                     eventsManager.processEvent(new DrtShiftBreakScheduledEvent(timer.getTimeOfDay(), shift.getId(),
                             activeShift.vehicle.getId(), breakFacility.getLinkId(),
-                            shift.getBreak().getScheduledLatestArrival()));
+                            shift.getBreak().orElseThrow().getScheduledLatestArrival()));
                 }
             }
         }
@@ -529,7 +529,7 @@ public class DrtShiftDispatcherImpl implements DrtShiftDispatcher {
     }
 
     private boolean shiftNeedsBreak(DrtShift shift, double timeStep) {
-        return shift.getBreak() != null && shift.getBreak().getEarliestBreakStartTime() == timeStep
-                && !shift.getBreak().isScheduled();
+        return shift.getBreak().isPresent() && shift.getBreak().get().getEarliestBreakStartTime() == timeStep
+                && !shift.getBreak().get().isScheduled();
     }
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/io/DrtShiftsWriter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/io/DrtShiftsWriter.java
@@ -72,8 +72,8 @@ public class DrtShiftsWriter extends MatsimXmlWriter {
             this.writeStartTag(SHIFT_NAME, atts);
 
             //Write break, if present
-            if (shift.getBreak() != null) {
-                final DrtShiftBreakSpecification shiftBreak = shift.getBreak();
+            if (shift.getBreak().isPresent()) {
+                final DrtShiftBreakSpecification shiftBreak = shift.getBreak().orElseThrow();
                 atts.clear();
                 atts.add(createTuple(EARLIEST_BREAK_START_TIME, shiftBreak.getEarliestBreakStartTime()));
                 atts.add(createTuple(LATEST_BREAK_END_TIME, shiftBreak.getLatestBreakEndTime()));

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/optimizer/ShiftRequestInsertionScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/optimizer/ShiftRequestInsertionScheduler.java
@@ -65,23 +65,8 @@ public class ShiftRequestInsertionScheduler implements RequestInsertionScheduler
 		this.scheduleTimingUpdater = scheduleTimingUpdater;
 		this.taskFactory = taskFactory;
 		this.shiftBreakNetwork = shiftBreakNetwork;
-		initSchedules();
 	}
 
-    public void initSchedules() {
-        final Map<Id<Link>, List<OperationFacility>> facilitiesByLink = shiftBreakNetwork.getDrtOperationFacilities().values().stream().collect(Collectors.groupingBy(Facility::getLinkId));
-        for (DvrpVehicle veh : fleet.getVehicles().values()) {
-            try {
-                final OperationFacility operationFacility = facilitiesByLink.get(veh.getStartLink().getId()).stream().findFirst().orElseThrow((Supplier<Throwable>) () -> new RuntimeException("Vehicles must start at an operation facility!"));
-                veh.getSchedule()
-                        .addTask(taskFactory.createWaitForShiftStayTask(veh, veh.getServiceBeginTime(), veh.getServiceEndTime(),
-                                veh.getStartLink(), operationFacility));
-                operationFacility.register(veh.getId());
-            } catch (Throwable throwable) {
-                throwable.printStackTrace();
-            }
-        }
-    }
 
     @Override
     public PickupDropoffTaskPair scheduleRequest(DrtRequest request, InsertionWithDetourData<OneToManyPathSearch.PathData> insertion) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/run/ShiftDrtModeOptimizerQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/run/ShiftDrtModeOptimizerQSimModule.java
@@ -104,7 +104,8 @@ public class ShiftDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule 
 				getter -> new ShiftTaskScheduler(getter.getModal(Network.class),
 						getter.getModal(TravelTime.class),
 						getter.getModal(TravelDisutilityFactory.class).createTravelDisutility(getter.getModal(TravelTime.class)),
-						getter.get(MobsimTimer.class), taskFactory,	shiftConfigGroup))
+						getter.get(MobsimTimer.class), taskFactory,	shiftConfigGroup,
+						getter.getModal(OperationFacilities.class), getter.getModal(Fleet.class)))
 		).asEagerSingleton();
 
 		bindModal(DrtScheduleInquiry.class).to(ShiftDrtScheduleInquiry.class).asEagerSingleton();

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/run/ShiftDrtQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/run/ShiftDrtQSimModule.java
@@ -42,11 +42,14 @@ public class ShiftDrtQSimModule extends AbstractDvrpModeQSimModule {
 				ImmutableMap<Id<DrtShift>, DrtShiftImpl> shifts = shiftsSpecification.getShiftSpecifications().values()
 						.stream()
 						.map(spec -> {
-							DrtShiftBreakSpecification breakSpec = spec.getBreak();
-							DefautShiftBreakImpl shiftBreak = new DefautShiftBreakImpl(
-									breakSpec.getEarliestBreakStartTime(),
-									breakSpec.getLatestBreakEndTime(),
-									breakSpec.getDuration());
+							DefautShiftBreakImpl shiftBreak = null;
+							DrtShiftBreakSpecification breakSpec = spec.getBreak().orElse(null);
+							if(breakSpec != null) {
+								shiftBreak = new DefautShiftBreakImpl(
+										breakSpec.getEarliestBreakStartTime(),
+										breakSpec.getLatestBreakEndTime(),
+										breakSpec.getDuration());
+							}
 							return new DrtShiftImpl(spec.getId(), spec.getStartTime(), spec.getEndTime(), spec.getOperationFacilityId().orElse(null), shiftBreak);
 						})
 						.collect(ImmutableMap.toImmutableMap(DrtShift::getId, s -> s));

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/scheduler/ShiftTaskScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/scheduler/ShiftTaskScheduler.java
@@ -4,12 +4,17 @@ import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.DRIVE;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import org.apache.log4j.Logger;
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.extension.shifts.config.ShiftDrtConfigGroup;
 import org.matsim.contrib.drt.extension.shifts.fleet.ShiftDvrpVehicle;
+import org.matsim.contrib.drt.extension.shifts.operationFacilities.OperationFacilities;
 import org.matsim.contrib.drt.extension.shifts.operationFacilities.OperationFacility;
 import org.matsim.contrib.drt.extension.shifts.schedule.ShiftBreakTask;
 import org.matsim.contrib.drt.extension.shifts.schedule.ShiftChangeOverTask;
@@ -21,6 +26,7 @@ import org.matsim.contrib.drt.schedule.DrtTaskBaseType;
 import org.matsim.contrib.drt.schedule.DrtTaskType;
 import org.matsim.contrib.drt.scheduler.EmptyVehicleRelocator;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
+import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.path.VrpPaths;
 import org.matsim.contrib.dvrp.schedule.DriveTask;
@@ -34,6 +40,7 @@ import org.matsim.core.router.FastAStarEuclideanFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
+import org.matsim.facilities.Facility;
 
 /**
  * @author nkuehnel / MOIA
@@ -51,17 +58,37 @@ public class ShiftTaskScheduler {
     private final LeastCostPathCalculator router;
 
     private final ShiftDrtConfigGroup shiftConfig;
+	private final OperationFacilities operationFacilities;
+	private final Fleet fleet;
 
-    private final Network network;
+	private final Network network;
 
 	public ShiftTaskScheduler(Network network, TravelTime travelTime, TravelDisutility travelDisutility,
-			MobsimTimer timer, ShiftDrtTaskFactory taskFactory, ShiftDrtConfigGroup shiftConfig) {
+							  MobsimTimer timer, ShiftDrtTaskFactory taskFactory, ShiftDrtConfigGroup shiftConfig,
+							  OperationFacilities operationFacilities, Fleet fleet) {
 		this.travelTime = travelTime;
 		this.timer = timer;
 		this.taskFactory = taskFactory;
 		this.network = network;
 		this.shiftConfig = shiftConfig;
+		this.operationFacilities = operationFacilities;
+		this.fleet = fleet;
 		this.router = new FastAStarEuclideanFactory().createPathCalculator(network, travelDisutility, travelTime);
+	}
+
+	public void initSchedules() {
+		final Map<Id<Link>, List<OperationFacility>> facilitiesByLink = operationFacilities.getDrtOperationFacilities().values().stream().collect(Collectors.groupingBy(Facility::getLinkId));
+		for (DvrpVehicle veh : fleet.getVehicles().values()) {
+			try {
+				final OperationFacility operationFacility = facilitiesByLink.get(veh.getStartLink().getId()).stream().findFirst().orElseThrow((Supplier<Throwable>) () -> new RuntimeException("Vehicles must start at an operation facility!"));
+				veh.getSchedule()
+						.addTask(taskFactory.createWaitForShiftStayTask(veh, veh.getServiceBeginTime(), veh.getServiceEndTime(),
+								veh.getStartLink(), operationFacility));
+				operationFacility.register(veh.getId());
+			} catch (Throwable throwable) {
+				throwable.printStackTrace();
+			}
+		}
 	}
 
     public void relocateForBreak(ShiftDvrpVehicle vehicle, OperationFacility breakFacility, DrtShift shift) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/shift/DrtShift.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/shift/DrtShift.java
@@ -15,7 +15,7 @@ public interface DrtShift extends Identifiable<DrtShift> {
 
 	double getEndTime();
 
-	DrtShiftBreak getBreak();
+	Optional<DrtShiftBreak> getBreak();
 
 	boolean isStarted();
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/shift/DrtShiftImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/shift/DrtShiftImpl.java
@@ -12,11 +12,11 @@ public class DrtShiftImpl implements DrtShift {
 
 	private final Id<DrtShift> id;
 
-	private double start;
-	private double end;
-	private Id<OperationFacility> operationFacilityId;
+	private final double start;
+	private final double end;
+	private final Id<OperationFacility> operationFacilityId;
 
-	private DrtShiftBreak shiftBreak;
+	private final DrtShiftBreak shiftBreak;
 
 	private boolean started = false;
 	private boolean ended = false;
@@ -41,8 +41,8 @@ public class DrtShiftImpl implements DrtShift {
 	}
 
 	@Override
-	public DrtShiftBreak getBreak() {
-		return shiftBreak;
+	public Optional<DrtShiftBreak> getBreak() {
+		return Optional.ofNullable(shiftBreak);
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/shift/DrtShiftSpecification.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/shift/DrtShiftSpecification.java
@@ -15,7 +15,7 @@ public interface DrtShiftSpecification extends Identifiable<DrtShift> {
 
 	double getEndTime();
 
-	DrtShiftBreakSpecification getBreak();
+	Optional<DrtShiftBreakSpecification> getBreak();
 
 	Optional<Id<OperationFacility>> getOperationFacilityId();
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/shift/DrtShiftSpecificationImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/shift/DrtShiftSpecificationImpl.java
@@ -35,8 +35,8 @@ public class DrtShiftSpecificationImpl implements DrtShiftSpecification {
 	}
 
 	@Override
-	public DrtShiftBreakSpecification getBreak() {
-		return shiftBreak;
+	public Optional<DrtShiftBreakSpecification> getBreak() {
+		return Optional.ofNullable(shiftBreak);
 	}
 
 	@Override
@@ -58,7 +58,7 @@ public class DrtShiftSpecificationImpl implements DrtShiftSpecification {
 		builder.id = copy.getId();
 		builder.start = copy.getStartTime();
 		builder.end = copy.getEndTime();
-		builder.shiftBreak = copy.getBreak();
+		builder.shiftBreak = copy.getBreak().orElse(null);
 		return builder;
 	}
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/extension/shifts/ShiftsIOTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/extension/shifts/ShiftsIOTest.java
@@ -68,9 +68,9 @@ public class ShiftsIOTest extends MatsimTestCase {
 		assertEquals(45000., shiftSpecification1.getEndTime());
 		assertTrue(shiftSpecification1.getOperationFacilityId().isPresent());
 		assertEquals(oid1, shiftSpecification1.getOperationFacilityId().get());
-		assertEquals(1800., shiftSpecification1.getBreak().getDuration());
-		assertEquals(28800., shiftSpecification1.getBreak().getEarliestBreakStartTime());
-		assertEquals(32400., shiftSpecification1.getBreak().getLatestBreakEndTime());
+		assertEquals(1800., shiftSpecification1.getBreak().orElseThrow().getDuration());
+		assertEquals(28800., shiftSpecification1.getBreak().orElseThrow().getEarliestBreakStartTime());
+		assertEquals(32400., shiftSpecification1.getBreak().orElseThrow().getLatestBreakEndTime());
 
 		DrtShiftSpecification shiftSpecification2 = shiftsSpecification.getShiftSpecifications().get(sid22);
 		assertNotNull(shiftSpecification2);
@@ -79,9 +79,9 @@ public class ShiftsIOTest extends MatsimTestCase {
 		assertEquals(49000., shiftSpecification2.getEndTime());
 		assertTrue(shiftSpecification2.getOperationFacilityId().isPresent());
 		assertEquals(oid2, shiftSpecification2.getOperationFacilityId().get());
-		assertEquals(3600., shiftSpecification2.getBreak().getDuration());
-		assertEquals(29200., shiftSpecification2.getBreak().getEarliestBreakStartTime());
-		assertEquals(32800., shiftSpecification2.getBreak().getLatestBreakEndTime());
+		assertEquals(3600., shiftSpecification2.getBreak().orElseThrow().getDuration());
+		assertEquals(29200., shiftSpecification2.getBreak().orElseThrow().getEarliestBreakStartTime());
+		assertEquals(32800., shiftSpecification2.getBreak().orElseThrow().getLatestBreakEndTime());
 
 		DrtShiftSpecification shiftSpecification3 = shiftsSpecification.getShiftSpecifications().get(sid33);
 		assertNotNull(shiftSpecification3);
@@ -90,8 +90,6 @@ public class ShiftsIOTest extends MatsimTestCase {
 		assertEquals(53000., shiftSpecification3.getEndTime());
 		assertFalse(shiftSpecification3.getOperationFacilityId().isPresent());
 		assertEquals(Optional.empty(), shiftSpecification3.getOperationFacilityId());
-		assertEquals(1800., shiftSpecification3.getBreak().getDuration());
-		assertEquals(29600., shiftSpecification3.getBreak().getEarliestBreakStartTime());
-		assertEquals(33200., shiftSpecification3.getBreak().getLatestBreakEndTime());
+		assertTrue(shiftSpecification3.getBreak().isEmpty());
 	}
 }

--- a/contribs/drt/src/test/resources/test/input/org/matsim/contrib/drt/extension/shifts/testShifts.xml
+++ b/contribs/drt/src/test/resources/test/input/org/matsim/contrib/drt/extension/shifts/testShifts.xml
@@ -6,6 +6,5 @@
         <break earliestStart="29200.0" latestEnd="32800.0" duration="3600.0"/>
     </shift>
     <shift id="33" start="22400" end="53000">
-        <break earliestStart="29600.0" latestEnd="33200.0" duration="1800.0"/>
     </shift>
 </shifts>


### PR DESCRIPTION
- optional drt shift breaks
- make sure that wait for shift stay tasks are initialized before setup of the shift dispatchers