### PR TITLE
include link2pollutants in emissions contrib

### DIFF
--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/analysis/EmissionsOnLinkEventHandler.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/analysis/EmissionsOnLinkEventHandler.java
@@ -85,17 +85,12 @@ public class EmissionsOnLinkEventHandler implements WarmEmissionEventHandler, Co
 
         TimeBinMap.TimeBin<Map<Id<Link>, EmissionsByPollutant>> currentBin = timeBins.getTimeBin(time);
 
-        if (!currentBin.hasValue()){
-            currentBin.setValue( new HashMap<>() );
-        }
+        if (!currentBin.hasValue()){ currentBin.setValue( new HashMap<>() ); }
         if (!currentBin.getValue().containsKey(linkId)){
             currentBin.getValue().put( linkId, new EmissionsByPollutant( new HashMap<>( emissions ) ) );
-        } else{
-            currentBin.getValue().get( linkId ).addEmissions( emissions );
-        }
+        } else { currentBin.getValue().get( linkId ).addEmissions( emissions ); }
 
-        if (link2pollutants.get(linkId) == null) {
-            link2pollutants.put(linkId, emissions);
+        if (link2pollutants.get(linkId) == null) { link2pollutants.put(linkId, emissions);
         } else {
             for (Pollutant pollutant : emissions.keySet()) {
                 link2pollutants.get(linkId).merge(pollutant, emissions.get(pollutant), Double::sum);

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/analysis/EmissionsOnLinkEventHandler.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/analysis/EmissionsOnLinkEventHandler.java
@@ -44,7 +44,6 @@ public class EmissionsOnLinkEventHandler implements WarmEmissionEventHandler, Co
 
 
     public EmissionsOnLinkEventHandler(double timeBinSizeInSeconds) {
-
         this.timeBins = new TimeBinMap<>(timeBinSizeInSeconds);
     }
 
@@ -84,16 +83,15 @@ public class EmissionsOnLinkEventHandler implements WarmEmissionEventHandler, Co
     private void handleEmissionEvent(double time, Id<Link> linkId, Map<Pollutant, Double> emissions) {
 
         TimeBinMap.TimeBin<Map<Id<Link>, EmissionsByPollutant>> currentBin = timeBins.getTimeBin(time);
-
         if (!currentBin.hasValue()){ currentBin.setValue( new HashMap<>() ); }
         if (!currentBin.getValue().containsKey(linkId)){
             currentBin.getValue().put( linkId, new EmissionsByPollutant( new HashMap<>( emissions ) ) );
         } else { currentBin.getValue().get( linkId ).addEmissions( emissions ); }
 
-        if (link2pollutants.get(linkId) == null) { link2pollutants.put(linkId, emissions);
-        } else {
-            for (Pollutant pollutant : emissions.keySet()) {
-                link2pollutants.get(linkId).merge(pollutant, emissions.get(pollutant), Double::sum);
+        if (link2pollutants.get(linkId) == null) { link2pollutants.put(linkId, emissions); }
+        else {
+            for (Pollutant key : emissions.keySet()) {
+                link2pollutants.get(linkId).merge(key, emissions.get(key), Double::sum);
             }
         }
     }

--- a/contribs/emissions/src/test/java/org/matsim/contrib/emissions/analysis/EmissionsOnLinkEventHandlerTest.java
+++ b/contribs/emissions/src/test/java/org/matsim/contrib/emissions/analysis/EmissionsOnLinkEventHandlerTest.java
@@ -13,8 +13,7 @@ import org.matsim.vehicles.Vehicle;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.*;
 import static org.matsim.contrib.emissions.Pollutant.HC;
 
 public class EmissionsOnLinkEventHandlerTest {
@@ -55,9 +54,12 @@ public class EmissionsOnLinkEventHandlerTest {
         handler.handleEvent(event);
 
         TimeBinMap.TimeBin<Map<Id<Link>, EmissionsByPollutant>> timeBin = handler.getTimeBins().getTimeBin(time);
+        Map<Id<Link>, Map<Pollutant, Double>> link2pollutantsMap = handler.getLink2pollutants();
 
         assertTrue(timeBin.hasValue());
         emissions.forEach((key, value) -> assertEquals(value, timeBin.getValue().get(linkId).getEmission(key), 0.0001));
+        assertFalse(link2pollutantsMap.isEmpty());
+        emissions.forEach((key, value) -> assertEquals(value, link2pollutantsMap.get(linkId).get(key), 0.0001));
     }
 
     @Test
@@ -75,9 +77,12 @@ public class EmissionsOnLinkEventHandlerTest {
         handler.handleEvent(event);
 
         TimeBinMap.TimeBin<Map<Id<Link>, EmissionsByPollutant>> timeBin = handler.getTimeBins().getTimeBin(time);
+        Map<Id<Link>, Map<Pollutant, Double>> link2pollutantsMap = handler.getLink2pollutants();
 
         assertTrue(timeBin.hasValue());
         emissions.forEach((key, value) -> assertEquals(value, timeBin.getValue().get(linkId).getEmission(key), 0.0001));
+        assertFalse(link2pollutantsMap.isEmpty());
+        emissions.forEach((key, value) -> assertEquals(value, link2pollutantsMap.get(linkId).get(key), 0.0001));
     }
 
     @Test
@@ -97,6 +102,7 @@ public class EmissionsOnLinkEventHandlerTest {
         thirdTimestep.forEach(handler::handleEvent);
 
         TimeBinMap<Map<Id<Link>, EmissionsByPollutant>> summedEmissions = handler.getTimeBins();
+        Map<Id<Link>, Map<Pollutant, Double>> link2pollutantsMap = handler.getLink2pollutants();
 
         assertEquals(2, summedEmissions.getTimeBins().size());
         TimeBinMap.TimeBin<Map<Id<Link>, EmissionsByPollutant>> firstBin = summedEmissions.getTimeBin(18);
@@ -106,6 +112,9 @@ public class EmissionsOnLinkEventHandlerTest {
         TimeBinMap.TimeBin<Map<Id<Link>, EmissionsByPollutant>> secondBin = summedEmissions.getTimeBin(20);
         assertTrue(secondBin.hasValue());
         assertEquals(numberOfEvents * emissionValue, secondBin.getValue().get(linkId).getEmission(HC));
+
+        link2pollutantsMap.get(linkId).forEach((pollutant, value) ->
+                assertEquals(3 * numberOfEvents * emissionValue, value, 0.0001));
     }
 
     @Test
@@ -124,9 +133,11 @@ public class EmissionsOnLinkEventHandlerTest {
         handler.handleEvent(event);
 
         TimeBinMap.TimeBin<Map<Id<Link>, EmissionsByPollutant>> timeBin = handler.getTimeBins().getTimeBin(time);
+        Map<Id<Link>, Map<Pollutant, Double>> link2pollutantsMap = handler.getLink2pollutants();
 
         timeBin.getValue().values().forEach(emissionsByPollutant ->
                 emissionsByPollutant.getEmissions().values().forEach(value -> assertEquals(emissionValue, value, 0.0001)));
+        link2pollutantsMap.get(linkId).forEach((pollutant, value) -> assertEquals(emissionValue, value, 0.0001));
     }
 
     @Test
@@ -145,8 +156,11 @@ public class EmissionsOnLinkEventHandlerTest {
         handler.handleEvent(new WarmEmissionEvent(time, linkId, vehicleId, emissions));
 
         TimeBinMap.TimeBin<Map<Id<Link>, EmissionsByPollutant>> timeBin = handler.getTimeBins().getTimeBin(time);
+        Map<Id<Link>, Map<Pollutant, Double>> link2pollutantsMap = handler.getLink2pollutants();
 
         timeBin.getValue().values().forEach(emissionsByPollutant ->
                 emissionsByPollutant.getEmissions().values().forEach(value -> assertEquals(emissionValue * 3, value, 0.0001)));
+        link2pollutantsMap.get(linkId).forEach((pollutant, value) ->
+                assertEquals(emissionValue * 3, value, 0.0001));
     }
 }


### PR DESCRIPTION
We frequently require summed emissions per link-id to perform emissions analysis (generating `*.output_events.xml.gz`). In particular, the data structure `link2pollutants` calculates this for us. However, the code to produce `link2pollutants` is duplicated each time we do emission analysis for a different project.

In this commit the `link2pollutants` Map is generated by `EmissionsOnLinkHandler` and can be called by:
```
EmissionsOnLinkEventHandler handler = new EmissionsOnLinkEventHandler(10); 
handler.handleEvent(event);
handler.getLink2pollutants();
```

The required parameter `timeBinSizeInSeconds` (=10 in example) is for generating a similar data structure, but groups link emissions by time bins.

The class `EmissionsOnLinkHandlerTest` has been updated to include cases for testing the new output structure `link2pollutants`.

Thought: I have never seen the use of or worked with the current output of `EmissionsOnLinkHandler`, [getTimeBins()](https://github.com/matsim-org/matsim-libs/blob/eeb6ed5e3d2c3ca9ae5eb794607805e473bb90e9/contribs/emissions/src/main/java/org/matsim/contrib/emissions/analysis/EmissionsOnLinkEventHandler.java#L53). If it is not relevant anymore, it might be worth removing the (current) required parameter `timeBinSizeInSeconds` to make `EmissionsOnLinkEventHandler` a bit more intuitive to use?