### PR TITLE
Add WaitForStopTask to DrtEventsReaders's list

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/util/DrtEventsReaders.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/util/DrtEventsReaders.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.matsim.contrib.drt.extension.edrt.schedule.EDrtChargingTask;
+import org.matsim.contrib.drt.extension.preplanned.optimizer.WaitForStopTask;
 import org.matsim.contrib.drt.passenger.events.DrtRequestSubmittedEvent;
 import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 import org.matsim.contrib.drt.schedule.DrtDriveTask;
@@ -41,7 +42,7 @@ import com.google.common.collect.ImmutableMap;
 
 public final class DrtEventsReaders {
 	public static final Map<String, DrtTaskType> TASK_TYPE_MAP = List.of(DrtDriveTask.TYPE, DefaultDrtStopTask.TYPE,
-					DrtStayTask.TYPE, EmptyVehicleRelocator.RELOCATE_VEHICLE_TASK_TYPE, EDrtChargingTask.TYPE)
+					DrtStayTask.TYPE, EmptyVehicleRelocator.RELOCATE_VEHICLE_TASK_TYPE, EDrtChargingTask.TYPE, WaitForStopTask.TYPE)
 			.stream()
 			.collect(toImmutableMap(DrtTaskType::name, type -> type));
 


### PR DESCRIPTION
The newly added WaitForStopTask is not yet in the list of the recognized DRT activity in the DrtEventsReaders. We need to add it in order to run DRT events reader properly. 