### PR TITLE
Allow for changing parameter values in all parameter sets from command line

### DIFF
--- a/matsim/src/main/java/org/matsim/core/config/CommandLine.java
+++ b/matsim/src/main/java/org/matsim/core/config/CommandLine.java
@@ -110,6 +110,8 @@ import org.matsim.core.config.groups.PlanCalcScoreConfigGroup.ScoringParameterSe
  * <li><code>--config:MODULE.SET_TYPE[ID_PARAM=ID_VALUE].PARAM VALUE</code> sets
  * a value in a specific parameter set, which is identified using a specific
  * parameter in that set with a specific selection value.</li>
+ * <li><code>--config:MODULE.SET_TYPE[*=*].PARAM VALUE</code> sets a value in
+ * <i>all</i> parameter sets of SET_TYPE</li>
  * </ul>
  * 
  * Some examples:
@@ -589,14 +591,20 @@ public class CommandLine {
 						Collection<? extends ConfigGroup> parameterSets = configGroup
 								.getParameterSets(parameterSetType);
 
-						if (parameterSets.size() > 0) {
+						// change values in *all* parameter sets of parameterSetType
+						final boolean changeValueInAllSets = selectionParameter.equals("*") && selectionValue.equals("*");
+
+						if (!parameterSets.isEmpty()) {
 							for (ConfigGroup parameterSet : parameterSets) {
-								if (parameterSet.getParams().containsKey(selectionParameter)) {
+								if (changeValueInAllSets || parameterSet.getParams().containsKey(selectionParameter)) {
 									String comparisonValue = parameterSet.getParams().get(selectionParameter);
 
-									if (comparisonValue.equals(selectionValue)) {
+									if (changeValueInAllSets || comparisonValue.equals(selectionValue)) {
 										processParameter(option, newPath, parameterSet, newRemainder);
-										return;
+										if (!changeValueInAllSets) {
+											// retain current behavior to only change value in first matching parameter set
+											return;
+										}
 									}
 									
 									// allow for the case subpopulation = 'null' in the scoring parameters
@@ -608,9 +616,13 @@ public class CommandLine {
 								}
 							}
 
-							throw new ConfigurationException(
-									String.format("Parameter set '%s' with %s=%s for %s is not available in %s",
-											parameterSetType, selectionParameter, selectionValue, path, option));
+							if (changeValueInAllSets) {
+								return;
+							} else {
+								throw new ConfigurationException(
+										String.format("Parameter set '%s' with %s=%s for %s is not available in %s",
+												parameterSetType, selectionParameter, selectionValue, path, option));
+							}
 						} else {
 							throw new ConfigurationException(
 									String.format("Parameter set of type '%s' for %s is not available in %s",

--- a/matsim/src/test/java/org/matsim/core/config/CommandLineTest.java
+++ b/matsim/src/test/java/org/matsim/core/config/CommandLineTest.java
@@ -45,6 +45,7 @@ public class CommandLineTest{
 		Assert.assertEquals( "abc", cmd.getOption( "someting" ).get() );
 
 	}
+
 	@Test
 	public void testAdditionalConfigGroup() {
 
@@ -64,6 +65,35 @@ public class CommandLineTest{
 			Assert.assertEquals( 28., mcg.getAbc(), 0. );
 		}
 	}
+
+	@Test
+	public void testSetParameterInAllParameterSets() {
+
+		final String configFilename = utils.getOutputDirectory() + "/config.xml";
+
+		{
+			// write some config:
+			final Config config = ConfigUtils.createConfig();
+			MockConfigGroup mockConfigGroup = ConfigUtils.addOrGetModule(config, MockConfigGroup.class);
+			MockParameterSet mockParameterSetA = new MockParameterSet();
+			mockParameterSetA.test = "a";
+			mockConfigGroup.addParameterSet(mockParameterSetA);
+			MockParameterSet mockParameterSetB = new MockParameterSet();
+			mockParameterSetB.test = "b";
+			mockConfigGroup.addParameterSet(mockParameterSetB);
+			ConfigUtils.writeConfig(config, configFilename);
+		}
+		{
+			String[] args = { configFilename, "--config:mockConfigGroup.mockSet[*=*].test=c" };
+			Config config = ConfigUtils.loadConfig(args);
+			MockConfigGroup mockConfigGroup = ConfigUtils.addOrGetModule(config, MockConfigGroup.class);
+			Assert.assertEquals(2, mockConfigGroup.getParameterSets(MockParameterSet.SET_TYPE).size());
+			for (ConfigGroup parameterSet : mockConfigGroup.getParameterSets(MockParameterSet.SET_TYPE)) {
+				Assert.assertEquals("c", ((MockParameterSet) parameterSet).test);
+			}
+		}
+	}
+
 	@Test( expected = RuntimeException.class )
 	public void testNotYetExistingAdditionalConfigGroup() {
 		final String configFilename = utils.getOutputDirectory() + "/config.xml";
@@ -97,18 +127,71 @@ public class CommandLineTest{
 	}
 
 	private static class MockConfigGroup extends ReflectiveConfigGroup {
+
 		MockConfigGroup(){
-			super( "mockConfigGroup" );
+			super("mockConfigGroup");
 		}
-		double abc = 0. ;
+
+		double abc = 0.;
+
 		@StringSetter("abc")
 		public void setAbc( double val ) {
 			this.abc = val ;
 		}
+
 		@StringGetter("abc")
 		public double getAbc() {
 			return this.abc ;
 		}
+
+		@Override
+		public ConfigGroup createParameterSet(final String type) {
+			switch (type) {
+				case MockParameterSet.SET_TYPE:
+					return new MockParameterSet();
+				default:
+					throw new IllegalArgumentException(type);
+			}
+		}
+
+		@Override
+		public void addParameterSet(final ConfigGroup set) {
+			switch (set.getName()) {
+				case MockParameterSet.SET_TYPE:
+					super.addParameterSet((MockParameterSet) set);
+					break;
+				default:
+					throw new IllegalArgumentException(set.getName());
+			}
+		}
+
+		@Override
+		protected void checkParameterSet(final ConfigGroup module) {
+			switch (module.getName()) {
+				case MockParameterSet.SET_TYPE:
+					if (!(module instanceof MockParameterSet)) {
+						throw new RuntimeException("wrong class for " + module);
+					}
+					break;
+				default:
+					throw new IllegalArgumentException(module.getName());
+			}
+		}
+
+	}
+
+	private static class MockParameterSet extends ReflectiveConfigGroup {
+
+		public static final String SET_TYPE = "mockSet";
+
+		public MockParameterSet() {
+			super(SET_TYPE);
+		}
+
+		@Parameter
+		@Comment("test")
+		String test;
+
 	}
 
 }


### PR DESCRIPTION
This change allows to change a parameter value in _all_ parameter sets of a specific type using the `CommandLine` class.

Currently, a value in a parameter set could be changed with the following command line arguments:
```bash
--config:planCalcScore.scoringParameters[performing=6.0].lateArrival=18
# or even
--config:planCalcScore.scoringParameters[performing=6.0].activityParams[activityType=dummy].priority=2.0
```

This change allows to set a parameter value (e.g., the `priority` value) for _all_ `activityParams` parameter sets like this:

```bash
--config:planCalcScore.scoringParameters[performing=6.0].activityParams[*=*].priority=2.0
```

This additional behavior is also helpful to set values in a parameter set whose type only appears _once_ in a config group. In that case, one does not need to know a key value pair to select that (single) parameter set.