### PR TITLE
Freight: Introduce an EventsReader for freight events

### DIFF
--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightEventsReaders.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightEventsReaders.java
@@ -1,0 +1,50 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2023 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.freight.events;
+
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.events.MatsimEventsReader;
+
+import java.util.Map;
+
+/**
+ *  Creates an {@link MatsimEventsReader} that also handles the freight specific events.
+ *  <p>
+ *  This is a quickfix for teaching and thus _not_ complete. Needs to get completed and secured by unit-testing later (KMT, feb'23)
+ *
+ * @author kturner (Kai Martins-Turner)
+ */
+public class FreightEventsReaders {
+
+	public static Map<String, MatsimEventsReader.CustomEventMapper> createCustomEventMappers() {
+		return Map.of(
+				FreightTourStartEvent.EVENT_TYPE, FreightTourStartEvent::convert, //
+				FreightTourEndEvent.EVENT_TYPE, FreightTourEndEvent::convert
+				// more will follow later, KMT feb'23
+		);
+	}
+
+	public static MatsimEventsReader createEventsReader(EventsManager eventsManager) {
+		MatsimEventsReader reader = new MatsimEventsReader(eventsManager);
+		createCustomEventMappers().forEach(reader::addCustomEventMapper);
+		return reader;
+	}
+}

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightTourEndEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightTourEndEvent.java
@@ -24,6 +24,7 @@ package org.matsim.contrib.freight.events;
 import java.util.Map;
 
 import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.events.GenericEvent;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.freight.carrier.Carrier;
 import org.matsim.contrib.freight.carrier.Tour;
@@ -63,5 +64,15 @@ public final class FreightTourEndEvent extends AbstractFreightEvent {
 		Map<String, String> attr = super.getAttributes();
 		attr.put(ATTRIBUTE_TOUR_ID, this.tourId.toString());
 		return attr;
+	}
+
+	public static FreightTourEndEvent convert(GenericEvent event) {
+		Map<String, String> attributes = event.getAttributes();
+		double time = Double.parseDouble(attributes.get(ATTRIBUTE_TIME));
+		Id<Carrier> carrierId = Id.create(attributes.get(ATTRIBUTE_CARRIER_ID), Carrier.class);
+		Id<Vehicle> vehicleId = Id.create(attributes.get(ATTRIBUTE_VEHICLE), Vehicle.class);
+		Id<Link> linkId = Id.createLinkId(attributes.get(ATTRIBUTE_LINK));
+		Id<Tour> tourId = Id.create(attributes.get(ATTRIBUTE_TOUR_ID), Tour.class);
+		return new FreightTourEndEvent(time, carrierId, linkId, vehicleId, tourId);
 	}
 }

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightTourStartEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/events/FreightTourStartEvent.java
@@ -22,12 +22,15 @@
 package org.matsim.contrib.freight.events;
 
 import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.events.GenericEvent;
 import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.freight.carrier.Carrier;
 import org.matsim.contrib.freight.carrier.Tour;
 import org.matsim.vehicles.Vehicle;
 
 import java.util.Map;
+import java.util.Objects;
 
 import static org.matsim.contrib.freight.events.FreightEventAttributes.ATTRIBUTE_TOUR_ID;
 
@@ -63,5 +66,15 @@ public final class FreightTourStartEvent extends AbstractFreightEvent {
 		Map<String, String> attr = super.getAttributes();
 		attr.put(ATTRIBUTE_TOUR_ID, this.tourId.toString());
 		return attr;
+	}
+
+	public static FreightTourStartEvent convert(GenericEvent event) {
+		Map<String, String> attributes = event.getAttributes();
+		double time = Double.parseDouble(attributes.get(ATTRIBUTE_TIME));
+		Id<Carrier> carrierId = Id.create(attributes.get(ATTRIBUTE_CARRIER_ID), Carrier.class);
+		Id<Vehicle> vehicleId = Id.create(attributes.get(ATTRIBUTE_VEHICLE), Vehicle.class);
+		Id<Link> linkId = Id.createLinkId(attributes.get(ATTRIBUTE_LINK));
+		Id<Tour> tourId = Id.create(attributes.get(ATTRIBUTE_TOUR_ID), Tour.class);
+		return new FreightTourStartEvent(time, carrierId, linkId, vehicleId, tourId);
 	}
 }


### PR DESCRIPTION
For reading in the freight specific events.

It bases on the [DvrpEventsReaders](https://github.com/matsim-org/matsim-libs/blob/master/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/util/DvrpEventsReaders.java).

Please not: It is not complete yet --> More Events-converter will come soon.