### PR TITLE
drt: add util method for creating standardised money events (drt fare)

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/fare/DrtFareHandler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/fare/DrtFareHandler.java
@@ -44,6 +44,11 @@ import com.google.inject.Inject;
  * Note that these fares are scored in excess to anything set in the modeparams in the config file.
  */
 public class DrtFareHandler implements DrtRequestSubmittedEventHandler, PassengerDroppedOffEventHandler {
+	public static PersonMoneyEvent createMoneyEvent(PassengerDroppedOffEvent e, double fee, String reference) {
+		return new PersonMoneyEvent(e.getTime(), e.getPersonId(), -fee, PERSON_MONEY_EVENT_PURPOSE_DRT_FARE,
+				e.getMode(), reference);
+	}
+
 	@Inject
 	private EventsManager events;
 
@@ -87,8 +92,7 @@ public class DrtFareHandler implements DrtRequestSubmittedEventHandler, Passenge
 		if (event.getMode().equals(mode)) {
 			if (!dailyFeeCharged.contains(event.getPersonId())) {
 				dailyFeeCharged.add(event.getPersonId());
-				events.processEvent(
-						new PersonMoneyEvent(event.getTime(), event.getPersonId(), -dailyFee, PERSON_MONEY_EVENT_PURPOSE_DRT_FARE, mode, PERSON_MONEY_EVENT_REFERENCE_DRT_FARE_DAILY_FEE));
+				events.processEvent(createMoneyEvent(event, dailyFee, PERSON_MONEY_EVENT_REFERENCE_DRT_FARE_DAILY_FEE));
 			}
 
 			DrtRequestSubmittedEvent submission = requestSubmissions.get(event.getRequestId());
@@ -96,8 +100,7 @@ public class DrtFareHandler implements DrtRequestSubmittedEventHandler, Passenge
 					+ timeFare_sec * submission.getUnsharedRideTime()
 					+ baseFare;
 			double actualFare = Math.max(fare, minFarePerTrip);
-			events.processEvent(
-					new PersonMoneyEvent(event.getTime(), event.getPersonId(), -actualFare, PERSON_MONEY_EVENT_PURPOSE_DRT_FARE, mode, event.getRequestId().toString()));
+			events.processEvent(createMoneyEvent(event, actualFare, event.getRequestId() + ""));
 		}
 	}
 


### PR DESCRIPTION
Preferably use this method when implementing your own `DrtFareHandler`.