### PR TITLE
ev: extend EventHandler in MissingEnergyEventHandler

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/MissingEnergyEventHandler.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/MissingEnergyEventHandler.java
@@ -20,9 +20,11 @@
 
 package org.matsim.contrib.ev.discharging;
 
+import org.matsim.core.events.handler.EventHandler;
+
 /**
  * @author Michal Maciejewski (michalm)
  */
-public interface MissingEnergyEventHandler {
+public interface MissingEnergyEventHandler extends EventHandler {
 	void handleEvent(MissingEnergyEvent event);
 }


### PR DESCRIPTION
I forgot to add `extend EventHandler` and so the handlers that implemented `MissingEnergyEventHandler` (among other handler interfaces) were not notified about `MissingEnergyEvent`s.

I wonder if that happens from time to time and not only to me, maybe then we should add some check that will at least log a warning while registering such a event handler.

This error only happens if an event handler implements **at least two** event handler interfaces and not all of the interfaces extend the top-lever `EventHandler` interface.