### PR TITLE
taxi: un-ignore assignment tests that Jenkins could not run

### DIFF
--- a/contribs/taxi/src/test/java/org/matsim/contrib/etaxi/run/RunETaxiBenchmarkTest.java
+++ b/contribs/taxi/src/test/java/org/matsim/contrib/etaxi/run/RunETaxiBenchmarkTest.java
@@ -20,72 +20,30 @@
 
 package org.matsim.contrib.etaxi.run;
 
-import java.net.URL;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.matsim.api.core.v01.population.Population;
-import org.matsim.core.config.ConfigUtils;
-import org.matsim.core.events.EventsUtils;
-import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.utils.io.IOUtils;
 import org.matsim.examples.ExamplesUtils;
-import org.matsim.run.RunMatsim;
 import org.matsim.testcases.MatsimTestUtils;
-import org.matsim.utils.eventsfilecomparison.EventsFileComparator;
 
 /**
  * @author Michal Maciejewski (michalm)
  */
 public class RunETaxiBenchmarkTest {
-	private static final Logger log = LogManager.getLogger(RunETaxiBenchmarkTest.class );
+	private static final Logger log = LogManager.getLogger(RunETaxiBenchmarkTest.class);
 
-	@Rule public final MatsimTestUtils utils = new MatsimTestUtils();
+	@Rule
+	public final MatsimTestUtils utils = new MatsimTestUtils();
 
 	@Test
 	public void testRuleBased() {
-		try {
-			String configPath = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("dvrp-grid"), "one_etaxi_benchmark_config.xml").toString();
-			String [] args = {configPath
-					,"--config:controler.outputDirectory", utils.getOutputDirectory()
-//					,"--config:controler.writeEventsInterval","1"
-//					,"--config:controler.writePlansInterval","1"
-//					,"--config:controler.lastIteration", "1"
-			} ;
-			// the config file suppresses most writing of output.  Presumably, since it is to be run as a benchmark.  One can override it here, but it is again overwritten later.  So
-			// I guess that the authors really mean it.  In consequence, cannot test regression on the functionality of the benchmark.  kai, nov'22
+		String configPath = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("dvrp-grid"), "one_etaxi_benchmark_config.xml").toString();
+		String[] args = { configPath, "--config:controler.outputDirectory", utils.getOutputDirectory() };
+		// the config file suppresses most writing of output.  Presumably, since it is to be run as a benchmark.  One can override it here, but it is again overwritten later.  So
+		// I guess that the authors really mean it.  In consequence, cannot test regression on the functionality of the benchmark.  kai, nov'22
 
-			RunETaxiBenchmark.run(args, 2);
-
-//			{
-//				Population expected = PopulationUtils.createPopulation( ConfigUtils.createConfig() ) ;
-//				PopulationUtils.readPopulation( expected, utils.getInputDirectory() + "/output_plans.xml.gz" );
-//
-//				Population actual = PopulationUtils.createPopulation( ConfigUtils.createConfig() ) ;
-//				PopulationUtils.readPopulation( actual, utils.getOutputDirectory() + "/output_plans.xml.gz" );
-//
-//				boolean result = PopulationUtils.comparePopulations( expected, actual );
-//				Assert.assertTrue( result );
-//			}
-//			{
-//				String expected = utils.getInputDirectory() + "/output_events.xml.gz" ;
-//				String actual = utils.getOutputDirectory() + "/output_events.xml.gz" ;
-//				EventsFileComparator.Result result = EventsUtils.compareEventsFiles( expected, actual );
-//				Assert.assertEquals( EventsFileComparator.Result.FILES_ARE_EQUAL, result );
-//			}
-
-		} catch ( Exception ee ) {
-			log.fatal("there was an exception: \n" + ee ) ;
-
-			// if one catches an exception, then one needs to explicitly fail the test:
-			Assert.fail();
-		}
-
-
-
-
+		RunETaxiBenchmark.run(args, 2);
 	}
 }

--- a/contribs/taxi/src/test/java/org/matsim/contrib/taxi/optimizer/assignment/AssignmentTaxiOptimizerIT.java
+++ b/contribs/taxi/src/test/java/org/matsim/contrib/taxi/optimizer/assignment/AssignmentTaxiOptimizerIT.java
@@ -23,7 +23,6 @@ import static org.matsim.contrib.taxi.optimizer.TaxiOptimizerTests.*;
 
 import java.util.List;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.matsim.contrib.taxi.optimizer.assignment.TaxiToRequestAssignmentCostProvider.Mode;
@@ -34,7 +33,6 @@ public class AssignmentTaxiOptimizerIT {
 	public final MatsimTestUtils utils = new MatsimTestUtils();
 
 	@Test
-	@Ignore // temporarily ignore this test due to problems on the build server
 	public void testAssignment_arrivalTime() {
 		PreloadedBenchmark benchmark = new PreloadedBenchmark("3.0", "25");
 		List<TaxiConfigVariant> variants = createDefaultTaxiConfigVariants(true);
@@ -49,7 +47,6 @@ public class AssignmentTaxiOptimizerIT {
 	}
 
 	@Test
-	@Ignore // temporarily ignore this test due to problems on the build server
 	public void testAssignment_pickupTime() {
 		PreloadedBenchmark benchmark = new PreloadedBenchmark("3.0", "25");
 		List<TaxiConfigVariant> variants = createDefaultTaxiConfigVariants(true);
@@ -65,7 +62,6 @@ public class AssignmentTaxiOptimizerIT {
 	}
 
 	@Test
-	@Ignore // temporarily ignore this test due to problems on the build server
 	public void testAssignment_dse() {
 		PreloadedBenchmark benchmark = new PreloadedBenchmark("3.0", "25");
 		List<TaxiConfigVariant> variants = createDefaultTaxiConfigVariants(true);
@@ -83,7 +79,6 @@ public class AssignmentTaxiOptimizerIT {
 	}
 
 	@Test
-	@Ignore // temporarily ignore this test due to problems on the build server
 	public void testAssignment_totalWaitTime() {
 		PreloadedBenchmark benchmark = new PreloadedBenchmark("3.0", "25");
 		List<TaxiConfigVariant> variants = createDefaultTaxiConfigVariants(true);


### PR DESCRIPTION
They caused JVM seg faults (in one of the build pipelines). Since we stopped using Jenkins, we can re-enable them.