### PR TITLE
Allow to override MATSimApplication.getConfigurableModules in subclasses

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/MATSimApplication.java
+++ b/contribs/application/src/main/java/org/matsim/application/MATSimApplication.java
@@ -311,7 +311,7 @@ public abstract class MATSimApplication implements Callable<Integer>, CommandLin
 	/**
 	 * Modules that are configurable via command line arguments.
 	 */
-	private List<ConfigGroup> getConfigurableModules() {
+	protected List<ConfigGroup> getConfigurableModules() {
 		return Lists.newArrayList(
 				new ControlerConfigGroup(),
 				new GlobalConfigGroup(),


### PR DESCRIPTION
This change allows to customize the list of config groups that are changeable via the `CommandLine` class in custom classes that extend `MatsimApplication`.

This change is related to #2279 and is an effort in making the powerful config-changing-functionality of the `CommandLine` a bit more customizable when used in custom subclasses of `MATSimApplication`.