### PR TITLE
Free speed flow factor configurable from CLI

### DIFF
--- a/contribs/application/pom.xml
+++ b/contribs/application/pom.xml
@@ -56,6 +56,13 @@
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>freight</artifactId>
 			<version>15.0-SNAPSHOT</version>
+			<exclusions>
+				<!-- Logging levels are all messed up without this exclusion -->
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-reload4j</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>		
 
 		<dependency>

--- a/contribs/application/src/main/java/org/matsim/application/prepare/network/CreateNetworkFromSumo.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/network/CreateNetworkFromSumo.java
@@ -17,6 +17,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.NetworkWriter;
+import org.matsim.contrib.osm.networkReader.LinkProperties;
 import org.matsim.contrib.sumo.SumoNetworkConverter;
 import org.matsim.contrib.sumo.SumoNetworkHandler;
 import org.matsim.core.network.NetworkUtils;
@@ -63,6 +64,9 @@ public final class CreateNetworkFromSumo implements MATSimAppCommand {
 	@CommandLine.Option(names = {"--capacities"}, description = "CSV file with lane capacities", required = false)
 	private Path capacities;
 
+	@CommandLine.Option(names = "--free-speed-factor", description = "Free-speed reduction for urban links")
+	private double freeSpeedFactor = LinkProperties.DEFAULT_FREESPEED_FACTOR;
+
 	public static void main(String[] args) {
 		System.exit(new CommandLine(new CreateNetworkFromSumo()).execute(args));
 	}
@@ -70,7 +74,7 @@ public final class CreateNetworkFromSumo implements MATSimAppCommand {
 	@Override
 	public Integer call() throws Exception {
 
-		SumoNetworkConverter converter = SumoNetworkConverter.newInstance(input, output, shp.getShapeFile(), crs.getInputCRS(), crs.getTargetCRS());
+		SumoNetworkConverter converter = SumoNetworkConverter.newInstance(input, output, shp.getShapeFile(), crs.getInputCRS(), crs.getTargetCRS(), freeSpeedFactor);
 
 		Network network = NetworkUtils.createNetwork();
         Lanes lanes = LanesUtils.createLanesContainer();

--- a/contribs/application/src/main/java/org/matsim/application/prepare/pt/CreateTransitScheduleFromGtfs.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/pt/CreateTransitScheduleFromGtfs.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -77,7 +78,7 @@ public class CreateTransitScheduleFromGtfs implements MATSimAppCommand {
 	private boolean mergeStops;
 
 	@CommandLine.Option(names = "--prefix", description = "Prefixes to add to the gtfs ids. Required if multiple inputs are used and ids are not unique.", split = ",")
-	private List<String> prefixes;
+	private List<String> prefixes = new ArrayList<>();
 
 	@CommandLine.Mixin
 	private CrsOptions crs = new CrsOptions("EPSG:4326");

--- a/contribs/sumo/src/main/java/org/matsim/contrib/sumo/SumoNetworkConverter.java
+++ b/contribs/sumo/src/main/java/org/matsim/contrib/sumo/SumoNetworkConverter.java
@@ -59,12 +59,16 @@ public class SumoNetworkConverter implements Callable<Integer> {
     @CommandLine.Option(names = "--to-crs", description = "Desired output coordinate system", required = true)
     private String toCRS;
 
-    private SumoNetworkConverter(List<Path> input, Path output, Path shapeFile, String fromCRS, String toCRS) {
+    @CommandLine.Option(names = "--free-speed-factor", description = "Free-speed reduction for urban links", defaultValue = "0.9")
+    private double freeSpeedFactor = LinkProperties.DEFAULT_FREESPEED_FACTOR;
+
+    private SumoNetworkConverter(List<Path> input, Path output, Path shapeFile, String fromCRS, String toCRS, double freeSpeedFactor) {
         this.input = input;
         this.output = output;
         this.shapeFile = shapeFile;
         this.fromCRS = fromCRS;
         this.toCRS = toCRS;
+        this.freeSpeedFactor = freeSpeedFactor;
     }
 
     private SumoNetworkConverter() {
@@ -79,7 +83,7 @@ public class SumoNetworkConverter implements Callable<Integer> {
      * @param toCRS   desired coordinate system of network
      */
     public static SumoNetworkConverter newInstance(List<Path> input, Path output, String fromCRS, String toCRS) {
-        return new SumoNetworkConverter(input, output, null, fromCRS, toCRS);
+        return new SumoNetworkConverter(input, output, null, fromCRS, toCRS, LinkProperties.DEFAULT_FREESPEED_FACTOR);
     }
 
     /**
@@ -89,7 +93,15 @@ public class SumoNetworkConverter implements Callable<Integer> {
      * @see #newInstance(List, Path, String, String)
      */
     public static SumoNetworkConverter newInstance(List<Path> input, Path output, Path shapeFile, String fromCRS, String toCRS) {
-        return new SumoNetworkConverter(input, output, shapeFile, fromCRS, toCRS);
+        return new SumoNetworkConverter(input, output, shapeFile, fromCRS, toCRS, LinkProperties.DEFAULT_FREESPEED_FACTOR);
+    }
+
+    /**
+     * Creates a new instance.
+     * @see #newInstance(List, Path, Path, String, String, double)
+     */
+    public static SumoNetworkConverter newInstance(List<Path> input, Path output, Path shapeFile, String inputCRS, String targetCRS, double freeSpeedFactor) {
+        return new SumoNetworkConverter(input, output, shapeFile, inputCRS, targetCRS, freeSpeedFactor);
     }
 
     /**
@@ -292,7 +304,7 @@ public class SumoNetworkConverter implements Callable<Integer> {
                 continue;
             }
 
-            link.setFreespeed(LinkProperties.calculateSpeedIfSpeedTag(speed, LinkProperties.DEFAULT_FREESPEED_FACTOR));
+            link.setFreespeed(LinkProperties.calculateSpeedIfSpeedTag(speed, freeSpeedFactor));
             link.setCapacity(LinkProperties.getLaneCapacity(link.getLength(), prop) * link.getNumberOfLanes());
 
             lanes.addLanesToLinkAssignment(l2l);


### PR DESCRIPTION
* added CLI option for the SUMO converter to configure the free flow speed adjustment for urban links
* fix default prefix values for the gtfs converter command
* add allowed free speed to network generated from travel time api