### PR TITLE
Add parking costs

### DIFF
--- a/contribs/parking/README.md
+++ b/contribs/parking/README.md
@@ -1,5 +1,15 @@
-
 # Parking
 
-The MATSim simulation by default does not consider parking infrastructure or supply constraints.
-For technical reasons, the modeling efforts around parking in MATSim are divided in two parts parking choice and parking search.
+The MATSim simulation by default does not consider parking infrastructure or supply constraints. There are different
+approaches as to how parking can be handled in MATSim, depending on the use case.
+
+- Parking Choice, based on work of Rashid Waraich. Parts of the contrib are used in the carsharing contrib. Its main
+  goal, as far as we understand it, is the simulation of parking choice (e.g. between garages). There is no modelling of
+  circulating traffic searching for parking or walking of agents to/from parking.
+- Parking Search, by Joschka Bischoff and Tillman Schlenther. This contrib has been currently developed at TU Berlin.
+  The main goal is to model parking search, including walk legs of agents and vehicles searching for parking spaces.
+- Parking Proxy, Parking Proxy by Tobias Kohl (Senozon)
+  . This was designed for large scenarios where it's not feasable to fully simulate parking agents. Rather, the
+  additional time needed for parking is estimated
+- Parking Costs, developed by Marcel Rieser and Joschka Bischoff at SBB. This modules allows the integration of parking
+  costs based on link attribute data.

--- a/contribs/parking/src/main/java/org/matsim/contrib/parking/package-info.java
+++ b/contribs/parking/src/main/java/org/matsim/contrib/parking/package-info.java
@@ -1,16 +1,19 @@
 /**
  * The parking contrib is split into three substantially different parts<ul>
  * <li> Parking Choice, based on work of Rashid Waraich. Parts of the contrib are used in the carsharing contrib.
- * 		<p> Its main goal, as far as we understand it, is the simulation of parking choice (e.g. between garages). There is no modelling of circulating traffic searching for parking or walking of agents to/from parking.
- * 
+ * <p> Its main goal, as far as we understand it, is the simulation of parking choice (e.g. between garages). There is no modelling of circulating traffic searching for parking or walking of agents to/from parking. Currently (2022) unmaintained.
+ *
  * <li> Parking Search, by Joschka Bischoff. This contrib is currently developed at TU Berlin.
- * 		<p> The main goal is to model parking search, including walk legs of agents and vehicles searching for parking spaces.
+ * <p> The main goal is to model parking search, including walk legs of agents and vehicles searching for parking spaces.
  * </ul>
- * 
+ *
  * <ul> Parking Proxy by Tobias Kohl (Senozon)
  * 		<p>This was designed for large scenarios where it's not feasable to fully simulate parking agents. Rather, the additional time needed for parking is estimated</p>
  * </ul>
- * @author jfbischoff, nagel
+ * * <ul> Parking Costs, developed by Marcel Rieser and Joschka Bischoff at SBB.
+ * 		<p> This modules allows the integration of parking costs based on link attribute data.</p>
+ * </ul>
  *
+ * @author of this doc: jfbischoff, nagel
  */
 package org.matsim.contrib.parking;

--- a/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingcost/RunParkingCostExample.java
+++ b/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingcost/RunParkingCostExample.java
@@ -1,0 +1,81 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+
+package org.matsim.contrib.parking.parkingcost;
+
+import org.apache.logging.log4j.LogManager;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.events.PersonMoneyEvent;
+import org.matsim.api.core.v01.events.handler.PersonMoneyEventHandler;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.parking.parkingcost.config.ParkingCostConfigGroup;
+import org.matsim.contrib.parking.parkingcost.module.ParkingCostModule;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.controler.AbstractModule;
+import org.matsim.core.controler.Controler;
+import org.matsim.core.scenario.ScenarioUtils;
+
+/**
+ * An example class that shows how parking costs can be added to a scenario.
+ */
+public final class RunParkingCostExample {
+	private RunParkingCostExample() {
+	}
+
+	public static void main(String[] args) {
+		Config config = ConfigUtils.loadConfig("parkingcosts/config.xml", new ParkingCostConfigGroup());
+		Scenario scenario = ScenarioUtils.loadScenario(config);
+		addParkingCostToLinks(scenario.getNetwork());
+		Controler controller = new Controler(scenario);
+		controller.addOverridingModule(new ParkingCostModule());
+
+		ParkingCostTracker parkingCostTracker = new ParkingCostTracker();
+		controller.addOverridingModule(new AbstractModule() {
+			@Override
+			public void install() {
+				addEventHandlerBinding().toInstance(parkingCostTracker);
+			}
+		});
+		controller.run();
+
+		LogManager.getLogger(RunParkingCostExample.class).info("Parking Cost charged in total: " + parkingCostTracker.parkingCostCollected);
+
+	}
+
+	private static void addParkingCostToLinks(Network network) {
+		network.getLinks().values().forEach(link -> {
+			link.getAttributes().putAttribute("pc_car", 2.50);
+		});
+	}
+
+	static class ParkingCostTracker implements PersonMoneyEventHandler {
+		double parkingCostCollected = 0.0;
+
+		@Override
+		public void handleEvent(PersonMoneyEvent event) {
+			if (event.getPurpose() != null) {
+				if (event.getPurpose().endsWith("parking cost")) {
+					parkingCostCollected += event.getAmount();
+				}
+			}
+		}
+	}
+}

--- a/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingcost/config/ParkingCostConfigGroup.java
+++ b/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingcost/config/ParkingCostConfigGroup.java
@@ -1,0 +1,65 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.parking.parkingcost.config;
+
+
+import org.matsim.core.config.ReflectiveConfigGroup;
+import org.matsim.core.utils.collections.CollectionUtils;
+
+import java.util.Set;
+
+/**
+ * @author mrieser, jfbischoff (SBB)
+ */
+public class ParkingCostConfigGroup extends ReflectiveConfigGroup {
+
+	public static final String GROUP_NAME = "parkingCosts";
+
+	@Parameter
+	@Comment("Enables / disables parkingCost use")
+	public boolean useParkingCost = true;
+
+	@Parameter
+	@Comment("Parking Cost link Attribute prefix." +
+			" This needs to be followed by the parking cost for the mode, " +
+			"e.g., \"pc_\" as prefix and \"car\" as mode would " +
+			"require an attribute \"pc_ride\" to be set on every " +
+			"link where parking costs should be considered.")
+	public String linkAttributePrefix = "pc_";
+
+	@Parameter
+	@Comment("Modes that should use parking costs, separated by comma")
+	public String modesWithParkingCosts = null;
+
+	@Parameter
+	@Comment("Activitiy types where no parking costs are charged, e.g., at home. char sequence must be part of the activity.")
+	public String activityTypesWithoutParkingCost = null;
+
+	public ParkingCostConfigGroup() {
+		super(GROUP_NAME);
+	}
+
+	public Set<String> getModesWithParkingCosts() {
+		return CollectionUtils.stringToSet(modesWithParkingCosts);
+	}
+
+	public Set<String> getActivityTypesWithoutParkingCost() {
+		return CollectionUtils.stringToSet(activityTypesWithoutParkingCost);
+	}
+}

--- a/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingcost/eventhandling/MainModeParkingCostVehicleTracker.java
+++ b/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingcost/eventhandling/MainModeParkingCostVehicleTracker.java
@@ -1,0 +1,131 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.parking.parkingcost.eventhandling;
+
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.events.ActivityStartEvent;
+import org.matsim.api.core.v01.events.PersonMoneyEvent;
+import org.matsim.api.core.v01.events.VehicleEntersTrafficEvent;
+import org.matsim.api.core.v01.events.VehicleLeavesTrafficEvent;
+import org.matsim.api.core.v01.events.handler.ActivityStartEventHandler;
+import org.matsim.api.core.v01.events.handler.VehicleEntersTrafficEventHandler;
+import org.matsim.api.core.v01.events.handler.VehicleLeavesTrafficEventHandler;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contrib.parking.parkingcost.config.ParkingCostConfigGroup;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.vehicles.Vehicle;
+
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author mrieser, jfbischoff (SBB)
+ */
+public class MainModeParkingCostVehicleTracker implements ActivityStartEventHandler, VehicleEntersTrafficEventHandler, VehicleLeavesTrafficEventHandler {
+
+	private final static Logger log = LogManager.getLogger(MainModeParkingCostVehicleTracker.class);
+	private final Map<Id<Vehicle>, ParkingInfo> parkingPerVehicle = new HashMap<>();
+	private final Map<Id<Person>, Id<Vehicle>> lastVehiclePerDriver = new HashMap<>();
+	private final String parkingCostAttributeName;
+	private final String trackedMode;
+	private final Set<String> untrackedActivities;
+	private final String purpose;
+	@Inject
+	EventsManager events;
+	@Inject
+	Network network;
+	private boolean badAttributeTypeWarningShown = false;
+
+	public MainModeParkingCostVehicleTracker(String mode, ParkingCostConfigGroup parkingCostConfigGroup) {
+		this.untrackedActivities = parkingCostConfigGroup.getActivityTypesWithoutParkingCost();
+		this.parkingCostAttributeName = parkingCostConfigGroup.linkAttributePrefix + mode;
+		this.trackedMode = mode;
+		this.purpose = mode + " parking cost";
+	}
+
+	@Override
+	public void handleEvent(VehicleEntersTrafficEvent event) {
+		if (event.getNetworkMode().equals(trackedMode)) {
+			ParkingInfo pi = this.parkingPerVehicle.remove(event.getVehicleId());
+			if (pi == null) {
+				return;
+			}
+			Link link = network.getLinks().get(pi.parkingLinkId);
+
+			Object value = link.getAttributes().getAttribute(this.parkingCostAttributeName);
+			if (value == null) {
+				return;
+			}
+			if (value instanceof Number n) {
+				double parkDuration = event.getTime() - pi.startParkingTime;
+				double hourlyParkingCost = n.doubleValue();
+				double parkingCost = hourlyParkingCost * (parkDuration / 3600.0);
+				this.events.processEvent(new PersonMoneyEvent(event.getTime(), pi.driverId, -parkingCost, purpose, null, link.getId().toString()));
+			} else if (!this.badAttributeTypeWarningShown) {
+				log.error("ParkingCost attribute must be of type Double or Integer, but is of type " + value.getClass() + ". This message is only given once.");
+				this.badAttributeTypeWarningShown = true;
+			}
+		}
+	}
+
+	@Override
+	public void handleEvent(VehicleLeavesTrafficEvent event) {
+		if (event.getNetworkMode().equals(trackedMode)) {
+			ParkingInfo pi = new ParkingInfo(event.getLinkId(), event.getPersonId(), event.getTime());
+			this.parkingPerVehicle.put(event.getVehicleId(), pi);
+			this.lastVehiclePerDriver.put(event.getPersonId(), event.getVehicleId());
+		}
+	}
+
+	@Override
+	public void handleEvent(ActivityStartEvent event) {
+		if (this.untrackedActivities.stream().anyMatch(s -> event.getActType().contains(s))) {
+			Id<Vehicle> vehicleId = this.lastVehiclePerDriver.get(event.getPersonId());
+			if (vehicleId != null) {
+				this.parkingPerVehicle.remove(vehicleId);
+			}
+		}
+	}
+
+	@Override
+	public void reset(int iteration) {
+		this.parkingPerVehicle.clear();
+		this.lastVehiclePerDriver.clear();
+	}
+
+	private static class ParkingInfo {
+
+		final Id<Link> parkingLinkId;
+		final Id<Person> driverId;
+		final double startParkingTime;
+
+		ParkingInfo(Id<Link> parkingLinkId, Id<Person> driverId, double startParkingTime) {
+			this.parkingLinkId = parkingLinkId;
+			this.driverId = driverId;
+			this.startParkingTime = startParkingTime;
+		}
+	}
+}

--- a/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingcost/eventhandling/TeleportedModeParkingCostTracker.java
+++ b/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingcost/eventhandling/TeleportedModeParkingCostTracker.java
@@ -1,0 +1,106 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.parking.parkingcost.eventhandling;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.events.ActivityEndEvent;
+import org.matsim.api.core.v01.events.PersonArrivalEvent;
+import org.matsim.api.core.v01.events.PersonMoneyEvent;
+import org.matsim.api.core.v01.events.handler.ActivityEndEventHandler;
+import org.matsim.api.core.v01.events.handler.PersonArrivalEventHandler;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contrib.parking.parkingcost.config.ParkingCostConfigGroup;
+import org.matsim.core.api.experimental.events.EventsManager;
+
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author mrieser, jfbischoff (SBB)
+ */
+public class TeleportedModeParkingCostTracker implements PersonArrivalEventHandler, ActivityEndEventHandler {
+
+	private final static Logger log = LogManager.getLogger(MainModeParkingCostVehicleTracker.class);
+
+	private final String parkingCostAttributeName;
+	private final Map<Id<Person>, Double> arrivalsPerPerson = new HashMap<>();
+	private final String trackedMode;
+	private final Set<String> untrackedActivities;
+	private final String purpose;
+	@Inject
+	EventsManager events;
+	@Inject
+	Network network;
+	private boolean badAttributeTypeWarningShown = false;
+
+	public TeleportedModeParkingCostTracker(String mode, ParkingCostConfigGroup parkingCostConfigGroup) {
+		this.untrackedActivities = parkingCostConfigGroup.getActivityTypesWithoutParkingCost();
+		this.parkingCostAttributeName = parkingCostConfigGroup.linkAttributePrefix + mode;
+		this.trackedMode = mode;
+		this.purpose = mode + " parking cost";
+
+	}
+
+	@Override
+	public void handleEvent(PersonArrivalEvent event) {
+		if (trackedMode.equals(event.getLegMode())) {
+			this.arrivalsPerPerson.put(event.getPersonId(), event.getTime());
+		}
+	}
+
+	@Override
+	public void handleEvent(ActivityEndEvent event) {
+		if (event.getActType().endsWith("interaction")) {
+			// do nothing in the case of a stageActivity
+			return;
+		}
+
+		Double arrivalTime = this.arrivalsPerPerson.remove(event.getPersonId());
+		if (arrivalTime == null ||
+				(this.untrackedActivities.stream().anyMatch(s -> event.getActType().contains(s)))) {
+			return;
+		}
+
+		Link link = network.getLinks().get(event.getLinkId());
+		Object value = link.getAttributes().getAttribute(this.parkingCostAttributeName);
+		if (value == null) {
+			return;
+		}
+		if (value instanceof Number n) {
+			double parkDuration = event.getTime() - arrivalTime;
+			double hourlyParkingCost = n.doubleValue();
+			double parkingCost = hourlyParkingCost * (parkDuration / 3600.0);
+			this.events.processEvent(new PersonMoneyEvent(event.getTime(), event.getPersonId(), -parkingCost, purpose, null, link.getId().toString()));
+		} else if (!this.badAttributeTypeWarningShown) {
+			log.error("Ride-ParkingCost attribute must be of type Double or Integer, but is of type " + value.getClass() + ". This message is only given once.");
+			this.badAttributeTypeWarningShown = true;
+		}
+	}
+
+	@Override
+	public void reset(int iteration) {
+		this.arrivalsPerPerson.clear();
+	}
+}

--- a/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingcost/module/ParkingCostModule.java
+++ b/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingcost/module/ParkingCostModule.java
@@ -1,0 +1,52 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.parking.parkingcost.module;
+
+import org.matsim.contrib.parking.parkingcost.config.ParkingCostConfigGroup;
+import org.matsim.contrib.parking.parkingcost.eventhandling.MainModeParkingCostVehicleTracker;
+import org.matsim.contrib.parking.parkingcost.eventhandling.TeleportedModeParkingCostTracker;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.controler.AbstractModule;
+
+import java.util.Collection;
+
+/**
+ * @author jfbischoff (SBB)
+ */
+public class ParkingCostModule extends AbstractModule {
+
+	@Override
+	public void install() {
+		ParkingCostConfigGroup parkingCostConfigGroup = ConfigUtils.addOrGetModule(getConfig(), ParkingCostConfigGroup.class);
+		if (parkingCostConfigGroup.useParkingCost) {
+			Collection<String> mainModes = switch (getConfig().controler().getMobsim()) {
+				case "qsim" -> getConfig().qsim().getMainModes();
+				case "hermes" -> getConfig().hermes().getMainModes();
+				default -> throw new RuntimeException("ParkingCosts are currently supported for Qsim and Hermes");
+			};
+			for (String mode : parkingCostConfigGroup.getModesWithParkingCosts()) {
+				if (mainModes.contains(mode)) {
+					addEventHandlerBinding().toInstance(new MainModeParkingCostVehicleTracker(mode, parkingCostConfigGroup));
+				} else {
+					addEventHandlerBinding().toInstance(new TeleportedModeParkingCostTracker(mode, parkingCostConfigGroup));
+				}
+			}
+		}
+	}
+}

--- a/contribs/parking/src/main/resources/parkingcosts/config.xml
+++ b/contribs/parking/src/main/resources/parkingcosts/config.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" ?>
+<!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
+<config>
+	<!-- This config file is fairly basic, only the most important parameters are set-->
+
+	<module name="parkingCosts">
+		<param name="modesWithParkingCosts" value="car,ride"/>
+		<param name="activityTypesWithoutParkingCost" value="home"/>
+	</module>
+
+
+	<module name="controler">
+		<param name="mobsim" value="qsim"/>
+		<param name="eventsFileFormat" value="xml"/>
+		<param name="outputDirectory" value="output/parkingCosts"/>
+		<param name="overwriteFiles" value="deleteDirectoryIfExists"/>
+		<param name="lastIteration" value="0"/>
+
+
+	</module>
+
+	<module name="plans">
+		<param name="inputPlansFile" value="../parkingsearch/population100.xml"/>
+	</module>
+
+
+	<module name="network">
+		<param name="inputNetworkFile" value="../parkingsearch/grid_network.xml"/>
+	</module>
+
+	<module name="qsim">
+		<param name="startTime" value="00:00:00"/>
+		<param name="endTime" value="24:00:00"/>
+		<param name="flowCapacityFactor" value="1.0"/>
+		<param name="storageCapacityFactor" value="1.0"/>
+		<param name="stuckTime" value="10"/>
+		<param name="removeStuckVehicles" value="false"/>
+		<param name="mainMode" value="car"/>
+		<param name="simStarttimeInterpretation" value="onlyUseStarttime"/>
+
+	</module>
+	<module name="strategy">
+
+		<parameterset type="strategysettings">
+			<param name="strategyName" value="ChangeExpBeta"/>
+			<param name="weight" value="1.0"/>
+
+		</parameterset>
+	</module>
+
+
+	<module name="planCalcScore">
+		<param name="performing" value="+6"/>
+		<param name="lateArrival" value="-18.0"/>
+
+		<parameterset type="activityParams">
+			<param name="activityType" value="home"/>
+			<param name="typicalDuration" value="08:00:00"/>
+		</parameterset>
+
+
+		<parameterset type="activityParams">
+			<param name="activityType" value="work"/>
+			<param name="typicalDuration" value="08:00:00"/>
+			<param name="openingTime" value="07:00:00"/>
+			<param name="latestStartTime" value="11:00:00"/>
+			<param name="closingTime" value="20:00:00"/>
+		</parameterset>
+
+
+	</module>
+
+
+</config>

--- a/contribs/parking/src/test/java/org/matsim/contrib/parking/parkingcost/eventhandling/ParkingCostVehicleTrackerTest.java
+++ b/contribs/parking/src/test/java/org/matsim/contrib/parking/parkingcost/eventhandling/ParkingCostVehicleTrackerTest.java
@@ -1,3 +1,22 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
 package org.matsim.contrib.parking.parkingcost.eventhandling;
 
 

--- a/contribs/parking/src/test/java/org/matsim/contrib/parking/parkingcost/eventhandling/ParkingCostVehicleTrackerTest.java
+++ b/contribs/parking/src/test/java/org/matsim/contrib/parking/parkingcost/eventhandling/ParkingCostVehicleTrackerTest.java
@@ -1,0 +1,182 @@
+package org.matsim.contrib.parking.parkingcost.eventhandling;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.events.ActivityStartEvent;
+import org.matsim.api.core.v01.events.PersonMoneyEvent;
+import org.matsim.api.core.v01.events.VehicleEntersTrafficEvent;
+import org.matsim.api.core.v01.events.VehicleLeavesTrafficEvent;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.NetworkFactory;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contrib.parking.parkingcost.config.ParkingCostConfigGroup;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.events.EventsUtils;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.core.utils.collections.CollectionUtils;
+import org.matsim.testcases.utils.EventsCollector;
+import org.matsim.testcases.utils.EventsLogger;
+import org.matsim.vehicles.Vehicle;
+
+/**
+ * @author mrieser, jfbischoff (SBB)
+ */
+public class ParkingCostVehicleTrackerTest {
+
+	@Test
+	public void testParkingCostEvents() {
+		Fixture f = new Fixture();
+
+		f.events.addHandler(new EventsLogger());
+		ParkingCostConfigGroup parkingCostConfigGroup = new ParkingCostConfigGroup();
+		parkingCostConfigGroup.activityTypesWithoutParkingCost = "home";
+		MainModeParkingCostVehicleTracker tracker = new MainModeParkingCostVehicleTracker(TransportMode.car, parkingCostConfigGroup);
+		tracker.events = f.events;
+		tracker.network = f.scenario.getNetwork();
+		f.events.addHandler(tracker);
+		EventsCollector collector = new EventsCollector();
+		f.events.addHandler(collector);
+
+		Id<Person> personId = Id.create(1, Person.class);
+		Id<Vehicle> vehicleId = Id.create(2, Vehicle.class);
+		Id<Link> linkHome = Id.create("L", Link.class);
+		Id<Link> linkWork = Id.create("B", Link.class);
+		Id<Link> linkShop = Id.create("T", Link.class);
+
+		double hourlyParkingCostWork = 20; // this is the value of at_car in zone Bern
+		double hourlyParkingCostShop = 3; // this is the value of at_car in zone Thun
+		f.scenario.getNetwork().getLinks().get(linkWork).getAttributes().putAttribute("pc_car", hourlyParkingCostWork);
+		f.scenario.getNetwork().getLinks().get(linkShop).getAttributes().putAttribute("pc_car", hourlyParkingCostShop);
+		f.events.processEvent(new VehicleEntersTrafficEvent(7.00 * 3600, personId, linkHome, vehicleId, "car", 1.0));
+		f.events.processEvent(new VehicleLeavesTrafficEvent(7.25 * 3600, personId, linkWork, vehicleId, "car", 1.0));
+		f.events.processEvent(new ActivityStartEvent(7.25 * 3600, personId, linkWork, null, "work", null));
+		Assert.assertEquals(3, collector.getEvents().size());
+
+		f.events.processEvent(new VehicleEntersTrafficEvent(12.00 * 3600, personId, linkWork, vehicleId, "car", 1.0));
+		Assert.assertEquals(5, collector.getEvents().size());
+
+		Assert.assertEquals(PersonMoneyEvent.class, collector.getEvents().get(3).getClass());
+		PersonMoneyEvent parkingEvent1 = (PersonMoneyEvent) collector.getEvents().get(3);
+		Assert.assertEquals(personId, parkingEvent1.getPersonId());
+		Assert.assertEquals(12.00 * 3600, parkingEvent1.getTime(), 1e-8);
+		Assert.assertEquals((12 - 7.25) * hourlyParkingCostWork, -parkingEvent1.getAmount(), 1e-8);
+
+		f.events.processEvent(new VehicleLeavesTrafficEvent(12.25 * 3600, personId, linkShop, vehicleId, "car", 1.0));
+		f.events.processEvent(new ActivityStartEvent(12.25 * 3600, personId, linkShop, null, "shop", null));
+		Assert.assertEquals(7, collector.getEvents().size());
+
+		f.events.processEvent(new VehicleEntersTrafficEvent(13.00 * 3600, personId, linkShop, vehicleId, "car", 1.0));
+		Assert.assertEquals(9, collector.getEvents().size());
+
+		Assert.assertEquals(PersonMoneyEvent.class, collector.getEvents().get(7).getClass());
+		PersonMoneyEvent parkingEvent2 = (PersonMoneyEvent) collector.getEvents().get(7);
+		Assert.assertEquals(personId, parkingEvent2.getPersonId());
+		Assert.assertEquals(13.00 * 3600, parkingEvent2.getTime(), 1e-8);
+		Assert.assertEquals((13 - 12.25) * hourlyParkingCostShop, -parkingEvent2.getAmount(), 1e-8);
+
+		f.events.processEvent(new VehicleLeavesTrafficEvent(13.25 * 3600, personId, linkHome, vehicleId, "car", 1.0));
+		f.events.processEvent(new ActivityStartEvent(13.25 * 3600, personId, linkHome, null, "home", null));
+		Assert.assertEquals(11, collector.getEvents().size());
+
+		f.events.processEvent(new VehicleEntersTrafficEvent(15.00 * 3600, personId, linkShop, vehicleId, "car", 1.0));
+		Assert.assertEquals(12, collector.getEvents().size()); // there should be no parking cost event at home
+
+		f.events.processEvent(new VehicleLeavesTrafficEvent(15.25 * 3600, personId, linkWork, vehicleId, "car", 1.0));
+		f.events.processEvent(new ActivityStartEvent(13.25 * 3600, personId, linkWork, null, "shop", null));
+		Assert.assertEquals(14, collector.getEvents().size());
+
+		f.events.processEvent(new VehicleEntersTrafficEvent(18.00 * 3600, personId, linkWork, vehicleId, "car", 1.0));
+		Assert.assertEquals(16, collector.getEvents().size());
+
+		Assert.assertEquals(PersonMoneyEvent.class, collector.getEvents().get(14).getClass());
+		PersonMoneyEvent parkingEvent3 = (PersonMoneyEvent) collector.getEvents().get(14);
+		Assert.assertEquals(personId, parkingEvent3.getPersonId());
+		Assert.assertEquals(18.00 * 3600, parkingEvent3.getTime(), 1e-8);
+		Assert.assertEquals((18 - 15.25) * hourlyParkingCostWork, -parkingEvent3.getAmount(), 1e-8);
+
+		f.events.processEvent(new VehicleLeavesTrafficEvent(18.50 * 3600, personId, linkHome, vehicleId, "car", 1.0));
+		f.events.processEvent(new ActivityStartEvent(18.00 * 3600, personId, linkHome, null, "shop", null));
+		Assert.assertEquals(18, collector.getEvents().size());
+	}
+
+	/**
+	 * Creates a simple test scenario matching the accesstime_zone.SHP test file.
+	 */
+	private static class Fixture {
+
+		final Config config;
+		final Scenario scenario;
+		EventsManager events;
+
+		public Fixture() {
+			this.config = ConfigUtils.createConfig();
+			prepareConfig();
+			this.scenario = ScenarioUtils.createScenario(this.config);
+			createNetwork();
+			prepareEvents();
+		}
+
+		private void prepareConfig() {
+			ParkingCostConfigGroup parkingConfig = ConfigUtils.addOrGetModule(this.config, ParkingCostConfigGroup.class);
+			parkingConfig.modesWithParkingCosts = TransportMode.car;
+		}
+
+		private void createNetwork() {
+			Network network = this.scenario.getNetwork();
+			NetworkFactory nf = network.getFactory();
+
+			Node nL1 = nf.createNode(Id.create("L1", Node.class), new Coord(545000, 150000));
+			Node nL2 = nf.createNode(Id.create("L2", Node.class), new Coord(540000, 165000));
+			Node nB1 = nf.createNode(Id.create("B1", Node.class), new Coord(595000, 205000));
+			Node nB2 = nf.createNode(Id.create("B2", Node.class), new Coord(605000, 195000));
+			Node nT1 = nf.createNode(Id.create("T1", Node.class), new Coord(610000, 180000));
+			Node nT2 = nf.createNode(Id.create("T2", Node.class), new Coord(620000, 175000));
+
+			network.addNode(nL1);
+			network.addNode(nL2);
+			network.addNode(nB1);
+			network.addNode(nB2);
+			network.addNode(nT1);
+			network.addNode(nT2);
+
+			Link lL = createLink(nf, "L", nL1, nL2, 500, 1000, 10);
+			Link lLB = createLink(nf, "LB", nL2, nB1, 5000, 2000, 25);
+			Link lB = createLink(nf, "B", nB1, nB2, 500, 1000, 10);
+			Link lBT = createLink(nf, "BT", nB2, nT1, 5000, 2000, 25);
+			Link lT = createLink(nf, "T", nT1, nT2, 500, 1000, 10);
+			Link lTL = createLink(nf, "TL", nT2, nL1, 5000, 2000, 25);
+
+			network.addLink(lL);
+			network.addLink(lLB);
+			network.addLink(lB);
+			network.addLink(lBT);
+			network.addLink(lT);
+			network.addLink(lTL);
+		}
+
+		private Link createLink(NetworkFactory nf, String id, Node fromNode, Node toNode, double length, double capacity, double freespeed) {
+			Link l = nf.createLink(Id.create(id, Link.class), fromNode, toNode);
+			l.setLength(length);
+			l.setCapacity(capacity);
+			l.setFreespeed(freespeed);
+			l.setAllowedModes(CollectionUtils.stringToSet("car"));
+			l.setNumberOfLanes(1);
+			return l;
+		}
+
+
+		private void prepareEvents() {
+			this.events = EventsUtils.createEventsManager(this.config);
+		}
+
+	}
+}

--- a/contribs/parking/src/test/java/org/matsim/contrib/parking/parkingcost/eventhandling/RideParkingCostTrackerTest.java
+++ b/contribs/parking/src/test/java/org/matsim/contrib/parking/parkingcost/eventhandling/RideParkingCostTrackerTest.java
@@ -1,0 +1,177 @@
+package org.matsim.contrib.parking.parkingcost.eventhandling;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.events.ActivityEndEvent;
+import org.matsim.api.core.v01.events.ActivityStartEvent;
+import org.matsim.api.core.v01.events.PersonArrivalEvent;
+import org.matsim.api.core.v01.events.PersonMoneyEvent;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.NetworkFactory;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contrib.parking.parkingcost.config.ParkingCostConfigGroup;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.events.EventsUtils;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.core.utils.collections.CollectionUtils;
+import org.matsim.testcases.utils.EventsCollector;
+import org.matsim.testcases.utils.EventsLogger;
+
+/**
+ * @author mrieser, jfbischoff (SBB)
+ */
+public class RideParkingCostTrackerTest {
+
+	@Test
+	public void testPersonMoneyEvents() {
+		Fixture f = new Fixture();
+
+		f.events.addHandler(new EventsLogger());
+		ParkingCostConfigGroup parkingCostConfigGroup = new ParkingCostConfigGroup();
+		parkingCostConfigGroup.activityTypesWithoutParkingCost = "home";
+		TeleportedModeParkingCostTracker tracker = new TeleportedModeParkingCostTracker(TransportMode.ride, parkingCostConfigGroup);
+		tracker.events = f.events;
+		tracker.network = f.scenario.getNetwork();
+		f.events.addHandler(tracker);
+		EventsCollector collector = new EventsCollector();
+		f.events.addHandler(collector);
+
+		Id<Person> personId = Id.create(1, Person.class);
+		Id<Link> linkHome = Id.create("L", Link.class);
+		Id<Link> linkWork = Id.create("B", Link.class);
+		Id<Link> linkShop = Id.create("T", Link.class);
+
+		double hourlyParkingCostWork = 20; // this is the value of at_car in zone Bern
+		double hourlyParkingCostShop = 3; // this is the value of at_car in zone Thun
+		f.scenario.getNetwork().getLinks().get(linkWork).getAttributes().putAttribute("pc_ride", hourlyParkingCostWork);
+		f.scenario.getNetwork().getLinks().get(linkShop).getAttributes().putAttribute("pc_ride", hourlyParkingCostShop);
+		f.events.processEvent(new PersonArrivalEvent(7.25 * 3600, personId, linkWork, "ride"));
+		f.events.processEvent(new ActivityStartEvent(7.25 * 3600, personId, linkWork, null, "work", null));
+		Assert.assertEquals(2, collector.getEvents().size());
+
+		f.events.processEvent(new ActivityEndEvent(12.00 * 3600, personId, linkWork, null, "work", new Coord(0, 0)));
+		Assert.assertEquals(4, collector.getEvents().size());
+
+		Assert.assertEquals(PersonMoneyEvent.class, collector.getEvents().get(2).getClass());
+		PersonMoneyEvent parkingEvent1 = (PersonMoneyEvent) collector.getEvents().get(2);
+		Assert.assertEquals(personId, parkingEvent1.getPersonId());
+		Assert.assertEquals(12.00 * 3600, parkingEvent1.getTime(), 1e-8);
+		Assert.assertEquals((12 - 7.25) * hourlyParkingCostWork, -parkingEvent1.getAmount(), 1e-8);
+
+		f.events.processEvent(new PersonArrivalEvent(12.25 * 3600, personId, linkShop, "ride"));
+		f.events.processEvent(new ActivityStartEvent(12.25 * 3600, personId, linkShop, null, "shop", null));
+		Assert.assertEquals(6, collector.getEvents().size());
+
+		f.events.processEvent(new ActivityEndEvent(13.00 * 3600, personId, linkShop, null, "shop", new Coord(0, 0)));
+		Assert.assertEquals(8, collector.getEvents().size());
+
+		Assert.assertEquals(PersonMoneyEvent.class, collector.getEvents().get(6).getClass());
+		PersonMoneyEvent parkingEvent2 = (PersonMoneyEvent) collector.getEvents().get(6);
+		Assert.assertEquals(personId, parkingEvent2.getPersonId());
+		Assert.assertEquals(13.00 * 3600, parkingEvent2.getTime(), 1e-8);
+		Assert.assertEquals((13 - 12.25) * hourlyParkingCostShop, -parkingEvent2.getAmount(), 1e-8);
+
+		f.events.processEvent(new PersonArrivalEvent(13.25 * 3600, personId, linkHome, "ride"));
+		f.events.processEvent(new ActivityStartEvent(13.25 * 3600, personId, linkHome, null, "home", null));
+		Assert.assertEquals(10, collector.getEvents().size());
+
+		f.events.processEvent(new ActivityEndEvent(15.00 * 3600, personId, linkShop, null, "home", new Coord(0, 0)));
+		Assert.assertEquals(11, collector.getEvents().size()); // there should be no parking cost event at home
+
+		f.events.processEvent(new PersonArrivalEvent(15.25 * 3600, personId, linkWork, "ride"));
+		f.events.processEvent(new ActivityStartEvent(13.25 * 3600, personId, linkWork, null, "shop", null));
+		Assert.assertEquals(13, collector.getEvents().size());
+
+		f.events.processEvent(new ActivityEndEvent(18.00 * 3600, personId, linkWork, null, "shop", new Coord(0, 0)));
+		Assert.assertEquals(15, collector.getEvents().size());
+
+		Assert.assertEquals(PersonMoneyEvent.class, collector.getEvents().get(13).getClass());
+		PersonMoneyEvent parkingEvent3 = (PersonMoneyEvent) collector.getEvents().get(13);
+		Assert.assertEquals(personId, parkingEvent3.getPersonId());
+		Assert.assertEquals(18.00 * 3600, parkingEvent3.getTime(), 1e-8);
+		Assert.assertEquals((18 - 15.25) * hourlyParkingCostWork, -parkingEvent3.getAmount(), 1e-8);
+
+		f.events.processEvent(new PersonArrivalEvent(18.50 * 3600, personId, linkHome, "ride"));
+		f.events.processEvent(new ActivityStartEvent(18.00 * 3600, personId, linkHome, null, "shop", null));
+		Assert.assertEquals(17, collector.getEvents().size());
+	}
+
+	/**
+	 * Creates a simple test scenario matching the accesstime_zone.SHP test file.
+	 */
+	private static class Fixture {
+
+		final Config config;
+		final Scenario scenario;
+		EventsManager events;
+
+		public Fixture() {
+			this.config = ConfigUtils.createConfig();
+			prepareConfig();
+			this.scenario = ScenarioUtils.createScenario(this.config);
+			createNetwork();
+			prepareEvents();
+		}
+
+		private void prepareConfig() {
+			ParkingCostConfigGroup parkingConfig = ConfigUtils.addOrGetModule(this.config, ParkingCostConfigGroup.class);
+			parkingConfig.modesWithParkingCosts = "ride";
+		}
+
+		private void createNetwork() {
+			Network network = this.scenario.getNetwork();
+			NetworkFactory nf = network.getFactory();
+
+			Node nL1 = nf.createNode(Id.create("L1", Node.class), new Coord(545000, 150000));
+			Node nL2 = nf.createNode(Id.create("L2", Node.class), new Coord(540000, 165000));
+			Node nB1 = nf.createNode(Id.create("B1", Node.class), new Coord(595000, 205000));
+			Node nB2 = nf.createNode(Id.create("B2", Node.class), new Coord(605000, 195000));
+			Node nT1 = nf.createNode(Id.create("T1", Node.class), new Coord(610000, 180000));
+			Node nT2 = nf.createNode(Id.create("T2", Node.class), new Coord(620000, 175000));
+
+			network.addNode(nL1);
+			network.addNode(nL2);
+			network.addNode(nB1);
+			network.addNode(nB2);
+			network.addNode(nT1);
+			network.addNode(nT2);
+
+			Link lL = createLink(nf, "L", nL1, nL2, 500, 1000, 10);
+			Link lLB = createLink(nf, "LB", nL2, nB1, 5000, 2000, 25);
+			Link lB = createLink(nf, "B", nB1, nB2, 500, 1000, 10);
+			Link lBT = createLink(nf, "BT", nB2, nT1, 5000, 2000, 25);
+			Link lT = createLink(nf, "T", nT1, nT2, 500, 1000, 10);
+			Link lTL = createLink(nf, "TL", nT2, nL1, 5000, 2000, 25);
+
+			network.addLink(lL);
+			network.addLink(lLB);
+			network.addLink(lB);
+			network.addLink(lBT);
+			network.addLink(lT);
+			network.addLink(lTL);
+		}
+
+		private Link createLink(NetworkFactory nf, String id, Node fromNode, Node toNode, double length, double capacity, double freespeed) {
+			Link l = nf.createLink(Id.create(id, Link.class), fromNode, toNode);
+			l.setLength(length);
+			l.setCapacity(capacity);
+			l.setFreespeed(freespeed);
+			l.setAllowedModes(CollectionUtils.stringToSet("car"));
+			l.setNumberOfLanes(1);
+			return l;
+		}
+
+		private void prepareEvents() {
+			this.events = EventsUtils.createEventsManager(this.config);
+		}
+
+	}
+}

--- a/contribs/parking/src/test/java/org/matsim/contrib/parking/parkingcost/eventhandling/RideParkingCostTrackerTest.java
+++ b/contribs/parking/src/test/java/org/matsim/contrib/parking/parkingcost/eventhandling/RideParkingCostTrackerTest.java
@@ -1,3 +1,22 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
 package org.matsim.contrib.parking.parkingcost.eventhandling;
 
 import org.junit.Assert;

--- a/contribs/parking/src/test/java/org/matsim/contrib/parking/parkingcost/eventhandling/RunParkingCostsExampleTest.java
+++ b/contribs/parking/src/test/java/org/matsim/contrib/parking/parkingcost/eventhandling/RunParkingCostsExampleTest.java
@@ -1,0 +1,12 @@
+package org.matsim.contrib.parking.parkingcost.eventhandling;
+
+import org.junit.Test;
+import org.matsim.contrib.parking.parkingcost.RunParkingCostExample;
+
+public class RunParkingCostsExampleTest {
+
+	@Test
+	public void testRunParkingCostsExample() {
+		RunParkingCostExample.main(new String[]{});
+	}
+}

--- a/contribs/parking/src/test/java/org/matsim/contrib/parking/parkingcost/eventhandling/RunParkingCostsExampleTest.java
+++ b/contribs/parking/src/test/java/org/matsim/contrib/parking/parkingcost/eventhandling/RunParkingCostsExampleTest.java
@@ -1,3 +1,22 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
 package org.matsim.contrib.parking.parkingcost.eventhandling;
 
 import org.junit.Test;

--- a/matsim/src/main/java/org/matsim/api/core/v01/events/PersonMoneyEvent.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/PersonMoneyEvent.java
@@ -20,10 +20,10 @@
 
 package org.matsim.api.core.v01.events;
 
-import java.util.Map;
-
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.population.Person;
+
+import java.util.Map;
 
 /**
  * This event specifies that an agent has gained (or paid) some money.
@@ -36,7 +36,7 @@ import org.matsim.api.core.v01.population.Person;
 public final class PersonMoneyEvent extends Event implements HasPersonId {
 
 	public static final String EVENT_TYPE = "personMoney";
-	
+
 	public static final String ATTRIBUTE_AMOUNT = "amount";
 	public static final String ATTRIBUTE_PURPOSE = "purpose";
 	public static final String ATTRIBUTE_TRANSACTION_PARTNER = "transactionPartner";
@@ -53,17 +53,18 @@ public final class PersonMoneyEvent extends Event implements HasPersonId {
 	 * some money at the specified <tt>time</tt>. Positive values for <tt>amount</tt>
 	 * mean the agent has gained money, negative values that the agent has paid money.
 	 * <br>
-	 * There are two optional fields: <tt>purpose</tt> and <tt>transactionPartner</tt>.
-	 * Those are currently not read by any core MATSim code, but can be useful for 
-	 * analysis, e.g. calculate the drt fare revenue (purpose = "drtFare") by 
-	 * drt operator (transactionPartner = "Greedy Shared Taxis Inc.").
+	 * There are three optional fields: <tt>purpose</tt> and <tt>transactionPartner</tt>.
+	 * Those are currently not read by any core MATSim code, but can be useful for
+	 * analysis, e.g. calculate the drt fare revenue (purpose = "drtFare") by
+	 * drt operator (transactionPartner = "Greedy Shared Taxis Inc."). Finally, there is a <tt>reference</tt>,
+	 * for example to specify a link or any other information one might find useful.
 	 *
 	 * @param time
 	 * @param agentId
 	 * @param amount
-	 * @param purpose (not required by dtd)
+	 * @param purpose            (not required by dtd)
 	 * @param transactionPartner (not required by dtd)
-	 * @param reference (not required by dtd)
+	 * @param reference          (not required by dtd)
 	 */
 	public PersonMoneyEvent(final double time, final Id<Person> agentId, final double amount, final String purpose,
 				final String transactionPartner, final String reference) {
@@ -88,21 +89,22 @@ public final class PersonMoneyEvent extends Event implements HasPersonId {
 	@Deprecated // add "reference"
 	public PersonMoneyEvent(final double time, final Id<Person> agentId, final double amount, final String purpose,
 							final String transactionPartner) {
-		this( time, agentId, amount, purpose, transactionPartner, null);
+		this(time, agentId, amount, purpose, transactionPartner, null);
 	}
 
+	@Override
 	public Id<Person> getPersonId() {
 		return this.personId;
 	}
-	
+
 	public double getAmount() {
 		return this.amount;
 	}
-	
+
 	public String getPurpose() {
 		return this.purpose;
 	}
-	
+
 	public String getTransactionPartner() {
 		return this.transactionPartner;
 	}
@@ -115,7 +117,7 @@ public final class PersonMoneyEvent extends Event implements HasPersonId {
 	public String getEventType() {
 		return EVENT_TYPE;
 	}
-	
+
 	@Override
 	public Map<String, String> getAttributes() {
 		Map<String, String> attr = super.getAttributes();


### PR DESCRIPTION
This PR adds the functionality to easily charge parking costs depending on link attributes. Both network and (pseudo)-teleported modes can be accessed.
Parking Charges are a major factor in mode choice - we have been using this code internally a long time and think it might be useful for others too. 
Effects of parking charges will depend on the handling of money events in the MATSim Scoring process.