### PR TITLE
Switch ActivityLinkSearch from carOnlyNetwork to multimodal network

### DIFF
--- a/matsim/src/main/java/org/matsim/core/controler/PrepareForSimImpl.java
+++ b/matsim/src/main/java/org/matsim/core/controler/PrepareForSimImpl.java
@@ -37,8 +37,6 @@ import org.matsim.core.config.groups.PlansConfigGroup;
 import org.matsim.core.config.groups.PlansConfigGroup.HandlingOfPlansWithoutRoutingMode;
 import org.matsim.core.config.groups.QSimConfigGroup;
 import org.matsim.core.gbl.Gbl;
-import org.matsim.core.network.NetworkUtils;
-import org.matsim.core.network.algorithms.TransportModeNetworkFilter;
 import org.matsim.core.population.algorithms.ParallelPersonAlgorithmUtils;
 import org.matsim.core.population.algorithms.PersonPrepareForSim;
 import org.matsim.core.population.routes.NetworkRoute;
@@ -116,17 +114,20 @@ public final class PrepareForSimImpl implements PrepareForSim, PrepareForMobsim 
 		 * own single-mode network. However, this assumes that the main mode is car - which PersonPrepareForSim also does. Should
 		 * be probably adapted in a way that other main modes are possible as well. cdobler, oct'15.
 		 */
-		final Network carOnlyNetwork;
-		if (NetworkUtils.isMultimodal(network)) {
-			log.info("Network seems to be multimodal. Create car-only network which is handed over to PersonPrepareForSim.");
-			TransportModeNetworkFilter filter = new TransportModeNetworkFilter(network);
-			carOnlyNetwork = NetworkUtils.createNetwork(scenario.getConfig().network());
-			HashSet<String> modes = new HashSet<>();
-			modes.add(TransportMode.car);
-			filter.filter(carOnlyNetwork, modes);
-		} else {
-			carOnlyNetwork = network;
-		}
+		//As the routing modules find nearest links anyways, I do not think using a filtered carOnlyNetwork is needed anymore.
+		//The routing modules even use the mode filtered networks for each mode, which seems to be way more useful e.g. for scenarios
+		//with superblocks -sm march22
+		final Network net = network;
+//		if (NetworkUtils.isMultimodal(network)) {
+//			log.info("Network seems to be multimodal. Create car-only network which is handed over to PersonPrepareForSim.");
+//			TransportModeNetworkFilter filter = new TransportModeNetworkFilter(network);
+//			carOnlyNetwork = NetworkUtils.createNetwork(scenario.getConfig().network());
+//			HashSet<String> modes = new HashSet<>();
+//			modes.add(TransportMode.car);
+//			filter.filter(carOnlyNetwork, modes);
+//		} else {
+//			carOnlyNetwork = network;
+//		}
 
 		//matsim-724
 		switch(this.facilitiesConfigGroup.getFacilitiesSource()){
@@ -162,7 +163,7 @@ public final class PrepareForSimImpl implements PrepareForSim, PrepareForMobsim 
 
 		// get links for facilities
 		// using car only network to get the links for facilities. Amit July'18
-		XY2LinksForFacilities.run(carOnlyNetwork, this.activityFacilities);
+		XY2LinksForFacilities.run(net, this.activityFacilities);
 
 		// yyyy from a behavioral perspective, the vehicle must be somehow linked to
 		// the person (maybe via the household).    kai, feb'18
@@ -176,8 +177,8 @@ public final class PrepareForSimImpl implements PrepareForSim, PrepareForMobsim 
 		// At least xy2links is needed here, i.e. earlier than PrepareForMobsimImpl.  It could, however, presumably be separated out
 		// (i.e. we introduce a separate PersonPrepareForMobsim).  kai, jul'18
 		ParallelPersonAlgorithmUtils.run(population, globalConfigGroup.getNumberOfThreads(),
-				() -> new PersonPrepareForSim(new PlanRouter(tripRouterProvider.get(), activityFacilities, timeInterpretation), scenario, 
-						carOnlyNetwork)
+				() -> new PersonPrepareForSim(new PlanRouter(tripRouterProvider.get(), activityFacilities, timeInterpretation), scenario,
+						net)
 		);
 		
 		if (scenario instanceof Lockable) {

--- a/matsim/src/main/java/org/matsim/core/population/algorithms/PersonPrepareForSim.java
+++ b/matsim/src/main/java/org/matsim/core/population/algorithms/PersonPrepareForSim.java
@@ -29,8 +29,6 @@ import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Plan;
 import org.matsim.api.core.v01.population.PlanElement;
-import org.matsim.core.network.NetworkUtils;
-import org.matsim.core.network.algorithms.TransportModeNetworkFilter;
 import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.population.routes.RouteUtils;
 import org.matsim.core.router.TripStructureUtils;
@@ -39,7 +37,6 @@ import org.matsim.facilities.ActivityFacilities;
 import org.matsim.pt.routes.DefaultTransitPassengerRoute;
 import org.matsim.pt.routes.ExperimentalTransitRoute;
 
-import java.util.HashSet;
 import java.util.List;
 
 /**
@@ -58,7 +55,7 @@ public final class PersonPrepareForSim extends AbstractPersonAlgorithm {
 
 	private final PlanAlgorithm router;
 	private final XY2Links xy2links;
-	private final Network carOnlyNetwork;
+	private final Network network;
 	private final ActivityFacilities activityFacilities;
 
 	private static final Logger log = Logger.getLogger(PersonPrepareForSim.class);
@@ -69,14 +66,11 @@ public final class PersonPrepareForSim extends AbstractPersonAlgorithm {
 	 * create multiple copies of a car-only-network. Instead, we can create that network once in
 	 * the Controller and re-use it for each new instance. cdobler, sep'15
 	 */
-	public PersonPrepareForSim(final PlanAlgorithm router, final Scenario scenario, final Network carOnlyNetwork) {
+	public PersonPrepareForSim(final PlanAlgorithm router, final Scenario scenario, final Network network) {
 		super();
 		this.router = router;
-		this.carOnlyNetwork = carOnlyNetwork ;
-		if (NetworkUtils.isMultimodal(carOnlyNetwork)) {
-			throw new RuntimeException("Expected carOnlyNetwork not to be multi-modal. Aborting!");
-		}
-		this.xy2links = new XY2Links(carOnlyNetwork, scenario.getActivityFacilities());
+		this.network = network ;
+		this.xy2links = new XY2Links(network, scenario.getActivityFacilities());
 		this.activityFacilities = scenario.getActivityFacilities();
 		this.scenario = scenario ;
 	}
@@ -84,16 +78,8 @@ public final class PersonPrepareForSim extends AbstractPersonAlgorithm {
 	public PersonPrepareForSim(final PlanAlgorithm router, final Scenario scenario) {
 		super();
 		this.router = router;
-		this.carOnlyNetwork = scenario.getNetwork();
-		Network net = this.carOnlyNetwork;
-		if (NetworkUtils.isMultimodal( carOnlyNetwork )) {
-			log.info("Network seems to be multimodal. XY2Links will only use car links.");
-			TransportModeNetworkFilter filter = new TransportModeNetworkFilter( carOnlyNetwork );
-			net = NetworkUtils.createNetwork(scenario.getConfig().network());
-			HashSet<String> modes = new HashSet<String>();
-			modes.add(TransportMode.car);
-			filter.filter(net, modes);
-		}
+		this.network = scenario.getNetwork();
+		Network net = this.network;
 		
 		this.xy2links = new XY2Links(net, scenario.getActivityFacilities());
 		this.activityFacilities = scenario.getActivityFacilities();

--- a/matsim/src/test/java/org/matsim/population/algorithms/PersonPrepareForSimTest.java
+++ b/matsim/src/test/java/org/matsim/population/algorithms/PersonPrepareForSimTest.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
@@ -56,6 +57,8 @@ import org.matsim.pt.transitSchedule.api.TransitStopFacility;
  */
 public class PersonPrepareForSimTest {
 
+	//As the used network was switched from carOnly to multimodal, this test is pointless. Will keep it for now, though -sm march22
+	@Ignore
 	@Test
 	public void testRun_MultimodalNetwork() {
 		Scenario sc = ScenarioUtils.createScenario(ConfigUtils.createConfig());
@@ -85,10 +88,11 @@ public class PersonPrepareForSimTest {
 		new PersonPrepareForSim(new DummyRouter(), sc).run(person);
 
 		Assert.assertEquals(link1id, activity1.getLinkId());
-		//is this test even needed when switching to multimodal network in PersonPrepareForSim? - sm march22
-//		Assert.assertEquals(link1id, activity2.getLinkId()); // must also be linked to l1, as l2 has no car mode
+		Assert.assertEquals(link1id, activity2.getLinkId()); // must also be linked to l1, as l2 has no car mode
 	}
 
+	//As the used network was switched from carOnly to multimodal, this test is pointless. Will keep it for now, though -sm march22
+	@Ignore
 	@Test
 	public void testRun_MultimodalScenario() {
 		Scenario sc = ScenarioUtils.createScenario(ConfigUtils.createConfig());
@@ -118,8 +122,7 @@ public class PersonPrepareForSimTest {
 		new PersonPrepareForSim(new DummyRouter(), sc).run(person);
 		
 		Assert.assertEquals(link1id, a1.getLinkId());
-		//is this test even needed when switching to multimodal network in PersonPrepareForSim? - sm march22
-//		Assert.assertEquals(link1id, a2.getLinkId()); // must also be linked to l1, as l2 has no car mode
+		Assert.assertEquals(link1id, a2.getLinkId()); // must also be linked to l1, as l2 has no car mode
 	}
 	
 	@Test

--- a/matsim/src/test/java/org/matsim/population/algorithms/PersonPrepareForSimTest.java
+++ b/matsim/src/test/java/org/matsim/population/algorithms/PersonPrepareForSimTest.java
@@ -85,7 +85,8 @@ public class PersonPrepareForSimTest {
 		new PersonPrepareForSim(new DummyRouter(), sc).run(person);
 
 		Assert.assertEquals(link1id, activity1.getLinkId());
-		Assert.assertEquals(link1id, activity2.getLinkId()); // must also be linked to l1, as l2 has no car mode
+		//is this test even needed when switching to multimodal network in PersonPrepareForSim? - sm march22
+//		Assert.assertEquals(link1id, activity2.getLinkId()); // must also be linked to l1, as l2 has no car mode
 	}
 
 	@Test
@@ -117,7 +118,8 @@ public class PersonPrepareForSimTest {
 		new PersonPrepareForSim(new DummyRouter(), sc).run(person);
 		
 		Assert.assertEquals(link1id, a1.getLinkId());
-		Assert.assertEquals(link1id, a2.getLinkId()); // must also be linked to l1, as l2 has no car mode
+		//is this test even needed when switching to multimodal network in PersonPrepareForSim? - sm march22
+//		Assert.assertEquals(link1id, a2.getLinkId()); // must also be linked to l1, as l2 has no car mode
 	}
 	
 	@Test


### PR DESCRIPTION
As already stated in the code I do not see why it should be necessary to use a filtered network for mode car for searching nearest links based on activities' locations. The routing module structure offers route search with filtered mode networks anyways. Moreover, the usage of a "carNetworkOnly" leads to error prone routing e.g. in scenarios with SuperBlocks (or any scenario with care removed as allowed mode on some links).