### PR TITLE
Refactor preplanned drt optimizer

### DIFF
--- a/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/preplanned/optimizer/RunPreplannedDrtExampleIT.java
+++ b/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/preplanned/optimizer/RunPreplannedDrtExampleIT.java
@@ -20,6 +20,7 @@
 
 package org.matsim.contrib.drt.extension.preplanned.optimizer;
 
+import static java.util.stream.Collectors.toMap;
 import static org.matsim.contrib.drt.extension.preplanned.optimizer.PreplannedDrtOptimizer.PreplannedRequest;
 import static org.matsim.contrib.drt.extension.preplanned.optimizer.PreplannedDrtOptimizer.PreplannedStop;
 
@@ -34,6 +35,7 @@ import java.util.stream.Stream;
 
 import org.junit.Test;
 import org.matsim.api.core.v01.Id;
+import org.matsim.contrib.drt.extension.preplanned.optimizer.PreplannedDrtOptimizer.PreplannedRequestKey;
 import org.matsim.contrib.drt.extension.preplanned.optimizer.PreplannedDrtOptimizer.PreplannedSchedules;
 import org.matsim.contrib.drt.extension.preplanned.run.RunPreplannedDrtExample;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
@@ -50,26 +52,36 @@ public class RunPreplannedDrtExampleIT {
 		URL configUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("dvrp-grid"), "one_shared_taxi_config.xml");
 
 		// create preplanned requests (they will be mapped to drt requests created during simulation)
-		var preplannedRequest_0 = new PreplannedRequest(Id.createPersonId("passenger_0"), 0.0, 900.0, 844.4,
-				Id.createLinkId("114"), Id.createLinkId("349"));
-		var preplannedRequest_1 = new PreplannedRequest(Id.createPersonId("passenger_1"), 300.0, 1200.0, 1011.8,
-				Id.createLinkId("144"), Id.createLinkId("437"));
-		var preplannedRequest_2 = new PreplannedRequest(Id.createPersonId("passenger_2"), 600.0, 1500.0, 1393.7,
-				Id.createLinkId("223"), Id.createLinkId("347"));
-		var preplannedRequest_3 = new PreplannedRequest(Id.createPersonId("passenger_3"), 900.0, 1800.0, 1825.0,
-				Id.createLinkId("234"), Id.createLinkId("119"));
-		var preplannedRequest_4 = new PreplannedRequest(Id.createPersonId("passenger_4"), 1200.0, 2100.0, 1997.6,
-				Id.createLinkId("314"), Id.createLinkId("260"));
-		var preplannedRequest_5 = new PreplannedRequest(Id.createPersonId("passenger_5"), 1500.0, 2400.0, 2349.6,
-				Id.createLinkId("333"), Id.createLinkId("438"));
-		var preplannedRequest_6 = new PreplannedRequest(Id.createPersonId("passenger_6"), 1800.0, 2700.0, 2600.2,
-				Id.createLinkId("325"), Id.createLinkId("111"));
-		var preplannedRequest_7 = new PreplannedRequest(Id.createPersonId("passenger_7"), 2100.0, 3000.0, 2989.9,
-				Id.createLinkId("412"), Id.createLinkId("318"));
-		var preplannedRequest_8 = new PreplannedRequest(Id.createPersonId("passenger_8"), 2400.0, 3300.0, 3110.5,
-				Id.createLinkId("455"), Id.createLinkId("236"));
-		var preplannedRequest_9 = new PreplannedRequest(Id.createPersonId("passenger_9"), 2700.0, 3600.0, 3410.5,
-				Id.createLinkId("139"), Id.createLinkId("330"));
+		var preplannedRequest_0 = new PreplannedRequest(
+				new PreplannedRequestKey(Id.createPersonId("passenger_0"), Id.createLinkId("114"),
+						Id.createLinkId("349")), 0.0, 900.0, 844.4);
+		var preplannedRequest_1 = new PreplannedRequest(
+				new PreplannedRequestKey(Id.createPersonId("passenger_1"), Id.createLinkId("144"),
+						Id.createLinkId("437")), 300.0, 1200.0, 1011.8);
+		var preplannedRequest_2 = new PreplannedRequest(
+				new PreplannedRequestKey(Id.createPersonId("passenger_2"), Id.createLinkId("223"),
+						Id.createLinkId("347")), 600.0, 1500.0, 1393.7);
+		var preplannedRequest_3 = new PreplannedRequest(
+				new PreplannedRequestKey(Id.createPersonId("passenger_3"), Id.createLinkId("234"),
+						Id.createLinkId("119")), 900.0, 1800.0, 1825.0);
+		var preplannedRequest_4 = new PreplannedRequest(
+				new PreplannedRequestKey(Id.createPersonId("passenger_4"), Id.createLinkId("314"),
+						Id.createLinkId("260")), 1200.0, 2100.0, 1997.6);
+		var preplannedRequest_5 = new PreplannedRequest(
+				new PreplannedRequestKey(Id.createPersonId("passenger_5"), Id.createLinkId("333"),
+						Id.createLinkId("438")), 1500.0, 2400.0, 2349.6);
+		var preplannedRequest_6 = new PreplannedRequest(
+				new PreplannedRequestKey(Id.createPersonId("passenger_6"), Id.createLinkId("325"),
+						Id.createLinkId("111")), 1800.0, 2700.0, 2600.2);
+		var preplannedRequest_7 = new PreplannedRequest(
+				new PreplannedRequestKey(Id.createPersonId("passenger_7"), Id.createLinkId("412"),
+						Id.createLinkId("318")), 2100.0, 3000.0, 2989.9);
+		var preplannedRequest_8 = new PreplannedRequest(
+				new PreplannedRequestKey(Id.createPersonId("passenger_8"), Id.createLinkId("455"),
+						Id.createLinkId("236")), 2400.0, 3300.0, 3110.5);
+		var preplannedRequest_9 = new PreplannedRequest(
+				new PreplannedRequestKey(Id.createPersonId("passenger_9"), Id.createLinkId("139"),
+						Id.createLinkId("330")), 2700.0, 3600.0, 3410.5);
 		var preplannedRequests = List.of(preplannedRequest_0, preplannedRequest_1, preplannedRequest_2,
 				preplannedRequest_3, preplannedRequest_4, preplannedRequest_5, preplannedRequest_6);
 
@@ -77,15 +89,17 @@ public class RunPreplannedDrtExampleIT {
 		var taxiId = Id.create("shared_taxi_one", DvrpVehicle.class);
 
 		// all requests are assigned to that taxi
-		var preplannedRequestsToVehicleId = preplannedRequests.stream().collect(Collectors.toMap(r -> r, r -> taxiId));
+		var preplannedRequestsToVehicleId = preplannedRequests.stream()
+				.collect(toMap(PreplannedRequest::key, r -> taxiId));
 
 		// the taxi will serve requests one by one (so actually no sharing, but of course we can change the sequence of stops)
 		var preplannedStops = preplannedRequests.stream()
 				.flatMap(r -> Stream.of(new PreplannedStop(r, true), new PreplannedStop(r, false)))
-				.collect(Collectors.toList());
+				.toList();
 		var preplannedStopsByVehicleId = Map.of(taxiId, (Queue<PreplannedStop>)new LinkedList<>(preplannedStops));
 
-		var unassignedRequests = Set.of(preplannedRequest_7, preplannedRequest_8, preplannedRequest_9);
+		var unassignedRequests = Stream.of(preplannedRequest_7, preplannedRequest_8, preplannedRequest_9)
+				.collect(toMap(PreplannedRequest::key, r -> r));
 
 		// put all input data together
 		var preplannedSchedules = new PreplannedSchedules(preplannedRequestsToVehicleId, preplannedStopsByVehicleId,

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/RequestQueue.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/RequestQueue.java
@@ -32,26 +32,6 @@ import org.matsim.contrib.dvrp.optimizer.Request;
  * @author Michal Maciejewski (michalm)
  */
 public final class RequestQueue<R extends PassengerRequest> {
-	public enum RequestStatus {oldRequest, newRequest, prescheduledRequest}
-
-	public static final class RequestEntry<R extends PassengerRequest> {
-		private final R request;
-		private final RequestStatus status;
-
-		public RequestEntry(R request, RequestStatus status) {
-			this.request = request;
-			this.status = status;
-		}
-
-		public R getRequest() {
-			return request;
-		}
-
-		public RequestStatus getStatus() {
-			return status;
-		}
-	}
-
 	public static <R extends PassengerRequest> RequestQueue<R> withLimitedAdvanceRequestPlanningHorizon(
 			double planningHorizon) {
 		//all immediate and selected advance (i.e. starting within the planning horizon) requests are scheduled
@@ -67,7 +47,7 @@ public final class RequestQueue<R extends PassengerRequest> {
 	}
 
 	private static final Comparator<PassengerRequest> ABSOLUTE_COMPARATOR = Comparator.comparing(
-			PassengerRequest::getEarliestStartTime)
+					PassengerRequest::getEarliestStartTime)
 			.thenComparing(PassengerRequest::getLatestStartTime)
 			.thenComparing(Request::getSubmissionTime)
 			.thenComparing(Request::getId);


### PR DESCRIPTION
- use records for fixed data classes
- introduce `PreplannedRequestKey` to better express how pre-planned requests are referenced/identified