### PR TITLE
bind LinkSpeedCalculator by mode

### DIFF
--- a/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/BicycleModule.java
+++ b/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/BicycleModule.java
@@ -20,13 +20,17 @@ package org.matsim.contrib.bicycle;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.google.inject.multibindings.MapBinder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
+import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.events.StartupEvent;
 import org.matsim.core.controler.listener.StartupListener;
+import org.matsim.core.mobsim.qsim.AbstractQSimModule;
+import org.matsim.core.mobsim.qsim.qnetsimengine.linkspeedcalculator.LinkSpeedCalculator;
 import org.matsim.vehicles.VehicleType;
 
 /**
@@ -60,6 +64,23 @@ final class BicycleModule extends AbstractModule {
 			addMobsimListenerBinding().to(MotorizedInteractionEngine.class);
 		}
 		addControlerListenerBinding().to(ConsistencyCheck.class);
+
+		this.installOverridingQSimModule( new AbstractQSimModule(){
+			@Inject EventsManager events;
+			@Inject Scenario scenario;
+			@Inject BicycleLinkSpeedCalculator bicycleLinkSpeedCalculator;
+			@Override protected void configureQSim(){
+//				final ConfigurableQNetworkFactory factory = new ConfigurableQNetworkFactory(events, scenario);
+//				factory.setLinkSpeedCalculator( bicycleLinkSpeedCalculator );
+//				bind( QNetworkFactory.class ).toInstance(factory );
+//				// NOTE: Other than when using a provider, this uses the same factory instance over all iterations, re-configuring
+//				// it in every iteration via the initializeFactory(...) method. kai, mar'16
+
+				var linkSpeedCalculator = MapBinder.newMapBinder( this.binder(), String.class, LinkSpeedCalculator.class );
+				linkSpeedCalculator.addBinding( "bicycle" ).toInstance( bicycleLinkSpeedCalculator );
+
+			}
+		} );
 	}
 
 	static class ConsistencyCheck implements StartupListener {

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/ConfigurableQNetworkFactory.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/ConfigurableQNetworkFactory.java
@@ -43,10 +43,10 @@ import org.matsim.vis.snapshotwriters.SnapshotLinkWidthCalculator;
  * @see DefaultQNetworkFactory
  */
 public final class ConfigurableQNetworkFactory implements QNetworkFactory {
-	private QSimConfigGroup qsimConfig;
-	private EventsManager events;
-	private Network network;
-	private Scenario scenario;
+	private final QSimConfigGroup qsimConfig;
+	private final EventsManager events;
+	private final Network network;
+	private final Scenario scenario;
 	private NetsimEngineContext context;
 	private NetsimInternalInterface netsimEngine;
 	private Optional<LinkSpeedCalculator> linkSpeedCalculator = Optional.empty();
@@ -63,16 +63,18 @@ public final class ConfigurableQNetworkFactory implements QNetworkFactory {
 	}
 
 	@Override
-	public void initializeFactory(AgentCounter agentCounter, MobsimTimer mobsimTimer, NetsimInternalInterface netsimEngine1) {
-		this.netsimEngine = netsimEngine1;
-		double effectiveCellSize = network.getEffectiveCellSize();
+	public void initializeFactory(AgentCounter agentCounter, MobsimTimer mobsimTimer, NetsimInternalInterface netsimEngine) {
+		this.netsimEngine = netsimEngine;
+
 		SnapshotLinkWidthCalculator linkWidthCalculator = new SnapshotLinkWidthCalculator();
 		linkWidthCalculator.setLinkWidthForVis(qsimConfig.getLinkWidthForVis());
 		if (!Double.isNaN(network.getEffectiveLaneWidth())) {
 			linkWidthCalculator.setLaneWidth(network.getEffectiveLaneWidth());
 		}
+
 		AbstractAgentSnapshotInfoBuilder agentSnapshotInfoBuilder = QNetsimEngineWithThreadpool.createAgentSnapshotInfoBuilder(scenario, linkWidthCalculator);
-		context = new NetsimEngineContext(events, effectiveCellSize, agentCounter, agentSnapshotInfoBuilder, qsimConfig, mobsimTimer, linkWidthCalculator);
+
+		context = new NetsimEngineContext(events, network.getEffectiveCellSize(), agentCounter, agentSnapshotInfoBuilder, qsimConfig, mobsimTimer, linkWidthCalculator);
 	}
 	@Override
 	public QLinkI createNetsimLink( final Link link, final QNodeI toQueueNode ) {


### PR DESCRIPTION
Steps towards https://github.com/matsim-org/matsim-libs/issues/2337 .  Text from there:


I am just looking at the bicycle contrib. It overwrites the QNetworkFactory so that it can set the LinkSpeedCalculator.

This means that it cannot be combined with anything else that overwrites the QNetworkFactory. (At least not without manual programming.)

My idea to make this more orthogonal would be:

allow things like LinkSpeedCalculator to be injected into the Default(!?)QNetworkFactory

make this injection by mode so that different contribs can set these things independently by mode

Wanted to ask if anybody can see a reason why this would be a stupid idea.

---

A disadvantage would be that we would get something like this in the inner QSim loop:
```
... linkSpeedCalculators.get(vehicle.getMode()).getMaximumVelocity(...)
```
That is, a get that would be an associative array. Can't say how much speed this would cost.