### PR TITLE
Introduce state profiles for shared mobility

### DIFF
--- a/contribs/shared_mobility/pom.xml
+++ b/contribs/shared_mobility/pom.xml
@@ -18,6 +18,11 @@
 			<artifactId>matsim-examples</artifactId>
 			<version>14.0-SNAPSHOT</version>
 		</dependency>
+		<dependency>
+			<groupId>org.matsim.contrib</groupId>
+			<artifactId>common</artifactId>
+			<version>14.0-SNAPSHOT</version>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/analysis/SharingAnalysisModule.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/analysis/SharingAnalysisModule.java
@@ -1,10 +1,22 @@
 package org.matsim.contrib.shared_mobility.analysis;
 
+import org.matsim.contrib.shared_mobility.run.SharingConfigGroup;
+import org.matsim.contrib.shared_mobility.run.SharingMode;
+import org.matsim.contrib.shared_mobility.run.SharingModes;
+import org.matsim.contrib.shared_mobility.run.SharingServiceConfigGroup;
+import org.matsim.contrib.shared_mobility.service.SharingUtils;
 import org.matsim.core.controler.AbstractModule;
+import org.matsim.core.controler.MatsimServices;
+import org.matsim.core.modal.AbstractModalModule;
+
+import com.google.inject.Inject;
 /**
  * @author steffenaxer
  */
 public class SharingAnalysisModule extends AbstractModule {
+
+	@Inject
+	SharingConfigGroup sharingConfig;
 
 	@Override
 	public void install() {
@@ -13,5 +25,20 @@ public class SharingAnalysisModule extends AbstractModule {
 		addEventHandlerBinding().to(SharingLegCollectorImpl.class);
 		addControlerListenerBinding().to(SharingLegCollectorImpl.class);
 		addControlerListenerBinding().to(SharingStatisticsAnalyzer.class);
+
+		// Install SharingVehicleStatusTimeProfileCollectorProvider for each service
+		for (SharingServiceConfigGroup serviceConfig : sharingConfig.getServices()) {
+			install(new AbstractModalModule<SharingMode>(SharingUtils.getServiceMode(serviceConfig), SharingModes::mode) {
+				@Override
+				public void install() {
+					bindModal(SharingVehicleStatusTimeProfileCollectorProvider.class).toProvider(modalProvider(getter -> {
+						MatsimServices matsimServices = getter.get(MatsimServices.class);
+						VehicleStateCollector vehicleStateCollector = getter.getModal(VehicleStateCollector.class);
+						return new SharingVehicleStatusTimeProfileCollectorProvider(vehicleStateCollector, matsimServices, SharingUtils.getServiceMode(serviceConfig));
+					}));
+					addMobsimListenerBinding().toProvider(modalKey(SharingVehicleStatusTimeProfileCollectorProvider.class));
+				}
+			});
+		}
 	}
 }

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/analysis/SharingVehicleStatusTimeProfileCollectorProvider.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/analysis/SharingVehicleStatusTimeProfileCollectorProvider.java
@@ -1,0 +1,56 @@
+package org.matsim.contrib.shared_mobility.analysis;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.contrib.common.histogram.UniformHistogram;
+import org.matsim.contrib.common.timeprofile.TimeProfileCharts.ChartType;
+import org.matsim.contrib.common.timeprofile.TimeProfileCollector;
+import org.matsim.contrib.common.timeprofile.TimeProfileCollector.ProfileCalculator;
+import org.matsim.contrib.common.timeprofile.TimeProfiles;
+import org.matsim.contrib.shared_mobility.service.SharingUtils.SHARING_VEHICLE_STATES;
+import org.matsim.contrib.shared_mobility.service.SharingVehicle;
+import org.matsim.core.controler.MatsimServices;
+import org.matsim.core.mobsim.framework.listeners.MobsimListener;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+
+public class SharingVehicleStatusTimeProfileCollectorProvider implements Provider<MobsimListener> {
+	private final VehicleStateCollector vehicleStateCollector;
+	private final MatsimServices matsimServices;
+	private final String serviceMode;
+	private final int interval = 120;
+
+	@Inject
+	public SharingVehicleStatusTimeProfileCollectorProvider(VehicleStateCollector vehicleStateCollector, MatsimServices matsimServices, String serviceMode) {
+		this.vehicleStateCollector = vehicleStateCollector;
+		this.matsimServices = matsimServices;
+		this.serviceMode = serviceMode;
+	}
+
+	@Override
+	public MobsimListener get() {
+		ProfileCalculator calc = createSharingVehicleStatusTimeProfileCollector(vehicleStateCollector, serviceMode);
+		TimeProfileCollector collector = new TimeProfileCollector(calc, interval, this.serviceMode + "_vehicle_status_time_profiles", matsimServices);
+		collector.setChartTypes(ChartType.StackedArea);
+		return collector;
+	}
+
+	public static ProfileCalculator createSharingVehicleStatusTimeProfileCollector(
+			final VehicleStateCollector vehicleStateCollector, String serviceMode) {
+		ImmutableList<String> header = ImmutableList.of(SHARING_VEHICLE_STATES.RESERVED.toString(),
+				SHARING_VEHICLE_STATES.BOOKED.toString(), SHARING_VEHICLE_STATES.IDLE.toString());
+		return TimeProfiles.createProfileCalculator(header, () -> {
+			UniformHistogram histogram = new UniformHistogram(1.0, header.size());
+			for (Id<SharingVehicle> vehicleId : vehicleStateCollector.getVehicleStatus().keySet()) {
+					histogram.addValue((vehicleStateCollector.getVehicleStatus().get(vehicleId)).ordinal());
+			}
+
+			ImmutableMap.Builder<String, Double> builder = ImmutableMap.builder();
+			for (int b = 0; b < header.size(); b++) {
+				builder.put(header.get(b), (double) histogram.getCount(b));
+			}
+			return builder.build();
+		});
+	}
+}

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/analysis/VehicleStateCollector.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/analysis/VehicleStateCollector.java
@@ -1,0 +1,16 @@
+package org.matsim.contrib.shared_mobility.analysis;
+
+import java.util.Map;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.contrib.shared_mobility.service.SharingUtils.SHARING_VEHICLE_STATES;
+import org.matsim.contrib.shared_mobility.service.SharingVehicle;
+import org.matsim.contrib.shared_mobility.service.events.SharingReservingEventHandler;
+import org.matsim.contrib.shared_mobility.service.events.SharingDropoffEventHandler;
+import org.matsim.contrib.shared_mobility.service.events.SharingPickupEventHandler;
+import org.matsim.core.controler.listener.IterationStartsListener;
+
+public interface VehicleStateCollector
+		extends SharingPickupEventHandler, SharingDropoffEventHandler, SharingReservingEventHandler, IterationStartsListener {
+	Map<Id<SharingVehicle>, SHARING_VEHICLE_STATES> getVehicleStatus();
+}

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/analysis/VehicleStateCollectorImpl.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/analysis/VehicleStateCollectorImpl.java
@@ -1,0 +1,65 @@
+package org.matsim.contrib.shared_mobility.analysis;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.IdMap;
+import org.matsim.contrib.shared_mobility.io.SharingServiceSpecification;
+import org.matsim.contrib.shared_mobility.service.SharingUtils.SHARING_VEHICLE_STATES;
+import org.matsim.contrib.shared_mobility.service.SharingVehicle;
+import org.matsim.contrib.shared_mobility.service.events.SharingReservingEvent;
+import org.matsim.contrib.shared_mobility.service.events.SharingDropoffEvent;
+import org.matsim.contrib.shared_mobility.service.events.SharingPickupEvent;
+import org.matsim.core.controler.events.IterationStartsEvent;
+
+public class VehicleStateCollectorImpl implements VehicleStateCollector {
+
+	SharingServiceSpecification sharingServiceSpecification;
+
+	private final IdMap<SharingVehicle, SHARING_VEHICLE_STATES> vehicle2VehicleStatus = new IdMap<>(
+			SharingVehicle.class);
+	private final Set<Id<SharingVehicle>> sharingVehicles = new HashSet<Id<SharingVehicle>>();
+
+	public VehicleStateCollectorImpl(SharingServiceSpecification sharingServiceSpecification) {
+		this.sharingServiceSpecification = sharingServiceSpecification;
+	}
+
+	@Override
+	public void handleEvent(SharingPickupEvent event) {
+		if (this.sharingVehicles.contains(event.getSharingVehicleId())) {
+			vehicle2VehicleStatus.put(event.getSharingVehicleId(), SHARING_VEHICLE_STATES.BOOKED);
+		}
+	}
+
+	@Override
+	public void handleEvent(SharingDropoffEvent event) {
+		if (this.sharingVehicles.contains(event.getSharingVehicleId())) {
+			vehicle2VehicleStatus.put(event.getSharingVehicleId(), SHARING_VEHICLE_STATES.IDLE);
+		}
+	}
+
+	@Override
+	public void handleEvent(SharingReservingEvent event) {
+		if (this.sharingVehicles.contains(event.getSharingVehicleId())) {
+			vehicle2VehicleStatus.put(event.getSharingVehicleId(), SHARING_VEHICLE_STATES.RESERVED);
+		}
+	}
+
+	@Override
+	public Map<Id<SharingVehicle>, SHARING_VEHICLE_STATES> getVehicleStatus() {
+		return vehicle2VehicleStatus;
+	}
+
+	@Override
+	public void notifyIterationStarts(IterationStartsEvent event) {
+		vehicle2VehicleStatus.clear();
+
+		// Initialize with idle state
+		sharingServiceSpecification.getVehicles().forEach(v -> {
+			vehicle2VehicleStatus.put(v.getId(), SHARING_VEHICLE_STATES.IDLE);
+			sharingVehicles.add(v.getId());
+		});
+	}
+}

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/run/SharingServiceModule.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/run/SharingServiceModule.java
@@ -5,6 +5,9 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.shared_mobility.analysis.SharingLegCollectorImpl;
+import org.matsim.contrib.shared_mobility.analysis.VehicleStateCollector;
+import org.matsim.contrib.shared_mobility.analysis.VehicleStateCollectorImpl;
 import org.matsim.contrib.shared_mobility.io.DefaultSharingServiceSpecification;
 import org.matsim.contrib.shared_mobility.io.SharingServiceReader;
 import org.matsim.contrib.shared_mobility.io.SharingServiceSpecification;
@@ -105,6 +108,15 @@ public class SharingServiceModule extends AbstractModalModule<SharingMode> {
 
 		addControlerListenerBinding().to(modalKey(ValidationListener.class));
 
+		bindModal(VehicleStateCollector.class).toProvider(modalProvider(getter -> {
+			SharingServiceSpecification specification = getter.getModal(SharingServiceSpecification.class);
+			return new VehicleStateCollectorImpl(specification);
+		})).in(Singleton.class);
+
+		addEventHandlerBinding().to(modalKey(VehicleStateCollector.class));
+		addControlerListenerBinding().to(modalKey(VehicleStateCollector.class));
+
+
 		// based on the underlying mode and how it is simulated
 		// teleported/network we need to bind different rental handler
 
@@ -124,16 +136,16 @@ public class SharingServiceModule extends AbstractModalModule<SharingMode> {
 		}
 
 		switch (serviceConfig.getServiceScheme()) {
-		case Freefloating:
-			bindModal(InteractionFinder.class).to(modalKey(FreefloatingInteractionFinder.class));
-			bindModal(SharingServiceValidator.class).to(modalKey(FreefloatingServiceValidator.class));
-			break;
-		case StationBased:
-			bindModal(InteractionFinder.class).to(modalKey(StationBasedInteractionFinder.class));
-			bindModal(SharingServiceValidator.class).to(modalKey(StationBasedServiceValidator.class));
-			break;
-		default:
-			throw new IllegalStateException();
+			case Freefloating:
+				bindModal(InteractionFinder.class).to(modalKey(FreefloatingInteractionFinder.class));
+				bindModal(SharingServiceValidator.class).to(modalKey(FreefloatingServiceValidator.class));
+				break;
+			case StationBased:
+				bindModal(InteractionFinder.class).to(modalKey(StationBasedInteractionFinder.class));
+				bindModal(SharingServiceValidator.class).to(modalKey(StationBasedServiceValidator.class));
+				break;
+			default:
+				throw new IllegalStateException();
 		}
 	}
 }

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/SharingUtils.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/SharingUtils.java
@@ -4,8 +4,8 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.population.Activity;
 import org.matsim.contrib.shared_mobility.run.SharingConfigGroup;
 import org.matsim.contrib.shared_mobility.run.SharingModes;
-import org.matsim.contrib.shared_mobility.run.SharingQSimServiceModule;
 import org.matsim.contrib.shared_mobility.run.SharingServiceConfigGroup;
+import org.matsim.contrib.shared_mobility.service.events.SharingReservingEvent;
 import org.matsim.contrib.shared_mobility.service.events.SharingDropoffEvent;
 import org.matsim.contrib.shared_mobility.service.events.SharingFailedDropoffEvent;
 import org.matsim.contrib.shared_mobility.service.events.SharingFailedPickupEvent;
@@ -27,6 +27,10 @@ public class SharingUtils {
 	static public final String MODE_PREFIX = "sharing_";
 
 	static public final double INTERACTION_DURATION = 60.0;
+
+	public enum SHARING_VEHICLE_STATES {
+		RESERVED, BOOKED, IDLE
+	};
 
 	static public void setStationId(Activity activity, Id<SharingStation> stationId) {
 		Verify.verify(activity.getType().equals(PICKUP_ACTIVITY) || activity.getType().equals(DROPOFF_ACTIVITY));
@@ -75,5 +79,6 @@ public class SharingUtils {
 		reader.addCustomEventMapper(SharingFailedPickupEvent.TYPE, SharingFailedPickupEvent::convert);
 		reader.addCustomEventMapper(SharingDropoffEvent.TYPE, SharingDropoffEvent::convert);
 		reader.addCustomEventMapper(SharingFailedDropoffEvent.TYPE, SharingFailedDropoffEvent::convert);
+		reader.addCustomEventMapper(SharingReservingEvent.TYPE, SharingReservingEvent::convert);
 	}
 }

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/events/AbstractSharingEvent.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/events/AbstractSharingEvent.java
@@ -17,13 +17,15 @@ public abstract class AbstractSharingEvent extends Event implements HasPersonId,
 	private final Id<SharingService> serviceId;
 
 	private final Id<Link> linkId;
+
 	private final Id<Person> personId;
 
 	protected final Optional<Id<SharingVehicle>> vehicleId;
 	protected final Optional<Id<SharingStation>> stationId;
+	protected final Optional<Id<Link>> destinationLinkId;
 
 	public AbstractSharingEvent(double time, Id<SharingService> serviceId, Id<Person> personId, Id<Link> linkId,
-			Optional<Id<SharingVehicle>> vehicleId, Optional<Id<SharingStation>> stationId) {
+			Optional<Id<SharingVehicle>> vehicleId, Optional<Id<SharingStation>> stationId, Optional<Id<Link>> destinationLinkId) {
 		super(time);
 
 		this.serviceId = serviceId;
@@ -32,6 +34,7 @@ public abstract class AbstractSharingEvent extends Event implements HasPersonId,
 
 		this.vehicleId = vehicleId;
 		this.stationId = stationId;
+		this.destinationLinkId = destinationLinkId;
 	}
 
 	public Map<String, String> getAttributes() {
@@ -39,6 +42,7 @@ public abstract class AbstractSharingEvent extends Event implements HasPersonId,
 		attributes.put("service", serviceId.toString());
 		attributes.put("link", linkId.toString());
 		attributes.put("person", personId.toString());
+		attributes.put("destinationLinkId",destinationLinkId.toString());
 
 		if (vehicleId.isPresent()) {
 			attributes.put("vehicle", vehicleId.get().toString());
@@ -46,6 +50,10 @@ public abstract class AbstractSharingEvent extends Event implements HasPersonId,
 
 		if (stationId.isPresent()) {
 			attributes.put("station", stationId.get().toString());
+		}
+
+		if (destinationLinkId.isPresent()) {
+			attributes.put("destinationLinkId", destinationLinkId.get().toString());
 		}
 
 		return attributes;
@@ -63,5 +71,12 @@ public abstract class AbstractSharingEvent extends Event implements HasPersonId,
 	
 	public Id<SharingService> getServiceId() {
 		return serviceId;
+	}
+	
+	public Id<SharingVehicle> getSharingVehicleId() {
+		return vehicleId.get();
+	}
+	public Id<Link> getDestinationLinkId() {
+		return destinationLinkId.get();
 	}
 }

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/events/SharingDropoffEvent.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/events/SharingDropoffEvent.java
@@ -12,16 +12,19 @@ import org.matsim.contrib.shared_mobility.service.SharingVehicle;
 
 public class SharingDropoffEvent extends AbstractSharingEvent {
 	static public final String TYPE = "sharing vehicle dropoff";
-
+	Id<SharingVehicle> sharingVehicleId;
+	
 	public SharingDropoffEvent(double time, Id<SharingService> serviceId, Id<Person> personId, Id<Link> linkId,
 			Id<SharingVehicle> vehicleId, Optional<Id<SharingStation>> stationId) {
-		super(time, serviceId, personId, linkId, Optional.of(vehicleId), stationId);
+		super(time, serviceId, personId, linkId, Optional.of(vehicleId), stationId, Optional.ofNullable(null));
+		this.sharingVehicleId = vehicleId;
 	}
 
 	@Override
 	public String getEventType() {
 		return TYPE;
 	}
+	
 
 	static public SharingDropoffEvent convert(GenericEvent event) {
 		return new SharingDropoffEvent(event.getTime(), //

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/events/SharingDropoffEvent.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/events/SharingDropoffEvent.java
@@ -16,7 +16,7 @@ public class SharingDropoffEvent extends AbstractSharingEvent {
 	
 	public SharingDropoffEvent(double time, Id<SharingService> serviceId, Id<Person> personId, Id<Link> linkId,
 			Id<SharingVehicle> vehicleId, Optional<Id<SharingStation>> stationId) {
-		super(time, serviceId, personId, linkId, Optional.of(vehicleId), stationId, Optional.ofNullable(null));
+		super(time, serviceId, personId, linkId, Optional.of(vehicleId), stationId, Optional.empty());
 		this.sharingVehicleId = vehicleId;
 	}
 

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/events/SharingFailedDropoffEvent.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/events/SharingFailedDropoffEvent.java
@@ -15,7 +15,7 @@ public class SharingFailedDropoffEvent extends AbstractSharingEvent {
 
 	public SharingFailedDropoffEvent(double time, Id<SharingService> serviceId, Id<Person> personId, Id<Link> linkId,
 			Id<SharingVehicle> vehicleId, Optional<Id<SharingStation>> stationId) {
-		super(time, serviceId, personId, linkId, Optional.of(vehicleId), stationId);
+		super(time, serviceId, personId, linkId, Optional.of(vehicleId), stationId, Optional.ofNullable(null));
 	}
 
 	@Override

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/events/SharingFailedDropoffEvent.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/events/SharingFailedDropoffEvent.java
@@ -15,7 +15,7 @@ public class SharingFailedDropoffEvent extends AbstractSharingEvent {
 
 	public SharingFailedDropoffEvent(double time, Id<SharingService> serviceId, Id<Person> personId, Id<Link> linkId,
 			Id<SharingVehicle> vehicleId, Optional<Id<SharingStation>> stationId) {
-		super(time, serviceId, personId, linkId, Optional.of(vehicleId), stationId, Optional.ofNullable(null));
+		super(time, serviceId, personId, linkId, Optional.of(vehicleId), stationId, Optional.empty());
 	}
 
 	@Override

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/events/SharingFailedPickupEvent.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/events/SharingFailedPickupEvent.java
@@ -14,7 +14,7 @@ public class SharingFailedPickupEvent extends AbstractSharingEvent {
 
 	public SharingFailedPickupEvent(double time, Id<SharingService> serviceId, Id<Person> personId, Id<Link> linkId,
 			Optional<Id<SharingStation>> stationId) {
-		super(time, serviceId, personId, linkId, Optional.empty(), stationId, Optional.ofNullable(null));
+		super(time, serviceId, personId, linkId, Optional.empty(), stationId, Optional.empty());
 	}
 
 	@Override

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/events/SharingFailedPickupEvent.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/events/SharingFailedPickupEvent.java
@@ -14,7 +14,7 @@ public class SharingFailedPickupEvent extends AbstractSharingEvent {
 
 	public SharingFailedPickupEvent(double time, Id<SharingService> serviceId, Id<Person> personId, Id<Link> linkId,
 			Optional<Id<SharingStation>> stationId) {
-		super(time, serviceId, personId, linkId, Optional.empty(), stationId);
+		super(time, serviceId, personId, linkId, Optional.empty(), stationId, Optional.ofNullable(null));
 	}
 
 	@Override

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/events/SharingPickupEvent.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/events/SharingPickupEvent.java
@@ -16,12 +16,8 @@ public class SharingPickupEvent extends AbstractSharingEvent {
 
 	public SharingPickupEvent(double time, Id<SharingService> serviceId, Id<Person> personId, Id<Link> linkId,
 			Id<SharingVehicle> vehicleId, Optional<Id<SharingStation>> stationId) {
-		super(time, serviceId, personId, linkId, Optional.of(vehicleId), stationId);
+		super(time, serviceId, personId, linkId, Optional.of(vehicleId), stationId, Optional.ofNullable(null));
 		this.sharingVehicleId = vehicleId;
-	}
-
-	public Id<SharingVehicle> getSharingVehicleId() {
-		return sharingVehicleId;
 	}
 
 	@Override

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/events/SharingPickupEvent.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/events/SharingPickupEvent.java
@@ -16,7 +16,7 @@ public class SharingPickupEvent extends AbstractSharingEvent {
 
 	public SharingPickupEvent(double time, Id<SharingService> serviceId, Id<Person> personId, Id<Link> linkId,
 			Id<SharingVehicle> vehicleId, Optional<Id<SharingStation>> stationId) {
-		super(time, serviceId, personId, linkId, Optional.of(vehicleId), stationId, Optional.ofNullable(null));
+		super(time, serviceId, personId, linkId, Optional.of(vehicleId), stationId, Optional.empty());
 		this.sharingVehicleId = vehicleId;
 	}
 

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/events/SharingReservingEvent.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/events/SharingReservingEvent.java
@@ -1,0 +1,42 @@
+package org.matsim.contrib.shared_mobility.service.events;
+
+import java.util.Optional;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.events.GenericEvent;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contrib.shared_mobility.service.SharingService;
+import org.matsim.contrib.shared_mobility.service.SharingStation;
+import org.matsim.contrib.shared_mobility.service.SharingVehicle;
+
+public class SharingReservingEvent extends AbstractSharingEvent {
+	static public final String TYPE = "sharing vehicle reserving";
+
+	public SharingReservingEvent(double time, Id<SharingService> serviceId, Id<Person> personId, Id<Link> linkId,
+			Id<SharingVehicle> vehicleId, Optional<Id<SharingStation>> stationId, Id<Link> destinationLinkId) {
+		super(time, serviceId, personId, linkId, Optional.of(vehicleId), stationId, Optional.of(destinationLinkId));
+
+	}
+
+	@Override
+	public String getEventType() {
+		return TYPE;
+	}
+
+	static public SharingReservingEvent convert(GenericEvent event) {
+		return new SharingReservingEvent(event.getTime(), //
+				Id.create(event.getAttributes().get("service"), SharingService.class), //
+				Id.createPersonId(event.getAttributes().get("person")), //
+				Id.createLinkId(event.getAttributes().get("link")), //
+				Id.create(event.getAttributes().get("vehicle"), SharingVehicle.class), //
+				Optional.ofNullable(event.getAttributes().get("station"))
+						.map(id -> Id.create(id, SharingStation.class)), //
+				Id.createLinkId(event.getAttributes().get("destinationLinkId")));
+	}
+
+	public Id<Link> getOriginLinkId() {
+		return this.getLinkId();
+	}
+
+}

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/events/SharingReservingEventHandler.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/events/SharingReservingEventHandler.java
@@ -1,0 +1,7 @@
+package org.matsim.contrib.shared_mobility.service.events;
+
+import org.matsim.core.events.handler.EventHandler;
+
+public interface SharingReservingEventHandler extends EventHandler {
+	void handleEvent(SharingReservingEvent event);
+}


### PR DESCRIPTION
Similar to DRT, this PR adds time profiles for vehicle states. The states of shared vehicles are idle, reserved and booked. 
![grafik](https://user-images.githubusercontent.com/26229392/161609585-e2e2baba-71a0-4409-9a42-065a49b1ad4d.png)
