### PR TITLE
Update DetourTimeEstimator.java

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourTimeEstimator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourTimeEstimator.java
@@ -44,7 +44,7 @@ public interface DetourTimeEstimator {
 			double duration = FIRST_LINK_TT;
 			duration += matrix.getTravelTime(from.getToNode(), to.getFromNode(), departureTime + duration);
 			duration += VrpPaths.getLastLinkTT(travelTime, to, departureTime + duration);
-			return duration / speedFactor;
+			return duration * speedFactor;
 		};
 	}
 


### PR DESCRIPTION
Since the speedFactor needs to be >=1, we need to multiply the speedFactor to the estimated detour duration in order to acquire some buffer.

Alternatively, we can modify the check for the speedFactor (i.e., speedFactor should be within the range of (0,1])