### PR TITLE
Enable reading and writing of 3D coordinates in facilities files

### DIFF
--- a/matsim/src/main/java/org/matsim/facilities/FacilitiesReaderMatsimV2.java
+++ b/matsim/src/main/java/org/matsim/facilities/FacilitiesReaderMatsimV2.java
@@ -1,0 +1,202 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * FacilitiesReaderMatsimV2.java
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2007 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.facilities;
+
+import java.util.Map;
+import java.util.Stack;
+
+import org.apache.log4j.Logger;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.core.scenario.ProjectionUtils;
+import org.matsim.core.utils.geometry.CoordinateTransformation;
+import org.matsim.core.utils.geometry.transformations.IdentityTransformation;
+import org.matsim.core.utils.geometry.transformations.TransformationFactory;
+import org.matsim.core.utils.io.MatsimXmlParser;
+import org.matsim.core.utils.misc.Time;
+import org.matsim.utils.objectattributes.AttributeConverter;
+import org.matsim.utils.objectattributes.attributable.AttributesXmlReaderDelegate;
+import org.xml.sax.Attributes;
+
+/**
+ * A reader for facilities-files of MATSim according to <code>facilities_v2.dtd</code>.
+ *
+ * @author mrieser
+ * @author balmermi
+ */
+final class FacilitiesReaderMatsimV2 extends MatsimXmlParser {
+    private static final  Logger log = Logger.getLogger(FacilitiesReaderMatsimV2.class);
+
+    private final static String FACILITIES = "facilities";
+    private final static String FACILITY = "facility";
+    private final static String ACTIVITY = "activity";
+    private final static String CAPACITY = "capacity";
+    private final static String OPENTIME = "opentime";
+    private static final String ATTRIBUTES = "attributes";
+    private static final String ATTRIBUTE = "attribute";
+
+    private final ActivityFacilities facilities;
+    private final ActivityFacilitiesFactory factory;
+    private final AttributesXmlReaderDelegate attributesReader = new AttributesXmlReaderDelegate();
+    private ActivityFacility currfacility = null;
+    private ActivityOption curractivity = null;
+    private org.matsim.utils.objectattributes.attributable.Attributes currAttributes = null;
+
+    private final String externalInputCRS;
+    private final String targetCRS;
+    private CoordinateTransformation coordinateTransformation = new IdentityTransformation();
+
+    FacilitiesReaderMatsimV2(
+            final String externalInputCRS,
+            final String targetCRS,
+            final ActivityFacilities facilities) {
+        this.externalInputCRS = externalInputCRS;
+        this.targetCRS = targetCRS;
+        this.facilities = facilities;
+        this.factory = this.facilities.getFactory();
+        if (externalInputCRS != null && targetCRS != null) {
+            this.coordinateTransformation = TransformationFactory.getCoordinateTransformation(externalInputCRS, targetCRS);
+            ProjectionUtils.putCRS(this.facilities, targetCRS);
+        }
+    }
+
+    public void putAttributeConverter(Class<?> clazz, AttributeConverter<?> converter) {
+        this.attributesReader.putAttributeConverter(clazz, converter);
+    }
+
+    public void putAttributeConverters(Map<Class<?>, AttributeConverter<?>> converters) {
+        this.attributesReader.putAttributeConverters(converters);
+    }
+
+    @Override
+    public void startTag(final String name, final org.xml.sax.Attributes atts, final Stack<String> context) {
+        if (FACILITIES.equals(name)) {
+            startFacilities(atts);
+        } else if (FACILITY.equals(name)) {
+            startFacility(atts);
+        } else if (ACTIVITY.equals(name)) {
+            startActivity(atts);
+        } else if (CAPACITY.equals(name)) {
+            startCapacity(atts);
+        } else if (OPENTIME.equals(name)) {
+            startOpentime(atts);
+        } else if (ATTRIBUTE.equals(name)) {
+            this.attributesReader.startTag(name, atts, context, this.currAttributes);
+        } else if (ATTRIBUTES.equals(name)) {
+            currAttributes = context.peek().equals(FACILITIES) ? this.facilities.getAttributes() : this.currfacility.getAttributes();
+            attributesReader.startTag(name, atts, context, currAttributes);
+        }
+    }
+
+    @Override
+    public void endTag(final String name, final String content, final Stack<String> context) {
+        if (FACILITY.equals(name)) {
+            this.facilities.addActivityFacility(this.currfacility);
+            this.currfacility = null;
+        } else if (ACTIVITY.equals(name)) {
+            this.curractivity = null;
+        } else if (ATTRIBUTES.equalsIgnoreCase(name)) {
+            if (context.peek().equals(FACILITIES)) {
+                String inputCRS = (String) currAttributes.getAttribute(ProjectionUtils.INPUT_CRS_ATT);
+
+                if (inputCRS != null && targetCRS != null) {
+                    if (externalInputCRS != null) {
+                        // warn or crash?
+                        log.warn("coordinate transformation defined both in config and in input file: setting from input file will be used");
+                    }
+                    coordinateTransformation = TransformationFactory.getCoordinateTransformation(inputCRS, targetCRS);
+                    currAttributes.putAttribute(ProjectionUtils.INPUT_CRS_ATT, targetCRS);
+                }
+            }
+            this.currAttributes = null;
+        } else if (ATTRIBUTE.equalsIgnoreCase(name)) {
+            this.attributesReader.endTag(name, content, context);
+        }
+    }
+
+    private void startFacilities(final Attributes atts) {
+        this.facilities.setName(atts.getValue("name"));
+        this.currAttributes = facilities.getAttributes();
+        if (atts.getValue("aggregation_layer") != null) {
+            Logger.getLogger(FacilitiesReaderMatsimV2.class).warn("aggregation_layer is deprecated.");
+        }
+    }
+
+    private void startFacility(final Attributes atts) {
+        if ( atts.getValue("x") !=null && atts.getValue("y") !=null ) {
+            if (atts.getValue("linkId") !=null) { //both coord and link present
+                this.currfacility =
+                        this.factory.createActivityFacility(
+                                Id.create(atts.getValue("id"), ActivityFacility.class),
+                                coordinateTransformation.transform(coordFromAtts(atts)),
+                                Id.create(atts.getValue("linkId"),Link.class));
+            } else { // only coord present
+                this.currfacility =
+                        this.factory.createActivityFacility(
+                                Id.create(atts.getValue("id"), ActivityFacility.class),
+                                coordinateTransformation.transform(coordFromAtts(atts)));
+            }
+        } else {
+            if (atts.getValue("linkId") !=null) { //only link present
+            this.currfacility =
+                    this.factory.createActivityFacility(
+                            Id.create(atts.getValue("id"), ActivityFacility.class),
+                            Id.create(atts.getValue("linkId"),Link.class));
+            } else { //neither coord nor link present
+                throw new RuntimeException("Neither coordinate nor linkId are available for facility id "+ atts.getValue("id")+". Aborting....");
+            }
+        }
+
+        ((ActivityFacilityImpl) this.currfacility).setDesc(atts.getValue("desc"));
+    }
+
+    private static Coord coordFromAtts(final Attributes atts) {
+        if (atts.getValue("z") != null) {
+            return new Coord(
+                Double.parseDouble(atts.getValue("x")),
+                Double.parseDouble(atts.getValue("y")),
+                Double.parseDouble(atts.getValue("z")));
+        } else {
+            return new Coord(
+                Double.parseDouble(atts.getValue("x")),
+                Double.parseDouble(atts.getValue("y")));
+        }
+    }
+
+    private void startActivity(final Attributes atts) {
+        this.curractivity = this.factory.createActivityOption(atts.getValue("type"));
+        this.currfacility.addActivityOption(this.curractivity);
+    }
+
+    private void startCapacity(final Attributes atts) {
+        double cap = Double.parseDouble(atts.getValue("value"));
+        this.curractivity.setCapacity(cap);
+    }
+
+    private void startOpentime(final Attributes atts) {
+        this.curractivity.addOpeningTime(OpeningTimeImpl.createFromOptionalTimes(
+                Time.parseOptionalTime(atts.getValue("start_time")),
+                Time.parseOptionalTime(atts.getValue("end_time"))));
+    }
+
+
+}

--- a/matsim/src/main/java/org/matsim/facilities/FacilitiesWriter.java
+++ b/matsim/src/main/java/org/matsim/facilities/FacilitiesWriter.java
@@ -62,19 +62,19 @@ public class FacilitiesWriter implements MatsimWriter {
 
     /**
      * Writes the activity facilities in the current default format
-     * (currently facilities_v1.dtd).
+     * (currently facilities_v2.dtd).
      */
     @Override
     public final void write(final String filename) {
-        writeV1(filename);
+        writeV2(filename);
     }
 
     /**
      * Writes the activity facilities in the current default format to the stream
-     * (currently facilities_v1.dtd).
+     * (currently facilities_v2.dtd).
      */
     public final void write(final OutputStream stream) {
-        FacilitiesWriterV1 writer = new FacilitiesWriterV1(coordinateTransformation, facilities);
+        FacilitiesWriterV2 writer = new FacilitiesWriterV2(coordinateTransformation, facilities);
         writer.putAttributeConverters(this.converters);
         writer.write(stream);
     }
@@ -93,5 +93,10 @@ public class FacilitiesWriter implements MatsimWriter {
         writer.write(filename);
     }
 
+    public final void writeV2(final String filename) {
+        FacilitiesWriterV2 writer = new FacilitiesWriterV2(coordinateTransformation, facilities);
+        writer.putAttributeConverters(this.converters);
+        writer.write(filename);
+    }
 
 }

--- a/matsim/src/main/java/org/matsim/facilities/FacilitiesWriterV2.java
+++ b/matsim/src/main/java/org/matsim/facilities/FacilitiesWriterV2.java
@@ -1,0 +1,211 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2007 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.facilities;
+
+import org.matsim.api.core.v01.Coord;
+import org.matsim.core.api.internal.MatsimWriter;
+import org.matsim.core.utils.collections.Tuple;
+import org.matsim.core.utils.geometry.CoordinateTransformation;
+import org.matsim.core.utils.io.MatsimXmlWriter;
+import org.matsim.core.utils.misc.Time;
+import org.matsim.utils.objectattributes.AttributeConverter;
+import org.matsim.utils.objectattributes.attributable.AttributesXmlWriterDelegate;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+
+/**
+ * @author mrieser
+ */
+class FacilitiesWriterV2 extends MatsimXmlWriter implements MatsimWriter {
+
+    private static final String DTD = "http://www.matsim.org/files/dtd/facilities_v2.dtd";
+
+    private final ActivityFacilities facilities;
+
+    private final CoordinateTransformation coordinateTransformation;
+
+    private AttributesXmlWriterDelegate attributesWriter = new AttributesXmlWriterDelegate();
+
+    FacilitiesWriterV2(
+        final CoordinateTransformation coordinateTransformation,
+        final ActivityFacilities facilities) {
+        this.coordinateTransformation = coordinateTransformation;
+        this.facilities = facilities;
+    }
+
+    @Override
+    public void write(String filename) {
+        openFile(filename);
+        this.writeInit();
+        for (ActivityFacility f : FacilitiesUtils.getSortedFacilities(this.facilities).values()) {
+            this.writeFacility((ActivityFacilityImpl) f);
+        }
+        this.writeFinish();
+    }
+
+    public void write(OutputStream stream) {
+        openOutputStream(stream);
+        this.writeInit();
+        for (ActivityFacility f : FacilitiesUtils.getSortedFacilities(this.facilities).values()) {
+            this.writeFacility((ActivityFacilityImpl) f);
+        }
+        this.writeFinish();
+    }
+
+    private void writeInit() {
+        this.writeXmlHead();
+        this.writeDoctype("facilities", DTD);
+        this.startFacilities(this.facilities, this.writer);
+    }
+
+    private void writeFacility(final ActivityFacilityImpl f) {
+        try {
+            this.startFacility(f);
+            for (ActivityOption a : f.getActivityOptions().values()) {
+                this.startActivity((ActivityOptionImpl) a);
+                this.writeCapacity((ActivityOptionImpl) a, this.writer);
+                SortedSet<OpeningTime> o_set = a.getOpeningTimes();
+                for (OpeningTime o : o_set) {
+                    this.writeOpentime(o, this.writer);
+                }
+                this.endActivity();
+            }
+            if (!f.getAttributes().isEmpty()) {
+                this.writer.write(NL);
+            }
+            this.attributesWriter.writeAttributes("\t\t", this.writer, f.getAttributes(), false);
+            this.endFacility();
+            this.writer.flush();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void writeFinish() {
+        try {
+            this.endFacilities();
+            this.writer.flush();
+            this.writer.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////////
+    // <facilities ... > ... </facilities>
+    //////////////////////////////////////////////////////////////////////
+
+    private void startFacilities(final ActivityFacilities facilities, final BufferedWriter out) {
+        List<Tuple<String, String>> attributes = new ArrayList<>();
+        if (facilities.getName() != null) {
+            attributes.add(new Tuple<>("name", facilities.getName()));
+        }
+        writeStartTag("facilities", attributes);
+        if (!facilities.getAttributes().isEmpty()) {
+            try {
+                this.writer.write(NL);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        this.attributesWriter.writeAttributes("\t", out, facilities.getAttributes());
+    }
+
+
+    private void endFacilities() {
+        writeEndTag("facilities");
+    }
+
+    //////////////////////////////////////////////////////////////////////
+    // <facility ... > ... </facility>
+    //////////////////////////////////////////////////////////////////////
+
+    private void startFacility(final ActivityFacilityImpl facility) {
+        List<Tuple<String, String>> attributes = new ArrayList<>();
+        attributes.add(new Tuple<>("id", facility.getId().toString()));
+        if (facility.getLinkId() != null) {
+            attributes.add(new Tuple<>("linkId", facility.getLinkId().toString()));
+        }
+        if (facility.getCoord()!=null) {
+            final Coord coord = this.coordinateTransformation.transform(facility.getCoord());
+            attributes.add(new Tuple<>("x", Double.toString(coord.getX())));
+            attributes.add(new Tuple<>("y", Double.toString(coord.getY())));
+            if (coord.hasZ()) {
+                attributes.add(new Tuple<>("z", Double.toString(coord.getZ())));
+            }
+        }
+        if (facility.getDesc() != null) {
+            attributes.add(new Tuple<>("desc", facility.getDesc()));
+        }
+        writeStartTag("facility", attributes, false);
+    }
+
+    private void endFacility() {
+        writeEndTag("facility");
+    }
+
+    //////////////////////////////////////////////////////////////////////
+    // <activity ... > ... </activity>
+    //////////////////////////////////////////////////////////////////////
+
+    public void startActivity(final ActivityOptionImpl activity) {
+        List<Tuple<String, String>> attributes = new ArrayList<>();
+        attributes.add(new Tuple<>("type", activity.getType()));
+        writeStartTag("activity", attributes);
+    }
+
+    public void endActivity() {
+        writeEndTag("activity");
+    }
+
+    //////////////////////////////////////////////////////////////////////
+    // <capacity ... />
+    //////////////////////////////////////////////////////////////////////
+
+    private void writeCapacity(final ActivityOptionImpl activity, final BufferedWriter out) throws IOException {
+        if (activity.getCapacity() != Integer.MAX_VALUE) {
+            out.write("\t\t\t<capacity");
+            out.write(" value=\"" + activity.getCapacity() + "\"");
+            out.write(" />\n");
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////////
+    // <opentime ... />
+    //////////////////////////////////////////////////////////////////////
+
+    private void writeOpentime(final OpeningTime opentime, final BufferedWriter out) throws IOException {
+        out.write("\t\t\t<opentime");
+        out.write(" day=\"wkday\"");
+        out.write(" start_time=\"" + Time.writeTime(opentime.getStartTime()) + "\"");
+        out.write(" end_time=\"" + Time.writeTime(opentime.getEndTime()) + "\"");
+        out.write(" />\n");
+    }
+
+    public void putAttributeConverters(Map<Class<?>, AttributeConverter<?>> converters) {
+        this.attributesWriter.putAttributeConverters(converters);
+    }
+}

--- a/matsim/src/main/java/org/matsim/facilities/MatsimFacilitiesReader.java
+++ b/matsim/src/main/java/org/matsim/facilities/MatsimFacilitiesReader.java
@@ -57,6 +57,7 @@ public class MatsimFacilitiesReader extends MatsimXmlParser {
 
 
     private final static String FACILITIES_V1 = "facilities_v1.dtd";
+    private final static String FACILITIES_V2 = "facilities_v2.dtd";
 
     private final static Logger log = Logger.getLogger(MatsimFacilitiesReader.class);
 
@@ -130,11 +131,14 @@ public class MatsimFacilitiesReader extends MatsimXmlParser {
     @Override
     protected void setDoctype(final String doctype) {
         super.setDoctype(doctype);
-        // Currently the only facilities-type is v1
         if (FACILITIES_V1.equals(doctype)) {
             this.delegate = new FacilitiesReaderMatsimV1(this.externalInputCRS, this.targetCRS, this.facilities);
             ((FacilitiesReaderMatsimV1)this.delegate).putAttributeConverters(this.attributeConverters);
             log.info("using facilities_v1-reader.");
+        } else if (FACILITIES_V2.equals(doctype)) { // v2 added support for 3D coordinates
+            this.delegate = new FacilitiesReaderMatsimV2(this.externalInputCRS, this.targetCRS, this.facilities);
+            ((FacilitiesReaderMatsimV2)this.delegate).putAttributeConverters(this.attributeConverters);
+            log.info("using facilities_v2-reader.");
         } else {
             throw new IllegalArgumentException("Doctype \"" + doctype + "\" not known.");
         }

--- a/matsim/src/main/resources/dtd/facilities_v2.dtd
+++ b/matsim/src/main/resources/dtd/facilities_v2.dtd
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+        <!-- $Id$ -->
+
+        <!-- ============================================================ -->
+
+        <!-- For further information or questions, please contact
+             Michael Balmer, balmermi at inf dot ethz dot ch -->
+
+        <!-- ============================================================ -->
+
+        <!ELEMENT facilities        (attributes?,facility*)>
+        <!ATTLIST facilities
+                name              CDATA   #IMPLIED
+                aggregation_layer CDATA   #IMPLIED
+                xml:lang          NMTOKEN "de-CH">
+
+        <!ELEMENT facility   (activity*,attributes?)>
+        <!ATTLIST facility
+                id         CDATA #REQUIRED
+                x          CDATA #IMPLIED
+                y          CDATA #IMPLIED
+                z          CDATA #IMPLIED
+                linkId     CDATA #IMPLIED
+                desc       CDATA #IMPLIED>
+
+        <!ELEMENT activity   (capacity?,opentime*)>
+        <!ATTLIST activity
+                type       CDATA #REQUIRED>
+
+        <!ELEMENT capacity   EMPTY>
+        <!ATTLIST capacity
+                value      CDATA #REQUIRED>
+
+        <!ELEMENT opentime   EMPTY>
+        <!ATTLIST opentime
+                day        (mon|tue|wed|thu|fri|sat|sun|wkday|wkend|wk) "wk"
+                start_time CDATA                                        #REQUIRED
+                end_time   CDATA                                        #REQUIRED>
+
+        <!ELEMENT attributes        (attribute*)>
+
+        <!ELEMENT attribute     ANY>
+        <!ATTLIST attribute
+                name          CDATA #REQUIRED
+                class         CDATA #REQUIRED>
+
+
+        <!-- ============================================================ -->
+
+        <!-- ROOT ELEMENT facilities:
+             Landuse data at the level of single organizations: shops, companies, houses. -->
+
+        <!-- ATTRIBUTE name:
+             The name should describe of which kind of data this
+             file holds. I.e. "Kanton Zurich - from database xyz".
+             format: string -->
+        <!-- ATTRIBUTE xml:lang:
+             Used by i.e. Java to know how to format and parse
+             times, dates, etc. according to a given locale (e.g. en_US, de_CH) -->
+
+        <!-- ============================================================ -->
+
+        <!-- ELEMENT facility:
+             A spatially aggregate organization where persons can perform activities.
+             The coordinate system of the x,y coordinates has to be specified in a
+             world file. -->
+
+        <!-- ATTRIBUTE id:
+             Identification of a facility -->
+
+        <!-- ATTRIBUTE x:
+             x-coordinate of that facility.
+             format: real number -->
+
+        <!-- ATTRIBUTE y:
+             y-coordinate of that facility.
+             format: real number -->
+
+        <!-- ATTRIBUTE z:
+             z-coordinate of that facility.
+             format: real number -->
+
+        <!-- ATTRIBUTE linkId:
+             id of a link in a network, on which this facility can be reached. -->
+
+        <!-- ============================================================ -->
+
+        <!-- ELEMENT activity:
+             Defines spatial and temporal properties for
+             a specific activity to be performed in a zone. -->
+
+        <!-- ATTRIBUTE type:
+             Activity type, e.g. work or shop.
+             format: string (can only be chosen from given values) -->
+
+        <!-- ============================================================ -->
+
+        <!-- ELEMENT capacity:
+             A cell can hold a limited capacity per activity.
+             A capacity is the maximum number of something in a given time range,
+             e.g. number of costumers shopping at the same time or number of
+             workplaces.
+             If this element is not specified, then the capacity of the defined
+             activity is unlimited. -->
+
+        <!-- ATTRIBUTE value:
+             Value of the capacity.
+             format: unsigned integer -->
+
+        <!-- ============================================================ -->
+
+        <!-- ELEMENT opentime:
+             Each zone/activity combination can hold a variable amount of opening
+             times describing on what times the facility is open and therefore
+             accessible.
+             The opening times are specified on a daily basis for maximum week periods.
+             If no opentime element is specified, the facility is closed all the time.
+             To make a facility open all the time, include the following opentime
+             element:
+             <opentime day="wk" start_time="00:00" end_time="24:00" /> -->
+
+        <!-- ATTRIBUTE day:
+             A schedule can be set for a single day, for all weekdays,
+             the weekend or for the whole week. Schedules for single days always
+             override schedules for time ranges, e.g. a "mon" schedule for
+             Monday overrides weekday or whole week schedules.
+
+             ATTENTION: for a given facility, schedules must
+             not overlap in time. I.e.
+               <opentime day="mon" start_time="09:00" end_time="14:00" />
+               <opentime day="mon" start_time="11:00" end_time="18:00" />
+             is not allowed.
+             mon - Monday
+             tue - Tuesday
+             wed - Wednesday
+             thu - Thursday
+             fri - Friday
+             sat - Saturday
+             sun - Sunday
+             wkday - week days (mon through fri)
+             wkend - week end (sat, sun)
+             wk - whole week (mon through sun)
+             format: string (can only be chosen from given values) -->
+
+        <!-- ATTRIBUTE start_time:
+             Defines when a facility opens.
+             format: compatible with the locale defined in xml:lang -->
+
+        <!-- ATTRIBUTE end_time:
+             Defines when a facility closes.
+             format: compatible with the locale defined in xml:lang -->
+
+        <!-- If start_time > end_time, then the facility is opened over
+             midnight. -->
+
+        <!-- ============================================================ -->

--- a/matsim/src/test/java/org/matsim/facilities/FacilitiesParserWriterTest.java
+++ b/matsim/src/test/java/org/matsim/facilities/FacilitiesParserWriterTest.java
@@ -29,6 +29,7 @@ import org.matsim.api.core.v01.Scenario;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.core.utils.geometry.transformations.IdentityTransformation;
 import org.matsim.core.utils.misc.CRCChecksum;
 import org.matsim.examples.TriangleScenario;
 import org.matsim.testcases.MatsimTestUtils;
@@ -53,7 +54,7 @@ public class FacilitiesParserWriterTest {
 		new MatsimFacilitiesReader(scenario).readFile(config.facilities().getInputFile());
 
 		String outputFilename = this.utils.getOutputDirectory() + "output_facilities.xml";
-		TriangleScenario.writeFacilities(facilities, outputFilename);
+		new FacilitiesWriterV1(new IdentityTransformation(), facilities).write(outputFilename);
 
 		long checksum_ref = CRCChecksum.getCRCFromFile(config.facilities().getInputFile());
 		long checksum_run = CRCChecksum.getCRCFromFile(outputFilename);
@@ -61,7 +62,7 @@ public class FacilitiesParserWriterTest {
 	}
 
 	@Test
-	public void testWriteReadV1_withActivities() {
+	public void testWriteReadV2_withActivities() {
 		Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
 		ActivityFacilities facilities = scenario.getActivityFacilities();
 
@@ -102,7 +103,7 @@ public class FacilitiesParserWriterTest {
 	}
 
 	@Test
-	public void testWriteReadV1_withAttributes() {
+	public void testWriteReadV2_withAttributes() {
 		Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
 		ActivityFacilities facilities = scenario.getActivityFacilities();
 
@@ -139,7 +140,7 @@ public class FacilitiesParserWriterTest {
 	}
 
 	@Test
-	public void testWriteReadV1_withActivitiesAndAttributes() { // MATSIM-859
+	public void testWriteReadV2_withActivitiesAndAttributes() { // MATSIM-859
 		Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
 		ActivityFacilities facilities = scenario.getActivityFacilities();
 

--- a/matsim/src/test/java/org/matsim/facilities/FacilitiesWriterTest.java
+++ b/matsim/src/test/java/org/matsim/facilities/FacilitiesWriterTest.java
@@ -84,6 +84,44 @@ public class FacilitiesWriterTest {
     }
 
     @Test
+    public void testWrite3DCoord() {
+        Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+        ActivityFacilities facilities = scenario.getActivityFacilities();
+        ActivityFacilitiesFactory factory = facilities.getFactory();
+
+        ActivityFacility fac1 = factory.createActivityFacility(Id.create("1", ActivityFacility.class), new Coord(10.0, 15.0, 12.3));
+        ActivityFacility fac2 = factory.createActivityFacility(Id.create("2", ActivityFacility.class), new Coord(20.0, 25.0, -4.2));
+        ActivityFacility fac3 = factory.createActivityFacility(Id.create("3", ActivityFacility.class), new Coord(30.0, 35.0));
+
+        facilities.addActivityFacility(fac1);
+        facilities.addActivityFacility(fac2);
+        facilities.addActivityFacility(fac3);
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream(1000);
+        new FacilitiesWriter(facilities).write(outputStream);
+
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+
+        scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+        facilities = scenario.getActivityFacilities();
+        MatsimFacilitiesReader reader = new MatsimFacilitiesReader(scenario);
+        reader.parse(inputStream);
+
+        Assert.assertEquals(3, facilities.getFacilities().size());
+
+        ActivityFacility fac1b = facilities.getFacilities().get(Id.create(1, ActivityFacility.class));
+        Assert.assertTrue(fac1b.getCoord().hasZ());
+        Assert.assertEquals(12.3, fac1b.getCoord().getZ(), Double.MIN_NORMAL);
+
+        ActivityFacility fac2b = facilities.getFacilities().get(Id.create(2, ActivityFacility.class));
+        Assert.assertTrue(fac2b.getCoord().hasZ());
+        Assert.assertEquals(-4.2, fac2b.getCoord().getZ(), Double.MIN_NORMAL);
+
+        ActivityFacility fac3b = facilities.getFacilities().get(Id.create(3, ActivityFacility.class));
+        Assert.assertFalse(fac3b.getCoord().hasZ());
+    }
+
+    @Test
     // the better fix for https://github.com/matsim-org/matsim/pull/505
     public void testFacilityDescription() {
         Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());

--- a/matsim/src/test/java/org/matsim/facilities/MatsimFacilitiesReaderTest.java
+++ b/matsim/src/test/java/org/matsim/facilities/MatsimFacilitiesReaderTest.java
@@ -83,4 +83,54 @@ public class MatsimFacilitiesReaderTest {
 		ActivityFacility fac20 = facilities.getFacilities().get(Id.create(20, ActivityFacility.class));
 		Assert.assertNull(fac20.getLinkId());
 	}
+
+	@Test
+	public void testRead3DCoord() {
+		String str = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+	"<!DOCTYPE facilities SYSTEM \"http://www.matsim.org/files/dtd/facilities_v2.dtd\">\n" +
+	"<facilities name=\"test facilities for triangle network\">\n" +
+	"\n" +
+	"	<facility id=\"1\" x=\"60.0\" y=\"110.0\" z=\"12.3\" linkId=\"Aa\">\n" +
+	"		<activity type=\"home\">\n" +
+	"			<capacity value=\"201.0\" />\n" +
+	"			<opentime start_time=\"00:00:00\" end_time=\"24:00:00\" />\n" +
+	"		</activity>\n" +
+	"		<attributes>" +
+	"			<attribute name=\"population\" class=\"java.lang.Integer\">1000</attribute>" +
+	"		</attributes>" +
+	"	</facility>\n" +
+	"\n" +
+	"	<facility id=\"10\" x=\"110.0\" y=\"270.0\" z=\"-4.2\" linkId=\"Bb\">\n" +
+	"		<activity type=\"education\">\n" +
+	"			<capacity value=\"201.0\" />\n" +
+	"			<opentime start_time=\"08:00:00\" end_time=\"12:00:00\" />\n" +
+	"		</activity>\n" +
+	"	</facility>\n" +
+	"\n" +
+	"	<facility id=\"20\" x=\"120.0\" y=\"240.0\">\n" +
+	"		<activity type=\"shop\">\n" +
+	"			<capacity value=\"50.0\" />\n" +
+	"			<opentime start_time=\"08:00:00\" end_time=\"20:00:00\" />\n" +
+	"		</activity>\n" +
+	"	</facility>\n" +
+	"</facilities>";
+
+		Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+		MatsimFacilitiesReader reader = new MatsimFacilitiesReader(scenario);
+		reader.parse(new ByteArrayInputStream(str.getBytes()));
+
+		ActivityFacilities facilities = scenario.getActivityFacilities();
+		Assert.assertEquals(3, facilities.getFacilities().size());
+
+		ActivityFacility fac1 = facilities.getFacilities().get(Id.create(1, ActivityFacility.class));
+		Assert.assertTrue(fac1.getCoord().hasZ());
+		Assert.assertEquals(12.3, fac1.getCoord().getZ(), Double.MIN_NORMAL);
+
+		ActivityFacility fac10 = facilities.getFacilities().get(Id.create(10, ActivityFacility.class));
+		Assert.assertTrue(fac10.getCoord().hasZ());
+		Assert.assertEquals(-4.2, fac10.getCoord().getZ(), Double.MIN_NORMAL);
+
+		ActivityFacility fac20 = facilities.getFacilities().get(Id.create(20, ActivityFacility.class));
+		Assert.assertFalse(fac20.getCoord().hasZ());
+	}
 }


### PR DESCRIPTION
This change adds support for reading and writing the z-component from/to `Coord`s in facilities files. 

Currently, nodes in networks and activities in plans support reading and writing of 3D-coordinates, but facilities do not. During runtime, it is possible to create an `ActivityFacility` with a 3D-coordinate, but once written to and read from a file, this component of the coordinate is currently lost.

This change adds
- `facilities_v2.dtd`
- `FacilitiesReaderMatsimV2`
- `FacilitiesWriterV2`

based on the corresponding *V1 files with a bit code added to support the third coordinate component.