### PR TITLE
core: add collectors for IdSet and IdMap

### DIFF
--- a/matsim/src/main/java/org/matsim/api/core/v01/IdCollectors.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/IdCollectors.java
@@ -1,0 +1,64 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2023 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.api.core.v01;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Collector.Characteristics;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class IdCollectors {
+	public static <T, K, V> Collector<T, ?, IdMap<K, V>> toIdMap(Class<K> idClass, Function<? super T, ? extends Id<K>> keyMapper,
+			Function<? super T, ? extends V> valueMapper) {
+		return Collector.of(() -> new IdMap<>(idClass), (map, element) -> {
+			Id<K> k = keyMapper.apply(element);
+			V v = Objects.requireNonNull(valueMapper.apply(element));
+			V u = map.putIfAbsent(k, v);
+			Preconditions.checkState(u == null, "Duplicate key %s (attempted merging values %s and %s)", k, u, v);
+		}, (m1, m2) -> {
+			for (Map.Entry<Id<K>, V> e : m2.entrySet()) {
+				Id<K> k = e.getKey();
+				V v = Objects.requireNonNull(e.getValue());
+				V u = m1.putIfAbsent(k, v);
+				Preconditions.checkState(u == null, "Duplicate key %s (attempted merging values %s and %s)", k, u, v);
+			}
+			return m1;
+		}, Characteristics.IDENTITY_FINISH);
+	}
+
+	public static <T> Collector<Id<T>, ?, IdSet<T>> toIdSet(Class<T> idClass) {
+		return Collector.of(() -> new IdSet<>(idClass), IdSet::add, (left, right) -> {
+			if (left.size() < right.size()) {
+				right.addAll(left);
+				return right;
+			} else {
+				left.addAll(right);
+				return left;
+			}
+		}, Characteristics.UNORDERED, Characteristics.IDENTITY_FINISH);
+	}
+}

--- a/matsim/src/main/java/org/matsim/api/core/v01/IdMap.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/IdMap.java
@@ -17,7 +17,7 @@ public class IdMap<T, V> implements Map<Id<T>, V>, Iterable<V> {
 
 	private static final int INCREMENT = 100;
 	private static final float INCREMENT_FACTOR = 1.5f;
-	private Class<T> idClass;
+	private final Class<T> idClass;
 	private int size = 0;
 	private Object[] data;
 
@@ -242,9 +242,7 @@ public class IdMap<T, V> implements Map<Id<T>, V>, Iterable<V> {
 							return false;
 					}
 				}
-			} catch (ClassCastException noIdAsKey) {
-				return false;
-			} catch (NullPointerException unused) {
+			} catch (ClassCastException | NullPointerException noIdAsKey) {
 				return false;
 			}
 			return true;
@@ -619,9 +617,7 @@ public class IdMap<T, V> implements Map<Id<T>, V>, Iterable<V> {
 					return false;
 				try {
 					return containsAll(c);
-				} catch (ClassCastException unused) {
-					return false;
-				} catch (NullPointerException unused) {
+				} catch (ClassCastException | NullPointerException unused) {
 					return false;
 				}
 			}
@@ -759,9 +755,7 @@ public class IdMap<T, V> implements Map<Id<T>, V>, Iterable<V> {
 					return false;
 				try {
 					return containsAll(c);
-				} catch (ClassCastException unused) {
-					return false;
-				} catch (NullPointerException unused) {
+				} catch (ClassCastException | NullPointerException unused) {
 					return false;
 				}
 			}

--- a/matsim/src/main/java/org/matsim/api/core/v01/IdSet.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/IdSet.java
@@ -7,9 +7,9 @@ import java.util.*;
  */
 public class IdSet<T> implements Set<Id<T>> {
 
-	private Class<T> idClass;
+	private final Class<T> idClass;
 	private int size = 0;
-	private BitSet data;
+	private final BitSet data;
 
 	public IdSet(Class<T> idClass) {
 		this(idClass, Math.max(Id.getNumberOfIds(idClass), 100));
@@ -229,9 +229,7 @@ public class IdSet<T> implements Set<Id<T>> {
 				return false;
 			try {
 				return containsAll(c);
-			} catch (ClassCastException unused) {
-				return false;
-			} catch (NullPointerException unused) {
+			} catch (ClassCastException | NullPointerException unused) {
 				return false;
 			}
 		}

--- a/matsim/src/test/java/org/matsim/api/core/v01/IdCollectorsTest.java
+++ b/matsim/src/test/java/org/matsim/api/core/v01/IdCollectorsTest.java
@@ -1,0 +1,78 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2023 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.api.core.v01;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.matsim.vehicles.Vehicle;
+
+/**
+ * @author Michal Maciejewski (michalm)
+ */
+public class IdCollectorsTest {
+
+	@Test
+	public void testToIdMap() {
+		record Entry(Id<Vehicle> id, String value) {
+		}
+
+		var e1 = new Entry(Id.createVehicleId("v1"), "1");
+		var e2 = new Entry(Id.createVehicleId("v2"), "2");
+		var e3 = new Entry(Id.createVehicleId("v3"), "3");
+
+		var entries = List.of(e1, e2, e3);
+		Map<Id<Vehicle>, String> map = entries.stream().collect(IdCollectors.toIdMap(Vehicle.class, Entry::id, Entry::value));
+
+		assertThat(map).hasSize(3);
+		assertThat(map).containsEntry(e1.id, e1.value);
+		assertThat(map).containsEntry(e2.id, e2.value);
+		assertThat(map).containsEntry(e3.id, e3.value);
+	}
+
+	@Test
+	public void testToIdMap_streamWithDuplicateKeys() {
+		record Entry(Id<Vehicle> id, String value) {
+		}
+
+		var e1 = new Entry(Id.createVehicleId("v"), "1");
+
+		var entries = List.of(e1, e1);
+		assertThatThrownBy(() -> entries.stream().collect(IdCollectors.toIdMap(Vehicle.class, Entry::id, Entry::value))).isInstanceOf(
+				IllegalStateException.class).hasMessage("Duplicate key %s (attempted merging values %s and %s)", e1.id, e1.value, e1.value);
+	}
+
+	@Test
+	public void testToIdSet() {
+		var id1 = Id.createVehicleId("v1");
+		var id2 = Id.createVehicleId("v2");
+		var id3 = Id.createVehicleId("v3");
+
+		var ids = List.of(id1, id2, id3, id1); // with duplicates
+		var set = ids.stream().collect(IdCollectors.toIdSet(Vehicle.class));
+
+		assertThat(set).containsExactlyInAnyOrder(id1, id2, id3);
+	}
+}


### PR DESCRIPTION
So we can collect streams to Id maps and sets:
```java
IdMap<Vehicle, Vehicle> map = vehicles.stream().collect(IdCollectors.toIdMap(Vehicle.class, Vehicle::id, v -> v)));
```
or
```java
IdSet<Vehicle> set = vehicles.stream().map(Vehicle::id).collect(IdCollectors.toIdSet(Vehicle.class));
```