### PR TITLE
Emissions maintenance

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/MATSimApplication.java
+++ b/contribs/application/src/main/java/org/matsim/application/MATSimApplication.java
@@ -86,7 +86,7 @@ public abstract class MATSimApplication implements Callable<Integer>, CommandLin
 			" |_|  |_/_/ \\_\\_| |___/_|_|_|_|\n|@";
 
 	@CommandLine.Option(names = "--config", description = "Path to config file used for the run.", order = 0)
-	protected File scenario;
+	protected File configPath;
 
 	@CommandLine.Option(names = "--yaml", description = "Path to yaml file with config params to overwrite.", required = false)
 	protected Path specs;
@@ -136,10 +136,10 @@ public abstract class MATSimApplication implements Callable<Integer>, CommandLin
 	/**
 	 * Constructor
 	 *
-	 * @param defaultScenario path to the default scenario config
+	 * @param defaultConfigPath path to the default scenario config
 	 */
-	public MATSimApplication(@Nullable String defaultScenario) {
-		this.defaultScenario = defaultScenario;
+	public MATSimApplication(@Nullable String defaultConfigPath) {
+		this.defaultScenario = defaultConfigPath;
 	}
 
 	/**
@@ -160,7 +160,7 @@ public abstract class MATSimApplication implements Callable<Integer>, CommandLin
 
 		// load config if not present yet.
 		if (config == null) {
-			config = loadConfig(Objects.requireNonNull(scenario, "No default scenario location given").getAbsoluteFile().toString());
+			config = loadConfig(Objects.requireNonNull( configPath, "No default scenario location given" ).getAbsoluteFile().toString() );
 		} else {
 			Config tmp = prepareConfig(config);
 			config = tmp != null ? tmp : config;
@@ -679,7 +679,10 @@ public abstract class MATSimApplication implements Callable<Integer>, CommandLin
 		}
 	}
 
-	@CommandLine.Command(name = "prepare", description = "Contains all commands for preparing the scenario. (See help prepare)",
+	@CommandLine.Command(name = "prepare", description = "Contains all commands for preparing the scenario. (See prepare help; \n" +
+									     "  needs to be ... \"prepare\", \"help\" ) if run from Java.)",
+			// (This used to be "help prepare", which works as well.  However, "prepare help <subcommand>" then also works while "help
+			// prepare <subcommand>" does not.  So I think that "prepare help" saves some time in understanding help options.  kai, nov'22)
 			subcommands = CommandLine.HelpCommand.class)
 	public static class PrepareCommand implements Callable<Integer> {
 

--- a/contribs/application/src/main/java/org/matsim/application/analysis/emissions/AirPollutionByVehicleCategory.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/emissions/AirPollutionByVehicleCategory.java
@@ -40,7 +40,6 @@ import org.matsim.contrib.emissions.events.WarmEmissionEvent;
 import org.matsim.contrib.emissions.events.WarmEmissionEventHandler;
 import org.matsim.contrib.emissions.utils.EmissionsConfigGroup;
 import org.matsim.contrib.emissions.utils.EmissionsConfigGroup.DetailedVsAverageLookupBehavior;
-import org.matsim.contrib.emissions.utils.EmissionsConfigGroup.HbefaRoadTypeSource;
 import org.matsim.contrib.emissions.utils.EmissionsConfigGroup.NonScenarioVehicles;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
@@ -140,7 +139,7 @@ public class AirPollutionByVehicleCategory implements MATSimAppCommand {
 		eConfig.setDetailedVsAverageLookupBehavior(lookupBehavior);
 		eConfig.setAverageColdEmissionFactorsFile(this.hbefaColdFile.toString());
 		eConfig.setAverageWarmEmissionFactorsFile(this.hbefaWarmFile.toString());
-		eConfig.setHbefaRoadTypeSource(HbefaRoadTypeSource.fromLinkAttributes);
+//		eConfig.setHbefaRoadTypeSource(HbefaRoadTypeSource.fromLinkAttributes);
 		eConfig.setNonScenarioVehicles(NonScenarioVehicles.ignore);
 
 		final String eventsFile = globFile(runDirectory, runId, "events");

--- a/contribs/application/src/main/java/org/matsim/application/commands/ShowGUI.java
+++ b/contribs/application/src/main/java/org/matsim/application/commands/ShowGUI.java
@@ -7,7 +7,7 @@ import picocli.CommandLine;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
-@CommandLine.Command(name = "gui", description = "Show the graphical user interface")
+@CommandLine.Command(name = "gui", description = "Run the scenario through the MATSim GUI")
 public class ShowGUI implements Callable<Integer> {
 
     @CommandLine.ParentCommand

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/ColdEmissionAnalysisModule.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/ColdEmissionAnalysisModule.java
@@ -97,10 +97,12 @@ final class ColdEmissionAnalysisModule {
 		this.eventsManager = eventsManager;
 	}
 
+	/**
+	 *  yy I do not know what the "W" in the method name means.  Normally, it means "With".  But that does not make sense here.  kai, dec'22
+	 */
 	/*package-private*/ Map<Pollutant, Double> checkVehicleInfoAndCalculateWColdEmissions(
 			VehicleType vehicleType, Id<Vehicle> vehicleId, Id<Link> coldEmissionEventLinkId,
 			double eventTime, double parkingDuration, int distance_km) {
-
 		{
 			String hbefaVehicleTypeDescription = EmissionUtils.getHbefaVehicleDescription( vehicleType, this.ecg );
 			// (this will, importantly, repair the hbefa description in the vehicle type. kai/kai, jan'20)
@@ -150,8 +152,8 @@ final class ColdEmissionAnalysisModule {
 		HbefaColdEmissionFactorKey key = new HbefaColdEmissionFactorKey();
 		key.setVehicleCategory(vehicleInformationTuple.getFirst());
 
-		//HBEFA 3 provide cold start emissions for "pass. car" and Light_Commercial_Vehicles (LCV) only.
-		//HBEFA 4.1 provide cold start emissions for "pass. car" and Light_Commercial_Vehicles (LCV) only.
+		//HBEFA 3 provides cold start emissions for "pass. car" and Light_Commercial_Vehicles (LCV) only.
+		//HBEFA 4.1 provides cold start emissions for "pass. car" and Light_Commercial_Vehicles (LCV) only.
 		//see https://www.hbefa.net/e/documents/HBEFA41_Development_Report.pdf (WP 4 , page 23)  kturner, may'20
 		//Mapping everything except "motorcycle" to "pass.car", since this was done in the last years for HGV.
 		//This may can be improved: What should be better set to LGV or zero???? kturner, may'20

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/ColdEmissionHandler.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/ColdEmissionHandler.java
@@ -119,6 +119,7 @@ final class ColdEmissionHandler implements LinkLeaveEventHandler, VehicleLeavesT
                     this.vehicleId2accumulatedDistance.put( vehicleId, distance );
                 }
                 // yyyy I have absolutely no clue what the distance stuff is doing here.  kai, jan'20
+                // I now think that this has to do with the fact that the cold emissions are smeared out over the initial distance.  Don't know the details, though.  kai, dec'22
             }
         }
     }

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/EmissionModule.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/EmissionModule.java
@@ -170,6 +170,11 @@ public final class EmissionModule {
 		if (shouldCreateAverageTables()) {
 			this.avgHbefaColdTable = HbefaTables.loadAverageCold(emissionConfigGroup.getAverageColdEmissionFactorsFileURL(scenario.getConfig().getContext()));
 			addPollutantsToMap(coldPollutants, avgHbefaColdTable.keySet());
+			// yy The naming and signature of the above should presumably be changed: (1) addPollutantsToX implies signature (pollutants,
+			// X).  But it is actually the other way round (even if it does not read that way.  (2) "coldPollutants" is not a Map.  Since
+			// this is a private method, maybe one could also have a method "memorizeColdPollutants" and then not have coldPollutants as
+			// field. kai, dec'22
+
 			this.avgHbefaWarmTable = HbefaTables.loadAverageWarm(emissionConfigGroup.getAverageWarmEmissionFactorsFileURL(scenario.getConfig().getContext()));
 			addPollutantsToMap(warmPollutants, avgHbefaWarmTable.keySet());
 		}

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/WarmEmissionAnalysisModule.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/WarmEmissionAnalysisModule.java
@@ -274,7 +274,7 @@ public final class WarmEmissionAnalysisModule implements LinkEmissionsCalculator
 			throw new RuntimeException("Average speed has been calculated to 0.0 or a negative value. Aborting...");
 		}
 		if ((averageSpeed_kmh - freeVelocity_ms * 3.6) > 1.0){
-			if (ecg.handlesHighAverageSpeeds()) {
+			if (ecg.getHandleHighAverageSpeeds()) {
 				logger.warn("averageSpeed was capped from " + averageSpeed_kmh + " to" + freeVelocity_ms * 3.6 );
 				averageSpeed_kmh = freeVelocity_ms * 3.6;
 			} else {

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/example/CreateEmissionConfig.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/example/CreateEmissionConfig.java
@@ -113,8 +113,8 @@ public final class CreateEmissionConfig {
 	        controler.getConfig().addModule(ecg);
 
 			// one can now directly set the hbefa road types as link attributes
-	        ecg.setEmissionRoadTypeMappingFile(roadTypeMappingFile);
-			ecg.setHbefaRoadTypeSource(EmissionsConfigGroup.HbefaRoadTypeSource.fromFile);
+//	        ecg.setEmissionRoadTypeMappingFile(roadTypeMappingFile);
+//			ecg.setHbefaRoadTypeSource(EmissionsConfigGroup.HbefaRoadTypeSource.fromFile);
 
 	        // emission vehicles are now set in the default vehicle container
 	        config.vehicles().setVehiclesFile(emissionVehicleFile);
@@ -134,8 +134,8 @@ public final class CreateEmissionConfig {
 	        ecg.setDetailedColdEmissionFactorsFile(detailedColdEmissionFactorsFile);
 
 	        ecg.setWritingEmissionsEvents(false);
-	        ecg.setEmissionCostMultiplicationFactor(1.0);
-	        ecg.setConsideringCO2Costs(true);
+//	        ecg.setEmissionCostMultiplicationFactor(1.0);
+//	        ecg.setConsideringCO2Costs(true);
 //	        ecg.setEmissionEfficiencyFactor(1.0);
 	        
 	   // write config     

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/utils/EmissionsConfigGroup.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/utils/EmissionsConfigGroup.java
@@ -21,7 +21,6 @@ package org.matsim.contrib.emissions.utils;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.matsim.api.core.v01.network.Link;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ReflectiveConfigGroup;
@@ -29,30 +28,17 @@ import org.matsim.core.config.ReflectiveConfigGroup;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public final class EmissionsConfigGroup extends ReflectiveConfigGroup {
 	private static final Logger log = LogManager.getLogger( EmissionsConfigGroup.class );
 
 	public static final String GROUP_NAME = "emissions";
 
-	@Deprecated // See elsewhere in this class.  kai, oct'18
-	private static final String EMISSION_ROADTYPE_MAPPING_FILE = "emissionRoadTypeMappingFile";
-	@Deprecated // kai, oct'18
-	private String emissionRoadTypeMappingFile = null;
-
 	private static final String EMISSION_FACTORS_WARM_FILE_AVERAGE = "averageFleetWarmEmissionFactorsFile";
 	private String averageFleetWarmEmissionFactorsFile = null;
 
 	private static final String EMISSION_FACTORS_COLD_FILE_AVERAGE = "averageFleetColdEmissionFactorsFile";
 	private String averageFleetColdEmissionFactorsFile = null;
-
-	/**
-	 * @deprecated -- use {{@link #DETAILED_VS_AVERAGE_LOOKUP_BEHAVIOR}}
-	 */
-	@Deprecated
-	private static final String USING_DETAILED_EMISSION_CALCULATION = "usingDetailedEmissionCalculation";
-//	private boolean isUsingDetailedEmissionCalculation = false;
 
 	private static final String EMISSION_FACTORS_WARM_FILE_DETAILED = "detailedWarmEmissionFactorsFile" ;
 	private String detailedWarmEmissionFactorsFile = null;
@@ -62,34 +48,6 @@ public final class EmissionsConfigGroup extends ReflectiveConfigGroup {
 
 	private static final String WRITING_EMISSIONS_EVENTS = "isWritingEmissionsEvents";
 	private boolean isWritingEmissionsEvents = true;
-
-	@Deprecated // see comments at getter/setter
-	private static final String EMISSION_EFFICIENCY_FACTOR = "emissionEfficiencyFactor";
-	@Deprecated // see comments at getter/setter
-	private double emissionEfficiencyFactor = 1.0;
-
-	@Deprecated // kai, oct'18
-	private static final String EMISSION_COST_MULTIPLICATION_FACTOR = "emissionCostMultiplicationFactor";
-//	@Deprecated // kai, oct'18
-//	private double emissionCostMultiplicationFactor = 1.0;
-
-	@Deprecated // kai, oct'18
-	private static final String CONSIDERING_CO2_COSTS = "consideringCO2Costs";
-//	@Deprecated // kai, oct'18
-//	private boolean consideringCO2Costs = false;
-
-	private static final String HANDLE_HIGH_AVERAGE_SPEEDS = "handleHighAverageSpeeds";
-	private boolean handleHighAverageSpeeds = false;
-	// yyyy should become an enum.  kai, jan'20
-
-//	@Deprecated // See elsewhere in this class.  kai, oct'18
-	public enum HbefaRoadTypeSource { fromFile, fromLinkAttributes, fromOsm }
-//	@Deprecated // See elsewhere in this class.  kai, oct'18
-	private static final String Hbefa_ROADTYPE_SOURCE = "hbefaRoadTypeSource";
-//	@Deprecated // my preference would be to phase out the "fromFile" option and use "fromLinkAttributes" only.  It can always be solved after reading the network.  kai, oct'18
-	// I am now thinking that it would be more expressive to keep that setting, because it makes users aware of the fact that there needs to be something
-	// in the network file.  kai, dec'19
-	private HbefaRoadTypeSource hbefaRoadTypeSource = HbefaRoadTypeSource.fromFile; // fromFile is to support backward compatibility
 
 	public enum NonScenarioVehicles { ignore, abort }
 	private static final String NON_SCENARIO_VEHICLES = "nonScenarioVehicles";
@@ -109,51 +67,27 @@ public final class EmissionsConfigGroup extends ReflectiveConfigGroup {
 	private static final String HBEFA_TABLE_CONSISTENCY_CHECKING_LEVEL = "hbefaTableConsistencyCheckingLevel";
 	private HbefaTableConsistencyCheckingLevel hbefaTableConsistencyCheckingLevel = HbefaTableConsistencyCheckingLevel.allCombinations;
 
-	@Deprecated // should be phased out.  kai, oct'18
-	private static final String EMISSION_ROADTYPE_MAPPING_FILE_CMT = "REQUIRED if source of the HBEFA road type is set to "+HbefaRoadTypeSource.fromFile +". It maps from input road types to HBEFA 3.1 road type strings";
 	private static final String EMISSION_FACTORS_WARM_FILE_AVERAGE_CMT = "file with HBEFA vehicle type specific fleet average warm emission factors";
 	private static final String EMISSION_FACTORS_COLD_FILE_AVERAGE_CMT = "file with HBEFA vehicle type specific fleet average cold emission factors";
-//	@Deprecated //Use DETAILED_VS_AVERAGE_LOOKUP_BEHAVIOR instead
-//	private static final String USING_DETAILED_EMISSION_CALCULATION_CMT = "This is now deprecated. Please use " + DETAILED_VS_AVERAGE_LOOKUP_BEHAVIOR + " instead to declare if detailed or average tables should be used.";
-	private static final String DETAILED_VS_AVERAGE_LOOKUP_BEHAVIOR_CMT = "Should the calculation bases on average or detailed emission factors? " + "\n\t\t" +
+	private static final String DETAILED_VS_AVERAGE_LOOKUP_BEHAVIOR_CMT = "Should the calculation bases on average or detailed emission factors? " + "\n\t\t\t" +
 			DetailedVsAverageLookupBehavior.onlyTryDetailedElseAbort.name() + " : try detailed values. Abort if values are not found. Requires DETAILED" +
-											      " emission factors. \n\t\t" +
+											      " emission factors. \n\t\t\t" +
 			DetailedVsAverageLookupBehavior.tryDetailedThenTechnologyAverageElseAbort.name() + " : try detailed values first, if not found try to use " +
-											      "semi-detailed values for 'vehicleType,technology,average,average', if then not found abort. Requires DETAILED emission factors. \n\t\t" +
+											      "semi-detailed values for 'vehicleType,technology,average,average', if then not found abort. Requires DETAILED emission factors. \n\t\t\t" +
 			DetailedVsAverageLookupBehavior.tryDetailedThenTechnologyAverageThenAverageTable.name() + "try detailed values first, if not found try to " +
-											      "use semi-detailed values for 'vehicleType,technology,average,average', if then not found try lookup in average table. Requires DETAILED and AVERAGE emission factors. \n\t\t" +
+											      "use semi-detailed values for 'vehicleType,technology,average,average', if then not found try lookup in average table. Requires DETAILED and AVERAGE emission factors. \n\t\t\t" +
 			DetailedVsAverageLookupBehavior.directlyTryAverageTable.name() + "only calculate from average table. Requires AVERAGE emission factors. " +
 			"Default is " + DetailedVsAverageLookupBehavior.onlyTryDetailedElseAbort.name();
 	private static final String EMISSION_FACTORS_WARM_FILE_DETAILED_CMT = "file with HBEFA detailed warm emission factors";
 	private static final String EMISSION_FACTORS_COLD_FILE_DETAILED_CMT = "file with HBEFA detailed cold emission factors";
-	@Deprecated // should be phased out.  kai, oct'18
-	private static final String USING_VEHICLE_TYPE_ID_AS_VEHICLE_DESCRIPTION_CMT = "The vehicle information (or vehicles file) should be passed to the scenario." +
-															   "The definition of emission specifications:" +  "\n\t\t" +
-															   " - REQUIRED: it must start with the respective HbefaVehicleCategory followed by `;'" + "\n\t\t" +
-															   " - OPTIONAL: if detailed emission calculation is switched on, the emission specifications should aditionally contain" +
-															   " HbefaVehicleAttributes (`Technology;SizeClasse;EmConcept'), corresponding to the strings in " + EMISSION_FACTORS_WARM_FILE_DETAILED+"."+
-															   "\n\t\t" +
-															   "TRUE (DO NOT USE except for backwards compatibility): vehicle type id is used for the emission specifications.\n\t\t" +
-															   "FALSE (DO NOT USE except for backwards compability): vehicle description is used for the emission specifications. The emission specifications of a vehicle " +
-															   "type should be surrounded by emission specification markers.\n\t\t" +
-															   "do not actively set (or set to null) (default): hbefa vehicle type description comes from attribute in vehicle type." ;
-
-	private static final String HBEFA_TABLE_CONSISTENCY_CHECKING_LEVEL_CMT = "Define on which level the entries in the provided hbefa tables are checked for consistency" + "\n\t\t" +
+	private static final String HBEFA_TABLE_CONSISTENCY_CHECKING_LEVEL_CMT = "Define on which level the entries in the provided hbefa tables are checked for consistency" + "\n\t\t\t" +
 			HbefaTableConsistencyCheckingLevel.allCombinations.name() + " : check if entries for all combinations of HbefaTrafficSituation, HbefaVehicleCategory, HbefaVehicleAttributes, HbefaComponent. " +
-																"are available in the table. It only checks for paramters that are available in the table (e.g. if there is no HGV in the table, it can also pass. \n\t\t" +
-			HbefaTableConsistencyCheckingLevel.consistent.name() + " : check if the entries for the two HbefaTrafficSituations 'StopAndGo' and 'FreeFlow' (nov 2020, maybe subject to change) are consistently available in the table. \n\t\t" + //TODO
-			HbefaTableConsistencyCheckingLevel.none.name() + " : There is no consistency check. This option is NOT recommended and only for backward capability to inputs from before spring 2020 . \n\t\t" +
+																"are available in the table. It only checks for paramters that are available in the table (e.g. if there is no HGV in the table, it can also pass. \n\t\t\t" +
+			HbefaTableConsistencyCheckingLevel.consistent.name() + " : check if the entries for the two HbefaTrafficSituations 'StopAndGo' and 'FreeFlow' (nov 2020, may be subject to change) are consistently available in the table. \n\t\t\t" + //TODO
+			HbefaTableConsistencyCheckingLevel.none.name() + " : There is no consistency check. This option is NOT recommended and only for backward capability to inputs from before spring 2020 . \n\t\t\t" +
 			"Default is " + HbefaTableConsistencyCheckingLevel.allCombinations.name();
 
-	// yyyy the EmissionsSpecificationMarker thing should be replaced by link attributes.  Did not exist when this functionality was written.  kai, oct'18
-
 	private static final String WRITING_EMISSIONS_EVENTS_CMT = "if false, emission events will not appear in the events file.";
-
-	private static final String EMISSION_EFFICIENCY_FACTOR_CMT = "A factor to include efficiency of the vehicles; all warn emissions are multiplied with this factor; the factor is applied to the whole fleet. ";
-	@Deprecated
-	private static final String EMISSION_COST_MULTIPLICATION_FACTOR_CMT = "A factor by which the emission cost factors from literature (Maibach et al. (2008)) are increased.";
-	@Deprecated
-	private static final String CONSIDERING_CO2_COSTS_CMT = "if true, only flat emissions will be considered irrespective of pricing either flat air pollution or exposure of air pollution.";
 
 	private static final String HANDLE_HIGH_AVERAGE_SPEEDS_CMT = "if true, don't fail when average speed is higher than the link freespeed, but cap it instead.";
 
@@ -161,7 +95,7 @@ public final class EmissionsConfigGroup extends ReflectiveConfigGroup {
 //			+ Arrays.stream(NonScenarioVehicles.values()).map(handling -> " " + handling.toString()).collect(Collectors.joining()) +"."
 											    //    https://stackoverflow.com/questions/48300252/getting-stackoverflowerror-while-initializing-a-static-variable .
 											    // really ugly compilation error with java8, difficult to find.  kai, nov'18
-											    + NonScenarioVehicles.values()
+											    + Arrays.toString( NonScenarioVehicles.values() )
 											    + " Should eventually be extended by 'getVehiclesFromMobsim'."
 		  ;
 
@@ -172,25 +106,10 @@ public final class EmissionsConfigGroup extends ReflectiveConfigGroup {
 	public Map<String, String> getComments() {
 		Map<String,String> map = super.getComments();
 
-
-		map.put(EMISSION_ROADTYPE_MAPPING_FILE, EMISSION_ROADTYPE_MAPPING_FILE_CMT);
-
-		{
-			String Hbefa_ROADTYPE_SOURCE_CMT = "Source of the HBEFFA road type. The options are:"+ Arrays.stream(HbefaRoadTypeSource.values())
-																		   .map(source -> " " + source.toString())
-																		   .collect(Collectors.joining()) +"."
-//			"\n"+HbefaRoadTypeSource.fromLinkAttributes+" is default i.e. put HBEFA road type directly to the link attributes." // unfortunately not default
-				  ;
-
-			map.put(Hbefa_ROADTYPE_SOURCE, Hbefa_ROADTYPE_SOURCE_CMT);
-		}
-
-
 		map.put(EMISSION_FACTORS_WARM_FILE_AVERAGE, EMISSION_FACTORS_WARM_FILE_AVERAGE_CMT);
 
 		map.put(EMISSION_FACTORS_COLD_FILE_AVERAGE, EMISSION_FACTORS_COLD_FILE_AVERAGE_CMT);
 
-//		map.put(USING_DETAILED_EMISSION_CALCULATION, USING_DETAILED_EMISSION_CALCULATION_CMT);	//is deprecated now. This functionality is integrated in DETAILED_VS_AVERAGE_LOOKUP_BEHAVIOR.
 		map.put(DETAILED_VS_AVERAGE_LOOKUP_BEHAVIOR, DETAILED_VS_AVERAGE_LOOKUP_BEHAVIOR_CMT);
 
 		map.put(HBEFA_TABLE_CONSISTENCY_CHECKING_LEVEL, HBEFA_TABLE_CONSISTENCY_CHECKING_LEVEL_CMT);
@@ -199,16 +118,9 @@ public final class EmissionsConfigGroup extends ReflectiveConfigGroup {
 
 		map.put(EMISSION_FACTORS_COLD_FILE_DETAILED, EMISSION_FACTORS_COLD_FILE_DETAILED_CMT);
 
-//		map.put(USING_VEHICLE_TYPE_ID_AS_VEHICLE_DESCRIPTION, USING_VEHICLE_TYPE_ID_AS_VEHICLE_DESCRIPTION_CMT);
 		map.put(HBEFA_VEHICLE_DESCRIPTION_SOURCE, HBEFA_VEHICLE_DESCRIPTION_SOURCE_CMT) ;
 
 		map.put(WRITING_EMISSIONS_EVENTS, WRITING_EMISSIONS_EVENTS_CMT);
-
-		map.put(EMISSION_EFFICIENCY_FACTOR, EMISSION_EFFICIENCY_FACTOR_CMT);
-
-//		map.put(EMISSION_COST_MULTIPLICATION_FACTOR, EMISSION_COST_MULTIPLICATION_FACTOR_CMT);
-
-//		map.put(CONSIDERING_CO2_COSTS, CONSIDERING_CO2_COSTS_CMT);
 
 		map.put(HANDLE_HIGH_AVERAGE_SPEEDS, HANDLE_HIGH_AVERAGE_SPEEDS_CMT);
 
@@ -219,26 +131,8 @@ public final class EmissionsConfigGroup extends ReflectiveConfigGroup {
 		return map;
 	}
 
-	/**
-	 * @param roadTypeMappingFile -- {@value #EMISSION_ROADTYPE_MAPPING_FILE_CMT}
-	 * @noinspection JavadocReference
-	 */
-	@StringSetter(EMISSION_ROADTYPE_MAPPING_FILE)
-	@Deprecated // See elsewhere in this class.  kai, oct'18
-	public void setEmissionRoadTypeMappingFile(String roadTypeMappingFile) {
-		this.emissionRoadTypeMappingFile = roadTypeMappingFile;
-	}
-	@StringGetter(EMISSION_ROADTYPE_MAPPING_FILE)
-	@Deprecated // See elsewhere in this class.  kai, oct'18
-	public String getEmissionRoadTypeMappingFile() {
-		return this.emissionRoadTypeMappingFile;
-	}
-
-	@Deprecated // See elsewhere in this class.  kai, oct'18
-	public URL getEmissionRoadTypeMappingFileURL(URL context) {
-		return ConfigGroup.getInputFileURL(context, this.emissionRoadTypeMappingFile);
-	}
-
+	// ===============
+	// ===============
 	/**
 	 * @param averageFleetWarmEmissionFactorsFile -- {@value #EMISSION_FACTORS_WARM_FILE_AVERAGE_CMT}
 	 */
@@ -254,7 +148,8 @@ public final class EmissionsConfigGroup extends ReflectiveConfigGroup {
 	public URL getAverageWarmEmissionFactorsFileURL(URL context) {
 		return ConfigGroup.getInputFileURL(context, this.averageFleetWarmEmissionFactorsFile);
 	}
-
+	// ===============
+	// ===============
 	/**
 	 * @param averageFleetColdEmissionFactorsFile -- {@value #EMISSION_FACTORS_COLD_FILE_AVERAGE_CMT}
 	 */
@@ -271,19 +166,22 @@ public final class EmissionsConfigGroup extends ReflectiveConfigGroup {
 		return ConfigGroup.getInputFileURL(context, this.averageFleetColdEmissionFactorsFile);
 	}
 	// ===============
+	// ===============
+	@Deprecated
+	private static final String USING_DETAILED_EMISSION_CALCULATION = "usingDetailedEmissionCalculation";
 	private static final String message = "The " + USING_DETAILED_EMISSION_CALCULATION + " switch is now disabled.  ";
 	private static final String messageTrue = "Please use <param name=\"detailedVsAverageLookupBehavior\" value=\"tryDetailedThenTechnologyAverageThenAverageTable\" />";
 	private static final String messageFalse = "Please use <param name=\"detailedVsAverageLookupBehavior\" value=\"directlyTryAverageTable\" />";
 	/** @noinspection MethodMayBeStatic*/ // ---
 	@StringGetter(USING_DETAILED_EMISSION_CALCULATION)
 	@Deprecated
-	public Boolean isUsingDetailedEmissionCalculationStringGetter(){
-		log.warn(message);
-		log.warn("returning null so that config writer does not abort");
+	Boolean isUsingDetailedEmissionCalculationStringGetter(){
+		log.info(message);
+		log.info("returning null so that config writer does not abort");
 		return null ;
 	}
 	@StringSetter(USING_DETAILED_EMISSION_CALCULATION)
-	public void setUsingDetailedEmissionCalculationStringSetter(final Boolean usingDetailedEmissionCalculation) {
+	void setUsingDetailedEmissionCalculationStringSetter(final Boolean usingDetailedEmissionCalculation) {
 		log.error( message );
 		if ( usingDetailedEmissionCalculation==null ){
 			log.warn( "null as entry in " + USING_DETAILED_EMISSION_CALCULATION + " has no meaning; ignoring it." );
@@ -293,16 +191,9 @@ public final class EmissionsConfigGroup extends ReflectiveConfigGroup {
 			log.warn( messageFalse );
 		}
 		throw new RuntimeException( );
-//		log.warn( message + " Will try to retrofit ...");
-//		if ( usingDetailedEmissionCalculation==null ){
-//			log.warn( "null as entry in " + USING_DETAILED_EMISSION_CALCULATION + " has no meaning; ignoring it." );
-//		} else if ( usingDetailedEmissionCalculation ) {
-//			this.detailedVsAverageLookupBehavior = DetailedVsAverageLookupBehavior.tryDetailedThenTechnologyAverageThenAverageTable;
-//		} else {
-//			this.detailedVsAverageLookupBehavior = DetailedVsAverageLookupBehavior.directlyTryAverageTable;
-//		}
 	}
-	// ---
+	// ===============
+	// ===============
 	/**
 	 * @param detailedVsAverageLookupBehavior -- {@value #DETAILED_VS_AVERAGE_LOOKUP_BEHAVIOR_CMT}
 	 * @noinspection JavadocReference
@@ -311,13 +202,12 @@ public final class EmissionsConfigGroup extends ReflectiveConfigGroup {
 	public void setDetailedVsAverageLookupBehavior(DetailedVsAverageLookupBehavior detailedVsAverageLookupBehavior) {
 		this.detailedVsAverageLookupBehavior = detailedVsAverageLookupBehavior;
 	}
-
 	@StringGetter(DETAILED_VS_AVERAGE_LOOKUP_BEHAVIOR)
 	public DetailedVsAverageLookupBehavior getDetailedVsAverageLookupBehavior() {
 		return this.detailedVsAverageLookupBehavior;
 	}
-
-	// ---
+	// ===============
+	// ===============
 	/**
 	 * @param hbefaTableConsistencyCheckingLevel -- {@value #HBEFA_TABLE_CONSISTENCY_CHECKING_LEVEL}
 	 * @noinspection JavadocReference
@@ -371,45 +261,6 @@ public final class EmissionsConfigGroup extends ReflectiveConfigGroup {
 	}
 	// ============================================
 	// ============================================
-	@Deprecated private static final String USING_VEHICLE_TYPE_ID_AS_VEHICLE_DESCRIPT_MSG = "replace Boolean by enum hbefaVehicleDescriptionSource.  true <--> usingVehicleTypeId; false <--> fromVehicleTypeDescription; null <--> asEngineInformationAttributes." ;
-	@Deprecated // kai, oct'18
-	private static final String USING_VEHICLE_TYPE_ID_AS_VEHICLE_DESCRIPTION = "isUsingVehicleTypeIdAsVehicleDescription";
-	@StringGetter(USING_VEHICLE_TYPE_ID_AS_VEHICLE_DESCRIPTION)
-	@Deprecated public Boolean isUsingVehicleTypeIdAsVehicleDescription() {
-		log.error(USING_VEHICLE_TYPE_ID_AS_VEHICLE_DESCRIPT_MSG);
-		return null; // otherwise config writer will fail. kai, nov'21
-/*
-//		switch ( this.getHbefaVehicleDescriptionSource() ) {
-//			case usingVehicleTypeId:
-//				return true ;
-//			case fromVehicleTypeDescription:
-//				return false ;
-//			case asEngineInformationAttributes:
-//				return null ;
-//			default:
-//				throw new RuntimeException( "config switch setting not understood" ) ;
-//		}
-*/
-	}
-	/**
-	 * @param usingVehicleIdAsVehicleDescription -- {@value #USING_VEHICLE_TYPE_ID_AS_VEHICLE_DESCRIPTION_CMT}
-	 */
-	@StringSetter(USING_VEHICLE_TYPE_ID_AS_VEHICLE_DESCRIPTION)
-	@Deprecated // is there to tell people what to do.  kai, nov'21
-	public void setUsingVehicleTypeIdAsVehicleDescription(Boolean usingVehicleIdAsVehicleDescription) {
-		throw new RuntimeException( USING_VEHICLE_TYPE_ID_AS_VEHICLE_DESCRIPT_MSG );
-/*
-//		if ( usingVehicleIdAsVehicleDescription==null ) {
-//			this.setHbefaVehicleDescriptionSource( HbefaVehicleDescriptionSource.asEngineInformationAttributes );
-//		} else if ( usingVehicleIdAsVehicleDescription ) {
-//			this.setHbefaVehicleDescriptionSource( HbefaVehicleDescriptionSource.usingVehicleTypeId );
-//		} else {
-//			this.setHbefaVehicleDescriptionSource( HbefaVehicleDescriptionSource.fromVehicleTypeDescription );
-//		}
-*/
-	}
-	// ---
-	// ---
 	// yy I now think that one can get away without the following.  kai, mar'19
 	private static final String HBEFA_VEHICLE_DESCRIPTION_SOURCE="hbefaVehicleDescriptionSource" ;
 	private static final String HBEFA_VEHICLE_DESCRIPTION_SOURCE_CMT="Each vehicle in matsim points to a VehicleType.  For the emissions package to work, " +
@@ -449,68 +300,13 @@ public final class EmissionsConfigGroup extends ReflectiveConfigGroup {
 		isWritingEmissionsEvents = writingEmissionsEvents;
 	}
 	// ============================================
-//	// ============================================
-//	/**
-//	 * @return {@value #EMISSION_EFFICIENCY_FACTOR_CMT}
-//	 *
-//	 * @deprecated -- I cannot see a goot use case for this: Since this is not even by vehicle type, it could easily be done in the events file
-//	 * postprocessing.  kai, jan'20
-//	 */
-//	@Deprecated
-//	@StringGetter(EMISSION_EFFICIENCY_FACTOR)
-//	public double getEmissionEfficiencyFactor() {
-//		return emissionEfficiencyFactor;
-//	}
-//	/**
-//	 * @param emissionEfficiencyFactor -- {@value #EMISSION_EFFICIENCY_FACTOR_CMT}
-//	 *
-//	 * @deprecated -- I cannot see a goot use case for this: Since this is not even by vehicle type, it could easily be done in the events file
-//	 * postprocessing.  kai, jan'20
-//	 */
-//	@Deprecated
-//	@StringSetter(EMISSION_EFFICIENCY_FACTOR)
-//	public void setEmissionEfficiencyFactor(double emissionEfficiencyFactor) {
-//		this.emissionEfficiencyFactor = emissionEfficiencyFactor;
-//	}
-//	// ============================================
-	private static final String COSTS_MSG="Cost calculations are not part of the emissions contrib.  Do not use this config setting.";
 	// ============================================
-//	@StringGetter(EMISSION_COST_MULTIPLICATION_FACTOR)
-	// not used in contrib itself --> does not belong here; disable xml functionality and set deprecated in code.  kai, oct'18
-//	@Deprecated // kai, oct'18
-//	public double getEmissionCostMultiplicationFactor() {
-//		throw new RuntimeException(COSTS_MSG);
-//	}
-//	/**
-//	 * @param emissionCostMultiplicationFactor -- {@value #EMISSION_COST_MULTIPLICATION_FACTOR_CMT}
-//	 */
-//	@StringSetter(EMISSION_COST_MULTIPLICATION_FACTOR)
-	// not used in contrib itself --> does not belong here; disable xml functionality and set deprecated in code.  kai, oct'18
-	@Deprecated // kai, oct'18
-	public void setEmissionCostMultiplicationFactor(double emissionCostMultiplicationFactor) {
-		throw new RuntimeException(COSTS_MSG);
-	}
-	// ============================================
-	// ============================================
-	// 	@StringGetter(CONSIDERING_CO2_COSTS)
-	// not used in contrib itself --> does not belong here; disable xml functionality and set deprecated in code.  kai, oct'18
-//	@Deprecated // kai, oct'18
-//	public boolean isConsideringCO2Costs() {
-//		throw new RuntimeException(COSTS_MSG);
-//	}
-//	/**
-//	 * @param consideringCO2Costs -- {@value #CONSIDERING_CO2_COSTS_CMT}
-//	 */
-	//	@StringSetter(CONSIDERING_CO2_COSTS)
-	// not used in contrib itself --> does not belong here; disable xml functionality and set deprecated in code.  kai, oct'18
-	@Deprecated // kai, oct'18
-	public void setConsideringCO2Costs(boolean consideringCO2Costs) {
-		throw new RuntimeException(COSTS_MSG);
-	}
-	// ============================================
-	// ============================================
+	private static final String HANDLE_HIGH_AVERAGE_SPEEDS = "handleHighAverageSpeeds";
+
+	private boolean handleHighAverageSpeeds = false;
+	// yyyy should become an enum.  kai, jan'20
 	@StringGetter(HANDLE_HIGH_AVERAGE_SPEEDS)
-	public boolean handlesHighAverageSpeeds() {
+	public boolean getHandleHighAverageSpeeds() {
 		return handleHighAverageSpeeds;
 	}
 	/**
@@ -520,30 +316,6 @@ public final class EmissionsConfigGroup extends ReflectiveConfigGroup {
 	public void setHandlesHighAverageSpeeds(boolean handleHighAverageSpeeds) {
 		this.handleHighAverageSpeeds = handleHighAverageSpeeds;
 	}
-
-	// ============================================
-	// ============================================
-	@StringGetter(Hbefa_ROADTYPE_SOURCE)
-	@Deprecated
-	public HbefaRoadTypeSource getHbefaRoadTypeSource() {
-		return hbefaRoadTypeSource;
-	}
-
-	/**
-	 * @param hbefaRoadTypeSource this is ignored. The Enum will be removed in future releases
-	 * @deprecated This used to set how the contrib was guessing HBEFA-Road types. The contib now expects the road types
-	 * to be set explicitly as link attribute. {@link org.matsim.contrib.emissions.EmissionUtils#setHbefaRoadType(Link, String)}
-	 * Also, there are mappers to set these attributes from Osm, Visum-files or by guessing based on the freespeed of links
-	 * {@link org.matsim.contrib.emissions.OsmHbefaMapping}, {@link org.matsim.contrib.emissions.VisumHbefaRoadTypeMapping} or
-	 * {@link org.matsim.contrib.emissions.VspHbefaRoadTypeMapping}
-	 */
-	@StringSetter(Hbefa_ROADTYPE_SOURCE)
-	@Deprecated
-	public void setHbefaRoadTypeSource(HbefaRoadTypeSource hbefaRoadTypeSource) {
-		log.warn("This property is deprecated and will be removed soon. The emission contrib expects HbefaRaodTypes to be set as link attributes explicitly");
-		this.hbefaRoadTypeSource = hbefaRoadTypeSource;
-	}
-
 	// ============================================
 	// ============================================
 	@StringGetter(NON_SCENARIO_VEHICLES)
@@ -564,22 +336,18 @@ public final class EmissionsConfigGroup extends ReflectiveConfigGroup {
 	public void setEmissionsComputationMethod(EmissionsComputationMethod emissionsComputationMethod) {
 		this.emissionsComputationMethod = emissionsComputationMethod;
 	}
-
+	// ============================================
+	// ============================================
 	@Override
 	protected final void checkConsistency(Config config){
-		switch (this.emissionsComputationMethod){
-			case StopAndGoFraction:
-				log.info("Please note that with setting of emissionsComputationMethod "+ EmissionsComputationMethod.StopAndGoFraction+ "" +
-						" the emission factors for both freeFlow and StopAndGo fractions are looked up independently and are " +
-						"therefore following the fallback behaviour set in " + DETAILED_VS_AVERAGE_LOOKUP_BEHAVIOR +
-						" independently. --> Depending on the input, it may be that e.g. for ff the detailed value is taken, while for the stopAndGo part " +
-						"a less detailed value is used, because the value with the same level of detail is missing.");
-				break;
-			case AverageSpeed:
-				log.warn("This setting of emissionsComputationMethod. "+ EmissionsComputationMethod.AverageSpeed + " is not covered by many test cases.");
-				break;
-			default:
-				throw new IllegalStateException("Unexpected value: " + this.emissionsComputationMethod);
+		switch( this.emissionsComputationMethod ){
+			case StopAndGoFraction -> log.info( "Please note that with setting of emissionsComputationMethod " + EmissionsComputationMethod.StopAndGoFraction + "" +
+									    " the emission factors for both freeFlow and StopAndGo fractions are looked up independently and are " +
+									    "therefore following the fallback behaviour set in " + DETAILED_VS_AVERAGE_LOOKUP_BEHAVIOR +
+									    " independently. --> Depending on the input, it may be that e.g. for ff the detailed value is taken, while for the stopAndGo part " +
+									    "a less detailed value is used, because the value with the same level of detail is missing." );
+			case AverageSpeed -> log.warn( "This setting of emissionsComputationMethod. " + EmissionsComputationMethod.AverageSpeed + " is not covered by many test cases." );
+			default -> throw new IllegalStateException( "Unexpected value: " + this.emissionsComputationMethod );
 		}
 	}
 

--- a/contribs/emissions/src/test/java/org/matsim/contrib/emissions/TestColdEmissionsFallbackBehaviour.java
+++ b/contribs/emissions/src/test/java/org/matsim/contrib/emissions/TestColdEmissionsFallbackBehaviour.java
@@ -28,7 +28,6 @@ import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.emissions.utils.EmissionsConfigGroup;
 import org.matsim.contrib.emissions.utils.EmissionsConfigGroup.DetailedVsAverageLookupBehavior;
-import org.matsim.contrib.emissions.utils.EmissionsConfigGroup.HbefaRoadTypeSource;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
@@ -257,7 +256,7 @@ public class TestColdEmissionsFallbackBehaviour {
 		Config config = ConfigUtils.loadConfig( configUrl );
 		EmissionsConfigGroup emissionsConfig = ConfigUtils.addOrGetModule( config, EmissionsConfigGroup.class );
 		emissionsConfig.setDetailedVsAverageLookupBehavior(lookupBehavior);
-		emissionsConfig.setHbefaRoadTypeSource( HbefaRoadTypeSource.fromLinkAttributes );							//Somehow needed even if deprecated, since a null pointer exception ids thrown when not set :( . kmt mar'20
+//		emissionsConfig.setHbefaRoadTypeSource( HbefaRoadTypeSource.fromLinkAttributes );							//Somehow needed even if deprecated, since a null pointer exception ids thrown when not set :( . kmt mar'20
 		emissionsConfig.setAverageColdEmissionFactorsFile("sample_41_EFA_ColdStart_vehcat_2020average.csv");
 		emissionsConfig.setDetailedColdEmissionFactorsFile("sample_41_EFA_ColdStart_SubSegm_2020detailed.csv");
 		emissionsConfig.setAverageWarmEmissionFactorsFile( "sample_41_EFA_HOT_vehcat_2020average.csv" );

--- a/contribs/emissions/src/test/java/org/matsim/contrib/emissions/TestWarmEmissionsFallbackBehaviour.java
+++ b/contribs/emissions/src/test/java/org/matsim/contrib/emissions/TestWarmEmissionsFallbackBehaviour.java
@@ -239,7 +239,7 @@ public class TestWarmEmissionsFallbackBehaviour {
 //		Config config = RunDetailedEmissionToolOnlineExample.prepareConfig( new String[]{"./scenarios/sampleScenario/testv2_Vehv2/config_detailed.xml"} ) ;
 		EmissionsConfigGroup emissionsConfig = ConfigUtils.addOrGetModule( config, EmissionsConfigGroup.class );
 		emissionsConfig.setDetailedVsAverageLookupBehavior(lookupBehavior);
-		emissionsConfig.setHbefaRoadTypeSource(EmissionsConfigGroup.HbefaRoadTypeSource.fromLinkAttributes);							//Somehow needed even if deprecated, since a null pointer exception ids thrown when not set :( . kmt mar'20
+//		emissionsConfig.setHbefaRoadTypeSource(EmissionsConfigGroup.HbefaRoadTypeSource.fromLinkAttributes);							//Somehow needed even if deprecated, since a null pointer exception ids thrown when not set :( . kmt mar'20
 		emissionsConfig.setAverageColdEmissionFactorsFile("sample_41_EFA_ColdStart_vehcat_2020average.csv");
 		emissionsConfig.setDetailedColdEmissionFactorsFile("sample_41_EFA_ColdStart_SubSegm_2020detailed.csv");
 		emissionsConfig.setAverageWarmEmissionFactorsFile( "sample_41_EFA_HOT_vehcat_2020average.csv" );

--- a/examples/scenarios/emissions-sampleScenario/testv2_Vehv1/config_average.xml
+++ b/examples/scenarios/emissions-sampleScenario/testv2_Vehv1/config_average.xml
@@ -28,16 +28,11 @@
 
 	<module name="emissions" >
 
-		<!-- REQUIRED: file with HBEFA 3.1 fleet average cold emission factors -->
 		<param name="averageFleetColdEmissionFactorsFile" value="../sample_EFA_ColdStart_vehcat_2005average.csv" />
 
-		<!-- REQUIRED: file with HBEFA 3.1 fleet average warm emission factors -->
 		<param name="averageFleetWarmEmissionFactorsFile" value="../sample_EFA_HOT_vehcat_2005average.csv" />
 
 		<param name="detailedVsAverageLookupBehavior" value="directlyTryAverageTable"/>
-
-		<!-- following should eventually become default but currently is not: -->
-		<param name="hbefaRoadTypeSource" value="fromLinkAttributes" />
 
 		<!-- Each vehicle in matsim points to a VehicleType.  For the emissions package to work,
 			each VehicleType needs to contain corresponding information.  This switch

--- a/examples/scenarios/emissions-sampleScenario/testv2_Vehv1/config_detailed.xml
+++ b/examples/scenarios/emissions-sampleScenario/testv2_Vehv1/config_detailed.xml
@@ -28,20 +28,13 @@
 
 	<module name="emissions" >
 
-		<!-- REQUIRED: file with HBEFA 3.1 fleet average cold emission factors -->
 		<param name="averageFleetColdEmissionFactorsFile" value="../sample_EFA_ColdStart_vehcat_2005average.csv" />
 
-		<!-- REQUIRED: file with HBEFA 3.1 fleet average warm emission factors -->
 		<param name="averageFleetWarmEmissionFactorsFile" value="../sample_EFA_HOT_vehcat_2005average.csv" />
 
-		<!-- OPTIONAL: file with HBEFA 3.1 detailed cold emission factors -->
 		<param name="detailedColdEmissionFactorsFile" value="../sample_EFA_ColdStart_SubSegm_2005detailed.csv" />
 
-		<!-- OPTIONAL: file with HBEFA 3.1 detailed warm emission factors -->
 		<param name="detailedWarmEmissionFactorsFile" value="../sample_EFA_HOT_SubSegm_2005detailed.csv" />
-
-		<!--"fromLinkAttributes" will eventually become default:-->
-		<param name="hbefaRoadTypeSource" value="fromLinkAttributes" />
 
 		<!-- if true then detailed emission factor files must be provided! -->
 <!--		<param name="usingDetailedEmissionCalculation" value="true" />-->

--- a/examples/scenarios/emissions-sampleScenario/testv2_Vehv2/config_average.xml
+++ b/examples/scenarios/emissions-sampleScenario/testv2_Vehv2/config_average.xml
@@ -28,16 +28,11 @@
 
 	<module name="emissions" >
 
-		<!-- REQUIRED: file with HBEFA 3.1 fleet average cold emission factors -->
 		<param name="averageFleetColdEmissionFactorsFile" value="../sample_EFA_ColdStart_vehcat_2005average.csv" />
 
-		<!-- REQUIRED: file with HBEFA 3.1 fleet average warm emission factors -->
 		<param name="averageFleetWarmEmissionFactorsFile" value="../sample_EFA_HOT_vehcat_2005average.csv" />
 
 		<param name="detailedVsAverageLookupBehavior" value="directlyTryAverageTable"/>
-
-		<!-- following should eventually become default but currently is not: -->
-		<param name="hbefaRoadTypeSource" value="fromLinkAttributes" />
 
 	</module>
 

--- a/examples/scenarios/emissions-sampleScenario/testv2_Vehv2/config_detailed.xml
+++ b/examples/scenarios/emissions-sampleScenario/testv2_Vehv2/config_detailed.xml
@@ -28,26 +28,18 @@
 
 	<module name="emissions" >
 
-		<!-- REQUIRED: file with HBEFA 3.1 fleet average cold emission factors -->
 		<param name="averageFleetColdEmissionFactorsFile" value="../sample_EFA_ColdStart_vehcat_2005average.csv" />
 
-		<!-- REQUIRED: file with HBEFA 3.1 fleet average warm emission factors -->
 		<param name="averageFleetWarmEmissionFactorsFile" value="../sample_EFA_HOT_vehcat_2005average.csv" />
 
-		<!-- OPTIONAL: file with HBEFA 3.1 detailed cold emission factors -->
 		<param name="detailedColdEmissionFactorsFile" value="../sample_EFA_ColdStart_SubSegm_2005detailed.csv" />
 
-		<!-- OPTIONAL: file with HBEFA 3.1 detailed warm emission factors -->
 		<param name="detailedWarmEmissionFactorsFile" value="../sample_EFA_HOT_SubSegm_2005detailed.csv" />
-
-		<!--"fromLinkAttributes" will eventually become default:-->
-		<param name="hbefaRoadTypeSource" value="fromLinkAttributes" />
 
 		<!-- Each vehicle in matsim points to a VehicleType.  For the emissions package to work, each VehicleType needs to contain corresponding information.  This switch determines _where_ in VehicleType that information is contained.  default: asEngineInformationAttributes -->
 		<param name="hbefaVehicleDescriptionSource" value="asEngineInformationAttributes" />
 
 		<!-- if true then detailed emission factor files must be provided! -->
-<!--		<param name="usingDetailedEmissionCalculation" value="true" />-->
 		<param name="detailedVsAverageLookupBehavior" value="tryDetailedThenTechnologyAverageThenAverageTable" />
 
 	</module>

--- a/matsim/src/main/java/org/matsim/vehicles/VehicleUtils.java
+++ b/matsim/src/main/java/org/matsim/vehicles/VehicleUtils.java
@@ -28,7 +28,6 @@ import org.matsim.api.core.v01.population.Person;
 import org.matsim.core.gbl.Gbl;
 import org.matsim.utils.objectattributes.attributable.AttributesUtils;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -360,5 +359,9 @@ public final class VehicleUtils {
 			log.info( "unable to find vehicle for vehicleId=" + vehicleId + "; will return null") ;
 		}
 		return vehicle ;
+	}
+	public static void writeVehicles( Vehicles vehicles, String filename ) {
+		new MatsimVehicleWriter( vehicles ).writeFile( filename );
+
 	}
 }


### PR DESCRIPTION
mostly removing material that has been deprecated for many years

this may hick up, since it also changes material in matsim-examples: some config switches now do not exist any more and thus had to be removed from config files there.