### PR TITLE
migrate from Java 11 to 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <argLine></argLine>
 
         <log4j.version>2.17.2</log4j.version>
@@ -279,6 +278,11 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>


### PR DESCRIPTION
It's been over 8 months now since Java 17 was released. Our code runs smooth on JDK 17, different tools, IDEs etc. already fully supports Java 17, and it's an LTS release. Lots of arguments for migrating to Java 17.

This is a draft PR so that we can discuss before we make the final decision.