### PR TITLE
core: disallow blank strings as elements of collections in config parameters

### DIFF
--- a/matsim/src/main/java/org/matsim/core/config/ReflectiveConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/ReflectiveConfigGroup.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -368,12 +369,20 @@ public abstract class ReflectiveConfigGroup extends ConfigGroup implements Matsi
 				throw new IllegalArgumentException(comment, e);
 			}
 		} else if (type.equals(Set.class)) {
-			return Arrays.stream(value.split(",")).map(String::trim).collect(toUnmodifiableSet());
+			return value.isBlank() ? Set.of() : splitStringToStream(value).collect(toUnmodifiableSet());
 		} else if (type.equals(List.class)) {
-			return Arrays.stream(value.split(",")).map(String::trim).toList();
+			return value.isBlank() ? List.of() : splitStringToStream(value).toList();
 		} else {
 			throw new RuntimeException("Unsupported type: " + type);
 		}
+	}
+
+	private Stream<String> splitStringToStream(String value) {
+		return Arrays.stream(value.split(","))
+				.peek(e -> Preconditions.checkArgument(!e.isBlank(),
+						"String '%s' contains comma-separated blank elements. Only non-blank elements are supported.",
+						value))
+				.map(String::trim);
 	}
 
 	@Override
@@ -425,7 +434,10 @@ public abstract class ReflectiveConfigGroup extends ConfigGroup implements Matsi
 			return null;
 		} else if (result instanceof Set<?> || result instanceof List<?>) {
 			//we only support Set<String> and List<String>, therefore we can safely cast to Collection<String>
-			return String.join(", ", ((Collection<String>)result));
+			var collection = ((Collection<String>)result);
+			Preconditions.checkArgument(collection.stream().noneMatch(String::isBlank),
+					"Collection %s contains blank elements. Only non-blank elements are supported.", collection);
+			return String.join(", ", collection);
 		} else {
 			return result + "";
 		}

--- a/matsim/test/input/org/matsim/core/config/ReflectiveConfigGroupTest/testReadCollectionsIncludingEmptyString/config_with_blank_comma_separated_elements.xml
+++ b/matsim/test/input/org/matsim/core/config/ReflectiveConfigGroupTest/testReadCollectionsIncludingEmptyString/config_with_blank_comma_separated_elements.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
+<config>
+	<module name="testModule" >
+		<!-- boolean -->
+		<param name="booleanField" value="false" />
+		<!-- byte -->
+		<param name="byteField" value="0" />
+		<!-- char -->
+		<param name="charField" value=" " />
+		<param name="coordField" value="null" />
+		<param name="doubleField" value="0.0" />
+		<!-- Possible values: VALUE1,VALUE2 -->
+		<param name="enumField" value="null" />
+		<!-- float -->
+		<param name="floatField" value="0.0" />
+		<param name="idField" value="null" />
+		<!-- int -->
+		<param name="intField" value="0" />
+		<param name="list" value="str1, , str2" />
+		<!-- long -->
+		<param name="longField" value="0" />
+		<!-- set -->
+		<param name="setField" value="str1, , str2" />
+		<!-- short -->
+		<param name="shortField" value="0" />
+	</module>
+
+</config>


### PR DESCRIPTION
In response to https://github.com/matsim-org/matsim-libs/issues/2225

(De)serialisation rules:
- "null" (string) <-> `null` (pointer)
- blank string <-> empty collection
- blank element in a comma separated string - thrown exception during deserialisation
- blank element in a collection - thrown exception during serialisation