### PR TITLE
fix(dvrp): change move-over-node time from 1 s to 1 time step in QSimFreeSpeedTravelTime

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/QSimFreeSpeedTravelTime.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/trafficmonitoring/QSimFreeSpeedTravelTime.java
@@ -22,7 +22,6 @@ import javax.inject.Inject;
 
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
-import org.matsim.contrib.dvrp.path.VrpPaths;
 import org.matsim.core.config.groups.QSimConfigGroup;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.vehicles.Vehicle;
@@ -49,6 +48,6 @@ public class QSimFreeSpeedTravelTime implements TravelTime {
 	public double getLinkTravelTime(Link link, double time, Person person, Vehicle vehicle) {
 		double freeSpeedTT = link.getLength() / link.getFreespeed(time); // equiv. to FreeSpeedTravelTime
 		double linkTravelTime = timeStepSize * Math.floor(freeSpeedTT / timeStepSize); // used in QSim for TT at link
-		return linkTravelTime + VrpPaths.NODE_TRANSITION_TIME;// adds 1 extra second for moving over nodes
+		return linkTravelTime + timeStepSize;// adds 1 extra time step for moving over nodes
 	}
 }


### PR DESCRIPTION
As pointed out by @tthunig, the time spent on moving over a node is equal to the time step duration.