### PR TITLE
Post-process option MATSim Application

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/MATSimAppCommand.java
+++ b/contribs/application/src/main/java/org/matsim/application/MATSimAppCommand.java
@@ -46,4 +46,18 @@ public interface MATSimAppCommand extends Callable<Integer> {
 
 		}
 	}
+
+	/**
+	 * Apply the given command line arguments to this instance and return it.
+	 */
+	default MATSimAppCommand withArgs(String... args) {
+		CommandLine cli = new CommandLine(this);
+		CommandLine.ParseResult parseResult = cli.parseArgs(args);
+
+		if (!parseResult.errors().isEmpty())
+			throw new IllegalStateException("Error parsing arguments", parseResult.errors().get(0));
+
+		return cli.getCommand();
+	}
+
 }

--- a/contribs/application/src/test/java/org/matsim/application/TestCommand.java
+++ b/contribs/application/src/test/java/org/matsim/application/TestCommand.java
@@ -1,0 +1,27 @@
+package org.matsim.application;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Test command that writes content to file.
+ */
+public class TestCommand implements MATSimAppCommand {
+
+	private final Path out;
+	private final String content;
+
+	public TestCommand(Path out, String content) {
+		this.out = out;
+		this.content = content;
+	}
+
+
+	@Override
+	public Integer call() throws Exception {
+
+		Files.writeString(out, content);
+
+		return 0;
+	}
+}


### PR DESCRIPTION
This PR adds the possibility to overwrite a `preparePostProcessing` method in a `MATSimApplication`.
This method may return a list of `MATSimAppCommand` instances that will be run automatically after the simulation has finished.