### PR TITLE
downgrade hibernate-validator to 7.0.2.Final

### DIFF
--- a/matsim/pom.xml
+++ b/matsim/pom.xml
@@ -228,12 +228,14 @@
 		<dependency>
 			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator</artifactId>
-			<version>7.0.4.Final</version>
+			<!-- versions 7.0.3 and 7.0.4 have issues with processing java records during compilation -->
+			<version>7.0.2.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator-annotation-processor</artifactId>
-			<version>7.0.4.Final</version>
+			<!-- versions 7.0.3 and 7.0.4 have issues with processing java records during compilation -->
+			<version>7.0.2.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish</groupId>


### PR DESCRIPTION
versions 7.0.3 and 7.0.4 have issues with processing java records during compilation