### PR TITLE
mvn: re-enable enforcer

### DIFF
--- a/contribs/otfvis/pom.xml
+++ b/contribs/otfvis/pom.xml
@@ -4,12 +4,6 @@
 		<artifactId>contrib</artifactId>
 		<version>15.0-SNAPSHOT</version>
 	</parent>
-	<repositories>
-		<repository>
-			<id>jzy3d</id>
-			<url>https://maven.jzy3d.org/releases/</url>
-		</repository>
-	</repositories>
 	<build>
 		<plugins>
 			<plugin>
@@ -23,7 +17,7 @@
 					<forkMode>once</forkMode>
 					<!-- avoid out of memory errors: -->
 					<argLine>-Xmx700m -Djava.awt.headless=true</argLine>
-					<enableAssertions>false</enableAssertions> <!-- this should be set to true, but we still have some tests that don't 
+					<enableAssertions>false</enableAssertions> <!-- this should be set to true, but we still have some tests that don't
 						work otherwise... -->
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -59,10 +59,6 @@
             <id>matsim</id>
             <url>https://repo.matsim.org/repository/matsim</url>
         </repository>
-<!--	    <repository>-->
-<!--		    <id>geo-solutions</id>-->
-<!--		    <url>https://maven.geo-solutions.it/</url>-->
-<!--	    </repository>-->
     </repositories>
 
     <distributionManagement>
@@ -295,35 +291,35 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.10.1</version>
             </plugin>
-<!--            <plugin>-->
-<!--                <groupId>org.apache.maven.plugins</groupId>-->
-<!--                <artifactId>maven-enforcer-plugin</artifactId>-->
-<!--                <version>3.1.0</version>-->
-<!--                <executions>-->
-<!--                    <execution>-->
-<!--                        <id>enforce</id>-->
-<!--                        <goals>-->
-<!--                            <goal>enforce</goal>-->
-<!--                        </goals>-->
-<!--                    </execution>-->
-<!--                </executions>-->
-<!--                <configuration>-->
-<!--                    <rules>-->
-<!--                        <requireUpperBoundDeps/>-->
-<!--                        <banDuplicatePomDependencyVersions/>-->
-<!--						<requireReleaseDeps>-->
-<!--							<failWhenParentIsSnapshot>false</failWhenParentIsSnapshot>-->
-<!--							<excludes>-->
-<!--								<exclude>org.matsim:*</exclude>-->
-<!--								<exclude>org.matsim.contrib:*</exclude>-->
-<!--							</excludes>-->
-<!--						</requireReleaseDeps>-->
-<!--                        <requireMavenVersion>-->
-<!--                            <version>3.6.3</version>-->
-<!--                        </requireMavenVersion>-->
-<!--                    </rules>-->
-<!--                </configuration>-->
-<!--            </plugin>-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <rules>
+                        <requireUpperBoundDeps/>
+                        <banDuplicatePomDependencyVersions/>
+						<requireReleaseDeps>
+							<failWhenParentIsSnapshot>false</failWhenParentIsSnapshot>
+							<excludes>
+								<exclude>org.matsim:*</exclude>
+								<exclude>org.matsim.contrib:*</exclude>
+							</excludes>
+						</requireReleaseDeps>
+                        <requireMavenVersion>
+                            <version>3.6.3</version>
+                        </requireMavenVersion>
+                    </rules>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
I think we can re-enable enforcer (disabled in #2344). There was an issue with an SSL certificate that expired on 1/1/23 for the https://maven.geo-solutions.it/ maven repo. Therefore we could not download `com.sun:clibwrapper_jiio:jar:1.1` from there. I think shading (fat jar creation) might have been affected too.