### PR TITLE
Support string list/set in reflective config group

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigGroup.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpConfigGroup.java
@@ -19,7 +19,7 @@
 
 package org.matsim.contrib.dvrp.run;
 
-import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 
@@ -30,9 +30,6 @@ import org.matsim.contrib.dynagent.run.DynQSimConfigConsistencyChecker;
 import org.matsim.contrib.util.ReflectiveConfigGroupWithConfigurableParameterSets;
 import org.matsim.contrib.zone.skims.DvrpTravelTimeMatrixParams;
 import org.matsim.core.config.Config;
-import org.matsim.core.utils.misc.StringUtils;
-
-import com.google.common.collect.ImmutableSet;
 
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.NotBlank;
@@ -50,18 +47,17 @@ public final class DvrpConfigGroup extends ReflectiveConfigGroupWithConfigurable
 		return (DvrpConfigGroup)config.getModule(GROUP_NAME);// will fail if not in the config
 	}
 
-	private static final String NETWORK_MODES = "networkModes";
-	private static final String NETWORK_MODES_EXP = ""
-			+ "Set of modes of which the network will be used for DVRP travel time "
+	@Parameter
+	@Comment("Set of modes of which the network will be used for DVRP travel time "
 			+ "estimation and routing DVRP vehicles. "
 			+ "Each specific DVRP mode may use a subnetwork of this network for routing vehicles (e.g. DRT buses "
 			+ "travelling only along a specified links or serving a limited area). "
 			+ "Default is \"car\" (i.e. single-element set of modes), i.e. the car network is used. "
 			+ "Empty value \"\" (i.e. empty set of modes) means no network filtering, i.e. "
-			+ "the original scenario.network is used";
+			+ "the original scenario.network is used")
 	// used for building route; empty ==> no filtering (routing network equals scenario.network)
 	@NotNull
-	public ImmutableSet<String> networkModes = ImmutableSet.of(TransportMode.car);
+	public Set<String> networkModes = Set.of(TransportMode.car);
 
 	@Parameter
 	@Comment("Mode of which the network will be used for throwing events and hence calculating travel times. "
@@ -150,30 +146,6 @@ public final class DvrpConfigGroup extends ReflectiveConfigGroupWithConfigurable
 		if (!config.parallelEventHandling().getSynchronizeOnSimSteps()) {
 			throw new RuntimeException("Synchronization on sim steps is required");
 		}
-	}
-
-	@Override
-	public Map<String, String> getComments() {
-		Map<String, String> map = super.getComments();
-		map.put(NETWORK_MODES, NETWORK_MODES_EXP);
-		return map;
-	}
-
-	/**
-	 * @return {@value #NETWORK_MODES_EXP}
-	 */
-	@StringGetter(NETWORK_MODES)
-	public String getNetworkModesAsString() {
-		return String.join(",", networkModes);
-	}
-
-	/**
-	 * @param networkModesString {@value #NETWORK_MODES_EXP}
-	 */
-	@StringSetter(NETWORK_MODES)
-	public DvrpConfigGroup setNetworkModesAsString(String networkModesString) {
-		this.networkModes = ImmutableSet.copyOf(StringUtils.explode(networkModesString, ','));
-		return this;
 	}
 
 	public DvrpTravelTimeMatrixParams getTravelTimeMatrixParams() {

--- a/matsim/src/test/java/org/matsim/core/config/ReflectiveConfigGroupTest.java
+++ b/matsim/src/test/java/org/matsim/core/config/ReflectiveConfigGroupTest.java
@@ -22,7 +22,9 @@ package org.matsim.core.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Rule;
@@ -54,6 +56,8 @@ public class ReflectiveConfigGroupTest {
 		dumpedModule.charField = 'z';
 		dumpedModule.byteField = 78;
 		dumpedModule.booleanField = true;
+		dumpedModule.setField = Set.of("a", "b", "c");
+		dumpedModule.listField = List.of("1", "2", "3");
 
 		final Config dumpedConfig = new Config();
 		dumpedConfig.addModule(dumpedModule);
@@ -99,8 +103,8 @@ public class ReflectiveConfigGroupTest {
 				"charField", "char",//
 				"byteField", "byte",//
 				"booleanField", "boolean",//
-				"enumField", "Possible values: VALUE1,VALUE2"//
-		);
+				"enumField", "Possible values: VALUE1,VALUE2",//
+				"setField", "set");
 
 		assertThat(new MyModule().getComments()).isEqualTo(expectedComments);
 	}
@@ -358,6 +362,14 @@ public class ReflectiveConfigGroupTest {
 		@Parameter
 		private boolean booleanField;
 
+		@Comment("set")
+		@Parameter
+		private Set<String> setField;
+
+		//		@Comment("list")
+		//		@Parameter
+		//		private List<String> listField;
+
 		// Object fields:
 		// Id: string representation is toString
 		private Id<Link> idField;
@@ -365,9 +377,20 @@ public class ReflectiveConfigGroupTest {
 		private Coord coordField;
 		// enum: handled especially
 		private MyEnum enumField;
+		private List<String> listField;
 
 		public MyModule() {
 			super(GROUP_NAME);
+		}
+
+		@StringGetter("list")
+		public List<String> getListField() {
+			return listField;
+		}
+
+		@StringSetter("list")
+		public void setListField(List<String> listField) {
+			this.listField = listField;
 		}
 
 		// /////////////////////////////////////////////////////////////////////
@@ -462,4 +485,3 @@ public class ReflectiveConfigGroupTest {
 		}
 	}
 }
-

--- a/matsim/src/test/java/org/matsim/core/config/ReflectiveConfigGroupTest.java
+++ b/matsim/src/test/java/org/matsim/core/config/ReflectiveConfigGroupTest.java
@@ -22,6 +22,8 @@ package org.matsim.core.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -247,6 +249,30 @@ public class ReflectiveConfigGroupTest {
 
 			@Parameter("field")
 			private double stuff;
+		}).isInstanceOf(InconsistentModuleException.class);
+	}
+
+	@Test
+	public void testFailUnsupportedType_StringCollections() {
+		assertThatThrownBy(() -> new ReflectiveConfigGroup("name") {
+			@Parameter("field")
+			private Collection<String> stuff;
+		}).isInstanceOf(InconsistentModuleException.class);
+	}
+
+	@Test
+	public void testFailUnsupportedType_NonStringList() {
+		assertThatThrownBy(() -> new ReflectiveConfigGroup("name") {
+			@Parameter("field")
+			private List<Double> stuff;
+		}).isInstanceOf(InconsistentModuleException.class);
+	}
+
+	@Test
+	public void testFailUnsupportedType_StringHashSet() {
+		assertThatThrownBy(() -> new ReflectiveConfigGroup("name") {
+			@Parameter("field")
+			private HashSet<String> stuff;
 		}).isInstanceOf(InconsistentModuleException.class);
 	}
 


### PR DESCRIPTION
I noticed that we frequently use lists/sets of strings as parameters in config group. Now we can also handle them without (de)serialising from/to String.

A few notes on this feature:
- it helped simplifying `DvrpConfigGroup` in this commit: 13568f6456c42c6d01da5fb302fa5be263f03112
- it can be used not only with `Parameter`s (as in linked commit), but also with `StringGetter`s/`StringSetter`s:
```java
	@StringGetter(NETWORK_MODES)
	public Set<String> getNetworkModes() {
		return networkModes;
	}

	@StringSetter(NETWORK_MODES)
	public void setNetworkModes(Set<String> networkModes) {
		this.networkModes = networkModes;
	}
```
- it works with parameters of exactly these two types: `List<String>` and `Set<String>`. For example, it will not work with:
   - `Collection<String>` (no information if this is a list or set or something else),
   - `ArrayList<String>` or `HashSet<String>` (no support for concrete implementation; currently immutable lists/sets are created during deserialisation),
   - `List<Double>` or `Set<CharSequence>` (elements must be exactly `String`s).