### PR TITLE
mvn: disable external javadoc link auto detection

### DIFF
--- a/matsim/pom.xml
+++ b/matsim/pom.xml
@@ -313,7 +313,7 @@
 									<packages>org.matsim.vis:org.matsim.vis.*</packages>
 								</group>
 							</groups>
-							<detectLinks>true</detectLinks>
+							<detectLinks>false</detectLinks>
 							<doclint>none</doclint>
 							<linksource>true</linksource>
 						</configuration>


### PR DESCRIPTION
Due to the recent build failures related to downloading assertJ javadocs, e.g. https://github.com/matsim-org/matsim-libs/actions/runs/3859888596/jobs/6579827504

At this point, it's hard to say what is the issue. Versions 3.23.x (May '22) worked fine and the recent bumps to 3.24.x (Jan '23) caused this issue. So this seems to be the quickest fix until we have time to look deeper into it.