### PR TITLE
(draft) DRT: Promised pickup time windows

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -104,6 +104,14 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 					+ "min(unsharedRideTime + maxAbsoluteDetour, maxTravelTimeAlpha * unsharedRideTime + maxTravelTimeBeta). "
 					+ "maxAbsoluteDetour should not be smaller than 0. and should be higher than the offset maxTravelTimeBeta.";
 
+	public static final String PROMISED_PICKUP_TIME_WINDOW = "promisedPickupTimeWindow";
+	static final String PROMISED_PICKUP_TIME_WINDOW_EXP =
+			"Defines the latest departure time offset in seconds for a request that has been assigned to a vehicle successfully. " +
+					"While the initial insertion search time windows depend on the defined optimization constraints, " +
+					"this offset ensures that a 'promised' pickup time (i.e., the one planned in the final insertion) may " +
+					"not be exceeded by the given amount of time. Future request insertions then have to respect the updated" +
+					"time window. Must be positive.";
+
 	public static final String REJECT_REQUEST_IF_MAX_WAIT_OR_TRAVEL_TIME_VIOLATED = "rejectRequestIfMaxWaitOrTravelTimeViolated";
 	static final String REJECT_REQUEST_IF_MAX_WAIT_OR_TRAVEL_TIME_VIOLATED_EXP =
 			"If true, the max travel and wait times of a submitted request"
@@ -178,6 +186,9 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 
 	@PositiveOrZero
 	private double maxAbsoluteDetour = Double.POSITIVE_INFINITY;// [s]
+
+	@PositiveOrZero
+	private double promisedPickupTimeWindow = Double.POSITIVE_INFINITY;// [s]
 
 	private boolean rejectRequestIfMaxWaitOrTravelTimeViolated = true;
 
@@ -326,6 +337,7 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 		map.put(MAX_TRAVEL_TIME_ALPHA, MAX_TRAVEL_TIME_ALPHA_EXP);
 		map.put(MAX_TRAVEL_TIME_BETA, MAX_TRAVEL_TIME_BETA_EXP);
 		map.put(MAX_ABSOLUTE_DETOUR, MAX_ABSOLUTE_DETOUR_EXP);
+		map.put(PROMISED_PICKUP_TIME_WINDOW, PROMISED_PICKUP_TIME_WINDOW_EXP);
 		map.put(CHANGE_START_LINK_TO_LAST_LINK_IN_SCHEDULE, CHANGE_START_LINK_TO_LAST_LINK_IN_SCHEDULE_EXP);
 		map.put(VEHICLES_FILE, VEHICLES_FILE_EXP);
 		map.put(WRITE_DETAILED_CUSTOMER_STATS, WRITE_DETAILED_CUSTOMER_STATS_EXP);
@@ -479,6 +491,23 @@ public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableP
 	@StringSetter(MAX_ABSOLUTE_DETOUR)
 	public DrtConfigGroup setMaxAbsoluteDetour(double maxAbsoluteDetour) {
 		this.maxAbsoluteDetour = maxAbsoluteDetour;
+		return this;
+	}
+
+	/**
+	 * @return -- {@value #PROMISED_PICKUP_TIME_WINDOW_EXP}
+	 */
+	@StringGetter(PROMISED_PICKUP_TIME_WINDOW)
+	public double getPromisedPickupTimeWindow() {
+		return promisedPickupTimeWindow;
+	}
+
+	/**
+	 * @param promisedPickupTimeWindow -- {@value #PROMISED_PICKUP_TIME_WINDOW_EXP}
+	 */
+	@StringSetter(PROMISED_PICKUP_TIME_WINDOW)
+	public DrtConfigGroup setPromisedPickupTimeWindow(double promisedPickupTimeWindow) {
+		this.promisedPickupTimeWindow = promisedPickupTimeWindow;
 		return this;
 	}
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserterTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserterTest.java
@@ -270,7 +270,7 @@ public class DefaultUnplannedRequestInserterTest {
 			VehicleEntry.EntryFactory vehicleEntryFactory, DrtRequestInsertionRetryQueue insertionRetryQueue,
 			DrtInsertionSearch insertionSearch, RequestInsertionScheduler insertionScheduler) {
 		return new DefaultUnplannedRequestInserter(mode, fleet, () -> now, eventsManager, insertionScheduler,
-				vehicleEntryFactory, insertionRetryQueue, rule.forkJoinPool, insertionSearch);
+				vehicleEntryFactory, insertionRetryQueue, rule.forkJoinPool, insertionSearch, Double.POSITIVE_INFINITY);
 	}
 
 	private Link link(String id) {


### PR DESCRIPTION
This PR is an exemplary implementation of "promised pickup time windows" for drt. The idea is that requests that have been scheduled and confirmed may not exceed the planned departure time of the found insertion by x amount of time. For finding an insertion the original time window of the request is considered (i.e., latestDepartureTime). Once it is scheduled, the time window is updated. Future insertions then have to respect the 'promised pickup time window'. In reality, this can be done to increase customer satisfaction after communicating an approval.

@michalmac please let us know if you find this useful, maybe you could also give a quick statement on the implementation. The way it is currently designed DrtRequests are immutable so they have to re-created. Also, they cannot be easily wrapped around since as there is no DrtRequest Interface. That's why for a minimally invasive implementation it is implemented directly in the RequestInserter. With the default config setting, nothing should change.

I saw that there is a comment in the DrtRequestInsertionRetryQueue bringing up the discussion of alternatively making latest start/arrival times modifiable.. in this case the update could also be implemented with a PassengerRequestScheduledEventHandler without needing to touch code in the optimizer :) 
https://github.com/matsim-org/matsim-libs/blob/1770f7dfc42f791b9d3bb6a299cf8b833be162a5/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DrtRequestInsertionRetryQueue.java#L64
