### PR TITLE
Add switch off for FISS in the last iteration

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISS.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISS.java
@@ -17,6 +17,7 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Leg;
 import org.matsim.contrib.dynagent.DynAgent;
 import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.controler.MatsimServices;
 import org.matsim.core.gbl.Gbl;
 import org.matsim.core.gbl.MatsimRandom;
 import org.matsim.core.mobsim.framework.MobsimAgent;
@@ -66,8 +67,10 @@ public class FISS implements DepartureHandler, MobsimEngine {
 	private final TravelTime travelTime;
 	private final Random random;
 
+	private final MatsimServices matsimServices;
 
-	FISS(QNetsimEngineI qNetsimEngine, Scenario scenario, EventsManager eventsManager, FISSConfigGroup fissConfigGroup,
+
+	FISS(MatsimServices matsimServices, QNetsimEngineI qNetsimEngine, Scenario scenario, EventsManager eventsManager, FISSConfigGroup fissConfigGroup,
 			TravelTime travelTime) {
 		this.qNetsimEngine = qNetsimEngine;
         this.delegate = qNetsimEngine.getDepartureHandler();
@@ -76,12 +79,13 @@ public class FISS implements DepartureHandler, MobsimEngine {
 		this.travelTime = travelTime;
 		this.network = scenario.getNetwork();
 		this.random = MatsimRandom.getLocalInstance();
+		this.matsimServices = matsimServices;
 	}
 
     @Override
     public boolean handleDeparture(double now, MobsimAgent agent, Id<Link> linkId) {
 		if (this.fissConfigGroup.sampledModes.contains(agent.getMode())) {
-			if (random.nextDouble() < fissConfigGroup.sampleFactor || agent instanceof TransitDriverAgent) {
+			if (random.nextDouble() < fissConfigGroup.sampleFactor || agent instanceof TransitDriverAgent || this.switchOffFISS()) {
 				return delegate.handleDeparture(now, agent, linkId);
 			} else {
 				if (!(agent instanceof DynAgent)) {
@@ -146,6 +150,14 @@ public class FISS implements DepartureHandler, MobsimEngine {
 	@Override
 	public void afterSim() {
 		teleport.afterSim();
+	}
+
+	private boolean switchOffFISS() {
+		if (this.matsimServices.getConfig().controler().getLastIteration() == this.matsimServices.getIterationNumber()) {
+			return true;
+		} else {
+			return false;
+		}
 	}
 
 	@Override

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISS.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISS.java
@@ -153,11 +153,7 @@ public class FISS implements DepartureHandler, MobsimEngine {
 	}
 
 	private boolean switchOffFISS() {
-		if (this.matsimServices.getConfig().controler().getLastIteration() == this.matsimServices.getIterationNumber()) {
-			return true;
-		} else {
-			return false;
-		}
+		return this.matsimServices.getConfig().controler().getLastIteration() == this.matsimServices.getIterationNumber();
 	}
 
 	@Override

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISSConfigGroup.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISSConfigGroup.java
@@ -34,6 +34,11 @@ public class FISSConfigGroup extends ReflectiveConfigGroup {
     @NotNull
     public Set<String> sampledModes = Collections.singleton(TransportMode.car);
 
+	@Parameter
+	@Comment("Disable FISS in the last iteration to get events of all agents. May be required for post-processing")
+	@Positive
+	public boolean switchOffFISSLastIteration = true;
+
     public FISSConfigGroup() {
         super(GROUP_NAME);
     }

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISSConfigGroup.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISSConfigGroup.java
@@ -36,7 +36,6 @@ public class FISSConfigGroup extends ReflectiveConfigGroup {
 
 	@Parameter
 	@Comment("Disable FISS in the last iteration to get events of all agents. May be required for post-processing")
-	@Positive
 	public boolean switchOffFISSLastIteration = true;
 
     public FISSConfigGroup() {

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISSQSimModule.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISSQSimModule.java
@@ -17,6 +17,7 @@ import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.groups.QSimConfigGroup;
+import org.matsim.core.controler.MatsimServices;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
 import org.matsim.core.mobsim.qsim.qnetsimengine.QNetsimEngineI;
 import org.matsim.core.router.util.TravelTime;
@@ -35,11 +36,11 @@ public class FISSQSimModule extends AbstractQSimModule {
 
     @Provides
     @Singleton
-    FISS provideMultiModalDepartureHandler(QNetsimEngineI qNetsimEngine,
-            QSimConfigGroup qsimConfig, Scenario scenario, EventsManager eventsManager,
-            @Named(TransportMode.car) TravelTime travelTime) {
+    FISS provideMultiModalDepartureHandler(MatsimServices matsimServices, QNetsimEngineI qNetsimEngine,
+										   QSimConfigGroup qsimConfig, Scenario scenario, EventsManager eventsManager,
+										   @Named(TransportMode.car) TravelTime travelTime) {
         Config config = scenario.getConfig();
         FISSConfigGroup fissConfigGroup = ConfigUtils.addOrGetModule(config, FISSConfigGroup.class);
-        return new FISS(qNetsimEngine, scenario, eventsManager, fissConfigGroup, travelTime);
+		return new FISS(matsimServices, qNetsimEngine, scenario, eventsManager, fissConfigGroup, travelTime);
     }
 }

--- a/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/fiss/RunFissDrtScenarioIT.java
+++ b/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/fiss/RunFissDrtScenarioIT.java
@@ -120,7 +120,7 @@ public class RunFissDrtScenarioIT {
 		stratSets.setStrategyName("ChangeExpBeta");
 		config.strategy().addStrategySettings(stratSets);
 
-		config.controler().setLastIteration(1);
+		config.controler().setLastIteration(2);
 		config.controler().setWriteEventsInterval(1);
 
 		config.controler().setOverwriteFileSetting(OutputDirectoryHierarchy.OverwriteFileSetting.deleteDirectoryIfExists);


### PR DESCRIPTION
This PR adds a config switch that disables FISS in the last iteration in order to generate events from all agents (even all car driving agents). This feature might be required for post processing analysis which requires all link enter and leave events to be available.