### PR TITLE
ResolveGridCoordinates: add warning if network contains non-car links.

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/prepare/population/ResolveGridCoordinates.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/population/ResolveGridCoordinates.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.locationtech.jts.geom.Geometry;
 import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.*;
@@ -29,6 +30,10 @@ public class ResolveGridCoordinates implements MATSimAppCommand {
 
 	private static final Logger log = LogManager.getLogger(ResolveGridCoordinates.class);
 
+	/**
+	 * It is highly recommended to <b>use a car-network</b> (i.e. a network where car is permitted) on each link, as otherwise you probably run into problems.
+	 * In scenarios that use access/egress routing, things might still work, but older scenarios will most likely break.
+	 */
 	@CommandLine.Parameters(paramLabel = "INPUT", arity = "1", description = "Path to population")
 	private Path input;
 
@@ -106,6 +111,12 @@ public class ResolveGridCoordinates implements MATSimAppCommand {
 
 						if (network != null) {
 							Link link = NetworkUtils.getNearestLink(network, act.getCoord());
+							if(link.getAllowedModes().contains(TransportMode.car)){
+								log.fatal("About to set linkId for activity" + act + "for person " + p + "to " + link.getId() + ".\n" +
+										"However, car is not permitted on this link.\n" +
+										"This might cause problems when running the scenario, especially if access/egress routing is not enabled.\n" +
+										"Please consider to use a car-network only here (i.e. a network where car is permitted on every link)");
+							}
 							if (link != null)
 								act.setLinkId(link.getId());
 						}


### PR DESCRIPTION
ResolveGridCoordinates sets the linkId for activities, similarly to `PersonPrepareForSim`.
This PR proposes to dump a warn message, when a linkId for an activity shall be set to a non-car link.
We could also think of throwing an exception instead.

In the past, `PersonPrepareForSim` considered only links with car allowed. This changed with #1917  but might actually be reversed. The reason was that, with car being the typical network mode (in old scenarios), activities need to be accessible, also when access and egress legs are not simulated (i.e. for backwards compatibility). Most likely, the linkId in the activity can be set to any link that does not allow for car but still can be reached by car, when accessand egress routing is enabled. However, we need to take care of backwards compatibility. Moreover, we ran into problems with the sharing contrib, when not setting the linkId to a car link, even with access/egress routing enabled.
