### PR TITLE
Allow loading of Scenario with AttributeConverters

### DIFF
--- a/matsim/src/main/java/org/matsim/core/scenario/ScenarioUtils.java
+++ b/matsim/src/main/java/org/matsim/core/scenario/ScenarioUtils.java
@@ -19,7 +19,10 @@
  *                                                                         *
  * *********************************************************************** */
 
- package org.matsim.core.scenario;
+package org.matsim.core.scenario;
+
+import java.util.Collections;
+import java.util.Map;
 
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Network;
@@ -29,6 +32,7 @@ import org.matsim.facilities.ActivityFacilities;
 import org.matsim.households.Households;
 import org.matsim.lanes.Lanes;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
+import org.matsim.utils.objectattributes.AttributeConverter;
 import org.matsim.vehicles.Vehicles;
 
 
@@ -75,9 +79,19 @@ public final class ScenarioUtils {
 	 *
 	 */
 	public static Scenario loadScenario(final Config config) {
+		return loadScenario(config, Collections.emptyMap());
+	}
+
+	/**
+	 *
+	 * Initializes a scenario and populates it with data read from the input files which are named in the config.
+	 * Uses provided {@link AttributeConverter}s when loading the scenario.
+	 *
+	 */
+	public static Scenario loadScenario(final Config config, Map<Class<?>, AttributeConverter<?>> attributeConverters) {
 		ScenarioLoaderImpl scenarioLoader = new ScenarioLoaderImpl(config);
-		Scenario scenario = scenarioLoader.loadScenario();
-		return scenario;
+		scenarioLoader.setAttributeConverters(attributeConverters);
+		return scenarioLoader.loadScenario();
 	}
 
 	/**
@@ -87,7 +101,18 @@ public final class ScenarioUtils {
 	 *
 	 */
 	public static void loadScenario(final Scenario scenario) {
+		loadScenario(scenario, Collections.emptyMap());
+	}
+
+	/**
+	 *
+	 * Populates a scenario with data read from the input files which are named in the config which is wrapped
+	 * in the scenario. Uses provided {@link AttributeConverter}s when loading the scenario.
+	 *
+	 */
+	public static void loadScenario(final Scenario scenario, Map<Class<?>, AttributeConverter<?>> attributeConverters) {
 		ScenarioLoaderImpl scenarioLoader = new ScenarioLoaderImpl(scenario);
+		scenarioLoader.setAttributeConverters(attributeConverters);
 		scenarioLoader.loadScenario();
 	}
 	


### PR DESCRIPTION
The `loadScenario` methods in `ScenarioUtils` load a scenario with all its containers (population, network, ...) from a config. However, it is not possible to supply [`AttributeConverter`](https://github.com/matsim-org/matsim-libs/blob/master/matsim/src/main/java/org/matsim/utils/objectattributes/AttributeConverter.java)s to be used during that process.

This change overloads the `loadScenario` methods with a map of `AttributeConverter` as additional argument, such that they will be used by the (private) [`ScenarioLoaderImpl`](https://github.com/matsim-org/matsim-libs/blob/master/matsim/src/main/java/org/matsim/core/scenario/ScenarioLoaderImpl.java) when loading the content of the containers.