### PR TITLE
core: propagate original exception cause in ParallelEventsManagerImpl

### DIFF
--- a/matsim/src/test/java/org/matsim/core/mobsim/qsim/QSimEventsIntegrationTest.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/qsim/QSimEventsIntegrationTest.java
@@ -60,8 +60,25 @@ public class QSimEventsIntegrationTest {
 	}
 
 	@Test
-	public void controlerHandlesExceptionCorrectly() {
+	public void controlerHandlesExceptionCorrectly_syncOnSimSteps() {
 		Config config = utils.loadConfig("test/scenarios/equil/config_plans1.xml");
+		config.parallelEventHandling().setNumberOfThreads(1);
+		config.parallelEventHandling().setSynchronizeOnSimSteps(true);
+
+		Controler controler = new Controler(config);
+		controler.getEvents().addHandler((LinkLeaveEventHandler)event -> {
+			throw new RuntimeException("Haha, I hope the QSim exits cleanly.");
+		});
+
+		// That's fine. Only timeout is bad, which would mean qsim would hang on an Exception in an EventHandler.
+		Assertions.assertThatThrownBy(controler::run).hasRootCauseMessage("Haha, I hope the QSim exits cleanly.");
+	}
+
+	@Test
+	public void controlerHandlesExceptionCorrectly_noSyncOnSimSteps() {
+		Config config = utils.loadConfig("test/scenarios/equil/config_plans1.xml");
+		config.parallelEventHandling().setNumberOfThreads(1);
+		config.parallelEventHandling().setSynchronizeOnSimSteps(false);
 
 		Controler controler = new Controler(config);
 		controler.getEvents().addHandler((LinkLeaveEventHandler)event -> {


### PR DESCRIPTION
Similar to #1958 (commit 4c365390bb17b884e7364b065c9c4b610d38bda7), but this time it improves event handling in `ParallelEventsManagerImpl` (the previous PR did that for `SimStepParallelEventsManagerImpl`).