### PR TITLE
Enable the writing of pt and car skim results

### DIFF
--- a/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/analysis/skims/CalculateSkimMatrices.java
+++ b/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/analysis/skims/CalculateSkimMatrices.java
@@ -162,12 +162,10 @@ public class CalculateSkimMatrices {
         // skims.loadSamplingPointsFromFile("coordinates.csv");
 
         if (modes.contains(TransportMode.car)) {
-//            skims.calculateNetworkMatrices(networkFilename, eventsFilename, timesCar, config, l -> true);
             skims.calculateAndWriteNetworkMatrices(networkFilename, eventsFilename, timesCar, config, "", l -> true);
         }
 
         if (modes.contains(TransportMode.pt)) {
-//            skims.calculatePTMatrices(networkFilename, transitScheduleFilename, timesPt[0], timesPt[1], config, (line, route) -> route.getTransportMode().equals("train"));
             skims.calculateAndWritePTMatrices(networkFilename,
                     transitScheduleFilename,
                     timesPt[0],
@@ -176,8 +174,7 @@ public class CalculateSkimMatrices {
                     "",
                     (line, route) -> route.getTransportMode().equals("train"));
         }
-
-//        skims.calculateBeelineMatrix();
+        
         skims.calculateAndWriteBeelineMatrix();
     }
 

--- a/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/analysis/skims/CalculateSkimMatrices.java
+++ b/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/analysis/skims/CalculateSkimMatrices.java
@@ -162,14 +162,23 @@ public class CalculateSkimMatrices {
         // skims.loadSamplingPointsFromFile("coordinates.csv");
 
         if (modes.contains(TransportMode.car)) {
-            skims.calculateNetworkMatrices(networkFilename, eventsFilename, timesCar, config, l -> true);
+//            skims.calculateNetworkMatrices(networkFilename, eventsFilename, timesCar, config, l -> true);
+            skims.calculateAndWriteNetworkMatrices(networkFilename, eventsFilename, timesCar, config, "", l -> true);
         }
 
         if (modes.contains(TransportMode.pt)) {
-            skims.calculatePTMatrices(networkFilename, transitScheduleFilename, timesPt[0], timesPt[1], config, (line, route) -> route.getTransportMode().equals("train"));
+//            skims.calculatePTMatrices(networkFilename, transitScheduleFilename, timesPt[0], timesPt[1], config, (line, route) -> route.getTransportMode().equals("train"));
+            skims.calculateAndWritePTMatrices(networkFilename,
+                    transitScheduleFilename,
+                    timesPt[0],
+                    timesPt[1],
+                    config,
+                    "",
+                    (line, route) -> route.getTransportMode().equals("train"));
         }
 
-        skims.calculateBeelineMatrix();
+//        skims.calculateBeelineMatrix();
+        skims.calculateAndWriteBeelineMatrix();
     }
 
     public Map<String, Coord[]> getCoordsPerZone() {
@@ -418,10 +427,16 @@ public class CalculateSkimMatrices {
         return xy2lNetwork;
     }
 
-    public final void calculateAndWritePTMatrices(String networkFilename, String transitScheduleFilename, double startTime, double endTime, Config config, String outputPrefix,
+    public final void calculateAndWritePTMatrices(String networkFilename,
+                                                  String transitScheduleFilename,
+                                                  double startTime,
+                                                  double endTime,
+                                                  Config config,
+                                                  String outputPrefix,
             BiPredicate<TransitLine, TransitRoute> trainDetector) throws IOException {
 
-        var matrices = calculatePTMatrices(networkFilename, transitScheduleFilename, startTime, endTime, config, trainDetector);
+        var matrices = calculatePTMatrices(networkFilename,
+                transitScheduleFilename, startTime, endTime, config, trainDetector);
         writePTMatricesAsCSV(matrices, outputPrefix);
     }
 
@@ -440,7 +455,11 @@ public class CalculateSkimMatrices {
         FloatMatrixIO.writeAsCSV(matrices.trainDistanceShareMatrix, outputDirectory + "/" + prefix + PT_TRAINSHARE_BYDISTANCE_FILENAME);
     }
 
-    public final PTSkimMatrices.PtIndicators<String> calculatePTMatrices(String networkFilename, String transitScheduleFilename, double startTime, double endTime, Config config,
+    public final PTSkimMatrices.PtIndicators<String> calculatePTMatrices(String networkFilename,
+                                                                         String transitScheduleFilename,
+                                                                         double startTime,
+                                                                         double endTime,
+                                                                         Config config,
             BiPredicate<TransitLine, TransitRoute> trainDetector) {
         Scenario scenario = ScenarioUtils.createScenario(config);
         log.info("loading schedule from " + transitScheduleFilename);


### PR DESCRIPTION
@mfitz and I found that the current (example) implementation of the CalculateSkimMatrices does not write the caluclated outputs. 

An example invocation using outputs from [Londinium](https://github.com/arup-group/londinium) :

```
java -cp target/jar-with-dependencies.jar ch.sbb.matsim.analysis.skims.CalculateSkimMatrices
/londinium/data/lsoas/Londinium_LSOA_2004_London_Low_Resolution.shp 
LSOA_CODE 
/londinium/matsim/output_facilities.xml 
/londinium/matsim/output_network.xml.gz 
/londinium/matsim/output_transitSchedule.xml.gz 
/londinium/matsim/output_events.xml.gz 
/londinium/matsim/skims/ 
1 
1 
"09:00;10:00" "09:00;10:00" 
car,pt
```

Before this change, the output was only the zone_cordinates generated:
```
zone_coordinates.csv
```

This is despite logging showing that pt and car calculations were occurring:
```
2022-02-23T15:32:45,076  INFO NetworkImpl:422 building QuadTree for nodes: xrange(522459.31943244237,531281.982355153); yrange(173088.82731069007,180340.19839062024)
2022-02-23T15:32:45,120  INFO NetworkImpl:431 Building QuadTree took 0.062 seconds.
2022-02-23T15:32:45,142  INFO Counter:69 CAR-TravelTimeMatrix-09:00:00 zone 2 / 214
2022-02-23T15:32:45,142  INFO Counter:69 CAR-TravelTimeMatrix-09:00:00 zone 1 / 214
2022-02-23T15:32:45,566  INFO Counter:69 CAR-TravelTimeMatrix-09:00:00 zone 4 / 214
2022-02-23T15:32:45,708  INFO Counter:69 CAR-TravelTimeMatrix-09:00:00 zone 8 / 214
2022-02-23T15:32:45,994  INFO Counter:69 CAR-TravelTimeMatrix-09:00:00 zone 16 / 214
2022-02-23T15:32:46,345  INFO Counter:69 CAR-TravelTimeMatrix-09:00:00 zone 32 / 214
....
2022-02-23T15:32:52,893  INFO Counter:69 PT-FrequencyMatrix-09:00:00-23:00:00 zone 2 / 214
2022-02-23T15:33:00,228  INFO Counter:69 PT-FrequencyMatrix-09:00:00-23:00:00 zone 4 / 214
2022-02-23T15:33:10,816  INFO Counter:69 PT-FrequencyMatrix-09:00:00-23:00:00 zone 8 / 214
2022-02-23T15:33:30,450  INFO Counter:69 PT-FrequencyMatrix-09:00:00-23:00:00 zone 16 / 214
2022-02-23T15:34:10,376  INFO Counter:69 PT-FrequencyMatrix-09:00:00-23:00:00 zone 32 / 214
2022-02-23T15:35:24,865  INFO Counter:69 PT-FrequencyMatrix-09:00:00-23:00:00 zone 64 / 214
```

After this change, the output was:
```
zone_coordinates.csv
pt_travel_times.csv.gz
pt_transfer_counts.csv.gz
pt_train_distance_shares.csv.gz
pt_train_traveltime_shares.csv.gz
pt_egress_times.csv.gz
pt_frequencies.csv.gz
pt_adaptiontimes.csv.gz
pt_distances.csv.gz
pt_access_times.csv.gz
car_travel_times.csv.gz
car_distances.csv.gz
beeline_distances.csv.gz
```