### PR TITLE
Fix for subtour modechoice to make sure no useful candidates are not filtered

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/analysis/population/SubTourAnalysis.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/population/SubTourAnalysis.java
@@ -103,6 +103,14 @@ public class SubTourAnalysis implements MATSimAppCommand {
 				massConserving++;
 		}
 
+		if (person != null && persons.size() > 0) {
+
+			Person p = persons.get(0);
+
+			log.info(p.getAttributes());
+			log.info(p.getSelectedPlan());
+		}
+
 		log.info("Subtours: {} | closed: {}% | massConserving: {}%", subtours.size(), 100d * closed / subtours.size(), 100d * massConserving / subtours.size());
 
 		DoubleList nChoices = new DoubleArrayList(persons.size());

--- a/matsim/src/main/java/org/matsim/core/population/algorithms/ChooseRandomLegModeForSubtour.java
+++ b/matsim/src/main/java/org/matsim/core/population/algorithms/ChooseRandomLegModeForSubtour.java
@@ -320,7 +320,19 @@ public final class ChooseRandomLegModeForSubtour implements PlanAlgorithm {
 				}
 			}
 
-			usableModes.remove(getTransportMode(subtour));
+			if (behavior == SubtourModeChoice.Behavior.betweenAllAndFewerConstraints) {
+
+				// only remove candidates if the whole trip uses the same mode
+				usableModes.removeIf(mode -> subtour.getTrips().stream().allMatch(
+						trip-> mode.equals(mainModeIdentifier.identifyMainMode(trip.getTripElements()))
+				));
+
+			} else {
+				// The old behaviour removes candidates that could change trips to a different mode
+				usableModes.remove(getTransportMode(subtour));
+			}
+
+
 			// (remove current mode so we don't get it again; note that the parent plan is kept anyways)
 			for (String transportMode : usableModes) {
 				choiceSet.add(


### PR DESCRIPTION
Subtour mode choice filters candidates that have the same mode, but it did only check the first trip. The new behaviour will check all trips of the subtour and only filter if all are equal.