### PR TITLE
Draft: allow proper reading of subclassed reflective config groups

### DIFF
--- a/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/shifts/ReadConfigTest.java
+++ b/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/shifts/ReadConfigTest.java
@@ -1,5 +1,6 @@
 package org.matsim.contrib.drt.extension.shifts;
 
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.matsim.contrib.drt.extension.shifts.config.DrtShiftParams;
@@ -8,15 +9,20 @@ import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.config.ConfigWriter;
 import org.matsim.core.utils.io.IOUtils;
 import org.matsim.examples.ExamplesUtils;
+import org.matsim.testcases.MatsimTestCase;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vis.otfvis.OTFVisConfigGroup;
 
 import java.net.URL;
 
-public class ReadConfigTest {
+public class ReadConfigTest extends MatsimTestCase {
+
+	private static final String TESTXMLOUTPUT  = "config.xml";
 
 	@Rule
 	public MatsimTestUtils utils = new MatsimTestUtils();
@@ -27,10 +33,24 @@ public class ReadConfigTest {
 		Config config = ConfigUtils.loadConfig(configUrl, new MultiModeDrtConfigGroup(DrtWithShiftsConfigGroup::new),
 				new DvrpConfigGroup(), new OTFVisConfigGroup());
 
-		MultiModeDrtConfigGroup multiModeDrtConfigGroup = MultiModeDrtConfigGroup.get(config);
-		for (DrtConfigGroup modalElement : multiModeDrtConfigGroup.getModalElements()) {
+		MultiModeDrtConfigGroup multiModeDrtConfigGroupOut = MultiModeDrtConfigGroup.get(config);
+		for (DrtConfigGroup modalElement : multiModeDrtConfigGroupOut.getModalElements()) {
+			ConfigGroup parameterSet = modalElement.createParameterSet(DrtShiftParams.SET_NAME);
+			modalElement.addParameterSet(parameterSet);
 			DrtShiftParams drtShiftParams = ((DrtWithShiftsConfigGroup) modalElement).getDrtShiftParams();
-			drtShiftParams.setAllowInFieldChangeover(false);
+			drtShiftParams.setChangeoverDuration(42);
+		}
+
+		String outfilename = this.getOutputDirectory() + TESTXMLOUTPUT;
+
+		new ConfigWriter(config).write(outfilename);
+
+		Config configIn = ConfigUtils.loadConfig(outfilename, new MultiModeDrtConfigGroup(DrtWithShiftsConfigGroup::new),
+				new DvrpConfigGroup(), new OTFVisConfigGroup());
+		MultiModeDrtConfigGroup multiModeDrtConfigGroupIn = MultiModeDrtConfigGroup.get(configIn);
+		for (DrtConfigGroup modalElement : multiModeDrtConfigGroupIn.getModalElements()) {
+			DrtShiftParams drtShiftParams = ((DrtWithShiftsConfigGroup) modalElement).getDrtShiftParams();
+			Assert.assertEquals(42, drtShiftParams.getChangeoverDuration(), 0);
 		}
 	}
 }

--- a/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/shifts/ReadConfigTest.java
+++ b/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/shifts/ReadConfigTest.java
@@ -1,0 +1,36 @@
+package org.matsim.contrib.drt.extension.shifts;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.matsim.contrib.drt.extension.shifts.config.DrtShiftParams;
+import org.matsim.contrib.drt.extension.shifts.config.DrtWithShiftsConfigGroup;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
+import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.utils.io.IOUtils;
+import org.matsim.examples.ExamplesUtils;
+import org.matsim.testcases.MatsimTestUtils;
+import org.matsim.vis.otfvis.OTFVisConfigGroup;
+
+import java.net.URL;
+
+public class ReadConfigTest {
+
+	@Rule
+	public MatsimTestUtils utils = new MatsimTestUtils();
+
+	@Test
+	public void test() {
+		URL configUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("mielec"), "mielec_drt_config.xml");
+		Config config = ConfigUtils.loadConfig(configUrl, new MultiModeDrtConfigGroup(DrtWithShiftsConfigGroup::new),
+				new DvrpConfigGroup(), new OTFVisConfigGroup());
+
+		MultiModeDrtConfigGroup multiModeDrtConfigGroup = MultiModeDrtConfigGroup.get(config);
+		for (DrtConfigGroup modalElement : multiModeDrtConfigGroup.getModalElements()) {
+			DrtShiftParams drtShiftParams = ((DrtWithShiftsConfigGroup) modalElement).getDrtShiftParams();
+			drtShiftParams.setAllowInFieldChangeover(false);
+		}
+	}
+}

--- a/matsim/src/main/java/org/matsim/core/config/ReflectiveConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/ReflectiveConfigGroup.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.core.api.internal.MatsimExtensionPoint;
@@ -128,7 +129,12 @@ public abstract class ReflectiveConfigGroup extends ConfigGroup implements Matsi
 	private void checkConvertNullAnnotations() {
 		final Class<? extends ReflectiveConfigGroup> c = getClass();
 
-		final Method[] allMethods = c.getDeclaredMethods();
+		Method[] allMethods = c.getDeclaredMethods();
+		Class<?> superclass = c.getSuperclass();
+		if(superclass != ReflectiveConfigGroup.class
+				&& ReflectiveConfigGroup.class.isAssignableFrom(superclass)) {
+			allMethods = ArrayUtils.addAll(allMethods, superclass.getDeclaredMethods());
+		}
 
 		for (Method m : allMethods) {
 			final StringGetter annotation = m.getAnnotation( StringGetter.class );
@@ -146,7 +152,12 @@ public abstract class ReflectiveConfigGroup extends ConfigGroup implements Matsi
 		final Map<String, Method> gs = new HashMap<String, Method>();
 		final Class<? extends ReflectiveConfigGroup> c = getClass();
 
-		final Method[] allMethods = c.getDeclaredMethods();
+		Method[] allMethods = c.getDeclaredMethods();
+		Class<?> superclass = c.getSuperclass();
+		if(superclass != ReflectiveConfigGroup.class
+				&& ReflectiveConfigGroup.class.isAssignableFrom(superclass)) {
+			allMethods = ArrayUtils.addAll(allMethods, superclass.getDeclaredMethods());
+		}
 
 		for (Method m : allMethods) {
 			final StringGetter annotation = m.getAnnotation( StringGetter.class );
@@ -176,7 +187,12 @@ public abstract class ReflectiveConfigGroup extends ConfigGroup implements Matsi
 		final Map<String, Method> ss = new HashMap<String, Method>();
 		final Class<? extends ReflectiveConfigGroup> c = getClass();
 
-		final Method[] allMethods = c.getDeclaredMethods();
+		Method[] allMethods = c.getDeclaredMethods();
+		Class<?> superclass = c.getSuperclass();
+		if(superclass != ReflectiveConfigGroup.class
+				&& ReflectiveConfigGroup.class.isAssignableFrom(superclass)) {
+			allMethods = ArrayUtils.addAll(allMethods, superclass.getDeclaredMethods());
+		}
 
 		for (Method m : allMethods) {
 			final StringSetter annotation = m.getAnnotation( StringSetter.class );


### PR DESCRIPTION
in https://github.com/matsim-org/matsim-libs/pull/1964 the DrtConfigGroup has been made extendable. 
This has been implemented for drt shifts in https://github.com/matsim-org/matsim-libs/pull/1986

However, it seems like it currently does not work for reading/parsing an existing config xml.
For example, the following
```
URL configUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("mielec"), "mielec_drt_config.xml");
Config config = ConfigUtils.loadConfig(configUrl, new MultiModeDrtConfigGroup(DrtWithShiftsConfigGroup::new), new DvrpConfigGroup(),
      new MultiModeAlonsoMoraConfigGroup(), new OTFVisConfigGroup());
```
results in 

> java.lang.IllegalArgumentException: Module drt of type org.matsim.contrib.drt.extension.shifts.config.DrtWithShiftsConfigGroup doesn't accept unknown parameters. Parameter stopDuration is not part of the valid parameters: []

stopDuration is a parameter of the basic drt config group. The reason it fails seems to be that the ReflectiveConfigGroup does not recognize the getter/setter methods of the parent class
https://github.com/matsim-org/matsim-libs/blob/28ec691fce67f029318dd8f0302cb80632d5070f/matsim/src/main/java/org/matsim/core/config/ReflectiveConfigGroup.java#L175-L193
because `c.getDeclaredMethods(); ` does not return methods from the parent class. As such, the DrtWithShiftsConfigGroup does not know the parameters of the DrtConfigGroup anymore.

This PR adds a test as well as a quick solution to this by also checking whether the respective class has a super class which is also a ReflectiveConfigGroup and checks for its declared methods as well. With that, the test included in this PR passes but I'm not sure if this is considered a good solution :)


