### PR TITLE
Adaptve histograms (for #1826)

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/analysis/ShiftHistogram.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/analysis/ShiftHistogram.java
@@ -5,6 +5,7 @@ import org.matsim.api.core.v01.population.Population;
 import org.matsim.contrib.drt.extension.shifts.events.*;
 import org.matsim.contrib.drt.extension.shifts.shift.DrtShift;
 import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.config.Config;
 import org.matsim.core.utils.io.IOUtils;
 import org.matsim.core.utils.io.UncheckedIOException;
 import org.matsim.core.utils.misc.Time;
@@ -21,6 +22,9 @@ import java.util.Set;
 public class ShiftHistogram implements DrtShiftStartedEventHandler, DrtShiftEndedEventHandler,
 		DrtShiftBreakStartedEventHandler, DrtShiftBreakEndedEventHandler {
 
+	public static final int DEFAULT_BIN_COUNT = 30 * 3600;
+	public static final int DEFAULT_BIN_SIZE = 300;
+
     private Set<Id<DrtShift>> shiftIds;
     private int iteration = 0;
     private final int binSize;
@@ -28,8 +32,11 @@ public class ShiftHistogram implements DrtShiftStartedEventHandler, DrtShiftEnde
     private DataFrame data = null;
 
 
-    public ShiftHistogram(Population population, EventsManager eventsManager) {
-        this(300);
+    public ShiftHistogram(Population population, EventsManager eventsManager, Config config) {
+		super();
+		this.binSize = DEFAULT_BIN_SIZE;
+		this.nofBins = ((int) config.qsim().getEndTime().orElse(DEFAULT_BIN_COUNT) ) / this.binSize + 1;
+		reset(0);
         if (population == null) {
             this.shiftIds = null;
         }
@@ -47,16 +54,6 @@ public class ShiftHistogram implements DrtShiftStartedEventHandler, DrtShiftEnde
         this.binSize = binSize;
         this.nofBins = nofBins;
         reset(0);
-    }
-
-    /**
-     * Creates a new LegHistogram with the specified binSize and a default number of bins, such
-     * that 30 hours are analyzed.
-     *
-     * @param binSize The size of a time bin in seconds.
-     */
-    public ShiftHistogram(final int binSize) {
-        this(binSize, 30 * 3600 / binSize + 1);
     }
 
     /* Implementation of EventHandler-Interfaces */

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/run/ShiftDrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/run/ShiftDrtModeModule.java
@@ -30,6 +30,7 @@ import org.matsim.contrib.util.stats.VehicleOccupancyProfileWriter;
 import org.matsim.contrib.util.stats.VehicleTaskProfileCalculator;
 import org.matsim.contrib.util.stats.VehicleTaskProfileWriter;
 import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.config.Config;
 import org.matsim.core.config.groups.QSimConfigGroup;
 import org.matsim.core.controler.MatsimServices;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
@@ -101,7 +102,7 @@ public class ShiftDrtModeModule extends AbstractDvrpModeModule {
 				getter -> new BreakCorridorXY(getter.getModal(DrtShiftsSpecification.class), getter.get(EventsManager.class)))).asEagerSingleton();
 
 		bindModal(ShiftHistogram.class).toProvider(modalProvider(
-				getter -> new ShiftHistogram(getter.get(Population.class), getter.get(EventsManager.class)))).asEagerSingleton();
+				getter -> new ShiftHistogram(getter.get(Population.class), getter.get(EventsManager.class), getter.get(Config.class)))).asEagerSingleton();
 
 		addEventHandlerBinding().to(modalKey(ShiftDurationXY.class));
 		addEventHandlerBinding().to(modalKey(BreakCorridorXY.class));

--- a/matsim/src/main/java/org/matsim/analysis/LegHistogram.java
+++ b/matsim/src/main/java/org/matsim/analysis/LegHistogram.java
@@ -30,6 +30,7 @@ import org.matsim.api.core.v01.events.handler.PersonStuckEventHandler;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Population;
 import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.config.Config;
 import org.matsim.core.utils.io.IOUtils;
 import org.matsim.core.utils.io.UncheckedIOException;
 import org.matsim.core.utils.misc.Time;
@@ -55,6 +56,9 @@ import java.util.TreeMap;
  */
 public class LegHistogram implements PersonDepartureEventHandler, PersonArrivalEventHandler, PersonStuckEventHandler {
 
+	public static final int DEFAULT_END_TIME = 30 * 3600;
+	public static final int DEFAULT_BIN_SIZE = 300;
+
 	private Set<Id<Person>> personIds;
 	private int iteration = 0;
 	private final int binSize;
@@ -62,8 +66,11 @@ public class LegHistogram implements PersonDepartureEventHandler, PersonArrivalE
 	private final Map<String, DataFrame> data = new TreeMap<>();
 
 	@Inject
-	LegHistogram(Population population, EventsManager eventsManager) {
-		this(300);
+	LegHistogram(Population population, EventsManager eventsManager, Config config) {
+		super();
+		this.binSize = DEFAULT_BIN_SIZE;
+		this.nofBins = ((int) config.qsim().getEndTime().orElse(DEFAULT_END_TIME) ) / this.binSize + 1;
+		reset(0);
 		if (population == null) {
 			this.personIds = null;
 		} else {
@@ -91,7 +98,7 @@ public class LegHistogram implements PersonDepartureEventHandler, PersonArrivalE
 	 * @param binSize The size of a time bin in seconds.
 	 */
 	public LegHistogram(final int binSize) {
-		this(binSize, 30*3600/binSize + 1);
+		this(binSize, DEFAULT_END_TIME / binSize + 1);
 	}
 
 	/* Implementation of EventHandler-Interfaces */


### PR DESCRIPTION
A simple fix for #1826 which ensures that leg and shift histograms expand until the defined QSim end time. If no end time is provided, the previous default of 30hrs is kept. 