### PR TITLE
freight: switch from slf4j-reload4j (log4j 1.2) to log4j-slf4j-impl (log4j 2)

### DIFF
--- a/contribs/freight/pom.xml
+++ b/contribs/freight/pom.xml
@@ -71,12 +71,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-reload4j</artifactId>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -226,13 +226,13 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>2.0.0</version>
+                <version>1.7.36</version>
             </dependency>
 
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-reload4j</artifactId>
-                <version>2.0.0</version>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <version>2.18.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
At the same time, we have to downgrade slf4j-api to 1.7.36 (as 1.8+ is not yet supported by log4j-slf4j-impl)