### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Enable dependabot version updates to keep our dependencies up to date with minimal effort: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates

Let's try it out and see if this is helpful. The basic rule: we can accept a PR created by dependabot or close it. By closing it, we tell the dependabot to skip the proposed version.