### PR TITLE
mvn: remove redundant test scope in assertj-core dependency declaration

### DIFF
--- a/contribs/application/pom.xml
+++ b/contribs/application/pom.xml
@@ -63,7 +63,7 @@
 					<artifactId>slf4j-reload4j</artifactId>
 				</exclusion>
 			</exclusions>
-		</dependency>		
+		</dependency>
 
 		<dependency>
 			<groupId>com.github.matsim-org</groupId>
@@ -106,9 +106,8 @@
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
-			<scope>test</scope>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>xerces</groupId>
 			<artifactId>xercesImpl</artifactId>


### PR DESCRIPTION
The scope is already declared as `test` in the dependency management (in matsim-all POM).