### PR TITLE
Freight: Make CarrierControlerListener public

### DIFF
--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/CarrierControlerListener.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/CarrierControlerListener.java
@@ -49,9 +49,15 @@ import javax.inject.Inject;
  * to set custom scoring- and replanning-functionalities.
  *
  * @author sschroeder, mzilske
+ *
+ * // not sure if this _should_ be public, but current LSP design makes this necessary.  kai, sep'20
  */
 
-class CarrierControlerListener implements ScoringListener, ReplanningListener {
+public class CarrierControlerListener implements ScoringListener, ReplanningListener {
+	// not sure if this _should_ be public, but current LSP design makes this necessary.
+	// It is done analogue to CarrierAgentTracker. kmt oct'22
+
+
 	private static final Logger log = LogManager.getLogger( CarrierControlerListener.class ) ;
 
 	private final CarrierStrategyManager strategyManager;


### PR DESCRIPTION
I need the `CarrierControlerListener` in the logistics project (upcoming contrib) and the current `LSP` design makes this necessary. (see https://github.com/matsim-vsp/logistics/pull/51)

Background: The `LSP` should take the scores of its `Carrier`(s) to generate its own (consistent) score. Therefore the carriers need to get scored. This is currently triggered by the `CarrierControlerListener,` which I now added to the `LSPModule.` To do that, it needs to be public :( 