### PR TITLE
ev: rename 'soc' to 'charge' and 'relativeSoc' to 'soc'

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/edrt/optimizer/EDrtVehicleDataEntryFactory.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/edrt/optimizer/EDrtVehicleDataEntryFactory.java
@@ -75,28 +75,28 @@ public class EDrtVehicleDataEntryFactory implements VehicleEntry.EntryFactory {
 
 		Battery battery = ((EvDvrpVehicle)vehicle).getElectricVehicle().getBattery();
 		int nextTaskIdx;
-		double socBeforeNextTask;
+		double chargeBeforeNextTask;
 		if (schedule.getStatus() == ScheduleStatus.PLANNED) {
 			nextTaskIdx = 0;
-			socBeforeNextTask = battery.getSoc();
+			chargeBeforeNextTask = battery.getCharge();
 		} else { // STARTED
 			Task currentTask = schedule.getCurrentTask();
 			ETaskTracker eTracker = (ETaskTracker)currentTask.getTaskTracker();
-			socBeforeNextTask = eTracker.predictSocAtEnd();
+			chargeBeforeNextTask = eTracker.predictChargeAtEnd();
 			nextTaskIdx = currentTask.getTaskIdx() + 1;
 		}
 
 		List<? extends Task> tasks = schedule.getTasks();
 		for (int i = nextTaskIdx; i < tasks.size() - 1; i++) {
-			socBeforeNextTask -= ((ETask)tasks.get(i)).getTotalEnergy();
+			chargeBeforeNextTask -= ((ETask)tasks.get(i)).getTotalEnergy();
 		}
 
-		if (socBeforeNextTask < minimumRelativeSoc * battery.getCapacity()) {
+		if (chargeBeforeNextTask < minimumRelativeSoc * battery.getCapacity()) {
 			return null;// skip undercharged vehicles
 		}
 
 		VehicleEntry entry = entryFactory.create(vehicle, currentTime);
-		return entry == null ? null : new EVehicleEntry(entry, socBeforeNextTask);
+		return entry == null ? null : new EVehicleEntry(entry, chargeBeforeNextTask);
 	}
 
 	public static class EDrtVehicleDataEntryFactoryProvider implements Provider<VehicleEntry.EntryFactory> {

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/eshifts/dispatcher/EDrtAssignShiftToVehicleLogic.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/eshifts/dispatcher/EDrtAssignShiftToVehicleLogic.java
@@ -49,7 +49,7 @@ public class EDrtAssignShiftToVehicleLogic implements AssignShiftToVehicleLogic 
 		// no, if below battery threshold
 		if (vehicle instanceof EvShiftDvrpVehicle) {
 			final Battery battery = ((EvShiftDvrpVehicle) vehicle).getElectricVehicle().getBattery();
-			if (battery.getSoc() / battery.getCapacity() < drtShiftParams.shiftAssignmentBatteryThreshold) {
+			if (battery.getCharge() / battery.getCapacity() < drtShiftParams.shiftAssignmentBatteryThreshold) {
 				return false;
 			}
 		}

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/eshifts/dispatcher/EDrtShiftDispatcherImpl.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/eshifts/dispatcher/EDrtShiftDispatcherImpl.java
@@ -5,7 +5,6 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.extension.operations.eshifts.fleet.EvShiftDvrpVehicle;
 import org.matsim.contrib.drt.extension.operations.eshifts.schedule.EDrtWaitForShiftStayTask;
 import org.matsim.contrib.drt.extension.operations.eshifts.scheduler.EShiftTaskScheduler;
-import org.matsim.contrib.drt.extension.operations.DrtOperationsParams;
 import org.matsim.contrib.drt.extension.operations.shifts.config.ShiftsParams;
 import org.matsim.contrib.drt.extension.operations.shifts.dispatcher.DrtShiftDispatcher;
 import org.matsim.contrib.drt.extension.operations.shifts.fleet.ShiftDvrpVehicle;
@@ -90,7 +89,7 @@ public class EDrtShiftDispatcherImpl implements DrtShiftDispatcher {
 							continue;
 						}
 						final ElectricVehicle electricVehicle = eShiftVehicle.getElectricVehicle();
-						if (electricVehicle.getBattery().getSoc() / electricVehicle.getBattery().getCapacity() < drtShiftParams.chargeAtHubThreshold) {
+						if (electricVehicle.getBattery().getCharge() / electricVehicle.getBattery().getCapacity() < drtShiftParams.chargeAtHubThreshold) {
 							final Task currentTask = eShiftVehicle.getSchedule().getCurrentTask();
 							if (currentTask instanceof EDrtWaitForShiftStayTask
 									&& ((EDrtWaitForShiftStayTask) currentTask).getChargingTask() == null) {

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/eshifts/scheduler/EShiftTaskScheduler.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/eshifts/scheduler/EShiftTaskScheduler.java
@@ -5,7 +5,6 @@ import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.contrib.drt.extension.operations.DrtOperationsParams;
 import org.matsim.contrib.drt.extension.operations.eshifts.schedule.EDrtShiftChangeoverTaskImpl;
 import org.matsim.contrib.drt.extension.operations.eshifts.schedule.ShiftEDrtTaskFactoryImpl;
 import org.matsim.contrib.drt.extension.operations.operationFacilities.OperationFacilities;
@@ -180,7 +179,7 @@ public class EShiftTaskScheduler implements ShiftTaskScheduler {
 			final double waitTime = ChargingEstimations
 					.estimateMaxWaitTimeForNextVehicle(chargerImpl);
 
-			if (ev.getBattery().getSoc() / ev.getBattery().getCapacity() < shiftsParams.chargeDuringBreakThreshold ||
+			if (ev.getBattery().getCharge() / ev.getBattery().getCapacity() < shiftsParams.chargeDuringBreakThreshold ||
 			waitTime > 0) {
                 dropoffStopTask = taskFactory.createShiftBreakTask(vehicle, startTime,
                         endTime, link, shiftBreak, breakFacility);
@@ -329,7 +328,7 @@ public class EShiftTaskScheduler implements ShiftTaskScheduler {
 			final double waitTime = ChargingEstimations
 					.estimateMaxWaitTimeForNextVehicle(chargingImpl);
 
-			if (ev.getBattery().getSoc() / ev.getBattery().getCapacity() < shiftsParams.chargeDuringBreakThreshold
+			if (ev.getBattery().getCharge() / ev.getBattery().getCapacity() < shiftsParams.chargeDuringBreakThreshold
                     || ((ChargingWithAssignmentLogic) chargingImpl.getLogic()).getAssignedVehicles().contains(ev)
 			|| waitTime >0) {
                 dropoffStopTask = taskFactory.createShiftChangeoverTask(vehicle, startTime,

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/evrp/tracker/ETaskTracker.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/evrp/tracker/ETaskTracker.java
@@ -26,5 +26,5 @@ import org.matsim.contrib.dvrp.tracker.TaskTracker;
  * @author michalm
  */
 public interface ETaskTracker extends TaskTracker {
-	double predictSocAtEnd();
+	double predictChargeAtEnd();
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/evrp/tracker/OfflineETaskTracker.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/evrp/tracker/OfflineETaskTracker.java
@@ -30,12 +30,12 @@ import org.matsim.core.mobsim.framework.MobsimTimer;
 public class OfflineETaskTracker implements ETaskTracker {
 	private final MobsimTimer timer;
 	private final ETask task;
-	private final double socAtStart;
+	private final double chargeAtStart;
 
 	public OfflineETaskTracker(EvDvrpVehicle vehicle, MobsimTimer timer) {
 		this.timer = timer;
 		task = (ETask)vehicle.getSchedule().getCurrentTask();
-		socAtStart = vehicle.getElectricVehicle().getBattery().getSoc();
+		chargeAtStart = vehicle.getElectricVehicle().getBattery().getCharge();
 	}
 
 	@Override
@@ -44,7 +44,7 @@ public class OfflineETaskTracker implements ETaskTracker {
 	}
 
 	@Override
-	public double predictSocAtEnd() {
-		return socAtStart - task.getTotalEnergy();
+	public double predictChargeAtEnd() {
+		return chargeAtStart - task.getTotalEnergy();
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/evrp/tracker/OnlineEDriveTaskTracker.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/evrp/tracker/OnlineEDriveTaskTracker.java
@@ -43,12 +43,12 @@ public class OnlineEDriveTaskTracker implements OnlineDriveTaskTracker, ETaskTra
 	}
 
 	@Override
-	public double predictSocAtEnd() {
+	public double predictChargeAtEnd() {
 		ElectricVehicle ev = vehicle.getElectricVehicle();
-		double currentSoc = ev.getBattery().getSoc();
+		double currentCharge = ev.getBattery().getCharge();
 		double driveEnergy = VrpPathEnergyConsumptions.calcRemainingTotalEnergy(ev, getPath(), getCurrentLinkIdx(),
 				getCurrentLinkEnterTime());
-		return currentSoc - driveEnergy;
+		return currentCharge - driveEnergy;
 	}
 
 	@Override

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/EvConfigGroup.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/EvConfigGroup.java
@@ -58,7 +58,7 @@ public final class EvConfigGroup extends ReflectiveConfigGroup {
 
 	// output
 	@Parameter
-	@Comment("If true, SOC time profile plots will be created")
+	@Comment("If true, charge/SoC time profile plots will be created")
 	public boolean timeProfiles = false;
 
 	@Parameter

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/ChargeUpToMaxSocStrategy.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/ChargeUpToMaxSocStrategy.java
@@ -29,20 +29,20 @@ import org.matsim.contrib.ev.infrastructure.ChargerSpecification;
  */
 public class ChargeUpToMaxSocStrategy implements ChargingStrategy {
 	private final ChargerSpecification charger;
-	private final double maxRelativeSoc;
+	private final double maxSoc;
 
-	public ChargeUpToMaxSocStrategy(ChargerSpecification charger, double maxRelativeSoc) {
-		if (maxRelativeSoc < 0 || maxRelativeSoc > 1) {
+	public ChargeUpToMaxSocStrategy(ChargerSpecification charger, double maxSoc) {
+		if (maxSoc < 0 || maxSoc > 1) {
 			throw new IllegalArgumentException();
 		}
 		this.charger = charger;
-		this.maxRelativeSoc = maxRelativeSoc;
+		this.maxSoc = maxSoc;
 	}
 
 	@Override
 	public double calcRemainingEnergyToCharge(ElectricVehicle ev) {
 		Battery battery = ev.getBattery();
-		return maxRelativeSoc * battery.getCapacity() - battery.getCharge();
+		return maxSoc * battery.getCapacity() - battery.getCharge();
 	}
 
 	@Override

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/ChargeUpToMaxSocStrategy.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/ChargeUpToMaxSocStrategy.java
@@ -42,7 +42,7 @@ public class ChargeUpToMaxSocStrategy implements ChargingStrategy {
 	@Override
 	public double calcRemainingEnergyToCharge(ElectricVehicle ev) {
 		Battery battery = ev.getBattery();
-		return maxRelativeSoc * battery.getCapacity() - battery.getSoc();
+		return maxRelativeSoc * battery.getCapacity() - battery.getCharge();
 	}
 
 	@Override

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/ChargingWithQueueingLogic.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/ChargingWithQueueingLogic.java
@@ -59,12 +59,12 @@ public class ChargingWithQueueingLogic implements ChargingLogic {
 			ElectricVehicle ev = evIter.next();
 			// with fast charging, we charge around 4% of SOC per minute,
 			// so when updating SOC every 10 seconds, SOC increases by less then 1%
-			ev.getBattery().changeSoc(ev.getChargingPower().calcChargingPower(charger) * chargePeriod);
+			ev.getBattery().changeCharge(ev.getChargingPower().calcChargingPower(charger) * chargePeriod);
 
 			if (chargingStrategy.isChargingCompleted(ev)) {
 				evIter.remove();
 				eventsManager.processEvent(
-						new ChargingEndEvent(now, charger.getId(), ev.getId(), ev.getBattery().getSoc()));
+						new ChargingEndEvent(now, charger.getId(), ev.getId(), ev.getBattery().getCharge()));
 				listeners.remove(ev.getId()).notifyChargingEnded(ev, now);
 			}
 		}
@@ -95,7 +95,7 @@ public class ChargingWithQueueingLogic implements ChargingLogic {
 	public void removeVehicle(ElectricVehicle ev, double now) {
 		if (pluggedVehicles.remove(ev.getId()) != null) {// successfully removed
 			eventsManager.processEvent(
-					new ChargingEndEvent(now, charger.getId(), ev.getId(), ev.getBattery().getSoc()));
+					new ChargingEndEvent(now, charger.getId(), ev.getId(), ev.getBattery().getCharge()));
 			listeners.remove(ev.getId()).notifyChargingEnded(ev, now);
 
 			if (!queuedVehicles.isEmpty()) {
@@ -120,7 +120,7 @@ public class ChargingWithQueueingLogic implements ChargingLogic {
 			throw new IllegalArgumentException();
 		}
 		eventsManager.processEvent(new ChargingStartEvent(now, charger.getId(), ev.getId(), charger.getChargerType(),
-				ev.getBattery().getSoc()));
+				ev.getBattery().getCharge()));
 		listeners.get(ev.getId()).notifyChargingStarted(ev, now);
 	}
 

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/FastThenSlowCharging.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/FastThenSlowCharging.java
@@ -43,7 +43,7 @@ public class FastThenSlowCharging implements BatteryCharging {
 
 	public double calcChargingPower(double maxPower) {
 		Battery b = electricVehicle.getBattery();
-		double relativeSoc = b.getSoc() / b.getCapacity();
+		double relativeSoc = b.getCharge() / b.getCapacity();
 		double c = b.getCapacity() / 3600;
 		if (relativeSoc <= 0.5) {
 			return Math.min(maxPower, 1.75 * c);
@@ -56,7 +56,7 @@ public class FastThenSlowCharging implements BatteryCharging {
 
 	@Override
 	public double calcEnergyCharged(ChargerSpecification charger, double chargingPeriod) {
-		Preconditions.checkArgument(chargingPeriod  >= 0, "Charging period is negative: %s", chargingPeriod );
+		Preconditions.checkArgument(chargingPeriod >= 0, "Charging period is negative: %s", chargingPeriod);
 
 		double remainingTime = chargingPeriod;
 
@@ -64,33 +64,33 @@ public class FastThenSlowCharging implements BatteryCharging {
 		double energyCharged = 0;
 
 		final Battery battery = electricVehicle.getBattery();
-		double maxRemainingEnergy = battery.getCapacity() - battery.getSoc();
-		double relativeSoc = battery.getSoc() / battery.getCapacity();
+		double maxRemainingEnergy = battery.getCapacity() - battery.getCharge();
+		double relativeSoc = battery.getCharge() / battery.getCapacity();
 
 		double c = battery.getCapacity() / 3600;
 		double capB = 0.5 * battery.getCapacity();
 		double capC = 0.75 * battery.getCapacity();
 
 		if (relativeSoc <= 0.5 && maxRemainingEnergy > 0) {
-			double diff = capB - battery.getSoc();
+			double diff = capB - battery.getCharge();
 			final double chargingSpeed = Math.min(maxChargingPower, 1.75 * c);
 			double maxTime = diff / chargingSpeed;
 			energyCharged += Math.min(maxTime, remainingTime) * chargingSpeed;
 			remainingTime -= maxTime;
-			relativeSoc = (battery.getSoc() + energyCharged) / battery.getCapacity();
+			relativeSoc = (battery.getCharge() + energyCharged) / battery.getCapacity();
 		}
 
 		if (remainingTime > 0 && relativeSoc <= 0.75 && maxRemainingEnergy > energyCharged) {
-			double diff = capC - (battery.getSoc() + energyCharged);
+			double diff = capC - (battery.getCharge() + energyCharged);
 			final double chargingSpeed = Math.min(maxChargingPower, 1.25 * c);
 			double maxTime = diff / chargingSpeed;
 			energyCharged += Math.min(maxTime, remainingTime) * chargingSpeed;
 			remainingTime -= maxTime;
-			relativeSoc = (battery.getSoc() + energyCharged) / battery.getCapacity();
+			relativeSoc = (battery.getCharge() + energyCharged) / battery.getCapacity();
 		}
 
 		if (remainingTime > 0 && relativeSoc < 1. && maxRemainingEnergy > energyCharged) {
-			double diff = battery.getCapacity() - (battery.getSoc() + energyCharged);
+			double diff = battery.getCapacity() - (battery.getCharge() + energyCharged);
 			final double chargingSpeed = Math.min(maxChargingPower, 0.5 * c);
 			double maxTime = diff / chargingSpeed;
 			energyCharged += Math.min(maxTime, remainingTime) * chargingSpeed;
@@ -103,23 +103,23 @@ public class FastThenSlowCharging implements BatteryCharging {
 		Preconditions.checkArgument(energy >= 0, "Energy is negative: %s", energy);
 
 		Battery b = electricVehicle.getBattery();
-		double startSoc = b.getSoc();
-		double endSoc = startSoc + energy;
-		Preconditions.checkArgument(endSoc <= b.getCapacity(), "End SOC greater than battery capacity: %s", endSoc);
+		double startCharge = b.getCharge();
+		double endCharge = startCharge + energy;
+		Preconditions.checkArgument(endCharge <= b.getCapacity(), "End charge greater than battery capacity: %s", endCharge);
 
 		double threshold1 = 0.5 * b.getCapacity();
 		double threshold2 = 0.75 * b.getCapacity();
 		double c = b.getCapacity() / 3600;
 
-		double energyA = startSoc >= threshold1 ? 0 : Math.min(threshold1, endSoc) - startSoc;
+		double energyA = startCharge >= threshold1 ? 0 : Math.min(threshold1, endCharge) - startCharge;
 		double timeA = energyA / Math.min(charger.getPlugPower(), 1.75 * c);
 
-		double energyB = startSoc >= threshold2 || endSoc <= threshold1 ?
+		double energyB = startCharge >= threshold2 || endCharge <= threshold1 ?
 				0 :
-				Math.min(threshold2, endSoc) - Math.max(threshold1, startSoc);
+				Math.min(threshold2, endCharge) - Math.max(threshold1, startCharge);
 		double timeB = energyB / Math.min(charger.getPlugPower(), 1.25 * c);
 
-		double energyC = endSoc <= threshold2 ? 0 : endSoc - Math.max(threshold2, startSoc);
+		double energyC = endCharge <= threshold2 ? 0 : endCharge - Math.max(threshold2, startCharge);
 		double timeC = energyC / Math.min(charger.getPlugPower(), 0.5 * c);
 
 		return timeA + timeB + timeC;

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/FastThenSlowCharging.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/FastThenSlowCharging.java
@@ -43,11 +43,11 @@ public class FastThenSlowCharging implements BatteryCharging {
 
 	public double calcChargingPower(double maxPower) {
 		Battery b = electricVehicle.getBattery();
-		double relativeSoc = b.getCharge() / b.getCapacity();
+		double soc = b.getCharge() / b.getCapacity();
 		double c = b.getCapacity() / 3600;
-		if (relativeSoc <= 0.5) {
+		if (soc <= 0.5) {
 			return Math.min(maxPower, 1.75 * c);
-		} else if (relativeSoc <= 0.75) {
+		} else if (soc <= 0.75) {
 			return Math.min(maxPower, 1.25 * c);
 		} else {
 			return Math.min(maxPower, 0.5 * c);
@@ -65,31 +65,31 @@ public class FastThenSlowCharging implements BatteryCharging {
 
 		final Battery battery = electricVehicle.getBattery();
 		double maxRemainingEnergy = battery.getCapacity() - battery.getCharge();
-		double relativeSoc = battery.getCharge() / battery.getCapacity();
+		double soc = battery.getCharge() / battery.getCapacity();
 
 		double c = battery.getCapacity() / 3600;
 		double capB = 0.5 * battery.getCapacity();
 		double capC = 0.75 * battery.getCapacity();
 
-		if (relativeSoc <= 0.5 && maxRemainingEnergy > 0) {
+		if (soc <= 0.5 && maxRemainingEnergy > 0) {
 			double diff = capB - battery.getCharge();
 			final double chargingSpeed = Math.min(maxChargingPower, 1.75 * c);
 			double maxTime = diff / chargingSpeed;
 			energyCharged += Math.min(maxTime, remainingTime) * chargingSpeed;
 			remainingTime -= maxTime;
-			relativeSoc = (battery.getCharge() + energyCharged) / battery.getCapacity();
+			soc = (battery.getCharge() + energyCharged) / battery.getCapacity();
 		}
 
-		if (remainingTime > 0 && relativeSoc <= 0.75 && maxRemainingEnergy > energyCharged) {
+		if (remainingTime > 0 && soc <= 0.75 && maxRemainingEnergy > energyCharged) {
 			double diff = capC - (battery.getCharge() + energyCharged);
 			final double chargingSpeed = Math.min(maxChargingPower, 1.25 * c);
 			double maxTime = diff / chargingSpeed;
 			energyCharged += Math.min(maxTime, remainingTime) * chargingSpeed;
 			remainingTime -= maxTime;
-			relativeSoc = (battery.getCharge() + energyCharged) / battery.getCapacity();
+			soc = (battery.getCharge() + energyCharged) / battery.getCapacity();
 		}
 
-		if (remainingTime > 0 && relativeSoc < 1. && maxRemainingEnergy > energyCharged) {
+		if (remainingTime > 0 && soc < 1. && maxRemainingEnergy > energyCharged) {
 			double diff = battery.getCapacity() - (battery.getCharge() + energyCharged);
 			final double chargingSpeed = Math.min(maxChargingPower, 0.5 * c);
 			double maxTime = diff / chargingSpeed;

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/FixedSpeedCharging.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/FixedSpeedCharging.java
@@ -47,7 +47,7 @@ public class FixedSpeedCharging implements BatteryCharging {
 	@Override
 	public double calcEnergyCharged(ChargerSpecification charger, double chargePeriod) {
 		final Battery battery = electricVehicle.getBattery();
-		return Math.min(calcChargingPower(charger) * chargePeriod, battery.getCapacity() - battery.getSoc());
+		return Math.min(calcChargingPower(charger) * chargePeriod, battery.getCapacity() - battery.getCharge());
 	}
 
 	@Override

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/VariableSpeedCharging.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/VariableSpeedCharging.java
@@ -100,7 +100,7 @@ public class VariableSpeedCharging implements ChargingPower {//TODO upgrade to B
 	@Override
 	public double calcChargingPower(ChargerSpecification charger) {
 		Battery b = electricVehicle.getBattery();
-		double relativeSoc = b.getSoc() / b.getCapacity();
+		double relativeSoc = b.getCharge() / b.getCapacity();
 		double c = b.getCapacity() / 3600.;
 
 		if (relativeSoc <= pointB.relativeSoc) {
@@ -120,7 +120,7 @@ public class VariableSpeedCharging implements ChargingPower {//TODO upgrade to B
 	//TODO convert to: calcChargingTime(Charger charger, double energy)
 	public double calcRemainingTimeToCharge(Charger charger) {
 		Battery b = electricVehicle.getBattery();
-		double relativeSoc = b.getSoc() / b.getCapacity();
+		double relativeSoc = b.getCharge() / b.getCapacity();
 		double c = b.getCapacity() / 3600.;
 		double relativeChargerPower = charger.getPlugPower() / c;
 

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/VariableSpeedCharging.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/VariableSpeedCharging.java
@@ -34,21 +34,21 @@ import com.google.common.base.Preconditions;
 public class VariableSpeedCharging implements ChargingPower {//TODO upgrade to BatteryCharging
 
 	public static class Point {
-		private final double relativeSoc;
+		private final double soc;
 		private final double relativePower;
 
-		public Point(double relativeSoc, double relativeSpeed) {
-			Preconditions.checkArgument(relativeSoc >= 0 && relativeSoc <= 1, "Relative SOC must be in [0,1]");
+		public Point(double soc, double relativeSpeed) {
+			Preconditions.checkArgument(soc >= 0 && soc <= 1, "SOC must be in [0,1]");
 			//XXX To avoid infinite charging simulation (e.g. at SOC==0 or close to 1.0)
 			Preconditions.checkArgument(relativeSpeed > 0, "Relative speed must be positive");
-			this.relativeSoc = relativeSoc;
+			this.soc = soc;
 			this.relativePower = relativeSpeed;
 		}
 
 		@Override
 		public String toString() {
 			return MoreObjects.toStringHelper(this)
-					.add("relativeSoc", relativeSoc)
+					.add("soc", soc)
 					.add("relativePower", relativePower)
 					.toString();
 		}
@@ -79,12 +79,12 @@ public class VariableSpeedCharging implements ChargingPower {//TODO upgrade to B
 	public VariableSpeedCharging(ElectricVehicle electricVehicle, Point pointA, Point pointB, Point pointC,
 			Point pointD) {
 		//checks whether the A-B-C-D profile
-		Preconditions.checkArgument(pointA.relativeSoc == 0, "PointA.relativeSoc must be 0");
-		Preconditions.checkArgument(pointD.relativeSoc == 1, "PointB.relativeSoc must be 1");
-		Preconditions.checkArgument(pointB.relativeSoc != 0, "PointB.relativeSoc must be greater than 0");
-		Preconditions.checkArgument(pointC.relativeSoc != 1, "PointB.relativeSoc must be less than 1");
-		Preconditions.checkArgument(pointB.relativeSoc < pointC.relativeSoc,
-				"PointB.relativeSoc must be less than PointC.relativeSoc");
+		Preconditions.checkArgument(pointA.soc == 0, "PointA.soc must be 0");
+		Preconditions.checkArgument(pointD.soc == 1, "PointB.soc must be 1");
+		Preconditions.checkArgument(pointB.soc != 0, "PointB.soc must be greater than 0");
+		Preconditions.checkArgument(pointC.soc != 1, "PointB.soc must be less than 1");
+		Preconditions.checkArgument(pointB.soc < pointC.soc,
+				"PointB.soc must be less than PointC.soc");
 		Preconditions.checkArgument(pointA.relativePower <= pointB.relativePower,
 				"PointA.relativePower must not be greater than PointB.relativePower");
 		Preconditions.checkArgument(pointD.relativePower <= pointC.relativePower,
@@ -100,27 +100,27 @@ public class VariableSpeedCharging implements ChargingPower {//TODO upgrade to B
 	@Override
 	public double calcChargingPower(ChargerSpecification charger) {
 		Battery b = electricVehicle.getBattery();
-		double relativeSoc = b.getCharge() / b.getCapacity();
+		double soc = b.getCharge() / b.getCapacity();
 		double c = b.getCapacity() / 3600.;
 
-		if (relativeSoc <= pointB.relativeSoc) {
-			return Math.min(charger.getPlugPower(), c * approxRelativePower(relativeSoc, pointA, pointB));
-		} else if (relativeSoc <= pointC.relativeSoc) {
-			return Math.min(charger.getPlugPower(), c * approxRelativePower(relativeSoc, pointB, pointC));
+		if (soc <= pointB.soc) {
+			return Math.min(charger.getPlugPower(), c * approxRelativePower(soc, pointA, pointB));
+		} else if (soc <= pointC.soc) {
+			return Math.min(charger.getPlugPower(), c * approxRelativePower(soc, pointB, pointC));
 		} else {
-			return Math.min(charger.getPlugPower(), c * approxRelativePower(relativeSoc, pointC, pointD));
+			return Math.min(charger.getPlugPower(), c * approxRelativePower(soc, pointC, pointD));
 		}
 	}
 
-	private double approxRelativePower(double relativeSoc, Point point0, Point point1) {
-		double a = (relativeSoc - point0.relativeSoc) / (point1.relativeSoc - point0.relativeSoc);
+	private double approxRelativePower(double soc, Point point0, Point point1) {
+		double a = (soc - point0.soc) / (point1.soc - point0.soc);
 		return point0.relativePower + a * (point1.relativePower - point0.relativePower);
 	}
 
 	//TODO convert to: calcChargingTime(Charger charger, double energy)
 	public double calcRemainingTimeToCharge(Charger charger) {
 		Battery b = electricVehicle.getBattery();
-		double relativeSoc = b.getCharge() / b.getCapacity();
+		double soc = b.getCharge() / b.getCapacity();
 		double c = b.getCapacity() / 3600.;
 		double relativeChargerPower = charger.getPlugPower() / c;
 
@@ -128,7 +128,7 @@ public class VariableSpeedCharging implements ChargingPower {//TODO upgrade to B
 		final Point adjustedPointB;
 		if (pointA.relativePower >= relativeChargerPower) {
 			adjustedPointA = new Point(0, relativeChargerPower);
-			adjustedPointB = new Point(pointB.relativeSoc, relativeChargerPower);
+			adjustedPointB = new Point(pointB.soc, relativeChargerPower);
 		} else {
 			adjustedPointA = pointA;
 			adjustedPointB = adjustPointIfSlowerCharging(relativeChargerPower, pointA, pointB);
@@ -138,21 +138,21 @@ public class VariableSpeedCharging implements ChargingPower {//TODO upgrade to B
 		final Point adjustedPointC;
 		if (pointD.relativePower >= relativeChargerPower) {//rather unlikely
 			adjustedPointD = new Point(1, relativeChargerPower);
-			adjustedPointC = new Point(pointC.relativeSoc, relativeChargerPower);
+			adjustedPointC = new Point(pointC.soc, relativeChargerPower);
 		} else {
 			adjustedPointD = pointD;
 			adjustedPointC = adjustPointIfSlowerCharging(relativeChargerPower, pointD, pointC);
 		}
 
-		if (relativeSoc <= adjustedPointB.relativeSoc) {
-			return approximateRemainingChargeTime(relativeSoc, adjustedPointA, adjustedPointB)//
+		if (soc <= adjustedPointB.soc) {
+			return approximateRemainingChargeTime(soc, adjustedPointA, adjustedPointB)//
 					+ approxChargeTime(adjustedPointB, adjustedPointC)//
 					+ approxChargeTime(adjustedPointC, adjustedPointD);
-		} else if (relativeSoc <= adjustedPointC.relativeSoc) {
-			return approximateRemainingChargeTime(relativeSoc, adjustedPointB, adjustedPointC)//
+		} else if (soc <= adjustedPointC.soc) {
+			return approximateRemainingChargeTime(soc, adjustedPointB, adjustedPointC)//
 					+ approxChargeTime(adjustedPointC, adjustedPointD);
 		} else {
-			return approximateRemainingChargeTime(relativeSoc, adjustedPointC, adjustedPointD);
+			return approximateRemainingChargeTime(soc, adjustedPointC, adjustedPointD);
 		}
 	}
 
@@ -163,16 +163,16 @@ public class VariableSpeedCharging implements ChargingPower {//TODO upgrade to B
 
 		double a = (relativeChargerPower - lowerPoint.relativePower) / (higherPoint.relativePower
 				- lowerPoint.relativePower);
-		double relativeSoc = lowerPoint.relativeSoc + a * (higherPoint.relativeSoc - lowerPoint.relativeSoc);
-		return new Point(relativeSoc, relativeChargerPower);
+		double soc = lowerPoint.soc + a * (higherPoint.soc - lowerPoint.soc);
+		return new Point(soc, relativeChargerPower);
 	}
 
-	private double approximateRemainingChargeTime(double relativeSoc, Point point0, Point point1) {
-		Point currentPoint = new Point(relativeSoc, approxRelativePower(relativeSoc, point0, point1));
+	private double approximateRemainingChargeTime(double soc, Point point0, Point point1) {
+		Point currentPoint = new Point(soc, approxRelativePower(soc, point0, point1));
 		return approxChargeTime(currentPoint, point1);
 	}
 
 	private double approxChargeTime(Point point0, Point point1) {
-		return 3600. * (point1.relativeSoc - point0.relativeSoc) / (point1.relativePower + point0.relativePower);
+		return 3600. * (point1.soc - point0.soc) / (point1.relativePower + point0.relativePower);
 	}
 }

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/AuxDischargingHandler.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/AuxDischargingHandler.java
@@ -86,7 +86,7 @@ public class AuxDischargingHandler
 				ElectricVehicle ev = vehicleAndLink.vehicle;
 				double energy = ev.getAuxEnergyConsumption()
 						.calcEnergyConsumption(e.getSimulationTime(), auxDischargeTimeStep, vehicleAndLink.linkId);
-				ev.getBattery().changeSoc(-energy);
+				ev.getBattery().changeCharge(-energy);
 			}
 		}
 	}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DriveDischargingHandler.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DriveDischargingHandler.java
@@ -100,8 +100,8 @@ public class DriveDischargingHandler
 		}
 	}
 
-	//XXX The current implementation is thread-safe because no other EventHandler modifies battery SOC
-	// (for instance, AUX discharging and battery charging modifies SOC outside event handling
+	//XXX The current implementation is thread-safe because no other EventHandler modifies battery charge
+	// (for instance, AUX discharging and battery charging modifies charge outside event handling
 	// (as MobsimAfterSimStepListeners)
 	//TODO In the long term, it will be safer to move the discharging procedure to a MobsimAfterSimStepListener
 	private EvDrive dischargeVehicle(Id<Vehicle> vehicleId, Id<Link> linkId, double eventTime) {
@@ -113,7 +113,7 @@ public class DriveDischargingHandler
 			double energy = ev.getDriveEnergyConsumption().calcEnergyConsumption(link, tt, eventTime - tt)
 					+ ev.getAuxEnergyConsumption().calcEnergyConsumption(eventTime - tt, tt, linkId);
 			//Energy consumption might be negative on links with negative slope
-			ev.getBattery().changeSoc(-energy);
+			ev.getBattery().changeCharge(-energy);
 
 			//FIXME emit a DriveOnLinkEnergyConsumptionEvent instead of calculating it here...
 			double linkConsumption = energy + energyConsumptionPerLink.getOrDefault(linkId, 0.0);

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/OhdeSlaskiDriveEnergyConsumption.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/OhdeSlaskiDriveEnergyConsumption.java
@@ -27,7 +27,7 @@ import org.matsim.api.core.v01.network.Link;
  * Ohde, B., Ślaski, G., Maciejewski, M. (2016). Statistical analysis of real-world urban driving cycles for modelling
  * energy consumption of electric vehicles. Journal of Mechanical and Transport Engineering, 68.
  * <p>
- * http://fwmt.put.poznan.pl/imgWYSIWYG/agill/File/2_68_2016/jmte_2016_68_2_03_ohde_b_slaski_g.pdf
+ * https://www.researchgate.net/profile/Michal-Maciejewski-3/publication/312393169_Statistical_analysis_of_real-world_urban_driving_cycles_for_modelling_energy_consumption_of_electric_vehicles/links/59b7a17faca2722453a5fc7f/Statistical-analysis-of-real-world-urban-driving-cycles-for-modelling-energy-consumption-of-electric-vehicles.pdf
  * TODO Add (dis-)charging efficiency relative to SOC, temperature, etc...
  */
 public class OhdeSlaskiDriveEnergyConsumption implements DriveEnergyConsumption {

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/Battery.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/Battery.java
@@ -27,21 +27,21 @@ public interface Battery {
 	double getCapacity();
 
 	/**
-	 * @return Vehicle State of Charge [J]
+	 * @return charge [J]
 	 */
-	double getSoc();
+	double getCharge();
 
 	/**
-	 * @param soc Vehicle State of Charge [J]
+	 * @param charge charge [J]
 	 */
-	void setSoc(double soc);
+	void setCharge(double charge);
 
 	/**
-	 * Changes SOC, making sure the charge level does not increase above the battery capacity or decrease below 0.
+	 * Changes charge, making sure the charge level does not increase above the battery capacity or decrease below 0.
 	 *
 	 * @param energy change in energy [J], can be negative or positive
 	 */
-	default void changeSoc(double energy) {
-		setSoc(Math.max(0, Math.min(getSoc() + energy, getCapacity())));
+	default void changeCharge(double energy) {
+		setCharge(Math.max(0, Math.min(getCharge() + energy, getCapacity())));
 	}
 }

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/BatteryImpl.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/BatteryImpl.java
@@ -25,11 +25,11 @@ import com.google.common.base.Preconditions;
 
 public class BatteryImpl implements Battery {
 	private final double capacity;
-	private double soc;
+	private double charge;
 
-	public BatteryImpl(double capacity, double soc) {
+	public BatteryImpl(double capacity, double charge) {
 		this.capacity = capacity;
-		this.soc = soc;
+		this.charge = charge;
 	}
 
 	@Override
@@ -38,18 +38,18 @@ public class BatteryImpl implements Battery {
 	}
 
 	@Override
-	public double getSoc() {
-		return soc;
+	public double getCharge() {
+		return charge;
 	}
 
 	@Override
-	public void setSoc(double soc) {
-		Preconditions.checkArgument(soc >= 0 && soc <= capacity, "SoC outside allowed range: %s", soc);
-		this.soc = soc;
+	public void setCharge(double charge) {
+		Preconditions.checkArgument(charge >= 0 && charge <= capacity, "Charge outside allowed range: %s", charge);
+		this.charge = charge;
 	}
 
 	@Override
 	public String toString() {
-		return MoreObjects.toStringHelper(this).add("capacity", capacity).add("soc", soc).toString();
+		return MoreObjects.toStringHelper(this).add("capacity", capacity).add("charge", charge).toString();
 	}
 }

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricFleetModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricFleetModule.java
@@ -91,14 +91,15 @@ public class ElectricFleetModule extends AbstractModule {
 						public void notifyMobsimBeforeCleanup(MobsimBeforeCleanupEvent e) {
 							for (var oldSpec : electricFleetSpecification.getVehicleSpecifications().values()) {
 								var matsimVehicle = oldSpec.getMatsimVehicle();
-								double socAtEndOfCurrentIteration = electricFleet.getElectricVehicles()
+								double chargeAtEndOfCurrentIteration = electricFleet.getElectricVehicles()
 										.get(oldSpec.getId())
 										.getBattery()
-										.getSoc();
+										.getCharge();
 
-								// INITIAL_ENERGY_kWh attribute is in kWh, the SoC is in J
+								// INITIAL_ENERGY_kWh attribute is in kWh, the charge is in J
 								matsimVehicle.getAttributes()
-										.putAttribute(INITIAL_ENERGY_kWh, EvUnits.J_to_kWh(socAtEndOfCurrentIteration));
+										.putAttribute(INITIAL_ENERGY_kWh,
+												EvUnits.J_to_kWh(chargeAtEndOfCurrentIteration));
 							}
 						}
 					});

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleImpl.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleImpl.java
@@ -51,7 +51,7 @@ public class ElectricVehicleImpl implements ElectricVehicle {
 
 	private ElectricVehicleImpl(ElectricVehicleSpecification vehicleSpecification) {
 		this.vehicleSpecification = vehicleSpecification;
-		battery = new BatteryImpl(vehicleSpecification.getBatteryCapacity(), vehicleSpecification.getInitialSoc());
+		battery = new BatteryImpl(vehicleSpecification.getBatteryCapacity(), vehicleSpecification.getInitialCharge());
 	}
 
 	@Override

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleSpecification.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleSpecification.java
@@ -33,8 +33,7 @@ public interface ElectricVehicleSpecification extends Identifiable<Vehicle> {
 
 	ImmutableList<String> getChargerTypes();
 
-	//FIXME consider renaming to getInitialCharge -- SOC suggest [%] not [J]
-	double getInitialSoc();//[J]
+	double getInitialCharge();//[J]
 
 	double getBatteryCapacity();//[J]
 }

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleSpecificationImpl.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleSpecificationImpl.java
@@ -52,7 +52,7 @@ public class ElectricVehicleSpecificationImpl implements ElectricVehicleSpecific
 	public ElectricVehicleSpecificationImpl(Vehicle matsimVehicle) {
 		this.matsimVehicle = matsimVehicle;
 		//provided per vehicle type (in engine info)
-		if (getInitialSoc() < 0 || getInitialSoc() > getBatteryCapacity()) {
+		if (getInitialCharge() < 0 || getInitialCharge() > getBatteryCapacity()) {
 			throw new IllegalArgumentException("Invalid initialSoc/batteryCapacity of vehicle: " + getId());
 		}
 	}
@@ -74,7 +74,7 @@ public class ElectricVehicleSpecificationImpl implements ElectricVehicleSpecific
 	}
 
 	@Override
-	public double getInitialSoc() {
+	public double getInitialCharge() {
 		return (double)matsimVehicle.getAttributes().getAttribute(INITIAL_ENERGY_kWh) * EvUnits.J_PER_kWh;
 	}
 

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/routing/EvNetworkRoutingModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/routing/EvNetworkRoutingModule.java
@@ -185,18 +185,18 @@ public final class EvNetworkRoutingModule implements RoutingModule {
 				});
 		DriveEnergyConsumption driveEnergyConsumption = pseudoVehicle.getDriveEnergyConsumption();
 		AuxEnergyConsumption auxEnergyConsumption = pseudoVehicle.getAuxEnergyConsumption();
-		double lastSoc = pseudoVehicle.getBattery().getSoc();
+		double lastCharge = pseudoVehicle.getBattery().getCharge();
 		double linkEnterTime = basicLeg.getDepartureTime().seconds();
 		for (Link l : links) {
 			double travelT = travelTime.getLinkTravelTime(l, basicLeg.getDepartureTime().seconds(), null, null);
 
 			double consumption = driveEnergyConsumption.calcEnergyConsumption(l, travelT, linkEnterTime)
 					+ auxEnergyConsumption.calcEnergyConsumption(basicLeg.getDepartureTime().seconds(), travelT, l.getId());
-			pseudoVehicle.getBattery().changeSoc(-consumption);
-			double currentSoc = pseudoVehicle.getBattery().getSoc();
+			pseudoVehicle.getBattery().changeCharge(-consumption);
+			double currentCharge = pseudoVehicle.getBattery().getCharge();
 			// to accomodate for ERS, where energy charge is directly implemented in the consumption model
-			double consumptionDiff = (lastSoc - currentSoc);
-			lastSoc = currentSoc;
+			double consumptionDiff = (lastCharge - currentCharge);
+			lastCharge = currentCharge;
 			consumptions.put(l, consumptionDiff);
 			linkEnterTime += travelT;
 		}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/stats/ChargerPowerCollector.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/stats/ChargerPowerCollector.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.matsim.api.core.v01.Id;
 import org.matsim.contrib.ev.EvUnits;
 import org.matsim.contrib.ev.charging.ChargingEndEvent;
@@ -48,7 +47,11 @@ public class ChargerPowerCollector
 
 	private final ChargingInfrastructure chargingInfrastructure;
 	private final ElectricFleet fleet;
-	private final Map<Id<Vehicle>, ImmutablePair<Double, Double>> chargeBeginSoc = new HashMap<>();
+
+	private record TimeCharge(double time, double charge) {
+	}
+
+	private final Map<Id<Vehicle>, TimeCharge> chargeBeginCharge = new HashMap<>();
 
 	private final List<ChargingLogEntry> logList = new ArrayList<>();
 
@@ -60,11 +63,11 @@ public class ChargerPowerCollector
 
 	@Override
 	public void handleEvent(ChargingEndEvent event) {
-		ImmutablePair<Double, Double> chargeStart = chargeBeginSoc.remove(event.getVehicleId());
+		var chargeStart = chargeBeginCharge.remove(event.getVehicleId());
 		if (chargeStart != null) {
-			double energy = this.fleet.getElectricVehicles().get(event.getVehicleId()).getBattery().getSoc()
-					- chargeStart.getValue();
-			ChargingLogEntry loge = new ChargingLogEntry(chargeStart.getKey(), event.getTime(),
+			double energy = this.fleet.getElectricVehicles().get(event.getVehicleId()).getBattery().getCharge()
+					- chargeStart.charge;
+			ChargingLogEntry loge = new ChargingLogEntry(chargeStart.time, event.getTime(),
 					chargingInfrastructure.getChargers().get(event.getChargerId()), energy, event.getVehicleId());
 			logList.add(loge);
 		} else
@@ -75,8 +78,8 @@ public class ChargerPowerCollector
 	public void handleEvent(ChargingStartEvent event) {
 		ElectricVehicle ev = this.fleet.getElectricVehicles().get(event.getVehicleId());
 		if (ev != null) {
-			this.chargeBeginSoc.put(event.getVehicleId(),
-					new ImmutablePair<>(event.getTime(), ev.getBattery().getSoc()));
+			this.chargeBeginCharge.put(event.getVehicleId(),
+					new TimeCharge(event.getTime(), ev.getBattery().getCharge()));
 		} else
 			throw new NullPointerException(event.getVehicleId().toString() + " is not in list");
 

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/stats/EvStatsModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/stats/EvStatsModule.java
@@ -47,12 +47,12 @@ public class EvStatsModule extends AbstractModule {
 					addQSimComponentBinding(EvModule.EV_COMPONENT).toProvider(
 							SocHistogramTimeProfileCollectorProvider.class);
 					addQSimComponentBinding(EvModule.EV_COMPONENT).toProvider(
-							IndividualSocTimeProfileCollectorProvider.class);
+							IndividualChargeTimeProfileCollectorProvider.class);
 					addQSimComponentBinding(EvModule.EV_COMPONENT).toProvider(
 							ChargerOccupancyTimeProfileCollectorProvider.class);
 					addQSimComponentBinding(EvModule.EV_COMPONENT).toProvider(ChargerOccupancyXYDataProvider.class);
 					addQSimComponentBinding(EvModule.EV_COMPONENT).toProvider(
-							VehicleTypeAggregatedSocTimeProfileCollectorProvider.class);
+							VehicleTypeAggregatedChargeTimeProfileCollectorProvider.class);
 					addQSimComponentBinding(EvModule.EV_COMPONENT).to(EvMobsimListener.class);
 
 					bind(ChargerPowerCollector.class).asEagerSingleton();

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/stats/IndividualChargeTimeProfileCollectorProvider.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/stats/IndividualChargeTimeProfileCollectorProvider.java
@@ -19,68 +19,53 @@
 
 package org.matsim.contrib.ev.stats;
 
-import static java.util.stream.Collectors.*;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Collectors;
 
+import org.matsim.contrib.ev.EvUnits;
+import org.matsim.contrib.ev.fleet.ElectricFleet;
+import org.matsim.contrib.ev.fleet.ElectricVehicle;
 import org.matsim.contrib.common.timeprofile.TimeProfileCollector;
 import org.matsim.contrib.common.timeprofile.TimeProfileCollector.ProfileCalculator;
 import org.matsim.contrib.common.timeprofile.TimeProfiles;
-import org.matsim.contrib.ev.EvUnits;
-import org.matsim.contrib.ev.fleet.ElectricFleet;
 import org.matsim.core.controler.MatsimServices;
 import org.matsim.core.mobsim.framework.listeners.MobsimListener;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
-public class VehicleTypeAggregatedSocTimeProfileCollectorProvider implements Provider<MobsimListener> {
+public class IndividualChargeTimeProfileCollectorProvider implements Provider<MobsimListener> {
 	private final ElectricFleet evFleet;
 	private final MatsimServices matsimServices;
 
 	@Inject
-	public VehicleTypeAggregatedSocTimeProfileCollectorProvider(ElectricFleet evFleet, MatsimServices matsimServices) {
+	public IndividualChargeTimeProfileCollectorProvider(ElectricFleet evFleet, MatsimServices matsimServices) {
 		this.evFleet = evFleet;
 		this.matsimServices = matsimServices;
 	}
 
 	@Override
 	public MobsimListener get() {
-		ProfileCalculator calc = createIndividualSocCalculator(evFleet);
-		return new TimeProfileCollector(calc, 300, "average_soc_time_profiles", matsimServices);
+		ProfileCalculator calc = createIndividualChargeCalculator(evFleet);
+		return new TimeProfileCollector(calc, 300, "individual_charge_time_profiles", matsimServices);
 	}
 
-	private static final String ALL_VEHICLES_ID = "all vehicles";
+	private static final int MAX_VEHICLE_COLUMNS = 50;
 
-	public static ProfileCalculator createIndividualSocCalculator(final ElectricFleet evFleet) {
+	public static ProfileCalculator createIndividualChargeCalculator(final ElectricFleet evFleet) {
+		int columns = Math.min(evFleet.getElectricVehicles().size(), MAX_VEHICLE_COLUMNS);
+		List<ElectricVehicle> allEvs = new ArrayList<>(evFleet.getElectricVehicles().values());
+		List<ElectricVehicle> selectedEvs = allEvs.stream().limit(columns).toList();
 
-		Set<String> vehicleTypes = evFleet.getElectricVehicles()
-				.values()
-				.stream()
-				.map(ev -> ev.getVehicleSpecification().getMatsimVehicle().getType().getId() + "")
-				.collect(Collectors.toCollection(LinkedHashSet::new));
-		vehicleTypes.add(ALL_VEHICLES_ID);
-		ImmutableList<String> header = ImmutableList.copyOf(vehicleTypes);
-		return TimeProfiles.createProfileCalculator(header, () -> {
-			Map<String, Double> averageSocByType = evFleet.getElectricVehicles()
-					.values()
-					.stream()
-					.collect(groupingBy(ev -> ev.getVehicleSpecification().getMatsimVehicle().getType().getId() + "",
-							mapping(ev -> EvUnits.J_to_kWh(ev.getBattery().getSoc()), averagingDouble(soc -> soc))));
-			double averageSoc = evFleet.getElectricVehicles()
-					.values()
-					.stream()
-					.mapToDouble(ev -> EvUnits.J_to_kWh(ev.getBattery().getSoc()))
-					.average()
-					.getAsDouble();
-			averageSocByType.put(ALL_VEHICLES_ID, averageSoc);
-			return ImmutableMap.copyOf(averageSocByType);
-		});
+		ImmutableList<String> header = selectedEvs.stream().map(ev -> ev.getId() + "").collect(toImmutableList());
+
+		return TimeProfiles.createProfileCalculator(header, () -> selectedEvs.stream()
+				.collect(toImmutableMap(ev -> ev.getId() + "",
+						ev -> EvUnits.J_to_kWh(ev.getBattery().getCharge()))));/*in [kWh]*/
 	}
-
 }

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/stats/SocHistogramTimeProfileCollectorProvider.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/stats/SocHistogramTimeProfileCollectorProvider.java
@@ -74,7 +74,7 @@ public class SocHistogramTimeProfileCollectorProvider implements Provider<Mobsim
 		return TimeProfiles.createProfileCalculator(header, () -> {
 			UniformHistogram histogram = new UniformHistogram(0.1, header.size());
 			for (ElectricVehicle ev : evFleet.getElectricVehicles().values()) {
-				histogram.addValue(ev.getBattery().getSoc() / ev.getBattery().getCapacity());
+				histogram.addValue(ev.getBattery().getCharge() / ev.getBattery().getCapacity());
 			}
 
 			ImmutableMap.Builder<String, Double> builder = ImmutableMap.builder();

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/stats/VehicleTypeAggregatedChargeTimeProfileCollectorProvider.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/stats/VehicleTypeAggregatedChargeTimeProfileCollectorProvider.java
@@ -19,54 +19,68 @@
 
 package org.matsim.contrib.ev.stats;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.stream.Collectors.*;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.matsim.contrib.ev.EvUnits;
-import org.matsim.contrib.ev.fleet.ElectricFleet;
-import org.matsim.contrib.ev.fleet.ElectricVehicle;
 import org.matsim.contrib.common.timeprofile.TimeProfileCollector;
 import org.matsim.contrib.common.timeprofile.TimeProfileCollector.ProfileCalculator;
 import org.matsim.contrib.common.timeprofile.TimeProfiles;
+import org.matsim.contrib.ev.EvUnits;
+import org.matsim.contrib.ev.fleet.ElectricFleet;
 import org.matsim.core.controler.MatsimServices;
 import org.matsim.core.mobsim.framework.listeners.MobsimListener;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
-public class IndividualSocTimeProfileCollectorProvider implements Provider<MobsimListener> {
+public class VehicleTypeAggregatedChargeTimeProfileCollectorProvider implements Provider<MobsimListener> {
 	private final ElectricFleet evFleet;
 	private final MatsimServices matsimServices;
 
 	@Inject
-	public IndividualSocTimeProfileCollectorProvider(ElectricFleet evFleet, MatsimServices matsimServices) {
+	public VehicleTypeAggregatedChargeTimeProfileCollectorProvider(ElectricFleet evFleet, MatsimServices matsimServices) {
 		this.evFleet = evFleet;
 		this.matsimServices = matsimServices;
 	}
 
 	@Override
 	public MobsimListener get() {
-		ProfileCalculator calc = createIndividualSocCalculator(evFleet);
-		return new TimeProfileCollector(calc, 300, "individual_soc_time_profiles", matsimServices);
+		ProfileCalculator calc = createIndividualChargeCalculator(evFleet);
+		return new TimeProfileCollector(calc, 300, "average_charge_time_profiles", matsimServices);
 	}
 
-	private static final int MAX_VEHICLE_COLUMNS = 50;
+	private static final String ALL_VEHICLES_ID = "all vehicles";
 
-	public static ProfileCalculator createIndividualSocCalculator(final ElectricFleet evFleet) {
-		int columns = Math.min(evFleet.getElectricVehicles().size(), MAX_VEHICLE_COLUMNS);
-		List<ElectricVehicle> allEvs = new ArrayList<>(evFleet.getElectricVehicles().values());
-		List<ElectricVehicle> selectedEvs = allEvs.stream().limit(columns).collect(Collectors.toList());
+	public static ProfileCalculator createIndividualChargeCalculator(final ElectricFleet evFleet) {
 
-		ImmutableList<String> header = selectedEvs.stream().map(ev -> ev.getId() + "").collect(toImmutableList());
-
-		return TimeProfiles.createProfileCalculator(header, () -> selectedEvs.stream()
-				.collect(toImmutableMap(ev -> ev.getId() + "",
-						ev -> EvUnits.J_to_kWh(ev.getBattery().getSoc()))));/*in [kWh]*/
+		Set<String> vehicleTypes = evFleet.getElectricVehicles()
+				.values()
+				.stream()
+				.map(ev -> ev.getVehicleSpecification().getMatsimVehicle().getType().getId() + "")
+				.collect(Collectors.toCollection(LinkedHashSet::new));
+		vehicleTypes.add(ALL_VEHICLES_ID);
+		ImmutableList<String> header = ImmutableList.copyOf(vehicleTypes);
+		return TimeProfiles.createProfileCalculator(header, () -> {
+			Map<String, Double> averageSocByType = evFleet.getElectricVehicles()
+					.values()
+					.stream()
+					.collect(groupingBy(ev -> ev.getVehicleSpecification().getMatsimVehicle().getType().getId() + "",
+							mapping(ev -> EvUnits.J_to_kWh(ev.getBattery().getCharge()), averagingDouble(c -> c))));
+			double averageSoc = evFleet.getElectricVehicles()
+					.values()
+					.stream()
+					.mapToDouble(ev -> EvUnits.J_to_kWh(ev.getBattery().getCharge()))
+					.average()
+					.getAsDouble();
+			averageSocByType.put(ALL_VEHICLES_ID, averageSoc);
+			return ImmutableMap.copyOf(averageSocByType);
+		});
 	}
 
 }

--- a/contribs/ev/src/test/java/org/matsim/contrib/ev/charging/FastThenSlowChargingTest.java
+++ b/contribs/ev/src/test/java/org/matsim/contrib/ev/charging/FastThenSlowChargingTest.java
@@ -67,10 +67,10 @@ public class FastThenSlowChargingTest {
 		assertCalcChargingPower(100, 100, 40, 40);
 	}
 
-	private void assertCalcChargingPower(double capacity_kWh, double soc_kWh, double chargerPower_kW,
+	private void assertCalcChargingPower(double capacity_kWh, double charge_kWh, double chargerPower_kW,
 			double expectedChargingPower_kW) {
 		ChargerSpecification charger = createCharger(chargerPower_kW);
-		ElectricVehicle electricVehicle = createElectricVehicle(capacity_kWh, soc_kWh);
+		ElectricVehicle electricVehicle = createElectricVehicle(capacity_kWh, charge_kWh);
 		Assertions.assertThat(electricVehicle.getChargingPower().calcChargingPower(charger))
 				.isCloseTo(EvUnits.kW_to_W(expectedChargingPower_kW), Percentage.withPercentage(1e-13));
 	}
@@ -130,13 +130,13 @@ public class FastThenSlowChargingTest {
 				.hasMessageStartingWith("Energy is negative: ");
 		Assertions.assertThatThrownBy(() -> assertCalcChargingTime(100, 90, 11, 200, 2 * 360))
 				.isExactlyInstanceOf(IllegalArgumentException.class)
-				.hasMessageStartingWith("End SOC greater than battery capacity: ");
+				.hasMessageStartingWith("End charge greater than battery capacity: ");
 	}
 
-	private void assertCalcChargingTime(double capacity_kWh, double soc_kWh, double energy_kWh, double chargerPower_kW,
+	private void assertCalcChargingTime(double capacity_kWh, double charge_kWh, double energy_kWh, double chargerPower_kW,
 			double expectedChargingTime_s) {
 		ChargerSpecification charger = createCharger(chargerPower_kW);
-		ElectricVehicle electricVehicle = createElectricVehicle(capacity_kWh, soc_kWh);
+		ElectricVehicle electricVehicle = createElectricVehicle(capacity_kWh, charge_kWh);
 		Assertions.assertThat(((FastThenSlowCharging)electricVehicle.getChargingPower()).calcChargingTime(charger,
 				EvUnits.kWh_to_J(energy_kWh))).isCloseTo(expectedChargingTime_s, Percentage.withPercentage(1e-13));
 	}
@@ -151,14 +151,14 @@ public class FastThenSlowChargingTest {
 				.build();
 	}
 
-	private ElectricVehicle createElectricVehicle(double capacity_kWh, double soc_kWh) {
+	private ElectricVehicle createElectricVehicle(double capacity_kWh, double charge_kWh) {
 		// this record is a bit hacky implementation of ElectricVehicleSpecification just meant for tests
 		record TestEvSpecification(Id<Vehicle> getId, Vehicle getMatsimVehicle, String getVehicleType,
 								   ImmutableList<String> getChargerTypes, double getBatteryCapacity,
 								   double getInitialSoc) implements ElectricVehicleSpecification {
 		}
 		var specification = new TestEvSpecification(Id.create("ev_id", Vehicle.class), null, "vt",
-				ImmutableList.of("ct"), EvUnits.kWh_to_J(capacity_kWh), EvUnits.kWh_to_J(soc_kWh));
+				ImmutableList.of("ct"), EvUnits.kWh_to_J(capacity_kWh), EvUnits.kWh_to_J(charge_kWh));
 
 		return ElectricVehicleImpl.create(specification, ev -> (link, travelTime, linkEnterTime) -> {
 			throw new UnsupportedOperationException();
@@ -176,10 +176,10 @@ public class FastThenSlowChargingTest {
 		assertCalcEnergyCharge(100, 0, 200, 10, 1750000);
 	}
 
-	private void assertCalcEnergyCharge(double capacity_kWh, double soc_kWh, double chargerPower_kW,
+	private void assertCalcEnergyCharge(double capacity_kWh, double charge_kWh, double chargerPower_kW,
 			double chargingPeriod, double expectedEnergy) {
 		ChargerSpecification charger = createCharger(chargerPower_kW);
-		ElectricVehicle electricVehicle = createElectricVehicle(capacity_kWh, soc_kWh);
+		ElectricVehicle electricVehicle = createElectricVehicle(capacity_kWh, charge_kWh);
 		double energy = ((FastThenSlowCharging)electricVehicle.getChargingPower()).calcEnergyCharged(charger,
 				chargingPeriod);
 		Assertions.assertThat(energy).isCloseTo(expectedEnergy, Percentage.withPercentage(1e-13));
@@ -200,10 +200,10 @@ public class FastThenSlowChargingTest {
 		assertEnergyAndDurationCalcCompliance(100, 0, 200, 3000);
 	}
 
-	private void assertEnergyAndDurationCalcCompliance(double capacity_kWh, double soc_kWh, double chargerPower_kW,
+	private void assertEnergyAndDurationCalcCompliance(double capacity_kWh, double charge_kWh, double chargerPower_kW,
 			double chargingPeriod) {
 		ChargerSpecification charger = createCharger(chargerPower_kW);
-		ElectricVehicle electricVehicle = createElectricVehicle(capacity_kWh, soc_kWh);
+		ElectricVehicle electricVehicle = createElectricVehicle(capacity_kWh, charge_kWh);
 		double energyCharged_J = ((FastThenSlowCharging)electricVehicle.getChargingPower()).calcEnergyCharged(charger,
 				chargingPeriod);
 		double chargingTime = ((FastThenSlowCharging)electricVehicle.getChargingPower()).calcChargingTime(charger,

--- a/contribs/ev/src/test/java/org/matsim/contrib/ev/charging/FastThenSlowChargingTest.java
+++ b/contribs/ev/src/test/java/org/matsim/contrib/ev/charging/FastThenSlowChargingTest.java
@@ -133,8 +133,8 @@ public class FastThenSlowChargingTest {
 				.hasMessageStartingWith("End charge greater than battery capacity: ");
 	}
 
-	private void assertCalcChargingTime(double capacity_kWh, double charge_kWh, double energy_kWh, double chargerPower_kW,
-			double expectedChargingTime_s) {
+	private void assertCalcChargingTime(double capacity_kWh, double charge_kWh, double energy_kWh,
+			double chargerPower_kW, double expectedChargingTime_s) {
 		ChargerSpecification charger = createCharger(chargerPower_kW);
 		ElectricVehicle electricVehicle = createElectricVehicle(capacity_kWh, charge_kWh);
 		Assertions.assertThat(((FastThenSlowCharging)electricVehicle.getChargingPower()).calcChargingTime(charger,
@@ -155,7 +155,7 @@ public class FastThenSlowChargingTest {
 		// this record is a bit hacky implementation of ElectricVehicleSpecification just meant for tests
 		record TestEvSpecification(Id<Vehicle> getId, Vehicle getMatsimVehicle, String getVehicleType,
 								   ImmutableList<String> getChargerTypes, double getBatteryCapacity,
-								   double getInitialSoc) implements ElectricVehicleSpecification {
+								   double getInitialCharge) implements ElectricVehicleSpecification {
 		}
 		var specification = new TestEvSpecification(Id.create("ev_id", Vehicle.class), null, "vt",
 				ImmutableList.of("ct"), EvUnits.kWh_to_J(capacity_kWh), EvUnits.kWh_to_J(charge_kWh));

--- a/contribs/ev/src/test/java/org/matsim/contrib/ev/charging/VariableSpeedChargingTest.java
+++ b/contribs/ev/src/test/java/org/matsim/contrib/ev/charging/VariableSpeedChargingTest.java
@@ -79,7 +79,7 @@ public class VariableSpeedChargingTest {
 		assertCalcChargingPower(100, 100, 50, 5);
 	}
 
-	private void assertCalcChargingPower(double capacity_kWh, double soc_kWh, double chargerPower_kW,
+	private void assertCalcChargingPower(double capacity_kWh, double charge_kWh, double chargerPower_kW,
 			double expectedChargingPower_kW) {
 		// this record is a bit hacky implementation of ElectricVehicleSpecification just meant for tests
 		record TestEvSpecification(Id<Vehicle> getId, Vehicle getMatsimVehicle,
@@ -88,7 +88,7 @@ public class VariableSpeedChargingTest {
 				implements ElectricVehicleSpecification {
 		}
 		var specification = new TestEvSpecification(Id.create("ev_id", Vehicle.class), null,
-				"vt", ImmutableList.of("ct"), EvUnits.kWh_to_J(capacity_kWh), EvUnits.kWh_to_J(soc_kWh));
+				"vt", ImmutableList.of("ct"), EvUnits.kWh_to_J(capacity_kWh), EvUnits.kWh_to_J(charge_kWh));
 
 		var charger = ImmutableChargerSpecification.newBuilder()
 				.id(Id.create("charger_id", Charger.class))

--- a/contribs/ev/src/test/java/org/matsim/contrib/ev/charging/VariableSpeedChargingTest.java
+++ b/contribs/ev/src/test/java/org/matsim/contrib/ev/charging/VariableSpeedChargingTest.java
@@ -25,7 +25,6 @@ import org.assertj.core.data.Percentage;
 import org.junit.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.contrib.ev.EvUnits;
-import org.matsim.contrib.ev.fleet.ElectricVehicle;
 import org.matsim.contrib.ev.fleet.ElectricVehicleImpl;
 import org.matsim.contrib.ev.fleet.ElectricVehicleSpecification;
 import org.matsim.contrib.ev.infrastructure.Charger;
@@ -82,13 +81,12 @@ public class VariableSpeedChargingTest {
 	private void assertCalcChargingPower(double capacity_kWh, double charge_kWh, double chargerPower_kW,
 			double expectedChargingPower_kW) {
 		// this record is a bit hacky implementation of ElectricVehicleSpecification just meant for tests
-		record TestEvSpecification(Id<Vehicle> getId, Vehicle getMatsimVehicle,
-								   String getVehicleType, ImmutableList<String> getChargerTypes,
-								   double getBatteryCapacity, double getInitialSoc)
-				implements ElectricVehicleSpecification {
+		record TestEvSpecification(Id<Vehicle> getId, Vehicle getMatsimVehicle, String getVehicleType,
+								   ImmutableList<String> getChargerTypes, double getBatteryCapacity,
+								   double getInitialCharge) implements ElectricVehicleSpecification {
 		}
-		var specification = new TestEvSpecification(Id.create("ev_id", Vehicle.class), null,
-				"vt", ImmutableList.of("ct"), EvUnits.kWh_to_J(capacity_kWh), EvUnits.kWh_to_J(charge_kWh));
+		var specification = new TestEvSpecification(Id.create("ev_id", Vehicle.class), null, "vt",
+				ImmutableList.of("ct"), EvUnits.kWh_to_J(capacity_kWh), EvUnits.kWh_to_J(charge_kWh));
 
 		var charger = ImmutableChargerSpecification.newBuilder()
 				.id(Id.create("charger_id", Charger.class))

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/assignment/AssignmentETaxiOptimizer.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/assignment/AssignmentETaxiOptimizer.java
@@ -197,11 +197,11 @@ public class AssignmentETaxiOptimizer extends DefaultTaxiOptimizer {
 		return new VehicleData(timer.getTimeOfDay(), eScheduler.getScheduleInquiry(), leastChargedVehicles.stream());
 	}
 
-	// TODO MIN_RELATIVE_SOC should depend on %idle
+	// TODO MIN_SOC should depend on %idle
 	private boolean isChargingSchedulable(EvDvrpVehicle eTaxi, TaxiScheduleInquiry scheduleInquiry,
 			double maxDepartureTime) {
 		Battery b = eTaxi.getElectricVehicle().getBattery();
-		boolean undercharged = b.getCharge() < params.minRelativeSoc * b.getCapacity();
+		boolean undercharged = b.getCharge() < params.minSoc * b.getCapacity();
 		if (!undercharged || !scheduledForCharging.containsKey(eTaxi.getId())) {
 			return false;// not needed or already planned
 		}

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/assignment/AssignmentETaxiOptimizer.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/assignment/AssignmentETaxiOptimizer.java
@@ -192,7 +192,7 @@ public class AssignmentETaxiOptimizer extends DefaultTaxiOptimizer {
 		// assumption: all b.capacities are equal
 		List<DvrpVehicle> leastChargedVehicles = PartialSort.kSmallestElements(pData.getSize(),
 				vehiclesBelowMinSocLevel,
-				Comparator.comparingDouble(v -> ((EvDvrpVehicle)v).getElectricVehicle().getBattery().getSoc()));
+				Comparator.comparingDouble(v -> ((EvDvrpVehicle)v).getElectricVehicle().getBattery().getCharge()));
 
 		return new VehicleData(timer.getTimeOfDay(), eScheduler.getScheduleInquiry(), leastChargedVehicles.stream());
 	}
@@ -201,7 +201,7 @@ public class AssignmentETaxiOptimizer extends DefaultTaxiOptimizer {
 	private boolean isChargingSchedulable(EvDvrpVehicle eTaxi, TaxiScheduleInquiry scheduleInquiry,
 			double maxDepartureTime) {
 		Battery b = eTaxi.getElectricVehicle().getBattery();
-		boolean undercharged = b.getSoc() < params.minRelativeSoc * b.getCapacity();
+		boolean undercharged = b.getCharge() < params.minRelativeSoc * b.getCapacity();
 		if (!undercharged || !scheduledForCharging.containsKey(eTaxi.getId())) {
 			return false;// not needed or already planned
 		}

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/assignment/AssignmentETaxiOptimizerParams.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/assignment/AssignmentETaxiOptimizerParams.java
@@ -38,7 +38,7 @@ public final class AssignmentETaxiOptimizerParams extends AbstractTaxiOptimizerP
 	// (for approx. 20 km => 3kWh) with 3 kW-heating on
 	@Positive
 	@DecimalMax("1.0")
-	public double minRelativeSoc = 0.3;
+	public double minSoc = 0.3;
 
 	@Parameter
 	@Comment("Specifies how often idle vehicles are checked if they have become"

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/rules/RuleBasedETaxiOptimizer.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/rules/RuleBasedETaxiOptimizer.java
@@ -94,6 +94,6 @@ public class RuleBasedETaxiOptimizer extends RuleBasedTaxiOptimizer {
 
 	private boolean isUndercharged(EvDvrpVehicle v) {
 		Battery b = v.getElectricVehicle().getBattery();
-		return b.getSoc() < params.minRelativeSoc * b.getCapacity();
+		return b.getCharge() < params.minRelativeSoc * b.getCapacity();
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/rules/RuleBasedETaxiOptimizer.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/rules/RuleBasedETaxiOptimizer.java
@@ -42,7 +42,7 @@ import org.matsim.core.mobsim.framework.events.MobsimBeforeSimStepEvent;
 
 public class RuleBasedETaxiOptimizer extends RuleBasedTaxiOptimizer {
 
-	// TODO MIN_RELATIVE_SOC should depend on the weather and time of day
+	// TODO MIN_SOC should depend on the weather and time of day
 	private final RuleBasedETaxiOptimizerParams params;
 	private final ChargingInfrastructure chargingInfrastructure;
 	private final BestChargerFinder eDispatchFinder;
@@ -94,6 +94,6 @@ public class RuleBasedETaxiOptimizer extends RuleBasedTaxiOptimizer {
 
 	private boolean isUndercharged(EvDvrpVehicle v) {
 		Battery b = v.getElectricVehicle().getBattery();
-		return b.getCharge() < params.minRelativeSoc * b.getCapacity();
+		return b.getCharge() < params.minSoc * b.getCapacity();
 	}
 }

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/rules/RuleBasedETaxiOptimizerParams.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/rules/RuleBasedETaxiOptimizerParams.java
@@ -38,7 +38,7 @@ public final class RuleBasedETaxiOptimizerParams extends AbstractTaxiOptimizerPa
 	// (for approx. 20 km => 3kWh) with 3 kW-heating on
 	@Positive
 	@DecimalMax("1.0")
-	public double minRelativeSoc = 0.3;
+	public double minSoc = 0.3;
 
 	@Parameter
 	@Comment("Specifies how often idle vehicles are checked if they have become"

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/RunETaxiBenchmark.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/RunETaxiBenchmark.java
@@ -68,7 +68,7 @@ import org.matsim.core.scenario.ScenarioUtils;
  */
 public class RunETaxiBenchmark {
 	private static final double CHARGING_SPEED_FACTOR = 1.5; // > 1 in this example
-	private static final double MAX_RELATIVE_SOC = 0.8; // charge up to 80% SOC
+	private static final double MAX_SOC = 0.8; // charge up to 80% SOC
 	private static final double TEMPERATURE = 20; // oC
 
 	public static void run(URL configUrl, int runs) {
@@ -114,7 +114,7 @@ public class RunETaxiBenchmark {
 			@Override
 			public void install() {
 				bind(ChargingLogic.Factory.class).toProvider(new ChargingWithQueueingAndAssignmentLogic.FactoryProvider(
-						charger -> new ChargeUpToMaxSocStrategy(charger, MAX_RELATIVE_SOC)));
+						charger -> new ChargeUpToMaxSocStrategy(charger, MAX_SOC)));
 				//TODO switch to VariableSpeedCharging for Nissan
 				bind(ChargingPower.Factory.class).toInstance(ev -> new FixedSpeedCharging(ev, CHARGING_SPEED_FACTOR));
 				bind(TemperatureService.class).toInstance(linkId -> TEMPERATURE);

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/RunETaxiScenario.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/RunETaxiScenario.java
@@ -54,7 +54,7 @@ import org.matsim.vis.otfvis.OTFVisConfigGroup;
 
 public class RunETaxiScenario {
 	private static final double CHARGING_SPEED_FACTOR = 1.5; // > 1 in this example
-	private static final double MAX_RELATIVE_SOC = 0.8; // charge up to 80% SOC
+	private static final double MAX_SOC = 0.8; // charge up to 80% SOC
 	private static final double TEMPERATURE = 20; // oC
 
 	public static void run(URL configUrl, boolean otfvis) {
@@ -95,7 +95,7 @@ public class RunETaxiScenario {
 			@Override
 			public void install() {
 				bind(ChargingLogic.Factory.class).toProvider(new ChargingWithQueueingAndAssignmentLogic.FactoryProvider(
-						charger -> new ChargeUpToMaxSocStrategy(charger, MAX_RELATIVE_SOC)));
+						charger -> new ChargeUpToMaxSocStrategy(charger, MAX_SOC)));
 				//TODO switch to VariableSpeedCharging for Nissan
 				bind(ChargingPower.Factory.class).toInstance(ev -> new FixedSpeedCharging(ev, CHARGING_SPEED_FACTOR));
 				bind(TemperatureService.class).toInstance(linkId -> TEMPERATURE);

--- a/contribs/vsp/src/main/java/playground/vsp/ev/UrbanEVTripsPlanner.java
+++ b/contribs/vsp/src/main/java/playground/vsp/ev/UrbanEVTripsPlanner.java
@@ -273,7 +273,7 @@ class UrbanEVTripsPlanner implements MobsimInitializedListener {
 
 				do {
 					double newSoC = EVUtils.getInitialEnergy(vehicles.getVehicles().get(ev)) * EvUnits.J_PER_kWh;
-					pseudoVehicle.getBattery().setSoc(newSoC);
+					pseudoVehicle.getBattery().setCharge(newSoC);
 					double capacityThreshold = pseudoVehicle.getBattery().getCapacity()
 							* (configGroup.getCriticalRelativeSOC());
 					legWithCriticalSOC = getCriticalOrLastEvLeg(modifiablePlan, pseudoVehicle, ev);
@@ -299,7 +299,7 @@ class UrbanEVTripsPlanner implements MobsimInitializedListener {
 							break;
 						} else if (evLegs.get(evLegs.size() - 1).equals(legWithCriticalSOC)
 								&& isHomeChargingTrip(mobsimagent, modifiablePlan, evLegs, pseudoVehicle)
-								&& pseudoVehicle.getBattery().getSoc() > 0) {
+								&& pseudoVehicle.getBattery().getCharge() > 0) {
 							//trip leads to location of the first (ev-leg-preceding-) activity in the plan and there is a charger and so we can charge at home do not search for opportunity charge before
 							//if SoC == 0, we should search for an earlier charge
 
@@ -322,7 +322,7 @@ class UrbanEVTripsPlanner implements MobsimInitializedListener {
 							break;
 
 						} else if (evLegs.get(evLegs.size() - 1).equals(legWithCriticalSOC)
-								&& pseudoVehicle.getBattery().getSoc() > capacityThreshold) {
+								&& pseudoVehicle.getBattery().getCharge() > capacityThreshold) {
 							//critical leg is the last of the day but energy is above the threshold
 							//TODO: plan for the next day! that means, check at least if the first leg can be done!
 							cnt = 0;
@@ -388,7 +388,7 @@ class UrbanEVTripsPlanner implements MobsimInitializedListener {
 						leg.getMode()).equals(originalVehicleId)) {
 					lastLegWithVehicle = leg;
 					emulateVehicleDischarging(pseudoVehicle, leg);
-					if (pseudoVehicle.getBattery().getSoc() <= capacityThreshold) {
+					if (pseudoVehicle.getBattery().getCharge() <= capacityThreshold) {
 						return leg;
 					}
 				}
@@ -416,7 +416,7 @@ class UrbanEVTripsPlanner implements MobsimInitializedListener {
 							.orElseThrow();
 
 					pseudoVehicle.getBattery()
-							.changeSoc(pseudoVehicle.getChargingPower().calcChargingPower(chargerSpecification)
+							.changeCharge(pseudoVehicle.getChargingPower().calcChargingPower(chargerSpecification)
 									* chargingDuration);
 				}
 			} else
@@ -717,7 +717,7 @@ class UrbanEVTripsPlanner implements MobsimInitializedListener {
 			//			double consumption = driveEnergyConsumption.calcEnergyConsumption(l, travelT, linkEnterTime)
 			//					+ auxEnergyConsumption.calcEnergyConsumption(leg.getDepartureTime().seconds(), travelT, l.getId());
 			double consumption = driveConsumption + auxConsumption;
-			ev.getBattery().changeSoc(-consumption);
+			ev.getBattery().changeCharge(-consumption);
 			linkEnterTime += travelT;
 		}
 	}

--- a/examples/scenarios/dvrp-grid/one_etaxi_benchmark_config.xml
+++ b/examples/scenarios/dvrp-grid/one_etaxi_benchmark_config.xml
@@ -21,7 +21,7 @@
 			<parameterset type="RuleBasedETaxiOptimizer">
 				<parameterset type="RuleBasedTaxiOptimizer"/>
 
-				<param name="minRelativeSoc" value="0.7"/>
+				<param name="minSoc" value="0.7"/>
 				<param name="socCheckTimeStep" value="60"/>
 			</parameterset>
 		</parameterset>

--- a/examples/scenarios/dvrp-grid/one_etaxi_config.xml
+++ b/examples/scenarios/dvrp-grid/one_etaxi_config.xml
@@ -17,7 +17,7 @@
 			<parameterset type="RuleBasedETaxiOptimizer">
 				<parameterset type="RuleBasedTaxiOptimizer"/>
 
-				<param name="minRelativeSoc" value="0.7"/>
+				<param name="minSoc" value="0.7"/>
 				<param name="socCheckTimeStep" value="60"/>
 			</parameterset>
 		</parameterset>

--- a/examples/scenarios/mielec/mielec_etaxi_benchmark_config.xml
+++ b/examples/scenarios/mielec/mielec_etaxi_benchmark_config.xml
@@ -18,7 +18,7 @@
 			<parameterset type="RuleBasedETaxiOptimizer">
 				<parameterset type="RuleBasedTaxiOptimizer"/>
 
-				<param name="minRelativeSoc" value="0.3"/>
+				<param name="minSoc" value="0.3"/>
 				<param name="socCheckTimeStep" value="60"/>
 			</parameterset>
 		</parameterset>

--- a/examples/scenarios/mielec/mielec_etaxi_config.xml
+++ b/examples/scenarios/mielec/mielec_etaxi_config.xml
@@ -18,7 +18,7 @@
 			<parameterset type="RuleBasedETaxiOptimizer">
 				<parameterset type="RuleBasedTaxiOptimizer"/>
 
-				<param name="minRelativeSoc" value="0.3"/>
+				<param name="minSoc" value="0.3"/>
 				<param name="socCheckTimeStep" value="60"/>
 			</parameterset>
 		</parameterset>

--- a/examples/scenarios/mielec/mielec_etaxi_config_assignment.xml
+++ b/examples/scenarios/mielec/mielec_etaxi_config_assignment.xml
@@ -25,7 +25,7 @@
 					<param name="nearestVehiclesLimit" value="99"/>
 				</parameterset>
 
-				<param name="minRelativeSoc" value="0.5"/>
+				<param name="minSoc" value="0.5"/>
 				<param name="socCheckTimeStep" value="60"/>
 			</parameterset>
 		</parameterset>


### PR DESCRIPTION
As discussed in #2222, the current naming scheme is confusing. This PR does the following renamings:
- `soc` -> `charge` (Joules)
- `relativeSoc` -> `soc` (0..1)

This impacts not only changes of variables, methods etc. We also have the two following changes that are visible from outside the code:
- two files with the battery charge stats are renamed ("average_soc_time_profiles" to "average_charge_time_profiles" and "individual_soc_time_profiles" to "individual_charge_time_profiles")
- a parameter in two e-taxi optimizer parameter sets is renamed from `minRelativeSoc` to `minSoc` (in `AssignmentETaxiOptimizerParams` and `RuleBasedETaxiOptimizerParams`)