### PR TITLE
Enable tasks other than Stay task at the end of DVRP schedule

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/VehicleDataEntryFactoryImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/VehicleDataEntryFactoryImpl.java
@@ -141,7 +141,7 @@ public class VehicleDataEntryFactoryImpl implements VehicleEntry.EntryFactory {
 	}
 
 	static double calcVehicleSlackTime(DvrpVehicle vehicle, double now) {
-		DefaultStayTask lastTask = (DefaultStayTask)Schedules.getLastTask(vehicle.getSchedule());
+		var lastTask = Schedules.getLastTask(vehicle.getSchedule());
 		//if the last task is started, take 'now', otherwise take the planned begin time
 		double availableFromTime = Math.max(lastTask.getBeginTime(), now);
 		//for an already delayed vehicle, assume slack is 0 (instead of a negative number)


### PR DESCRIPTION
With this update, the schedule of a DVRP can end with different types of task. 

This is necessary when we want to have partial DVRP schedule during the day. By not computing the full schedule whenever the schedule gets update, we can save some computational workload. This can also be helpful for customize DRT optimizer. 