### PR TITLE
freight: switch to slf4j-reload4j and bump to 2.0.0

### DIFF
--- a/contribs/freight/pom.xml
+++ b/contribs/freight/pom.xml
@@ -76,7 +76,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
+			<artifactId>slf4j-reload4j</artifactId>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -231,8 +231,8 @@
 
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-log4j12</artifactId>
-                <version>1.7.36</version>
+                <artifactId>slf4j-reload4j</artifactId>
+                <version>2.0.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
log4j 1.x has been declared EOL and the slf4j authors strongly encourage to use slf4j-reload4j binding (instead of slf4j-log4j12).
Reload4j is a drop-in replacement for log4j version 1.2.7.
For more info see: https://www.slf4j.org/manual.html#swapping