### PR TITLE
Add QSimComponentsConfigurator to SBBTransitEngineQSimModule

### DIFF
--- a/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/RunSBBExtension.java
+++ b/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/RunSBBExtension.java
@@ -38,7 +38,7 @@ public class RunSBBExtension {
 
         // To use the deterministic pt simulation (Part 2 of 2):
         controler.configureQSimComponents(components -> {
-            SBBTransitEngineQSimModule.configure(components);
+            new SBBTransitEngineQSimModule().configure(components);
 
             // if you have other extensions that provide QSim components, call their configure-method here
         });

--- a/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitEngineQSimModule.java
+++ b/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitEngineQSimModule.java
@@ -2,16 +2,18 @@ package ch.sbb.matsim.mobsim.qsim.pt;
 
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
 import org.matsim.core.mobsim.qsim.components.QSimComponentsConfig;
+import org.matsim.core.mobsim.qsim.components.QSimComponentsConfigurator;
 import org.matsim.core.mobsim.qsim.pt.TransitEngineModule;
 
 /**
  * @author Sebastian Hörl / ETHZ
  */
-public class SBBTransitEngineQSimModule extends AbstractQSimModule {
+public class SBBTransitEngineQSimModule extends AbstractQSimModule implements QSimComponentsConfigurator {
 
     public static final String COMPONENT_NAME = "SBBTransit";
 
-    static public void configure(QSimComponentsConfig components) {
+    @Override
+    public void configure(QSimComponentsConfig components) {
         if (components.hasNamedComponent(TransitEngineModule.TRANSIT_ENGINE_NAME)) {
             components.removeNamedComponent(TransitEngineModule.TRANSIT_ENGINE_NAME);
         }

--- a/contribs/sbb-extensions/src/test/java/ch/sbb/matsim/mobsim/qsim/SBBQSimModuleTest.java
+++ b/contribs/sbb-extensions/src/test/java/ch/sbb/matsim/mobsim/qsim/SBBQSimModuleTest.java
@@ -71,7 +71,7 @@ public class SBBQSimModuleTest {
             QSimComponentsConfig provideQSimComponentsConfig() {
                 QSimComponentsConfig components = new QSimComponentsConfig();
                 new StandardQSimComponentConfigurator(config).configure(components);
-                SBBTransitEngineQSimModule.configure(components);
+                new SBBTransitEngineQSimModule().configure(components);
                 return components;
             }
         });

--- a/contribs/sbb-extensions/src/test/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitQSimEngineIntegrationTest.java
+++ b/contribs/sbb-extensions/src/test/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitQSimEngineIntegrationTest.java
@@ -36,7 +36,7 @@ public class SBBTransitQSimEngineIntegrationTest {
         Controler controler = new Controler(f.scenario);
         controler.addOverridingModule(new SBBTransitModule());
         controler.configureQSimComponents(components -> {
-            SBBTransitEngineQSimModule.configure(components);
+            new SBBTransitEngineQSimModule();
         });
 
         controler.run();
@@ -65,7 +65,7 @@ public class SBBTransitQSimEngineIntegrationTest {
         Controler controler = new Controler(f.scenario);
         controler.addOverridingModule(new SBBTransitModule());
         controler.configureQSimComponents(components -> {
-            SBBTransitEngineQSimModule.configure(components);
+            new SBBTransitEngineQSimModule();
         });
 
         try {

--- a/contribs/sbb-extensions/src/test/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitQSimEngineIntegrationTest.java
+++ b/contribs/sbb-extensions/src/test/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitQSimEngineIntegrationTest.java
@@ -36,7 +36,7 @@ public class SBBTransitQSimEngineIntegrationTest {
         Controler controler = new Controler(f.scenario);
         controler.addOverridingModule(new SBBTransitModule());
         controler.configureQSimComponents(components -> {
-            new SBBTransitEngineQSimModule();
+            new SBBTransitEngineQSimModule().configure(components);
         });
 
         controler.run();
@@ -65,7 +65,7 @@ public class SBBTransitQSimEngineIntegrationTest {
         Controler controler = new Controler(f.scenario);
         controler.addOverridingModule(new SBBTransitModule());
         controler.configureQSimComponents(components -> {
-            new SBBTransitEngineQSimModule();
+            new SBBTransitEngineQSimModule().configure(components);
         });
 
         try {

--- a/contribs/sbb-extensions/src/test/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitQSimEngineTest.java
+++ b/contribs/sbb-extensions/src/test/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitQSimEngineTest.java
@@ -108,7 +108,7 @@ public class SBBTransitQSimEngineTest {
                 .addQSimModule(new ActivityEngineModule())
                 .addQSimModule(new SBBTransitEngineQSimModule())
                 .addQSimModule(new TestQSimModule(f.config))
-                .configureQSimComponents(SBBTransitEngineQSimModule::configure)
+                .configureQSimComponents(new SBBTransitEngineQSimModule())
                 .configureQSimComponents(configurator -> {
                     configurator.addNamedComponent(ActivityEngineModule.COMPONENT_NAME);
                 })
@@ -155,7 +155,7 @@ public class SBBTransitQSimEngineTest {
                 .addQSimModule(new SBBTransitEngineQSimModule())
                 .addQSimModule(new TestQSimModule(f.config))
                 .addQSimModule(new PopulationModule())
-                .configureQSimComponents(SBBTransitEngineQSimModule::configure)
+                .configureQSimComponents(new SBBTransitEngineQSimModule())
                 .configureQSimComponents(configurator -> {
                     configurator.addNamedComponent(ActivityEngineModule.COMPONENT_NAME);
                     configurator.addNamedComponent(PopulationModule.COMPONENT_NAME);
@@ -207,7 +207,7 @@ public class SBBTransitQSimEngineTest {
                 .addQSimModule(new SBBTransitEngineQSimModule())
                 .addQSimModule(new TestQSimModule(f.config))
                 .addQSimModule(new PopulationModule())
-                .configureQSimComponents(SBBTransitEngineQSimModule::configure)
+                .configureQSimComponents(new SBBTransitEngineQSimModule())
                 .configureQSimComponents(configurator -> {
                     configurator.addNamedComponent(ActivityEngineModule.COMPONENT_NAME);
                     configurator.addNamedComponent(PopulationModule.COMPONENT_NAME);
@@ -272,7 +272,7 @@ public class SBBTransitQSimEngineTest {
                 .addQSimModule(new ActivityEngineModule())
                 .addQSimModule(new SBBTransitEngineQSimModule())
                 .addQSimModule(new TestQSimModule(f.config))
-                .configureQSimComponents(SBBTransitEngineQSimModule::configure)
+                .configureQSimComponents(new SBBTransitEngineQSimModule())
                 .configureQSimComponents(configurator -> {
                     configurator.addNamedComponent(ActivityEngineModule.COMPONENT_NAME);
                 })
@@ -327,7 +327,7 @@ public class SBBTransitQSimEngineTest {
                 .configureQSimComponents(configurator -> {
                     configurator.addNamedComponent(ActivityEngineModule.COMPONENT_NAME);
                 })
-                .configureQSimComponents(SBBTransitEngineQSimModule::configure)
+                .configureQSimComponents(new SBBTransitEngineQSimModule())
                 .build(f.scenario, eventsManager);
 
         EventsCollector collector = new EventsCollector();
@@ -371,7 +371,7 @@ public class SBBTransitQSimEngineTest {
                 .addQSimModule(new ActivityEngineModule())
                 .addQSimModule(new SBBTransitEngineQSimModule())
                 .addQSimModule(new TestQSimModule(f.config))
-                .configureQSimComponents(SBBTransitEngineQSimModule::configure)
+                .configureQSimComponents(new SBBTransitEngineQSimModule())
                 .configureQSimComponents(configurator -> {
                     configurator.addNamedComponent(ActivityEngineModule.COMPONENT_NAME);
                 })
@@ -417,7 +417,7 @@ public class SBBTransitQSimEngineTest {
                 .addQSimModule(new ActivityEngineModule())
                 .addQSimModule(new SBBTransitEngineQSimModule())
                 .addQSimModule(new TestQSimModule(f.config))
-                .configureQSimComponents(SBBTransitEngineQSimModule::configure)
+                .configureQSimComponents(new SBBTransitEngineQSimModule())
                 .configureQSimComponents(configurator -> {
                     configurator.addNamedComponent(ActivityEngineModule.COMPONENT_NAME);
                 })
@@ -475,7 +475,7 @@ public class SBBTransitQSimEngineTest {
                 .configureQSimComponents(configurator -> {
                     configurator.addNamedComponent(ActivityEngineModule.COMPONENT_NAME);
                 })
-                .configureQSimComponents(SBBTransitEngineQSimModule::configure)
+                .configureQSimComponents(new SBBTransitEngineQSimModule())
                 .build(f.scenario, eventsManager);
 
         EventsCollector collector = new EventsCollector();
@@ -524,7 +524,7 @@ public class SBBTransitQSimEngineTest {
                 .addQSimModule(new ActivityEngineModule())
                 .addQSimModule(new SBBTransitEngineQSimModule())
                 .addQSimModule(new TestQSimModule(f.config))
-                .configureQSimComponents(SBBTransitEngineQSimModule::configure)
+                .configureQSimComponents(new SBBTransitEngineQSimModule())
                 .configureQSimComponents(configurator -> {
                     configurator.addNamedComponent(ActivityEngineModule.COMPONENT_NAME);
                 })
@@ -551,7 +551,7 @@ public class SBBTransitQSimEngineTest {
                 .addQSimModule(new ActivityEngineModule())
                 .addQSimModule(new SBBTransitEngineQSimModule())
                 .addQSimModule(testModule)
-                .configureQSimComponents(SBBTransitEngineQSimModule::configure)
+                .configureQSimComponents(new SBBTransitEngineQSimModule())
                 .configureQSimComponents(configurator -> {
                     configurator.addNamedComponent(ActivityEngineModule.COMPONENT_NAME);
                 });


### PR DESCRIPTION
Changed the SBBTransitEngineQSimModule in order to implements QSimComponentsConfigurator. SBBTransitEngineQSimModule has been used till now as an QSimComponentsConfigurator but never implemeted the specified interface correctly.