### PR TITLE
Modify preplannedDrtControlerCreator

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/preplanned/run/PreplannedDrtControlerCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/preplanned/run/PreplannedDrtControlerCreator.java
@@ -79,6 +79,7 @@ public final class PreplannedDrtControlerCreator {
 				log.warn("The rebalancing parameter set is defined for drt mode: "
 						+ drtConfigGroup.getMode()
 						+ ". It will be ignored. No rebalancing will happen.");
+				drtConfigGroup.removeParameterSet(drtConfigGroup.getRebalancingParams().get());
 				controler.addOverridingQSimModule(new AbstractDvrpModeQSimModule(drtConfigGroup.getMode()) {
 					@Override
 					protected void configureQSim() {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/preplanned/run/PreplannedDrtControlerCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/preplanned/run/PreplannedDrtControlerCreator.java
@@ -79,11 +79,10 @@ public final class PreplannedDrtControlerCreator {
 				log.warn("The rebalancing parameter set is defined for drt mode: "
 						+ drtConfigGroup.getMode()
 						+ ". It will be ignored. No rebalancing will happen.");
-				drtConfigGroup.removeParameterSet(drtConfigGroup.getRebalancingParams().get());
 				controler.addOverridingQSimModule(new AbstractDvrpModeQSimModule(drtConfigGroup.getMode()) {
 					@Override
 					protected void configureQSim() {
-						bindModal(RebalancingStrategy.class).to(NoRebalancingStrategy.class).asEagerSingleton();
+						bindModal(RebalancingStrategy.class).to(NoRebalancingStrategy.class).asEagerSingleton();  //TODO if we reach here, the run will fail (at line 93, PreplannedDrtModeModule)
 					}
 				});
 			}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/preplanned/run/RunPreplannedDrtExample.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/preplanned/run/RunPreplannedDrtExample.java
@@ -25,6 +25,7 @@ import static org.matsim.contrib.drt.extension.preplanned.optimizer.PreplannedDr
 import java.net.URL;
 import java.util.Map;
 
+import org.apache.log4j.Logger;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
@@ -39,11 +40,22 @@ import org.matsim.vis.otfvis.OTFVisConfigGroup;
  * @author michal.mac
  */
 public class RunPreplannedDrtExample {
+	private static final Logger log = Logger.getLogger(RunPreplannedDrtExample.class);
+
 	public static void run(URL configUrl, boolean otfvis, int lastIteration,
 			Map<String, PreplannedSchedules> preplannedSchedulesByMode) {
 		Config config = ConfigUtils.loadConfig(configUrl, new MultiModeDrtConfigGroup(), new DvrpConfigGroup(),
 				new OTFVisConfigGroup());
 		config.controler().setLastIteration(lastIteration);
+		MultiModeDrtConfigGroup multiModeDrtConfigGroup = MultiModeDrtConfigGroup.get(config);
+		for (DrtConfigGroup drtCfg : multiModeDrtConfigGroup.getModalElements()) {
+			if (drtCfg.getRebalancingParams().isPresent()) {
+				log.warn("The rebalancing parameter set is defined for drt mode: "
+						+ drtCfg.getMode()
+						+ ". It will be ignored. No rebalancing will happen.");
+				drtCfg.removeParameterSet(drtCfg.getRebalancingParams().get());
+			}
+		}
 
 		Controler controler = PreplannedDrtControlerCreator.createControler(config, otfvis);
 


### PR DESCRIPTION
Remove the rebalancing parameter set when preplanned drt controler is created. This is needed because there is a check later. It will fail if the rebalancing parameter is still there (even if we have bound it to the NoRebalancingStrategy)

Alternatively, we can modify the pre-condition check. We will also accept "NoRebalancingStrategy" in the line 93 at PreplannedDrtModeModule. But I dont know how to do that.
https://github.com/matsim-org/matsim-libs/blob/6659f0bb01b46eba88b2d0d7c24d4d055ba53c4b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/preplanned/run/PreplannedDrtModeModule.java#L93