### PR TITLE
build: run code-coverage weekly

### DIFF
--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -1,11 +1,8 @@
 name: weekly-code-coverage
 
 on:
-  push: # TEMP for testing purposes; ultimately it will be weekly (on: schedule)
-    branches:
-      - master
-#  schedule:
-#    - crone: '30 3 * * 0' # Sun 3:30 UTC
+  schedule:
+    - cron: '30 3 * * 0' # Sun 3:30 UTC
 
 jobs:
   code-coverage:


### PR DESCRIPTION
After confirming that the code-coverage workflow works fine, we can change the trigger so it is run weekly (Sun 3:30 UTC).