### PR TITLE
core: ensure deterministic iteration order over set deserialised in ReflectiveConfigGroup

### DIFF
--- a/matsim/src/main/java/org/matsim/core/config/ReflectiveConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/ReflectiveConfigGroup.java
@@ -19,8 +19,8 @@
  * *********************************************************************** */
 package org.matsim.core.config;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toUnmodifiableSet;
 
 import java.io.Serial;
 import java.lang.annotation.Documented;
@@ -49,6 +49,7 @@ import org.matsim.core.api.internal.MatsimExtensionPoint;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 /**
@@ -369,7 +370,7 @@ public abstract class ReflectiveConfigGroup extends ConfigGroup implements Matsi
 				throw new IllegalArgumentException(comment, e);
 			}
 		} else if (type.equals(Set.class)) {
-			return value.isBlank() ? Set.of() : splitStringToStream(value).collect(toUnmodifiableSet());
+			return value.isBlank() ? ImmutableSet.of() : splitStringToStream(value).collect(toImmutableSet());
 		} else if (type.equals(List.class)) {
 			return value.isBlank() ? List.of() : splitStringToStream(value).toList();
 		} else {

--- a/matsim/src/test/java/org/matsim/core/config/ReflectiveConfigGroupTest.java
+++ b/matsim/src/test/java/org/matsim/core/config/ReflectiveConfigGroupTest.java
@@ -37,6 +37,8 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.core.config.ReflectiveConfigGroup.InconsistentModuleException;
 import org.matsim.testcases.MatsimTestUtils;
 
+import com.google.common.collect.ImmutableSet;
+
 /**
  * @author thibautd
  */
@@ -58,7 +60,7 @@ public class ReflectiveConfigGroupTest {
 		dumpedModule.charField = 'z';
 		dumpedModule.byteField = 78;
 		dumpedModule.booleanField = true;
-		dumpedModule.setField = Set.of("a", "b", "c");
+		dumpedModule.setField = ImmutableSet.of("a", "b", "c");
 		dumpedModule.listField = List.of("1", "2", "3");
 		assertEqualAfterDumpAndRead(dumpedModule);
 	}
@@ -73,7 +75,7 @@ public class ReflectiveConfigGroupTest {
 	public void testDumpAndReadEmptyCollections() {
 		MyModule dumpedModule = new MyModule();
 		dumpedModule.listField = List.of();
-		dumpedModule.setField = Set.of();
+		dumpedModule.setField = ImmutableSet.of();
 		assertEqualAfterDumpAndRead(dumpedModule);
 	}
 
@@ -89,7 +91,7 @@ public class ReflectiveConfigGroupTest {
 
 		//fail on set
 		dumpedModule.listField = null;
-		dumpedModule.setField = Set.of("");
+		dumpedModule.setField = ImmutableSet.of("");
 		assertThatThrownBy(() -> assertEqualAfterDumpAndRead(dumpedModule)).isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("Collection [] contains blank elements. Only non-blank elements are supported.");
 	}
@@ -100,13 +102,13 @@ public class ReflectiveConfigGroupTest {
 
 		//fail on list
 		dumpedModule.listField = List.of("non-empty", "");
-		dumpedModule.setField = Set.of("non-empty");
+		dumpedModule.setField = ImmutableSet.of("non-empty");
 		assertThatThrownBy(() -> assertEqualAfterDumpAndRead(dumpedModule)).isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("Collection [non-empty, ] contains blank elements. Only non-blank elements are supported.");
 
 		//fail on set
 		dumpedModule.listField = List.of("non-empty");
-		dumpedModule.setField = Set.of("non-empty", "");
+		dumpedModule.setField = ImmutableSet.of("non-empty", "");
 		assertThatThrownBy(() -> assertEqualAfterDumpAndRead(dumpedModule)).isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("Collection [non-empty, ] contains blank elements. Only non-blank elements are supported.");
 	}


### PR DESCRIPTION
The issue was revealed by this failing build: https://ci.appveyor.com/project/michalmac/matsim-libs/builds/45047502