### PR TITLE
fix bug for check of located in relevantArea

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/prepare/freight/tripExtraction/ExtractRelevantFreightTrips.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/freight/tripExtraction/ExtractRelevantFreightTrips.java
@@ -144,8 +144,8 @@ public class ExtractRelevantFreightTrips implements MATSimAppCommand {
             Coord endCoord = endActivity.getCoord();
             double departureTime = startActivity.getEndTime().orElse(0);
 
-            boolean originIsInside = relevantArea.contains(MGC.coord2Point(startCoord));
-            boolean destinationIsInside = relevantArea.contains(MGC.coord2Point(endCoord));
+			boolean originIsInside = relevantArea.contains(MGC.coord2Point(sct.transform(startCoord)));
+			boolean destinationIsInside = relevantArea.contains(MGC.coord2Point(sct.transform(endCoord)));
 
             Activity act0 = populationFactory.createActivityFromCoord("freight_start", null);
             Leg leg = populationFactory.createLeg("freight");


### PR DESCRIPTION
The relevantArea check up was not correct when the acitivity csr and the shape crs are different. This should be fixed now.