### PR TITLE
ev: report MissingEnergyEvents in simulation instead of throwing exception

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/MissingEnergyEvent.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/MissingEnergyEvent.java
@@ -1,0 +1,71 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2016 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.ev.discharging;
+
+import java.util.Map;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.events.Event;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.vehicles.Vehicle;
+
+public class MissingEnergyEvent extends Event {
+	public static final String EVENT_TYPE = "missing_energy";
+	public static final String ATTRIBUTE_VEHICLE = "vehicle";
+	public static final String ATTRIBUTE_ENERGY = "energy";
+	public static final String ATTRIBUTE_LINK = "link";
+
+	private final Id<Vehicle> vehicleId;
+	private final Id<Link> linkId;
+	private final double energy;
+
+	public MissingEnergyEvent(double time, Id<Vehicle> vehicleId, Id<Link> linkId, double energy) {
+		super(time);
+		this.linkId = linkId;
+		this.vehicleId = vehicleId;
+		this.energy = energy;
+	}
+
+	public Id<Vehicle> getVehicleId() {
+		return vehicleId;
+	}
+
+	public Id<Link> getLinkId() {
+		return linkId;
+	}
+
+	public double getEnergy() {
+		return energy;
+	}
+
+	@Override
+	public String getEventType() {
+		return EVENT_TYPE;
+	}
+
+	@Override
+	public Map<String, String> getAttributes() {
+		Map<String, String> attr = super.getAttributes();
+		attr.put(ATTRIBUTE_VEHICLE, vehicleId + "");
+		attr.put(ATTRIBUTE_LINK, linkId + "");
+		attr.put(ATTRIBUTE_ENERGY, energy + "");
+		return attr;
+	}
+}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/Battery.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/Battery.java
@@ -20,6 +20,8 @@
 
 package org.matsim.contrib.ev.fleet;
 
+import java.util.function.DoubleConsumer;
+
 public interface Battery {
 	/**
 	 * @return Battery Capacity [J]
@@ -40,12 +42,15 @@ public interface Battery {
 		return getCharge() / getCapacity();
 	}
 
-	/**
-	 * Changes charge, making sure the charge level does not increase above the battery capacity or decrease below 0.
-	 *
-	 * @param energy change in energy [J], can be negative or positive
-	 */
-	default void changeCharge(double energy) {
-		setCharge(getCharge() + energy);
+	// energy [J], positive value reduces the battery charge
+	// missingEnergyNotifier -- meant for emitting a MissingEnergyEvent, logging a warning or throwing an exception
+	default void dischargeEnergy(double energy, DoubleConsumer missingEnergyNotifier) {
+		double oldCharge = getCharge();
+		if (oldCharge < energy) {
+			missingEnergyNotifier.accept(energy - oldCharge);
+			setCharge(0);
+		} else {
+			setCharge(oldCharge - energy);
+		}
 	}
 }

--- a/contribs/vsp/src/main/java/playground/vsp/ev/UrbanEVTripsPlanner.java
+++ b/contribs/vsp/src/main/java/playground/vsp/ev/UrbanEVTripsPlanner.java
@@ -658,7 +658,9 @@ class UrbanEVTripsPlanner implements MobsimInitializedListener {
 			//			double consumption = driveEnergyConsumption.calcEnergyConsumption(l, travelT, linkEnterTime)
 			//					+ auxEnergyConsumption.calcEnergyConsumption(leg.getDepartureTime().seconds(), travelT, l.getId());
 			double consumption = driveConsumption + auxConsumption;
-			ev.getBattery().changeCharge(-consumption);
+			ev.getBattery().dischargeEnergy(consumption, missingEnergy -> {
+				throw new RuntimeException("Energy consumed greater than the current charge. Missing energy: " + missingEnergy);
+			});
 			linkEnterTime += travelT;
 		}
 	}


### PR DESCRIPTION
We still throw an exception in the planning (UrbanEVTripsPlanner).