### PR TITLE
Allow Subtours to use coordinates of activities

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/analysis/population/SubTourAnalysis.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/population/SubTourAnalysis.java
@@ -46,6 +46,9 @@ public class SubTourAnalysis implements MATSimAppCommand {
 	@CommandLine.Option(names = "--st-proba", description = "Probability for single trip mode-choice", defaultValue = "0.5")
 	private double singleTrip;
 
+	@CommandLine.Option(names = "--coord-dist", description = "Use coordinate distance for subtours if greater 0", defaultValue = "0")
+	private double coordDist;
+
 	@CommandLine.Option(names = "--iter", description = "Iterate strategy to output choice sets", defaultValue = "1")
 	private int iter;
 
@@ -87,7 +90,7 @@ public class SubTourAnalysis implements MATSimAppCommand {
 		log.info("Detected modes: {}", modes);
 
 		ChooseRandomLegModeForSubtour strategy = new ChooseRandomLegModeForSubtour(new DefaultAnalysisMainModeIdentifier(), plan -> modes,
-				modes.toArray(new String[0]), chainBasedModes.toArray(new String[0]), new Random(1234), behavior, singleTrip);
+				modes.toArray(new String[0]), chainBasedModes.toArray(new String[0]), new Random(1234), behavior, singleTrip, coordDist);
 
 		int closed = 0;
 		int massConserving = 0;

--- a/contribs/application/src/main/java/org/matsim/application/prepare/population/FixSubtourModes.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/population/FixSubtourModes.java
@@ -125,7 +125,7 @@ public class FixSubtourModes implements MATSimAppCommand, PersonAlgorithm {
 
 				}
 			} catch (Exception e) {
-				log.warn("Exception occurred when handling person {}: {}. Whole plan will be set to walk.", person.getId(), e.getMessage());
+				log.warn("Exception occurred when handling person {}: {}. Whole plan will be set to walk.", person.getId(), e);
 
 				for (Leg leg : TripStructureUtils.getLegs(plan)) {
 					leg.setRoute(null);
@@ -134,6 +134,8 @@ public class FixSubtourModes implements MATSimAppCommand, PersonAlgorithm {
 				}
 
 				fixed++;
+
+				throw e;
 			}
 		}
 

--- a/contribs/application/src/main/java/org/matsim/application/prepare/population/FixSubtourModes.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/population/FixSubtourModes.java
@@ -45,6 +45,9 @@ public class FixSubtourModes implements MATSimAppCommand, PersonAlgorithm {
 	@CommandLine.Option(names = "--mass-conservation", description = "Whether to check for the mass conservation of the whole plan", defaultValue = "true", negatable = true)
 	private boolean massConservation;
 
+	@CommandLine.Option(names = "--coord-dist", description = "Use coordinate distance for subtours if greater 0", defaultValue = "0")
+	private double coordDist;
+
 	private final SplittableRandom rnd = new SplittableRandom();
 	private ChooseRandomLegModeForSubtour strategy = null;
 
@@ -110,7 +113,7 @@ public class FixSubtourModes implements MATSimAppCommand, PersonAlgorithm {
 		for (Plan plan : plans) {
 
 			try {
-				Collection<TripStructureUtils.Subtour> subtours = TripStructureUtils.getSubtours(plan);
+				Collection<TripStructureUtils.Subtour> subtours = TripStructureUtils.getSubtours(plan, coordDist);
 				for (TripStructureUtils.Subtour st : subtours) {
 
 					if (fixSubtour(person, st))

--- a/matsim/src/main/java/org/matsim/core/config/groups/SubtourModeChoiceConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/SubtourModeChoiceConfigGroup.java
@@ -37,6 +37,7 @@ public final class SubtourModeChoiceConfigGroup extends ReflectiveConfigGroup {
 	public final static String CHAINBASEDMODES = "chainBasedModes";
 	public final static String CARAVAIL = "considerCarAvailability";
 	public final static String SINGLE_PROBA = "probaForRandomSingleTripMode";
+	public final static String COORD_DISTANCE = "coordDistance";
 
 	private static final String BEHAVIOR = "behavior";
 	
@@ -47,6 +48,8 @@ public final class SubtourModeChoiceConfigGroup extends ReflectiveConfigGroup {
 	private SubtourModeChoice.Behavior behavior = SubtourModeChoice.Behavior.fromSpecifiedModesToSpecifiedModes ;
 	
 	private double probaForRandomSingleTripMode = 0. ; // yyyyyy backwards compatibility setting; should be change. kai, may'18
+
+	private double coordDistance = 0;
 	
 	public SubtourModeChoiceConfigGroup() {
 		super(GROUP_NAME);
@@ -103,6 +106,8 @@ public final class SubtourModeChoiceConfigGroup extends ReflectiveConfigGroup {
 		comments.put(CHAINBASEDMODES, "Defines the chain-based modes, seperated by commas" );
 		comments.put(CARAVAIL, "Defines whether car availability must be considered or not. A agent has no car only if it has no license, or never access to a car" );
 		comments.put(SINGLE_PROBA, "Defines the probability of changing a single trip for a unchained mode instead of subtour.");
+		comments.put(COORD_DISTANCE, "If greater than 0, subtours will also consider coordinates to be at the same location when smaller than set distance.");
+
 		{
 			StringBuilder msg = new StringBuilder("Only for backwards compatibility.  Defines if only trips from modes list should change mode, or all trips.  Options: ");
 			for ( SubtourModeChoice.Behavior behavior : SubtourModeChoice.Behavior.values() ) {
@@ -159,6 +164,14 @@ public final class SubtourModeChoiceConfigGroup extends ReflectiveConfigGroup {
 	public void setProbaForRandomSingleTripMode(double probaForRandomSingleTripMode) {
 		this.probaForRandomSingleTripMode = probaForRandomSingleTripMode;
 	}
-	
-	
+
+	@StringGetter(COORD_DISTANCE)
+	public double getCoordDistance() {
+		return coordDistance;
+	}
+
+	@StringSetter(COORD_DISTANCE)
+	public void setCoordDistance(double coordDistance) {
+		this.coordDistance = coordDistance;
+	}
 }

--- a/matsim/src/main/java/org/matsim/core/population/algorithms/ChooseRandomLegModeForSubtour.java
+++ b/matsim/src/main/java/org/matsim/core/population/algorithms/ChooseRandomLegModeForSubtour.java
@@ -247,7 +247,7 @@ public final class ChooseRandomLegModeForSubtour implements PlanAlgorithm {
 			final List<Trip> trips,
 			final Collection<String> permissibleModesForThisPerson) {
 
-		final List<Subtour> subtours = new ArrayList<>(TripStructureUtils.getSubtours(plan));
+		final List<Subtour> subtours = new ArrayList<>(TripStructureUtils.getSubtours(plan, coordDist));
 		final ArrayList<Candidate> choiceSet = new ArrayList<>();
 
 		// there is no subtour containing all trips, so it will be added

--- a/matsim/src/main/java/org/matsim/core/population/algorithms/ChooseRandomLegModeForSubtour.java
+++ b/matsim/src/main/java/org/matsim/core/population/algorithms/ChooseRandomLegModeForSubtour.java
@@ -354,11 +354,12 @@ public final class ChooseRandomLegModeForSubtour implements PlanAlgorithm {
 
 	private boolean atSameLocation(Activity firstLegUsingMode,
 	                               Activity lastLegUsingMode) {
-		return firstLegUsingMode.getFacilityId() != null ?
-				firstLegUsingMode.getFacilityId().equals(
-						lastLegUsingMode.getFacilityId()) :
-				firstLegUsingMode.getLinkId().equals(
-						lastLegUsingMode.getLinkId());
+		if (firstLegUsingMode.getFacilityId() != null)
+			return firstLegUsingMode.getFacilityId().equals(lastLegUsingMode.getFacilityId());
+		else if (firstLegUsingMode.getCoord() != null && lastLegUsingMode.getCoord() != null)
+			return firstLegUsingMode.getCoord().equals(lastLegUsingMode.getCoord());
+		else
+			return firstLegUsingMode.getLinkId().equals(lastLegUsingMode.getLinkId());
 	}
 
 	private Activity findLastDestinationOfMode(

--- a/matsim/src/main/java/org/matsim/core/population/algorithms/ChooseRandomLegModeForSubtour.java
+++ b/matsim/src/main/java/org/matsim/core/population/algorithms/ChooseRandomLegModeForSubtour.java
@@ -36,6 +36,7 @@ import org.matsim.core.router.TripRouter;
 import org.matsim.core.router.TripStructureUtils;
 import org.matsim.core.router.TripStructureUtils.Subtour;
 import org.matsim.core.router.TripStructureUtils.Trip;
+import org.matsim.core.utils.geometry.CoordUtils;
 
 /**
  * Changes the transportation mode of one random non-empty subtour in a plan to a randomly chosen
@@ -106,12 +107,23 @@ public final class ChooseRandomLegModeForSubtour implements PlanAlgorithm {
 	private TripsToLegsAlgorithm tripsToLegs = null;
 	private ChooseRandomSingleLegMode changeSingleLegMode = null;
 
+	private double coordDist = 0;
+
 	public ChooseRandomLegModeForSubtour(
 			final MainModeIdentifier mainModeIdentifier,
 			final PermissibleModesCalculator permissibleModesCalculator,
 			final String[] modes,
 			final String[] chainBasedModes,
 			final Random rng, SubtourModeChoice.Behavior behavior, double probaForChooseRandomSingleTripMode) {
+		this(mainModeIdentifier, permissibleModesCalculator, modes, chainBasedModes, rng, behavior, probaForChooseRandomSingleTripMode, 0);
+	}
+
+	public ChooseRandomLegModeForSubtour(
+			final MainModeIdentifier mainModeIdentifier,
+			final PermissibleModesCalculator permissibleModesCalculator,
+			final String[] modes,
+			final String[] chainBasedModes,
+			final Random rng, SubtourModeChoice.Behavior behavior, double probaForChooseRandomSingleTripMode, double coordDist) {
 		this.mainModeIdentifier = mainModeIdentifier;
 		this.permissibleModesCalculator = permissibleModesCalculator;
 		this.modes = Arrays.asList(modes);
@@ -119,6 +131,7 @@ public final class ChooseRandomLegModeForSubtour implements PlanAlgorithm {
 		this.behavior = behavior;
 		this.probaForChangeSingleTripMode = probaForChooseRandomSingleTripMode;
 		this.singleTripSubtourModes = this.chainBasedModes;
+		this.coordDist = coordDist;
 
 		this.rng = rng;
 		logger.info("Chain based modes: " + this.chainBasedModes.toString());
@@ -356,8 +369,8 @@ public final class ChooseRandomLegModeForSubtour implements PlanAlgorithm {
 	                               Activity lastLegUsingMode) {
 		if (firstLegUsingMode.getFacilityId() != null)
 			return firstLegUsingMode.getFacilityId().equals(lastLegUsingMode.getFacilityId());
-		else if (firstLegUsingMode.getCoord() != null && lastLegUsingMode.getCoord() != null)
-			return firstLegUsingMode.getCoord().equals(lastLegUsingMode.getCoord());
+		else if ( coordDist > 0 && firstLegUsingMode.getCoord() != null && lastLegUsingMode.getCoord() != null)
+			return CoordUtils.calcEuclideanDistance(firstLegUsingMode.getCoord(), lastLegUsingMode.getCoord()) <= coordDist;
 		else
 			return firstLegUsingMode.getLinkId().equals(lastLegUsingMode.getLinkId());
 	}

--- a/matsim/src/main/java/org/matsim/core/replanning/choosers/ForceInnovationStrategyChooser.java
+++ b/matsim/src/main/java/org/matsim/core/replanning/choosers/ForceInnovationStrategyChooser.java
@@ -22,9 +22,9 @@ public class ForceInnovationStrategyChooser<PL extends BasicPlan, AG extends Has
 	 * @param permute Permute which agents are selected at which iteration.
 	 *                This requires a sufficiently large number of agents (> 10.000) or the amount of agents forced to innovate each iteration may deviate from the mean.
 	 */
-	public ForceInnovationStrategyChooser(int iter, boolean permute) {
+	public ForceInnovationStrategyChooser(int iter, Permute permute) {
 		this.iter = iter;
-		this.permute = permute;
+		this.permute = permute == Permute.yes;
 	}
 
 	/**
@@ -75,6 +75,11 @@ public class ForceInnovationStrategyChooser<PL extends BasicPlan, AG extends Has
 		}
 		return null;
 
+	}
+
+	public enum Permute {
+		yes,
+		no;
 	}
 
 }

--- a/matsim/src/main/java/org/matsim/core/replanning/modules/SubtourModeChoice.java
+++ b/matsim/src/main/java/org/matsim/core/replanning/modules/SubtourModeChoice.java
@@ -49,6 +49,7 @@ import org.matsim.core.router.TripStructureUtils;
 public class SubtourModeChoice extends AbstractMultithreadedModule {
 
 	private final double probaForChangeSingleTripMode;
+	private final double coordDist;
 
 	public enum Behavior {fromAllModesToSpecifiedModes, fromSpecifiedModesToSpecifiedModes, betweenAllAndFewerConstraints}
 
@@ -65,7 +66,7 @@ public class SubtourModeChoice extends AbstractMultithreadedModule {
 				subtourModeChoiceConfigGroup.getModes(),
 				subtourModeChoiceConfigGroup.getChainBasedModes(),
 				subtourModeChoiceConfigGroup.getProbaForRandomSingleTripMode(),
-				permissibleModesCalculator
+				permissibleModesCalculator, subtourModeChoiceConfigGroup.getCoordDistance()
 		);
 		this.setBehavior(subtourModeChoiceConfigGroup.getBehavior());
 	}
@@ -75,12 +76,14 @@ public class SubtourModeChoice extends AbstractMultithreadedModule {
 			final String[] modes,
 			final String[] chainBasedModes,
 			double probaForChangeSingleTripMode,
-			PermissibleModesCalculator permissibleModesCalculator) {
+			PermissibleModesCalculator permissibleModesCalculator,
+			double coordDist) {
 		super(numberOfThreads);
 		this.modes = modes.clone();
 		this.chainBasedModes = chainBasedModes.clone();
 		this.permissibleModesCalculator = permissibleModesCalculator;
 		this.probaForChangeSingleTripMode = probaForChangeSingleTripMode;
+		this.coordDist = coordDist;
 	}
 	
 	@Deprecated // only use when backwards compatibility is needed. kai, may'18
@@ -101,7 +104,7 @@ public class SubtourModeChoice extends AbstractMultithreadedModule {
 						this.permissibleModesCalculator,
 						this.modes,
 						this.chainBasedModes,
-						MatsimRandom.getLocalInstance(), behavior, probaForChangeSingleTripMode);
+						MatsimRandom.getLocalInstance(), behavior, probaForChangeSingleTripMode, coordDist);
 		return chooseRandomLegMode;
 	}
 

--- a/matsim/src/main/java/org/matsim/core/router/TripStructureUtils.java
+++ b/matsim/src/main/java/org/matsim/core/router/TripStructureUtils.java
@@ -19,14 +19,10 @@
  * *********************************************************************** */
 package org.matsim.core.router;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.function.Predicate;
 
 import org.apache.log4j.Logger;
-import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.population.Activity;
 import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.Plan;
@@ -230,21 +226,26 @@ public final class TripStructureUtils {
 			final Predicate<String> isStageActivity ) {
 		final List<Subtour> subtours = new ArrayList<>();
 
-		Id<?> destinationId = null;
-		final List<Id<?>> originIds = new ArrayList<>();
+		Object destinationId = null;
+
+		// can be either id or coordinate
+		final List<Object> originIds = new ArrayList<>();
 		final List<Trip> trips = getTrips( planElements, isStageActivity );
 		final List<Trip> nonAllocatedTrips = new ArrayList<>( trips );
+
 		for (Trip trip : trips) {
-			final Id<?> originId;
+			final Object originId;
 			//use facilities if available
-			if (trip.getOriginActivity().getFacilityId()!=null ) {
+			if (trip.getOriginActivity().getFacilityId() != null) {
 				originId = trip.getOriginActivity().getFacilityId();
+			} else if (trip.getOriginActivity().getCoord() != null) {
+				originId = trip.getOriginActivity().getCoord();
 			} else {
 				originId = trip.getOriginActivity().getLinkId();
 			}
 
 			if ( originId == null ) {
-				throw new NullPointerException( "Both facility id and link id for origin activity "+trip.getOriginActivity()+
+				throw new NullPointerException( "Facility id, link id and coordinates for origin activity "+trip.getOriginActivity()+
 										" are null!" );
 			}
 
@@ -252,14 +253,16 @@ public final class TripStructureUtils {
 				throw new RuntimeException( "unconsistent trip location sequence: "+destinationId+" != "+originId );
 			}
 
-			if (trip.getDestinationActivity().getFacilityId()!=null ) {
+			if (trip.getDestinationActivity().getFacilityId() != null) {
 				destinationId = trip.getDestinationActivity().getFacilityId();
+			} else if (trip.getDestinationActivity().getCoord() != null) {
+				destinationId = trip.getDestinationActivity().getCoord();
 			} else {
 				destinationId = trip.getDestinationActivity().getLinkId();
 			}
 
 			if ( destinationId == null ) {
-				throw new NullPointerException( "Both facility id and link id for destination activity "+trip.getDestinationActivity()+
+				throw new NullPointerException( "Facility id, and link id and coordinates for destination activity "+trip.getDestinationActivity()+
 										" are null!" );
 			}
 

--- a/matsim/src/main/java/org/matsim/core/router/TripStructureUtils.java
+++ b/matsim/src/main/java/org/matsim/core/router/TripStructureUtils.java
@@ -200,6 +200,10 @@ public final class TripStructureUtils {
 	 * in case of successive activities not being located at the same location
 	 * (that is, if the origin of a trip is not the destination of the preceding
 	 * trip), an exception will be thrown.
+	 * <br>
+	 * Note: We (VSP) are not sure what this code does exactly. The correct definition
+	 * of what a subtour is in MATSim needs to be found!
+	 * Theresa, VSP mode choice seminar in jul'22
 	 *
 	 * @param coordDistance if larger 0, also consider coordinates to be at same location if smaller than distance
 	 *

--- a/matsim/src/test/java/org/matsim/core/router/TripStructureUtilsTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/TripStructureUtilsTest.java
@@ -20,6 +20,7 @@
 package org.matsim.core.router;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.log4j.Logger;
@@ -451,7 +452,7 @@ public class TripStructureUtilsTest {
 		}
 	}
 
-	@Ignore("Subtours now also uses the coordinates if available. This test does not throw an NPE anymore. -- jul'22")
+
 	@Test( expected=NullPointerException.class )
 	public void testNPEWhenLocationNullInSubtourAnalysis() {
 		// this may sound surprising, but for a long time the algorithm
@@ -471,6 +472,37 @@ public class TripStructureUtilsTest {
 						new Coord((double) 0, (double) 0)) );
 
 		TripStructureUtils.getSubtours( plan );
+	}
+
+	@Test
+	public void testSubtourCoords() {
+
+		final Plan plan = populationFactory.createPlan();
+
+		// link ids are null
+		plan.addActivity(populationFactory.createActivityFromCoord("type", new Coord(0,  0)) );
+		plan.addLeg( populationFactory.createLeg( "mode" ) );
+		plan.addActivity(populationFactory.createActivityFromCoord("type", new Coord( 50, 50)) );
+		plan.addLeg( populationFactory.createLeg( "mode" ) );
+		plan.addActivity(populationFactory.createActivityFromCoord("type", new Coord( 10, 10)) );
+		plan.addLeg( populationFactory.createLeg( "mode" ) );
+		plan.addActivity(populationFactory.createActivityFromCoord("type", new Coord( 0, 0)) );
+
+		Collection<TripStructureUtils.Subtour> st = TripStructureUtils.getSubtours(plan, 14);
+
+		st.forEach(System.out::println);
+
+		System.out.println("---");
+
+		assert st.size() == 1;
+
+		// distance between 10,10 and 0,0 is sqrt(200), above this threshold there will be one more subtour
+		st = TripStructureUtils.getSubtours(plan, 15);
+
+		st.forEach(System.out::println);
+
+		assert st.size() == 2;
+
 	}
 
 	@Test

--- a/matsim/src/test/java/org/matsim/core/router/TripStructureUtilsTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/TripStructureUtilsTest.java
@@ -23,10 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.log4j.Logger;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
@@ -454,12 +451,14 @@ public class TripStructureUtilsTest {
 		}
 	}
 
+	@Ignore("Subtours now also uses the coordinates if available. This test does not throw an NPE anymore. -- jul'22")
 	@Test( expected=NullPointerException.class )
 	public void testNPEWhenLocationNullInSubtourAnalysis() {
 		// this may sound surprising, but for a long time the algorithm
 		// was perfectly fine with that if assertions were disabled...
 
 		final Plan plan = populationFactory.createPlan();
+
 		// link ids are null
 		plan.addActivity(
 				populationFactory.createActivityFromCoord(


### PR DESCRIPTION
 Before this PR, subtours are determined by either location id or link id of activities.

This PR adds the option to also consider the coordinates of activities. 
Coordinates are matched by their distance, which enables to allow a little more fuzzy definition of a subtour.
This can be configured with a new setting `coordDistance` in the `SubtourModeChoiceConfigGroup`.