### PR TITLE
Introduce simple DRT request acceptance

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/edrt/run/EDrtModeOptimizerQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/edrt/run/EDrtModeOptimizerQSimModule.java
@@ -43,6 +43,7 @@ import org.matsim.contrib.drt.optimizer.insertion.DrtRequestInsertionRetryQueue;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator;
 import org.matsim.contrib.drt.optimizer.insertion.UnplannedRequestInserter;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
+import org.matsim.contrib.drt.passenger.DrtOfferAcceptor;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtTaskFactory;
 import org.matsim.contrib.drt.scheduler.DefaultRequestInsertionScheduler;
@@ -126,7 +127,7 @@ public class EDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 						getter.get(MobsimTimer.class), getter.get(EventsManager.class),
 						getter.getModal(RequestInsertionScheduler.class),
 						getter.getModal(VehicleEntry.EntryFactory.class), getter.getModal(DrtInsertionSearch.class),
-						getter.getModal(DrtRequestInsertionRetryQueue.class),
+						getter.getModal(DrtRequestInsertionRetryQueue.class), getter.getModal(DrtOfferAcceptor.class),
 						getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool()))).asEagerSingleton();
 
 		bindModal(InsertionCostCalculator.class).toProvider(modalProvider(
@@ -166,6 +167,8 @@ public class EDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 								getter.get(MobsimTimer.class), getter.getModal(TravelTime.class),
 								getter.getModal(ScheduleTimingUpdater.class), getter.getModal(DrtTaskFactory.class))))
 				.asEagerSingleton();
+
+		bindModal(DrtOfferAcceptor.class).toInstance(DrtOfferAcceptor.DEFAULT_ACCEPTOR);
 
 		bindModal(ScheduleTimingUpdater.class).toProvider(modalProvider(
 				getter -> new ScheduleTimingUpdater(getter.get(MobsimTimer.class),

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/charging/ChargingBreakActivity.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/charging/ChargingBreakActivity.java
@@ -50,7 +50,7 @@ public class ChargingBreakActivity extends FirstLastSimStepDynActivity implement
     protected boolean isLastStep(double now) {
         if(chargingDelegate.getEndTime() < now && now >= endTime) {
             for (PassengerRequest request : pickupRequests.values()) {
-                if (passengerHandler.tryPickUpPassenger(this, driver, request, now)) {
+                if (passengerHandler.tryPickUpPassenger(this, driver, request.getId(), now)) {
                     passengersPickedUp++;
                 }
             }
@@ -70,7 +70,7 @@ public class ChargingBreakActivity extends FirstLastSimStepDynActivity implement
         }
 
         PassengerRequest request = getRequestForPassenger(passenger.getId());
-        if (passengerHandler.tryPickUpPassenger(this, driver, request, now)) {
+        if (passengerHandler.tryPickUpPassenger(this, driver, request.getId(), now)) {
             passengersPickedUp++;
         } else {
             throw new IllegalStateException("The passenger is not on the link or not available for departure!");
@@ -81,7 +81,7 @@ public class ChargingBreakActivity extends FirstLastSimStepDynActivity implement
     protected void beforeFirstStep(double now) {
         // TODO probably we should simulate it more accurately (passenger by passenger, not all at once...)
         for (PassengerRequest request : dropoffRequests.values()) {
-            passengerHandler.dropOffPassenger(driver, request, now);
+            passengerHandler.dropOffPassenger(driver, request.getId(), now);
         }
     }
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/charging/ChargingBreakActivity.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/charging/ChargingBreakActivity.java
@@ -3,7 +3,7 @@ package org.matsim.contrib.drt.extension.eshifts.charging;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.dvrp.optimizer.Request;
-import org.matsim.contrib.dvrp.passenger.BusStopActivity;
+import org.matsim.contrib.drt.passenger.DrtStopActivity;
 import org.matsim.contrib.dvrp.passenger.PassengerHandler;
 import org.matsim.contrib.dvrp.passenger.PassengerPickupActivity;
 import org.matsim.contrib.dvrp.passenger.PassengerRequest;
@@ -18,7 +18,7 @@ import org.matsim.core.mobsim.framework.MobsimPassengerAgent;
 import java.util.Map;
 
 /**
- * based on {@link BusStopActivity} and {@link ChargingActivity}
+ * based on {@link DrtStopActivity} and {@link ChargingActivity}
  * @author nkuehnel / MOIA
  */
 public class ChargingBreakActivity extends FirstLastSimStepDynActivity implements DynActivity, PassengerPickupActivity {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/charging/ChargingChangeoverActivity.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/charging/ChargingChangeoverActivity.java
@@ -2,7 +2,7 @@ package org.matsim.contrib.drt.extension.eshifts.charging;
 
 import org.matsim.api.core.v01.Id;
 import org.matsim.contrib.dvrp.optimizer.Request;
-import org.matsim.contrib.dvrp.passenger.BusStopActivity;
+import org.matsim.contrib.drt.passenger.DrtStopActivity;
 import org.matsim.contrib.dvrp.passenger.PassengerHandler;
 import org.matsim.contrib.dvrp.passenger.PassengerRequest;
 import org.matsim.contrib.dvrp.schedule.StayTask;
@@ -18,7 +18,7 @@ import java.util.Map;
 public class ChargingChangeoverActivity implements DynActivity {
 
     private final FixedTimeChargingActivity chargingDelegate;
-    private final BusStopActivity busStopDelegate;
+    private final DrtStopActivity busStopDelegate;
 	private final double endTime;
 
 	public ChargingChangeoverActivity(ChargingTask chargingTask, PassengerHandler passengerHandler,
@@ -26,7 +26,7 @@ public class ChargingChangeoverActivity implements DynActivity {
                                       Map<Id<Request>, ? extends PassengerRequest> dropoffRequests,
                                       Map<Id<Request>, ? extends PassengerRequest> pickupRequests) {
         chargingDelegate = new FixedTimeChargingActivity(chargingTask, task.getEndTime());
-        busStopDelegate = new BusStopActivity(passengerHandler, driver, task, dropoffRequests, pickupRequests, "");
+        busStopDelegate = new DrtStopActivity(passengerHandler, driver, task, dropoffRequests, pickupRequests, "");
 		endTime = task.getEndTime();
 	}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/charging/ChargingChangeoverActivity.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/charging/ChargingChangeoverActivity.java
@@ -1,10 +1,10 @@
 package org.matsim.contrib.drt.extension.eshifts.charging;
 
 import org.matsim.api.core.v01.Id;
+import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
 import org.matsim.contrib.dvrp.optimizer.Request;
 import org.matsim.contrib.drt.passenger.DrtStopActivity;
 import org.matsim.contrib.dvrp.passenger.PassengerHandler;
-import org.matsim.contrib.dvrp.passenger.PassengerRequest;
 import org.matsim.contrib.dvrp.schedule.StayTask;
 import org.matsim.contrib.dynagent.DynActivity;
 import org.matsim.contrib.dynagent.DynAgent;
@@ -23,8 +23,8 @@ public class ChargingChangeoverActivity implements DynActivity {
 
 	public ChargingChangeoverActivity(ChargingTask chargingTask, PassengerHandler passengerHandler,
                                       DynAgent driver, StayTask task,
-                                      Map<Id<Request>, ? extends PassengerRequest> dropoffRequests,
-                                      Map<Id<Request>, ? extends PassengerRequest> pickupRequests) {
+                                      Map<Id<Request>, ? extends AcceptedDrtRequest> dropoffRequests,
+                                      Map<Id<Request>, ? extends AcceptedDrtRequest> pickupRequests) {
         chargingDelegate = new FixedTimeChargingActivity(chargingTask, task.getEndTime());
         busStopDelegate = new DrtStopActivity(passengerHandler, driver, task, dropoffRequests, pickupRequests, "");
 		endTime = task.getEndTime();

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/schedule/EDrtShiftChangeoverTaskImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/eshifts/schedule/EDrtShiftChangeoverTaskImpl.java
@@ -3,7 +3,7 @@ package org.matsim.contrib.drt.extension.eshifts.schedule;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.extension.shifts.shift.DrtShift;
-import org.matsim.contrib.drt.passenger.DrtRequest;
+import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
 import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.drt.schedule.DrtTaskType;
@@ -64,22 +64,22 @@ public class EDrtShiftChangeoverTaskImpl extends DefaultStayTask implements Shif
     }
 
 	@Override
-	public Map<Id<Request>, DrtRequest> getDropoffRequests() {
+	public Map<Id<Request>, AcceptedDrtRequest> getDropoffRequests() {
 		return delegate.getDropoffRequests();
 	}
 
 	@Override
-	public Map<Id<Request>, DrtRequest> getPickupRequests() {
+	public Map<Id<Request>, AcceptedDrtRequest> getPickupRequests() {
 		return delegate.getPickupRequests();
 	}
 
 	@Override
-	public void addDropoffRequest(DrtRequest request) {
+	public void addDropoffRequest(AcceptedDrtRequest request) {
 		delegate.addDropoffRequest(request);
 	}
 
 	@Override
-	public void addPickupRequest(DrtRequest request) {
+	public void addPickupRequest(AcceptedDrtRequest request) {
 		delegate.addPickupRequest(request);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/preplanned/optimizer/PreplannedDrtOptimizer.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/preplanned/optimizer/PreplannedDrtOptimizer.java
@@ -32,6 +32,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.drt.optimizer.DrtOptimizer;
+import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtDriveTask;
@@ -178,11 +179,11 @@ public class PreplannedDrtOptimizer implements DrtOptimizer {
 			if (nextStop.pickup) {
 				var request = Preconditions.checkNotNull(openRequests.get(nextStop.preplannedRequest),
 						"Request (%s) has not been yet submitted", nextStop.preplannedRequest);
-				stopTask.addPickupRequest(request);
+				stopTask.addPickupRequest(AcceptedDrtRequest.createFromOriginalRequest(request));
 			} else {
 				var request = Preconditions.checkNotNull(openRequests.remove(nextStop.preplannedRequest),
 						"Request (%s) has not been yet submitted", nextStop.preplannedRequest);
-				stopTask.addDropoffRequest(request);
+				stopTask.addDropoffRequest(AcceptedDrtRequest.createFromOriginalRequest(request));
 			}
 			schedule.addTask(stopTask);
 		}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/optimizer/ShiftRequestInsertionScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/optimizer/ShiftRequestInsertionScheduler.java
@@ -8,20 +8,18 @@ import java.util.List;
 
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.extension.shifts.fleet.ShiftDvrpVehicle;
-import org.matsim.contrib.drt.extension.shifts.operationFacilities.OperationFacilities;
 import org.matsim.contrib.drt.extension.shifts.schedule.OperationalStop;
 import org.matsim.contrib.drt.extension.shifts.schedule.ShiftChangeOverTask;
 import org.matsim.contrib.drt.extension.shifts.schedule.ShiftDrtTaskFactory;
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
 import org.matsim.contrib.drt.optimizer.Waypoint;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionWithDetourData;
-import org.matsim.contrib.drt.passenger.DrtRequest;
+import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtDriveTask;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
 import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.drt.scheduler.RequestInsertionScheduler;
-import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.path.VrpPaths;
 import org.matsim.contrib.dvrp.schedule.Schedule;
@@ -56,13 +54,13 @@ public class ShiftRequestInsertionScheduler implements RequestInsertionScheduler
 
 
     @Override
-    public PickupDropoffTaskPair scheduleRequest(DrtRequest request, InsertionWithDetourData insertion) {
+    public PickupDropoffTaskPair scheduleRequest(AcceptedDrtRequest request, InsertionWithDetourData insertion) {
         var pickupTask = insertPickup(request, insertion);
         var dropoffTask = insertDropoff(request, insertion, pickupTask);
         return new PickupDropoffTaskPair(pickupTask, dropoffTask);
     }
 
-    private DrtStopTask insertPickup(DrtRequest request, InsertionWithDetourData insertionWithDetourData) {
+    private DrtStopTask insertPickup(AcceptedDrtRequest request, InsertionWithDetourData insertionWithDetourData) {
 		var insertion = insertionWithDetourData.insertion;
         VehicleEntry vehicleEntry = insertion.vehicleEntry;
         Schedule schedule = vehicleEntry.vehicle.getSchedule();
@@ -239,7 +237,7 @@ public class ShiftRequestInsertionScheduler implements RequestInsertionScheduler
         return pickupStopTask;
     }
 
-    private DrtStopTask insertDropoff(DrtRequest request, InsertionWithDetourData insertionWithDetourData,
+    private DrtStopTask insertDropoff(AcceptedDrtRequest request, InsertionWithDetourData insertionWithDetourData,
                                       DrtStopTask pickupTask) {
 		var insertion = insertionWithDetourData.insertion;
         VehicleEntry vehicleEntry = insertion.vehicleEntry;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/schedule/ShiftBreakTaskImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/schedule/ShiftBreakTaskImpl.java
@@ -4,7 +4,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.extension.shifts.operationFacilities.OperationFacility;
 import org.matsim.contrib.drt.extension.shifts.shift.DrtShiftBreak;
-import org.matsim.contrib.drt.passenger.DrtRequest;
+import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
 import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.drt.schedule.DrtTaskType;
@@ -45,22 +45,22 @@ public class ShiftBreakTaskImpl extends DefaultStayTask implements ShiftBreakTas
     }
 
 	@Override
-	public Map<Id<Request>, DrtRequest> getDropoffRequests() {
+	public Map<Id<Request>, AcceptedDrtRequest> getDropoffRequests() {
 		return delegate.getDropoffRequests();
 	}
 
 	@Override
-	public Map<Id<Request>, DrtRequest> getPickupRequests() {
+	public Map<Id<Request>, AcceptedDrtRequest> getPickupRequests() {
 		return delegate.getPickupRequests();
 	}
 
 	@Override
-	public void addDropoffRequest(DrtRequest request) {
+	public void addDropoffRequest(AcceptedDrtRequest request) {
 		delegate.addDropoffRequest(request);
 	}
 
 	@Override
-	public void addPickupRequest(DrtRequest request) {
+	public void addPickupRequest(AcceptedDrtRequest request) {
 		delegate.addPickupRequest(request);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/schedule/ShiftChangeoverTaskImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/schedule/ShiftChangeoverTaskImpl.java
@@ -3,7 +3,7 @@ package org.matsim.contrib.drt.extension.shifts.schedule;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.extension.shifts.operationFacilities.OperationFacility;
-import org.matsim.contrib.drt.passenger.DrtRequest;
+import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
 import org.matsim.contrib.drt.extension.shifts.shift.DrtShift;
 import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 import org.matsim.contrib.drt.schedule.DrtStopTask;
@@ -46,22 +46,22 @@ public class ShiftChangeoverTaskImpl extends DefaultStayTask implements ShiftCha
 	}
 
 	@Override
-	public Map<Id<Request>, DrtRequest> getDropoffRequests() {
+	public Map<Id<Request>, AcceptedDrtRequest> getDropoffRequests() {
 		return delegate.getDropoffRequests();
 	}
 
 	@Override
-	public Map<Id<Request>, DrtRequest> getPickupRequests() {
+	public Map<Id<Request>, AcceptedDrtRequest> getPickupRequests() {
 		return delegate.getPickupRequests();
 	}
 
 	@Override
-	public void addDropoffRequest(DrtRequest request) {
+	public void addDropoffRequest(AcceptedDrtRequest request) {
 		delegate.addDropoffRequest(request);
 	}
 
 	@Override
-	public void addPickupRequest(DrtRequest request) {
+	public void addPickupRequest(AcceptedDrtRequest request) {
 		delegate.addPickupRequest(request);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/schedule/ShiftDrtActionCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/extension/shifts/schedule/ShiftDrtActionCreator.java
@@ -2,7 +2,7 @@ package org.matsim.contrib.drt.extension.shifts.schedule;
 
 import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
-import org.matsim.contrib.dvrp.passenger.BusStopActivity;
+import org.matsim.contrib.drt.passenger.DrtStopActivity;
 import org.matsim.contrib.dvrp.passenger.PassengerHandler;
 import org.matsim.contrib.dvrp.schedule.Task;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic.DynActionCreator;
@@ -32,11 +32,11 @@ public class ShiftDrtActionCreator implements DynActionCreator {
         Task task = vehicle.getSchedule().getCurrentTask();
         if (task instanceof ShiftBreakTask) {
             DrtStopTask t = (DrtStopTask)task;
-            return new BusStopActivity(passengerHandler, dynAgent, t, t.getDropoffRequests(), t.getPickupRequests(),
+            return new DrtStopActivity(passengerHandler, dynAgent, t, t.getDropoffRequests(), t.getPickupRequests(),
                     DRT_SHIFT_BREAK_NAME);
         } else if (task instanceof ShiftChangeOverTask) {
             DrtStopTask t = (DrtStopTask) task;
-            return new BusStopActivity(passengerHandler, dynAgent, t, t.getDropoffRequests(), t.getPickupRequests(),
+            return new DrtStopActivity(passengerHandler, dynAgent, t, t.getDropoffRequests(), t.getPickupRequests(),
                     DRT_SHIFT_CHANGEOVER_NAME);
         } else if (task instanceof WaitForShiftStayTask) {
             return new IdleDynActivity(DRT_SHIFT_WAIT_FOR_SHIFT_NAME, task::getEndTime);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtModeOptimizerQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtModeOptimizerQSimModule.java
@@ -36,6 +36,7 @@ import org.matsim.contrib.drt.optimizer.insertion.extensive.ExtensiveInsertionSe
 import org.matsim.contrib.drt.optimizer.insertion.selective.SelectiveInsertionSearchParams;
 import org.matsim.contrib.drt.optimizer.insertion.selective.SelectiveInsertionSearchQSimModule;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
+import org.matsim.contrib.drt.passenger.DrtOfferAcceptor;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtStayTaskEndTimeCalculator;
 import org.matsim.contrib.drt.schedule.DrtTaskFactory;
@@ -96,7 +97,7 @@ public class DrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 						getter.get(MobsimTimer.class), getter.get(EventsManager.class),
 						getter.getModal(RequestInsertionScheduler.class),
 						getter.getModal(VehicleEntry.EntryFactory.class), getter.getModal(DrtInsertionSearch.class),
-						getter.getModal(DrtRequestInsertionRetryQueue.class),
+						getter.getModal(DrtRequestInsertionRetryQueue.class), getter.getModal(DrtOfferAcceptor.class),
 						getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool()))).asEagerSingleton();
 
 		bindModal(InsertionCostCalculator.class).toProvider(modalProvider(
@@ -135,6 +136,8 @@ public class DrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 								getter.get(MobsimTimer.class), getter.getModal(TravelTime.class),
 								getter.getModal(ScheduleTimingUpdater.class), getter.getModal(DrtTaskFactory.class))))
 				.asEagerSingleton();
+
+		bindModal(DrtOfferAcceptor.class).toInstance(DrtOfferAcceptor.DEFAULT_ACCEPTOR);
 
 		bindModal(ScheduleTimingUpdater.class).toProvider(modalProvider(
 				getter -> new ScheduleTimingUpdater(getter.get(MobsimTimer.class),

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/Waypoint.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/Waypoint.java
@@ -27,6 +27,7 @@ import java.util.stream.DoubleStream;
 import javax.annotation.Nullable;
 
 import org.matsim.api.core.v01.network.Link;
+import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.dvrp.schedule.Task;
@@ -186,13 +187,13 @@ public interface Waypoint {
 
 		private double calcLatestArrivalTime() {
 			return getMaxTimeConstraint(
-					task.getDropoffRequests().values().stream().mapToDouble(DrtRequest::getLatestArrivalTime),
+					task.getDropoffRequests().values().stream().mapToDouble(AcceptedDrtRequest::getLatestArrivalTime),
 					task.getBeginTime());
 		}
 
 		private double calcLatestDepartureTime() {
 			return getMaxTimeConstraint(
-					task.getPickupRequests().values().stream().mapToDouble(DrtRequest::getLatestStartTime),
+					task.getPickupRequests().values().stream().mapToDouble(AcceptedDrtRequest::getLatestStartTime),
 					task.getEndTime());
 		}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
+import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.scheduler.RequestInsertionScheduler;
@@ -130,8 +131,12 @@ public class DefaultUnplannedRequestInserter implements UnplannedRequestInserter
 			}
 		} else {
 			InsertionWithDetourData insertion = best.get();
+
+			// accept offered drt ride
+			var acceptedRequest = Optional.of(AcceptedDrtRequest.createFromOriginalRequest(req));
+
 			var vehicle = insertion.insertion.vehicleEntry.vehicle;
-			var pickupDropoffTaskPair = insertionScheduler.scheduleRequest(req, insertion);
+			var pickupDropoffTaskPair = insertionScheduler.scheduleRequest(acceptedRequest.get(), insertion);
 
 			VehicleEntry newVehicleEntry = vehicleEntryFactory.create(vehicle, now);
 			if (newVehicleEntry != null) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
-import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
+import org.matsim.contrib.drt.passenger.DrtOfferAcceptor;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.scheduler.RequestInsertionScheduler;
@@ -58,24 +58,25 @@ public class DefaultUnplannedRequestInserter implements UnplannedRequestInserter
 	private final EventsManager eventsManager;
 	private final RequestInsertionScheduler insertionScheduler;
 	private final VehicleEntry.EntryFactory vehicleEntryFactory;
-	private final DrtRequestInsertionRetryQueue insertionRetryQueue;
-
-	private final ForkJoinPool forkJoinPool;
 	private final DrtInsertionSearch insertionSearch;
+	private final DrtRequestInsertionRetryQueue insertionRetryQueue;
+	private final DrtOfferAcceptor drtOfferAcceptor;
+	private final ForkJoinPool forkJoinPool;
 
 	public DefaultUnplannedRequestInserter(DrtConfigGroup drtCfg, Fleet fleet, MobsimTimer mobsimTimer,
 			EventsManager eventsManager, RequestInsertionScheduler insertionScheduler,
 			VehicleEntry.EntryFactory vehicleEntryFactory, DrtInsertionSearch insertionSearch,
-			DrtRequestInsertionRetryQueue insertionRetryQueue, ForkJoinPool forkJoinPool) {
+			DrtRequestInsertionRetryQueue insertionRetryQueue, DrtOfferAcceptor drtOfferAcceptor,
+			ForkJoinPool forkJoinPool) {
 		this(drtCfg.getMode(), fleet, mobsimTimer::getTimeOfDay, eventsManager, insertionScheduler, vehicleEntryFactory,
-				insertionRetryQueue, forkJoinPool, insertionSearch);
+				insertionRetryQueue, insertionSearch, drtOfferAcceptor, forkJoinPool);
 	}
 
 	@VisibleForTesting
 	DefaultUnplannedRequestInserter(String mode, Fleet fleet, DoubleSupplier timeOfDay, EventsManager eventsManager,
 			RequestInsertionScheduler insertionScheduler, VehicleEntry.EntryFactory vehicleEntryFactory,
-			DrtRequestInsertionRetryQueue insertionRetryQueue, ForkJoinPool forkJoinPool,
-			DrtInsertionSearch insertionSearch) {
+			DrtRequestInsertionRetryQueue insertionRetryQueue, DrtInsertionSearch insertionSearch,
+			DrtOfferAcceptor drtOfferAcceptor, ForkJoinPool forkJoinPool) {
 		this.mode = mode;
 		this.fleet = fleet;
 		this.timeOfDay = timeOfDay;
@@ -83,8 +84,9 @@ public class DefaultUnplannedRequestInserter implements UnplannedRequestInserter
 		this.insertionScheduler = insertionScheduler;
 		this.vehicleEntryFactory = vehicleEntryFactory;
 		this.insertionRetryQueue = insertionRetryQueue;
-		this.forkJoinPool = forkJoinPool;
 		this.insertionSearch = insertionSearch;
+		this.drtOfferAcceptor = drtOfferAcceptor;
+		this.forkJoinPool = forkJoinPool;
 	}
 
 	@Override
@@ -133,7 +135,9 @@ public class DefaultUnplannedRequestInserter implements UnplannedRequestInserter
 			InsertionWithDetourData insertion = best.get();
 
 			// accept offered drt ride
-			var acceptedRequest = Optional.of(AcceptedDrtRequest.createFromOriginalRequest(req));
+			var acceptedRequest = drtOfferAcceptor.acceptDrtOffer(req,
+					insertion.detourTimeInfo.pickupDetourInfo.departureTime,
+					insertion.detourTimeInfo.dropoffDetourInfo.arrivalTime);
 
 			var vehicle = insertion.insertion.vehicleEntry.vehicle;
 			var pickupDropoffTaskPair = insertionScheduler.scheduleRequest(acceptedRequest.get(), insertion);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/AcceptedDrtRequest.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/AcceptedDrtRequest.java
@@ -1,0 +1,152 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.passenger;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contrib.dvrp.optimizer.Request;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class AcceptedDrtRequest {
+	public static AcceptedDrtRequest createFromOriginalRequest(DrtRequest request) {
+		return AcceptedDrtRequest.newBuilder()
+				.request(request)
+				.earliestStartTime(request.getEarliestStartTime())
+				.latestStartTime(request.getLatestStartTime())
+				.latestArrivalTime(request.getLatestArrivalTime())
+				.build();
+	}
+
+	private final DrtRequest request;
+
+	private final double earliestStartTime;
+	private final double latestStartTime;
+	private final double latestArrivalTime;
+
+	private AcceptedDrtRequest(Builder builder) {
+		request = builder.request;
+		earliestStartTime = builder.earliestStartTime;
+		latestStartTime = builder.latestStartTime;
+		latestArrivalTime = builder.latestArrivalTime;
+	}
+
+	public static Builder newBuilder() {
+		return new Builder();
+	}
+
+	public static Builder newBuilder(AcceptedDrtRequest copy) {
+		Builder builder = new Builder();
+		builder.request = copy.getRequest();
+		builder.earliestStartTime = copy.getEarliestStartTime();
+		builder.latestStartTime = copy.getLatestStartTime();
+		builder.latestArrivalTime = copy.getLatestArrivalTime();
+		return builder;
+	}
+
+	public DrtRequest getRequest() {
+		return request;
+	}
+
+	public double getEarliestStartTime() {
+		return earliestStartTime;
+	}
+
+	public double getLatestStartTime() {
+		return latestStartTime;
+	}
+
+	public double getLatestArrivalTime() {
+		return latestArrivalTime;
+	}
+
+	public Id<Request> getId() {
+		return request.getId();
+	}
+
+	public double getSubmissionTime() {
+		return request.getSubmissionTime();
+	}
+
+	public Link getFromLink() {
+		return request.getFromLink();
+	}
+
+	public Link getToLink() {
+		return request.getToLink();
+	}
+
+	public Id<Person> getPassengerId() {
+		return request.getPassengerId();
+	}
+
+	public String getMode() {
+		return request.getMode();
+	}
+
+	@Override
+	public String toString() {
+		return MoreObjects.toStringHelper(this)
+				.add("request", request)
+				.add("earliestStartTime", earliestStartTime)
+				.add("latestStartTime", latestStartTime)
+				.add("latestArrivalTime", latestArrivalTime)
+				.toString();
+	}
+
+	public static final class Builder {
+		private DrtRequest request;
+		private double earliestStartTime;
+		private double latestStartTime;
+		private double latestArrivalTime;
+
+		private Builder() {
+		}
+
+		public Builder request(DrtRequest val) {
+			request = val;
+			return this;
+		}
+
+		public Builder earliestStartTime(double val) {
+			earliestStartTime = val;
+			return this;
+		}
+
+		public Builder latestStartTime(double val) {
+			latestStartTime = val;
+			return this;
+		}
+
+		public Builder latestArrivalTime(double val) {
+			latestArrivalTime = val;
+			return this;
+		}
+
+		public AcceptedDrtRequest build() {
+			return new AcceptedDrtRequest(this);
+		}
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DrtOfferAcceptor.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DrtOfferAcceptor.java
@@ -1,0 +1,39 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.passenger;
+
+import java.util.Optional;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public interface DrtOfferAcceptor {
+	DrtOfferAcceptor DEFAULT_ACCEPTOR = (request, departureTime, arrivalTime) -> Optional.of(
+			AcceptedDrtRequest.createFromOriginalRequest(request));
+
+	/**
+	 * @param request       drt request
+	 * @param departureTime offered departure time for the new request
+	 * @param arrivalTime   offered arrival time for the new request
+	 * @return accepted request (if accepted) or empty
+	 */
+	Optional<AcceptedDrtRequest> acceptDrtOffer(DrtRequest request, double departureTime, double arrivalTime);
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DrtStopActivity.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DrtStopActivity.java
@@ -27,7 +27,6 @@ import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.dvrp.optimizer.Request;
 import org.matsim.contrib.dvrp.passenger.PassengerHandler;
 import org.matsim.contrib.dvrp.passenger.PassengerPickupActivity;
-import org.matsim.contrib.dvrp.passenger.PassengerRequest;
 import org.matsim.contrib.dvrp.schedule.StayTask;
 import org.matsim.contrib.dynagent.DynAgent;
 import org.matsim.contrib.dynagent.FirstLastSimStepDynActivity;
@@ -41,15 +40,15 @@ import org.matsim.core.mobsim.framework.MobsimPassengerAgent;
 public class DrtStopActivity extends FirstLastSimStepDynActivity implements PassengerPickupActivity {
 	private final PassengerHandler passengerHandler;
 	private final DynAgent driver;
-	private final Map<Id<Request>, ? extends PassengerRequest> dropoffRequests;
-	private final Map<Id<Request>, ? extends PassengerRequest> pickupRequests;
+	private final Map<Id<Request>, ? extends AcceptedDrtRequest> dropoffRequests;
+	private final Map<Id<Request>, ? extends AcceptedDrtRequest> pickupRequests;
 	private final double expectedEndTime;
 
 	private int passengersPickedUp = 0;
 
 	public DrtStopActivity(PassengerHandler passengerHandler, DynAgent driver, StayTask task,
-			Map<Id<Request>, ? extends PassengerRequest> dropoffRequests,
-			Map<Id<Request>, ? extends PassengerRequest> pickupRequests, String activityType) {
+			Map<Id<Request>, ? extends AcceptedDrtRequest> dropoffRequests,
+			Map<Id<Request>, ? extends AcceptedDrtRequest> pickupRequests, String activityType) {
 		super(activityType);
 		this.passengerHandler = passengerHandler;
 		this.driver = driver;
@@ -66,7 +65,7 @@ public class DrtStopActivity extends FirstLastSimStepDynActivity implements Pass
 	@Override
 	protected void beforeFirstStep(double now) {
 		// TODO probably we should simulate it more accurately (passenger by passenger, not all at once...)
-		for (PassengerRequest request : dropoffRequests.values()) {
+		for (var request : dropoffRequests.values()) {
 			passengerHandler.dropOffPassenger(driver, request.getId(), now);
 		}
 	}
@@ -74,7 +73,7 @@ public class DrtStopActivity extends FirstLastSimStepDynActivity implements Pass
 	@Override
 	protected void simStep(double now) {
 		if (now == expectedEndTime) {
-			for (PassengerRequest request : pickupRequests.values()) {
+			for (var request : pickupRequests.values()) {
 				if (passengerHandler.tryPickUpPassenger(this, driver, request.getId(), now)) {
 					passengersPickedUp++;
 				}
@@ -88,7 +87,7 @@ public class DrtStopActivity extends FirstLastSimStepDynActivity implements Pass
 			return;// pick up only at the end of stop activity
 		}
 
-		PassengerRequest request = getRequestForPassenger(passenger.getId());
+		var request = getRequestForPassenger(passenger.getId());
 		if (passengerHandler.tryPickUpPassenger(this, driver, request.getId(), now)) {
 			passengersPickedUp++;
 		} else {
@@ -96,7 +95,7 @@ public class DrtStopActivity extends FirstLastSimStepDynActivity implements Pass
 		}
 	}
 
-	private PassengerRequest getRequestForPassenger(Id<Person> passengerId) {
+	private AcceptedDrtRequest getRequestForPassenger(Id<Person> passengerId) {
 		return pickupRequests.values()
 				.stream()
 				.filter(r -> passengerId.equals(r.getPassengerId()))

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DrtStopActivity.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DrtStopActivity.java
@@ -1,9 +1,9 @@
-/* *********************************************************************** *
- *                                                                         *
+/*
+ * *********************************************************************** *
  * project: org.matsim.*
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2014 by the members listed in the COPYING,        *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -15,15 +15,19 @@
  *   (at your option) any later version.                                   *
  *   See also COPYING, LICENSE and WARRANTY file                           *
  *                                                                         *
- * *********************************************************************** */
+ * *********************************************************************** *
+ */
 
-package org.matsim.contrib.dvrp.passenger;
+package org.matsim.contrib.drt.passenger;
 
 import java.util.Map;
 
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.dvrp.optimizer.Request;
+import org.matsim.contrib.dvrp.passenger.PassengerHandler;
+import org.matsim.contrib.dvrp.passenger.PassengerPickupActivity;
+import org.matsim.contrib.dvrp.passenger.PassengerRequest;
 import org.matsim.contrib.dvrp.schedule.StayTask;
 import org.matsim.contrib.dynagent.DynAgent;
 import org.matsim.contrib.dynagent.FirstLastSimStepDynActivity;
@@ -34,7 +38,7 @@ import org.matsim.core.mobsim.framework.MobsimPassengerAgent;
  *
  * @author michalm
  */
-public class BusStopActivity extends FirstLastSimStepDynActivity implements PassengerPickupActivity {
+public class DrtStopActivity extends FirstLastSimStepDynActivity implements PassengerPickupActivity {
 	private final PassengerHandler passengerHandler;
 	private final DynAgent driver;
 	private final Map<Id<Request>, ? extends PassengerRequest> dropoffRequests;
@@ -43,7 +47,7 @@ public class BusStopActivity extends FirstLastSimStepDynActivity implements Pass
 
 	private int passengersPickedUp = 0;
 
-	public BusStopActivity(PassengerHandler passengerHandler, DynAgent driver, StayTask task,
+	public DrtStopActivity(PassengerHandler passengerHandler, DynAgent driver, StayTask task,
 			Map<Id<Request>, ? extends PassengerRequest> dropoffRequests,
 			Map<Id<Request>, ? extends PassengerRequest> pickupRequests, String activityType) {
 		super(activityType);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DefaultDrtStopTask.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DefaultDrtStopTask.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.contrib.drt.passenger.DrtRequest;
+import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
 import org.matsim.contrib.dvrp.optimizer.Request;
 import org.matsim.contrib.dvrp.schedule.DefaultStayTask;
 
@@ -43,8 +43,8 @@ import com.google.common.base.MoreObjects;
 public class DefaultDrtStopTask extends DefaultStayTask implements DrtStopTask {
 	public static final DrtTaskType TYPE = new DrtTaskType(STOP);
 
-	private final Map<Id<Request>, DrtRequest> dropoffRequests = new LinkedHashMap<>();
-	private final Map<Id<Request>, DrtRequest> pickupRequests = new LinkedHashMap<>();
+	private final Map<Id<Request>, AcceptedDrtRequest> dropoffRequests = new LinkedHashMap<>();
+	private final Map<Id<Request>, AcceptedDrtRequest> pickupRequests = new LinkedHashMap<>();
 
 	public DefaultDrtStopTask(double beginTime, double endTime, Link link) {
 		super(TYPE, beginTime, endTime, link);
@@ -54,7 +54,7 @@ public class DefaultDrtStopTask extends DefaultStayTask implements DrtStopTask {
 	 * @return requests associated with passengers being dropped off at this stop
 	 */
 	@Override
-	public Map<Id<Request>, DrtRequest> getDropoffRequests() {
+	public Map<Id<Request>, AcceptedDrtRequest> getDropoffRequests() {
 		return Collections.unmodifiableMap(dropoffRequests);
 	}
 
@@ -62,17 +62,17 @@ public class DefaultDrtStopTask extends DefaultStayTask implements DrtStopTask {
 	 * @return requests associated with passengers being picked up at this stop
 	 */
 	@Override
-	public Map<Id<Request>, DrtRequest> getPickupRequests() {
+	public Map<Id<Request>, AcceptedDrtRequest> getPickupRequests() {
 		return Collections.unmodifiableMap(pickupRequests);
 	}
 
 	@Override
-	public void addDropoffRequest(DrtRequest request) {
+	public void addDropoffRequest(AcceptedDrtRequest request) {
 		dropoffRequests.put(request.getId(), request);
 	}
 
 	@Override
-	public void addPickupRequest(DrtRequest request) {
+	public void addPickupRequest(AcceptedDrtRequest request) {
 		pickupRequests.put(request.getId(), request);
 	}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtStayTaskEndTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtStayTaskEndTimeCalculator.java
@@ -21,7 +21,7 @@ package org.matsim.contrib.drt.schedule;
 import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.getBaseTypeOrElseThrow;
 import static org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater.REMOVE_STAY_TASK;
 
-import org.matsim.contrib.drt.passenger.DrtRequest;
+import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
@@ -58,7 +58,7 @@ public class DrtStayTaskEndTimeCalculator implements ScheduleTimingUpdater.StayT
 				double maxEarliestPickupTime = ((DrtStopTask)task).getPickupRequests()
 						.values()
 						.stream()
-						.mapToDouble(DrtRequest::getEarliestStartTime)
+						.mapToDouble(AcceptedDrtRequest::getEarliestStartTime)
 						.max()
 						.orElse(Double.NEGATIVE_INFINITY); //TODO REMOVE_STAY_TASK ?? @michal
 				return Math.max(newBeginTime + stopDuration, maxEarliestPickupTime);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtStopTask.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtStopTask.java
@@ -23,7 +23,7 @@ package org.matsim.contrib.drt.schedule;
 import java.util.Map;
 
 import org.matsim.api.core.v01.Id;
-import org.matsim.contrib.drt.passenger.DrtRequest;
+import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
 import org.matsim.contrib.dvrp.optimizer.Request;
 import org.matsim.contrib.dvrp.schedule.StayTask;
 
@@ -35,11 +35,11 @@ import org.matsim.contrib.dvrp.schedule.StayTask;
  * @author Michal Maciejewski (michalm)
  */
 public interface DrtStopTask extends StayTask {
-	Map<Id<Request>, DrtRequest> getDropoffRequests();
+	Map<Id<Request>, AcceptedDrtRequest> getDropoffRequests();
 
-	Map<Id<Request>, DrtRequest> getPickupRequests();
+	Map<Id<Request>, AcceptedDrtRequest> getPickupRequests();
 
-	void addDropoffRequest(DrtRequest request);
+	void addDropoffRequest(AcceptedDrtRequest request);
 
-	void addPickupRequest(DrtRequest request);
+	void addPickupRequest(AcceptedDrtRequest request);
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
@@ -28,6 +28,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
 import org.matsim.contrib.drt.optimizer.Waypoint;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionWithDetourData;
+import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtDriveTask;
@@ -80,7 +81,7 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 	}
 
 	@Override
-	public PickupDropoffTaskPair scheduleRequest(DrtRequest request, InsertionWithDetourData insertion) {
+	public PickupDropoffTaskPair scheduleRequest(AcceptedDrtRequest request, InsertionWithDetourData insertion) {
 		var pickupTask = insertPickup(request, insertion);
 		verifyTimes("Inconsistent pickup departure time", insertion.detourTimeInfo.pickupDetourInfo.departureTime,
 				pickupTask.getEndTime());
@@ -101,7 +102,7 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 				timeFromInsertionData);
 	}
 
-	private DrtStopTask insertPickup(DrtRequest request, InsertionWithDetourData insertionWithDetourData) {
+	private DrtStopTask insertPickup(AcceptedDrtRequest request, InsertionWithDetourData insertionWithDetourData) {
 		var insertion = insertionWithDetourData.insertion;
 		VehicleEntry vehicleEntry = insertion.vehicleEntry;
 		Schedule schedule = vehicleEntry.vehicle.getSchedule();
@@ -246,7 +247,7 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 		return pickupStopTask;
 	}
 
-	private DrtStopTask insertDropoff(DrtRequest request, InsertionWithDetourData insertionWithDetourData,
+	private DrtStopTask insertDropoff(AcceptedDrtRequest request, InsertionWithDetourData insertionWithDetourData,
 			DrtStopTask pickupTask) {
 		var insertion = insertionWithDetourData.insertion;
 		VehicleEntry vehicleEntry = insertion.vehicleEntry;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/RequestInsertionScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/RequestInsertionScheduler.java
@@ -21,6 +21,7 @@
 package org.matsim.contrib.drt.scheduler;
 
 import org.matsim.contrib.drt.optimizer.insertion.InsertionWithDetourData;
+import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.schedule.DrtStopTask;
 
@@ -38,5 +39,5 @@ public interface RequestInsertionScheduler {
 		}
 	}
 
-	PickupDropoffTaskPair scheduleRequest(DrtRequest request, InsertionWithDetourData insertion);
+	PickupDropoffTaskPair scheduleRequest(AcceptedDrtRequest request, InsertionWithDetourData insertion);
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/vrpagent/DrtActionCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/vrpagent/DrtActionCreator.java
@@ -21,9 +21,9 @@ package org.matsim.contrib.drt.vrpagent;
 
 import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.getBaseTypeOrElseThrow;
 
+import org.matsim.contrib.drt.passenger.DrtStopActivity;
 import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
-import org.matsim.contrib.dvrp.passenger.BusStopActivity;
 import org.matsim.contrib.dvrp.passenger.PassengerHandler;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.schedule.Task;
@@ -63,7 +63,7 @@ public class DrtActionCreator implements VrpAgentLogic.DynActionCreator {
 
 			case STOP:
 				DrtStopTask t = (DrtStopTask)task;
-				return new BusStopActivity(passengerHandler, dynAgent, t, t.getDropoffRequests(), t.getPickupRequests(),
+				return new DrtStopActivity(passengerHandler, dynAgent, t, t.getDropoffRequests(), t.getPickupRequests(),
 						DRT_STOP_NAME);
 
 			case STAY:

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserterTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserterTest.java
@@ -38,6 +38,7 @@ import org.matsim.api.core.v01.Identifiable;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
 import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
+import org.matsim.contrib.drt.passenger.DrtOfferAcceptor;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 import org.matsim.contrib.drt.scheduler.RequestInsertionScheduler;
@@ -205,7 +206,10 @@ public class DefaultUnplannedRequestInserterTest {
 
 		DrtInsertionSearch insertionSearch = (drtRequest, vEntries) -> drtRequest == request1 ?
 				Optional.of(new InsertionWithDetourData(
-						new InsertionGenerator.Insertion(vEntries.iterator().next(), null, null), null, null)) :
+						new InsertionGenerator.Insertion(vEntries.iterator().next(), null, null), null,
+						new InsertionDetourTimeCalculator.DetourTimeInfo(
+								mock(InsertionDetourTimeCalculator.PickupDetourInfo.class),
+								mock(InsertionDetourTimeCalculator.DropoffDetourInfo.class)))) :
 				fail("request1 expected");
 
 		double pickupEndTime = now + 20;
@@ -272,7 +276,8 @@ public class DefaultUnplannedRequestInserterTest {
 			VehicleEntry.EntryFactory vehicleEntryFactory, DrtRequestInsertionRetryQueue insertionRetryQueue,
 			DrtInsertionSearch insertionSearch, RequestInsertionScheduler insertionScheduler) {
 		return new DefaultUnplannedRequestInserter(mode, fleet, () -> now, eventsManager, insertionScheduler,
-				vehicleEntryFactory, insertionRetryQueue, rule.forkJoinPool, insertionSearch);
+				vehicleEntryFactory, insertionRetryQueue, insertionSearch, DrtOfferAcceptor.DEFAULT_ACCEPTOR,
+				rule.forkJoinPool);
 	}
 
 	private Link link(String id) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserterTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserterTest.java
@@ -37,6 +37,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Identifiable;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
+import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 import org.matsim.contrib.drt.scheduler.RequestInsertionScheduler;
@@ -59,6 +60,7 @@ public class DefaultUnplannedRequestInserterTest {
 	private static final String mode = "DRT_MODE";
 
 	private final DrtRequest request1 = request("r1", "from1", "to1");
+	private final AcceptedDrtRequest acceptedDrtRequest1 = AcceptedDrtRequest.createFromOriginalRequest(request1);
 
 	private final EventsManager eventsManager = mock(EventsManager.class);
 
@@ -210,9 +212,9 @@ public class DefaultUnplannedRequestInserterTest {
 		double dropoffBeginTime = now + 40;
 		RequestInsertionScheduler insertionScheduler = (request, insertion) -> {
 			var pickupTask = new DefaultDrtStopTask(pickupEndTime - 10, pickupEndTime, request1.getFromLink());
-			pickupTask.addPickupRequest(request1);
+			pickupTask.addPickupRequest(acceptedDrtRequest1);
 			var dropoffTask = new DefaultDrtStopTask(dropoffBeginTime, dropoffBeginTime + 10, request1.getToLink());
-			dropoffTask.addPickupRequest(request1);
+			dropoffTask.addPickupRequest(acceptedDrtRequest1);
 			return new PickupDropoffTaskPair(pickupTask, dropoffTask);
 		};
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/BusStopActivity.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/BusStopActivity.java
@@ -63,7 +63,7 @@ public class BusStopActivity extends FirstLastSimStepDynActivity implements Pass
 	protected void beforeFirstStep(double now) {
 		// TODO probably we should simulate it more accurately (passenger by passenger, not all at once...)
 		for (PassengerRequest request : dropoffRequests.values()) {
-			passengerHandler.dropOffPassenger(driver, request, now);
+			passengerHandler.dropOffPassenger(driver, request.getId(), now);
 		}
 	}
 
@@ -71,7 +71,7 @@ public class BusStopActivity extends FirstLastSimStepDynActivity implements Pass
 	protected void simStep(double now) {
 		if (now == expectedEndTime) {
 			for (PassengerRequest request : pickupRequests.values()) {
-				if (passengerHandler.tryPickUpPassenger(this, driver, request, now)) {
+				if (passengerHandler.tryPickUpPassenger(this, driver, request.getId(), now)) {
 					passengersPickedUp++;
 				}
 			}
@@ -85,7 +85,7 @@ public class BusStopActivity extends FirstLastSimStepDynActivity implements Pass
 		}
 
 		PassengerRequest request = getRequestForPassenger(passenger.getId());
-		if (passengerHandler.tryPickUpPassenger(this, driver, request, now)) {
+		if (passengerHandler.tryPickUpPassenger(this, driver, request.getId(), now)) {
 			passengersPickedUp++;
 		} else {
 			throw new IllegalStateException("The passenger is not on the link or not available for departure!");
@@ -93,7 +93,8 @@ public class BusStopActivity extends FirstLastSimStepDynActivity implements Pass
 	}
 
 	private PassengerRequest getRequestForPassenger(Id<Person> passengerId) {
-		return pickupRequests.values().stream()
+		return pickupRequests.values()
+				.stream()
 				.filter(r -> passengerId.equals(r.getPassengerId()))
 				.findAny()
 				.orElseThrow(() -> new IllegalArgumentException("I am waiting for different passengers!"));

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/DefaultPassengerEngine.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/DefaultPassengerEngine.java
@@ -35,7 +35,6 @@ import org.matsim.api.core.v01.population.Route;
 import org.matsim.contrib.dvrp.optimizer.Request;
 import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
 import org.matsim.contrib.dvrp.run.DvrpModes;
-import org.matsim.core.modal.ModalProviders;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.framework.MobsimAgent;
 import org.matsim.core.mobsim.framework.MobsimDriverAgent;
@@ -43,6 +42,7 @@ import org.matsim.core.mobsim.framework.MobsimPassengerAgent;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.mobsim.framework.PlanAgent;
 import org.matsim.core.mobsim.qsim.InternalInterface;
+import org.matsim.core.modal.ModalProviders;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
@@ -149,17 +149,16 @@ public final class DefaultPassengerEngine implements PassengerEngine, PassengerR
 
 	@Override
 	public boolean tryPickUpPassenger(PassengerPickupActivity pickupActivity, MobsimDriverAgent driver,
-			PassengerRequest request, double now) {
-		boolean pickedUp = internalPassengerHandling.tryPickUpPassenger(driver, activePassengers.get(request.getId()),
-				request.getId(), now);
+			Id<Request> requestId, double now) {
+		boolean pickedUp = internalPassengerHandling.tryPickUpPassenger(driver, activePassengers.get(requestId),
+				requestId, now);
 		Verify.verify(pickedUp, "Not possible without prebooking");
 		return pickedUp;
 	}
 
 	@Override
-	public void dropOffPassenger(MobsimDriverAgent driver, PassengerRequest request, double now) {
-		internalPassengerHandling.dropOffPassenger(driver, activePassengers.remove(request.getId()), request.getId(),
-				now);
+	public void dropOffPassenger(MobsimDriverAgent driver, Id<Request> requestId, double now) {
+		internalPassengerHandling.dropOffPassenger(driver, activePassengers.remove(requestId), requestId, now);
 	}
 
 	@Override

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/MultiPassengerDropoffActivity.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/MultiPassengerDropoffActivity.java
@@ -54,7 +54,7 @@ public class MultiPassengerDropoffActivity extends FirstLastSimStepDynActivity {
 	protected void afterLastStep(double now) {
 		// dropoff at the end of stop activity
 		for (PassengerRequest request : requests.values()) {
-			passengerHandler.dropOffPassenger(driver, request, now);
+			passengerHandler.dropOffPassenger(driver, request.getId(), now);
 		}
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/MultiPassengerPickupActivity.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/MultiPassengerPickupActivity.java
@@ -55,7 +55,7 @@ public class MultiPassengerPickupActivity extends FirstLastSimStepDynActivity im
 	@Override
 	protected void beforeFirstStep(double now) {
 		for (PassengerRequest request : requests.values()) {
-			if (passengerHandler.tryPickUpPassenger(this, driver, request, now)) {
+			if (passengerHandler.tryPickUpPassenger(this, driver, request.getId(), now)) {
 				passengersPickedUp++;
 			}
 		}
@@ -64,7 +64,7 @@ public class MultiPassengerPickupActivity extends FirstLastSimStepDynActivity im
 	@Override
 	public void notifyPassengerIsReadyForDeparture(MobsimPassengerAgent passenger, double now) {
 		PassengerRequest request = getRequestForPassenger(passenger.getId());
-		if (passengerHandler.tryPickUpPassenger(this, driver, request, now)) {
+		if (passengerHandler.tryPickUpPassenger(this, driver, request.getId(), now)) {
 			passengersPickedUp++;
 		} else {
 			throw new IllegalStateException("The passenger is not on the link or not available for departure!");
@@ -72,7 +72,8 @@ public class MultiPassengerPickupActivity extends FirstLastSimStepDynActivity im
 	}
 
 	private PassengerRequest getRequestForPassenger(Id<Person> passengerId) {
-		return requests.values().stream()
+		return requests.values()
+				.stream()
 				.filter(r -> passengerId.equals(r.getPassengerId()))
 				.findAny()
 				.orElseThrow(() -> new IllegalArgumentException("I am waiting for different passengers!"));

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/PassengerEngineWithPrebooking.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/PassengerEngineWithPrebooking.java
@@ -38,7 +38,6 @@ import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.dvrp.optimizer.Request;
 import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
 import org.matsim.contrib.dvrp.run.DvrpModes;
-import org.matsim.core.modal.ModalProviders;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.gbl.Gbl;
 import org.matsim.core.mobsim.framework.MobsimAgent;
@@ -49,6 +48,7 @@ import org.matsim.core.mobsim.qsim.InternalInterface;
 import org.matsim.core.mobsim.qsim.PreplanningEngine;
 import org.matsim.core.mobsim.qsim.interfaces.TripInfo;
 import org.matsim.core.mobsim.qsim.interfaces.TripInfoWithRequiredBooking;
+import org.matsim.core.modal.ModalProviders;
 import org.matsim.facilities.FacilitiesUtils;
 
 import com.google.common.base.Preconditions;
@@ -202,32 +202,33 @@ public final class PassengerEngineWithPrebooking
 
 	// ================ PICKUP / DROPOFF
 
+	@Override
 	public boolean tryPickUpPassenger(PassengerPickupActivity pickupActivity, MobsimDriverAgent driver,
-			PassengerRequest request, double now) {
+			Id<Request> requestId, double now) {
 		Id<Link> linkId = driver.getCurrentLinkId();
-		RequestEntry requestEntry = activeRequests.get(request.getId());
+		RequestEntry requestEntry = activeRequests.get(requestId);
 		MobsimPassengerAgent passenger = requestEntry.passenger;
 
 		if (passenger.getCurrentLinkId() != linkId
 				|| passenger.getState() != MobsimAgent.State.LEG
 				|| !passenger.getMode().equals(mode)) {
-			awaitingPickups.put(request.getId(), pickupActivity);
+			awaitingPickups.put(requestId, pickupActivity);
 			return false;// wait for the passenger
 		}
 
-		if (!internalPassengerHandling.tryPickUpPassenger(driver, passenger, request.getId(), now)) {
+		if (!internalPassengerHandling.tryPickUpPassenger(driver, passenger, requestId, now)) {
 			// the passenger has already been picked up and is on another taxi trip
 			// seems there have been at least 2 requests made by this passenger for this location
-			awaitingPickups.put(request.getId(), pickupActivity);
+			awaitingPickups.put(requestId, pickupActivity);
 			return false;// wait for the passenger (optimistically, he/she should appear soon)
 		}
 
 		return true;
 	}
 
-	public void dropOffPassenger(MobsimDriverAgent driver, PassengerRequest request, double now) {
-		internalPassengerHandling.dropOffPassenger(driver, activeRequests.remove(request.getId()).passenger,
-				request.getId(), now);
+	@Override
+	public void dropOffPassenger(MobsimDriverAgent driver, Id<Request> requestId, double now) {
+		internalPassengerHandling.dropOffPassenger(driver, activeRequests.remove(requestId).passenger, requestId, now);
 	}
 
 	// ================ REJECTED/SCHEDULED EVENTS

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/PassengerHandler.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/PassengerHandler.java
@@ -20,14 +20,16 @@
 
 package org.matsim.contrib.dvrp.passenger;
 
+import org.matsim.api.core.v01.Id;
+import org.matsim.contrib.dvrp.optimizer.Request;
 import org.matsim.core.mobsim.framework.MobsimDriverAgent;
 
 /**
  * @author Michal Maciejewski (michalm)
  */
 public interface PassengerHandler {
-	boolean tryPickUpPassenger(PassengerPickupActivity pickupActivity, MobsimDriverAgent driver,
-			PassengerRequest request, double now);
+	boolean tryPickUpPassenger(PassengerPickupActivity pickupActivity, MobsimDriverAgent driver, Id<Request> requestId,
+			double now);
 
-	void dropOffPassenger(MobsimDriverAgent driver, PassengerRequest request, double now);
+	void dropOffPassenger(MobsimDriverAgent driver, Id<Request> requestId, double now);
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/SinglePassengerDropoffActivity.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/SinglePassengerDropoffActivity.java
@@ -48,6 +48,6 @@ public class SinglePassengerDropoffActivity extends FirstLastSimStepDynActivity 
 
 	@Override
 	protected void afterLastStep(double now) {
-		passengerHandler.dropOffPassenger(driver, request, now);
+		passengerHandler.dropOffPassenger(driver, request.getId(), now);
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/SinglePassengerPickupActivity.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/SinglePassengerPickupActivity.java
@@ -49,7 +49,7 @@ public class SinglePassengerPickupActivity extends FirstLastSimStepDynActivity i
 
 	@Override
 	protected void beforeFirstStep(double now) {
-		passengerAboard = passengerHandler.tryPickUpPassenger(this, driver, request, now);
+		passengerAboard = passengerHandler.tryPickUpPassenger(this, driver, request.getId(), now);
 	}
 
 	@Override
@@ -58,7 +58,7 @@ public class SinglePassengerPickupActivity extends FirstLastSimStepDynActivity i
 			throw new IllegalArgumentException("I am waiting for a different passenger!");
 		}
 
-		passengerAboard = passengerHandler.tryPickUpPassenger(this, driver, request, now);
+		passengerAboard = passengerHandler.tryPickUpPassenger(this, driver, request.getId(), now);
 		if (!passengerAboard) {
 			throw new IllegalStateException("The passenger is not on the link or not available for departure!");
 		}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/TeleportingPassengerEngine.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/TeleportingPassengerEngine.java
@@ -36,8 +36,8 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.Route;
+import org.matsim.contrib.dvrp.optimizer.Request;
 import org.matsim.contrib.dvrp.run.DvrpModes;
-import org.matsim.core.modal.ModalProviders;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.framework.MobsimAgent;
 import org.matsim.core.mobsim.framework.MobsimDriverAgent;
@@ -48,6 +48,7 @@ import org.matsim.core.mobsim.qsim.DefaultTeleportationEngine;
 import org.matsim.core.mobsim.qsim.InternalInterface;
 import org.matsim.core.mobsim.qsim.TeleportationEngine;
 import org.matsim.core.mobsim.qsim.agents.WithinDayAgentUtils;
+import org.matsim.core.modal.ModalProviders;
 import org.matsim.vis.snapshotwriters.AgentSnapshotInfo;
 import org.matsim.vis.snapshotwriters.VisData;
 
@@ -184,12 +185,12 @@ public class TeleportingPassengerEngine implements PassengerEngine, VisData {
 
 	@Override
 	public boolean tryPickUpPassenger(PassengerPickupActivity pickupActivity, MobsimDriverAgent driver,
-			PassengerRequest request, double now) {
+			Id<Request> requestId, double now) {
 		throw new UnsupportedOperationException("No picking-up when teleporting");
 	}
 
 	@Override
-	public void dropOffPassenger(MobsimDriverAgent driver, PassengerRequest request, double now) {
+	public void dropOffPassenger(MobsimDriverAgent driver, Id<Request> requestId, double now) {
 		throw new UnsupportedOperationException("No dropping-off when teleporting");
 	}
 


### PR DESCRIPTION
This PR tries to build the basis for #1954 and similar. The idea is that once the best insertion is selected for a given `DrtRequest`, this proposed insertion needs to be accepted/confirmed/finalised using a mode-specific `DrtOfferAcceptor`. This opens up many opportunities for shaping the final `AcceptedDrtRequest` (e.g. limiting the buffer of the pickup/dropoff times as in #1954). It is also possible to not accept the offer.

There are no special assumptions around `AcceptedDrtRequest`, such as which side accepts the offer (passenger/service provider or both) and how the acceptance process looks like. The purpose is to keep it as simple as possible for the time being (until a more comprehensive prebooking approach is introduced).