### PR TITLE
Deploy matsim-release.zip to the maven repository

### DIFF
--- a/.github/workflows/deploy-on-pr-merge.yaml
+++ b/.github/workflows/deploy-on-pr-merge.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Publish jars to matsim maven repo
         # fail at end to deploy as many jars as possible
-        run: mvn deploy --batch-mode --fail-at-end -DskipTests -Dmaven.resources.skip=true -Dmaven.install.skip=true
+        run: mvn deploy -P release --batch-mode --fail-at-end -DskipTests -Dmaven.resources.skip=true -Dmaven.install.skip=true
         env:
           MAVEN_USERNAME: ${{ secrets.REPOMATSIM_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.REPOMATSIM_TOKEN }}

--- a/matsim/pom.xml
+++ b/matsim/pom.xml
@@ -393,6 +393,28 @@
 							</execution>
 						</executions>
 					</plugin>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>build-helper-maven-plugin</artifactId>
+						<version>3.3.0</version>
+						<executions>
+							<execution>
+								<id>attach-artifacts</id>
+								<phase>package</phase>
+								<goals>
+									<goal>attach-artifact</goal>
+								</goals>
+								<configuration>
+									<artifacts>
+										<artifact>
+											<file>${project.build.directory}/${project.artifactId}-${project.version}-release.zip</file>
+											<type>zip</type>
+										</artifact>
+									</artifacts>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
 				</plugins>
 			</build>
 		</profile>


### PR DESCRIPTION
Hi,
This PR deploys matsim-x.x-release.zip to the maven repository as releases and PR-labeled releases.

### background

I have used matsim-13.0-release.zip in our project, and would like to use recent changes/fixes on master branch. However, 14.x series of matsim-release.zip has not been published yet. Although I can build it, it would be happy if a PR release includes matsim-release.zip. 

Thanks