### PR TITLE
Less restrictive option for subtour mode-choice

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/analysis/population/SubTourAnalysis.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/population/SubTourAnalysis.java
@@ -1,0 +1,63 @@
+package org.matsim.application.analysis.population;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Plan;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.application.MATSimAppCommand;
+import org.matsim.application.analysis.DefaultAnalysisMainModeIdentifier;
+import org.matsim.core.population.PopulationUtils;
+import org.matsim.core.population.algorithms.ChooseRandomLegModeForSubtour;
+import org.matsim.core.replanning.modules.SubtourModeChoice;
+import org.matsim.core.router.TripStructureUtils;
+import picocli.CommandLine;
+
+import java.nio.file.Path;
+import java.util.*;
+
+@CommandLine.Command(
+		name = "subtours",
+		description = "Analyze subtours of a population."
+)
+public class SubTourAnalysis implements MATSimAppCommand {
+
+	private static final Logger log = LogManager.getLogger(SubTourAnalysis.class);
+
+	@CommandLine.Parameters(arity = "1", description = "Path to population")
+	private Path input;
+
+	@CommandLine.Option(names = "--chain-modes", description = "Chain-based modes", defaultValue = "car,bike", split = ",")
+	private List<String> chainBasedModes;
+
+	@Override
+	public Integer call() throws Exception {
+
+		Population population = PopulationUtils.readPopulation(input.toString());
+
+		List<TripStructureUtils.Subtour> subtours = new ArrayList<>();
+
+		Set<String> modes = new HashSet<>();
+
+		for (Person agent : population.getPersons().values()) {
+			Plan plan = agent.getSelectedPlan();
+
+			List<Leg> legs = TripStructureUtils.getLegs(plan);
+
+			for (Leg leg : legs) {
+				modes.add(leg.getMode());
+			}
+
+			subtours.addAll(TripStructureUtils.getSubtours(plan));
+		}
+
+		log.info("Detected modes: {}", modes);
+
+		ChooseRandomLegModeForSubtour strategy = new ChooseRandomLegModeForSubtour(new DefaultAnalysisMainModeIdentifier(), plan -> modes,
+				modes.toArray(new String[0]), chainBasedModes.toArray(new String[0]), new Random(1234), SubtourModeChoice.Behavior.fromAllModesToSpecifiedModes, 0.0);
+
+
+		return 0;
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/preplanned/optimizer/PreplannedDrtOptimizer.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/preplanned/optimizer/PreplannedDrtOptimizer.java
@@ -75,16 +75,16 @@ public class PreplannedDrtOptimizer implements DrtOptimizer {
 	public PreplannedDrtOptimizer(DrtConfigGroup drtCfg, PreplannedSchedules preplannedSchedules, Network network,
 			TravelTime travelTime, TravelDisutility travelDisutility, MobsimTimer timer, DrtTaskFactory taskFactory,
 			EventsManager eventsManager, Fleet fleet) {
+		Preconditions.checkArgument(
+				fleet.getVehicles().keySet().equals(preplannedSchedules.vehicleToPreplannedStops.keySet()),
+				"Some schedules are preplanned for vehicles outside the fleet");
+
 		this.preplannedSchedules = preplannedSchedules;
 		this.network = network;
 		this.travelTime = travelTime;
 		this.timer = timer;
 		this.taskFactory = taskFactory;
 		this.eventsManager = eventsManager;
-
-		Preconditions.checkArgument(
-				fleet.getVehicles().keySet().equals(preplannedSchedules.vehicleToPreplannedStops.keySet()),
-				"Some schedules are preplanned for vehicles outside the fleet");
 
 		router = new SpeedyALTFactory().createPathCalculator(network, travelDisutility, travelTime);
 		stopDuration = drtCfg.getStopDuration();
@@ -153,9 +153,12 @@ public class PreplannedDrtOptimizer implements DrtOptimizer {
 			VrpPathWithTravelData path = VrpPaths.calcAndCreatePath(currentLink, nextLink, currentTime, router,
 					travelTime);
 			schedule.addTask(taskFactory.createDriveTask(vehicle, path, DrtDriveTask.TYPE));
-		} else if (nextStop.preplannedRequest.earliestStartTime > timer.getTimeOfDay()) {
+		} else if (nextStop.preplannedRequest.earliestStartTime >= timer.getTimeOfDay()) {
+			// we need to wait 1 time step to make sure we have already received the request submission event
+			// otherwise we may not be able to get the request and insert it to the stop task
+			// TODO currently assuming the mobsim time step is 1 s
 			schedule.addTask(
-					taskFactory.createStayTask(vehicle, currentTime, nextStop.preplannedRequest.earliestStartTime,
+					taskFactory.createStayTask(vehicle, currentTime, nextStop.preplannedRequest.earliestStartTime + 1,
 							currentLink));
 		} else {
 			nonVisitedPreplannedStops.poll();//remove this stop from queue
@@ -225,18 +228,14 @@ public class PreplannedDrtOptimizer implements DrtOptimizer {
 			if (!(o instanceof PreplannedRequest))
 				return false;
 			PreplannedRequest that = (PreplannedRequest)o;
-			return Double.compare(that.earliestStartTime, earliestStartTime) == 0
-					&& Double.compare(that.latestStartTime, latestStartTime) == 0
-					&& Double.compare(that.latestArrivalTime, latestArrivalTime) == 0
-					&& Objects.equal(passengerId, that.passengerId)
+			return Objects.equal(passengerId, that.passengerId)
 					&& Objects.equal(fromLinkId, that.fromLinkId)
 					&& Objects.equal(toLinkId, that.toLinkId);
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hashCode(passengerId, earliestStartTime, latestStartTime, latestArrivalTime, fromLinkId,
-					toLinkId);
+			return Objects.hashCode(passengerId, fromLinkId, toLinkId);
 		}
 
 		@Override

--- a/matsim/src/main/java/org/matsim/core/config/groups/SubtourModeChoiceConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/SubtourModeChoiceConfigGroup.java
@@ -36,6 +36,8 @@ public final class SubtourModeChoiceConfigGroup extends ReflectiveConfigGroup {
 	public final static String MODES = "modes";
 	public final static String CHAINBASEDMODES = "chainBasedModes";
 	public final static String CARAVAIL = "considerCarAvailability";
+	public final static String SINGLE_PROBA = "probaForRandomSingleTripMode";
+
 	private static final String BEHAVIOR = "behavior";
 	
 	private String[] chainBasedModes = new String[] { TransportMode.car, TransportMode.bike };
@@ -100,6 +102,7 @@ public final class SubtourModeChoiceConfigGroup extends ReflectiveConfigGroup {
 		comments.put(MODES, "Defines all the modes available, including chain-based modes, seperated by commas" );
 		comments.put(CHAINBASEDMODES, "Defines the chain-based modes, seperated by commas" );
 		comments.put(CARAVAIL, "Defines whether car availability must be considered or not. A agent has no car only if it has no license, or never access to a car" );
+		comments.put(SINGLE_PROBA, "Defines the probability of changing a single trip for a unchained mode instead of subtour.");
 		{
 			StringBuilder msg = new StringBuilder("Only for backwards compatibility.  Defines if only trips from modes list should change mode, or all trips.  Options: ");
 			for ( SubtourModeChoice.Behavior behavior : SubtourModeChoice.Behavior.values() ) {
@@ -146,10 +149,13 @@ public final class SubtourModeChoiceConfigGroup extends ReflectiveConfigGroup {
 	public final SubtourModeChoice.Behavior getBehavior() {
 		return this.behavior ;
 	}
-	
+
+	@StringGetter(SINGLE_PROBA)
 	public double getProbaForRandomSingleTripMode() {
 		return this.probaForRandomSingleTripMode;
 	}
+
+	@StringSetter(SINGLE_PROBA)
 	public void setProbaForRandomSingleTripMode(double probaForRandomSingleTripMode) {
 		this.probaForRandomSingleTripMode = probaForRandomSingleTripMode;
 	}

--- a/matsim/src/main/java/org/matsim/core/population/algorithms/ChooseRandomLegModeForSubtour.java
+++ b/matsim/src/main/java/org/matsim/core/population/algorithms/ChooseRandomLegModeForSubtour.java
@@ -20,14 +20,8 @@
 
 package org.matsim.core.population.algorithms;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
+
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.BasicLocation;
 import org.matsim.api.core.v01.Id;
@@ -54,7 +48,7 @@ public final class ChooseRandomLegModeForSubtour implements PlanAlgorithm {
 	private static final  Logger logger = Logger.getLogger(ChooseRandomLegModeForSubtour.class);
 
 	/**
-	 * Candidate to change mode-choice
+	 * Candidate to change mode-choice,
 	 */
 	public static class Candidate {
 		final Subtour subtour;
@@ -65,6 +59,19 @@ public final class ChooseRandomLegModeForSubtour implements PlanAlgorithm {
 				final String newTransportMode) {
 			this.subtour = subtour;
 			this.newTransportMode = newTransportMode;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			Candidate candidate = (Candidate) o;
+			return subtour.equals(candidate.subtour) && newTransportMode.equals(candidate.newTransportMode);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(subtour, newTransportMode);
 		}
 	}
 
@@ -147,7 +154,7 @@ public final class ChooseRandomLegModeForSubtour implements PlanAlgorithm {
 	}
 
 	/**
-	 * Return whether a subtour is mass conservating according to configuration.
+	 * Return whether a subtour is mass conserving according to configuration.
 	 */
 	public boolean isMassConserving(final Subtour subtour) {
 		for (String mode : chainBasedModes) {

--- a/matsim/src/main/java/org/matsim/core/replanning/modules/SubtourModeChoice.java
+++ b/matsim/src/main/java/org/matsim/core/replanning/modules/SubtourModeChoice.java
@@ -50,7 +50,7 @@ public class SubtourModeChoice extends AbstractMultithreadedModule {
 
 	private final double probaForChangeSingleTripMode;
 
-	public enum Behavior {fromAllModesToSpecifiedModes, fromSpecifiedModesToSpecifiedModes}
+	public enum Behavior {fromAllModesToSpecifiedModes, fromSpecifiedModesToSpecifiedModes, betweenAllLessConstraints}
 
 	private Behavior behavior = Behavior.fromSpecifiedModesToSpecifiedModes;
 


### PR DESCRIPTION
Adds a behavior option to subtour mode-choice called `betweenAllLessConstraints`.

With this option, non-closed subtour are also considered as mass-conserving if they span the whole day.
Agents will also always able to freely changes to one mode for the whole day. 
There is also a new analysis class printing some statistic about the subtours to identify if agents don't have a choice set.
