### PR TITLE
Freight: Hand over the original LinkEnterEvent instead of creating a new one

### DIFF
--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/CarrierDriverAgent.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/controler/CarrierDriverAgent.java
@@ -125,7 +125,7 @@ final class CarrierDriverAgent{
 
 	private void handleEvent( LinkEnterEvent event ){
 		if( scoringFunction != null ){
-			scoringFunction.handleEvent( new LinkEnterEvent( event.getTime(), getVehicle().getId(), event.getLinkId() ) );
+			scoringFunction.handleEvent( event );
 		}
 		currentRoute.add( event.getLinkId() );
 		createAdditionalEvents( event, null, scheduledTour, driverId, planElementCounter );


### PR DESCRIPTION
There is no reason to create a new object (with slightly different information) instead of using the original `LinkEnterEvent` for the scoring function.

With the original `LinkEnterEvent`, the `vehicleTypeId` (and other information) will become consistent to the stuff in the event log. Since we are using the MATSim vehicles also in the freight contrib, we can access all relevant information from there - and thus need the vehicleId, that is available in the mobsim and e.g. the `allVehicles`-container.