### PR TITLE
Fix wrong iteration handling for MATSimApplication

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/MATSimApplication.java
+++ b/contribs/application/src/main/java/org/matsim/application/MATSimApplication.java
@@ -177,7 +177,7 @@ public abstract class MATSimApplication implements Callable<Integer>, CommandLin
 		}
 
 		if (iterations > -1)
-			config.controler().setLastIteration(iterations - 1);
+			config.controler().setLastIteration(iterations);
 
 		if (output != null)
 			config.controler().setOutputDirectory(output.toString());


### PR DESCRIPTION
This PR fixes a wrong handling of the iterations argument of a MATSimApplication. Without this fix and a given iterations argument, there would be always one iteration too less.