### PR TITLE
some bugfixes and improvements for CompressedNetworkRoutes

### DIFF
--- a/matsim/src/main/java/org/matsim/core/network/algorithms/SubsequentLinksAnalyzer.java
+++ b/matsim/src/main/java/org/matsim/core/network/algorithms/SubsequentLinksAnalyzer.java
@@ -22,6 +22,7 @@ package org.matsim.core.network.algorithms;
 
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.IdMap;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
@@ -46,7 +47,7 @@ public final class SubsequentLinksAnalyzer {
 	private final Network network;
 
 	/** Stores the logical subsequent link (value) for a given link (key). */
-	private final TreeMap<Id<Link>, Id<Link>> subsequentLinks = new TreeMap<>();
+	private final Map<Id<Link>, Id<Link>> subsequentLinks = new IdMap<>(Link.class);
 
 	public SubsequentLinksAnalyzer(final Network network) {
 		this.network = network;
@@ -104,7 +105,6 @@ public final class SubsequentLinksAnalyzer {
 	private Link computeSubsequentLink(final Map<Link, Double> thetas) {
 		List<Link> minThetaOutLinks = new ArrayList<>();
 
-		minThetaOutLinks.clear();
 		double absMin = Collections.min(thetas.values());
 		for (Map.Entry<Link, Double> entry : thetas.entrySet()) {
 			if (absMin == entry.getValue()) {

--- a/matsim/src/main/java/org/matsim/core/population/routes/CompressedNetworkRouteImpl.java
+++ b/matsim/src/main/java/org/matsim/core/population/routes/CompressedNetworkRouteImpl.java
@@ -60,8 +60,6 @@ final class CompressedNetworkRouteImpl extends AbstractRoute implements NetworkR
 	private double travelCost = Double.NaN;
 	/** number of links in uncompressed route */
 	private int uncompressedLength = -1;
-	private final int modCount = 0;
-	private int routeModCountState = 0;
 	private Id<Vehicle> vehicleId = null;
 	private final Network network;
 	private final Map<Id<Link>, ? extends Link> links;
@@ -87,10 +85,6 @@ final class CompressedNetworkRouteImpl extends AbstractRoute implements NetworkR
 			return new ArrayList<>(0);
 		}
 		ArrayList<Id<Link>> links = new ArrayList<>(this.uncompressedLength);
-		if (this.modCount != this.routeModCountState) {
-			log.error("Route was modified after storing it! modCount=" + this.modCount + " routeModCount=" + this.routeModCountState);
-			return links;
-		}
 		Id<Link> previousLinkId = getStartLinkId();
 		Id<Link> endLinkId = getEndLinkId();
 		if ((previousLinkId == null) || (endLinkId == null)) {
@@ -184,7 +178,6 @@ final class CompressedNetworkRouteImpl extends AbstractRoute implements NetworkR
 		this.route.clear();
 		setStartLinkId(startLinkId);
 		setEndLinkId(endLinkId);
-		this.routeModCountState = this.modCount;
 		if ((srcRoute == null) || (srcRoute.size() == 0)) {
 			this.uncompressedLength = 0;
 			return;

--- a/matsim/src/main/java/org/matsim/core/population/routes/CompressedNetworkRouteImpl.java
+++ b/matsim/src/main/java/org/matsim/core/population/routes/CompressedNetworkRouteImpl.java
@@ -93,7 +93,7 @@ final class CompressedNetworkRouteImpl extends AbstractRoute implements NetworkR
 		if ((previousLinkId == null) || (endLinkId == null)) {
 			return links;
 		}
-		if (previousLinkId.equals(endLinkId)) {
+		if (previousLinkId.equals(endLinkId) && this.uncompressedLength == 0) {
 			return links;
 		}
 		for (Id<Link> linkId : this.route) {

--- a/matsim/src/main/java/org/matsim/core/population/routes/CompressedNetworkRouteImpl.java
+++ b/matsim/src/main/java/org/matsim/core/population/routes/CompressedNetworkRouteImpl.java
@@ -55,19 +55,21 @@ final class CompressedNetworkRouteImpl extends AbstractRoute implements NetworkR
 
 	private final static Logger log = Logger.getLogger(CompressedNetworkRouteImpl.class);
 
-	private ArrayList<Id<Link>> route = new ArrayList<Id<Link>>(0);
+	private ArrayList<Id<Link>> route = new ArrayList<>(0);
 	private final Map<Id<Link>, Id<Link>> subsequentLinks;
 	private double travelCost = Double.NaN;
 	/** number of links in uncompressed route */
 	private int uncompressedLength = -1;
-	private int modCount = 0;
+	private final int modCount = 0;
 	private int routeModCountState = 0;
 	private Id<Vehicle> vehicleId = null;
 	private final Network network;
+	private final Map<Id<Link>, ? extends Link> links;
 
 	public CompressedNetworkRouteImpl(final Id<Link> startLinkId, final Id<Link> endLinkId, Network network, final Map<Id<Link>, Id<Link>> subsequentLinks) {
 		super(startLinkId, endLinkId);
 		this.network = network;
+		this.links = network.getLinks();
 		this.subsequentLinks = subsequentLinks;
 	}
 
@@ -75,16 +77,16 @@ final class CompressedNetworkRouteImpl extends AbstractRoute implements NetworkR
 	public CompressedNetworkRouteImpl clone() {
 		CompressedNetworkRouteImpl cloned = (CompressedNetworkRouteImpl) super.clone();
 		ArrayList<Id<Link>> tmpRoute = cloned.route;
-		cloned.route = new ArrayList<Id<Link>>(tmpRoute); // deep copy
+		cloned.route = new ArrayList<>(tmpRoute); // deep copy
 		return cloned;
 	}
 
 	@Override
 	public List<Id<Link>> getLinkIds() {
 		if (this.uncompressedLength < 0) { // it seems the route never got initialized correctly
-			return new ArrayList<Id<Link>>(0);
+			return new ArrayList<>(0);
 		}
-		ArrayList<Id<Link>> links = new ArrayList<Id<Link>>(this.uncompressedLength);
+		ArrayList<Id<Link>> links = new ArrayList<>(this.uncompressedLength);
 		if (this.modCount != this.routeModCountState) {
 			log.error("Route was modified after storing it! modCount=" + this.modCount + " routeModCount=" + this.routeModCountState);
 			return links;
@@ -109,9 +111,9 @@ final class CompressedNetworkRouteImpl extends AbstractRoute implements NetworkR
 
 	private void getLinksTillLink(final List<Id<Link>> links, final Id<Link> nextLinkId, final Id<Link> startLinkId) {
 		Id<Link> linkId = startLinkId;
-		Link nextLink = this.network.getLinks().get(nextLinkId);
+		Link nextLink = this.links.get(nextLinkId);
 		while (true) { // loop until we hit "return;"
-			Link link = this.network.getLinks().get(linkId);
+			Link link = this.links.get(linkId);
 			if (link.getToNode() == nextLink.getFromNode()) {
 				return;
 			}
@@ -120,22 +122,9 @@ final class CompressedNetworkRouteImpl extends AbstractRoute implements NetworkR
 		}
 	}
 
-//	@Override
-//	public void setEndLinkId(final Id<Link> linkId) {
-//		this.modCount++;
-//		super.setEndLinkId(linkId);
-//	}
-//
-//	@Override
-//	public void setStartLinkId(final Id<Link> linkId) {
-//		this.modCount++;
-//		super.setStartLinkId(linkId);
-//	}
-	// AbstractRoute is now implements Lockable and I have addressed this via that feature.  kai, sep/17
-
 	@Override
 	public NetworkRoute getSubRoute(Id<Link> fromLinkId, Id<Link> toLinkId) {
-		List<Id<Link>> newLinkIds = new ArrayList<Id<Link>>(10);
+		List<Id<Link>> newLinkIds = new ArrayList<>(10);
 		boolean foundFromLink = fromLinkId.equals(this.getStartLinkId());
 		boolean collectLinks = foundFromLink;
 		boolean equalFromTo = fromLinkId.equals(toLinkId);

--- a/matsim/src/test/java/org/matsim/core/population/routes/CompressedNetworkRouteTest.java
+++ b/matsim/src/test/java/org/matsim/core/population/routes/CompressedNetworkRouteTest.java
@@ -72,8 +72,7 @@ public class CompressedNetworkRouteTest extends AbstractNetworkRouteTest {
 		Link linkM24 = network.getLinks().get(Id.create("-24", Link.class));
 		Link link4 = network.getLinks().get(Id.create("4", Link.class));
 
-		List<Id<Link>> linkIds = new ArrayList<Id<Link>>(5);
-		Collections.addAll(linkIds, link22.getId(), link12.getId(), link13.getId(), linkM24.getId());
+		List<Id<Link>> linkIds = List.of(link22.getId(), link12.getId(), link13.getId(), linkM24.getId());
 		NetworkRoute route = getNetworkRouteInstance(link1.getId(), link4.getId(), network);
 		route.setLinkIds(link1.getId(), linkIds, link4.getId());
 
@@ -93,10 +92,9 @@ public class CompressedNetworkRouteTest extends AbstractNetworkRouteTest {
 		Link link3 = network.getLinks().get(Id.create("3", Link.class));
 		Link link4 = network.getLinks().get(Id.create("4", Link.class));
 
-		List<Id<Link>> linkIds = new ArrayList<Id<Link>>(4);
-		Collections.addAll(linkIds, link1.getId(), link2.getId(), link3.getId());
+		List<Id<Link>> linkIds = List.of(link1.getId(), link2.getId(), link3.getId());
 
-		Map<Id<Link>, Id<Link>> subsequentLinks = new TreeMap<Id<Link>, Id<Link>>();
+		Map<Id<Link>, Id<Link>> subsequentLinks = new TreeMap<>();
 		subsequentLinks.put(link0.getId(), link1.getId());
 		subsequentLinks.put(link1.getId(), link2.getId());
 		subsequentLinks.put(link2.getId(), link3.getId());
@@ -125,7 +123,7 @@ public class CompressedNetworkRouteTest extends AbstractNetworkRouteTest {
 		Link link3 = network.getLinks().get(Id.create("3", Link.class));
 		Link link4 = network.getLinks().get(Id.create("4", Link.class));
 
-		Map<Id<Link>, Id<Link>> subsequentLinks = new TreeMap<Id<Link>, Id<Link>>();
+		Map<Id<Link>, Id<Link>> subsequentLinks = new TreeMap<>();
 		subsequentLinks.put(link0.getId(), link1.getId());
 		subsequentLinks.put(link1.getId(), link2.getId());
 		subsequentLinks.put(link2.getId(), link3.getId());
@@ -143,12 +141,12 @@ public class CompressedNetworkRouteTest extends AbstractNetworkRouteTest {
 		Network network = NetworkUtils.createNetwork();
         NetworkFactory builder = network.getFactory();
 
-		Node node1 = builder.createNode(Id.create(1, Node.class), new Coord((double) 0, (double) 1000));
-		Node node2 = builder.createNode(Id.create(2, Node.class), new Coord((double) 0, (double) 2000));
-		Node node3 = builder.createNode(Id.create(3, Node.class), new Coord((double) 0, (double) 3000));
-		Node node4 = builder.createNode(Id.create(4, Node.class), new Coord((double) 0, (double) 4000));
-		Node node5 = builder.createNode(Id.create(5, Node.class), new Coord((double) 0, (double) 5000));
-		Node node6 = builder.createNode(Id.create(6, Node.class), new Coord((double) 0, (double) 6000));
+		Node node1 = builder.createNode(Id.create(1, Node.class), new Coord(0, 1000));
+		Node node2 = builder.createNode(Id.create(2, Node.class), new Coord(0, 2000));
+		Node node3 = builder.createNode(Id.create(3, Node.class), new Coord(0, 3000));
+		Node node4 = builder.createNode(Id.create(4, Node.class), new Coord(0, 4000));
+		Node node5 = builder.createNode(Id.create(5, Node.class), new Coord(0, 5000));
+		Node node6 = builder.createNode(Id.create(6, Node.class), new Coord(0, 6000));
 
 		network.addNode(node1);
 		network.addNode(node2);
@@ -200,8 +198,7 @@ public class CompressedNetworkRouteTest extends AbstractNetworkRouteTest {
 		Link link3 = network.getLinks().get(Id.create("3", Link.class));
 		Link link4 = network.getLinks().get(Id.create("4", Link.class));
 
-		List<Id<Link>> linkIds = new ArrayList<>(5);
-		Collections.addAll(linkIds, link22.getId(), link12.getId(), linkM23.getId(), link3.getId());
+		List<Id<Link>> linkIds = List.of(link22.getId(), link12.getId(), linkM23.getId(), link3.getId());
 		NetworkRoute route = getNetworkRouteInstance(link1.getId(), link4.getId(), network);
 		route.setLinkIds(link1.getId(), linkIds, link4.getId());
 
@@ -217,7 +214,7 @@ public class CompressedNetworkRouteTest extends AbstractNetworkRouteTest {
 		Network network = createTestNetwork();
 
 		final Node node5 = network.getNodes().get(Id.create("5", Node.class));
-		NetworkUtils.createAndAddLink(network,Id.create("loop5", Link.class), node5, node5, 1000.0, 100.0, 3600.0, (double) 1 );
+		NetworkUtils.createAndAddLink(network,Id.create("loop5", Link.class), node5, node5, 1000.0, 100.0, 3600.0, 1);
 
 		Link link1 = network.getLinks().get(Id.create("1", Link.class));
 		Link link22 = network.getLinks().get(Id.create("22", Link.class));
@@ -227,8 +224,7 @@ public class CompressedNetworkRouteTest extends AbstractNetworkRouteTest {
 		Link link4 = network.getLinks().get(Id.create("4", Link.class));
 		Link linkLoop5 = network.getLinks().get(Id.create("loop5", Link.class));
 
-		List<Id<Link>> linkIds = new ArrayList<>(6);
-		Collections.addAll(linkIds, link22.getId(), link12.getId(), linkM23.getId(), link3.getId(), link4.getId());
+		List<Id<Link>> linkIds = List.of(link22.getId(), link12.getId(), linkM23.getId(), link3.getId(), link4.getId());
 		NetworkRoute route = getNetworkRouteInstance(link1.getId(), linkLoop5.getId(), network);
 		route.setLinkIds(link1.getId(), linkIds, linkLoop5.getId());
 
@@ -245,7 +241,7 @@ public class CompressedNetworkRouteTest extends AbstractNetworkRouteTest {
 
 		final Node node13 = network.getNodes().get(Id.create("13", Node.class));
 		final Node node12 = network.getNodes().get(Id.create("12", Node.class));
-		NetworkUtils.createAndAddLink(network,Id.create("-12", Link.class), node13, node12, 1000.0, 100.0, 3600.0, (double) 1 );
+		NetworkUtils.createAndAddLink(network,Id.create("-12", Link.class), node13, node12, 1000.0, 100.0, 3600.0, 1);
 
 		Link link1 = network.getLinks().get(Id.create("1", Link.class));
 		Link link2 = network.getLinks().get(Id.create("2", Link.class));
@@ -281,8 +277,8 @@ public class CompressedNetworkRouteTest extends AbstractNetworkRouteTest {
 		final Node node14 = network.getNodes().get(Id.create("14", Node.class));
 		final Node node13 = network.getNodes().get(Id.create("13", Node.class));
 		final Node node12 = network.getNodes().get(Id.create("12", Node.class));
-		NetworkUtils.createAndAddLink(network,Id.create("-12", Link.class), node13, node12, 1000.0, 100.0, 3600.0, (double) 1 );
-		NetworkUtils.createAndAddLink(network,Id.create("-13", Link.class), node14, node13, 1000.0, 100.0, 3600.0, (double) 1 );
+		NetworkUtils.createAndAddLink(network,Id.create("-12", Link.class), node13, node12, 1000.0, 100.0, 3600.0, 1);
+		NetworkUtils.createAndAddLink(network,Id.create("-13", Link.class), node14, node13, 1000.0, 100.0, 3600.0, 1);
 
 		Link link1 = network.getLinks().get(Id.create("1", Link.class));
 		Link link2 = network.getLinks().get(Id.create("2", Link.class));

--- a/matsim/src/test/java/org/matsim/core/population/routes/CompressedNetworkRouteTest.java
+++ b/matsim/src/test/java/org/matsim/core/population/routes/CompressedNetworkRouteTest.java
@@ -236,7 +236,7 @@ public class CompressedNetworkRouteTest extends AbstractNetworkRouteTest {
 	}
 
 	@Test
-	public void testGetLinks_setLinks_largeLoop() {
+	public void testGetLinks_setLinks_containsLargeLoop() {
 		Network network = createTestNetwork();
 
 		final Node node13 = network.getNodes().get(Id.create("13", Node.class));
@@ -264,7 +264,7 @@ public class CompressedNetworkRouteTest extends AbstractNetworkRouteTest {
 	}
 
 	@Test
-	public void testGetLinks_setLinks_largeLoop_alternative() {
+	public void testGetLinks_setLinks_containsLargeLoop_alternative() {
 		Network network = createTestNetwork();
 
 		network.removeLink(Id.create("4", Link.class));
@@ -293,6 +293,35 @@ public class CompressedNetworkRouteTest extends AbstractNetworkRouteTest {
 
 		NetworkRoute route = getNetworkRouteInstance(link1.getId(), link23.getId(), network);
 		route.setLinkIds(link1.getId(), linkIds, link23.getId());
+
+		List<Id<Link>> linksId2 = route.getLinkIds();
+		Assert.assertEquals("wrong number of links.", linkIds.size(), linksId2.size());
+		for (int i = 0, n = linkIds.size(); i < n; i++) {
+			Assert.assertEquals("different link at position " + i, linkIds.get(i), linksId2.get(i));
+		}
+	}
+
+	@Test
+	public void testGetLinks_setLinks_isLargeLoop() {
+		Network network = createTestNetwork();
+
+		final Node node14 = network.getNodes().get(Id.create("14", Node.class));
+		final Node node13 = network.getNodes().get(Id.create("13", Node.class));
+		final Node node12 = network.getNodes().get(Id.create("12", Node.class));
+		NetworkUtils.createAndAddLink(network,Id.create("-12", Link.class), node13, node12, 1000.0, 100.0, 3600.0, 1);
+		NetworkUtils.createAndAddLink(network,Id.create("-13", Link.class), node14, node13, 1000.0, 100.0, 3600.0, 1);
+
+		Link link2 = network.getLinks().get(Id.create("2", Link.class));
+		Link link3 = network.getLinks().get(Id.create("3", Link.class));
+		Link link24 = network.getLinks().get(Id.create("24", Link.class));
+		Link linkM13 = network.getLinks().get(Id.create("-13", Link.class));
+		Link linkM12 = network.getLinks().get(Id.create("-12", Link.class));
+		Link linkM22 = network.getLinks().get(Id.create("-22", Link.class));
+
+		List<Id<Link>> linkIds = List.of(link3.getId(), link24.getId(), linkM13.getId(), linkM12.getId(), linkM22.getId());
+
+		NetworkRoute route = getNetworkRouteInstance(link2.getId(), link2.getId(), network);
+		route.setLinkIds(link2.getId(), linkIds, link2.getId());
 
 		List<Id<Link>> linksId2 = route.getLinkIds();
 		Assert.assertEquals("wrong number of links.", linkIds.size(), linksId2.size());

--- a/matsim/src/test/java/org/matsim/core/population/routes/CompressedNetworkRouteTest.java
+++ b/matsim/src/test/java/org/matsim/core/population/routes/CompressedNetworkRouteTest.java
@@ -21,6 +21,7 @@
 package org.matsim.core.population.routes;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -30,12 +31,19 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.NetworkFactory;
 import org.matsim.api.core.v01.network.Node;
+import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.network.algorithms.SubsequentLinksAnalyzer;
+import org.matsim.core.network.io.MatsimNetworkReader;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.pt.transitSchedule.api.TransitLine;
+import org.matsim.pt.transitSchedule.api.TransitRoute;
+import org.matsim.pt.transitSchedule.api.TransitScheduleReader;
 
 /**
  * @author mrieser
@@ -180,6 +188,121 @@ public class CompressedNetworkRouteTest extends AbstractNetworkRouteTest {
 
 		Assert.assertEquals(2, route1.getLinkIds().size());
 		Assert.assertEquals(3, route2.getLinkIds().size());
+	}
+
+	@Test
+	public void testGetLinks_setLinks_alternative() {
+		Network network = createTestNetwork();
+		Link link1 = network.getLinks().get(Id.create("1", Link.class));
+		Link link22 = network.getLinks().get(Id.create("22", Link.class));
+		Link link12 = network.getLinks().get(Id.create("12", Link.class));
+		Link linkM23 = network.getLinks().get(Id.create("-23", Link.class));
+		Link link3 = network.getLinks().get(Id.create("3", Link.class));
+		Link link4 = network.getLinks().get(Id.create("4", Link.class));
+
+		List<Id<Link>> linkIds = new ArrayList<>(5);
+		Collections.addAll(linkIds, link22.getId(), link12.getId(), linkM23.getId(), link3.getId());
+		NetworkRoute route = getNetworkRouteInstance(link1.getId(), link4.getId(), network);
+		route.setLinkIds(link1.getId(), linkIds, link4.getId());
+
+		List<Id<Link>> linksId2 = route.getLinkIds();
+		Assert.assertEquals("wrong number of links.", linkIds.size(), linksId2.size());
+		for (int i = 0, n = linkIds.size(); i < n; i++) {
+			Assert.assertEquals("different link at position " + i, linkIds.get(i), linksId2.get(i));
+		}
+	}
+
+	@Test
+	public void testGetLinks_setLinks_endLoopLink() {
+		Network network = createTestNetwork();
+
+		final Node node5 = network.getNodes().get(Id.create("5", Node.class));
+		NetworkUtils.createAndAddLink(network,Id.create("loop5", Link.class), node5, node5, 1000.0, 100.0, 3600.0, (double) 1 );
+
+		Link link1 = network.getLinks().get(Id.create("1", Link.class));
+		Link link22 = network.getLinks().get(Id.create("22", Link.class));
+		Link link12 = network.getLinks().get(Id.create("12", Link.class));
+		Link linkM23 = network.getLinks().get(Id.create("-23", Link.class));
+		Link link3 = network.getLinks().get(Id.create("3", Link.class));
+		Link link4 = network.getLinks().get(Id.create("4", Link.class));
+		Link linkLoop5 = network.getLinks().get(Id.create("loop5", Link.class));
+
+		List<Id<Link>> linkIds = new ArrayList<>(6);
+		Collections.addAll(linkIds, link22.getId(), link12.getId(), linkM23.getId(), link3.getId(), link4.getId());
+		NetworkRoute route = getNetworkRouteInstance(link1.getId(), linkLoop5.getId(), network);
+		route.setLinkIds(link1.getId(), linkIds, linkLoop5.getId());
+
+		List<Id<Link>> linksId2 = route.getLinkIds();
+		Assert.assertEquals("wrong number of links.", linkIds.size(), linksId2.size());
+		for (int i = 0, n = linkIds.size(); i < n; i++) {
+			Assert.assertEquals("different link at position " + i, linkIds.get(i), linksId2.get(i));
+		}
+	}
+
+	@Test
+	public void testGetLinks_setLinks_largeLoop() {
+		Network network = createTestNetwork();
+
+		final Node node13 = network.getNodes().get(Id.create("13", Node.class));
+		final Node node12 = network.getNodes().get(Id.create("12", Node.class));
+		NetworkUtils.createAndAddLink(network,Id.create("-12", Link.class), node13, node12, 1000.0, 100.0, 3600.0, (double) 1 );
+
+		Link link1 = network.getLinks().get(Id.create("1", Link.class));
+		Link link2 = network.getLinks().get(Id.create("2", Link.class));
+		Link link23 = network.getLinks().get(Id.create("23", Link.class));
+		Link linkM12 = network.getLinks().get(Id.create("-12", Link.class));
+		Link linkM22 = network.getLinks().get(Id.create("-22", Link.class));
+		Link link3 = network.getLinks().get(Id.create("3", Link.class));
+		Link link4 = network.getLinks().get(Id.create("4", Link.class));
+
+		List<Id<Link>> linkIds = List.of(link2.getId(), link23.getId(), linkM12.getId(), linkM22.getId(), link2.getId(), link3.getId());
+
+		NetworkRoute route = getNetworkRouteInstance(link1.getId(), link4.getId(), network);
+		route.setLinkIds(link1.getId(), linkIds, link4.getId());
+
+		List<Id<Link>> linksId2 = route.getLinkIds();
+		Assert.assertEquals("wrong number of links.", linkIds.size(), linksId2.size());
+		for (int i = 0, n = linkIds.size(); i < n; i++) {
+			Assert.assertEquals("different link at position " + i, linkIds.get(i), linksId2.get(i));
+		}
+	}
+
+	@Test
+	public void testGetLinks_setLinks_largeLoop_alternative() {
+		Network network = createTestNetwork();
+
+		network.removeLink(Id.create("4", Link.class));
+		network.removeNode(Id.create("5", Node.class));
+		network.removeLink(Id.create("14", Link.class));
+		network.removeLink(Id.create("15", Link.class));
+		network.removeNode(Id.create("15", Node.class));
+		network.removeNode(Id.create("16", Node.class));
+
+		final Node node14 = network.getNodes().get(Id.create("14", Node.class));
+		final Node node13 = network.getNodes().get(Id.create("13", Node.class));
+		final Node node12 = network.getNodes().get(Id.create("12", Node.class));
+		NetworkUtils.createAndAddLink(network,Id.create("-12", Link.class), node13, node12, 1000.0, 100.0, 3600.0, (double) 1 );
+		NetworkUtils.createAndAddLink(network,Id.create("-13", Link.class), node14, node13, 1000.0, 100.0, 3600.0, (double) 1 );
+
+		Link link1 = network.getLinks().get(Id.create("1", Link.class));
+		Link link2 = network.getLinks().get(Id.create("2", Link.class));
+		Link link3 = network.getLinks().get(Id.create("3", Link.class));
+		Link link24 = network.getLinks().get(Id.create("24", Link.class));
+		Link linkM13 = network.getLinks().get(Id.create("-13", Link.class));
+		Link linkM12 = network.getLinks().get(Id.create("-12", Link.class));
+		Link linkM22 = network.getLinks().get(Id.create("-22", Link.class));
+		Link link23 = network.getLinks().get(Id.create("23", Link.class));
+
+		List<Id<Link>> linkIds = List.of(link2.getId(), link3.getId(), link24.getId(), linkM13.getId(), linkM12.getId(), linkM22.getId(), link2.getId());
+
+		NetworkRoute route = getNetworkRouteInstance(link1.getId(), link23.getId(), network);
+		route.setLinkIds(link1.getId(), linkIds, link23.getId());
+
+		List<Id<Link>> linksId2 = route.getLinkIds();
+		Assert.assertEquals("wrong number of links.", linkIds.size(), linksId2.size());
+		for (int i = 0, n = linkIds.size(); i < n; i++) {
+			Assert.assertEquals("different link at position " + i, linkIds.get(i), linksId2.get(i));
+		}
 	}
 
 }


### PR DESCRIPTION
CompressedNetworkRoutes had a problem with routes containing loops (routes passing a node multiple times). This wasn't an issue when compressed network routes were originally developed for car traffic only, as it couldn't happen there, but now with public transport routes, such loops are possible.