### PR TITLE
Early prune insertion generation

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGenerator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGenerator.java
@@ -177,10 +177,15 @@ public class InsertionGenerator {
 		var pickupDetourInfo = detourTimeCalculator.calcPickupDetourInfo(vEntry, pickupInsertion, toPickupTT,
 				fromPickupTT, true);
 
+		int j = i;
+		if (vEntry.getSlackTime(i) < pickupDetourInfo.pickupTimeLoss) {
+			j++; // skip insertion: i -> pickup -> dropoff -> i+1
+		}
+
 		boolean recalculated = false;
 
 		int stopCount = vEntry.stops.size();
-		for (int j = i; j < stopCount; j++) {// insertions up to before last stop
+		for (; j < stopCount; j++) {// insertions up to before last stop
 			// i -> pickup -> i+1 && j -> dropoff -> j+1
 			if (j == i + 1) {
 				//calculate it once for all j > i
@@ -190,6 +195,10 @@ public class InsertionGenerator {
 				pickupDetourInfo = detourTimeCalculator.calcPickupDetourInfo(vEntry, pickupInsertion, toPickupTT,
 						fromPickupTT, false);
 				recalculated = true;
+
+				if (vEntry.getSlackTime(i) < pickupDetourInfo.pickupTimeLoss) {
+					return; // skip all insertions: i -> pickup -> dropoff
+				}
 			}
 
 			if (j > i) {// no need to check the capacity constraints if i == j (already validated for `i`)
@@ -197,8 +206,9 @@ public class InsertionGenerator {
 				if (currentStop.outgoingOccupancy == vEntry.vehicle.getCapacity()) {
 					if (request.getToLink() == currentStop.task.getLink()) {
 						//special case -- we can insert dropoff exactly at node j
-						insertions.add(createInsertionWithDetourData(request, vEntry, pickupInsertion, toPickupTT,
-								fromPickupTT, pickupDetourInfo, j));
+						addInsertion(insertions,
+								createInsertionWithDetourData(request, vEntry, pickupInsertion, fromPickupTT,
+										pickupDetourInfo, j));
 					}
 
 					return;// stop iterating -- cannot insert dropoff after node j
@@ -206,8 +216,9 @@ public class InsertionGenerator {
 			}
 
 			if (request.getToLink() != nextStop(vEntry, j).task.getLink()) {// next stop at different link
-				insertions.add(createInsertionWithDetourData(request, vEntry, pickupInsertion, toPickupTT, fromPickupTT,
-						pickupDetourInfo, j));
+				addInsertion(insertions,
+						createInsertionWithDetourData(request, vEntry, pickupInsertion, fromPickupTT, pickupDetourInfo,
+								j));
 			}
 			// else: do not evaluate insertion _before_stop j, evaluate only insertion _after_ stop j
 		}
@@ -219,10 +230,21 @@ public class InsertionGenerator {
 					pickupInsertion.nextWaypoint.getLink());
 			pickupDetourInfo = detourTimeCalculator.calcPickupDetourInfo(vEntry, pickupInsertion, toPickupTT,
 					fromPickupTT, false);
+
+			if (vEntry.getSlackTime(i) < pickupDetourInfo.pickupTimeLoss) {
+				return; // skip insertion: i -> pickup -> dropoff -> end
+			}
 		}
 
-		insertions.add(createInsertionWithDetourData(request, vEntry, pickupInsertion, toPickupTT, fromPickupTT,
-				pickupDetourInfo, stopCount));
+		addInsertion(insertions,
+				createInsertionWithDetourData(request, vEntry, pickupInsertion, fromPickupTT, pickupDetourInfo,
+						stopCount));
+	}
+
+	private void addInsertion(List<InsertionWithDetourData> insertions, InsertionWithDetourData insertion) {
+		if (insertion != null) {
+			insertions.add(insertion);
+		}
 	}
 
 	private Waypoint.Stop currentStop(VehicleEntry entry, int insertionIdx) {
@@ -234,8 +256,7 @@ public class InsertionGenerator {
 	}
 
 	private InsertionWithDetourData createInsertionWithDetourData(DrtRequest request, VehicleEntry vehicleEntry,
-			InsertionPoint pickupInsertion, double toPickupTT, double fromPickupTT, PickupDetourInfo pickupDetourInfo,
-			int dropoffIdx) {
+			InsertionPoint pickupInsertion, double fromPickupTT, PickupDetourInfo pickupDetourInfo, int dropoffIdx) {
 		var dropoffInsertion = createDropoffInsertion(request, vehicleEntry, pickupInsertion, dropoffIdx);
 		var insertion = new Insertion(vehicleEntry, pickupInsertion, dropoffInsertion);
 
@@ -248,6 +269,12 @@ public class InsertionGenerator {
 
 		var dropoffDetourInfo = detourTimeCalculator.calcDropoffDetourInfo(insertion, toDropoffTT, fromDropoffTT,
 				pickupDetourInfo);
+
+		if (vehicleEntry.getSlackTime(dropoffIdx)
+				< pickupDetourInfo.pickupTimeLoss + dropoffDetourInfo.dropoffTimeLoss) {
+			return null; // skip this dropoff insertion
+		}
+
 		return new InsertionWithDetourData(insertion, null, new DetourTimeInfo(pickupDetourInfo, dropoffDetourInfo));
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
@@ -25,6 +25,7 @@ import static org.matsim.contrib.drt.optimizer.insertion.InsertionDetourTimeCalc
 import static org.matsim.contrib.drt.optimizer.insertion.InsertionDetourTimeCalculator.PickupDetourInfo;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
@@ -365,6 +366,8 @@ public class InsertionGeneratorTest {
 	}
 
 	private VehicleEntry entry(Waypoint.Start start, Waypoint.Stop... stops) {
-		return new VehicleEntry(vehicle, start, ImmutableList.copyOf(stops), null);
+		var slackTimes = new double[stops.length + 1];
+		Arrays.fill(slackTimes, Double.POSITIVE_INFINITY);
+		return new VehicleEntry(vehicle, start, ImmutableList.copyOf(stops), slackTimes);
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
@@ -75,7 +75,7 @@ public class InsertionGeneratorTest {
 	private final DvrpVehicle vehicle = new DvrpVehicleImpl(vehicleSpecification, depotLink);
 
 	@Test
-	public void generateInsertions_startEmpty_noStops() {
+	public void startEmpty_noStops() {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, 0); //no stops => must be empty
 		VehicleEntry entry = entry(start);
 
@@ -91,7 +91,7 @@ public class InsertionGeneratorTest {
 	}
 
 	@Test
-	public void generateInsertions_startNotFull_oneStop() {
+	public void startNotFull_oneStop() {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, 1); // 1 pax aboard
 		Waypoint.Stop stop0 = stop(start.time + TIME_REPLACED_DRIVE, link("stop0"), 0);//drop off 1 pax
 		VehicleEntry entry = entry(start, stop0);
@@ -124,7 +124,7 @@ public class InsertionGeneratorTest {
 	}
 
 	@Test
-	public void generateInsertions_startFull_oneStop() {
+	public void startFull_oneStop() {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, CAPACITY); //full
 		Waypoint.Stop stop0 = stop(start.time + TIME_REPLACED_DRIVE, link("stop0"), 0);//drop off 4 pax
 		VehicleEntry entry = entry(start, stop0);
@@ -141,7 +141,7 @@ public class InsertionGeneratorTest {
 	}
 
 	@Test
-	public void generateInsertions_startEmpty_twoStops_notFullBetweenStops() {
+	public void startEmpty_twoStops_notFullBetweenStops() {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, 0); //empty
 		Waypoint.Stop stop0 = stop(start.time + TIME_REPLACED_DRIVE, link("stop0"), 1);//pick up 1 pax
 		Waypoint.Stop stop1 = stop(stop0.getDepartureTime() + TIME_REPLACED_DRIVE, link("stop1"), 0);//drop off 1 pax
@@ -199,7 +199,38 @@ public class InsertionGeneratorTest {
 	}
 
 	@Test
-	public void generateInsertions_startEmpty_twoStops_fullBetweenStops() {
+	public void startEmpty_twoStops_notFullBetweenStops_tightSlackTimes() {
+		//same as startEmpty_twoStops_notFullBetweenStops() but with different slack times
+		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, 0); //empty
+		Waypoint.Stop stop0 = stop(start.time + TIME_REPLACED_DRIVE, link("stop0"), 1);//pick up 1 pax
+		Waypoint.Stop stop1 = stop(stop0.getDepartureTime() + TIME_REPLACED_DRIVE, link("stop1"), 0);//drop off 1 pax
+
+		double[] slackTimes = { 0, // impossible insertions: 00, 01, 02 (pickup at 0 is not possible)
+				500, // additional impossible insertions: 11 (too long total detour); however 12 is possible
+				1000 }; // 22 is possible
+		VehicleEntry entry = new VehicleEntry(vehicle, start, ImmutableList.of(stop0, stop1), slackTimes);
+
+		var insertions = new ArrayList<InsertionWithDetourData>();
+		{//12
+			var insertion = new Insertion(drtRequest, entry, 1, 2);
+			var pickup = new PickupDetourInfo(stop0.getDepartureTime() + TIME_TO_PICKUP + STOP_DURATION,
+					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP - TIME_REPLACED_DRIVE);
+			var dropoff = new DropoffDetourInfo(stop1.getDepartureTime() + pickup.pickupTimeLoss + TIME_TO_DROPOFF,
+					TIME_TO_DROPOFF + STOP_DURATION);
+			insertions.add(insertion(insertion, pickup, dropoff));
+		}
+		{//22
+			var insertion = new Insertion(drtRequest, entry, 2, 2);
+			var pickup = new PickupDetourInfo(stop1.getDepartureTime() + TIME_TO_PICKUP + STOP_DURATION,
+					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP);
+			var dropoff = new DropoffDetourInfo(stop1.getDepartureTime() + pickup.pickupTimeLoss, STOP_DURATION);
+			insertions.add(insertion(insertion, pickup, dropoff));
+		}
+		assertInsertionsWithDetour(drtRequest, entry, insertions);
+	}
+
+	@Test
+	public void startEmpty_twoStops_fullBetweenStops() {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, 0); //empty
 		Waypoint.Stop stop0 = stop(0, link("stop0"), CAPACITY);//pick up 4 pax (full)
 		Waypoint.Stop stop1 = stop(0, link("stop1"), 0);//drop off 4 pax
@@ -213,7 +244,7 @@ public class InsertionGeneratorTest {
 	}
 
 	@Test
-	public void generateInsertions_startFull_twoStops_notFullBetweenStops() {
+	public void startFull_twoStops_notFullBetweenStops() {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, CAPACITY); //full
 		Waypoint.Stop stop0 = stop(0, link("stop0"), 2);//drop off 2 pax
 		Waypoint.Stop stop1 = stop(0, link("stop1"), 0);//drop off 2 pax
@@ -228,7 +259,7 @@ public class InsertionGeneratorTest {
 	}
 
 	@Test
-	public void generateInsertions_startFull_twoStops_fullBetweenStops() {
+	public void startFull_twoStops_fullBetweenStops() {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, CAPACITY); //full
 		Waypoint.Stop stop0 = stop(0, link("stop0"), CAPACITY);//drop off 1 pax, pickup 1 pax (full)
 		Waypoint.Stop stop1 = stop(0, link("stop1"), 0);//drop off 4 pax
@@ -241,7 +272,7 @@ public class InsertionGeneratorTest {
 	}
 
 	@Test
-	public void generateInsertions_startNotFull_threeStops_emptyBetweenStops01_fullBetweenStops12() {
+	public void startNotFull_threeStops_emptyBetweenStops01_fullBetweenStops12() {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, 1); //empty
 		Waypoint.Stop stop0 = stop(0, link("stop0"), 0);// dropoff 1 pax
 		Waypoint.Stop stop1 = stop(0, link("stop1"), CAPACITY);// pickup 4 pax
@@ -259,7 +290,7 @@ public class InsertionGeneratorTest {
 	}
 
 	@Test
-	public void generateInsertions_startFull_threeStops_emptyBetweenStops01_fullBetweenStops12() {
+	public void startFull_threeStops_emptyBetweenStops01_fullBetweenStops12() {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, CAPACITY); //full
 		Waypoint.Stop stop0 = stop(0, link("stop0"), 0);// dropoff 4 pax
 		Waypoint.Stop stop1 = stop(0, link("stop1"), CAPACITY);// pickup 4 pax
@@ -275,7 +306,7 @@ public class InsertionGeneratorTest {
 	}
 
 	@Test
-	public void generateInsertions_noDetourForPickup_noDuplicatedInsertions() {
+	public void noDetourForPickup_noDuplicatedInsertions() {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, 1); // 1 pax
 		Waypoint.Stop stop0 = stop(0, fromLink, 0);//dropoff 1 pax
 		VehicleEntry entry = entry(start, stop0);
@@ -286,7 +317,7 @@ public class InsertionGeneratorTest {
 	}
 
 	@Test
-	public void generateInsertions_noDetourForDropoff_noDuplicatedInsertions() {
+	public void noDetourForDropoff_noDuplicatedInsertions() {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, 1); // 1 pax
 		Waypoint.Stop stop0 = stop(0, toLink, 0);//dropoff 1 pax
 		VehicleEntry entry = entry(start, stop0);
@@ -298,7 +329,7 @@ public class InsertionGeneratorTest {
 	}
 
 	@Test
-	public void generateInsertions_noDetourForDropoff_vehicleOutgoingFullAfterDropoff_insertionPossible() {
+	public void noDetourForDropoff_vehicleOutgoingFullAfterDropoff_insertionPossible() {
 		// a special case where we allow inserting the dropoff after a stop despite outgoingOccupancy == maxCapacity
 		// this is only because the the dropoff happens exactly at (not after) the stop
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, 1); // 1 pax


### PR DESCRIPTION
Incorporate checks of slack time into the insertion generation procedure. If a potential insertion is infeasible due to the pre-computed slack times being smaller than the expected detour times (pickup or pickup+dropoff), it will not be generated.