### PR TITLE
Freight: Store MATSim vehicle type during jsprit run

### DIFF
--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/jsprit/MatsimJspritFactory.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/jsprit/MatsimJspritFactory.java
@@ -261,9 +261,14 @@ public class MatsimJspritFactory {
 				Id.create(vehicleId, org.matsim.vehicles.Vehicle.class),
 				Id.create(vehicle.getStartLocation().getId(), Link.class));
 
-//		VehicleType carrierVehicleType = createCarrierVehicleType(vehicle.getType());
-//		vehicleBuilder.setType(carrierVehicleType);
-		vehicleBuilder.setType((VehicleType) vehicle.getType().getUserData()); //Read in store MATSimVehicleType... Attention: This will not take care for any chances during the jsprit run
+		if (vehicle.getType().getUserData() != null){
+			log.info("Use the (MATSim) vehicleType that was stored inside the (jsprit) vehicleType during the jsprit run but never interacted with jsprit. ");
+			vehicleBuilder.setType((VehicleType) vehicle.getType().getUserData()); //Read in store MATSimVehicleType... Attention: This will not take care for any changes during the jsprit run
+		} else {
+			log.info("There was no (MATSim) vehicleType stored inside the (jsprit) vehicleType. -> create one from the available data of the (jsprit) vehicle type");
+			VehicleType carrierVehicleType = createCarrierVehicleType(vehicle.getType());
+			vehicleBuilder.setType(carrierVehicleType);
+		}
 		vehicleBuilder.setEarliestStart(vehicle.getEarliestDeparture());
 		vehicleBuilder.setLatestEnd(vehicle.getLatestArrival());
 		CarrierVehicle carrierVehicle = vehicleBuilder.build();

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/jsprit/MatsimJspritFactory.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/jsprit/MatsimJspritFactory.java
@@ -260,8 +260,10 @@ public class MatsimJspritFactory {
 		CarrierVehicle.Builder vehicleBuilder = CarrierVehicle.Builder.newInstance(
 				Id.create(vehicleId, org.matsim.vehicles.Vehicle.class),
 				Id.create(vehicle.getStartLocation().getId(), Link.class));
-		VehicleType carrierVehicleType = createCarrierVehicleType(vehicle.getType());
-		vehicleBuilder.setType(carrierVehicleType);
+
+//		VehicleType carrierVehicleType = createCarrierVehicleType(vehicle.getType());
+//		vehicleBuilder.setType(carrierVehicleType);
+		vehicleBuilder.setType((VehicleType) vehicle.getType().getUserData()); //Read in store MATSimVehicleType... Attention: This will not take care for any chances during the jsprit run
 		vehicleBuilder.setEarliestStart(vehicle.getEarliestDeparture());
 		vehicleBuilder.setLatestEnd(vehicle.getLatestArrival());
 		CarrierVehicle carrierVehicle = vehicleBuilder.build();
@@ -347,6 +349,10 @@ public class MatsimJspritFactory {
 		}
 		typeBuilder.setFixedCost(carrierVehicleType.getCostInformation().getFixedCosts());
 		typeBuilder.setMaxVelocity(carrierVehicleType.getMaximumVelocity());
+
+		//KMT Jan22 Store MATSimVehType here
+		typeBuilder.setUserData(carrierVehicleType);
+
 		return typeBuilder.build();
 	}
 


### PR DESCRIPTION
and (re)use it afterwards.

This makes it possible that the (MATSim) vehicleType will be available after the jsprit run.
Before, a new (MATSim) vehicleType was created based on the data of the (jsprit) vehicle type. That let to losses of information, that were not available in the jsprit vehicleType, e.g. engineInformation.

Con: If there are made any chances in the (jsprit) vehicleType, they get now lost. But I do not think that that happens anywhere in our workflow, because we are creating a MATSim vehType, which will be transformed to the jsprit one... After that step, there were usually no changes done to the jsprit type.

((Maybe we can add some checks, that the value are the same...))

Closes #1845 