### PR TITLE
Initial version of DrtCompanion extension

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/DrtWithExtensionsConfigGroup.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/DrtWithExtensionsConfigGroup.java
@@ -1,0 +1,60 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.drt.extension;
+
+import org.matsim.contrib.drt.extension.companions.DrtCompanionParams;
+import org.matsim.contrib.drt.extension.operations.DrtOperationsParams;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+/**
+ * @author Steffen Axer
+ *
+ * This class summarizes all optional drt parametersets and should be used while creating MultiModeDrtConfigGroup instances
+ */
+public class DrtWithExtensionsConfigGroup extends DrtConfigGroup {
+
+	@Nullable
+	private DrtCompanionParams drtCompanionParams;
+
+	@Nullable
+	private DrtOperationsParams drtOperationsParams;
+
+	public DrtWithExtensionsConfigGroup() {
+		// Optional
+		addDefinition(DrtCompanionParams.SET_NAME, DrtCompanionParams::new, () -> drtCompanionParams,
+				params -> drtCompanionParams = (DrtCompanionParams) params);
+
+		// Optional
+		addDefinition(DrtOperationsParams.SET_NAME, DrtOperationsParams::new, () -> drtOperationsParams,
+				params -> drtOperationsParams = (DrtOperationsParams) params);
+	}
+
+	public Optional<DrtCompanionParams> getDrtCompanionParams() {
+		return Optional.ofNullable(drtCompanionParams);
+	}
+
+	public Optional<DrtOperationsParams> getDrtOperationsParams() {
+		return Optional.ofNullable(drtOperationsParams);
+	}
+
+}

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionControlerCreator.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionControlerCreator.java
@@ -1,0 +1,58 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+
+package org.matsim.contrib.drt.extension.companions;
+
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.contrib.drt.extension.companions.MultiModeDrtCompanionModule;
+import org.matsim.contrib.drt.run.DrtConfigs;
+import org.matsim.contrib.drt.run.DrtControlerCreator;
+import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
+import org.matsim.contrib.drt.run.MultiModeDrtModule;
+import org.matsim.contrib.dvrp.run.DvrpModule;
+import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
+import org.matsim.contrib.otfvis.OTFVisLiveModule;
+import org.matsim.core.config.Config;
+import org.matsim.core.controler.Controler;
+import org.matsim.core.scenario.ScenarioUtils;
+
+/**
+ * @author Steffen Axer
+ *
+ */
+public final class DrtCompanionControlerCreator {
+
+
+	public static Controler createControler(Config config) {
+		MultiModeDrtConfigGroup multiModeDrtConfig = MultiModeDrtConfigGroup.get(config);
+		DrtConfigs.adjustMultiModeDrtConfig(multiModeDrtConfig, config.planCalcScore(), config.plansCalcRoute());
+
+		Scenario scenario = DrtControlerCreator.createScenarioWithDrtRouteFactory(config);
+		ScenarioUtils.loadScenario(scenario);
+
+		Controler controler = new Controler(scenario);
+		controler.addOverridingModule(new DvrpModule());
+		controler.addOverridingModule(new MultiModeDrtModule());
+		controler.addOverridingModule(new MultiModeDrtCompanionModule());
+		controler.configureQSimComponents(DvrpQSimComponents.activateAllModes(multiModeDrtConfig));
+
+		return controler;
+	}
+}

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionModule.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionModule.java
@@ -1,0 +1,56 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.drt.extension.companions;
+
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.drt.extension.DrtWithExtensionsConfigGroup;
+import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
+import org.matsim.core.router.MainModeIdentifier;
+
+/**
+ * This module samples additional drt rides on booked drt trips in order to
+ * replicate a more realistic vehicle occupancy.
+ *
+ * @author Steffen Axer
+ *
+ */
+public class DrtCompanionModule extends AbstractDvrpModeModule {
+    DrtWithExtensionsConfigGroup drtWithExtensionsConfigGroup;
+
+	public DrtCompanionModule(String mode, DrtWithExtensionsConfigGroup drtWithExtensionsConfigGroup) {
+		super(mode);
+		this.drtWithExtensionsConfigGroup = drtWithExtensionsConfigGroup;
+
+	}
+
+	@Override
+	public void install() {
+		bindModal(DrtCompanionRideGenerator.class).toProvider(
+				modalProvider(getter -> new DrtCompanionRideGenerator(
+						getMode(), //
+						getter.get(MainModeIdentifier.class), //
+						getter.get(Scenario.class), //
+						getter.getModal(Network.class),  //
+						this.drtWithExtensionsConfigGroup)))
+				.asEagerSingleton();
+		addControlerListenerBinding().to(modalKey(DrtCompanionRideGenerator.class));
+	}
+}

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionParams.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionParams.java
@@ -1,0 +1,91 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.drt.extension.companions;
+
+import org.matsim.contrib.util.ReflectiveConfigGroupWithConfigurableParameterSets;
+import org.matsim.core.config.Config;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.matsim.core.utils.misc.StringUtils;
+
+/**
+ *
+ * @author Steffen Axer
+ *
+ */
+public class DrtCompanionParams extends ReflectiveConfigGroupWithConfigurableParameterSets {
+	private static final char DEFAULT_COLLECTION_DELIMITER = ',';
+	public static final String SET_NAME = "companions";
+	private static final String DRT_COMPANION_SAMPLING_WEIGHTS_NAME = "drtCompanionSamplingWeights";
+
+	private List<Double> drtCompanionSamplingWeights = List.of(0.7, 0.3);
+
+	public DrtCompanionParams() {
+		super(SET_NAME);
+
+	}
+
+	@StringGetter(DRT_COMPANION_SAMPLING_WEIGHTS_NAME)
+	private String getDrtCompanionSamplingWeightsAsString() {
+
+		return this.drtCompanionSamplingWeights.stream().map(Object::toString)
+				.collect(Collectors.joining(String.valueOf(DEFAULT_COLLECTION_DELIMITER)));
+	}
+
+	@StringSetter(DRT_COMPANION_SAMPLING_WEIGHTS_NAME)
+	private void setDrtCompanionSamplingWeightsAsStringList(String values) {
+
+		if (values.equals("")) {
+			throw new IllegalArgumentException("DrtCompanionParams can not be empty, please specify at least two values!");
+		}
+
+		this.drtCompanionSamplingWeights = Arrays.stream(StringUtils.explode(values, DEFAULT_COLLECTION_DELIMITER))
+				.map(Double::parseDouble).collect(Collectors.toList());
+	}
+
+	public List<Double> getDrtCompanionSamplingWeights() {
+		return this.drtCompanionSamplingWeights;
+	}
+
+	public void setDrtCompanionSamplingWeights(List<Double> values) {
+		this.drtCompanionSamplingWeights = values;
+	}
+
+
+	@Override
+	public Map<String, String> getComments() {
+		Map<String, String> map = super.getComments();
+		map.put(DRT_COMPANION_SAMPLING_WEIGHTS_NAME,
+				"Weights to sample an additional drt passenger. E.g. 70 % +0 pax, 30 % +1 pax. Please specify at least two values.");
+		return map;
+	}
+
+	protected void checkConsistency(Config config) {
+		super.checkConsistency(config);
+
+		if (drtCompanionSamplingWeights.isEmpty()) {
+			throw new IllegalStateException("drtCompanionSamplingWeights can not be empty. Please check configurations");
+		}
+	}
+
+
+}

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionRideGenerator.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionRideGenerator.java
@@ -1,0 +1,158 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.drt.extension.companions;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.population.Activity;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Plan;
+import org.matsim.contrib.drt.extension.DrtWithExtensionsConfigGroup;
+import org.matsim.contrib.util.random.WeightedRandomSelection;
+import org.matsim.core.controler.events.AfterMobsimEvent;
+import org.matsim.core.controler.events.BeforeMobsimEvent;
+import org.matsim.core.controler.listener.AfterMobsimListener;
+import org.matsim.core.controler.listener.BeforeMobsimListener;
+import org.matsim.core.population.PopulationUtils;
+import org.matsim.core.router.MainModeIdentifier;
+import org.matsim.core.router.TripStructureUtils;
+import org.matsim.utils.objectattributes.attributable.AttributesUtils;
+
+/**
+ * @author Steffen Axer
+ */
+public final class DrtCompanionRideGenerator implements BeforeMobsimListener, AfterMobsimListener {
+
+	private static final Logger LOG = LogManager.getLogger(DrtCompanionRideGenerator.class);
+	public final static String DRT_COMPANION_AGENT_PREFIX = "COMPANION";
+
+	private final Scenario scenario;
+	private final String drtModes;
+	private final MainModeIdentifier mainModeIdentifier;
+
+	private Set<Id<Person>> companionAgentIds = new HashSet<>();
+	private WeightedRandomSelection<Integer> sampler;
+
+	DrtCompanionRideGenerator(final String drtMode, final MainModeIdentifier mainModeIdentifier, final Scenario scenario, final Network network,
+							  final DrtWithExtensionsConfigGroup drtWithExtensionsConfigGroup) {
+		this.scenario = scenario;
+		this.mainModeIdentifier = mainModeIdentifier;
+		this.drtModes = drtMode;
+		installSampler(drtWithExtensionsConfigGroup);
+	}
+
+	private String getCompanionPrefix(String drtMode) {
+		return DRT_COMPANION_AGENT_PREFIX + "_" + drtMode;
+	}
+
+	private void installSampler(DrtWithExtensionsConfigGroup drtWithExtensionsConfigGroup) {
+		if (!drtWithExtensionsConfigGroup.getDrtCompanionParams().orElseThrow().getDrtCompanionSamplingWeights()
+				.isEmpty()) {
+			this.sampler = DrtCompanionUtils.createIntegerSampler(
+					drtWithExtensionsConfigGroup.getDrtCompanionParams().orElseThrow().getDrtCompanionSamplingWeights());
+		} else {
+			throw new IllegalStateException("drtCompanionSamplingWeights are empty, please check your DrtCompanionParams");
+		}
+	}
+
+	void addCompanionAgents() {
+		HashMap<String, Integer> drtCompanionAgents = new HashMap<>();
+		Collection<Person> companions = new ArrayList<>();
+		for (Person person : this.scenario.getPopulation().getPersons().values()) {
+			for (TripStructureUtils.Trip trip : TripStructureUtils.getTrips(person.getSelectedPlan())) {
+				String mainMode = mainModeIdentifier.identifyMainMode(trip.getTripElements());
+				if (this.drtModes.equals(mainMode)) {
+					int additionalCompanions = sampler.select();
+					for (int i = 0; i < additionalCompanions; i++) {
+						int currentCounter = drtCompanionAgents.getOrDefault(mainMode, 0);
+						currentCounter++;
+						drtCompanionAgents.put(mainMode, currentCounter);
+						companions.add(createCompanionAgent(mainMode, person, trip, trip.getOriginActivity(),
+								trip.getDestinationActivity()));
+					}
+				}
+			}
+		}
+		companions.forEach(p -> {
+			this.scenario.getPopulation().addPerson(p);
+			this.companionAgentIds.add(p.getId());
+		});
+
+		for (Map.Entry<String, Integer> drtModeEntry : drtCompanionAgents.entrySet()) {
+			LOG.info("Added # {} drt companion agents for mode {}", drtModeEntry.getValue(), drtModeEntry.getKey());
+		}
+	}
+
+	private Person createCompanionAgent(String drtMode, Person originalPerson, TripStructureUtils.Trip trip,
+										Activity fromActivity, Activity toActivity) {
+		String prefix = getCompanionPrefix(drtMode);
+		String companionId = prefix + "_" + originalPerson.getId().toString() + "_" + UUID.randomUUID();
+		Person person = PopulationUtils.getFactory().createPerson(Id.createPersonId(companionId));
+
+		// Copy attributes from person
+		AttributesUtils.copyAttributesFromTo(originalPerson, person);
+
+		// Ensure that we have a timed end
+		Activity copyFromActivity = PopulationUtils.createActivity(fromActivity);
+		if (copyFromActivity.getEndTime().isUndefined()) {
+			copyFromActivity.setEndTime(trip.getLegsOnly().get(0).getDepartureTime().seconds());
+		}
+
+		Plan plan = PopulationUtils.createPlan();
+		plan.getPlanElements().add(copyFromActivity);
+		plan.getPlanElements().addAll(trip.getTripElements());
+		plan.getPlanElements().add(toActivity);
+		person.addPlan(plan);
+		return person;
+	}
+
+	void removeCompanionAgents() {
+		int counter = 0;
+
+		for (Id<Person> drtCompanion : companionAgentIds) {
+			this.scenario.getPopulation().getPersons().remove(drtCompanion);
+			counter++;
+		}
+		companionAgentIds.clear();
+		LOG.info("Removed # {} drt companion agents", counter);
+	}
+
+	@Override
+	public void notifyAfterMobsim(AfterMobsimEvent event) {
+		this.removeCompanionAgents();
+	}
+
+	@Override
+	public void notifyBeforeMobsim(BeforeMobsimEvent event) {
+		this.addCompanionAgents();
+	}
+
+}

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionUtils.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionUtils.java
@@ -1,0 +1,44 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.drt.extension.companions;
+
+import java.util.List;
+
+import org.matsim.contrib.util.random.RandomUtils;
+import org.matsim.contrib.util.random.UniformRandom;
+import org.matsim.contrib.util.random.WeightedRandomSelection;
+
+/**
+ *
+ * @author Steffen Axer
+ *
+ */
+public class DrtCompanionUtils {
+
+	public static WeightedRandomSelection<Integer> createIntegerSampler(final List<Double> distribution) {
+		WeightedRandomSelection<Integer> wrs = new WeightedRandomSelection<>(
+				new UniformRandom(RandomUtils.getLocalGenerator()));
+		for (int i = 0; i < distribution.size(); ++i) {
+			wrs.add(i, distribution.get(i));
+		}
+		return wrs;
+	}
+
+}

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/MultiModeDrtCompanionModule.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/MultiModeDrtCompanionModule.java
@@ -1,0 +1,47 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.drt.extension.companions;
+
+import org.matsim.contrib.drt.extension.DrtWithExtensionsConfigGroup;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
+import org.matsim.core.controler.AbstractModule;
+
+import com.google.inject.Inject;
+
+/**
+ *
+ * @author Steffen Axer
+ *
+ */
+public class MultiModeDrtCompanionModule extends AbstractModule {
+	@Inject
+	private MultiModeDrtConfigGroup multiModeDrtCfg;
+
+	@Override
+	public void install() {
+		for (DrtConfigGroup drtCfg : multiModeDrtCfg.getModalElements()) {
+			if (drtCfg instanceof DrtWithExtensionsConfigGroup && ((DrtWithExtensionsConfigGroup) drtCfg).getDrtCompanionParams().isPresent()) {
+			    DrtWithExtensionsConfigGroup drtWithExtensionsConfigGroup = (DrtWithExtensionsConfigGroup) drtCfg;
+				install(new DrtCompanionModule(drtCfg.getMode(), drtWithExtensionsConfigGroup));
+			}
+		}
+	}
+}

--- a/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/DrtWithExtensionsConfigGroupTest.java
+++ b/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/DrtWithExtensionsConfigGroupTest.java
@@ -1,0 +1,94 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.drt.extension;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.matsim.contrib.drt.extension.DrtWithExtensionsConfigGroup;
+import org.matsim.contrib.drt.extension.companions.DrtCompanionParams;
+import org.matsim.contrib.drt.extension.operations.DrtOperationsParams;
+import org.matsim.contrib.drt.extension.operations.operationFacilities.OperationFacilitiesParams;
+import org.matsim.contrib.drt.extension.operations.shifts.config.ShiftsParams;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+
+/**
+ *
+ * @author Steffen Axer
+ *
+ */
+public class DrtWithExtensionsConfigGroupTest {
+	private final static double WEIGHT_1 = 4711.;
+	private final static double WEIGHT_2 = 1337.;
+	private final static double WEIGHT_3 = 911.;
+
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+
+    private static Config createConfig(List<Double> values) {
+        Config config = ConfigUtils.createConfig();
+
+        DrtWithExtensionsConfigGroup configGroup = new DrtWithExtensionsConfigGroup();
+        DrtCompanionParams drtCompanionParams = new DrtCompanionParams();
+
+        DrtOperationsParams operationsParams = new DrtOperationsParams();
+        ShiftsParams shiftsParams = new ShiftsParams();
+        OperationFacilitiesParams operationFacilitiesParams = new OperationFacilitiesParams();
+
+        operationsParams.addParameterSet(shiftsParams);
+        operationsParams.addParameterSet(operationFacilitiesParams);
+
+        drtCompanionParams.setDrtCompanionSamplingWeights(values);
+        configGroup.addParameterSet(drtCompanionParams);
+        configGroup.addParameterSet(operationsParams);
+        config.addModule(configGroup);
+        return config;
+    }
+
+    private static Path writeConfig(final TemporaryFolder tempFolder, List<Double> weights) throws IOException {
+        Config config = createConfig(weights);
+        Path configFile = tempFolder.newFile("config.xml").toPath();
+        ConfigUtils.writeConfig(config, configFile.toString());
+        return configFile;
+    }
+
+    @Test
+    public void loadConfigGroupTest() throws IOException {
+
+		/* Test that exported values are correct imported again */
+		Path configFile = writeConfig(tempFolder, List.of(WEIGHT_1,WEIGHT_2,WEIGHT_3));
+        Config config = ConfigUtils.createConfig();
+        ConfigUtils.loadConfig(config, configFile.toString());
+        DrtWithExtensionsConfigGroup loadedCfg = ConfigUtils.addOrGetModule(config, DrtWithExtensionsConfigGroup.class);
+		Assert.assertTrue(loadedCfg.getDrtCompanionParams().isPresent());
+		Assert.assertTrue(loadedCfg.getDrtCompanionParams().get().getDrtCompanionSamplingWeights().get(0).equals(WEIGHT_1));
+		Assert.assertTrue(loadedCfg.getDrtCompanionParams().get().getDrtCompanionSamplingWeights().get(1).equals(WEIGHT_2));
+		Assert.assertTrue(loadedCfg.getDrtCompanionParams().get().getDrtCompanionSamplingWeights().get(2).equals(WEIGHT_3));
+    }
+
+}

--- a/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/companions/RunDrtWithCompanionExampleIT.java
+++ b/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/companions/RunDrtWithCompanionExampleIT.java
@@ -1,0 +1,99 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.drt.extension.companions;
+
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.matsim.api.core.v01.Id;
+import org.matsim.contrib.drt.extension.DrtWithExtensionsConfigGroup;
+import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
+import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.controler.Controler;
+import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
+import org.matsim.core.utils.io.IOUtils;
+import org.matsim.examples.ExamplesUtils;
+import org.matsim.testcases.MatsimTestUtils;
+import org.matsim.vis.otfvis.OTFVisConfigGroup;
+
+/**
+ * @author Steffen Axer
+ */
+public class RunDrtWithCompanionExampleIT {
+
+	@Rule
+	public MatsimTestUtils utils = new MatsimTestUtils();
+
+	@Test
+	public void testRunDrtWithCompanions() {
+		Id.resetCaches();
+		URL configUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("mielec"), "mielec_drt_config.xml");
+		Config config = ConfigUtils.loadConfig(configUrl, new OTFVisConfigGroup(), new MultiModeDrtConfigGroup(DrtWithExtensionsConfigGroup::new), new DvrpConfigGroup());
+
+		// Add DrtCompanionParams with some default values into existing Drt configurations
+		MultiModeDrtConfigGroup multiModeDrtConfigGroup = MultiModeDrtConfigGroup.get(config);
+		DrtWithExtensionsConfigGroup drtWithExtensionsConfigGroup = (DrtWithExtensionsConfigGroup) multiModeDrtConfigGroup.getModalElements().iterator().next();
+		drtWithExtensionsConfigGroup.addParameterSet(new DrtCompanionParams());
+
+		config.controler().setOverwriteFileSetting(OverwriteFileSetting.deleteDirectoryIfExists);
+		config.controler().setOutputDirectory(utils.getOutputDirectory());
+
+		Controler controler = DrtCompanionControlerCreator.createControler(config);
+		controler.run();
+
+		verifyTotalNumberOfDrtRides(utils.getOutputDirectory(), 477);
+	}
+
+	private void verifyTotalNumberOfDrtRides(String outputDirectory, int expectedNumberOfTrips) {
+
+		String filename = outputDirectory + "/drt_customer_stats_drt.csv";
+
+		final List<String> collect;
+		try {
+			collect = Files.lines(Paths.get(filename)).collect(Collectors.toList());
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+
+		int size = collect.size();
+		List<String> keys = List.of(collect.get(0).split(";"));
+		List<String> lastIterationValues = List.of(collect.get(size - 1).split(";"));
+
+		Map<String, String> params = new HashMap<>();
+		for (int i = 0; i < keys.size(); i++) {
+			params.put(keys.get(i), lastIterationValues.get(i));
+		}
+
+		int actualRides = Integer.parseInt(params.get("rides"));
+		assert(actualRides == expectedNumberOfTrips);
+	}
+}


### PR DESCRIPTION
**What it does:**
This PR provides the functionality to sample additional rides to an existing booked drt trip. Such a behavior is somehow required, if one would like to replicate more realistic occupancy rates in drt services. In other words. Without such an approach you will very likely underestimate real world vehicle occupancy and fleet sizes. The provided default sampling distribution is just a functional placeholder. Please fill it with your empirically observed values.

**How it works:**
Before starting the mobsim, additional, so called companions, are generated (sampled) by observing existing drt trips in the selected plan. The sampling distribution gets provided by DrtCompanionParams. At the end of the mobsim all companion agents are removed. They will never reach the replanning phase of MATSim.

**Remarks:**
Because the current drt contrib does not allow to book multiple seats per request, this approach is in my point of view the only straight-forward way to reach the desired objective. However @michalmac, @sebhoerl  maybe this PR is the initial spark to implement a more sophisticated approach. In between, have fun with this approach.
