### PR TITLE
drt: make DrtConfigGroup extendable/customisable

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -56,7 +56,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 
-public final class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableParameterSets implements Modal {
+public class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableParameterSets implements Modal {
 	private static final Logger log = Logger.getLogger(DrtConfigGroup.class);
 
 	public static final String GROUP_NAME = "drt";

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/MultiModeDrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/MultiModeDrtConfigGroup.java
@@ -28,6 +28,7 @@ import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ReflectiveConfigGroup;
 
+import com.google.common.base.Supplier;
 import com.google.common.base.Verify;
 
 /**
@@ -44,8 +45,15 @@ public final class MultiModeDrtConfigGroup extends ReflectiveConfigGroup impleme
 		return (MultiModeDrtConfigGroup)config.getModule(GROUP_NAME);
 	}
 
+	private final Supplier<DrtConfigGroup> drtConfigSupplier;
+
 	public MultiModeDrtConfigGroup() {
+		this(DrtConfigGroup::new);
+	}
+
+	public MultiModeDrtConfigGroup(Supplier<DrtConfigGroup> drtConfigSupplier) {
 		super(GROUP_NAME);
+		this.drtConfigSupplier = drtConfigSupplier;
 	}
 
 	@Override
@@ -59,7 +67,7 @@ public final class MultiModeDrtConfigGroup extends ReflectiveConfigGroup impleme
 	@Override
 	public ConfigGroup createParameterSet(String type) {
 		if (type.equals(DrtConfigGroup.GROUP_NAME)) {
-			return new DrtConfigGroup();
+			return drtConfigSupplier.get();
 		} else {
 			throw new IllegalArgumentException("Unsupported parameter set type: " + type);
 		}
@@ -74,8 +82,8 @@ public final class MultiModeDrtConfigGroup extends ReflectiveConfigGroup impleme
 		}
 	}
 
-	public final void addDrtConfig( DrtConfigGroup set ) {
-		addParameterSet( set );
+	public final void addDrtConfig(DrtConfigGroup set) {
+		addParameterSet(set);
 	}
 
 	@Override


### PR DESCRIPTION
One of several changes in #1937 is adding `DrtShiftsParams` to `DrtConfigGroup`.

I would like to avoid doing that:
- Since this param set is used in the shifts extension, this change introduces a reverse dependency (standard drt depends on drt extensions). As a result, changes to this extension (incl. removal of it) may potentially impact the standard drt implementation.
- Following this change, we might also want to add param sets of other extensions to the drt config, which would result in `DrtConfigGroup` becoming bigger and bigger (and more fragile).

This PR a generic approach for making the drt config extendable/customisable:
- make `DrtConfigGroup` non-final (to allow extending it)
- add `Supplier<DrtConfigGroup>` to `MultiModeDrtConfigGroup` so we can instantiate any custom drt config

An example of a custom drt config (optional param set):
```java
public class DrtWithShiftsConfigGroup extends DrtConfigGroup {

	@Nullable
	private DrtShiftParams drtShiftParams;

	public DrtWithShiftsConfigGroup() {
		addDefinition(DrtShiftParams.SET_NAME, DrtShiftParams::new,
				() -> drtShiftParams,
				params -> drtShiftParams = (DrtShiftParams)params);
	}

	public Optional<DrtShiftParams> getDrtShiftParams() {
		return Optional.ofNullable(drtShiftParams);
	}
}
```
or (mandatory param set):
```java
public class DrtWithShiftsConfigGroup extends DrtConfigGroup {

	@NotNull
	private DrtShiftParams drtShiftParams;

	public DrtWithShiftsConfigGroup() {
		addDefinition(DrtShiftParams.SET_NAME, DrtShiftParams::new,
				() -> drtShiftParams,
				params -> drtShiftParams = (DrtShiftParams)params);
	}

	public DrtShiftParams getDrtShiftParams() {
		return drtShiftParams;
	}
}
```
To load it from the file, pass `DrtWithShiftsConfigGroup::new` as the drt config supplier to the `MultiModeDrtConfigGroup` constructor:
```java
Config config = ConfigUtils.loadConfig(configFile, new MultiModeDrtConfigGroup(DrtWithShiftsConfigGroup::new), new DvrpConfigGroup(), new OTFVisConfigGroup());
```