### PR TITLE
core: add IdSet.contains(int index) and IdMap.containsKey(int index)

### DIFF
--- a/matsim/src/main/java/org/matsim/api/core/v01/IdMap.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/IdMap.java
@@ -118,6 +118,10 @@ public class IdMap<T, V> implements Map<Id<T>, V>, Iterable<V> {
 		return idx < this.data.length && this.data[idx] != null;
 	}
 
+	public boolean containsKey(int index) {
+		return index < this.data.length && this.data[index] != null;
+	}
+
 	public V get(Id<T> key) {
 		int idx = key.index();
 		if (idx < this.data.length) {

--- a/matsim/src/main/java/org/matsim/api/core/v01/IdSet.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/IdSet.java
@@ -42,6 +42,10 @@ public class IdSet<T> implements Set<Id<T>> {
 		return this.data.get(id.index());
 	}
 
+	public boolean contains(int index) {
+		return this.data.get(index);
+	}
+
 	@Override
 	public Iterator<Id<T>> iterator() {
 		return new IdSetIterator<>(this);

--- a/matsim/src/test/java/org/matsim/api/core/v01/IdMapTest.java
+++ b/matsim/src/test/java/org/matsim/api/core/v01/IdMapTest.java
@@ -121,6 +121,13 @@ public class IdMapTest {
 		Assert.assertTrue(map.containsKey(Id.create(5, Person.class)));
 		Assert.assertFalse(map.containsKey(Id.create(6, Person.class)));
 
+		Assert.assertTrue(map.containsKey(Id.create(1, Person.class).index()));
+		Assert.assertTrue(map.containsKey(Id.create(2, Person.class).index()));
+		Assert.assertFalse(map.containsKey(Id.create(3, Person.class).index()));
+		Assert.assertTrue(map.containsKey(Id.create(4, Person.class).index()));
+		Assert.assertTrue(map.containsKey(Id.create(5, Person.class).index()));
+		Assert.assertFalse(map.containsKey(Id.create(6, Person.class).index()));
+
 		Assert.assertTrue(map.containsKey((Object) Id.create(1, Person.class)));
 		Assert.assertTrue(map.containsKey((Object) Id.create(2, Person.class)));
 		Assert.assertFalse(map.containsKey((Object) Id.create(3, Person.class)));

--- a/matsim/src/test/java/org/matsim/api/core/v01/IdSetTest.java
+++ b/matsim/src/test/java/org/matsim/api/core/v01/IdSetTest.java
@@ -31,6 +31,8 @@ public class IdSetTest {
 		Assert.assertFalse(set.isEmpty());
 		Assert.assertTrue(set.contains(id1));
 		Assert.assertFalse(set.contains(id2));
+		Assert.assertTrue(set.contains(id1.index()));
+		Assert.assertFalse(set.contains(id2.index()));
 
 		Assert.assertFalse(set.add(id1));
 		Assert.assertEquals(1, set.size());
@@ -40,6 +42,9 @@ public class IdSetTest {
 		Assert.assertTrue(set.contains(id1));
 		Assert.assertFalse(set.contains(id2));
 		Assert.assertTrue(set.contains(id3));
+		Assert.assertTrue(set.contains(id1.index()));
+		Assert.assertFalse(set.contains(id2.index()));
+		Assert.assertTrue(set.contains(id3.index()));
 
 		Assert.assertFalse(set.remove(id4));
 		Assert.assertEquals(2, set.size());


### PR DESCRIPTION
We already have `IdMap.get(int index)`, so these two methods follow this patter.

These two methods are useful when checking termination criteria in speedy routers when we want to stop when one or more of the end nodes are reached. Currently, to do it efficiently, we need to create a `BitSet`, which is unnecessary if we already have an `IdSet` or `IdMap`.