### PR TITLE
ci: set timeout to 45 min per job in verify-push

### DIFF
--- a/.github/workflows/verify-push.yaml
+++ b/.github/workflows/verify-push.yaml
@@ -14,6 +14,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Currently, it is 6 hours (default value). Given that we have 41 jobs and only 20 can be run at the same time, we can block all other workflows for up to 12 hours with just one git push.

After this change, this will be reduced to 1.5 hours (the worst case).