### PR TITLE
prototype for simulating pre-planned DRT services

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/preplanned/optimizer/PreplannedDrtModeOptimizerQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/preplanned/optimizer/PreplannedDrtModeOptimizerQSimModule.java
@@ -1,0 +1,67 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2018 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.extension.preplanned.optimizer;
+
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.drt.optimizer.DrtOptimizer;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.drt.schedule.DrtTaskFactory;
+import org.matsim.contrib.drt.schedule.DrtTaskFactoryImpl;
+import org.matsim.contrib.drt.vrpagent.DrtActionCreator;
+import org.matsim.contrib.dvrp.fleet.Fleet;
+import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
+import org.matsim.contrib.dvrp.passenger.PassengerHandler;
+import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
+import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.mobsim.framework.MobsimTimer;
+import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
+import org.matsim.core.router.util.TravelTime;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class PreplannedDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
+	private final DrtConfigGroup drtCfg;
+
+	public PreplannedDrtModeOptimizerQSimModule(DrtConfigGroup drtCfg) {
+		super(drtCfg.getMode());
+		this.drtCfg = drtCfg;
+	}
+
+	@Override
+	protected void configureQSim() {
+		addModalComponent(DrtOptimizer.class, modalProvider(getter -> new PreplannedDrtOptimizer(drtCfg,
+				getter.getModal(PreplannedDrtOptimizer.PreplannedSchedules.class), getter.getModal(Network.class),
+				getter.getModal(TravelTime.class), getter.getModal(TravelDisutilityFactory.class)
+				.createTravelDisutility(getter.getModal(TravelTime.class)), getter.get(MobsimTimer.class),
+				getter.getModal(DrtTaskFactory.class), getter.get(EventsManager.class), getter.getModal(Fleet.class))));
+
+		bindModal(DrtTaskFactory.class).toInstance(new DrtTaskFactoryImpl());
+
+		bindModal(VrpAgentLogic.DynActionCreator.class).toProvider(modalProvider(
+				getter -> new DrtActionCreator(getter.getModal(PassengerHandler.class), getter.get(MobsimTimer.class),
+						getter.get(DvrpConfigGroup.class)))).asEagerSingleton();
+
+		bindModal(VrpOptimizer.class).to(modalKey(DrtOptimizer.class));
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/preplanned/optimizer/PreplannedDrtOptimizer.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/preplanned/optimizer/PreplannedDrtOptimizer.java
@@ -1,0 +1,269 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.extension.preplanned.optimizer;
+
+import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.STAY;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contrib.drt.optimizer.DrtOptimizer;
+import org.matsim.contrib.drt.passenger.DrtRequest;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.drt.schedule.DrtDriveTask;
+import org.matsim.contrib.drt.schedule.DrtTaskFactory;
+import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
+import org.matsim.contrib.dvrp.fleet.Fleet;
+import org.matsim.contrib.dvrp.optimizer.Request;
+import org.matsim.contrib.dvrp.passenger.PassengerRequestScheduledEvent;
+import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
+import org.matsim.contrib.dvrp.path.VrpPaths;
+import org.matsim.contrib.dvrp.schedule.Schedule;
+import org.matsim.contrib.dvrp.schedule.Tasks;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.mobsim.framework.MobsimTimer;
+import org.matsim.core.mobsim.framework.events.MobsimBeforeSimStepEvent;
+import org.matsim.core.router.speedy.SpeedyALTFactory;
+import org.matsim.core.router.util.LeastCostPathCalculator;
+import org.matsim.core.router.util.TravelDisutility;
+import org.matsim.core.router.util.TravelTime;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class PreplannedDrtOptimizer implements DrtOptimizer {
+	private final PreplannedSchedules preplannedSchedules;
+
+	private final Map<PreplannedRequest, DrtRequest> openRequests = new HashMap<>();
+
+	private final Network network;
+	private final TravelTime travelTime;
+	private final MobsimTimer timer;
+	private final DrtTaskFactory taskFactory;
+	private final EventsManager eventsManager;
+
+	private final LeastCostPathCalculator router;
+	private final double stopDuration;
+
+	public PreplannedDrtOptimizer(DrtConfigGroup drtCfg, PreplannedSchedules preplannedSchedules, Network network,
+			TravelTime travelTime, TravelDisutility travelDisutility, MobsimTimer timer, DrtTaskFactory taskFactory,
+			EventsManager eventsManager, Fleet fleet) {
+		this.preplannedSchedules = preplannedSchedules;
+		this.network = network;
+		this.travelTime = travelTime;
+		this.timer = timer;
+		this.taskFactory = taskFactory;
+		this.eventsManager = eventsManager;
+
+		Preconditions.checkArgument(
+				fleet.getVehicles().keySet().equals(preplannedSchedules.vehicleToPreplannedStops.keySet()),
+				"Some schedules are preplanned for vehicles outside the fleet");
+
+		router = new SpeedyALTFactory().createPathCalculator(network, travelDisutility, travelTime);
+		stopDuration = drtCfg.getStopDuration();
+
+		initSchedules(fleet);
+	}
+
+	private void initSchedules(Fleet fleet) {
+		for (DvrpVehicle veh : fleet.getVehicles().values()) {
+			veh.getSchedule()
+					.addTask(taskFactory.createStayTask(veh, veh.getServiceBeginTime(), veh.getServiceBeginTime(),
+							veh.getStartLink()));
+		}
+	}
+
+	@Override
+	public void requestSubmitted(Request request) {
+		var drtRequest = (DrtRequest)request;
+		var preplannedRequest = PreplannedRequest.createFromRequest(drtRequest);
+		openRequests.put(preplannedRequest, drtRequest);
+
+		var vehicleId = Preconditions.checkNotNull(
+				preplannedSchedules.preplannedRequestToVehicle.get(preplannedRequest),
+				"No vehicle assigned to pre-planned request (%s)", preplannedRequest);
+		var preplannedStops = preplannedSchedules.vehicleToPreplannedStops.get(vehicleId);
+
+		Preconditions.checkState(!preplannedStops.isEmpty(),
+				"Expected to contain at least preplanned stops for request (%s)", request.getId());
+
+		//TODO in the current implementation we do not know the scheduled pickup and dropoff times
+		eventsManager.processEvent(
+				new PassengerRequestScheduledEvent(timer.getTimeOfDay(), drtRequest.getMode(), drtRequest.getId(),
+						drtRequest.getPassengerId(), vehicleId, Double.NaN, Double.NaN));
+	}
+
+	@Override
+	public void nextTask(DvrpVehicle vehicle) {
+		var schedule = vehicle.getSchedule();
+
+		//TODO we could even skip adding this dummy task
+		if (schedule.getStatus() == Schedule.ScheduleStatus.PLANNED) {
+			//just execute the initially inserted 0-duration wait task
+			schedule.nextTask();
+			return;
+		}
+
+		var currentTask = schedule.getCurrentTask();
+		var currentLink = Tasks.getEndLink(currentTask);
+		double currentTime = timer.getTimeOfDay();
+		var nonVisitedPreplannedStops = preplannedSchedules.vehicleToPreplannedStops.get(vehicle.getId());
+		var nextStop = nonVisitedPreplannedStops.peek();
+
+		if (nextStop == null) {
+			// no more preplanned stops, add STAY only if still operating
+			if (currentTime < vehicle.getServiceEndTime()) {
+				// fill the time gap with STAY
+				schedule.addTask(
+						taskFactory.createStayTask(vehicle, currentTime, vehicle.getServiceEndTime(), currentLink));
+			} else if (!STAY.isBaseTypeOf(currentTask)) {
+				// always end with STAY even if delayed
+				schedule.addTask(taskFactory.createStayTask(vehicle, currentTime, currentTime, currentLink));
+			}
+			//if none of the above, this is the end of schedule
+		} else if (!nextStop.getLinkId().equals(currentLink.getId())) {
+			var nextLink = network.getLinks().get(nextStop.getLinkId());
+			VrpPathWithTravelData path = VrpPaths.calcAndCreatePath(currentLink, nextLink, currentTime, router,
+					travelTime);
+			schedule.addTask(taskFactory.createDriveTask(vehicle, path, DrtDriveTask.TYPE));
+		} else if (nextStop.preplannedRequest.earliestStartTime > timer.getTimeOfDay()) {
+			schedule.addTask(
+					taskFactory.createStayTask(vehicle, currentTime, nextStop.preplannedRequest.earliestStartTime,
+							currentLink));
+		} else {
+			nonVisitedPreplannedStops.poll();//remove this stop from queue
+
+			var stopTask = taskFactory.createStopTask(vehicle, currentTime, currentTime + stopDuration, currentLink);
+			if (nextStop.pickup) {
+				var request = Preconditions.checkNotNull(openRequests.get(nextStop.preplannedRequest),
+						"Request (%s) has not been yet submitted", nextStop.preplannedRequest);
+				stopTask.addPickupRequest(request);
+			} else {
+				var request = Preconditions.checkNotNull(openRequests.remove(nextStop.preplannedRequest),
+						"Request (%s) has not been yet submitted", nextStop.preplannedRequest);
+				stopTask.addDropoffRequest(request);
+			}
+			schedule.addTask(stopTask);
+		}
+
+		// switch to the next task and update currentTasks
+		schedule.nextTask();
+	}
+
+	@Override
+	public void notifyMobsimBeforeSimStep(MobsimBeforeSimStepEvent e) {
+	}
+
+	public static class PreplannedSchedules {
+		private final Map<PreplannedRequest, Id<DvrpVehicle>> preplannedRequestToVehicle;
+		//TODO use (immutable)list instead of queue (queue assumes we modify this collection, but we should not - it's input data)
+		private final Map<Id<DvrpVehicle>, Queue<PreplannedStop>> vehicleToPreplannedStops;
+
+		public PreplannedSchedules(Map<PreplannedRequest, Id<DvrpVehicle>> preplannedRequestToVehicle,
+				Map<Id<DvrpVehicle>, Queue<PreplannedStop>> vehicleToPreplannedStops) {
+			this.preplannedRequestToVehicle = preplannedRequestToVehicle;
+			this.vehicleToPreplannedStops = vehicleToPreplannedStops;
+		}
+	}
+
+	// also input to the external optimiser
+	public static final class PreplannedRequest {
+		private final Id<Person> passengerId;
+		private final double earliestStartTime;
+		private final double latestStartTime;
+		private final double latestArrivalTime;
+		private final Id<Link> fromLinkId;
+		private final Id<Link> toLinkId;
+
+		static PreplannedRequest createFromRequest(DrtRequest request) {
+			return new PreplannedRequest(request.getPassengerId(), request.getEarliestStartTime(),
+					request.getLatestStartTime(), request.getLatestArrivalTime(), request.getFromLink().getId(),
+					request.getToLink().getId());
+		}
+
+		public PreplannedRequest(Id<Person> passengerId, double earliestStartTime, double latestStartTime,
+				double latestArrivalTime, Id<Link> fromLinkId, Id<Link> toLinkId) {
+			this.passengerId = passengerId;
+			this.earliestStartTime = earliestStartTime;
+			this.latestStartTime = latestStartTime;
+			this.latestArrivalTime = latestArrivalTime;
+			this.fromLinkId = fromLinkId;
+			this.toLinkId = toLinkId;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o)
+				return true;
+			if (!(o instanceof PreplannedRequest))
+				return false;
+			PreplannedRequest that = (PreplannedRequest)o;
+			return Double.compare(that.earliestStartTime, earliestStartTime) == 0
+					&& Double.compare(that.latestStartTime, latestStartTime) == 0
+					&& Double.compare(that.latestArrivalTime, latestArrivalTime) == 0
+					&& Objects.equal(passengerId, that.passengerId)
+					&& Objects.equal(fromLinkId, that.fromLinkId)
+					&& Objects.equal(toLinkId, that.toLinkId);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hashCode(passengerId, earliestStartTime, latestStartTime, latestArrivalTime, fromLinkId,
+					toLinkId);
+		}
+
+		@Override
+		public String toString() {
+			return MoreObjects.toStringHelper(this)
+					.add("passengerId", passengerId)
+					.add("earliestStartTime", earliestStartTime)
+					.add("latestStartTime", latestStartTime)
+					.add("latestArrivalTime", latestArrivalTime)
+					.add("fromLinkId", fromLinkId)
+					.add("toLinkId", toLinkId)
+					.toString();
+		}
+	}
+
+	// sequence of preplanned tasks is the output from the external optimiser and the input to the drt simulation
+	public static final class PreplannedStop {
+		private final PreplannedRequest preplannedRequest;
+		private final boolean pickup;//pickup or dropoff
+
+		public PreplannedStop(PreplannedRequest preplannedRequest, boolean pickup) {
+			this.preplannedRequest = preplannedRequest;
+			this.pickup = pickup;
+		}
+
+		private Id<Link> getLinkId() {
+			return pickup ? preplannedRequest.fromLinkId : preplannedRequest.toLinkId;
+		}
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/preplanned/run/MultiModePreplannedDrtModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/preplanned/run/MultiModePreplannedDrtModule.java
@@ -1,0 +1,53 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2019 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.extension.preplanned.run;
+
+import org.matsim.contrib.drt.analysis.DrtModeAnalysisModule;
+import org.matsim.contrib.drt.extension.preplanned.optimizer.PreplannedDrtModeOptimizerQSimModule;
+import org.matsim.contrib.drt.routing.MultiModeDrtMainModeIdentifier;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.drt.run.DrtModeModule;
+import org.matsim.contrib.drt.run.DrtModeQSimModule;
+import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
+import org.matsim.core.controler.AbstractModule;
+import org.matsim.core.router.MainModeIdentifier;
+
+import com.google.inject.Inject;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class MultiModePreplannedDrtModule extends AbstractModule {
+
+	@Inject
+	private MultiModeDrtConfigGroup multiModeDrtCfg;
+
+	@Override
+	public void install() {
+		for (DrtConfigGroup drtCfg : multiModeDrtCfg.getModalElements()) {
+			install(new DrtModeModule(drtCfg));
+			installQSimModule(new DrtModeQSimModule(drtCfg, new PreplannedDrtModeOptimizerQSimModule(drtCfg)));
+			install(new DrtModeAnalysisModule(drtCfg));
+		}
+
+		bind(MainModeIdentifier.class).toInstance(new MultiModeDrtMainModeIdentifier(multiModeDrtCfg));
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/preplanned/run/PreplannedDrtControlerCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/preplanned/run/PreplannedDrtControlerCreator.java
@@ -1,0 +1,68 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2017 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+/**
+ *
+ */
+package org.matsim.contrib.drt.extension.preplanned.run;
+
+import static org.matsim.contrib.drt.run.DrtControlerCreator.createScenarioWithDrtRouteFactory;
+
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.contrib.drt.run.DrtConfigs;
+import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
+import org.matsim.contrib.drt.run.MultiModeDrtModule;
+import org.matsim.contrib.dvrp.run.DvrpModule;
+import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
+import org.matsim.contrib.otfvis.OTFVisLiveModule;
+import org.matsim.core.config.Config;
+import org.matsim.core.controler.Controler;
+import org.matsim.core.scenario.ScenarioUtils;
+
+/**
+ * @author jbischoff
+ * @author michalm (Michal Maciejewski)
+ */
+public final class PreplannedDrtControlerCreator {
+
+	/**
+	 * Creates a controller in one step.
+	 *
+	 * @param config
+	 * @param otfvis
+	 * @return
+	 */
+	public static Controler createControler(Config config, boolean otfvis) {
+		MultiModeDrtConfigGroup multiModeDrtConfig = MultiModeDrtConfigGroup.get(config);
+		DrtConfigs.adjustMultiModeDrtConfig(multiModeDrtConfig, config.planCalcScore(), config.plansCalcRoute());
+
+		Scenario scenario = createScenarioWithDrtRouteFactory(config);
+		ScenarioUtils.loadScenario(scenario);
+
+		Controler controler = new Controler(scenario);
+		controler.addOverridingModule(new DvrpModule());
+		controler.addOverridingModule(new MultiModePreplannedDrtModule());
+		controler.configureQSimComponents(DvrpQSimComponents.activateAllModes(multiModeDrtConfig));
+
+		if (otfvis) {
+			controler.addOverridingModule(new OTFVisLiveModule());
+		}
+		return controler;
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/preplanned/run/PreplannedDrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/preplanned/run/PreplannedDrtModeModule.java
@@ -1,0 +1,212 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2018 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.extension.preplanned.run;
+
+import java.net.URL;
+import java.util.List;
+
+import org.locationtech.jts.geom.prep.PreparedGeometry;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.contrib.drt.fare.DrtFareHandler;
+import org.matsim.contrib.drt.routing.DefaultDrtRouteUpdater;
+import org.matsim.contrib.drt.routing.DrtRouteCreator;
+import org.matsim.contrib.drt.routing.DrtRouteUpdater;
+import org.matsim.contrib.drt.routing.DrtStopFacility;
+import org.matsim.contrib.drt.routing.DrtStopFacilityImpl;
+import org.matsim.contrib.drt.routing.DrtStopNetwork;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.dvrp.fleet.FleetModule;
+import org.matsim.contrib.dvrp.router.ClosestAccessEgressFacilityFinder;
+import org.matsim.contrib.dvrp.router.DecideOnLinkAccessEgressFacilityFinder;
+import org.matsim.contrib.dvrp.router.DefaultMainLegRouter;
+import org.matsim.contrib.dvrp.router.DvrpModeRoutingModule;
+import org.matsim.contrib.dvrp.router.DvrpModeRoutingNetworkModule;
+import org.matsim.contrib.dvrp.router.DvrpRoutingModule.AccessEgressFacilityFinder;
+import org.matsim.contrib.dvrp.router.DvrpRoutingModuleProvider;
+import org.matsim.contrib.dvrp.router.TimeAsTravelDisutility;
+import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
+import org.matsim.contrib.dvrp.run.DvrpMode;
+import org.matsim.contrib.dvrp.run.DvrpModes;
+import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.modal.ModalProviders;
+import org.matsim.core.router.RoutingModule;
+import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
+import org.matsim.core.router.speedy.SpeedyALTFactory;
+import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
+import org.matsim.core.router.util.TravelTime;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.core.utils.collections.QuadTrees;
+import org.matsim.pt.transitSchedule.api.TransitScheduleReader;
+import org.matsim.utils.gis.shp2matsim.ShpGeometryUtils;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import com.google.inject.Key;
+import com.google.inject.name.Names;
+
+/**
+ * @author michalm (Michal Maciejewski)
+ */
+public final class PreplannedDrtModeModule extends AbstractDvrpModeModule {
+
+	private final DrtConfigGroup drtCfg;
+
+	public PreplannedDrtModeModule(DrtConfigGroup drtCfg) {
+		super(drtCfg.getMode());
+		this.drtCfg = drtCfg;
+	}
+
+	@Override
+	public void install() {
+		DvrpModes.registerDvrpMode(binder(), getMode());
+		install(new DvrpModeRoutingNetworkModule(getMode(), drtCfg.isUseModeFilteredSubnetwork()));
+		bindModal(TravelTime.class).to(Key.get(TravelTime.class, Names.named(DvrpTravelTimeModule.DVRP_ESTIMATED)));
+		bindModal(TravelDisutilityFactory.class).toInstance(TimeAsTravelDisutility::new);
+
+		install(new FleetModule(getMode(), drtCfg.getVehiclesFileUrl(getConfig().getContext()),
+				drtCfg.isChangeStartLinkToLastLinkInSchedule()));
+
+		Preconditions.checkArgument(drtCfg.getRebalancingParams().isEmpty());
+
+		//this is a customised version of DvrpModeRoutingModule.install()
+		addRoutingModuleBinding(getMode()).toProvider(new DvrpRoutingModuleProvider(getMode()));// not singleton
+		modalMapBinder(DvrpRoutingModuleProvider.Stage.class, RoutingModule.class).addBinding(
+						DvrpRoutingModuleProvider.Stage.MAIN)
+				.toProvider(new DvrpModeRoutingModule.DefaultMainLegRouterProvider(getMode()));// not singleton
+		bindModal(DefaultMainLegRouter.RouteCreator.class).toProvider(
+				new DrtRouteCreatorProvider(drtCfg));// not singleton
+
+		bindModal(DrtStopNetwork.class).toProvider(new DrtStopNetworkProvider(getConfig(), drtCfg)).asEagerSingleton();
+
+		if (drtCfg.getOperationalScheme() == DrtConfigGroup.OperationalScheme.door2door) {
+			bindModal(AccessEgressFacilityFinder.class).toProvider(
+							modalProvider(getter -> new DecideOnLinkAccessEgressFacilityFinder(getter.getModal(Network.class))))
+					.asEagerSingleton();
+		} else {
+			bindModal(AccessEgressFacilityFinder.class).toProvider(modalProvider(
+							getter -> new ClosestAccessEgressFacilityFinder(drtCfg.getMaxWalkDistance(),
+									getter.get(Network.class),
+									QuadTrees.createQuadTree(getter.getModal(DrtStopNetwork.class).getDrtStops().values()))))
+					.asEagerSingleton();
+		}
+
+		bindModal(DrtRouteUpdater.class).toProvider(new ModalProviders.AbstractProvider<>(getMode(), DvrpModes::mode) {
+			@Inject
+			private Population population;
+
+			@Inject
+			private Config config;
+
+			@Override
+			public DefaultDrtRouteUpdater get() {
+				var travelTime = getModalInstance(TravelTime.class);
+				Network network = getModalInstance(Network.class);
+				return new DefaultDrtRouteUpdater(drtCfg, network, travelTime,
+						getModalInstance(TravelDisutilityFactory.class), population, config);
+			}
+		}).asEagerSingleton();
+
+		addControlerListenerBinding().to(modalKey(DrtRouteUpdater.class));
+
+		drtCfg.getDrtFareParams()
+				.ifPresent(params -> addEventHandlerBinding().toInstance(new DrtFareHandler(getMode(), params)));
+
+		Preconditions.checkArgument(drtCfg.getDrtSpeedUpParams().isEmpty());
+	}
+
+	private static class DrtRouteCreatorProvider extends ModalProviders.AbstractProvider<DvrpMode, DrtRouteCreator> {
+		private final LeastCostPathCalculatorFactory leastCostPathCalculatorFactory;
+
+		private final DrtConfigGroup drtCfg;
+
+		private DrtRouteCreatorProvider(DrtConfigGroup drtCfg) {
+			super(drtCfg.getMode(), DvrpModes::mode);
+			this.drtCfg = drtCfg;
+			leastCostPathCalculatorFactory = new SpeedyALTFactory();
+		}
+
+		@Override
+		public DrtRouteCreator get() {
+			var travelTime = getModalInstance(TravelTime.class);
+			return new DrtRouteCreator(drtCfg, getModalInstance(Network.class), leastCostPathCalculatorFactory,
+					travelTime, getModalInstance(TravelDisutilityFactory.class));
+		}
+	}
+
+	private static class DrtStopNetworkProvider extends ModalProviders.AbstractProvider<DvrpMode, DrtStopNetwork> {
+
+		private final DrtConfigGroup drtCfg;
+		private final Config config;
+
+		private DrtStopNetworkProvider(Config config, DrtConfigGroup drtCfg) {
+			super(drtCfg.getMode(), DvrpModes::mode);
+			this.drtCfg = drtCfg;
+			this.config = config;
+		}
+
+		@Override
+		public DrtStopNetwork get() {
+			switch (drtCfg.getOperationalScheme()) {
+				case door2door:
+					return ImmutableMap::of;
+				case stopbased:
+					return createDrtStopNetworkFromTransitSchedule(config, drtCfg);
+				case serviceAreaBased:
+					return createDrtStopNetworkFromServiceArea(config, drtCfg, getModalInstance(Network.class));
+				default:
+					throw new RuntimeException("Unsupported operational scheme: " + drtCfg.getOperationalScheme());
+			}
+		}
+	}
+
+	private static DrtStopNetwork createDrtStopNetworkFromServiceArea(Config config, DrtConfigGroup drtCfg,
+			Network drtNetwork) {
+		final List<PreparedGeometry> preparedGeometries = ShpGeometryUtils.loadPreparedGeometries(
+				drtCfg.getDrtServiceAreaShapeFileURL(config.getContext()));
+		ImmutableMap<Id<DrtStopFacility>, DrtStopFacility> drtStops = drtNetwork.getLinks()
+				.values()
+				.stream()
+				.filter(link -> ShpGeometryUtils.isCoordInPreparedGeometries(link.getToNode().getCoord(),
+						preparedGeometries))
+				.map(DrtStopFacilityImpl::createFromLink)
+				.collect(ImmutableMap.toImmutableMap(DrtStopFacility::getId, f -> f));
+		return () -> drtStops;
+	}
+
+	private static DrtStopNetwork createDrtStopNetworkFromTransitSchedule(Config config, DrtConfigGroup drtCfg) {
+		URL url = drtCfg.getTransitStopsFileUrl(config.getContext());
+		Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+		new TransitScheduleReader(scenario).readURL(url);
+		ImmutableMap<Id<DrtStopFacility>, DrtStopFacility> drtStops = scenario.getTransitSchedule()
+				.getFacilities()
+				.values()
+				.stream()
+				.map(DrtStopFacilityImpl::createFromFacility)
+				.collect(ImmutableMap.toImmutableMap(DrtStopFacility::getId, f -> f));
+		return () -> drtStops;
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/preplanned/run/RunPreplannedDrtExample.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/preplanned/run/RunPreplannedDrtExample.java
@@ -1,0 +1,67 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2018 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.extension.preplanned.run;
+
+import static org.matsim.contrib.drt.extension.preplanned.optimizer.PreplannedDrtOptimizer.PreplannedSchedules;
+
+import java.net.URL;
+import java.util.Map;
+
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
+import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
+import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.contrib.otfvis.OTFVisLiveModule;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.controler.Controler;
+import org.matsim.vis.otfvis.OTFVisConfigGroup;
+
+/**
+ * @author michal.mac
+ */
+public class RunPreplannedDrtExample {
+	public static void run(URL configUrl, boolean otfvis, int lastIteration,
+			Map<String, PreplannedSchedules> preplannedSchedulesByMode) {
+		Config config = ConfigUtils.loadConfig(configUrl, new MultiModeDrtConfigGroup(), new DvrpConfigGroup(),
+				new OTFVisConfigGroup());
+		config.controler().setLastIteration(lastIteration);
+
+		Controler controler = PreplannedDrtControlerCreator.createControler(config, otfvis);
+
+		MultiModeDrtConfigGroup.get(config)
+				.getModalElements()
+				.stream()
+				.map(DrtConfigGroup::getMode)
+				.forEach(mode -> controler.addOverridingQSimModule(new AbstractDvrpModeQSimModule(mode) {
+					@Override
+					protected void configureQSim() {
+						bindModal(PreplannedSchedules.class).toInstance(preplannedSchedulesByMode.get(mode));
+					}
+				}));
+
+		if (otfvis) {
+			controler.addOverridingModule(new OTFVisLiveModule());
+		}
+
+		controler.run();
+	}
+}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/extension/preplanned/optimizer/RunPreplannedDrtExampleIT.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/extension/preplanned/optimizer/RunPreplannedDrtExampleIT.java
@@ -1,0 +1,94 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.extension.preplanned.optimizer;
+
+import static org.matsim.contrib.drt.extension.preplanned.optimizer.PreplannedDrtOptimizer.PreplannedRequest;
+import static org.matsim.contrib.drt.extension.preplanned.optimizer.PreplannedDrtOptimizer.PreplannedStop;
+
+import java.net.URL;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+import org.matsim.api.core.v01.Id;
+import org.matsim.contrib.drt.extension.preplanned.optimizer.PreplannedDrtOptimizer.PreplannedSchedules;
+import org.matsim.contrib.drt.extension.preplanned.run.RunPreplannedDrtExample;
+import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
+import org.matsim.core.utils.io.IOUtils;
+import org.matsim.examples.ExamplesUtils;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class RunPreplannedDrtExampleIT {
+	@Test
+	public void testRun() {
+		// scenario with 1 shared taxi (max 2 pax) and 10 requests
+		URL configUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("dvrp-grid"), "one_shared_taxi_config.xml");
+
+		// create preplanned requests (they will be mapped to drt requests created during simulation)
+		var preplannedRequest_0 = new PreplannedRequest(Id.createPersonId("passenger_0"), 0.0, 900.0, 844.4,
+				Id.createLinkId("114"), Id.createLinkId("349"));
+		var preplannedRequest_1 = new PreplannedRequest(Id.createPersonId("passenger_1"), 300.0, 1200.0, 1011.8,
+				Id.createLinkId("144"), Id.createLinkId("437"));
+		var preplannedRequest_2 = new PreplannedRequest(Id.createPersonId("passenger_2"), 600.0, 1500.0, 1393.7,
+				Id.createLinkId("223"), Id.createLinkId("347"));
+		var preplannedRequest_3 = new PreplannedRequest(Id.createPersonId("passenger_3"), 900.0, 1800.0, 1825.0,
+				Id.createLinkId("234"), Id.createLinkId("119"));
+		var preplannedRequest_4 = new PreplannedRequest(Id.createPersonId("passenger_4"), 1200.0, 2100.0, 1997.6,
+				Id.createLinkId("314"), Id.createLinkId("260"));
+		var preplannedRequest_5 = new PreplannedRequest(Id.createPersonId("passenger_5"), 1500.0, 2400.0, 2349.6,
+				Id.createLinkId("333"), Id.createLinkId("438"));
+		var preplannedRequest_6 = new PreplannedRequest(Id.createPersonId("passenger_6"), 1800.0, 2700.0, 2600.2,
+				Id.createLinkId("325"), Id.createLinkId("111"));
+		var preplannedRequest_7 = new PreplannedRequest(Id.createPersonId("passenger_7"), 2100.0, 3000.0, 2989.9,
+				Id.createLinkId("412"), Id.createLinkId("318"));
+		var preplannedRequest_8 = new PreplannedRequest(Id.createPersonId("passenger_8"), 2400.0, 3300.0, 3110.5,
+				Id.createLinkId("455"), Id.createLinkId("236"));
+		var preplannedRequest_9 = new PreplannedRequest(Id.createPersonId("passenger_9"), 2700.0, 3600.0, 3410.5,
+				Id.createLinkId("139"), Id.createLinkId("330"));
+		var preplannedRequests = List.of(preplannedRequest_0, preplannedRequest_1, preplannedRequest_2,
+				preplannedRequest_3, preplannedRequest_4, preplannedRequest_5, preplannedRequest_6, preplannedRequest_7,
+				preplannedRequest_8, preplannedRequest_9);
+
+		// there is only one shared taxi
+		var taxiId = Id.create("shared_taxi_one", DvrpVehicle.class);
+
+		// all requests are assigned to that taxi
+		var preplannedRequestsToVehicleId = preplannedRequests.stream().collect(Collectors.toMap(r -> r, r -> taxiId));
+
+		// the taxi will serve requests one by one (so actually no sharing, but of course we can change the sequence of stops)
+		var preplannedStops = preplannedRequests.stream()
+				.flatMap(r -> Stream.of(new PreplannedStop(r, true), new PreplannedStop(r, false)))
+				.collect(Collectors.toList());
+		var preplannedStopsByVehicleId = Map.of(taxiId, (Queue<PreplannedStop>)new LinkedList<>(preplannedStops));
+
+		// put all input data together
+		var preplannedSchedules = new PreplannedSchedules(preplannedRequestsToVehicleId, preplannedStopsByVehicleId);
+
+		// run simulation that re-plays the pre-computed vehicle schedules
+		RunPreplannedDrtExample.run(configUrl, false, 0, Map.of("drt", preplannedSchedules));
+	}
+}


### PR DESCRIPTION
Vehicle schedules are computed before simulation is started (could be even outside matsim). Then matsim (simulation) replays the pre-computed vehicle schedules.

This is a first operational prototype. There are a few TODOs that need to be addressed.

`RunPreplannedDrtExampleIT` gives an idea how to set up such a simulation (there are no assertions yet)