### PR TITLE
Counts from bast maintenance

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/options/CountsOption.java
+++ b/contribs/application/src/main/java/org/matsim/application/options/CountsOption.java
@@ -1,4 +1,4 @@
-package org.matsim.application.prepare.counts;
+package org.matsim.application.options;
 
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
@@ -65,8 +65,9 @@ public final class CountsOption {
 		}
 
 		try (var reader = Files.newBufferedReader(manual)) {
-			List<CSVRecord> records = CSVFormat.newFormat(';')
-					.withAllowMissingColumnNames()
+			List<CSVRecord> records = CSVFormat.Builder.create()
+					.setAllowMissingColumnNames(true)
+					.build()
 					.parse(reader)
 					.getRecords();
 

--- a/contribs/application/src/main/java/org/matsim/application/options/CountsOption.java
+++ b/contribs/application/src/main/java/org/matsim/application/options/CountsOption.java
@@ -67,6 +67,7 @@ public final class CountsOption {
 		try (var reader = Files.newBufferedReader(manual)) {
 			List<CSVRecord> records = CSVFormat.Builder.create()
 					.setAllowMissingColumnNames(true)
+					.setDelimiter(';')
 					.build()
 					.parse(reader)
 					.getRecords();

--- a/contribs/application/src/main/java/org/matsim/application/prepare/counts/CreateCountsFromBAStData.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/counts/CreateCountsFromBAStData.java
@@ -13,6 +13,7 @@ import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.application.MATSimAppCommand;
+import org.matsim.application.options.CountsOption;
 import org.matsim.application.options.CrsOptions;
 import org.matsim.application.options.ShpOptions;
 import org.matsim.core.config.groups.NetworkConfigGroup;
@@ -238,7 +239,7 @@ public class CreateCountsFromBAStData implements MATSimAppCommand {
 		try{
 			CSVParser records = CSVFormat
 					.Builder.create()
-					.setAllowMissingColumnNames(false)
+					.setAllowMissingColumnNames(true)
 					.setDelimiter(';')
 					.setHeader()
 					.build()
@@ -478,7 +479,7 @@ public class CreateCountsFromBAStData implements MATSimAppCommand {
 
 			CSVParser records = CSVFormat
 					.Builder.create()
-					.setAllowMissingColumnNames(false)
+					.setAllowMissingColumnNames(true)
 					.setDelimiter(';')
 					.setHeader()
 					.build()


### PR DESCRIPTION
replaced depricated methods in CountsOption and moved class to option package
allow missing column names in CreateCountsFromBASt because BASt data contains an empty column without column name