### PR TITLE
EV: migrate from initial charge to initial SOC in electric vehicle attributes

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/Battery.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/Battery.java
@@ -36,6 +36,10 @@ public interface Battery {
 	 */
 	void setCharge(double charge);
 
+	default double getSoc() {
+		return getCharge() / getCapacity();
+	}
+
 	/**
 	 * Changes charge, making sure the charge level does not increase above the battery capacity or decrease below 0.
 	 *

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ConvertInitialChargeToInitialSoc.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ConvertInitialChargeToInitialSoc.java
@@ -3,7 +3,7 @@
  * project: org.matsim.*
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2019 by the members listed in the COPYING,        *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -20,24 +20,31 @@
 
 package org.matsim.contrib.ev.fleet;
 
-import org.matsim.api.core.v01.Identifiable;
-import org.matsim.vehicles.Vehicle;
+import static org.matsim.contrib.ev.fleet.ElectricVehicleSpecificationImpl.INITIAL_ENERGY_kWh;
+import static org.matsim.contrib.ev.fleet.ElectricVehicleSpecificationImpl.INITIAL_SOC;
 
-import com.google.common.collect.ImmutableList;
+import org.matsim.vehicles.MatsimVehicleReader;
+import org.matsim.vehicles.MatsimVehicleWriter;
+import org.matsim.vehicles.VehicleUtils;
 
 /**
  * @author Michal Maciejewski (michalm)
  */
-public interface ElectricVehicleSpecification extends Identifiable<Vehicle> {
-	Vehicle getMatsimVehicle();
+public class ConvertInitialChargeToInitialSoc {
+	public static void run(String file) {
+		var vehicles = VehicleUtils.createVehiclesContainer();
+		var reader = new MatsimVehicleReader(vehicles);
+		reader.readFile(file);
 
-	ImmutableList<String> getChargerTypes();
+		for (var v : vehicles.getVehicles().values()) {
+			double battery_kWh = VehicleUtils.getEnergyCapacity(v.getType().getEngineInformation());
+			double initial_kWh = (double)v.getAttributes().getAttribute(INITIAL_ENERGY_kWh);
+			double initial_soc = initial_kWh / battery_kWh;
+			v.getAttributes().removeAttribute(INITIAL_ENERGY_kWh);
+			v.getAttributes().putAttribute(INITIAL_SOC, initial_soc);
+		}
 
-	double getInitialSoc(); //in [0, 1]
-
-	default double getInitialCharge() {
-		return getInitialSoc() * getBatteryCapacity();
+		var writer = new MatsimVehicleWriter(vehicles);
+		writer.writeFile(file);
 	}
-
-	double getBatteryCapacity();//[J]
 }

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricFleetModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricFleetModule.java
@@ -20,11 +20,8 @@
 
 package org.matsim.contrib.ev.fleet;
 
-import static org.matsim.contrib.ev.fleet.ElectricVehicleSpecificationImpl.INITIAL_ENERGY_kWh;
-
 import org.matsim.contrib.ev.EvConfigGroup;
 import org.matsim.contrib.ev.EvModule;
-import org.matsim.contrib.ev.EvUnits;
 import org.matsim.contrib.ev.charging.ChargingPower;
 import org.matsim.contrib.ev.discharging.AuxEnergyConsumption;
 import org.matsim.contrib.ev.discharging.DriveEnergyConsumption;
@@ -74,8 +71,8 @@ public class ElectricFleetModule extends AbstractModule {
 
 					@Override
 					public ElectricFleet get() {
-						return ElectricFleets.createDefaultFleet(fleetSpecification, driveConsumptionFactory,
-								auxConsumptionFactory, chargingPowerFactory);
+						return ElectricFleets.createDefaultFleet(fleetSpecification, driveConsumptionFactory, auxConsumptionFactory,
+								chargingPowerFactory);
 					}
 				}).asEagerSingleton();
 
@@ -91,15 +88,8 @@ public class ElectricFleetModule extends AbstractModule {
 						public void notifyMobsimBeforeCleanup(MobsimBeforeCleanupEvent e) {
 							for (var oldSpec : electricFleetSpecification.getVehicleSpecifications().values()) {
 								var matsimVehicle = oldSpec.getMatsimVehicle();
-								double chargeAtEndOfCurrentIteration = electricFleet.getElectricVehicles()
-										.get(oldSpec.getId())
-										.getBattery()
-										.getCharge();
-
-								// INITIAL_ENERGY_kWh attribute is in kWh, the charge is in J
-								matsimVehicle.getAttributes()
-										.putAttribute(INITIAL_ENERGY_kWh,
-												EvUnits.J_to_kWh(chargeAtEndOfCurrentIteration));
+								double socAtEndOfCurrentIteration = electricFleet.getElectricVehicles().get(oldSpec.getId()).getBattery().getSoc();
+								ElectricVehicleSpecifications.setInitialSoc(matsimVehicle, socAtEndOfCurrentIteration);
 							}
 						}
 					});

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleSpecificationImpl.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleSpecificationImpl.java
@@ -36,13 +36,13 @@ public class ElectricVehicleSpecificationImpl implements ElectricVehicleSpecific
 	public static final String EV_ENGINE_HBEFA_TECHNOLOGY = "electricity";
 
 	public static final String INITIAL_ENERGY_kWh = "initialEnergyInKWh";
+	public static final String INITIAL_SOC = "initialSoc";// in [0, 1]
 	public static final String CHARGER_TYPES = "chargerTypes";
 
-	public static void createAndAddVehicleSpecificationsFromMatsimVehicles(
-			ElectricFleetSpecification fleetSpecification, Collection<Vehicle> vehicles) {
+	public static void createAndAddVehicleSpecificationsFromMatsimVehicles(ElectricFleetSpecification fleetSpecification,
+			Collection<Vehicle> vehicles) {
 		vehicles.stream()
-				.filter(vehicle -> EV_ENGINE_HBEFA_TECHNOLOGY.equals(
-						VehicleUtils.getHbefaTechnology(vehicle.getType().getEngineInformation())))
+				.filter(vehicle -> EV_ENGINE_HBEFA_TECHNOLOGY.equals(VehicleUtils.getHbefaTechnology(vehicle.getType().getEngineInformation())))
 				.map(ElectricVehicleSpecificationImpl::new)
 				.forEach(fleetSpecification::addVehicleSpecification);
 	}
@@ -74,8 +74,8 @@ public class ElectricVehicleSpecificationImpl implements ElectricVehicleSpecific
 	}
 
 	@Override
-	public double getInitialCharge() {
-		return (double)matsimVehicle.getAttributes().getAttribute(INITIAL_ENERGY_kWh) * EvUnits.J_PER_kWh;
+	public double getInitialSoc() {
+		return (double)matsimVehicle.getAttributes().getAttribute(INITIAL_SOC);
 	}
 
 	@Override

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleSpecifications.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleSpecifications.java
@@ -1,10 +1,9 @@
-/* *********************************************************************** *
+/*
+ * *********************************************************************** *
  * project: org.matsim.*
- * Controler.java
- *                                                                         *
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2007 by the members listed in the COPYING,        *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -16,44 +15,26 @@
  *   (at your option) any later version.                                   *
  *   See also COPYING, LICENSE and WARRANTY file                           *
  *                                                                         *
- * *********************************************************************** */
+ * *********************************************************************** *
+ */
 
-package playground.vsp.ev;
+package org.matsim.contrib.ev.fleet;
 
 import java.util.Collection;
 
-import org.matsim.contrib.ev.fleet.ElectricVehicleSpecificationImpl;
 import org.matsim.vehicles.EngineInformation;
 import org.matsim.vehicles.Vehicle;
 
-import com.google.common.collect.ImmutableList;
-
-public class EVUtils {
-	/**
-	 * @param vehicle
-	 * @return the initial energy in kWh
-	 */
-	static Double getInitialEnergy_kWh(Vehicle vehicle) {
-		return (Double)vehicle.getAttributes()
-				.getAttribute(ElectricVehicleSpecificationImpl.INITIAL_ENERGY_kWh);
-	}
-
+public class ElectricVehicleSpecifications {
 	/**
 	 * @param vehicle
 	 * @param initialEnergyInKWh initial energy [kWh]
 	 */
 	public static void setInitialEnergy_kWh(Vehicle vehicle, double initialEnergyInKWh) {
-		vehicle.getAttributes()
-				.putAttribute(ElectricVehicleSpecificationImpl.INITIAL_ENERGY_kWh, initialEnergyInKWh);
-	}
-
-	static ImmutableList<String> getChargerTypes(EngineInformation engineInformation) {
-		return ImmutableList.copyOf((Collection<String>)engineInformation.getAttributes()
-				.getAttribute(ElectricVehicleSpecificationImpl.CHARGER_TYPES));
+		vehicle.getAttributes().putAttribute(ElectricVehicleSpecificationImpl.INITIAL_ENERGY_kWh, initialEnergyInKWh);
 	}
 
 	public static void setChargerTypes(EngineInformation engineInformation, Collection<String> chargerTypes) {
-		engineInformation.getAttributes()
-				.putAttribute(ElectricVehicleSpecificationImpl.CHARGER_TYPES, chargerTypes);
+		engineInformation.getAttributes().putAttribute(ElectricVehicleSpecificationImpl.CHARGER_TYPES, chargerTypes);
 	}
 }

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleSpecifications.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricVehicleSpecifications.java
@@ -26,12 +26,8 @@ import org.matsim.vehicles.EngineInformation;
 import org.matsim.vehicles.Vehicle;
 
 public class ElectricVehicleSpecifications {
-	/**
-	 * @param vehicle
-	 * @param initialEnergyInKWh initial energy [kWh]
-	 */
-	public static void setInitialEnergy_kWh(Vehicle vehicle, double initialEnergyInKWh) {
-		vehicle.getAttributes().putAttribute(ElectricVehicleSpecificationImpl.INITIAL_ENERGY_kWh, initialEnergyInKWh);
+	public static void setInitialSoc(Vehicle vehicle, double initialSoc) {
+		vehicle.getAttributes().putAttribute(ElectricVehicleSpecificationImpl.INITIAL_SOC, initialSoc);
 	}
 
 	public static void setChargerTypes(EngineInformation engineInformation, Collection<String> chargerTypes) {

--- a/contribs/ev/src/test/java/org/matsim/contrib/ev/charging/FastThenSlowChargingTest.java
+++ b/contribs/ev/src/test/java/org/matsim/contrib/ev/charging/FastThenSlowChargingTest.java
@@ -155,10 +155,10 @@ public class FastThenSlowChargingTest {
 		// this record is a bit hacky implementation of ElectricVehicleSpecification just meant for tests
 		record TestEvSpecification(Id<Vehicle> getId, Vehicle getMatsimVehicle, String getVehicleType,
 								   ImmutableList<String> getChargerTypes, double getBatteryCapacity,
-								   double getInitialCharge) implements ElectricVehicleSpecification {
+								   double getInitialSoc) implements ElectricVehicleSpecification {
 		}
 		var specification = new TestEvSpecification(Id.create("ev_id", Vehicle.class), null, "vt",
-				ImmutableList.of("ct"), EvUnits.kWh_to_J(capacity_kWh), EvUnits.kWh_to_J(charge_kWh));
+				ImmutableList.of("ct"), EvUnits.kWh_to_J(capacity_kWh), charge_kWh / capacity_kWh);
 
 		return ElectricVehicleImpl.create(specification, ev -> (link, travelTime, linkEnterTime) -> {
 			throw new UnsupportedOperationException();

--- a/contribs/ev/src/test/java/org/matsim/contrib/ev/charging/VariableSpeedChargingTest.java
+++ b/contribs/ev/src/test/java/org/matsim/contrib/ev/charging/VariableSpeedChargingTest.java
@@ -83,10 +83,10 @@ public class VariableSpeedChargingTest {
 		// this record is a bit hacky implementation of ElectricVehicleSpecification just meant for tests
 		record TestEvSpecification(Id<Vehicle> getId, Vehicle getMatsimVehicle, String getVehicleType,
 								   ImmutableList<String> getChargerTypes, double getBatteryCapacity,
-								   double getInitialCharge) implements ElectricVehicleSpecification {
+								   double getInitialSoc) implements ElectricVehicleSpecification {
 		}
 		var specification = new TestEvSpecification(Id.create("ev_id", Vehicle.class), null, "vt",
-				ImmutableList.of("ct"), EvUnits.kWh_to_J(capacity_kWh), EvUnits.kWh_to_J(charge_kWh));
+				ImmutableList.of("ct"), EvUnits.kWh_to_J(capacity_kWh), charge_kWh / capacity_kWh);
 
 		var charger = ImmutableChargerSpecification.newBuilder()
 				.id(Id.create("charger_id", Charger.class))

--- a/contribs/ev/test/input/org/matsim/contrib/ev/example/RunEvExample/evehicles.xml
+++ b/contribs/ev/test/input/org/matsim/contrib/ev/example/RunEvExample/evehicles.xml
@@ -11,9 +11,9 @@
 		<width meter="1.0"/>
 		<engineInformation>
 			<attributes>
-				<attribute name="chargerTypes" class="java.util.ImmutableCollections$List12">["default"]</attribute>
-				<attribute name="energyCapacityInKWhOrLiters" class="java.lang.Double">60.0</attribute>
 				<attribute name="HbefaTechnology" class="java.lang.String">electricity</attribute>
+				<attribute name="chargerTypes" class="java.util.Collections$UnmodifiableCollection">["default"]</attribute>
+				<attribute name="energyCapacityInKWhOrLiters" class="java.lang.Double">60.0</attribute>
 			</attributes>
 		</engineInformation>
 		<costInformation>
@@ -26,77 +26,77 @@
 
 	<vehicle id="0" type="EV_60.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">60.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="1" type="EV_60.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">60.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="10" type="EV_60.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">60.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="11" type="EV_60.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">60.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="12" type="EV_60.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">60.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="13" type="EV_60.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">60.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="14" type="EV_60.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">60.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="2" type="EV_60.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">60.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="3" type="EV_60.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">60.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="4" type="EV_60.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">60.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="5" type="EV_60.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">60.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="6" type="EV_60.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">60.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="7" type="EV_60.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">60.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="8" type="EV_60.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">60.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="9" type="EV_60.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">60.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 

--- a/contribs/vsp/src/main/java/playground/vsp/ev/EVUtils.java
+++ b/contribs/vsp/src/main/java/playground/vsp/ev/EVUtils.java
@@ -33,7 +33,7 @@ public class EVUtils {
 	 * @param vehicle
 	 * @return the initial energy in kWh
 	 */
-	static Double getInitialEnergy(Vehicle vehicle) {
+	static Double getInitialEnergy_kWh(Vehicle vehicle) {
 		return (Double)vehicle.getAttributes()
 				.getAttribute(ElectricVehicleSpecificationImpl.INITIAL_ENERGY_kWh);
 	}
@@ -42,7 +42,7 @@ public class EVUtils {
 	 * @param vehicle
 	 * @param initialEnergyInKWh initial energy [kWh]
 	 */
-	public static void setInitialEnergy(Vehicle vehicle, double initialEnergyInKWh) {
+	public static void setInitialEnergy_kWh(Vehicle vehicle, double initialEnergyInKWh) {
 		vehicle.getAttributes()
 				.putAttribute(ElectricVehicleSpecificationImpl.INITIAL_ENERGY_kWh, initialEnergyInKWh);
 	}

--- a/contribs/vsp/src/main/java/playground/vsp/ev/RunUrbanEVExample.java
+++ b/contribs/vsp/src/main/java/playground/vsp/ev/RunUrbanEVExample.java
@@ -72,8 +72,7 @@ import org.matsim.vehicles.VehiclesFactory;
  */
 public class RunUrbanEVExample {
 
-	static final double CAR_INITIAL_ENERGY = 4.;
-	static final double BIKE_INITIAL_ENERGY = 4.;
+	static final double CAR_INITIAL_ENERGY_kWh = 4.;
 
 	public static void main(String[] args) {
 		EvConfigGroup evConfigGroup = new EvConfigGroup();
@@ -134,7 +133,7 @@ public class RunUrbanEVExample {
 			scenario.getVehicles().addVehicleType(carVehicleType);
 			Vehicle carVehicle = vehicleFactory.createVehicle(VehicleUtils.createVehicleId(person, TransportMode.car),
 					carVehicleType);
-			EVUtils.setInitialEnergy(carVehicle, CAR_INITIAL_ENERGY);
+			EVUtils.setInitialEnergy_kWh(carVehicle, CAR_INITIAL_ENERGY_kWh);
 			scenario.getVehicles().addVehicle(carVehicle);
 
 			VehicleType bikeVehicleType = vehicleFactory.createVehicleType(

--- a/contribs/vsp/src/main/java/playground/vsp/ev/RunUrbanEVExample.java
+++ b/contribs/vsp/src/main/java/playground/vsp/ev/RunUrbanEVExample.java
@@ -73,7 +73,8 @@ import org.matsim.vehicles.VehiclesFactory;
  */
 public class RunUrbanEVExample {
 
-	static final double CAR_INITIAL_ENERGY_kWh = 4.;
+	static final double CAR_BATTERY_CAPACITY_kWh = 10.;
+	static final double CAR_INITIAL_SOC = 0.4;
 
 	public static void main(String[] args) {
 		EvConfigGroup evConfigGroup = new EvConfigGroup();
@@ -129,12 +130,12 @@ public class RunUrbanEVExample {
 			VehicleType carVehicleType = vehicleFactory.createVehicleType(Id.create(person.getId().toString(),
 					VehicleType.class)); //TODO should at least have a suffix "_car"
 			VehicleUtils.setHbefaTechnology(carVehicleType.getEngineInformation(), "electricity");
-			VehicleUtils.setEnergyCapacity(carVehicleType.getEngineInformation(), 10);
+			VehicleUtils.setEnergyCapacity(carVehicleType.getEngineInformation(), CAR_BATTERY_CAPACITY_kWh);
 			ElectricVehicleSpecifications.setChargerTypes(carVehicleType.getEngineInformation(), Arrays.asList("a", "b", "default"));
 			scenario.getVehicles().addVehicleType(carVehicleType);
 			Vehicle carVehicle = vehicleFactory.createVehicle(VehicleUtils.createVehicleId(person, TransportMode.car),
 					carVehicleType);
-			ElectricVehicleSpecifications.setInitialEnergy_kWh(carVehicle, CAR_INITIAL_ENERGY_kWh);
+			ElectricVehicleSpecifications.setInitialSoc(carVehicle, CAR_INITIAL_SOC);
 			scenario.getVehicles().addVehicle(carVehicle);
 
 			VehicleType bikeVehicleType = vehicleFactory.createVehicleType(

--- a/contribs/vsp/src/main/java/playground/vsp/ev/RunUrbanEVExample.java
+++ b/contribs/vsp/src/main/java/playground/vsp/ev/RunUrbanEVExample.java
@@ -51,6 +51,7 @@ import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.ev.EvConfigGroup;
 import org.matsim.contrib.ev.EvModule;
+import org.matsim.contrib.ev.fleet.ElectricVehicleSpecifications;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.groups.PlanCalcScoreConfigGroup;
@@ -129,11 +130,11 @@ public class RunUrbanEVExample {
 					VehicleType.class)); //TODO should at least have a suffix "_car"
 			VehicleUtils.setHbefaTechnology(carVehicleType.getEngineInformation(), "electricity");
 			VehicleUtils.setEnergyCapacity(carVehicleType.getEngineInformation(), 10);
-			EVUtils.setChargerTypes(carVehicleType.getEngineInformation(), Arrays.asList("a", "b", "default"));
+			ElectricVehicleSpecifications.setChargerTypes(carVehicleType.getEngineInformation(), Arrays.asList("a", "b", "default"));
 			scenario.getVehicles().addVehicleType(carVehicleType);
 			Vehicle carVehicle = vehicleFactory.createVehicle(VehicleUtils.createVehicleId(person, TransportMode.car),
 					carVehicleType);
-			EVUtils.setInitialEnergy_kWh(carVehicle, CAR_INITIAL_ENERGY_kWh);
+			ElectricVehicleSpecifications.setInitialEnergy_kWh(carVehicle, CAR_INITIAL_ENERGY_kWh);
 			scenario.getVehicles().addVehicle(carVehicle);
 
 			VehicleType bikeVehicleType = vehicleFactory.createVehicleType(

--- a/contribs/vsp/src/test/java/playground/vsp/ev/TransferFinalSocToNextIterTest.java
+++ b/contribs/vsp/src/test/java/playground/vsp/ev/TransferFinalSocToNextIterTest.java
@@ -41,7 +41,7 @@ public class TransferFinalSocToNextIterTest {
 	private final Scenario scenario = CreateUrbanEVTestScenario.createTestScenario();
 	private final SOCHandler handler = new SOCHandler(scenario);
 	private static final Integer LAST_ITERATION = 1;
-	private static final double INITIAL_ENERGY = 9.5;
+	private static final double INITIAL_ENERGY_kWh = 9.5;
 
 	@Rule
 	public MatsimTestUtils matsimTestUtils = new MatsimTestUtils();
@@ -53,7 +53,7 @@ public class TransferFinalSocToNextIterTest {
 		scenario.getConfig().controler().setOutputDirectory("test/output/playground/vsp/ev/FinalSoc2VehicleTypeTest/");
 
 		var vehicle1 = scenario.getVehicles().getVehicles().get(Id.create("Triple Charger_car", Vehicle.class));
-		EVUtils.setInitialEnergy(vehicle1, INITIAL_ENERGY);
+		EVUtils.setInitialEnergy_kWh(vehicle1, INITIAL_ENERGY_kWh);
 
 		//controler
 		Controler controler = RunUrbanEVExample.prepareControler(scenario);
@@ -61,13 +61,13 @@ public class TransferFinalSocToNextIterTest {
 		controler.run();
 
 		// testInitialEnergyInIter0
-		Assert.assertEquals(INITIAL_ENERGY, handler.iterationInitialSOC.get(0), 0.0);
+		Assert.assertEquals(INITIAL_ENERGY_kWh, handler.iterationInitialSOC.get(0), 0.0);
 
 		// testSOCIsDumpedIntoVehicleType
 		//agent has driven the car so SOC should have changed and should be dumped into the vehicle type
 		var vehicle = scenario.getVehicles().getVehicles().get(Id.create("Triple Charger_car", Vehicle.class));
-		Assert.assertNotEquals(EVUtils.getInitialEnergy(vehicle), INITIAL_ENERGY);
-		Assert.assertEquals(10, EVUtils.getInitialEnergy(vehicle), MatsimTestUtils.EPSILON); //should be fully charged
+		Assert.assertNotEquals(EVUtils.getInitialEnergy_kWh(vehicle), INITIAL_ENERGY_kWh);
+		Assert.assertEquals(10, EVUtils.getInitialEnergy_kWh(vehicle), MatsimTestUtils.EPSILON); //should be fully charged
 
 		// testSOCisTransferredToNextIteration
 		for (int i = 0; i < LAST_ITERATION; i++) {
@@ -86,12 +86,12 @@ public class TransferFinalSocToNextIterTest {
 
 		@Override
 		public void notifyAfterMobsim(AfterMobsimEvent event) {
-			this.iterationEndSOC.put(event.getIteration(), EVUtils.getInitialEnergy(car));
+			this.iterationEndSOC.put(event.getIteration(), EVUtils.getInitialEnergy_kWh(car));
 		}
 
 		@Override
 		public void notifyBeforeMobsim(BeforeMobsimEvent event) {
-			this.iterationInitialSOC.put(event.getIteration(), EVUtils.getInitialEnergy(car));
+			this.iterationInitialSOC.put(event.getIteration(), EVUtils.getInitialEnergy_kWh(car));
 		}
 	}
 }

--- a/examples/scenarios/dvrp-grid/one_etaxi_evehicles.xml
+++ b/examples/scenarios/dvrp-grid/one_etaxi_evehicles.xml
@@ -11,9 +11,9 @@
 		<width meter="1.0"/>
 		<engineInformation>
 			<attributes>
-				<attribute name="chargerTypes" class="java.util.ImmutableCollections$List12">["default"]</attribute>
-				<attribute name="energyCapacityInKWhOrLiters" class="java.lang.Double">20.0</attribute>
 				<attribute name="HbefaTechnology" class="java.lang.String">electricity</attribute>
+				<attribute name="chargerTypes" class="java.util.Collections$UnmodifiableCollection">["default"]</attribute>
+				<attribute name="energyCapacityInKWhOrLiters" class="java.lang.Double">20.0</attribute>
 			</attributes>
 		</engineInformation>
 		<costInformation>
@@ -26,7 +26,7 @@
 
 	<vehicle id="taxi_one" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">16.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.8</attribute>
 		</attributes>
 	</vehicle>
 		

--- a/examples/scenarios/holzkirchen/holzkirchenElectricFleet.xml
+++ b/examples/scenarios/holzkirchen/holzkirchenElectricFleet.xml
@@ -11,9 +11,9 @@
 		<width meter="1.0"/>
 		<engineInformation>
 			<attributes>
-				<attribute name="chargerTypes" class="java.util.ImmutableCollections$List12">["default"]</attribute>
-				<attribute name="energyCapacityInKWhOrLiters" class="java.lang.Double">30.0</attribute>
 				<attribute name="HbefaTechnology" class="java.lang.String">electricity</attribute>
+				<attribute name="chargerTypes" class="java.util.Collections$UnmodifiableCollection">["default"]</attribute>
+				<attribute name="energyCapacityInKWhOrLiters" class="java.lang.Double">30.0</attribute>
 			</attributes>
 		</engineInformation>
 		<costInformation>
@@ -33,9 +33,9 @@
 		<width meter="1.0"/>
 		<engineInformation>
 			<attributes>
-				<attribute name="chargerTypes" class="java.util.ImmutableCollections$List12">["default"]</attribute>
-				<attribute name="energyCapacityInKWhOrLiters" class="java.lang.Double">77.0</attribute>
 				<attribute name="HbefaTechnology" class="java.lang.String">electricity</attribute>
+				<attribute name="chargerTypes" class="java.util.Collections$UnmodifiableCollection">["default"]</attribute>
+				<attribute name="energyCapacityInKWhOrLiters" class="java.lang.Double">77.0</attribute>
 			</attributes>
 		</engineInformation>
 		<costInformation>
@@ -48,102 +48,102 @@
 
 	<vehicle id="drt_0" type="EV_77.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">77.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_1" type="EV_77.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">77.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_10" type="EV_30.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">30.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_11" type="EV_30.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">30.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_12" type="EV_77.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">77.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_13" type="EV_77.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">77.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_14" type="EV_77.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">77.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_15" type="EV_77.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">77.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_16" type="EV_77.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">77.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_17" type="EV_30.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">30.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_18" type="EV_77.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">77.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_19" type="EV_77.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">77.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_2" type="EV_77.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">77.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_3" type="EV_30.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">30.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_4" type="EV_77.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">77.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_5" type="EV_30.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">30.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_6" type="EV_77.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">77.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_7" type="EV_30.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">30.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_8" type="EV_77.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">77.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_9" type="EV_77.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">77.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">1.0</attribute>
 		</attributes>
 	</vehicle>
 		

--- a/examples/scenarios/mielec/etaxis-25.xml
+++ b/examples/scenarios/mielec/etaxis-25.xml
@@ -11,9 +11,9 @@
 		<width meter="1.0"/>
 		<engineInformation>
 			<attributes>
-				<attribute name="chargerTypes" class="java.util.ImmutableCollections$List12">["default"]</attribute>
-				<attribute name="energyCapacityInKWhOrLiters" class="java.lang.Double">20.0</attribute>
 				<attribute name="HbefaTechnology" class="java.lang.String">electricity</attribute>
+				<attribute name="chargerTypes" class="java.util.Collections$UnmodifiableCollection">["default"]</attribute>
+				<attribute name="energyCapacityInKWhOrLiters" class="java.lang.Double">20.0</attribute>
 			</attributes>
 		</engineInformation>
 		<costInformation>
@@ -26,127 +26,127 @@
 
 	<vehicle id="taxi_1_1" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">16.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.8</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_1_2" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">14.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.7</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_1_3" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">12.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.6</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_1_4" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">10.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.5</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_1_5" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">8.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.4</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_2_1" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">15.5</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.775</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_2_2" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">13.5</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.675</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_2_3" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">11.5</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.575</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_2_4" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">9.5</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.475</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_2_5" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">7.5</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.375</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_3_1" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">15.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.75</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_3_2" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">13.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.65</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_3_3" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">11.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.55</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_3_4" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">9.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.45</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_3_5" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">7.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.35</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_4_1" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">14.5</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.725</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_4_2" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">12.5</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.625</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_4_3" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">10.5</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.525</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_4_4" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">8.5</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.425</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_4_5" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">6.5</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.325</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_5_1" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">14.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.7</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_5_2" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">12.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.6</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_5_3" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">10.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.5</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_5_4" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">8.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.4</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="taxi_5_5" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">6.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.3</attribute>
 		</attributes>
 	</vehicle>
 		

--- a/examples/scenarios/mielec/evehicles-10.xml
+++ b/examples/scenarios/mielec/evehicles-10.xml
@@ -11,9 +11,9 @@
 		<width meter="1.0"/>
 		<engineInformation>
 			<attributes>
-				<attribute name="chargerTypes" class="java.util.ImmutableCollections$List12">["default"]</attribute>
-				<attribute name="energyCapacityInKWhOrLiters" class="java.lang.Double">20.0</attribute>
 				<attribute name="HbefaTechnology" class="java.lang.String">electricity</attribute>
+				<attribute name="chargerTypes" class="java.util.Collections$UnmodifiableCollection">["default"]</attribute>
+				<attribute name="energyCapacityInKWhOrLiters" class="java.lang.Double">20.0</attribute>
 			</attributes>
 		</engineInformation>
 		<costInformation>
@@ -26,52 +26,52 @@
 
 	<vehicle id="drt_veh_1_1" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">16.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.8</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_1_2" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">14.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.7</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_2_1" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">15.5</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.775</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_2_2" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">13.5</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.675</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_3_1" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">15.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.75</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_3_2" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">13.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.65</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_4_1" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">14.5</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.725</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_4_2" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">12.5</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.625</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_5_1" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">14.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.7</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_5_2" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">12.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.6</attribute>
 		</attributes>
 	</vehicle>
 		

--- a/examples/scenarios/mielec/evehicles-20.xml
+++ b/examples/scenarios/mielec/evehicles-20.xml
@@ -11,9 +11,9 @@
 		<width meter="1.0"/>
 		<engineInformation>
 			<attributes>
-				<attribute name="chargerTypes" class="java.util.ImmutableCollections$List12">["default"]</attribute>
-				<attribute name="energyCapacityInKWhOrLiters" class="java.lang.Double">20.0</attribute>
 				<attribute name="HbefaTechnology" class="java.lang.String">electricity</attribute>
+				<attribute name="chargerTypes" class="java.util.Collections$UnmodifiableCollection">["default"]</attribute>
+				<attribute name="energyCapacityInKWhOrLiters" class="java.lang.Double">20.0</attribute>
 			</attributes>
 		</engineInformation>
 		<costInformation>
@@ -26,102 +26,102 @@
 
 	<vehicle id="drt_veh_1_1" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">16.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.8</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_1_2" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">14.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.7</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_1_3" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">12.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.6</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_1_4" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">10.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.5</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_2_1" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">15.5</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.775</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_2_2" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">13.5</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.675</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_2_3" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">11.5</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.575</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_2_4" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">9.5</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.475</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_3_1" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">15.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.75</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_3_2" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">13.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.65</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_3_3" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">11.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.55</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_3_4" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">9.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.45</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_4_1" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">14.5</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.725</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_4_2" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">12.5</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.625</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_4_3" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">10.5</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.525</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_4_4" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">8.5</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.425</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_5_1" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">14.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.7</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_5_2" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">12.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.6</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_5_3" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">10.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.5</attribute>
 		</attributes>
 	</vehicle>
 	<vehicle id="drt_veh_5_4" type="EV_20.0kWh">
 		<attributes>
-			<attribute name="initialEnergyInKWh" class="java.lang.Double">8.0</attribute>
+			<attribute name="initialSoc" class="java.lang.Double">0.4</attribute>
 		</attributes>
 	</vehicle>
 		


### PR DESCRIPTION
As discussed in #2222, we want to define `initialSoc` instead of `initialEnergyInKWh`. This PR adapts both code and input files.

The input files were converted using `ConvertInitialChargeToInitialSoc`. Please use it for converting external input files (residing outside this repo).