### PR TITLE
Fix renames in application contrib

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/MATSimApplication.java
+++ b/contribs/application/src/main/java/org/matsim/application/MATSimApplication.java
@@ -398,9 +398,9 @@ public abstract class MATSimApplication implements Callable<Integer>, CommandLin
 	@Override
 	public String defaultValue(CommandLine.Model.ArgSpec argSpec) throws Exception {
 		Object obj = argSpec.userObject();
-		if (obj instanceof Field) {
-			Field field = (Field) obj;
-			if (field.getName().equals("scenario") && field.getDeclaringClass().equals(MATSimApplication.class)) {
+		if (obj instanceof Field field) {
+			// Make sure default config path is propagated to the field
+			if (field.getName().equals("configPath") && field.getDeclaringClass().equals(MATSimApplication.class)) {
 				return defaultScenario;
 			}
 		}


### PR DESCRIPTION
In a recent PR, some fields were renamed in the application contrib. 
One line was overseen, which makes sure the default value is set to the field.