### PR TITLE
Improve exception handling

### DIFF
--- a/contribs/signals/src/test/java/org/matsim/contrib/signals/builder/QSimSignalTest.java
+++ b/contribs/signals/src/test/java/org/matsim/contrib/signals/builder/QSimSignalTest.java
@@ -100,7 +100,7 @@ public class QSimSignalTest implements
 	/**
 	 * Tests the setup with a traffic light that shows red less than the specified intergreen time of five seconds.
 	 */
-	@Test
+	@Test(expected = RuntimeException.class)
 	public void testIntergreensAbortOneAgentDriving() {
 		//configure and load standard scenario
 		Scenario scenario = fixture.createAndLoadTestScenarioOneSignal(true );
@@ -116,7 +116,10 @@ public class QSimSignalTest implements
 		groupData.setOnset(0);
 		groupData.setDropping(59);	
 		
-		Assert.assertFalse("The simulation should abort because of intergreens violation.", runQSimWithSignals(scenario, false));
+		runQSimWithSignals(scenario, false);
+
+		// if this code is reached, no exception has been thrown
+		Assert.fail("The simulation should abort because of intergreens violation.");
 	}
 	
 	/**
@@ -145,13 +148,15 @@ public class QSimSignalTest implements
 	/**
 	 * Tests the setup with two conflicting directions showing green together
 	 */
-	@Test
+	@Test(expected = RuntimeException.class)
 	public void testConflictingDirectionsAbortOneAgentDriving() {
 		//configure and load test scenario with data about conflicting directions
 		Scenario scenario = fixture.createAndLoadTestScenarioTwoSignals(true );
 
 		runQSimWithSignals(scenario, false);
-		Assert.assertFalse("The simulation should abort because of intergreens violation.", runQSimWithSignals(scenario, false));
+
+		// if this code is reached, no exception has been thrown
+		Assert.fail("The simulation should abort because of intergreens violation.");
 	}
 	
 	/**
@@ -173,7 +178,7 @@ public class QSimSignalTest implements
 
 	
 	
-	private boolean runQSimWithSignals(final Scenario scenario, boolean handleEvents) throws RuntimeException {
+	private void runQSimWithSignals(final Scenario scenario, boolean handleEvents) throws RuntimeException {
 //		/*
 //		 * this is the old version how to build an injector without a controler and
 //		 * still be able to add a SignalsModule. A new version using Sebastians
@@ -217,7 +222,6 @@ public class QSimSignalTest implements
 				.addOverridingQSimModule( new SignalsQSimModule() )
 				.build(scenario, events)
 				.run();
-		return !events.hadException();
 	}
 
 
@@ -232,9 +236,6 @@ public class QSimSignalTest implements
 		}
 	}
 
-	@Override
-	public void reset(int iteration) {
-	}
 
 	@Override
 	public void handleEvent(SignalGroupStateChangedEvent event) {

--- a/matsim/src/main/java/org/matsim/core/events/ParallelEventsManager.java
+++ b/matsim/src/main/java/org/matsim/core/events/ParallelEventsManager.java
@@ -191,10 +191,6 @@ public final class ParallelEventsManager implements EventsManager {
 		}
 	}
 
-	public boolean hadException() {
-		return this.uncaughtExceptionHandler.hadException;
-	}
-
 	@Override
 	public void initProcessing() {
 

--- a/matsim/src/test/java/org/matsim/core/mobsim/qsim/QSimEventsIntegrationTest.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/qsim/QSimEventsIntegrationTest.java
@@ -21,23 +21,19 @@
 
 package org.matsim.core.mobsim.qsim;
 
-import java.util.Map;
-
 import org.assertj.core.api.Assertions;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
-import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
-import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.events.handler.LinkLeaveEventHandler;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.controler.Controler;
+import org.matsim.core.controler.PrepareForSimUtils;
 import org.matsim.core.events.EventsUtils;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.testcases.MatsimTestUtils;
-import org.matsim.vehicles.VehicleUtils;
 
 public class QSimEventsIntegrationTest {
 	@Rule
@@ -51,14 +47,9 @@ public class QSimEventsIntegrationTest {
 		Config config = utils.loadConfig("test/scenarios/equil/config_plans1.xml");
 
 		Scenario scenario = ScenarioUtils.loadScenario(config);
+		PrepareForSimUtils.createDefaultPrepareForSim(scenario).run();
+
 		EventsManager events = EventsUtils.createEventsManager();
-
-		var vehicleId = Id.createVehicleId("v1");
-		VehicleUtils.insertVehicleIdsIntoAttributes(scenario.getPopulation().getPersons().get(Id.createPersonId("1")),
-				Map.of(TransportMode.car, vehicleId));
-		scenario.getVehicles().addVehicleType(VehicleUtils.getDefaultVehicleType());
-		scenario.getVehicles().addVehicle(VehicleUtils.createVehicle(vehicleId, VehicleUtils.getDefaultVehicleType()));
-
 		events.addHandler((LinkLeaveEventHandler)event -> {
 			throw new RuntimeException("Haha, I hope the QSim exits cleanly.");
 		});

--- a/matsim/src/test/java/org/matsim/core/mobsim/qsim/QSimEventsIntegrationTest.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/qsim/QSimEventsIntegrationTest.java
@@ -23,7 +23,7 @@ package org.matsim.core.mobsim.qsim;
 
 import java.util.Map;
 
-import org.junit.Assert;
+import org.assertj.core.api.Assertions;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -44,12 +44,11 @@ public class QSimEventsIntegrationTest {
 	public MatsimTestUtils utils = new MatsimTestUtils();
 
 	@Rule
-	public Timeout globalTimeout = new Timeout(20000);
+	public Timeout globalTimeout = new Timeout(10000);
 
 	@Test
 	public void netsimEngineHandlesExceptionCorrectly() {
 		Config config = utils.loadConfig("test/scenarios/equil/config_plans1.xml");
-		config.controler().setLastIteration(1);
 
 		Scenario scenario = ScenarioUtils.loadScenario(config);
 		EventsManager events = EventsUtils.createEventsManager();
@@ -63,29 +62,22 @@ public class QSimEventsIntegrationTest {
 		events.addHandler((LinkLeaveEventHandler)event -> {
 			throw new RuntimeException("Haha, I hope the QSim exits cleanly.");
 		});
-		try {
-			new QSimBuilder(config).useDefaults().build(scenario, events).run();
-		} catch (RuntimeException e) {
-			// That's fine. Only timeout is bad, which would mean qsim would hang on an Exception in an EventHandler.
-			Assert.assertEquals("Haha, I hope the QSim exits cleanly.", e.getCause().getMessage());
-		}
+
+		// That's fine. Only timeout is bad, which would mean qsim would hang on an Exception in an EventHandler.
+		Assertions.assertThatThrownBy(new QSimBuilder(config).useDefaults().build(scenario, events)::run)
+				.hasRootCauseMessage("Haha, I hope the QSim exits cleanly.");
 	}
 
 	@Test
 	public void controlerHandlesExceptionCorrectly() {
 		Config config = utils.loadConfig("test/scenarios/equil/config_plans1.xml");
-		config.controler().setLastIteration(1);
 
 		Controler controler = new Controler(config);
 		controler.getEvents().addHandler((LinkLeaveEventHandler)event -> {
 			throw new RuntimeException("Haha, I hope the QSim exits cleanly.");
 		});
-		try {
-			controler.run();
-		} catch (RuntimeException e) {
-			// That's fine. Only timeout is bad, which would mean qsim would hang on an Exception in an EventHandler.
-			Assert.assertEquals("Haha, I hope the QSim exits cleanly.", e.getMessage());
-		}
-	}
 
+		// That's fine. Only timeout is bad, which would mean qsim would hang on an Exception in an EventHandler.
+		Assertions.assertThatThrownBy(controler::run).hasRootCauseMessage("Haha, I hope the QSim exits cleanly.");
+	}
 }


### PR DESCRIPTION
I realised that the timeouts mentioned in #1957 were caused by QSim swallowing some exceptions and decided to explore it a bit.

Changes/fixes:
- fix the handling of exceptions in QSim: re-throw the exception caught during the cleanup step if no other exception was thrown during earlier QSim steps.
- ensure `QSimEventsIntegrationTest` will fail if no (expected) exception is thrown
- adapt asserting exceptions in `QSimSignalTest` for the fixed exception handling
- always propagate the original exception from event handlers (currently sometimes a subsequent BrokenBarrierException is propagated instead)
- throw event processing exception at the end of the current step instead of in the next step or when finalising event processing

Note: The fixes around parallel event processing (last 2 bullets) were applied to `SimStepParallelEventsManagerImpl`, but not to `ParallelEventsManagerImpl`.