### PR TITLE
make it possible to transfer final SoC of an EV as initial SoC to the…

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/EvConfigGroup.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/EvConfigGroup.java
@@ -58,6 +58,10 @@ public final class EvConfigGroup extends ReflectiveConfigGroup {
 	public static final String TIME_PROFILES = "timeProfiles";
 	static final String TIME_PROFILES_EXP = "If true, SOC time profile plots will be created";
 
+	private static final String TRANSFER_FINAL_SOC_TO_NEXT_ITERATION_EXP = "determines whether the resulting SoC at the end of the iteration X is set to be the initial SoC in iteration X+1 for each EV." +
+			" If set to true, bear in mind that EV might start with 0% battery charge.";
+	private static final String TRANSFER_FINAL_SOC_TO_NEXT_ITERATION = "transferFinalSoCToNextIteration";
+
 	// no need to simulate with 1-second time step
 	@Positive
 	private int chargeTimeStep = 5; // 5 s ==> 0.35% SOC (fast charging, 50 kW)
@@ -75,6 +79,8 @@ public final class EvConfigGroup extends ReflectiveConfigGroup {
 	private String vehiclesFile = null;
 
 	private boolean timeProfiles = false;
+
+	private boolean transferFinalSoCToNextIteration = false;
 
 	public EvConfigGroup() {
 		super(GROUP_NAME);
@@ -150,6 +156,16 @@ public final class EvConfigGroup extends ReflectiveConfigGroup {
 	@StringGetter(MINCHARGETIME)
 	public int getMinimumChargeTime() {
 		return minimumChargeTime;
+	}
+
+	@StringSetter(TRANSFER_FINAL_SOC_TO_NEXT_ITERATION)
+	public void setTransferFinalSoCToNextIteration(boolean transferFinalSoCToNextIteration) {
+		this.transferFinalSoCToNextIteration = transferFinalSoCToNextIteration;
+	}
+
+	@StringGetter(TRANSFER_FINAL_SOC_TO_NEXT_ITERATION)
+	public boolean getTransferFinalSoCToNextIteration() {
+		return transferFinalSoCToNextIteration;
 	}
 }
 

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricFleetModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricFleetModule.java
@@ -21,17 +21,27 @@
 package org.matsim.contrib.ev.fleet;
 
 import org.matsim.contrib.ev.EvConfigGroup;
+import org.matsim.contrib.ev.EvModule;
+import org.matsim.contrib.ev.EvUnits;
 import org.matsim.contrib.ev.charging.ChargingPower;
 import org.matsim.contrib.ev.discharging.AuxEnergyConsumption;
 import org.matsim.contrib.ev.discharging.DriveEnergyConsumption;
 import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.groups.QSimConfigGroup;
 import org.matsim.core.controler.AbstractModule;
+import org.matsim.core.mobsim.framework.events.MobsimBeforeCleanupEvent;
+import org.matsim.core.mobsim.framework.listeners.MobsimBeforeCleanupListener;
+import org.matsim.core.mobsim.framework.listeners.MobsimListener;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
+import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.Vehicles;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import java.util.Iterator;
+import java.util.Optional;
+
+import static org.matsim.contrib.ev.fleet.ElectricVehicleSpecificationWithMatsimVehicle.INITIAL_ENERGY_kWh;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -86,6 +96,42 @@ public class ElectricFleetModule extends AbstractModule {
 								auxConsumptionFactory, chargingPowerFactory);
 					}
 				}).asEagerSingleton();
+
+				if(evCfg.getTransferFinalSoCToNextIteration()){
+					addQSimComponentBinding(EvModule.EV_COMPONENT).toProvider(new Provider<MobsimListener>() {
+						@Inject
+						private ElectricFleetSpecification electricFleetSpecification;
+
+						@Inject
+						private ElectricFleet electricFleet;
+
+						@Override
+						public MobsimListener get() {
+							return new MobsimBeforeCleanupListener() {
+								@Override
+								public void notifyMobsimBeforeCleanup(MobsimBeforeCleanupEvent e) {
+									Iterator<ElectricVehicleSpecification> it = electricFleetSpecification.getVehicleSpecifications().values().iterator();
+									while (it.hasNext()){
+										ElectricVehicleSpecification oldSpecification = it.next();
+										Optional<Vehicle> matsimVehicle = oldSpecification.getMatsimVehicle();
+										double socAtEndOfCurrentIteration = electricFleet.getElectricVehicles().get(oldSpecification.getId()).getBattery().getSoc();
+
+										if(matsimVehicle.isPresent()){
+											//should (and need to) overwrite the matsimVehicle attribute. careful: this attribute is in kWh, the SoC is in J
+											matsimVehicle.get().getAttributes().putAttribute(INITIAL_ENERGY_kWh, EvUnits.J_to_kWh(socAtEndOfCurrentIteration));
+											electricFleetSpecification.replaceVehicleSpecification(new ElectricVehicleSpecificationWithMatsimVehicle(matsimVehicle.get()));
+										} else {
+											electricFleetSpecification.replaceVehicleSpecification(ImmutableElectricVehicleSpecification
+													.newBuilder(oldSpecification)
+													.initialSoc(socAtEndOfCurrentIteration)
+													.build());
+										}
+									}
+								}
+							};
+						}
+					});
+				}
 			}
 		});
 	}


### PR DESCRIPTION
… next iteration

This is useful in some scenarios, e.g. when inevstigating charging behavior in urban areas (over multiple days).
By default, this feature is not enabled.

I know that normally, the intention behind `ElectricVehicleSpecification` is to be immutable. This PR kind of moves around that. However, i feel like especially the `initalSoC` variable should be allowed to change over iterations.

So far, no unit tests are included in this PR. BTW: The `ev` contrib seems not to be heavily covered by tests in general.
I have run the RunEVExample for multiple iterations and compared the SoC line plots; it seems to work :)

Until now, this kind of functionality was included in the `vsp` contrib in the `playground.vsp.ev` package but in a more ugly way. There, the initial SoC is still read from / written to the vehicle type. If @michalmac approves to make this functionality more central, i.e. include it in the ev contrib, I will clean up the `playground.vsp.ev` package as well. 

