### PR TITLE
fix(application): bump freight to 15.0-SNAPSHOT

### DIFF
--- a/contribs/application/pom.xml
+++ b/contribs/application/pom.xml
@@ -55,7 +55,7 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>freight</artifactId>
-			<version>14.0-SNAPSHOT</version>
+			<version>15.0-SNAPSHOT</version>
 		</dependency>		
 
 		<dependency>


### PR DESCRIPTION
This is a new dependency added in #1952. However, #1952 was created from 14.0-SNAPSHOT (before 14.0 was released) but merged into 15.0-SNAPSHOT (after 14.0 was released), so it couldn't get bumped automatically.

This may be the reason why http://ci.matsim.org:8080/job/MATSim_GitHub/6502/ (ran for origin/master) failed. Let's see if it's resolved now.