### PR TITLE
Proposal for max absolute detour time for drt

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRouteCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRouteCreator.java
@@ -61,7 +61,7 @@ public class DrtRouteCreator implements DefaultMainLegRouter.RouteCreator {
 	 * @return maximum travel time
 	 */
 	static double getMaxTravelTime(DrtConfigGroup drtCfg, double unsharedRideTime) {
-		return drtCfg.getMaxTravelTimeAlpha() * unsharedRideTime + drtCfg.getMaxTravelTimeBeta();
+		return Math.min(unsharedRideTime + drtCfg.getMaxAbsoluteDetour(), drtCfg.getMaxTravelTimeAlpha() * unsharedRideTime + drtCfg.getMaxTravelTimeBeta());
 	}
 
 	public Route createRoute(double departureTime, Link accessActLink, Link egressActLink, Person person,

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -88,14 +88,20 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 	public static final String MAX_TRAVEL_TIME_ALPHA = "maxTravelTimeAlpha";
 	static final String MAX_TRAVEL_TIME_ALPHA_EXP =
 			"Defines the slope of the maxTravelTime estimation function (optimisation constraint), i.e. "
-					+ "maxTravelTimeAlpha * unsharedRideTime + maxTravelTimeBeta. "
+					+ "min(unsharedRideTime + maxAbsoluteDetour, maxTravelTimeAlpha * unsharedRideTime + maxTravelTimeBeta). "
 					+ "Alpha should not be smaller than 1.";
 
 	public static final String MAX_TRAVEL_TIME_BETA = "maxTravelTimeBeta";
 	static final String MAX_TRAVEL_TIME_BETA_EXP =
 			"Defines the shift of the maxTravelTime estimation function (optimisation constraint), i.e. "
-					+ "maxTravelTimeAlpha * unsharedRideTime + maxTravelTimeBeta. "
+					+ "min(unsharedRideTime + maxAbsoluteDetour, maxTravelTimeAlpha * unsharedRideTime + maxTravelTimeBeta). "
 					+ "Beta should not be smaller than 0.";
+
+	public static final String MAX_ABSOLUTE_DETOUR = "maxAbsoluteDetour";
+	static final String MAX_ABSOLUTE_DETOUR_EXP =
+			"Defines the maximum allowed absolute detour in seconds of the maxTravelTime estimation function (optimisation constraint), i.e. "
+					+ "min(unsharedRideTime + maxAbsoluteDetour, maxTravelTimeAlpha * unsharedRideTime + maxTravelTimeBeta). "
+					+ "maxAbsoluteDetour should not be smaller than 0. and should be higher than the offset maxTravelTimeBeta.";
 
 	public static final String REJECT_REQUEST_IF_MAX_WAIT_OR_TRAVEL_TIME_VIOLATED = "rejectRequestIfMaxWaitOrTravelTimeViolated";
 	static final String REJECT_REQUEST_IF_MAX_WAIT_OR_TRAVEL_TIME_VIOLATED_EXP =
@@ -161,13 +167,16 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 	private double maxWaitTime = Double.NaN;// seconds
 
 	// max arrival time defined as:
-	// maxTravelTimeAlpha * unshared_ride_travel_time(fromLink, toLink) + maxTravelTimeBeta,
+	// min(unshared_ride_travel_time(fromLink, toLink) + maxAbsoluteDetour, maxTravelTimeAlpha * unshared_ride_travel_time(fromLink, toLink) + maxTravelTimeBeta),
 	// where unshared_ride_travel_time(fromLink, toLink) is calculated during replanning (see: DrtRouteCreator)
 	@DecimalMin("1.0")
 	private double maxTravelTimeAlpha = Double.NaN;// [-]
 
 	@PositiveOrZero
 	private double maxTravelTimeBeta = Double.NaN;// [s]
+
+	@PositiveOrZero
+	private double maxAbsoluteDetour = Double.POSITIVE_INFINITY;// [s]
 
 	private boolean rejectRequestIfMaxWaitOrTravelTimeViolated = true;
 
@@ -315,6 +324,7 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 		map.put(MAX_WAIT_TIME, MAX_WAIT_TIME_EXP);
 		map.put(MAX_TRAVEL_TIME_ALPHA, MAX_TRAVEL_TIME_ALPHA_EXP);
 		map.put(MAX_TRAVEL_TIME_BETA, MAX_TRAVEL_TIME_BETA_EXP);
+		map.put(MAX_ABSOLUTE_DETOUR, MAX_ABSOLUTE_DETOUR_EXP);
 		map.put(CHANGE_START_LINK_TO_LAST_LINK_IN_SCHEDULE, CHANGE_START_LINK_TO_LAST_LINK_IN_SCHEDULE_EXP);
 		map.put(VEHICLES_FILE, VEHICLES_FILE_EXP);
 		map.put(WRITE_DETAILED_CUSTOMER_STATS, WRITE_DETAILED_CUSTOMER_STATS_EXP);
@@ -453,6 +463,24 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 		this.maxTravelTimeBeta = maxTravelTimeBeta;
 		return this;
 	}
+
+	/**
+	 * @return -- {@value #MAX_ABSOLUTE_DETOUR_EXP}
+	 */
+	@StringGetter(MAX_ABSOLUTE_DETOUR)
+	public double getMaxAbsoluteDetour() {
+		return maxAbsoluteDetour;
+	}
+
+	/**
+	 * @param maxAbsoluteDetour -- {@value #MAX_ABSOLUTE_DETOUR_EXP}
+	 */
+	@StringSetter(MAX_ABSOLUTE_DETOUR)
+	public DrtConfigGroup setMaxAbsoluteDetour(double maxAbsoluteDetour) {
+		this.maxAbsoluteDetour = maxAbsoluteDetour;
+		return this;
+	}
+
 
 	/**
 	 * @return -- {@value #REJECT_REQUEST_IF_MAX_WAIT_OR_TRAVEL_TIME_VIOLATED_EXP}


### PR DESCRIPTION
Hey, this is a proposal for a max absolute detour time for drt requests such that max travel time becomes min(unsharedRideTime + maxAbsoluteDetour, maxTravelTimeAlpha * unsharedRideTime + maxTravelTimeBeta)

By default, maxAbsoluteDetour is set to positive infinity and therefore ignored.