### PR TITLE
MATSimApplication with other loadScenario signatures

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/MATSimApplication.java
+++ b/contribs/application/src/main/java/org/matsim/application/MATSimApplication.java
@@ -185,7 +185,7 @@ public abstract class MATSimApplication implements Callable<Integer>, CommandLin
 		if (runId != null)
 			config.controler().setRunId(runId);
 
-		final Scenario scenario = ScenarioUtils.loadScenario(config);
+		final Scenario scenario = createScenario(config);
 
 		prepareScenario(scenario);
 
@@ -339,6 +339,14 @@ public abstract class MATSimApplication implements Callable<Integer>, CommandLin
 	 * Preparation step for the controller.
 	 */
 	protected void prepareControler(Controler controler) {
+	}
+
+	/**
+	 * Allows scenario creation with other loadScenario signatures
+	 * e.g. with AttributeConverter
+	 */
+	protected Scenario createScenario(Config config) {
+		return ScenarioUtils.loadScenario(config);
 	}
 
 	/**
@@ -535,7 +543,7 @@ public abstract class MATSimApplication implements Callable<Integer>, CommandLin
 			ConfigUtils.applyCommandline(config, extraArgs);
 		}
 
-		final Scenario scenario = ScenarioUtils.loadScenario(config);
+		final Scenario scenario = app.createScenario(config);
 		app.prepareScenario(scenario);
 
 		final Controler controler = new Controler(scenario);


### PR DESCRIPTION
This PR provides only a minor change but allows to exchange the way how a scenario is loaded for the MATSimApplication. There is now a exchangeable createScenario(Config config) that is pre-configured with the orignal default behavior. However, this likewise protected method could be overridden and thus allows to load a scenario with attribute converters, which might be mandatory for some users (see #2148 from @marecabo).  