### PR TITLE
Include schedule updater in PreplannedDrtOptimizer

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preplanned/optimizer/PreplannedDrtModeOptimizerQSimModule.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preplanned/optimizer/PreplannedDrtModeOptimizerQSimModule.java
@@ -23,14 +23,17 @@ package org.matsim.contrib.drt.extension.preplanned.optimizer;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.optimizer.DrtOptimizer;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.drt.schedule.DrtStayTaskEndTimeCalculator;
 import org.matsim.contrib.drt.schedule.DrtTaskFactory;
 import org.matsim.contrib.drt.schedule.DrtTaskFactoryImpl;
+import org.matsim.contrib.drt.schedule.StopDurationEstimator;
 import org.matsim.contrib.drt.vrpagent.DrtActionCreator;
 import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
 import org.matsim.contrib.dvrp.passenger.PassengerHandler;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.framework.MobsimTimer;
@@ -54,7 +57,8 @@ public class PreplannedDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimMo
 				getter.getModal(PreplannedDrtOptimizer.PreplannedSchedules.class), getter.getModal(Network.class),
 				getter.getModal(TravelTime.class), getter.getModal(TravelDisutilityFactory.class)
 				.createTravelDisutility(getter.getModal(TravelTime.class)), getter.get(MobsimTimer.class),
-				getter.getModal(DrtTaskFactory.class), getter.get(EventsManager.class), getter.getModal(Fleet.class))));
+				getter.getModal(DrtTaskFactory.class), getter.get(EventsManager.class), getter.getModal(Fleet.class),
+				getter.getModal(ScheduleTimingUpdater.class))));
 
 		bindModal(DrtTaskFactory.class).toInstance(new DrtTaskFactoryImpl());
 
@@ -63,5 +67,9 @@ public class PreplannedDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimMo
 						getter.get(DvrpConfigGroup.class)))).asEagerSingleton();
 
 		bindModal(VrpOptimizer.class).to(modalKey(DrtOptimizer.class));
+
+		bindModal(ScheduleTimingUpdater.class).toProvider(modalProvider(
+				getter -> new ScheduleTimingUpdater(getter.get(MobsimTimer.class),
+						new DrtStayTaskEndTimeCalculator(getter.getModal(StopDurationEstimator.class))))).asEagerSingleton();
 	}
 }

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preplanned/optimizer/PreplannedDrtOptimizer.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preplanned/optimizer/PreplannedDrtOptimizer.java
@@ -45,6 +45,7 @@ import org.matsim.contrib.dvrp.passenger.PassengerRequestScheduledEvent;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.path.VrpPaths;
 import org.matsim.contrib.dvrp.schedule.Schedule;
+import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
 import org.matsim.contrib.dvrp.schedule.Tasks;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.framework.MobsimTimer;
@@ -72,13 +73,14 @@ public class PreplannedDrtOptimizer implements DrtOptimizer {
 	private final MobsimTimer timer;
 	private final DrtTaskFactory taskFactory;
 	private final EventsManager eventsManager;
+	private final ScheduleTimingUpdater scheduleTimingUpdater;
 
 	private final LeastCostPathCalculator router;
 	private final double stopDuration;
 
 	public PreplannedDrtOptimizer(DrtConfigGroup drtCfg, PreplannedSchedules preplannedSchedules, Network network,
 			TravelTime travelTime, TravelDisutility travelDisutility, MobsimTimer timer, DrtTaskFactory taskFactory,
-			EventsManager eventsManager, Fleet fleet) {
+			EventsManager eventsManager, Fleet fleet, ScheduleTimingUpdater scheduleTimingUpdater) {
 		Preconditions.checkArgument(
 				fleet.getVehicles().keySet().equals(preplannedSchedules.vehicleToPreplannedStops.keySet()),
 				"Some schedules are preplanned for vehicles outside the fleet");
@@ -90,6 +92,7 @@ public class PreplannedDrtOptimizer implements DrtOptimizer {
 		this.timer = timer;
 		this.taskFactory = taskFactory;
 		this.eventsManager = eventsManager;
+		this.scheduleTimingUpdater = scheduleTimingUpdater;
 
 		router = new SpeedyALTFactory().createPathCalculator(network, travelDisutility, travelTime);
 		stopDuration = drtCfg.getStopDuration();
@@ -135,6 +138,7 @@ public class PreplannedDrtOptimizer implements DrtOptimizer {
 
 	@Override
 	public void nextTask(DvrpVehicle vehicle) {
+		scheduleTimingUpdater.updateBeforeNextTask(vehicle);
 		var schedule = vehicle.getSchedule();
 
 		//TODO we could even skip adding this dummy task

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preplanned/run/PreplannedDrtModeModule.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preplanned/run/PreplannedDrtModeModule.java
@@ -23,6 +23,7 @@ package org.matsim.contrib.drt.extension.preplanned.run;
 import org.matsim.contrib.drt.fare.DrtFareHandler;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.run.DrtModeRoutingModule;
+import org.matsim.contrib.drt.schedule.StopDurationEstimator;
 import org.matsim.contrib.dvrp.fleet.FleetModule;
 import org.matsim.contrib.dvrp.router.DvrpModeRoutingNetworkModule;
 import org.matsim.contrib.dvrp.router.TimeAsTravelDisutility;
@@ -54,6 +55,7 @@ public final class PreplannedDrtModeModule extends AbstractDvrpModeModule {
 		install(new DvrpModeRoutingNetworkModule(getMode(), drtCfg.isUseModeFilteredSubnetwork()));
 		bindModal(TravelTime.class).to(Key.get(TravelTime.class, Names.named(DvrpTravelTimeModule.DVRP_ESTIMATED)));
 		bindModal(TravelDisutilityFactory.class).toInstance(TimeAsTravelDisutility::new);
+		bindModal(StopDurationEstimator.class).toInstance((vehicle, dropoffRequests, pickupRequests) -> drtCfg.getStopDuration());
 
 		install(new FleetModule(getMode(), drtCfg.getVehiclesFileUrl(getConfig().getContext()),
 				drtCfg.isChangeStartLinkToLastLinkInSchedule()));


### PR DESCRIPTION
Add ScheduleTimingUpdater to the PreplannedDrtOptimizer, so that it can update the schedule based on the actual arrival time of the vehicle. This is necessary for the studies with fluctuating network travel time (e.g., through network loading, or network change events).

Currently, if a vehicle arrives earlier than the originaly scheduled time and starts the next task, then the end time of the current task (drive task, with end time based on the schedule) will be different from the start time of the next task (which starts from "now").