### PR TITLE
Freight introduce tour Ids

### DIFF
--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanWriter.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanWriter.java
@@ -44,7 +44,7 @@ public class CarrierPlanWriter {
 	}
 
 	public void write(String filename) {
-		this.writeV2(filename);
+		this.writeV2_1(filename);
 	}
 
 	/**
@@ -58,12 +58,29 @@ public class CarrierPlanWriter {
 
 	/**
 	 * Writes out the Carriers file in version 2.
-//	 * Please use the method {@link #write(String)} instead to always ensure writing out to the newest format.
+	 * Please use the method {@link #write(String)} instead to always ensure writing out to the newest format.
+	 *
+	 * @deprecated The underlining {@Link{CarrierPlanXmlWriterV2} is deprecated since Sep'22
 	 *
 	 * @param filename Name of the file that should be written.
 	 */
 	public void writeV2(String filename) {
 		CarrierPlanXmlWriterV2 writer = new CarrierPlanXmlWriterV2(this.carriers);
+		if (this.attributeConverters != null) {
+			writer.putAttributeConverters(this.attributeConverters);
+		}
+		writer.write(filename);
+	}
+
+	/**
+	 * Writes out the Carriers file in version 2.1.
+	 * Please use the method {@link #write(String)} to always ensure writing out to the newest format.
+	 * --> keeping it private
+	 *
+	 * @param filename Name of the file that should be written.
+	 */
+	private void writeV2_1(String filename) {
+		CarrierPlanXmlWriterV2_1 writer = new CarrierPlanXmlWriterV2_1(this.carriers);
 		if (this.attributeConverters != null) {
 			writer.putAttributeConverters(this.attributeConverters);
 		}

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlParserV2_1.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlParserV2_1.java
@@ -1,0 +1,423 @@
+/*
+ *   *********************************************************************** *
+ *   project: org.matsim.*
+ *   *********************************************************************** *
+ *                                                                           *
+ *   copyright       : (C)  by the members listed in the COPYING,        *
+ *                     LICENSE and WARRANTY file.                            *
+ *   email           : info at matsim dot org                                *
+ *                                                                           *
+ *   *********************************************************************** *
+ *                                                                           *
+ *     This program is free software; you can redistribute it and/or modify  *
+ *     it under the terms of the GNU General Public License as published by  *
+ *     the Free Software Foundation; either version 2 of the License, or     *
+ *     (at your option) any later version.                                   *
+ *     See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                           *
+ *   ***********************************************************************
+ *
+ */
+
+package org.matsim.contrib.freight.carrier;
+
+import com.google.inject.Inject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.contrib.freight.carrier.CarrierCapabilities.Builder;
+import org.matsim.contrib.freight.carrier.CarrierCapabilities.FleetSize;
+import org.matsim.core.gbl.Gbl;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.population.routes.NetworkRoute;
+import org.matsim.core.population.routes.RouteUtils;
+import org.matsim.core.utils.io.MatsimXmlParser;
+import org.matsim.core.utils.misc.Time;
+import org.matsim.utils.objectattributes.AttributeConverter;
+import org.matsim.utils.objectattributes.attributable.AttributesXmlReaderDelegate;
+import org.matsim.vehicles.Vehicle;
+import org.matsim.vehicles.VehicleType;
+import org.xml.sax.Attributes;
+
+import java.util.*;
+
+class CarrierPlanXmlParserV2_1 extends MatsimXmlParser {
+
+	public static final  Logger logger = LogManager.getLogger(CarrierPlanXmlParserV2_1.class);
+
+	public static final String CARRIERS = "carriers";
+	public static final String CARRIER = "carrier";
+	public static final String LINKID = "linkId";
+	public static final String SHIPMENTS = "shipments";
+	public static final String SHIPMENT = "shipment";
+	static final String SERVICES = "services";
+	static final String SERVICE = "service";
+	public static final String ID = "id";
+	public static final String FROM = "from";
+	public static final String TO = "to";
+	public static final String SIZE = "size";
+	public static final String ACTIVITY = "act";
+	public static final String TYPE = "type";
+	public static final String SHIPMENTID = "shipmentId";
+	public static final String START = "start";
+	public static final String VEHICLE = "vehicle";
+	public static final String VEHICLES = "vehicles";
+	private static final String VEHICLE_EARLIEST_START = "earliestStart";
+	private static final String VEHICLE_LATEST_END = "latestEnd";
+	private static final String VEHICLE_TYPES_MSG = "It used to be possible to have vehicle types both in the plans file, and in a separate file.  The " +
+										  "first option is no longer possible." ;
+	private static final String ATTRIBUTES = "attributes";
+	private static final String ATTRIBUTE = "attribute";
+
+	private Carrier currentCarrier = null;
+	private CarrierVehicle currentVehicle = null;
+	private CarrierService currentService = null;
+	private CarrierShipment currentShipment = null;
+	private Tour.Builder currentTourBuilder = null;
+	private Id<Link> previousActLoc = null;
+	private String previousRouteContent;
+	private Map<String, CarrierShipment> currentShipments = null;
+	private Map<String, CarrierVehicle> vehicles = null;
+	private Collection<ScheduledTour> scheduledTours = null;
+	private Double currentScore;
+	private boolean selected;
+	private final Carriers carriers;
+	private final CarrierVehicleTypes carrierVehicleTypes;
+	private double currentLegTransTime;
+	private double currentLegDepTime;
+	private Builder capabilityBuilder;
+
+	private double currentStartTime;
+
+	private Map<Id<CarrierService>, CarrierService> serviceMap;
+
+	private final AttributesXmlReaderDelegate attributesReader = new AttributesXmlReaderDelegate();
+	private org.matsim.utils.objectattributes.attributable.Attributes currAttributes =
+			new org.matsim.utils.objectattributes.attributable.Attributes();
+
+	/**
+	 * Constructs a reader with an empty carriers-container for the carriers to be constructed.
+	 *
+	 * @param carriers which is a map that stores carriers
+	 * @param carrierVehicleTypes
+	 */
+	CarrierPlanXmlParserV2_1(Carriers carriers, CarrierVehicleTypes carrierVehicleTypes ) {
+		super();
+		this.carriers = carriers;
+		this.carrierVehicleTypes = carrierVehicleTypes;
+	}
+
+	public void putAttributeConverter( final Class<?> clazz , AttributeConverter<?> converter ) {
+		attributesReader.putAttributeConverter( clazz , converter );
+	}
+
+	@Inject
+	public void putAttributeConverters( final Map<Class<?>, AttributeConverter<?>> converters ) {
+		attributesReader.putAttributeConverters( converters );
+	}
+
+	@Override
+	public void startTag(String name, Attributes atts, Stack<String> context) {
+		switch (name) {
+			case CARRIER: {
+				String id = atts.getValue(ID);
+				if (id == null) throw new IllegalStateException("carrierId is missing.");
+				currentCarrier = CarrierUtils.createCarrier(Id.create(id, Carrier.class));
+				break;
+			}
+
+			//services
+			case SERVICES:
+				serviceMap = new HashMap<>();
+				break;
+			case SERVICE: {
+				String idString = atts.getValue("id");
+				if (idString == null) throw new IllegalStateException("service.id is missing.");
+				Id<CarrierService> id = Id.create(idString, CarrierService.class);
+				String toLocation = atts.getValue("to");
+				if (toLocation == null) throw new IllegalStateException("service.to is missing. ");
+				Id<Link> to = Id.create(toLocation, Link.class);
+				CarrierService.Builder serviceBuilder = CarrierService.Builder.newInstance(id, to);
+				String capDemandString = atts.getValue("capacityDemand");
+				if (capDemandString != null) serviceBuilder.setCapacityDemand(getInt(capDemandString));
+				String startString = atts.getValue("earliestStart");
+				double start = parseTimeToDouble(startString);
+				double end;
+				String endString = atts.getValue("latestEnd");
+				end = parseTimeToDouble(endString);
+				serviceBuilder.setServiceStartTimeWindow(TimeWindow.newInstance(start, end));
+				String serviceTimeString = atts.getValue("serviceDuration");
+				if (serviceTimeString != null) serviceBuilder.setServiceDuration(parseTimeToDouble(serviceTimeString));
+				currentService = serviceBuilder.build();
+				serviceMap.put(currentService.getId(), currentService);
+				CarrierUtils.addService(currentCarrier, currentService);
+				break;
+			}
+
+			//shipments
+			case SHIPMENTS:
+				currentShipments = new HashMap<>();
+				break;
+			case SHIPMENT: {
+				String idString = atts.getValue("id");
+				if (idString == null) throw new IllegalStateException("shipment.id is missing.");
+				Id<CarrierShipment> id = Id.create(idString, CarrierShipment.class);
+				String from = atts.getValue(FROM);
+				if (from == null) throw new IllegalStateException("shipment.from is missing.");
+				String to = atts.getValue(TO);
+				if (to == null) throw new IllegalStateException("shipment.to is missing.");
+				String sizeString = atts.getValue(SIZE);
+				if (sizeString == null) throw new IllegalStateException("shipment.size is missing.");
+				int size = getInt(sizeString);
+				CarrierShipment.Builder shipmentBuilder = CarrierShipment.Builder.newInstance(id, Id.create(from, Link.class), Id.create(to, Link.class), size);
+
+				String startPickup = atts.getValue("startPickup");
+				String endPickup = atts.getValue("endPickup");
+				String startDelivery = atts.getValue("startDelivery");
+				String endDelivery = atts.getValue("endDelivery");
+				String pickupServiceTime = atts.getValue("pickupServiceTime");
+				String deliveryServiceTime = atts.getValue("deliveryServiceTime");
+
+				if (startPickup != null && endPickup != null)
+					shipmentBuilder.setPickupTimeWindow(TimeWindow.newInstance(parseTimeToDouble(startPickup), parseTimeToDouble(endPickup)));
+				if (startDelivery != null && endDelivery != null)
+					shipmentBuilder.setDeliveryTimeWindow(TimeWindow.newInstance(parseTimeToDouble(startDelivery), parseTimeToDouble(endDelivery)));
+				if (pickupServiceTime != null)
+					shipmentBuilder.setPickupServiceTime(parseTimeToDouble(pickupServiceTime));
+				if (deliveryServiceTime != null)
+					shipmentBuilder.setDeliveryServiceTime(parseTimeToDouble(deliveryServiceTime));
+
+				currentShipment = shipmentBuilder.build();
+				currentShipments.put(atts.getValue(ID), currentShipment);
+				CarrierUtils.addShipment(currentCarrier, currentShipment);
+				break;
+			}
+
+			//capabilities
+			case "capabilities":
+				String fleetSize = atts.getValue("fleetSize");
+				if (fleetSize == null) throw new IllegalStateException("fleetSize is missing.");
+				this.capabilityBuilder = Builder.newInstance();
+				if (fleetSize.toUpperCase().equals(FleetSize.FINITE.toString())) {
+					this.capabilityBuilder.setFleetSize(FleetSize.FINITE);
+				} else {
+					this.capabilityBuilder.setFleetSize(FleetSize.INFINITE);
+				}
+				break;
+
+			//vehicle-type
+			case "vehicleType":
+				throw new RuntimeException(VEHICLE_TYPES_MSG);
+			case "engineInformation":
+				throw new RuntimeException(VEHICLE_TYPES_MSG);
+			case "costInformation":
+				throw new RuntimeException(VEHICLE_TYPES_MSG);
+
+
+				//vehicle
+			case VEHICLES:
+				vehicles = new HashMap<>();
+				break;
+			case VEHICLE:
+
+				String vId = atts.getValue(ID);
+				if (vId == null) throw new IllegalStateException("vehicleId is missing.");
+
+				String depotLinkId = atts.getValue("depotLinkId");
+				if (depotLinkId == null) throw new IllegalStateException("depotLinkId of vehicle is missing.");
+
+				String typeId = atts.getValue("typeId");
+				if (typeId == null) throw new IllegalStateException("vehicleTypeId is missing.");
+				VehicleType vehicleType = this.carrierVehicleTypes.getVehicleTypes().get(Id.create(typeId, VehicleType.class));
+				if (vehicleType == null) {
+					throw new RuntimeException("vehicleTypeId=" + typeId + " is missing.");
+				}
+
+				CarrierVehicle.Builder vehicleBuilder = CarrierVehicle.Builder.newInstance(Id.create(vId, Vehicle.class), Id.create(depotLinkId, Link.class), vehicleType);
+				String startTime = atts.getValue(VEHICLE_EARLIEST_START);
+				if (startTime != null) vehicleBuilder.setEarliestStart(parseTimeToDouble(startTime));
+				String endTime = atts.getValue(VEHICLE_LATEST_END);
+				if (endTime != null) vehicleBuilder.setLatestEnd(parseTimeToDouble(endTime));
+
+				CarrierVehicle vehicle = vehicleBuilder.build();
+				capabilityBuilder.addVehicle(vehicle);
+				vehicles.put(vId, vehicle);
+				break;
+
+			//plans
+			case "plan":
+				String score = atts.getValue("score");
+				if (score != null) currentScore = parseTimeToDouble(score);
+				String selected = atts.getValue("selected");
+				if (selected == null) this.selected = false;
+				else this.selected = selected.equals("true");
+				scheduledTours = new ArrayList<>();
+				break;
+			case "tour":
+				String tourId = atts.getValue("tourId");
+				if (tourId == null) throw new IllegalStateException("TourId is missing in tour.");
+				String vehicleId = atts.getValue("vehicleId");
+				if (vehicleId == null) throw new IllegalStateException("vehicleId is missing in tour.");
+				currentVehicle = vehicles.get(vehicleId);
+				if (currentVehicle == null)
+					throw new IllegalStateException("vehicle to vehicleId " + vehicleId + " is missing.");
+				currentTourBuilder = Tour.Builder.newInstance(Id.create(tourId, Tour.class));
+				break;
+			case "leg":
+				String depTime = atts.getValue("expected_dep_time");
+				if (depTime == null) depTime = atts.getValue("dep_time");
+				if (depTime == null) throw new IllegalStateException("leg.expected_dep_time is missing.");
+				currentLegDepTime = parseTimeToDouble(depTime);
+				String transpTime = atts.getValue("expected_transp_time");
+				if (transpTime == null) transpTime = atts.getValue("transp_time");
+				if (transpTime == null) throw new IllegalStateException("leg.expected_transp_time is missing.");
+				currentLegTransTime = parseTimeToDouble(transpTime);
+				break;
+			case ACTIVITY:
+				String type = atts.getValue(TYPE);
+				if (type == null) throw new IllegalStateException("activity type is missing");
+				String actEndTime = atts.getValue("end_time");
+				switch (type) {
+					case "start":
+						if (actEndTime == null)
+							throw new IllegalStateException("endTime of activity \"" + type + "\" missing.");
+						currentStartTime = parseTimeToDouble(actEndTime);
+						previousActLoc = currentVehicle.getLinkId();
+						currentTourBuilder.scheduleStart(currentVehicle.getLinkId(), TimeWindow.newInstance(currentVehicle.getEarliestStartTime(), currentVehicle.getLatestEndTime() ) );
+
+						break;
+					case "pickup": {
+						String id = atts.getValue(SHIPMENTID);
+						if (id == null) throw new IllegalStateException("pickup.shipmentId is missing.");
+						CarrierShipment s = currentShipments.get(id);
+						finishLeg(s.getFrom());
+						currentTourBuilder.schedulePickup(s);
+						previousActLoc = s.getFrom();
+						break;
+					}
+					case "delivery": {
+						String id = atts.getValue(SHIPMENTID);
+						if (id == null) throw new IllegalStateException("delivery.shipmentId is missing.");
+						CarrierShipment s = currentShipments.get(id);
+						finishLeg(s.getTo());
+						currentTourBuilder.scheduleDelivery(s);
+						previousActLoc = s.getTo();
+						break;
+					}
+					case "service": {
+						String id = atts.getValue("serviceId");
+						if (id == null) throw new IllegalStateException("act.serviceId is missing.");
+						CarrierService s = serviceMap.get(Id.create(id, CarrierService.class));
+						if (s == null) throw new IllegalStateException("serviceId is not known.");
+						finishLeg(s.getLocationLinkId());
+						currentTourBuilder.scheduleService(s);
+						previousActLoc = s.getLocationLinkId();
+						break;
+					}
+					case "end":
+						finishLeg(currentVehicle.getLinkId() );
+						currentTourBuilder.scheduleEnd(currentVehicle.getLinkId(), TimeWindow.newInstance(currentVehicle.getEarliestStartTime(), currentVehicle.getLatestEndTime() ) );
+						break;
+				}
+				break;
+			case ATTRIBUTES:
+				switch (context.peek()) {
+					case CARRIER:
+						currAttributes = currentCarrier.getAttributes();
+						break;
+					case SERVICE:
+						currAttributes = currentService.getAttributes();
+						break;
+					case SHIPMENT:
+						currAttributes = currentShipment.getAttributes();
+						break;
+					default:
+						throw new RuntimeException("could not derive context for attributes. context=" + context.peek());
+				}
+				attributesReader.startTag(name, atts, context, currAttributes);
+				break;
+			case ATTRIBUTE:
+				attributesReader.startTag(name, atts, context, currAttributes);
+				break;
+			case "route":
+				// do nothing
+				break ;
+			default:
+				logger.warn("Unexpected value while reading in. This field will be ignored: " + name);
+		}
+	}
+
+	@Override
+	public void endTag(String name, String content, Stack<String> context) {
+		switch (name) {
+			case "capabilities":
+				currentCarrier.setCarrierCapabilities(capabilityBuilder.build());
+				break;
+			case "vehicleType":
+				throw new RuntimeException("I am confused now if, for carriers, vehicleType is in the plans file, or in a separate file.");
+			case "route":
+				this.previousRouteContent = content;
+				break;
+			case "carrier":
+				Gbl.assertNotNull(currentCarrier);
+				Gbl.assertNotNull(carriers);
+				Gbl.assertNotNull(carriers.getCarriers());
+				carriers.getCarriers().put(currentCarrier.getId(), currentCarrier);
+				currentCarrier = null;
+				break;
+			case "plan":
+				CarrierPlan currentPlan = new CarrierPlan(currentCarrier, scheduledTours);
+				currentPlan.setScore(currentScore);
+				currentCarrier.getPlans().add(currentPlan);
+				if (this.selected) {
+					currentCarrier.setSelectedPlan(currentPlan);
+				}
+				break;
+			case "tour":
+				ScheduledTour sTour = ScheduledTour.newInstance(currentTourBuilder.build(), currentVehicle, currentStartTime);
+				scheduledTours.add(sTour);
+				break;
+			case "description":
+				throw new RuntimeException(VEHICLE_TYPES_MSG);
+			case SERVICE:
+				this.currentService = null;
+				break;
+			case SHIPMENT:
+				this.currentShipment = null;
+				break;
+			case ATTRIBUTE:
+				this.attributesReader.endTag(name, content, context);
+				break;
+			case ATTRIBUTES:
+				this.currAttributes = null;
+				break;
+		}
+	}
+
+	private void finishLeg(Id<Link> toLocation) {
+		NetworkRoute route = null;
+		if (previousRouteContent != null) {
+			List<Id<Link>> linkIds = NetworkUtils.getLinkIds(previousRouteContent);
+			route = RouteUtils.createLinkNetworkRouteImpl(previousActLoc, toLocation);
+			if (!linkIds.isEmpty()) {
+				route.setLinkIds(previousActLoc, linkIds, toLocation);
+			}
+		}
+		currentTourBuilder.addLeg(currentTourBuilder.createLeg(route, currentLegDepTime,currentLegTransTime));
+		previousRouteContent = null;
+	}
+
+	private double parseTimeToDouble(String timeString) {
+		if (timeString.contains(":")) {
+			return Time.parseTime(timeString);
+		} else {
+			return Double.parseDouble(timeString);
+		}
+	}
+
+	private int getInt(String value) {
+		return Integer.parseInt(value);
+	}
+
+}

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlParserV2_1.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlParserV2_1.java
@@ -279,33 +279,30 @@ class CarrierPlanXmlParserV2_1 extends MatsimXmlParser {
 				if (type == null) throw new IllegalStateException("activity type is missing");
 				String actEndTime = atts.getValue("end_time");
 				switch (type) {
-					case "start":
+					case "start" -> {
 						if (actEndTime == null)
 							throw new IllegalStateException("endTime of activity \"" + type + "\" missing.");
 						currentStartTime = parseTimeToDouble(actEndTime);
 						previousActLoc = currentVehicle.getLinkId();
-						currentTourBuilder.scheduleStart(currentVehicle.getLinkId(), TimeWindow.newInstance(currentVehicle.getEarliestStartTime(), currentVehicle.getLatestEndTime() ) );
-
-						break;
-					case "pickup": {
+						currentTourBuilder.scheduleStart(currentVehicle.getLinkId(), TimeWindow.newInstance(currentVehicle.getEarliestStartTime(), currentVehicle.getLatestEndTime()));
+					}
+					case "pickup" -> {
 						String id = atts.getValue(SHIPMENTID);
 						if (id == null) throw new IllegalStateException("pickup.shipmentId is missing.");
 						CarrierShipment s = currentShipments.get(id);
 						finishLeg(s.getFrom());
 						currentTourBuilder.schedulePickup(s);
 						previousActLoc = s.getFrom();
-						break;
 					}
-					case "delivery": {
+					case "delivery" -> {
 						String id = atts.getValue(SHIPMENTID);
 						if (id == null) throw new IllegalStateException("delivery.shipmentId is missing.");
 						CarrierShipment s = currentShipments.get(id);
 						finishLeg(s.getTo());
 						currentTourBuilder.scheduleDelivery(s);
 						previousActLoc = s.getTo();
-						break;
 					}
-					case "service": {
+					case "service" -> {
 						String id = atts.getValue("serviceId");
 						if (id == null) throw new IllegalStateException("act.serviceId is missing.");
 						CarrierService s = serviceMap.get(Id.create(id, CarrierService.class));
@@ -313,27 +310,20 @@ class CarrierPlanXmlParserV2_1 extends MatsimXmlParser {
 						finishLeg(s.getLocationLinkId());
 						currentTourBuilder.scheduleService(s);
 						previousActLoc = s.getLocationLinkId();
-						break;
 					}
-					case "end":
-						finishLeg(currentVehicle.getLinkId() );
-						currentTourBuilder.scheduleEnd(currentVehicle.getLinkId(), TimeWindow.newInstance(currentVehicle.getEarliestStartTime(), currentVehicle.getLatestEndTime() ) );
-						break;
+					case "end" -> {
+						finishLeg(currentVehicle.getLinkId());
+						currentTourBuilder.scheduleEnd(currentVehicle.getLinkId(), TimeWindow.newInstance(currentVehicle.getEarliestStartTime(), currentVehicle.getLatestEndTime()));
+					}
 				}
 				break;
 			case ATTRIBUTES:
 				switch (context.peek()) {
-					case CARRIER:
-						currAttributes = currentCarrier.getAttributes();
-						break;
-					case SERVICE:
-						currAttributes = currentService.getAttributes();
-						break;
-					case SHIPMENT:
-						currAttributes = currentShipment.getAttributes();
-						break;
-					default:
-						throw new RuntimeException("could not derive context for attributes. context=" + context.peek());
+					case CARRIER -> currAttributes = currentCarrier.getAttributes();
+					case SERVICE -> currAttributes = currentService.getAttributes();
+					case SHIPMENT -> currAttributes = currentShipment.getAttributes();
+					default ->
+							throw new RuntimeException("could not derive context for attributes. context=" + context.peek());
 				}
 				attributesReader.startTag(name, atts, context, currAttributes);
 				break;
@@ -351,47 +341,34 @@ class CarrierPlanXmlParserV2_1 extends MatsimXmlParser {
 	@Override
 	public void endTag(String name, String content, Stack<String> context) {
 		switch (name) {
-			case "capabilities":
-				currentCarrier.setCarrierCapabilities(capabilityBuilder.build());
-				break;
-			case "vehicleType":
-				throw new RuntimeException("I am confused now if, for carriers, vehicleType is in the plans file, or in a separate file.");
-			case "route":
-				this.previousRouteContent = content;
-				break;
-			case "carrier":
+			case "capabilities" -> currentCarrier.setCarrierCapabilities(capabilityBuilder.build());
+			case "vehicleType" ->
+					throw new RuntimeException("I am confused now if, for carriers, vehicleType is in the plans file, or in a separate file.");
+			case "route" -> this.previousRouteContent = content;
+			case "carrier" -> {
 				Gbl.assertNotNull(currentCarrier);
 				Gbl.assertNotNull(carriers);
 				Gbl.assertNotNull(carriers.getCarriers());
 				carriers.getCarriers().put(currentCarrier.getId(), currentCarrier);
 				currentCarrier = null;
-				break;
-			case "plan":
+			}
+			case "plan" -> {
 				CarrierPlan currentPlan = new CarrierPlan(currentCarrier, scheduledTours);
 				currentPlan.setScore(currentScore);
 				currentCarrier.getPlans().add(currentPlan);
 				if (this.selected) {
 					currentCarrier.setSelectedPlan(currentPlan);
 				}
-				break;
-			case "tour":
+			}
+			case "tour" -> {
 				ScheduledTour sTour = ScheduledTour.newInstance(currentTourBuilder.build(), currentVehicle, currentStartTime);
 				scheduledTours.add(sTour);
-				break;
-			case "description":
-				throw new RuntimeException(VEHICLE_TYPES_MSG);
-			case SERVICE:
-				this.currentService = null;
-				break;
-			case SHIPMENT:
-				this.currentShipment = null;
-				break;
-			case ATTRIBUTE:
-				this.attributesReader.endTag(name, content, context);
-				break;
-			case ATTRIBUTES:
-				this.currAttributes = null;
-				break;
+			}
+			case "description" -> throw new RuntimeException(VEHICLE_TYPES_MSG);
+			case SERVICE -> this.currentService = null;
+			case SHIPMENT -> this.currentShipment = null;
+			case ATTRIBUTE -> this.attributesReader.endTag(name, content, context);
+			case ATTRIBUTES -> this.currAttributes = null;
 		}
 	}
 

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlParserV2_1.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlParserV2_1.java
@@ -46,23 +46,20 @@ class CarrierPlanXmlParserV2_1 extends MatsimXmlParser {
 
 	public static final  Logger logger = LogManager.getLogger(CarrierPlanXmlParserV2_1.class);
 
-	public static final String CARRIERS = "carriers";
-	public static final String CARRIER = "carrier";
-	public static final String LINKID = "linkId";
-	public static final String SHIPMENTS = "shipments";
-	public static final String SHIPMENT = "shipment";
-	static final String SERVICES = "services";
-	static final String SERVICE = "service";
-	public static final String ID = "id";
-	public static final String FROM = "from";
-	public static final String TO = "to";
-	public static final String SIZE = "size";
-	public static final String ACTIVITY = "act";
-	public static final String TYPE = "type";
-	public static final String SHIPMENTID = "shipmentId";
-	public static final String START = "start";
-	public static final String VEHICLE = "vehicle";
-	public static final String VEHICLES = "vehicles";
+	private static final String CARRIER = "carrier";
+	private static final String SHIPMENTS = "shipments";
+	private static final String SHIPMENT = "shipment";
+	private static final String SERVICES = "services";
+	private static final String SERVICE = "service";
+	private static final String ID = "id";
+	private static final String FROM = "from";
+	private static final String TO = "to";
+	private static final String SIZE = "size";
+	private static final String ACTIVITY = "act";
+	private static final String TYPE = "type";
+	private static final String SHIPMENTID = "shipmentId";
+	private static final String VEHICLE = "vehicle";
+	private static final String VEHICLES = "vehicles";
 	private static final String VEHICLE_EARLIEST_START = "earliestStart";
 	private static final String VEHICLE_LATEST_END = "latestEnd";
 	private static final String VEHICLE_TYPES_MSG = "It used to be possible to have vehicle types both in the plans file, and in a separate file.  The " +

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlReader.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlReader.java
@@ -113,14 +113,17 @@ public class CarrierPlanXmlReader implements MatsimReader {
 				log.info("Found following schemeLocation in carriers definition file: " + str);
 				if (str == null){
 					log.warn("Carrier plans file does not contain a valid xsd header. Using CarrierPlanReaderV2.");
-					delegate = new CarrierPlanXmlParserV2( carriers, carrierVehicleTypes ) ;
+					delegate = new CarrierPlanXmlParserV2_1( carriers, carrierVehicleTypes ) ;
 				} else if ( str.contains( "carriersDefinitions_v1.0.xsd" ) ){
 					log.info("Found carriersDefinitions_v1.0.xsd. Using CarrierPlanReaderV1.");
 					delegate = new CarrierPlanReaderV1(carriers, carrierVehicleTypes );
-				} else if ( str.contains( "carriersDefinitions_v2.0.xsd" ) ) { //This is the current one - but no validation file existing, kmt aug19
+				} else if ( str.contains( "carriersDefinitions_v2.0.xsd" ) ) {
 					log.warn("Found carriersDefinitions_v2.0.xsd. Using CarrierPlanReaderV2.");
 					delegate = new CarrierPlanXmlParserV2( carriers, carrierVehicleTypes );
-				} else {
+				} else if ( str.contains( "carriersDefinitions_v2.1.xsd" ) ) {
+					log.warn("Found carriersDefinitions_v2.1.xsd. Using CarrierPlanReaderV2.1");
+					delegate = new CarrierPlanXmlParserV2_1( carriers, carrierVehicleTypes );
+				}else {
 					throw new RuntimeException("no reader found for " + str ) ;
 				}
 			} else{

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlReader.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlReader.java
@@ -113,7 +113,7 @@ public class CarrierPlanXmlReader implements MatsimReader {
 				log.info("Found following schemeLocation in carriers definition file: " + str);
 				if (str == null){
 					log.warn("Carrier plans file does not contain a valid xsd header. Using CarrierPlanReaderV2.");
-					delegate = new CarrierPlanXmlParserV2_1( carriers, carrierVehicleTypes ) ;
+					delegate = new CarrierPlanXmlParserV2( carriers, carrierVehicleTypes ) ;
 				} else if ( str.contains( "carriersDefinitions_v1.0.xsd" ) ){
 					log.info("Found carriersDefinitions_v1.0.xsd. Using CarrierPlanReaderV1.");
 					delegate = new CarrierPlanReaderV1(carriers, carrierVehicleTypes );

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlReader.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlReader.java
@@ -118,10 +118,10 @@ public class CarrierPlanXmlReader implements MatsimReader {
 					log.info("Found carriersDefinitions_v1.0.xsd. Using CarrierPlanReaderV1.");
 					delegate = new CarrierPlanReaderV1(carriers, carrierVehicleTypes );
 				} else if ( str.contains( "carriersDefinitions_v2.0.xsd" ) ) {
-					log.warn("Found carriersDefinitions_v2.0.xsd. Using CarrierPlanReaderV2.");
+					log.info("Found carriersDefinitions_v2.0.xsd. Using CarrierPlanReaderV2.");
 					delegate = new CarrierPlanXmlParserV2( carriers, carrierVehicleTypes );
 				} else if ( str.contains( "carriersDefinitions_v2.1.xsd" ) ) {
-					log.warn("Found carriersDefinitions_v2.1.xsd. Using CarrierPlanReaderV2.1");
+					log.info("Found carriersDefinitions_v2.1.xsd. Using CarrierPlanReaderV2.1");
 					delegate = new CarrierPlanXmlParserV2_1( carriers, carrierVehicleTypes );
 				}else {
 					throw new RuntimeException("no reader found for " + str ) ;

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlWriterV2_1.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlWriterV2_1.java
@@ -31,7 +31,6 @@ import org.matsim.contrib.freight.carrier.Tour.ServiceActivity;
 import org.matsim.contrib.freight.carrier.Tour.ShipmentBasedActivity;
 import org.matsim.contrib.freight.carrier.Tour.TourElement;
 import org.matsim.core.population.routes.NetworkRoute;
-import org.matsim.core.utils.collections.Tuple;
 import org.matsim.core.utils.io.MatsimXmlWriter;
 import org.matsim.core.utils.misc.Time;
 import org.matsim.utils.objectattributes.AttributeConverter;
@@ -40,15 +39,17 @@ import org.matsim.vehicles.VehicleType;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
-import java.util.*;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
- * A writer that writes carriers and their plans in an xml-file.
+ * A writer that writes carriers and their plans in a xml-file.
  * 
  * @author sschroeder
  *
  */
-/*pacakge-private*/ class CarrierPlanXmlWriterV2_1 extends MatsimXmlWriter {
+/*package-private*/ class CarrierPlanXmlWriterV2_1 extends MatsimXmlWriter {
 
 	private static final  Logger logger = LogManager.getLogger(CarrierPlanXmlWriterV2_1.class);
 
@@ -59,7 +60,6 @@ import java.util.*;
 	private final Map<CarrierService, Id<CarrierService>> serviceMap = new HashMap<>();
 
 	private final AttributesXmlWriterDelegate attributesWriter = new AttributesXmlWriterDelegate();
-	private final List<Tuple<String, String>> atts = new ArrayList<>();
 
 
 	/**
@@ -87,11 +87,6 @@ import java.util.*;
 		try {
 			openFile(filename);
 			writeXmlHead();
-//			atts.clear();
-//			atts.add(this.createTuple(XMLNS, MatsimXmlWriter.MATSIM_NAMESPACE));
-//			atts.add(this.createTuple(XMLNS + ":xsi", DEFAULTSCHEMANAMESPACELOCATION));
-//			atts.add(this.createTuple("xsi:schemaLocation", MATSIM_NAMESPACE + " " + DEFAULT_DTD_LOCATION + "carriersDefinitions_v2.0.xsd"));
-//			this.writeStartTag("carriers", atts);
 
 			startCarriers(this.writer);
 			for (Carrier carrier : carriers) {
@@ -124,17 +119,6 @@ import java.util.*;
 
 	private void writeVehiclesAndTheirTypes(Carrier carrier, BufferedWriter writer)throws IOException {
 		writer.write("\t\t\t<capabilities fleetSize=\""+ carrier.getCarrierCapabilities().getFleetSize().toString() + "\">\n");
-//		writer.write("\t\t\t\t<vehicleTypes>\n");
-//		for(VehicleType type : carrier.getCarrierCapabilities().getVehicleTypes()){
-//			writer.write("\t\t\t\t\t<vehicleType id=\"" + type.getId() + "\">\n");
-//			writer.write("\t\t\t\t\t\t<description>" + type.getDescription() + "</description>\n");
-//			writer.write("\t\t\t\t\t\t<engineInformation fuelType=\"" + type.getEngineInformation().getFuelType().toString() + "\" gasConsumption=\"" + type.getEngineInformation().getFuelConsumption() + "\"/>\n");
-//			writer.write("\t\t\t\t\t\t<capacity>" + type.getCapacity() + "</capacity>\n");
-//			writer.write("\t\t\t\t\t\t<costInformation fix=\"" + type.getCostInformation().getFixedCosts() + "\" perMeter=\"" + type.getCostInformation().getCostsPerMeter() +
-//					"\" perSecond=\"" + type.getCostInformation().getCostsPerSecond() + "\"/>\n");
-//			writer.write("\t\t\t\t\t</vehicleType>\n");
-//		}
-//		writer.write("\t\t\t\t</vehicleTypes>\n\n");
 		//vehicles
 		writer.write("\t\t\t\t<vehicles>\n");
 		for (CarrierVehicle v : carrier.getCarrierCapabilities().getCarrierVehicles().values()) {
@@ -143,7 +127,7 @@ import java.util.*;
 			if(vehicleTypeId == null) throw new IllegalStateException("vehicleTypeId is missing.");
 			writer.write("\t\t\t\t\t<vehicle id=\"" + v.getId()
 					+ "\" depotLinkId=\"" + v.getLinkId()
-					+ "\" typeId=\"" + vehicleTypeId.toString()
+					+ "\" typeId=\"" + vehicleTypeId
 					+ "\" earliestStart=\"" + getTime(v.getEarliestStartTime())
 					+ "\" latestEnd=\"" + getTime(v.getLatestEndTime())
 					+ "\"/>\n");
@@ -156,7 +140,6 @@ import java.util.*;
 		if(carrier.getShipments().isEmpty()) return;
 		writer.write("\t\t\t<shipments>\n");
 		for (CarrierShipment s : carrier.getShipments().values()) {
-			// CarrierShipment s = contract.getShipment();
 			Id<CarrierShipment> shipmentId = s.getId();
 			registeredShipments.put(s, shipmentId);
 			writer.write("\t\t\t\t<shipment ");
@@ -249,8 +232,7 @@ import java.util.*;
 						+ "\" end_time=\"" + Time.writeTime(tour.getDeparture())
 						+ "\"/>\n");
 				for (TourElement tourElement : tour.getTour().getTourElements()) {
-					if (tourElement instanceof Leg) {
-						Leg leg = (Leg) tourElement;
+					if (tourElement instanceof Leg leg) {
 						writer.write("\t\t\t\t\t<leg expected_dep_time=\""
 								+ Time.writeTime(leg.getExpectedDepartureTime())
 								+ "\" expected_transp_time=\""
@@ -275,15 +257,13 @@ import java.util.*;
 							writer.write("</leg>\n");
 						}
 					}
-					else if (tourElement instanceof ShipmentBasedActivity) {
-						ShipmentBasedActivity act = (ShipmentBasedActivity) tourElement;
+					else if (tourElement instanceof ShipmentBasedActivity act) {
 						writer.write("\t\t\t\t\t<act ");
 						writer.write("type=\"" + act.getActivityType() + "\" ");
 						writer.write("shipmentId=\"" + registeredShipments.get(act.getShipment()) + "\" ");
 						writer.write("/>\n");
 					}
-					else if (tourElement instanceof ServiceActivity){
-						ServiceActivity act = (ServiceActivity) tourElement;
+					else if (tourElement instanceof ServiceActivity act){
 						writer.write("\t\t\t\t\t<act ");
 						writer.write("type=\"" + act.getActivityType() + "\" ");
 						writer.write("serviceId=\"" + serviceMap.get(act.getService()) + "\" ");

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlWriterV2_1.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlWriterV2_1.java
@@ -21,10 +21,6 @@
 
 package org.matsim.contrib.freight.carrier;
 
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.util.*;
-
 import com.google.inject.Inject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -42,21 +38,24 @@ import org.matsim.utils.objectattributes.AttributeConverter;
 import org.matsim.utils.objectattributes.attributable.AttributesXmlWriterDelegate;
 import org.matsim.vehicles.VehicleType;
 
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.util.*;
+
 /**
  * A writer that writes carriers and their plans in an xml-file.
  * 
  * @author sschroeder
  *
- * @deprecated Use {@link CarrierPlanWriter} instead which writes the newest format
  */
-public class CarrierPlanXmlWriterV2 extends MatsimXmlWriter {
+/*pacakge-private*/ class CarrierPlanXmlWriterV2_1 extends MatsimXmlWriter {
 
-	private static final  Logger logger = LogManager.getLogger(CarrierPlanXmlWriterV2.class);
+	private static final  Logger logger = LogManager.getLogger(CarrierPlanXmlWriterV2_1.class);
 
 	private final Collection<Carrier> carriers;
 
 	private final Map<CarrierShipment, Id<CarrierShipment>> registeredShipments = new HashMap<>();
-	
+
 	private final Map<CarrierService, Id<CarrierService>> serviceMap = new HashMap<>();
 
 	private final AttributesXmlWriterDelegate attributesWriter = new AttributesXmlWriterDelegate();
@@ -65,10 +64,10 @@ public class CarrierPlanXmlWriterV2 extends MatsimXmlWriter {
 
 	/**
 	 * Constructs the writer with the carriers to be written.
-	 * 
+	 *
 	 * @param carriers to be written
 	 */
-	public CarrierPlanXmlWriterV2(Carriers carriers) {
+	public CarrierPlanXmlWriterV2_1(Carriers carriers) {
 		super();
 		this.carriers = carriers.getCarriers().values();
 	}

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierVehicleTypeReader.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierVehicleTypeReader.java
@@ -136,7 +136,7 @@ public class CarrierVehicleTypeReader implements MatsimReader{
 				if ( str==null ){
 					throw new RuntimeException( "should not happen" );
 				} else {
-					log.warn("Using central vehicle parser") ;
+					log.info("Using central vehicle parser") ;
 					vehicles = VehicleUtils.createVehiclesContainer();
 					delegate = new MatsimVehicleReader.VehicleReader(vehicles) ;
 					// only takes a vehicle container as argument :-(

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/Tour.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/Tour.java
@@ -55,24 +55,46 @@ public class Tour {
 	 *
 	 */
 	public static class Builder {
-		
-		/**
-		 * Returns a new tour builder.
-		 * 
-		 * @return the builder
-		 */
-		public static Builder newInstance(){ return new Builder(); }
-		
-		private Builder(){
-			
-		}
 
+		private final Id<Tour> tourId;
 		private final List<TourElement> tourElements = new ArrayList<>();
 		private final Set<CarrierShipment> openPickups = new HashSet<>();
 		private boolean previousElementIsActivity;
 		private Start start;
 		private End end;
-		
+
+
+		/**
+		 * Returns a new tour builder.
+		 *
+		 * @deprecated
+		 * Please use {@link #newInstance(Id)} instead. kmt' sep22
+		 *
+		 *
+		 *
+		 * @return the builder including "unknown" as tourId
+		 */
+		@Deprecated
+		public static Builder newInstance(){
+			return new Builder(Id.create("unknown", Tour.class));
+		}
+
+		/**
+		 * Returns a new tour builder.
+		 * This now also includes an Id for this tour.
+		 *
+		 * @param tourId Id of this tour
+		 * @return the builder
+		 */
+		public static Builder newInstance(Id<Tour> tourId){
+			return new Builder(tourId);
+		}
+
+
+		private Builder(Id<Tour> tourId) {
+			this.tourId = tourId;
+		}
+
 		/**
 		 * Schedules the start of the tour.
 		 * 
@@ -632,14 +654,18 @@ public class Tour {
 	private final Start start;
 	
 	private final End end;
+
+	private final Id<Tour> tourId;
 	
 	private Tour(Builder builder){
+		tourId = builder.tourId;
 		tourElements = builder.tourElements;
 		start = builder.start;
 		end = builder.end;
 	}
 
 	private Tour(Tour tour) {
+		this.tourId = Id.create(tour.tourId.toString(), Tour.class);
 		this.start = (Start) tour.start.duplicate();
 		this.end = (End) tour.end.duplicate();
 		List<TourElement> elements = new ArrayList<>();
@@ -656,7 +682,11 @@ public class Tour {
 	public List<TourElement> getTourElements() {
 		return Collections.unmodifiableList(tourElements);
 	}
-	
+
+	public Id<Tour> getId(){
+		return tourId;
+	}
+
 	public Start getStart(){
 		return start;
 	}
@@ -672,7 +702,7 @@ public class Tour {
 	public Id<Link> getEndLinkId() {
 		return end.getLocation();
 	}
-	
+
 	@Override
 	public String toString() {
 		return "[ startLinkId="+getStartLinkId()+" ][ endLinkId="+getEndLinkId()+" ][ #tourElements=" + tourElements.size() + "]";

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/Tour.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/Tour.java
@@ -21,12 +21,6 @@
 
 package org.matsim.contrib.freight.carrier;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
@@ -35,6 +29,8 @@ import org.matsim.api.core.v01.population.Route;
 import org.matsim.core.gbl.Gbl;
 import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.population.routes.RouteUtils;
+
+import java.util.*;
 
 /**
  * This is a tour of a carrier which is a sequence of activities and legs.
@@ -60,9 +56,11 @@ public class Tour {
 		private final List<TourElement> tourElements = new ArrayList<>();
 		private final Set<CarrierShipment> openPickups = new HashSet<>();
 		private boolean previousElementIsActivity;
-		private Start start;
-		private End end;
 
+
+		private Start start;
+
+		private End end;
 
 		/**
 		 * Returns a new tour builder.
@@ -664,8 +662,8 @@ public class Tour {
 		end = builder.end;
 	}
 
-	private Tour(Tour tour) {
-		this.tourId = Id.create(tour.tourId.toString(), Tour.class);
+	private Tour(Tour tour, Id<Tour> newTourId) {
+		this.tourId = newTourId;
 		this.start = (Start) tour.start.duplicate();
 		this.end = (End) tour.end.duplicate();
 		List<TourElement> elements = new ArrayList<>();
@@ -676,7 +674,14 @@ public class Tour {
 	}
 
 	public Tour duplicate() {
-		return new Tour(this);
+		return new Tour(this, Id.create(this.tourId.toString(), Tour.class));
+	}
+
+	/*
+	 * returns a copy of the tour, but with a new Tour Id.
+	 */
+	public Tour duplicateWithNewId(Id<Tour> newTourId) {
+		return new Tour(this, newTourId);
 	}
 
 	public List<TourElement> getTourElements() {

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/CarrierDriverAgent.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/CarrierDriverAgent.java
@@ -217,9 +217,9 @@ final class CarrierDriverAgent{
 	/**
 	 * Basic event handler that collects the relation between vehicles and drivers.
 	 * Necessary since link enter and leave events do not contain the driver anymore.
-	 *
+	 * <p>
 	 * This is the vice-versa implementation of {@link org.matsim.core.events.algorithms.Vehicle2DriverEventHandler}.
-	 *
+	 * <p>
 	 * In a first step only used internally. When needed more often, I have nothing against putting it more central.
 	 *
 	 * @author kturner

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightEventAttributes.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightEventAttributes.java
@@ -29,6 +29,7 @@ package org.matsim.contrib.freight.events;
 public class FreightEventAttributes {
 	public static final String ATTRIBUTE_SERVICE_ID = "serviceId";
 	public static final String ATTRIBUTE_SHIPMENT_ID = "shipmentId";
+	public static final String ATTRIBUTE_TOUR_ID = "tourId";
 	public static final String ATTRIBUTE_SERVICE_DURATION = "serviceDuration";
 	public static final String ATTRIBUTE_PICKUP_DURATION = "pickupDuration";
 	public static final String ATTRIBUTE_DROPOFF_DURATION = "dropoffDuration";

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightTourEndEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightTourEndEvent.java
@@ -29,6 +29,8 @@ import org.matsim.contrib.freight.carrier.Carrier;
 import org.matsim.contrib.freight.carrier.Tour;
 import org.matsim.vehicles.Vehicle;
 
+import static org.matsim.contrib.freight.events.FreightEventAttributes.ATTRIBUTE_TOUR_ID;
+
 /**
  * An event, that informs when a Freight {@link Tour} has ended.
  * There are NO specific information of the tour given, because the {@link Tour} is determined by the {@link Vehicle} and its {@link Carrier}.
@@ -40,8 +42,11 @@ public final class FreightTourEndEvent extends AbstractFreightEvent {
 
 	public static final String EVENT_TYPE = "Freight tour ends";
 
-	public FreightTourEndEvent(double time, Id<Carrier>  carrierId, Id<Link> linkId, Id<Vehicle> vehicleId) {
+	private final Id<Tour> tourId;
+
+	public FreightTourEndEvent(double time, Id<Carrier>  carrierId, Id<Link> linkId, Id<Vehicle> vehicleId, Id<Tour> tourId) {
 		super(time, carrierId, linkId, vehicleId);
+		this.tourId = tourId;
 	}
 
 	@Override
@@ -49,8 +54,14 @@ public final class FreightTourEndEvent extends AbstractFreightEvent {
 		return EVENT_TYPE;
 	}
 
+	public Id<Tour> getTourId() {
+		return tourId;
+	}
+
 	@Override
 	public Map<String, String> getAttributes() {
-		return super.getAttributes();
+		Map<String, String> attr = super.getAttributes();
+		attr.put(ATTRIBUTE_TOUR_ID, this.tourId.toString());
+		return attr;
 	}
 }

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightTourEndEventCreator.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightTourEndEventCreator.java
@@ -35,7 +35,8 @@ import org.matsim.vehicles.Vehicle;
 	@Override
 	public Event createEvent(Event event, Carrier carrier, Activity activity, ScheduledTour scheduledTour, int activityCounter, Id<Vehicle> vehicleId) {
 		if(event instanceof ActivityStartEvent startEvent && FreightConstants.END.equals(startEvent.getActType()) ) {
-				return new FreightTourEndEvent(startEvent.getTime(), carrier.getId(), scheduledTour.getTour().getEndLinkId(), vehicleId);
+				return new FreightTourEndEvent(startEvent.getTime(), carrier.getId(), scheduledTour.getTour().getEndLinkId(), // TODO: If we have the tourId, we do not need to store the link here, kmt sep 22
+						vehicleId, scheduledTour.getTour().getId());
 		}	
 		return null;
 	}

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightTourStartEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightTourStartEvent.java
@@ -29,6 +29,8 @@ import org.matsim.vehicles.Vehicle;
 
 import java.util.Map;
 
+import static org.matsim.contrib.freight.events.FreightEventAttributes.ATTRIBUTE_TOUR_ID;
+
 /**
  * An event, that informs when a Freight {@link Tour} has started.
  * There are NO specific information of the tour given, because the {@link Tour} is determined by the {@link Vehicle} and its {@link Carrier}.
@@ -40,8 +42,11 @@ public final class FreightTourStartEvent extends AbstractFreightEvent {
 
 	public static final String EVENT_TYPE = "Freight tour starts";
 
-	public FreightTourStartEvent(double time, Id<Carrier>  carrierId, Id<Link> linkId, Id<Vehicle> vehicleId) {
+	private final Id<Tour> tourId;
+
+	public FreightTourStartEvent(double time, Id<Carrier>  carrierId, Id<Link> linkId, Id<Vehicle> vehicleId, Id<Tour> tourId) {
 		super(time, carrierId, linkId, vehicleId);
+		this.tourId = tourId;
 	}
 
 	@Override
@@ -49,8 +54,14 @@ public final class FreightTourStartEvent extends AbstractFreightEvent {
 		return EVENT_TYPE;
 	}
 
+	public Id<Tour> getTourId() {
+		return tourId;
+	}
+
 	@Override
 	public Map<String, String> getAttributes() {
-		return super.getAttributes();
+		Map<String, String> attr = super.getAttributes();
+		attr.put(ATTRIBUTE_TOUR_ID, this.tourId.toString());
+		return attr;
 	}
 }

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightTourStartEventCreator.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightTourStartEventCreator.java
@@ -35,7 +35,8 @@ import org.matsim.vehicles.Vehicle;
 	@Override
 	public Event createEvent(Event event, Carrier carrier, Activity activity, ScheduledTour scheduledTour, int activityCounter, Id<Vehicle> vehicleId) {
 		if((event instanceof ActivityEndEvent endEvent) && FreightConstants.START.equals(endEvent.getActType()) ) {
-				return new FreightTourStartEvent(endEvent.getTime(), carrier.getId(), scheduledTour.getTour().getStartLinkId(), vehicleId);
+				return new FreightTourStartEvent(endEvent.getTime(), carrier.getId(), scheduledTour.getTour().getStartLinkId(), // TODO: If we have the tourId, we do not need to store the link here, kmt sep 22
+						vehicleId, scheduledTour.getTour().getId());
 		}
 		return null;	
 	}

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/jsprit/MatsimJspritFactory.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/jsprit/MatsimJspritFactory.java
@@ -367,7 +367,7 @@ public final class MatsimJspritFactory {
 	 * @return ScheduledTour
 	 * @throws IllegalStateException if tourActivity is NOT {@link ServiceActivity}.
 	 */
-	static ScheduledTour createTour(VehicleRoute jspritRoute) {
+	static ScheduledTour createTour(VehicleRoute jspritRoute, Id<Tour> tourId) {
 		// have made this non-public for the time being since it is nowhere used within the freight contrib, and we might want to add the
 		// vehicle types as argument.  If this is publicly used, please move back to public.  kai, jan'22
 
@@ -378,7 +378,7 @@ public final class MatsimJspritFactory {
 		CarrierVehicle carrierVehicle = createCarrierVehicle(jspritRoute.getVehicle());
 		double depTime = jspritRoute.getStart().getEndTime();
 
-		Tour.Builder matsimFreightTourBuilder = Tour.Builder.newInstance();
+		Tour.Builder matsimFreightTourBuilder = Tour.Builder.newInstance(tourId);
 		matsimFreightTourBuilder.scheduleStart(Id.create(jspritRoute.getStart().getLocation().getId(), Link.class));
 		for (TourActivity act : tour.getActivities()) {
 			if (act instanceof ServiceActivity || act instanceof PickupService) {
@@ -728,8 +728,10 @@ public final class MatsimJspritFactory {
 	 */
 	public static CarrierPlan createPlan(Carrier carrier, VehicleRoutingProblemSolution solution) {
 		Collection<ScheduledTour> tours = new ArrayList<>();
+		int tourIdindex = 1;
 		for (VehicleRoute route : solution.getRoutes()) {
-			ScheduledTour scheduledTour = createTour(route);
+			ScheduledTour scheduledTour = createTour(route, Id.create(tourIdindex, Tour.class));
+			tourIdindex++;
 			tours.add(scheduledTour);
 		}
 		CarrierPlan carrierPlan = new CarrierPlan(carrier, tours);

--- a/matsim/src/main/resources/dtd/carriersDefinitions_v2.1.xsd
+++ b/matsim/src/main/resources/dtd/carriersDefinitions_v2.1.xsd
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.matsim.org/files/dtd" xmlns="http://www.matsim.org/files/dtd"
+           elementFormDefault="qualified"
+           xml:lang="en">
+  <!-- Editor: Kai Martins-Turner, VSP, Berlin Institute of Technology -->
+  <!-- This xml schema contains xml definitions for freight carriers information in the MATSim framework (freight contrib)  -->
+
+  <xs:include schemaLocation="http://www.matsim.org/files/dtd/matsimCommon.xsd"/>
+
+  <xs:element name="carriers">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="carrier" type="carrierDefinition" maxOccurs="unbounded" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:complexType name="carrierDefinition">
+    <xs:complexContent>
+      <xs:extension base="matsimObjectType">
+        <xs:sequence>
+          <xs:element name="description" type="xs:string" minOccurs="0"  />
+          <xs:element name="capabilities" >
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element name="vehicles" type="VehicleType"/>
+              </xs:sequence>
+              <xs:attribute name="fleetSize" type="xs:string" use="required"/>
+            </xs:complexType>
+          </xs:element>
+
+          <xs:element name="services" type="ServiceType" minOccurs="0" />
+
+          <xs:element name="shipments" type="ShipmentType" minOccurs="0" />
+
+          <xs:element name="plans" type="PlanType" minOccurs="0" />
+
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="VehicleType">
+    <xs:sequence>
+      <xs:element name="vehicle" maxOccurs="unbounded" >
+        <xs:complexType>
+          <xs:attribute name="id" type="xs:string" use="required"/>
+          <xs:attribute name="depotLinkId" type="xs:string" use="required"/>
+          <xs:attribute name="typeId" type="xs:string" use="required"/>
+          <xs:attribute name="earliestStart" />
+          <xs:attribute name="latestEnd" />
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+
+  <xs:complexType name="ServiceType">
+    <xs:sequence>
+      <xs:element name="service" maxOccurs="unbounded" >
+        <xs:complexType>
+          <xs:attribute name="id" type="xs:string" use="required"/>
+          <xs:attribute name="to" type="xs:string" use="required"/>
+          <xs:attribute name="capacityDemand" type="xs:double" use="required"/>
+          <xs:attribute name="earliestStart" />
+          <xs:attribute name="latestEnd" />
+          <xs:attribute name="serviceDuration" />
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="ShipmentType">
+    <xs:sequence>
+      <xs:element name="shipment" maxOccurs="unbounded" >
+        <xs:complexType>
+          <xs:attribute name="id" type="xs:string" use="required"/>
+          <xs:attribute name="from" type="xs:string" use="required"/>
+          <xs:attribute name="to" type="xs:string" use="required"/>
+          <xs:attribute name="size" type="xs:double" use="required"/>
+          <xs:attribute name="startPickup" />
+          <xs:attribute name="endPickup"/>
+          <xs:attribute name="pickupServiceTime" />
+          <xs:attribute name="startDelivery" />
+          <xs:attribute name="endDelivery" />
+          <xs:attribute name="deliveryServiceTime" />
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="PlanType">
+    <xs:sequence>
+      <xs:element name="plan" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="tour" minOccurs="0">
+              <xs:complexType>
+                <xs:sequence maxOccurs="unbounded">
+                  <xs:element name="act" minOccurs="0" >
+                    <xs:complexType>
+                      <xs:attribute name="type" type="xs:string" />
+                      <xs:attribute name="serviceId" type="xs:string" />
+                      <xs:attribute name="shipmentId" type="xs:string" />
+                      <xs:attribute name="end_time"/>
+                    </xs:complexType>
+                  </xs:element>
+                  <xs:element name="leg" minOccurs="0" >
+                    <xs:complexType>
+                      <xs:sequence>
+                        <xs:element name="route" minOccurs="0" />
+                      </xs:sequence>
+                      <xs:attribute name="dep_time" />
+                      <xs:attribute name="transp_time"/>
+                    </xs:complexType>
+                  </xs:element>
+                </xs:sequence>
+                <xs:attribute name="tourId" type="xs:string" />
+                <xs:attribute name="vehicleId" type="xs:string" />
+              </xs:complexType>
+            </xs:element>
+          </xs:sequence>
+          <xs:attribute name="score" type="xs:double" />
+          <xs:attribute name="selected" type="xs:boolean" />
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+</xs:schema>


### PR DESCRIPTION
With this PR, an `Id` for the carrier `Tour`s is added.

Now, we are able to identify specific tours of a carrier. It is done in a more or less stupid way: Using an int and increase it by one. 

- Since this is a minor change of the CarrierFileDefinition, I also provide an updated version (v2.1) including the corresponding Reader/Writer.
- The new `tourId` is also integrated to the FreightEvents. -> This is already used in [matsim-vsp/logistics](https://github.com/matsim-vsp/logistics)

The new Reader/Writer will need some junit testing. This will be added later -> I create an Issue for it.
