### PR TITLE
Add comfort methods to get Coord from Activity

### DIFF
--- a/matsim/src/main/java/org/matsim/analysis/TripsAndLegsCSVWriter.java
+++ b/matsim/src/main/java/org/matsim/analysis/TripsAndLegsCSVWriter.java
@@ -32,6 +32,7 @@ import org.matsim.api.core.v01.IdMap;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.*;
+import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.router.AnalysisMainModeIdentifier;
 import org.matsim.core.router.RoutingModeMainModeIdentifier;
 import org.matsim.core.router.TripStructureUtils;
@@ -149,8 +150,8 @@ public class TripsAndLegsCSVWriter {
             Id<ActivityFacility> toFacilityId = trip.getDestinationActivity().getFacilityId();
             Id<Link> fromLinkId = trip.getOriginActivity().getLinkId();
             Id<Link> toLinkId = trip.getDestinationActivity().getLinkId();
-            Coord fromCoord = getCoordFromActivity(trip.getOriginActivity());
-            Coord toCoord = getCoordFromActivity(trip.getDestinationActivity());
+            Coord fromCoord = PopulationUtils.getCoordFromActivityOrNetwork(scenario,trip.getOriginActivity());
+            Coord toCoord = PopulationUtils.getCoordFromActivityOrNetwork(scenario,trip.getDestinationActivity());
             int euclideanDistance = (int) CoordUtils.calcEuclideanDistance(fromCoord, toCoord);
             String firstPtBoardingStop = null;
             String lastPtEgressStop = null;
@@ -271,8 +272,8 @@ public class TripsAndLegsCSVWriter {
         record.add(Integer.toString((int) leg.getRoute().getDistance()));
         record.add(leg.getMode());
         record.add(leg.getRoute().getStartLinkId().toString());
-        Coord startCoord = getCoordFromActivity(previousAct);
-        Coord endCoord = getCoordFromActivity(nextAct);
+        Coord startCoord = PopulationUtils.getCoordFromActivityOrNetwork(scenario,previousAct);
+        Coord endCoord = PopulationUtils.getCoordFromActivityOrNetwork(scenario,nextAct);
         record.add(Double.toString(startCoord.getX()));
         record.add(Double.toString(startCoord.getY()));
         record.add(leg.getRoute().getEndLinkId().toString());
@@ -321,20 +322,6 @@ public class TripsAndLegsCSVWriter {
         }
 
         return record;
-    }
-
-    private Coord getCoordFromActivity(Activity activity) {
-        if (activity.getCoord() != null) {
-            return activity.getCoord();
-        } else if (activity.getFacilityId() != null && scenario.getActivityFacilities().getFacilities().containsKey(activity.getFacilityId())) {
-            Coord coord = scenario.getActivityFacilities().getFacilities().get(activity.getFacilityId()).getCoord();
-            return coord != null ? coord : getCoordFromLink(activity.getLinkId());
-        } else return getCoordFromLink(activity.getLinkId());
-    }
-
-    //this is the least desirable way
-    private Coord getCoordFromLink(Id<Link> linkId) {
-        return scenario.getNetwork().getLinks().get(linkId).getToNode().getCoord();
     }
 
     public interface CustomTripsWriterExtension {

--- a/matsim/src/main/java/org/matsim/core/population/PopulationUtils.java
+++ b/matsim/src/main/java/org/matsim/core/population/PopulationUtils.java
@@ -1168,5 +1168,28 @@ public final class PopulationUtils {
 		return person ;
 	}
 
+	public static Coord getCoordFromActivityOrNetwork(Scenario scenario, Activity activity) {
+		return getCoordFromActivityOrNetwork(scenario.getActivityFacilities(), activity, scenario.getNetwork());
+	}
 
+	public static Coord getCoordFromActivityOrNetwork(ActivityFacilities facilities, Activity activity, Network network) {
+		Coord coord = getCoordFromActivity(facilities, activity);
+		return coord != null ? coord : getCoordFromLink(network, activity.getLinkId());
+	}
+
+	public static Coord getCoordFromActivity(ActivityFacilities activityFacilities, Activity activity) {
+		Id<ActivityFacility> facilityId = activity.getFacilityId();
+		if (facilityId != null && activityFacilities != null) {
+			ActivityFacility activityFacility = activityFacilities.getFacilities().get(facilityId);
+			if(activityFacility!= null && activityFacility.getCoord() != null)
+			{
+				return activityFacility.getCoord();
+			}
+		}
+		return activity.getCoord();
+	}
+
+	public static Coord getCoordFromLink(Network network, Id<Link> linkId) {
+		return network.getLinks().get(linkId).getToNode().getCoord();
+	}
 }


### PR DESCRIPTION
The TripsAndLegsCSVWriter has some nice buildin methods (getCoordFromActivity) that are very usefull in general and should be centrally available in order to avoid multiple implementations. 
I added different method signatures to the PopulationUtils that search the Coord at different locations (Activity, Facility or the Link as last resort).