### PR TITLE
Dvrp: TT matrix with max TT neighbourhood criterion

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrixParams.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrixParams.java
@@ -37,6 +37,8 @@ public class DvrpTravelTimeMatrixParams extends ReflectiveConfigGroup {
 	@Positive
 	public double cellSize = 200; //[m]
 
+	// Satisfying only one criterion (max distance or travel time) is enough to be considered a neighbour.
+
 	@Parameter
 	@Comment("Max network distance from node A to node B for B to be considered a neighbor of A."
 			+ " In such cases, a network travel time from A to B is calculated and stored in the sparse travel time matrix."
@@ -46,6 +48,16 @@ public class DvrpTravelTimeMatrixParams extends ReflectiveConfigGroup {
 			+ " The unit is meters. Default value is 1000 m.")
 	@PositiveOrZero
 	public double maxNeighborDistance = 1000; //[m]
+
+	@Parameter
+	@Comment("Max network travel time from node A to node B for B to be considered a neighbor of A."
+			+ " In such cases, a network travel time from A to B is calculated and stored in the sparse travel time matrix."
+			+ " Typically, 'maxNeighborTravelTime' should correspond to a distance that are higher than 'cellSize' (e.g. 5-10 times)"
+			+ " in order to reduce the impact of imprecise zonal travel times for short distances."
+			+ " On the other, a too big value will result in large neighborhoods, which may slow down queries."
+			+ " The unit is seconds. Default value is 0 s (for backward compatibility).")
+	@PositiveOrZero
+	public double maxNeighborTravelTime = 0; //[s]
 
 	public DvrpTravelTimeMatrixParams() {
 		super(SET_NAME);

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrixParams.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrixParams.java
@@ -35,7 +35,7 @@ public class DvrpTravelTimeMatrixParams extends ReflectiveConfigGroup {
 	@Parameter
 	@Comment("size of square cells (meters) used for computing travel time matrix." + " Default value is 200 m")
 	@Positive
-	public int cellSize = 200; //[m]
+	public double cellSize = 200; //[m]
 
 	@Parameter
 	@Comment("Max network distance from node A to node B for B to be considered a neighbor of A."
@@ -45,7 +45,7 @@ public class DvrpTravelTimeMatrixParams extends ReflectiveConfigGroup {
 			+ " On the other, a too big value will result in large neighborhoods, which may slow down queries."
 			+ " The unit is meters. Default value is 1000 m.")
 	@PositiveOrZero
-	public int maxNeighborDistance = 1000; //[m]
+	public double maxNeighborDistance = 1000; //[m]
 
 	public DvrpTravelTimeMatrixParams() {
 		super(SET_NAME);

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/FreeSpeedTravelTimeMatrix.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/FreeSpeedTravelTimeMatrix.java
@@ -47,7 +47,8 @@ public class FreeSpeedTravelTimeMatrix implements TravelTimeMatrix {
 		var travelDisutility = new TimeAsTravelDisutility(travelTime);
 		var routingParams = new TravelTimeMatrices.RoutingParams(dvrpNetwork, travelTime, travelDisutility, numberOfThreads);
 		freeSpeedTravelTimeMatrix = TravelTimeMatrices.calculateTravelTimeMatrix(routingParams, centralNodes, 0);
-		freeSpeedTravelTimeSparseMatrix = TravelTimeMatrices.calculateTravelTimeSparseMatrix(routingParams, params.maxNeighborDistance, 0);
+		freeSpeedTravelTimeSparseMatrix = TravelTimeMatrices.calculateTravelTimeSparseMatrix(routingParams, params.maxNeighborDistance,
+				params.maxNeighborTravelTime, 0);
 	}
 
 	@Override

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/TravelTimeMatrices.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/TravelTimeMatrices.java
@@ -56,19 +56,20 @@ public final class TravelTimeMatrices {
 		}
 	}
 
-	public static SparseMatrix calculateTravelTimeSparseMatrix(RoutingParams params, double maxDistance, double departureTime) {
+	public static SparseMatrix calculateTravelTimeSparseMatrix(RoutingParams params, double maxDistance, double maxTravelTime, double departureTime) {
 		SparseMatrix travelTimeMatrix = new SparseMatrix();
 		var nodes = params.routingNetwork.getNodes().values();
 		var counter = "DVRP free-speed TT sparse matrix: node ";
-		Calculation<Node> calculation = (lcpTree, n) -> computeForDepartureNode(n, nodes, departureTime, travelTimeMatrix, lcpTree, maxDistance);
+		Calculation<Node> calculation = (lcpTree, n) -> computeForDepartureNode(n, nodes, departureTime, travelTimeMatrix, lcpTree, maxDistance,
+				maxTravelTime);
 		calculate(params, nodes, calculation, counter);
 		return travelTimeMatrix;
 	}
 
 	private static void computeForDepartureNode(Node fromNode, Collection<? extends Node> nodes, double departureTime, SparseMatrix sparseMatrix,
-			LeastCostPathTree lcpTree, double maxDistance) {
+			LeastCostPathTree lcpTree, double maxDistance, double maxTravelTime) {
 		lcpTree.calculate(fromNode.getId().index(), departureTime, null, null,
-				(nodeIndex, arrivalTime, travelCost, distance, departTime) -> distance >= maxDistance);
+				(nodeIndex, arrivalTime, travelCost, distance, departTime) -> distance >= maxDistance && arrivalTime >= departTime + maxTravelTime);
 
 		List<NodeAndTime> neighborNodes = new ArrayList<>();
 		for (Node toNode : nodes) {

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/zone/skims/TravelTimeMatricesTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/zone/skims/TravelTimeMatricesTest.java
@@ -58,7 +58,7 @@ public class TravelTimeMatricesTest {
 	}
 
 	@Test
-	public void travelTimeSparseMatrix() {
+	public void travelTimeSparseMatrix_maxDistance() {
 		Network network = NetworkUtils.createNetwork();
 		Node nodeA = NetworkUtils.createAndAddNode(network, Id.createNodeId("A"), new Coord(0, 0));
 		Node nodeB = NetworkUtils.createAndAddNode(network, Id.createNodeId("B"), new Coord(150, 150));
@@ -69,7 +69,35 @@ public class TravelTimeMatricesTest {
 		NetworkUtils.createAndAddLink(network, Id.createLinkId("CA"), nodeC, nodeA, 600, 15, 80, 1);
 
 		double maxDistance = 300;// B->A->C and C->A->B are pruned by  the limit
-		var matrix = TravelTimeMatrices.calculateTravelTimeSparseMatrix(routingParams(network), maxDistance, 0);
+		var matrix = TravelTimeMatrices.calculateTravelTimeSparseMatrix(routingParams(network), maxDistance, 0, 0);
+
+		assertThat(matrix.get(nodeA, nodeA)).isEqualTo(0);
+		assertThat(matrix.get(nodeA, nodeB)).isEqualTo(10);
+		assertThat(matrix.get(nodeA, nodeC)).isEqualTo(30);
+
+		assertThat(matrix.get(nodeB, nodeA)).isEqualTo(20);
+		assertThat(matrix.get(nodeB, nodeB)).isEqualTo(0);
+		assertThat(matrix.get(nodeB, nodeC)).isEqualTo(-1);// max distance limit
+
+		assertThat(matrix.get(nodeC, nodeA)).isEqualTo(40);
+		assertThat(matrix.get(nodeC, nodeB)).isEqualTo(-1);// max distance limit
+		assertThat(matrix.get(nodeC, nodeC)).isEqualTo(0);
+	}
+
+	@Test
+	public void travelTimeSparseMatrix_maxTravelTime() {
+		Network network = NetworkUtils.createNetwork();
+		Node nodeA = NetworkUtils.createAndAddNode(network, Id.createNodeId("A"), new Coord(0, 0));
+		Node nodeB = NetworkUtils.createAndAddNode(network, Id.createNodeId("B"), new Coord(150, 150));
+		Node nodeC = NetworkUtils.createAndAddNode(network, Id.createNodeId("C"), new Coord(-150, -150));
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("AB"), nodeA, nodeB, 150, 15, 20, 1);
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("BA"), nodeB, nodeA, 300, 15, 40, 1);
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("AC"), nodeA, nodeC, 450, 15, 60, 1);
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("CA"), nodeC, nodeA, 600, 15, 80, 1);
+
+		// 20 s (max TT) corresponds to 300 m (max distance) in another test (see: travelTimeSparseMatrix_maxDistance())
+		double maxTravelTime = 20;// B->A->C and C->A->B are pruned by  the limit
+		var matrix = TravelTimeMatrices.calculateTravelTimeSparseMatrix(routingParams(network), 0, maxTravelTime, 0);
 
 		assertThat(matrix.get(nodeA, nodeA)).isEqualTo(0);
 		assertThat(matrix.get(nodeA, nodeB)).isEqualTo(10);


### PR DESCRIPTION
Add `maxNeighborTravelTime` as another criterion (next to `maxNeighborDistance`) when calculating TT to all nodes in the neighbourhood in the sparse TT matrix. Satisfying only one criterion (either max distance or travel time) is enough to be considered a neighbour.

The TT matrix works reasonably well for urban areas. However, we have recently observed substantial estimation errors for rural areas. The errors were produced mainly along motorways. This is where two nodes may be very close to each other (and therefore considered to belong to one zone), but at the same time too far away (in terms of the network distance) to be considered neighbours and included in the sparse matrix (where accurate travel times are stored).

Adding `maxNeighborTravelTime` as a criterion helps reaching a bit further along faster roads (esp. motorways) and hence reduce these errors. This is not a complete solution yet, but it has already helped to eliminate many errors.

Here is an image that presents a part of the network from the Vulkaneifel scenario. To get from the start node (S) to the end node (E), we need to travel for about 300 s and cover 11 km (mean speed ~130 km/h). With `maxNeighborDistance = 2000` (meters) this was too far away, but after changing to `maxNeighborTravelTime = 300` (seconds), the end point was actually reached.

Note: since this is a rural area, the avarage free-flow speed is almost 40 km/h, and so 2000 m corresponds to ~300 s.

<img width="1005" alt="TTmatrix2" src="https://user-images.githubusercontent.com/9891415/221317750-a4b5732f-57da-4297-962c-ce0eff3528e2.png">
