### PR TITLE
Fix formatting in FacilitiesWriterV1

### DIFF
--- a/matsim/src/main/java/org/matsim/facilities/FacilitiesWriterV1.java
+++ b/matsim/src/main/java/org/matsim/facilities/FacilitiesWriterV1.java
@@ -93,7 +93,10 @@ class FacilitiesWriterV1 extends MatsimXmlWriter implements MatsimWriter {
                 }
                 this.endActivity();
             }
-						this.attributesWriter.writeAttributes("\t\t", this.writer, f.getAttributes());
+            if (!f.getAttributes().isEmpty()) {
+                this.writer.write(NL);
+            }
+            this.attributesWriter.writeAttributes("\t\t", this.writer, f.getAttributes(), false);
             this.endFacility();
             this.writer.flush();
         } catch (IOException e) {
@@ -121,6 +124,13 @@ class FacilitiesWriterV1 extends MatsimXmlWriter implements MatsimWriter {
             attributes.add(new Tuple<>("name", facilities.getName()));
         }
         writeStartTag("facilities", attributes);
+        if (!facilities.getAttributes().isEmpty()) {
+            try {
+                this.writer.write(NL);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
         this.attributesWriter.writeAttributes("\t", out, facilities.getAttributes());
     }
 


### PR DESCRIPTION
Before, facilities looked like this:

```xml
	<facility id="100053726" x="683175.6732123105" y="5338987.57620341">
		<activity type="leisure">
		</activity>
		<activity type="other">
		</activity>		<attributes>
			<attribute name="type" class="java.lang.String">park</attribute>
		</attributes>
	</facility>
```

Now they look like this:

```xml
	<facility id="100053726" x="683175.6732123105" y="5338987.57620341">
		<activity type="leisure">
		</activity>
		<activity type="other">
		</activity>
		<attributes>
			<attribute name="type" class="java.lang.String">park</attribute>
		</attributes>
	</facility>
```

The same issue appeared with the attributes in the `facilities` tag.

Before:

```xml
<facilities name="city">	<attributes>
		<attribute name="coordinateReferenceSystem" class="java.lang.String">EPSG:25832</attribute>
	</attributes>
```

After:

```xml
<facilities name="city">
	<attributes>
		<attribute name="coordinateReferenceSystem" class="java.lang.String">EPSG:25832</attribute>
	</attributes>
```