### PR TITLE
ev: clearing up inconsistencies

### DIFF
--- a/contribs/vsp/src/main/java/playground/vsp/ev/README.md
+++ b/contribs/vsp/src/main/java/playground/vsp/ev/README.md
@@ -1,9 +1,9 @@
-#UrbanEV
+# UrbanEV
 This package represents an ongoing project on modeling charging behavior for private motorized transport in urban environments.
 The code is in experimental state.
-Please refer to VSP (Tilmann Schlenther) for any question.
+Please refer to VSP (Tilmann Schlenther, @tschlenter or Michal Maciejewski, @michalmac) for any questions.
 
-##Description of the model
+## Description of the model
 The model lets agents plan their charging in advance, meaning that they do not show reactive behavior to the SoC over the course of the day.
 At the beginning of the qsim (after the official replanning phase), all selected plans are processed. For each selected plan that contains legs of a network mode using an EV,
 the energy consumption is estimated. If, during leg _Y_, the estimated SoC falls under a configurable threshold, the agent tries to incorporate charging into it's plan, prior to _Y_.<br>
@@ -18,19 +18,26 @@ If an agent estimates to run beyond the energy threshold on it's way back home (
 and if there is a charger on the home link, it does not search for a suitable activity prior to this leg but just plugs in the EV at home.<br>
 The final SoC at the end of the iteration is maintained and transferred as the initial SoC to the next iteration. 
 
-For this to work, vehicles that represent an EV need to be attached to a vehicle type that is tagged as EV by providing a specific attribute (see *MATSimVehicleWrappingEVSpecificationProvider.class*).
+For this to work, vehicles that represent an EV need to be attached to a vehicle type that is tagged as EV by providing a specific attribute (see `MATSimVehicleWrappingEVSpecificationProvider.class`).
 
-##A few notes to the current state of this package (and it's issues and TODOs)
-1. The code generally was tested only with the Open Berlin Scenario v5.5.x 
-1. The initial SoC (as well as other important attributes) is read/written from/to the vehicle _type_ instead of the (single) vehicle. This is, because the corresponding code was written before MATSim-PR1605. So, the code could use adoption to PR1605. Now, if you want to have individual initial SoCs, you need to have one vehicle type for each person/value.
-1. With MATSim-PR-2120, the functionality to transfer the final SoC of an EV to the next iteration (as initial SoC) was centralized into the ev contrib. So the corresponding infrastructure should be removed from here. This can easily be addressed in conjunction with the previous point. After that, the UrbanEVConfigGroup should/could require corresponding settings (EVConfigGroup.getTransferFinalSoCToNextIteration()).    
+## A few notes to the current state of this package (and it's issues and TODOs)
+
+- The code generally was tested only with the Open Berlin Scenario v5.5.x ]
+- The official EV specification is the one coming from the matsim-vehicle, similar to the `ev` contrib. (MATSim-PR2218, Oct '22) 
+- The initial SoC (as well as other important attributes) is read/written from/to the vehicle _type_ instead of the (single) vehicle. This is, because the corresponding code was written before MATSim-PR1605. So, the code could use adoption to PR1605. Now, if you want to have individual initial SoCs, you need to have one vehicle type for each person/value.
+- With MATSim-PR2120, the functionality to transfer the final SoC of an EV to the next iteration (as initial SoC) was centralized into the `ev` contrib. So the corresponding infrastructure should be removed from here. This can easily be addressed in conjunction with the previous point. After that, the `UrbanEVConfigGroup` should/could require corresponding settings (`EVConfigGroup.getTransferFinalSoCToNextIteration()`). 
+
+### Overnight/home charging
 1. Overnight charging currently only takes place on the overnight (home) activity. Instead, nearby chargers should be considered.
-1. The first leg of the next day is not considered in the planning of the charging. So, if no home charger is available, a vehicle might run out of energy during it's first trip of the next day.
+1. Overnight charging should be modelled with a custom `VehicleChargingHandler` that observes vehicles still charging at the end of iteration x and adds them to the charging logic in the first time step of the next iteration - instead of incorporating an additional (plug-in) trip in the person's plan (in the `UrbanEVTripsPlanner`), one could still have a plug-out trip.
+1. The first leg of the next day is not considered in the planning of the charging. So, if no home charger is available, a vehicle might run out of energy during it's first trip of the next day (this may change if the model instead assumes that every EV owner also owns a home charger).
 1. Related to the last point: If a vehicle (is expected to) runs out of energy during it's first leg of the day, this can not be prevented at the moment.
-While the UrbanEVTripsPlanner actually is equipped to detect that and to plan charging from the beginning of the day/qsim, in case there is a home charger, this is strangely not reflected in the qsim. Meaning,
+While the `UrbanEVTripsPlanner` actually is equipped to detect that and to plan charging from the beginning of the day/qsim, in case there is a home charger, this is strangely not reflected in the qsim. Meaning,
    the planner builds in an additional 0m trip to and from the home charger at the beginning of the qsim, but the plugin activity is never executed in the qsim. This seems like a fixeable bug, but currently persists in the code. (July 2022)
 1. The code has not been heavily tested with 'open plans and/or subtours'. This means plans where people do not return to their first activity of the day. There might evolve artefacts when simulating such plans. There is one test that checks whether the build-in of home charging respects the mass conservation logic, which it does.
-   That means, home charging only takes place if destination of the last ev leg is equal (same link id) as origin of the first ev leg. Having said this, open subtours/plans should hopefully not cause major problems. But it should be investigated again.
-1. if an agent does not find a possibility to charge prior to a leg for which the SoC is to fall under the threshold but stay over 0, it will not explore whether it would be possible to charge _after_ the critical leg (i.e. after the threshold is crossed).
+   That means, home charging only takes place if destination of the last ev-leg is equal (same link id) as origin of the first ev leg. Having said this, open subtours/plans should hopefully not cause major problems. But it should be investigated again.
+   
+### Critical leg
+1. If an agent does not find a possibility to charge prior to a leg for which the SoC is to fall under the threshold but stay over 0, it will not explore whether it would be possible to charge _after_ the critical leg (i.e. after the threshold is crossed).
 
    


### PR DESCRIPTION
Clearing up inconsistencies/new features between the urban ev (vsp) model and the ev contrib.