### PR TITLE
Update Array based travel time data

### DIFF
--- a/matsim/src/main/java/org/matsim/core/trafficmonitoring/TravelTimeDataArray.java
+++ b/matsim/src/main/java/org/matsim/core/trafficmonitoring/TravelTimeDataArray.java
@@ -58,10 +58,12 @@ class TravelTimeDataArray extends TravelTimeData {
 	 */
 	private final long[] data;
 	private final Link link;
+	private final double timeStepSize;
 
-	TravelTimeDataArray(final Link link, final int numSlots) {
+	TravelTimeDataArray(final Link link, final int numSlots, double qsimTimeStepSize) {
 		this.data = new long[numSlots];
 		this.link = link;
+		this.timeStepSize = qsimTimeStepSize;
 		resetTravelTimes();
 	}
 
@@ -111,10 +113,11 @@ class TravelTimeDataArray extends TravelTimeData {
 		double ttime = traveltime(val);
 		if (ttime >= 0.0) return ttime; // negative values are invalid.
 
-		// ttime can only be <0 if it never accumulated anything, i.e. if cnt == 9, so just use freespeed
-		double freespeed = this.link.getLength() / this.link.getFreespeed(now);
-		this.data[timeSlot] = encode(0, freespeed);
-		return freespeed;
+		// ttime can only be <0 if it never accumulated anything, i.e. if cnt == 9, so just use freeSpeedTravelTime
+		double freeSpeedTravelTime = this.link.getLength() / this.link.getFreespeed(now);
+		freeSpeedTravelTime = (Math.floor(freeSpeedTravelTime / timeStepSize) + 1) * timeStepSize;
+		this.data[timeSlot] = encode(0, freeSpeedTravelTime);
+		return freeSpeedTravelTime;
 	}
 
 	/* package-private for debugging */ String cntToString(){

--- a/matsim/src/main/java/org/matsim/core/trafficmonitoring/TravelTimeDataArrayFactory.java
+++ b/matsim/src/main/java/org/matsim/core/trafficmonitoring/TravelTimeDataArrayFactory.java
@@ -23,20 +23,29 @@ package org.matsim.core.trafficmonitoring;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
+import org.matsim.core.config.groups.QSimConfigGroup;
 
 class TravelTimeDataArrayFactory implements TravelTimeDataFactory {
 
 	private final Network network;
 	private final int numSlots;
+	private final double qSimTimeStepSize;
 	
 	public TravelTimeDataArrayFactory(final Network network, final int numSlots) {
 		this.network = network;
 		this.numSlots = numSlots;
+		this.qSimTimeStepSize = 1.0;
+	}
+
+	public TravelTimeDataArrayFactory(final Network network, final int numSlots, QSimConfigGroup qSimConfigGroup) {
+		this.network = network;
+		this.numSlots = numSlots;
+		this.qSimTimeStepSize = qSimConfigGroup.getTimeStepSize();
 	}
 	
 	@Override
 	public TravelTimeData createTravelTimeData(Id<Link> linkId) {
-		return new TravelTimeDataArray(this.network.getLinks().get(linkId), this.numSlots);
+		return new TravelTimeDataArray(this.network.getLinks().get(linkId), this.numSlots, qSimTimeStepSize);
 	}
 
 }

--- a/matsim/src/test/java/org/matsim/core/trafficmonitoring/TravelTimeDataArrayTest.java
+++ b/matsim/src/test/java/org/matsim/core/trafficmonitoring/TravelTimeDataArrayTest.java
@@ -21,7 +21,7 @@ public class TravelTimeDataArrayTest{
 		Node to = NetworkUtils.createNode( Id.createNodeId( "2" ) );
 		Link link = NetworkUtils.createLink( Id.createLinkId( "1-2" ), from, to, network, 10, 10, 10, 1 );
 		final int numSlots = 24;
-		TravelTimeDataArray abc = new TravelTimeDataArray( link, numSlots );
+		TravelTimeDataArray abc = new TravelTimeDataArray( link, numSlots, 1.0 );
 		log.info( abc.ttToString() );
 		log.info( abc.cntToString() );
 		abc.resetTravelTimes();


### PR DESCRIPTION
As mentioned in the issue #1933, the travel time observer does not return the correct value for the travel time for the unused links. This difference is due to the discrete QSim time step (see QSimFreeSpeedTravelTime vs FreeSpeedTravelTime). This fix incorporate the QSim config in the Travel Time data construction, such that the travel time for the unused link can be calculated more accurately.

In the future, we should also consider fixing the map based travel time data. 