### PR TITLE
Revert changes from PR1917 (#2080)

### DIFF
--- a/matsim/src/main/java/org/matsim/core/controler/PrepareForSimImpl.java
+++ b/matsim/src/main/java/org/matsim/core/controler/PrepareForSimImpl.java
@@ -37,6 +37,8 @@ import org.matsim.core.config.groups.PlansConfigGroup;
 import org.matsim.core.config.groups.PlansConfigGroup.HandlingOfPlansWithoutRoutingMode;
 import org.matsim.core.config.groups.QSimConfigGroup;
 import org.matsim.core.gbl.Gbl;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.network.algorithms.TransportModeNetworkFilter;
 import org.matsim.core.population.algorithms.ParallelPersonAlgorithmUtils;
 import org.matsim.core.population.algorithms.PersonPrepareForSim;
 import org.matsim.core.population.routes.NetworkRoute;
@@ -114,11 +116,17 @@ public final class PrepareForSimImpl implements PrepareForSim, PrepareForMobsim 
 		 * own single-mode network. However, this assumes that the main mode is car - which PersonPrepareForSim also does. Should
 		 * be probably adapted in a way that other main modes are possible as well. cdobler, oct'15.
 		 */
-
-		//As the routing modules find nearest links anyways, I do not think using a filtered single-mode network (in this case: carOnlyNetwork) is needed anymore.
-		//The routing modules even use the mode filtered networks for each mode, which seems to be way more useful e.g. for scenarios
-		//with superblocks -sm march22
-		final Network net = network;
+		final Network carOnlyNetwork;
+		if (NetworkUtils.isMultimodal(network)) {
+			log.info("Network seems to be multimodal. Create car-only network which is handed over to PersonPrepareForSim.");
+			TransportModeNetworkFilter filter = new TransportModeNetworkFilter(network);
+			carOnlyNetwork = NetworkUtils.createNetwork(scenario.getConfig().network());
+			HashSet<String> modes = new HashSet<>();
+			modes.add(TransportMode.car);
+			filter.filter(carOnlyNetwork, modes);
+		} else {
+			carOnlyNetwork = network;
+		}
 
 		//matsim-724
 		switch(this.facilitiesConfigGroup.getFacilitiesSource()){
@@ -154,7 +162,7 @@ public final class PrepareForSimImpl implements PrepareForSim, PrepareForMobsim 
 
 		// get links for facilities
 		// using car only network to get the links for facilities. Amit July'18
-		XY2LinksForFacilities.run(net, this.activityFacilities);
+		XY2LinksForFacilities.run(carOnlyNetwork, this.activityFacilities);
 
 		// yyyy from a behavioral perspective, the vehicle must be somehow linked to
 		// the person (maybe via the household).    kai, feb'18
@@ -169,7 +177,7 @@ public final class PrepareForSimImpl implements PrepareForSim, PrepareForMobsim 
 		// (i.e. we introduce a separate PersonPrepareForMobsim).  kai, jul'18
 		ParallelPersonAlgorithmUtils.run(population, globalConfigGroup.getNumberOfThreads(),
 				() -> new PersonPrepareForSim(new PlanRouter(tripRouterProvider.get(), activityFacilities, timeInterpretation), scenario,
-						net)
+						carOnlyNetwork)
 		);
 		
 		if (scenario instanceof Lockable) {

--- a/matsim/src/main/java/org/matsim/core/population/algorithms/PersonPrepareForSim.java
+++ b/matsim/src/main/java/org/matsim/core/population/algorithms/PersonPrepareForSim.java
@@ -29,6 +29,8 @@ import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Plan;
 import org.matsim.api.core.v01.population.PlanElement;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.network.algorithms.TransportModeNetworkFilter;
 import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.population.routes.RouteUtils;
 import org.matsim.core.router.TripStructureUtils;
@@ -37,6 +39,7 @@ import org.matsim.facilities.ActivityFacilities;
 import org.matsim.pt.routes.DefaultTransitPassengerRoute;
 import org.matsim.pt.routes.ExperimentalTransitRoute;
 
+import java.util.HashSet;
 import java.util.List;
 
 /**
@@ -55,7 +58,7 @@ public final class PersonPrepareForSim extends AbstractPersonAlgorithm {
 
 	private final PlanAlgorithm router;
 	private final XY2Links xy2links;
-	private final Network network;
+	private final Network carOnlyNetwork;
 	private final ActivityFacilities activityFacilities;
 
 	private static final Logger log = Logger.getLogger(PersonPrepareForSim.class);
@@ -66,11 +69,14 @@ public final class PersonPrepareForSim extends AbstractPersonAlgorithm {
 	 * create multiple copies of a car-only-network. Instead, we can create that network once in
 	 * the Controller and re-use it for each new instance. cdobler, sep'15
 	 */
-	public PersonPrepareForSim(final PlanAlgorithm router, final Scenario scenario, final Network network) {
+	public PersonPrepareForSim(final PlanAlgorithm router, final Scenario scenario, final Network carOnlyNetwork) {
 		super();
 		this.router = router;
-		this.network = network ;
-		this.xy2links = new XY2Links(network, scenario.getActivityFacilities());
+		this.carOnlyNetwork = carOnlyNetwork ;
+		if (NetworkUtils.isMultimodal(carOnlyNetwork)) {
+			throw new RuntimeException("Expected carOnlyNetwork not to be multi-modal. Aborting!");
+		}
+		this.xy2links = new XY2Links(carOnlyNetwork, scenario.getActivityFacilities());
 		this.activityFacilities = scenario.getActivityFacilities();
 		this.scenario = scenario ;
 	}
@@ -78,9 +84,17 @@ public final class PersonPrepareForSim extends AbstractPersonAlgorithm {
 	public PersonPrepareForSim(final PlanAlgorithm router, final Scenario scenario) {
 		super();
 		this.router = router;
-		this.network = scenario.getNetwork();
-		Network net = this.network;
-		
+		this.carOnlyNetwork = scenario.getNetwork();
+		Network net = this.carOnlyNetwork;
+		if (NetworkUtils.isMultimodal( carOnlyNetwork )) {
+			log.info("Network seems to be multimodal. XY2Links will only use car links.");
+			TransportModeNetworkFilter filter = new TransportModeNetworkFilter( carOnlyNetwork );
+			net = NetworkUtils.createNetwork(scenario.getConfig().network());
+			HashSet<String> modes = new HashSet<String>();
+			modes.add(TransportMode.car);
+			filter.filter(net, modes);
+		}
+
 		this.xy2links = new XY2Links(net, scenario.getActivityFacilities());
 		this.activityFacilities = scenario.getActivityFacilities();
 		this.scenario = scenario ;

--- a/matsim/src/test/java/org/matsim/population/algorithms/PersonPrepareForSimTest.java
+++ b/matsim/src/test/java/org/matsim/population/algorithms/PersonPrepareForSimTest.java
@@ -57,8 +57,6 @@ import org.matsim.pt.transitSchedule.api.TransitStopFacility;
  */
 public class PersonPrepareForSimTest {
 
-	//As the used network was switched from carOnly to multimodal, this test is pointless. Will keep it for now, though -sm march22
-	@Ignore
 	@Test
 	public void testRun_MultimodalNetwork() {
 		Scenario sc = ScenarioUtils.createScenario(ConfigUtils.createConfig());
@@ -91,8 +89,6 @@ public class PersonPrepareForSimTest {
 		Assert.assertEquals(link1id, activity2.getLinkId()); // must also be linked to l1, as l2 has no car mode
 	}
 
-	//As the used network was switched from carOnly to multimodal, this test is pointless. Will keep it for now, though -sm march22
-	@Ignore
 	@Test
 	public void testRun_MultimodalScenario() {
 		Scenario sc = ScenarioUtils.createScenario(ConfigUtils.createConfig());


### PR DESCRIPTION
* reverse changes from PR1917 because we do need carOnlyNetwork here

* incorrect placement of networkFilter caused PersonPrepareForSimTest.testRun_MultimodalNetwork to fail

Co-authored-by: simei94 <simonmeinhardt94@gmail.com>
(cherry picked from commit 1e43b2948f9c23a6c20e93ed38052ae139fe1537)