### PR TITLE
Fix QSim events integration tests

### DIFF
--- a/matsim/src/test/java/org/matsim/core/mobsim/qsim/QSimEventsIntegrationTest.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/qsim/QSimEventsIntegrationTest.java
@@ -49,6 +49,7 @@ public class QSimEventsIntegrationTest {
 	@Test
 	public void netsimEngineHandlesExceptionCorrectly() {
 		Config config = utils.loadConfig("test/scenarios/equil/config_plans1.xml");
+		config.controler().setLastIteration(1);
 
 		Scenario scenario = ScenarioUtils.loadScenario(config);
 		EventsManager events = EventsUtils.createEventsManager();
@@ -73,6 +74,7 @@ public class QSimEventsIntegrationTest {
 	@Test
 	public void controlerHandlesExceptionCorrectly() {
 		Config config = utils.loadConfig("test/scenarios/equil/config_plans1.xml");
+		config.controler().setLastIteration(1);
 
 		Controler controler = new Controler(config);
 		controler.getEvents().addHandler((LinkLeaveEventHandler)event -> {


### PR DESCRIPTION
1. QSim did not reach the point at which our expected exception is thrown (due to a missing vehicle) and threw a different RuntimeException.

   - Fixed the test (by adding the missing vehicle).

   - Added assertions for specific error messages to make sure we only accept the expected exceptions.

2. Reduce the number of iterations, so we do not hit the timeout when executing on Jenkins, like here:
   - http://ci.matsim.org:8080/job/MATSim_M2/5959/
   - http://ci.matsim.org:8080/job/MATSim_M2/5954/