### PR TITLE
Fix for allowing evs to leave charging queue

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/scheduler/EShiftTaskScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/scheduler/EShiftTaskScheduler.java
@@ -235,7 +235,7 @@ public class EShiftTaskScheduler {
 					if (charger.getLogic().getChargingStrategy().isChargingCompleted(electricVehicle)) {
 						return false;
 					}
-					return ChargingEstimations.estimateMaxWaitTimeForNextVehicle(charger) < 5 * 60;
+					return true;
 				}
 			}
 		}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/ChargingEventSequenceCollector.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/ChargingEventSequenceCollector.java
@@ -38,7 +38,7 @@ import com.google.common.base.Preconditions;
  * @author Michal Maciejewski (michalm)
  */
 public class ChargingEventSequenceCollector
-		implements QueuedAtChargerEventHandler, ChargingStartEventHandler, ChargingEndEventHandler {
+		implements QueuedAtChargerEventHandler, QuitQueueAtChargerEventHandler, ChargingStartEventHandler, ChargingEndEventHandler {
 
 	public static class ChargingSequence {
 		@Nullable //null if no queueing occurred
@@ -75,6 +75,17 @@ public class ChargingEventSequenceCollector
 	public void handleEvent(QueuedAtChargerEvent event) {
 		Preconditions.checkState(ongoingSequences.put(event.getVehicleId(), new ChargingSequence(event)) == null,
 				"Vehicle (%s) already at a charger", event.getVehicleId());
+	}
+
+	@Override
+	public void handleEvent(QuitQueueAtChargerEvent event) {
+		Preconditions.checkState(ongoingSequences.containsKey(event.getVehicleId()),
+				"Vehicle (%s) was not at charger (%s)", event.getVehicleId(), event.getChargerId());
+		Preconditions.checkState(ongoingSequences.get(event.getVehicleId()).queuedAtCharger != null,
+				"Vehicle (%s) was not queued at charger (%s)", event.getVehicleId(), event.getChargerId());
+		Preconditions.checkState(ongoingSequences.get(event.getVehicleId()).queuedAtCharger != null,
+				"Vehicle (%s) already is already plugged", event.getVehicleId(), event.getChargerId());
+		ongoingSequences.remove(event.getVehicleId());
 	}
 
 	@Override

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/ChargingEventSequenceCollector.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/ChargingEventSequenceCollector.java
@@ -79,13 +79,14 @@ public class ChargingEventSequenceCollector
 
 	@Override
 	public void handleEvent(QuitQueueAtChargerEvent event) {
-		Preconditions.checkState(ongoingSequences.containsKey(event.getVehicleId()),
-				"Vehicle (%s) was not at charger (%s)", event.getVehicleId(), event.getChargerId());
-		Preconditions.checkState(ongoingSequences.get(event.getVehicleId()).queuedAtCharger != null,
-				"Vehicle (%s) was not queued at charger (%s)", event.getVehicleId(), event.getChargerId());
-		Preconditions.checkState(ongoingSequences.get(event.getVehicleId()).chargingStartEvent == null,
-				"Vehicle (%s) already is already plugged", event.getVehicleId(), event.getChargerId());
-		ongoingSequences.remove(event.getVehicleId());
+		var sequence = ongoingSequences.remove(event.getVehicleId());
+		Preconditions.checkState(sequence != null, "Vehicle (%s) was not at charger (%s)", event.getVehicleId(),
+				event.getChargerId());
+		Preconditions.checkState(sequence.queuedAtCharger != null, "Vehicle (%s) was not queued at charger (%s)",
+				event.getVehicleId(), event.getChargerId());
+		Preconditions.checkState(sequence.chargingStartEvent == null, "Vehicle (%s) is already plugged",
+				event.getVehicleId(), event.getChargerId());
+		completedSequences.add(sequence);
 	}
 
 	@Override

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/ChargingEventSequenceCollector.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/ChargingEventSequenceCollector.java
@@ -83,7 +83,7 @@ public class ChargingEventSequenceCollector
 				"Vehicle (%s) was not at charger (%s)", event.getVehicleId(), event.getChargerId());
 		Preconditions.checkState(ongoingSequences.get(event.getVehicleId()).queuedAtCharger != null,
 				"Vehicle (%s) was not queued at charger (%s)", event.getVehicleId(), event.getChargerId());
-		Preconditions.checkState(ongoingSequences.get(event.getVehicleId()).queuedAtCharger != null,
+		Preconditions.checkState(ongoingSequences.get(event.getVehicleId()).chargingStartEvent == null,
 				"Vehicle (%s) already is already plugged", event.getVehicleId(), event.getChargerId());
 		ongoingSequences.remove(event.getVehicleId());
 	}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/ChargingWithQueueingLogic.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/ChargingWithQueueingLogic.java
@@ -103,6 +103,7 @@ public class ChargingWithQueueingLogic implements ChargingLogic {
 			// make sure ev was in the queue
 			Preconditions.checkState(queuedVehicles.remove(ev),
 					"Vehicle (%s) is neither queued nor plugged at charger (%s)", ev.getId(), charger.getId());
+			eventsManager.processEvent(new QuitQueueAtChargerEvent(now, charger.getId(), ev.getId()));
 		}
 	}
 

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/QuitQueueAtChargerEvent.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/QuitQueueAtChargerEvent.java
@@ -61,4 +61,3 @@ public class QuitQueueAtChargerEvent extends Event {
 		return attr;
 	}
 }
-

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/QuitQueueAtChargerEvent.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/QuitQueueAtChargerEvent.java
@@ -1,0 +1,64 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2016 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.ev.charging;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.events.Event;
+import org.matsim.contrib.ev.fleet.ElectricVehicle;
+import org.matsim.contrib.ev.infrastructure.Charger;
+
+import java.util.Map;
+
+public class QuitQueueAtChargerEvent extends Event {
+	public static final String EVENT_TYPE = "quit_queue_at_charger";
+	public static final String ATTRIBUTE_CHARGER = "charger";
+	public static final String ATTRIBUTE_VEHICLE = "vehicle";
+
+	private final Id<Charger> chargerId;
+	private final Id<ElectricVehicle> vehicleId;
+
+	public QuitQueueAtChargerEvent(double time, Id<Charger> chargerId, Id<ElectricVehicle> vehicleId) {
+		super(time);
+		this.chargerId = chargerId;
+		this.vehicleId = vehicleId;
+	}
+
+	public Id<Charger> getChargerId() {
+		return chargerId;
+	}
+
+	public Id<ElectricVehicle> getVehicleId() {
+		return vehicleId;
+	}
+
+	@Override
+	public String getEventType() {
+		return EVENT_TYPE;
+	}
+
+	@Override
+	public Map<String, String> getAttributes() {
+		Map<String, String> attr = super.getAttributes();
+		attr.put(ATTRIBUTE_CHARGER, chargerId.toString());
+		attr.put(ATTRIBUTE_VEHICLE, vehicleId.toString());
+		return attr;
+	}
+}
+

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/QuitQueueAtChargerEventHandler.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/QuitQueueAtChargerEventHandler.java
@@ -1,0 +1,24 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2016 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.ev.charging;
+
+public interface QuitQueueAtChargerEventHandler {
+	void handleEvent(QuitQueueAtChargerEvent event);
+}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/QuitQueueAtChargerEventHandler.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/QuitQueueAtChargerEventHandler.java
@@ -19,6 +19,8 @@
 
 package org.matsim.contrib.ev.charging;
 
-public interface QuitQueueAtChargerEventHandler {
+import org.matsim.core.events.handler.EventHandler;
+
+public interface QuitQueueAtChargerEventHandler extends EventHandler {
 	void handleEvent(QuitQueueAtChargerEvent event);
 }


### PR DESCRIPTION
Hi,

in some of our scenarios vehicles may want to leave the queue at a charger without having started the charging activity. This can happen, for example, when it was initially planned to charge the vehicle during a driver shift break and the queueing time exceeds the break duration.

The ChargingWithQueueingLogic already allows to remove vehicles that are not yet plugged:
https://github.com/matsim-org/matsim-libs/blob/ff60f269b30dc6e57d170d259599880f25bc2685/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/ChargingWithQueueingLogic.java#L94-L106

However, our simulations crashed because the ChargingEventSequenceCollector does not yet seem to be designed for this case. This is what happens:
1. a vehicle is queued at a charger -> the ChargingEventSequenceCollector takes note of the QueuedAtChargerEvent with an ongoing charging sequence
2. the vehicle is removed from the ChargingWithQueueingLogic because the driver has to resume service before being able to charge (or any other reason) -> there is no notification for the sequence collector and the vehicle will be kept with an ongoing sequence
3. at a later time step, the vehicle may wants to charge again at the same charger and is queued -> the sequence collector tries to handle the new QueuedAtChargerEvent and crashes, since the vehicle is still in an ongoing sequence:
https://github.com/matsim-org/matsim-libs/blob/ff60f269b30dc6e57d170d259599880f25bc2685/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/ChargingEventSequenceCollector.java#L74-L78

This PR introduces a possible fix by also introducing a QuitQueueAtChargerEvent (or a better name) next to the QueueAtChargerEvent. This event is thrown when a vehicle is removed from the charger queue without having started charging. The ChargingEventSequenceCollector can then react by removing the vehicle from the ongoing sequences.

It is tested with a large scenario with a lot of charging activity. 

There is a caveat: if the vehicle is removed from the sequence collector, it will not be recorded as a "completed sequence". Not sure if that should be the intended behvavior..


(Sorry for all the review requests, @michalmac ) :)  