### PR TITLE
freight: Use the vehicleId from the mobsim in freightEvents

### DIFF
--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/CarrierAgent.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/CarrierAgent.java
@@ -193,10 +193,10 @@ final class CarrierAgent implements Identifiable<Carrier>
 		log.warn("score=" + score);
 		carrier.getSelectedPlan().setScore( score );
 	}
-	void handleEvent( Event event, Id<Person> driverId ) {
+	void handleEvent(Event event, Id<Person> driverId) {
 		// the event comes to here from CarrierAgentTracker only for those drivers that belong to this carrier.  The driver IDs are also
 		// passed on "as a service", which means that here we can distribute the events to the drivers.
-		getDriver( driverId ).handleAnEvent( event );
+		getDriver( driverId ).handleAnEvent( event);
 	}
 	CarrierDriverAgent getDriver(Id<Person> driverId){
 		return carrierDriverAgents.get(driverId);

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/CarrierAgentTracker.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/CarrierAgentTracker.java
@@ -111,7 +111,7 @@ public final class CarrierAgentTracker implements BasicEventHandler
 		}
 		CarrierAgent carrierAgent = getCarrierAgentFromDriver( driverId );
 		if(carrierAgent == null) return;
-		carrierAgent.handleEvent(event, driverId );
+		carrierAgent.handleEvent(event, driverId);
 	}
 
 	// ---

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightEventCreator.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightEventCreator.java
@@ -21,14 +21,16 @@
 
 package org.matsim.contrib.freight.events;
 
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.events.Event;
 import org.matsim.api.core.v01.population.Activity;
 import org.matsim.contrib.freight.carrier.Carrier;
 import org.matsim.contrib.freight.carrier.ScheduledTour;
+import org.matsim.vehicles.Vehicle;
 
 public interface FreightEventCreator {
 
-	Event createEvent(Event event, Carrier carrier, Activity activity, ScheduledTour scheduledTour, int activityCounter);
+	Event createEvent(Event event, Carrier carrier, Activity activity, ScheduledTour scheduledTour, int activityCounter, Id<Vehicle> vehicleId);
 	// activityCounter is currently needed to get the correct "service" or "pickup" / "delivery" activity out auf the scheduled plan.
 	// It is well integrated in the {@link CarrierEventTracker}.
 	// Maybe it can be replaced by the correct freight-activity here --> move the getTourElement ... up

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightServiceEndEventCreator.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightServiceEndEventCreator.java
@@ -21,6 +21,7 @@
 
 package org.matsim.contrib.freight.events;
 
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.events.ActivityEndEvent;
 import org.matsim.api.core.v01.events.Event;
 import org.matsim.api.core.v01.population.Activity;
@@ -29,15 +30,16 @@ import org.matsim.contrib.freight.carrier.FreightConstants;
 import org.matsim.contrib.freight.carrier.ScheduledTour;
 import org.matsim.contrib.freight.carrier.Tour.ServiceActivity;
 import org.matsim.contrib.freight.carrier.Tour.TourElement;
+import org.matsim.vehicles.Vehicle;
 
 /*package-private*/  final class FreightServiceEndEventCreator implements FreightEventCreator {
 
 	@Override
-	public Event createEvent(Event event, Carrier carrier, Activity activity, ScheduledTour scheduledTour, int activityCounter) {
+	public Event createEvent(Event event, Carrier carrier, Activity activity, ScheduledTour scheduledTour, int activityCounter, Id<Vehicle> vehicleId) {
 		if(event instanceof ActivityEndEvent endEvent && FreightConstants.SERVICE.equals(endEvent.getActType())) {
 			TourElement element = scheduledTour.getTour().getTourElements().get(activityCounter);
 			if(element instanceof ServiceActivity serviceActivity) {
-				return new FreightServiceEndEvent(event.getTime(), carrier.getId(), serviceActivity.getService(), scheduledTour.getVehicle().getId());
+				return new FreightServiceEndEvent(event.getTime(), carrier.getId(), serviceActivity.getService(), vehicleId);
 			}
 		}
 		return null;

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightServiceStartEventCreator.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightServiceStartEventCreator.java
@@ -21,6 +21,7 @@
 
 package org.matsim.contrib.freight.events;
 
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.events.ActivityStartEvent;
 import org.matsim.api.core.v01.events.Event;
 import org.matsim.api.core.v01.population.Activity;
@@ -29,15 +30,16 @@ import org.matsim.contrib.freight.carrier.FreightConstants;
 import org.matsim.contrib.freight.carrier.ScheduledTour;
 import org.matsim.contrib.freight.carrier.Tour.ServiceActivity;
 import org.matsim.contrib.freight.carrier.Tour.TourElement;
+import org.matsim.vehicles.Vehicle;
 
 /*package-private*/  final class FreightServiceStartEventCreator implements FreightEventCreator {
 
 	@Override
-	public Event createEvent(Event event, Carrier carrier, Activity activity, ScheduledTour scheduledTour, int activityCounter) {
+	public Event createEvent(Event event, Carrier carrier, Activity activity, ScheduledTour scheduledTour, int activityCounter, Id<Vehicle> vehicleId) {
 		if( event instanceof ActivityStartEvent startEvent && FreightConstants.SERVICE.equals(startEvent.getActType()) ){
 			TourElement element = scheduledTour.getTour().getTourElements().get(activityCounter);
 			if( element instanceof ServiceActivity serviceActivity ) {
-				return new FreightServiceStartEvent(event.getTime(), carrier.getId(), serviceActivity.getService(), scheduledTour.getVehicle().getId());
+				return new FreightServiceStartEvent(event.getTime(), carrier.getId(), serviceActivity.getService(), vehicleId);
 			}
 		}
 		return null;

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightShipmentDeliveryEndEventCreator.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightShipmentDeliveryEndEventCreator.java
@@ -21,6 +21,7 @@
 
 package org.matsim.contrib.freight.events;
 
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.events.ActivityEndEvent;
 import org.matsim.api.core.v01.events.Event;
 import org.matsim.api.core.v01.population.Activity;
@@ -29,15 +30,16 @@ import org.matsim.contrib.freight.carrier.FreightConstants;
 import org.matsim.contrib.freight.carrier.ScheduledTour;
 import org.matsim.contrib.freight.carrier.Tour.Delivery;
 import org.matsim.contrib.freight.carrier.Tour.TourElement;
+import org.matsim.vehicles.Vehicle;
 
 /*package-private*/  final class FreightShipmentDeliveryEndEventCreator implements FreightEventCreator {
 
 	@Override
-	public Event createEvent(Event event, Carrier carrier, Activity activity, ScheduledTour scheduledTour, int activityCounter) {
+	public Event createEvent(Event event, Carrier carrier, Activity activity, ScheduledTour scheduledTour, int activityCounter, Id<Vehicle> vehicleId) {
 		if(event instanceof ActivityEndEvent endEvent && FreightConstants.DELIVERY.equals(endEvent.getActType()) ) {
 			TourElement element = scheduledTour.getTour().getTourElements().get(activityCounter);
 			if (element instanceof Delivery deliveryActivity) {
-				return new FreightShipmentDeliveryEndEvent(event.getTime(), carrier.getId(), deliveryActivity.getShipment(), scheduledTour.getVehicle().getId() );
+				return new FreightShipmentDeliveryEndEvent(event.getTime(), carrier.getId(), deliveryActivity.getShipment(), vehicleId );
 			}
 		}
 		return null;

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightShipmentDeliveryStartEventCreator.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightShipmentDeliveryStartEventCreator.java
@@ -21,6 +21,7 @@
 
 package org.matsim.contrib.freight.events;
 
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.events.ActivityStartEvent;
 import org.matsim.api.core.v01.events.Event;
 import org.matsim.api.core.v01.population.Activity;
@@ -29,15 +30,16 @@ import org.matsim.contrib.freight.carrier.FreightConstants;
 import org.matsim.contrib.freight.carrier.ScheduledTour;
 import org.matsim.contrib.freight.carrier.Tour.Delivery;
 import org.matsim.contrib.freight.carrier.Tour.TourElement;
+import org.matsim.vehicles.Vehicle;
 
 /*package-private*/  final class FreightShipmentDeliveryStartEventCreator implements FreightEventCreator {
 
 	@Override
-	public Event createEvent(Event event, Carrier carrier, Activity activity, ScheduledTour scheduledTour, int activityCounter) {
+	public Event createEvent(Event event, Carrier carrier, Activity activity, ScheduledTour scheduledTour, int activityCounter, Id<Vehicle> vehicleId) {
 		if(event instanceof ActivityStartEvent startEvent && FreightConstants.DELIVERY.equals(startEvent.getActType()) ) {
 			TourElement element = scheduledTour.getTour().getTourElements().get(activityCounter);
 			if (element instanceof Delivery deliveryActivity) {
-				return new FreightShipmentDeliveryStartEvent(event.getTime(), carrier.getId(), deliveryActivity.getShipment(), scheduledTour.getVehicle().getId() );
+				return new FreightShipmentDeliveryStartEvent(event.getTime(), carrier.getId(), deliveryActivity.getShipment(), vehicleId );
 			}
 		}
 		return null;

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightShipmentPickupEndEventCreator.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightShipmentPickupEndEventCreator.java
@@ -21,6 +21,7 @@
 
 package org.matsim.contrib.freight.events;
 
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.events.ActivityEndEvent;
 import org.matsim.api.core.v01.events.Event;
 import org.matsim.api.core.v01.population.Activity;
@@ -29,15 +30,16 @@ import org.matsim.contrib.freight.carrier.FreightConstants;
 import org.matsim.contrib.freight.carrier.ScheduledTour;
 import org.matsim.contrib.freight.carrier.Tour.Pickup;
 import org.matsim.contrib.freight.carrier.Tour.TourElement;
+import org.matsim.vehicles.Vehicle;
 
 /*package-private*/  final class FreightShipmentPickupEndEventCreator implements FreightEventCreator {
 
 	@Override
-	public Event createEvent(Event event, Carrier carrier, Activity activity, ScheduledTour scheduledTour, int activityCounter) {
+	public Event createEvent(Event event, Carrier carrier, Activity activity, ScheduledTour scheduledTour, int activityCounter, Id<Vehicle> vehicleId) {
 		if(event instanceof ActivityEndEvent endEvent && FreightConstants.PICKUP.equals((endEvent).getActType()) ) {
 			TourElement element = scheduledTour.getTour().getTourElements().get(activityCounter);
 			if (element instanceof Pickup pickupActivity) {
-				return new FreightShipmentPickupEndEvent(event.getTime(), carrier.getId(), pickupActivity.getShipment(), scheduledTour.getVehicle().getId() );
+				return new FreightShipmentPickupEndEvent(event.getTime(), carrier.getId(), pickupActivity.getShipment(), vehicleId );
 			}
 		}
 		return null;

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightShipmentPickupStartEventCreator.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightShipmentPickupStartEventCreator.java
@@ -21,6 +21,7 @@
 
 package org.matsim.contrib.freight.events;
 
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.events.ActivityStartEvent;
 import org.matsim.api.core.v01.events.Event;
 import org.matsim.api.core.v01.population.Activity;
@@ -29,15 +30,16 @@ import org.matsim.contrib.freight.carrier.FreightConstants;
 import org.matsim.contrib.freight.carrier.ScheduledTour;
 import org.matsim.contrib.freight.carrier.Tour.Pickup;
 import org.matsim.contrib.freight.carrier.Tour.TourElement;
+import org.matsim.vehicles.Vehicle;
 
 /*package-private*/  final class FreightShipmentPickupStartEventCreator implements FreightEventCreator {
 
 	@Override
-	public Event createEvent(Event event, Carrier carrier, Activity activity, ScheduledTour scheduledTour, int activityCounter) {
+	public Event createEvent(Event event, Carrier carrier, Activity activity, ScheduledTour scheduledTour, int activityCounter, Id<Vehicle> vehicleId) {
 		if(event instanceof ActivityStartEvent startEvent && FreightConstants.PICKUP.equals((startEvent).getActType()) ) {
 			TourElement element = scheduledTour.getTour().getTourElements().get(activityCounter);
 			if (element instanceof Pickup pickupActivity) {
-				return new FreightShipmentPickupStartEvent(event.getTime(), carrier.getId(), pickupActivity.getShipment(), scheduledTour.getVehicle().getId() );
+				return new FreightShipmentPickupStartEvent(event.getTime(), carrier.getId(), pickupActivity.getShipment(), vehicleId );
 			}
 		}
 		return null;

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightTourEndEventCreator.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightTourEndEventCreator.java
@@ -21,19 +21,21 @@
 
 package org.matsim.contrib.freight.events;
 
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.events.ActivityStartEvent;
 import org.matsim.api.core.v01.events.Event;
 import org.matsim.api.core.v01.population.Activity;
 import org.matsim.contrib.freight.carrier.Carrier;
 import org.matsim.contrib.freight.carrier.FreightConstants;
 import org.matsim.contrib.freight.carrier.ScheduledTour;
+import org.matsim.vehicles.Vehicle;
 
 /*package-private*/ final class FreightTourEndEventCreator implements FreightEventCreator {
 
 	@Override
-	public Event createEvent(Event event, Carrier carrier, Activity activity, ScheduledTour scheduledTour, int activityCounter) {
+	public Event createEvent(Event event, Carrier carrier, Activity activity, ScheduledTour scheduledTour, int activityCounter, Id<Vehicle> vehicleId) {
 		if(event instanceof ActivityStartEvent startEvent && FreightConstants.END.equals(startEvent.getActType()) ) {
-				return new FreightTourEndEvent(startEvent.getTime(), carrier.getId(), scheduledTour.getTour().getEndLinkId(), scheduledTour.getVehicle().getId());
+				return new FreightTourEndEvent(startEvent.getTime(), carrier.getId(), scheduledTour.getTour().getEndLinkId(), vehicleId);
 		}	
 		return null;
 	}

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightTourStartEventCreator.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightTourStartEventCreator.java
@@ -21,19 +21,21 @@
 
 package org.matsim.contrib.freight.events;
 
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.events.ActivityEndEvent;
 import org.matsim.api.core.v01.events.Event;
 import org.matsim.api.core.v01.population.Activity;
 import org.matsim.contrib.freight.carrier.Carrier;
 import org.matsim.contrib.freight.carrier.FreightConstants;
 import org.matsim.contrib.freight.carrier.ScheduledTour;
+import org.matsim.vehicles.Vehicle;
 
 /*package-private*/  final class FreightTourStartEventCreator implements FreightEventCreator {
 
 	@Override
-	public Event createEvent(Event event, Carrier carrier, Activity activity, ScheduledTour scheduledTour, int activityCounter) {
+	public Event createEvent(Event event, Carrier carrier, Activity activity, ScheduledTour scheduledTour, int activityCounter, Id<Vehicle> vehicleId) {
 		if((event instanceof ActivityEndEvent endEvent) && FreightConstants.START.equals(endEvent.getActType()) ) {
-				return new FreightTourStartEvent(endEvent.getTime(), carrier.getId(), scheduledTour.getTour().getStartLinkId(), scheduledTour.getVehicle().getId());
+				return new FreightTourStartEvent(endEvent.getTime(), carrier.getId(), scheduledTour.getTour().getStartLinkId(), vehicleId);
 		}
 		return null;	
 	}


### PR DESCRIPTION
... instead of the vehicleIds from the (carrier) tours. - They were neither unique nor consistent with the vehicleIds available in the mobsim

Now, the vehicleIds should be unique AND consistent to the MATSim (all)Vehicles container and the other vehicle-based events.