### PR TITLE
Accept custom task based on DefaultStayTask

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/VehicleDataEntryFactoryImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/VehicleDataEntryFactoryImpl.java
@@ -83,7 +83,7 @@ public class VehicleDataEntryFactoryImpl implements VehicleEntry.EntryFactory {
 					break;
 
 				case STAY:
-					DrtStayTask stayTask = (DrtStayTask)startTask;
+					DefaultStayTask stayTask = (DefaultStayTask) startTask;
 					start = new LinkTimePair(stayTask.getLink(), currentTime);
 					break;
 


### PR DESCRIPTION
Now, we also want to include the "WaitForStopTask" in this loop. I think it makes sense to use the superclass DefaultStayTask when doing the casting, such that we can also accept custom tasks that are based on task type STAY. 