### PR TITLE
OsmPoiReader: Make CompressionMethod exchangeable

### DIFF
--- a/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/osm/OsmPoiReader.java
+++ b/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/osm/OsmPoiReader.java
@@ -81,11 +81,15 @@ public class OsmPoiReader {
 	 * Parses a given <i>OpenStreetMap</i> file for data in it that can be converted into MATSim facilities.
 	 */
 	public void parseOsmFileAndAddFacilities(Map<String, String> osmToMatsimTypeMap, String osmKey) {
+		parseOsmFileAndAddFacilities(osmToMatsimTypeMap,  osmKey, CompressionMethod.None);
+	}
+
+	public void parseOsmFileAndAddFacilities(Map<String, String> osmToMatsimTypeMap, String osmKey, CompressionMethod compressionMethod) {
 		OsmPoiSink sink = new OsmPoiSink(this.ct, osmToMatsimTypeMap, osmKey, useGeneralTypeIsSpecificTypeUnknown);
-		XmlReader xmlReader = new XmlReader(inputFile, false, CompressionMethod.None);
+		XmlReader xmlReader = new XmlReader(inputFile, false, compressionMethod);
 		xmlReader.setSink(sink);
-		xmlReader.run();		
-		
+		xmlReader.run();
+
 		for (ActivityFacility af : sink.getFacilities().getFacilities().values()) {
 			if (!this.facilities.getFacilities().containsKey(af.getId())) {
 				this.facilities.addActivityFacility(af);


### PR DESCRIPTION
This PR allows to change the supported CompressionMethod (i.e. gz, bz2 or none). Quite usefull in order to save HDD storage. The previous implementation accessed only plain xml. This PR is retrofit, because old method signiture is maintained by the help of a wrapping function.

Best,
Steffen