### PR TITLE
core: fix PseudoTransitRoutingModuleTest failing on AppVeyor

### DIFF
--- a/matsim/src/test/java/org/matsim/core/router/PseudoTransitRoutingModuleTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/PseudoTransitRoutingModuleTest.java
@@ -22,6 +22,7 @@ package org.matsim.core.router;
 import java.util.List;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
@@ -51,11 +52,14 @@ import org.matsim.core.scenario.ScenarioByInstanceModule;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.facilities.FacilitiesUtils;
 import org.matsim.facilities.Facility;
+import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.utils.objectattributes.attributable.Attributes;
 
 public class PseudoTransitRoutingModuleTest {
 
-	@SuppressWarnings("static-method")
+	@Rule
+	public MatsimTestUtils utils = new MatsimTestUtils();
+
 	@Test
 	public void testRouteLeg() {
 		final Fixture f = new Fixture();
@@ -100,6 +104,7 @@ public class PseudoTransitRoutingModuleTest {
 			params.setBeelineDistanceFactor(1.);
 			params.setTeleportedModeFreespeedLimit(5.);
 			f.s.getConfig().plansCalcRoute().addModeRoutingParams(params);
+			f.s.getConfig().controler().setOutputDirectory(utils.getOutputDirectory());
 			
 			com.google.inject.Injector injector = Injector.createInjector(f.s.getConfig(), new AbstractModule() {
 				@Override public void install() {


### PR DESCRIPTION
Hopefully, the last fix as this is green on a non-master branch: https://ci.appveyor.com/project/michalmac/matsim-libs/builds/45315314