### PR TITLE
Speedup drt plot generation

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
@@ -278,8 +278,8 @@ public class DrtAnalysisControlerListener implements IterationEndsListener {
 			bw.append(line("RequestId", "actualWaitTime", "estimatedWaitTime", "deviate"));
 			for (EventSequence seq : performedRequestEventSequences) {
 				if (seq.getPickedUp().isPresent()) {
-					double actualWaitTime = seq.getPickedUp().get().getTime() - seq.getSubmitted().getTime();
-					double estimatedWaitTime = seq.getScheduled().get().getPickupTime() - seq.getSubmitted().getTime();
+					double actualWaitTime = seq.getPickedUp().get().getTime() - seq.getDeparted().get().getTime();
+					double estimatedWaitTime = seq.getScheduled().get().getPickupTime() - seq.getDeparted().get().getTime();
 					bw.append(line(seq.getSubmitted().getRequestId(), actualWaitTime, estimatedWaitTime,
 							actualWaitTime - estimatedWaitTime));
 					times.add(actualWaitTime, estimatedWaitTime);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
@@ -278,8 +278,8 @@ public class DrtAnalysisControlerListener implements IterationEndsListener {
 			bw.append(line("RequestId", "actualWaitTime", "estimatedWaitTime", "deviate"));
 			for (EventSequence seq : performedRequestEventSequences) {
 				if (seq.getPickedUp().isPresent()) {
-					double actualWaitTime = seq.getPickedUp().get().getTime() - seq.getDeparted().get().getTime();
-					double estimatedWaitTime = seq.getScheduled().get().getPickupTime() - seq.getDeparted().get().getTime();
+					double actualWaitTime = seq.getPickedUp().get().getTime() - seq.getDeparture().get().getTime();
+					double estimatedWaitTime = seq.getScheduled().get().getPickupTime() - seq.getDeparture().get().getTime();
 					bw.append(line(seq.getSubmitted().getRequestId(), actualWaitTime, estimatedWaitTime,
 							actualWaitTime - estimatedWaitTime));
 					times.add(actualWaitTime, estimatedWaitTime);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
@@ -198,7 +198,7 @@ public class DrtAnalysisControlerListener implements IterationEndsListener {
 				filename(event, "drt_detours"), createGraphs);
 		DrtLegsAnalyser.analyseWaitTimes(filename(event, "waitStats"), legs, 1800, createGraphs);
 		DrtLegsAnalyser.analyseConstraints(filename(event, "constraints"), legs, createGraphs);
-		
+
 		double endTime = qSimCfg.getEndTime()
 				.orElseGet(() -> legs.isEmpty() ?
 						qSimCfg.getStartTime().orElse(0) :
@@ -273,7 +273,7 @@ public class DrtAnalysisControlerListener implements IterationEndsListener {
 			Collection<EventSequence> performedRequestEventSequences, String plotFileName,
 			String textFileName, boolean createChart) {
 		try (var bw = IOUtils.getBufferedWriter(textFileName)) {
-			XYSeries times = new XYSeries("waittimes", true, true);
+			XYSeries times = new XYSeries("waittimes", false, true);
 
 			bw.append(line("RequestId", "actualWaitTime", "estimatedWaitTime", "deviate"));
 			for (EventSequence seq : performedRequestEventSequences) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtLeg.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtLeg.java
@@ -51,21 +51,21 @@ final class DrtLeg {
 	final double fare;
 	final double latestDepartureTime;
 	final double latestArrivalTime;
-	
+
 	DrtLeg(EventSequence sequence, Function<Id<Link>, ? extends Link> linkProvider) {
 		Preconditions.checkArgument(sequence.isCompleted());
 		DrtRequestSubmittedEvent submittedEvent = sequence.getSubmitted();
-		PersonDepartureEvent departedEvent = sequence.getDeparted().get();
+		PersonDepartureEvent departureEvent = sequence.getDeparture().get();
 		PassengerPickedUpEvent pickedUpEvent = sequence.getPickedUp().get();
 		this.request = submittedEvent.getRequestId();
-		this.departureTime = departedEvent.getTime();
+		this.departureTime = departureEvent.getTime();
 		this.person = submittedEvent.getPersonId();
 		this.vehicle = pickedUpEvent.getVehicleId();
 		this.fromLinkId = submittedEvent.getFromLinkId();
 		this.fromCoord = linkProvider.apply(fromLinkId).getToNode().getCoord();
 		this.toLink = submittedEvent.getToLinkId();
 		this.toCoord = linkProvider.apply(toLink).getToNode().getCoord();
-		this.waitTime = pickedUpEvent.getTime() - departedEvent.getTime();
+		this.waitTime = pickedUpEvent.getTime() - departureEvent.getTime();
 		this.unsharedDistanceEstimate_m = submittedEvent.getUnsharedRideDistance();
 		this.unsharedTimeEstimate_m = submittedEvent.getUnsharedRideTime();
 		this.arrivalTime = sequence.getDroppedOff().get().getTime();

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtLegsAnalyser.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtLegsAnalyser.java
@@ -185,9 +185,9 @@ public class DrtLegsAnalyser {
 			return;
 
 		List<String> detours = new ArrayList<>();
-		XYSeries distances = new XYSeries("distances");
-		XYSeries travelTimes = new XYSeries("travel times");
-		XYSeries rideTimes = new XYSeries("ride times");
+		XYSeries distances = new XYSeries("distances", false, true);
+		XYSeries travelTimes = new XYSeries("travel times", false, true);
+		XYSeries rideTimes = new XYSeries("ride times", false, true);
 
 		for (DrtLeg leg : legs) {
 			if (leg.toLink == null) {
@@ -196,9 +196,11 @@ public class DrtLegsAnalyser {
 
 			double travelDistance = travelDistances.get(leg.request);
 			double travelTime = leg.arrivalTime - leg.departureTime;
-			distances.add(travelDistance, leg.unsharedDistanceEstimate_m);
-			travelTimes.add(travelTime, leg.unsharedTimeEstimate_m);
-			rideTimes.add(leg.arrivalTime - leg.departureTime - leg.waitTime, leg.unsharedTimeEstimate_m);
+			if (createGraphs) {
+				distances.add(travelDistance, leg.unsharedDistanceEstimate_m);
+				travelTimes.add(travelTime, leg.unsharedTimeEstimate_m);
+				rideTimes.add(leg.arrivalTime - leg.departureTime - leg.waitTime, leg.unsharedTimeEstimate_m);
+			}
 
 			double distanceDetour = travelDistance / leg.unsharedDistanceEstimate_m;
 			double timeDetour = travelTime / leg.unsharedTimeEstimate_m;
@@ -491,7 +493,7 @@ public class DrtLegsAnalyser {
 		double count = (double)Arrays.stream(waitingTimes).filter(t -> t < timeCriteria).count();
 		return count * 100 / waitingTimes.length;
 	}
-	
+
 	public static void analyseConstraints(String fileName, List<DrtLeg> legs, boolean createGraphs) {
 		if (legs == null)
 			return;
@@ -499,8 +501,8 @@ public class DrtLegsAnalyser {
 		if (!createGraphs)
 			return;
 
-		XYSeries waitingTimes = new XYSeries("max_wait_times");
-		XYSeries travelTimes = new XYSeries("max_travel_times");
+		XYSeries waitingTimes = new XYSeries("max_wait_times", false, true);
+		XYSeries travelTimes = new XYSeries("max_travel_times", false, true);
 
 		for (DrtLeg leg : legs) {
 			double waitingTime = leg.waitTime;

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/speedup/DrtSpeedUpTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/speedup/DrtSpeedUpTest.java
@@ -279,9 +279,9 @@ public class DrtSpeedUpTest {
 				null);
 		var drtFare = new PersonMoneyEvent(submittedTime, null, 5.5, DrtFareHandler.PERSON_MONEY_EVENT_PURPOSE_DRT_FARE,
 				MODE, requestId.toString());
-		var departedEvent = mock(PersonDepartureEvent.class);
-				
-		return new EventSequence(departedEvent, submittedEvent,
+		var departureEvent = mock(PersonDepartureEvent.class);
+
+		return new EventSequence(departureEvent, submittedEvent,
 				mock(PassengerRequestScheduledEvent.class), pickupEvent, dropoffEvent, List.of(drtFare));
 	}
 


### PR DESCRIPTION
For bigger scenarios, creation of scatter plots could take quite some time. In particular, the recently added "Maximum wait time" plot was taking a lot of time as often all samples (drt legs) have the same max wait time (X value).