### PR TITLE
Also add AttributeConverters to HouseholdsReader in ScenarioLoaderImpl

### DIFF
--- a/matsim/src/main/java/org/matsim/core/scenario/ScenarioLoaderImpl.java
+++ b/matsim/src/main/java/org/matsim/core/scenario/ScenarioLoaderImpl.java
@@ -248,7 +248,9 @@ class ScenarioLoaderImpl {
 		if ( (this.config.households() != null) && (this.config.households().getInputFile() != null) ) {
 			URL householdsFile = this.config.households().getInputFileURL(this.config.getContext());
 			log.info("loading households from " + householdsFile);
-			new HouseholdsReaderV10(this.scenario.getHouseholds()).parse(householdsFile);
+			HouseholdsReaderV10 reader = new HouseholdsReaderV10(this.scenario.getHouseholds());
+			reader.putAttributeConverters(this.attributeConverters);
+			reader.parse(householdsFile);
 			log.info("households loaded.");
 		}
 		else {


### PR DESCRIPTION
Currently, the method `ScenarioLoaderImpl.loadHouseholds()` is not using the `AttributeConverter`s although other MATSim containers like population and network use them. This change also adds the supplied `AttributeConverter`s to the HouseholdsReader object before parsing the households file.