### PR TITLE
Freight: CarrierWriter - add validation, tourId and some small fixes

### DIFF
--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlWriterV2_1.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlWriterV2_1.java
@@ -31,7 +31,9 @@ import org.matsim.contrib.freight.carrier.Tour.ServiceActivity;
 import org.matsim.contrib.freight.carrier.Tour.ShipmentBasedActivity;
 import org.matsim.contrib.freight.carrier.Tour.TourElement;
 import org.matsim.core.population.routes.NetworkRoute;
+import org.matsim.core.utils.collections.Tuple;
 import org.matsim.core.utils.io.MatsimXmlWriter;
+import org.matsim.core.utils.io.UncheckedIOException;
 import org.matsim.core.utils.misc.Time;
 import org.matsim.utils.objectattributes.AttributeConverter;
 import org.matsim.utils.objectattributes.attributable.AttributesXmlWriterDelegate;
@@ -39,9 +41,7 @@ import org.matsim.vehicles.VehicleType;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * A writer that writes carriers and their plans in a xml-file.
@@ -88,8 +88,8 @@ import java.util.Map;
 		try {
 			openFile(filename);
 			writeXmlHead();
-
-			startCarriers(this.writer);
+			writeRootElement();
+//			startCarriers(this.writer);
 			for (Carrier carrier : carriers) {
 				startCarrier(carrier, this.writer);
 				writeVehiclesAndTheirTypes(carrier, this.writer);
@@ -98,7 +98,7 @@ import java.util.Map;
 				writePlans(carrier, this.writer);
 				endCarrier(this.writer);
 			}
-			endCarriers(this.writer);
+			writeEndElement(this.writer);
 			close();
 			logger.info("done");
 		} catch (IOException e) {
@@ -108,9 +108,18 @@ import java.util.Map;
 		}
 	}
 
-	private void startCarriers(BufferedWriter writer) throws IOException {
-		writer.write("\t<carriers>\n");
+	private void writeRootElement() throws UncheckedIOException, IOException {
+		List<Tuple<String, String>> atts = new ArrayList<Tuple<String, String>>();
+		atts.add(createTuple(XMLNS, MatsimXmlWriter.MATSIM_NAMESPACE));
+		atts.add(createTuple(XMLNS + ":xsi", DEFAULTSCHEMANAMESPACELOCATION));
+		atts.add(createTuple("xsi:schemaLocation", MATSIM_NAMESPACE + " " + DEFAULT_DTD_LOCATION + "carriersDefinitions_v2.1.xsd"));
+		this.writeStartTag("carriers", atts);
+		this.writer.write(NL);
 	}
+
+//	private void startCarriers(BufferedWriter writer) throws IOException {
+//		writer.write("\t<carriers>\n");
+//	}
 
 	private void startCarrier(Carrier carrier, BufferedWriter writer)
 			throws IOException {
@@ -286,7 +295,7 @@ import java.util.Map;
 		registeredShipments.clear();
 	}
 
-	private void endCarriers(BufferedWriter writer) throws IOException {
+	private void writeEndElement(BufferedWriter writer) throws IOException {
 		writer.write("\t</carriers>\n");
 
 	}

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlWriterV2_1.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlWriterV2_1.java
@@ -89,7 +89,6 @@ import java.util.*;
 			openFile(filename);
 			writeXmlHead();
 			writeRootElement();
-//			startCarriers(this.writer);
 			for (Carrier carrier : carriers) {
 				startCarrier(carrier, this.writer);
 				writeVehiclesAndTheirTypes(carrier, this.writer);
@@ -116,10 +115,6 @@ import java.util.*;
 		this.writeStartTag("carriers", atts);
 		this.writer.write(NL);
 	}
-
-//	private void startCarriers(BufferedWriter writer) throws IOException {
-//		writer.write("\t<carriers>\n");
-//	}
 
 	private void startCarrier(Carrier carrier, BufferedWriter writer)
 			throws IOException {

--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlWriterV2_1.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlWriterV2_1.java
@@ -93,8 +93,8 @@ import java.util.*;
 			for (Carrier carrier : carriers) {
 				startCarrier(carrier, this.writer);
 				writeVehiclesAndTheirTypes(carrier, this.writer);
-				writeShipments(carrier, this.writer);
 				writeServices(carrier,this.writer);
+				writeShipments(carrier, this.writer);
 				writePlans(carrier, this.writer);
 				endCarrier(this.writer);
 			}
@@ -109,7 +109,7 @@ import java.util.*;
 	}
 
 	private void writeRootElement() throws UncheckedIOException, IOException {
-		List<Tuple<String, String>> atts = new ArrayList<Tuple<String, String>>();
+		List<Tuple<String, String>> atts = new ArrayList<>();
 		atts.add(createTuple(XMLNS, MatsimXmlWriter.MATSIM_NAMESPACE));
 		atts.add(createTuple(XMLNS + ":xsi", DEFAULTSCHEMANAMESPACELOCATION));
 		atts.add(createTuple("xsi:schemaLocation", MATSIM_NAMESPACE + " " + DEFAULT_DTD_LOCATION + "carriersDefinitions_v2.1.xsd"));
@@ -123,36 +123,36 @@ import java.util.*;
 
 	private void startCarrier(Carrier carrier, BufferedWriter writer)
 			throws IOException {
-		writer.write("\t\t<carrier id=\"" + carrier.getId() + "\">\n");
-		attributesWriter.writeAttributes("\t\t\t", writer, carrier.getAttributes());
+		writer.write("\t<carrier id=\"" + carrier.getId() + "\">\n");
+		attributesWriter.writeAttributes("\t\t", writer, carrier.getAttributes());
 	}
 
 	private void writeVehiclesAndTheirTypes(Carrier carrier, BufferedWriter writer)throws IOException {
-		writer.write("\t\t\t<capabilities fleetSize=\""+ carrier.getCarrierCapabilities().getFleetSize().toString() + "\">\n");
+		writer.write("\t\t<capabilities fleetSize=\""+ carrier.getCarrierCapabilities().getFleetSize().toString() + "\">\n");
 		//vehicles
-		writer.write("\t\t\t\t<vehicles>\n");
+		writer.write("\t\t\t<vehicles>\n");
 		for (CarrierVehicle v : carrier.getCarrierCapabilities().getCarrierVehicles().values()) {
 			Id<VehicleType> vehicleTypeId = v.getVehicleTypeId();
 			if(vehicleTypeId == null) vehicleTypeId = v.getType() == null ? null : v.getType().getId();
 			if(vehicleTypeId == null) throw new IllegalStateException("vehicleTypeId is missing.");
-			writer.write("\t\t\t\t\t<vehicle id=\"" + v.getId()
+			writer.write("\t\t\t\t<vehicle id=\"" + v.getId()
 					+ "\" depotLinkId=\"" + v.getLinkId()
 					+ "\" typeId=\"" + vehicleTypeId
 					+ "\" earliestStart=\"" + getTime(v.getEarliestStartTime())
 					+ "\" latestEnd=\"" + getTime(v.getLatestEndTime())
 					+ "\"/>\n");
 		}
-		writer.write("\t\t\t\t</vehicles>\n\n");
-		writer.write("\t\t\t</capabilities>\n\n");
+		writer.write("\t\t\t</vehicles>\n\n");
+		writer.write("\t\t</capabilities>\n\n");
 	}
 
 	private void writeShipments(Carrier carrier, BufferedWriter writer) throws IOException {
 		if(carrier.getShipments().isEmpty()) return;
-		writer.write("\t\t\t<shipments>\n");
+		writer.write("\t\t<shipments>\n");
 		for (CarrierShipment s : carrier.getShipments().values()) {
 			Id<CarrierShipment> shipmentId = s.getId();
 			registeredShipments.put(s, shipmentId);
-			writer.write("\t\t\t\t<shipment ");
+			writer.write("\t\t\t<shipment ");
 			writer.write("id=\"" + shipmentId + "\" ");
 			writer.write("from=\"" + s.getFrom() + "\" ");
 			writer.write("to=\"" + s.getTo() + "\" ");
@@ -173,18 +173,18 @@ import java.util.*;
 				writer.write("\"/>\n");
 			} else {
 				writer.write("\">\n");
-				this.attributesWriter.writeAttributes("\t\t\t\t\t", writer, s.getAttributes());
-				writer.write("\t\t\t\t</shipment>\n");
+				this.attributesWriter.writeAttributes("\t\t\t\t", writer, s.getAttributes());
+				writer.write("\t\t\t</shipment>\n");
 			}
 		}
-		writer.write("\t\t\t</shipments>\n\n");
+		writer.write("\t\t</shipments>\n\n");
 	}
 
 	private void writeServices(Carrier carrier, BufferedWriter writer) throws IOException {
-		writer.write("\t\t\t<services>\n");
+		writer.write("\t\t<services>\n");
 		for (CarrierService s : carrier.getServices().values()) {
 			serviceMap.put(s, s.getId());
-			writer.write("\t\t\t\t<service ");
+			writer.write("\t\t\t<service ");
 			writer.write("id=\"" + s.getId().toString() + "\" ");
 			writer.write("to=\"" + s.getLocationLinkId() + "\" ");
 			// capacity which must be available when vehicle services this service.
@@ -197,12 +197,12 @@ import java.util.*;
 				writer.write("\"/>\n");
 			} else {
 				writer.write("\">\n");
-				this.attributesWriter.writeAttributes("\t\t\t\t\t", writer, s.getAttributes());
-				writer.write("\t\t\t\t</service>\n");
+				this.attributesWriter.writeAttributes("\t\t\t\t", writer, s.getAttributes());
+				writer.write("\t\t\t</service>\n");
 			}
 
 		}
-		writer.write("\t\t\t</services>\n\n");
+		writer.write("\t\t</services>\n\n");
 
 	}
 
@@ -215,7 +215,7 @@ import java.util.*;
 		if (carrier.getSelectedPlan() == null) {
 			return;
 		}
-
+		writer.write("\t\t<plans>\n");
 		for(CarrierPlan plan : carrier.getPlans()){
 			writer.write("\t\t\t<plan");
 			if(plan.getScore() != null){
@@ -236,8 +236,8 @@ import java.util.*;
 
 			for (ScheduledTour tour : plan.getScheduledTours()) {
 				writer.write("\t\t\t\t<tour ");
-				writer.write("vehicleId=\"" + tour.getVehicle().getId()
-						+ "\">\n");
+				writer.write("tourId=\"" + tour.getTour().getId() + "\" ");
+				writer.write("vehicleId=\"" + tour.getVehicle().getId() +"\">\n");
 				writer.write("\t\t\t\t\t<act type=\"" + FreightConstants.START
 						+ "\" end_time=\"" + Time.writeTime(tour.getDeparture())
 						+ "\"/>\n");
@@ -270,13 +270,13 @@ import java.util.*;
 					else if (tourElement instanceof ShipmentBasedActivity act) {
 						writer.write("\t\t\t\t\t<act ");
 						writer.write("type=\"" + act.getActivityType() + "\" ");
-						writer.write("shipmentId=\"" + registeredShipments.get(act.getShipment()) + "\" ");
+						writer.write("shipmentId=\"" + registeredShipments.get(act.getShipment()) + "\"");
 						writer.write("/>\n");
 					}
 					else if (tourElement instanceof ServiceActivity act){
 						writer.write("\t\t\t\t\t<act ");
 						writer.write("type=\"" + act.getActivityType() + "\" ");
-						writer.write("serviceId=\"" + serviceMap.get(act.getService()) + "\" ");
+						writer.write("serviceId=\"" + serviceMap.get(act.getService()) + "\"");
 						writer.write("/>\n");
 					}
 
@@ -287,16 +287,16 @@ import java.util.*;
 			}
 			writer.write("\t\t\t</plan>\n\n");
 		}
-
+		writer.write("\t\t</plans>\n\n");
 	}
 
 	private void endCarrier(BufferedWriter writer) throws IOException {
-		writer.write("\t\t</carrier>\n\n");
+		writer.write("\t</carrier>\n\n");
 		registeredShipments.clear();
 	}
 
 	private void writeEndElement(BufferedWriter writer) throws IOException {
-		writer.write("\t</carriers>\n");
+		writer.write("</carriers>\n");
 
 	}
 }

--- a/contribs/freight/src/test/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlWriterV2Test.java
+++ b/contribs/freight/src/test/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlWriterV2Test.java
@@ -1,7 +1,5 @@
 package org.matsim.contrib.freight.carrier;
 
-import java.util.*;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -11,6 +9,8 @@ import org.matsim.contrib.freight.carrier.CarrierCapabilities.FleetSize;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.Vehicle;
 
+import java.util.*;
+
 import static org.junit.Assert.*;
 
 public class CarrierPlanXmlWriterV2Test {
@@ -19,7 +19,7 @@ public class CarrierPlanXmlWriterV2Test {
 	public MatsimTestUtils testUtils = new MatsimTestUtils();
 
 	private Carrier testCarrier;
-	
+
 	@Before
 	public void setUp() throws Exception{
 
@@ -27,19 +27,18 @@ public class CarrierPlanXmlWriterV2Test {
 		new CarrierVehicleTypeReader( carrierVehicleTypes ).readFile( this.testUtils.getPackageInputDirectory() + "vehicleTypes_v2.xml" );
 
 		Carriers carriers = new Carriers();
-		String classInputDirectory = this.testUtils.getClassInputDirectory();
-		new CarrierPlanXmlReader(carriers, carrierVehicleTypes ).readFile(classInputDirectory + "carrierPlansEquils.xml" );
+		new CarrierPlanXmlReader(carriers, carrierVehicleTypes ).readFile(this.testUtils.getClassInputDirectory() + "carrierPlansEquils.xml" );
 		new CarrierPlanXmlWriterV2(carriers).write(this.testUtils.getClassInputDirectory() + "carrierPlansEquilsWritten.xml");
 		carriers.getCarriers().clear();
 		new CarrierPlanXmlReader(carriers, carrierVehicleTypes ).readFile(this.testUtils.getClassInputDirectory() + "carrierPlansEquilsWritten.xml" );
 		testCarrier = carriers.getCarriers().get(Id.create("testCarrier", Carrier.class));
 	}
-	
+
 	@Test
 	public void test_whenReadingServices_nuOfServicesIsCorrect(){
 		assertEquals(3,testCarrier.getServices().size());
 	}
-	
+
 	@Test
 	public void test_whenReadingCarrier_itReadsTypeIdsCorrectly(){
 
@@ -52,7 +51,7 @@ public class CarrierPlanXmlWriterV2Test {
 		CarrierVehicle heavy = CarrierUtils.getCarrierVehicle(testCarrier, Id.createVehicleId("heavyVehicle"));
 		assertEquals("heavy",heavy.getVehicleTypeId().toString());
 	}
-	
+
 	@Test
 	public void test_whenReadingCarrier_itReadsVehiclesCorrectly(){
 		Map<Id<Vehicle>, CarrierVehicle> carrierVehicles = testCarrier.getCarrierCapabilities().getCarrierVehicles();
@@ -60,28 +59,27 @@ public class CarrierPlanXmlWriterV2Test {
 		assertTrue(exactlyTheseVehiclesAreInVehicleCollection(Arrays.asList(Id.create("lightVehicle", Vehicle.class),
 				Id.create("mediumVehicle", Vehicle.class),Id.create("heavyVehicle", Vehicle.class)),carrierVehicles.values()));
 	}
-	
+
 	@Test
 	public void test_whenReadingCarrier_itReadsFleetSizeCorrectly(){
 		assertEquals(FleetSize.INFINITE, testCarrier.getCarrierCapabilities().getFleetSize());
 	}
-	
+
 	@Test
 	public void test_whenReadingCarrier_itReadsShipmentsCorrectly(){
 		assertEquals(2, testCarrier.getShipments().size());
 	}
-	
+
 	@Test
 	public void test_whenReadingCarrier_itReadsPlansCorrectly(){
 		assertEquals(3, testCarrier.getPlans().size());
 	}
-	
+
 	@Test
 	public void test_whenReadingCarrier_itSelectsPlansCorrectly(){
 		assertNotNull(testCarrier.getSelectedPlan());
 	}
-	
-	
+
 	@Test
 	public void test_whenReadingPlans_nuOfToursIsCorrect(){
 		List<CarrierPlan> plans = new ArrayList<CarrierPlan>(testCarrier.getPlans());
@@ -89,7 +87,7 @@ public class CarrierPlanXmlWriterV2Test {
 		assertEquals(1, plans.get(1).getScheduledTours().size());
 		assertEquals(1, plans.get(2).getScheduledTours().size());
 	}
-	
+
 	@Test
 	public void test_whenReadingToursOfPlan1_nuOfActivitiesIsCorrect(){
 		List<CarrierPlan> plans = new ArrayList<CarrierPlan>(testCarrier.getPlans());
@@ -97,7 +95,7 @@ public class CarrierPlanXmlWriterV2Test {
 		ScheduledTour tour1 = plan1.getScheduledTours().iterator().next();
 		assertEquals(5,tour1.getTour().getTourElements().size());
 	}
-	
+
 	@Test
 	public void test_whenReadingToursOfPlan2_nuOfActivitiesIsCorrect(){
 		List<CarrierPlan> plans = new ArrayList<CarrierPlan>(testCarrier.getPlans());
@@ -105,7 +103,7 @@ public class CarrierPlanXmlWriterV2Test {
 		ScheduledTour tour1 = plan2.getScheduledTours().iterator().next();
 		assertEquals(9,tour1.getTour().getTourElements().size());
 	}
-	
+
 	@Test
 	public void test_whenReadingToursOfPlan3_nuOfActivitiesIsCorrect(){
 		List<CarrierPlan> plans = new ArrayList<CarrierPlan>(testCarrier.getPlans());
@@ -113,22 +111,13 @@ public class CarrierPlanXmlWriterV2Test {
 		ScheduledTour tour1 = plan3.getScheduledTours().iterator().next();
 		assertEquals(9,tour1.getTour().getTourElements().size());
 	}
-	
-	
+
+
 	private boolean exactlyTheseVehiclesAreInVehicleCollection(List<Id<Vehicle>> asList, Collection<CarrierVehicle> carrierVehicles) {
 		List<CarrierVehicle> vehicles = new ArrayList<CarrierVehicle>(carrierVehicles);
 		for(CarrierVehicle type : carrierVehicles) if(asList.contains(type.getId() )) vehicles.remove(type );
 		return vehicles.isEmpty();
 	}
-
-//	private CarrierVehicle getVehicle(String vehicleName) {
-//		Id<Vehicle> vehicleId = Id.create(vehicleName, Vehicle.class);
-//		if(testCarrier.getCarrierCapabilities().getCarrierVehicles().containsKey(vehicleId)){
-//			return testCarrier.getCarrierCapabilities().getCarrierVehicles().get(vehicleId);
-//		}
-//		log.error("Vehicle with Id does not exists", new IllegalStateException("vehicle with id " + vehicleId + " is missing"));
-//		return null;
-//	}
 
 	@Test
 	public void test_CarrierHasAttributes(){
@@ -145,36 +134,5 @@ public class CarrierPlanXmlWriterV2Test {
 		assertNotNull(shipmentCustomerAtt);
 		assertEquals("someRandomCustomer", (String) shipmentCustomerAtt);
 	}
-
-//	@Test
-//	public void test_properErrorWhenVehicleTypeIdIsMissing() {
-//		Config config = ConfigUtils.createConfig();
-//		Scenario scenario = ScenarioUtils.createScenario(config);
-//		Carriers carriers = FreightUtils.addOrGetCarriers(scenario);
-//
-//		Carrier carrier1 = CarrierUtils.createCarrier(Id.create("1", Carrier.class));
-//		CarrierUtils.setJspritIterations(carrier1, 50);
-//
-//		CarrierVehicle c1hv = new CarrierVehicle.Builder(Id.create("carrier_1_heavyVehicle", Vehicle.class), Id.create("3", Link.class), vehicleType )
-//				// don't use setType() or setTypeId()
-//				.setEarliestStart(6 * 3600)
-//				.setLatestEnd(16 * 3600)
-//				.build();
-//
-//		carrier1.getCarrierCapabilities().setFleetSize(FleetSize.INFINITE);
-//		carrier1.getCarrierCapabilities().getCarrierVehicles().put(c1hv.getId(), c1hv);
-//
-//		carriers.addCarrier(carrier1);
-//
-//		String outputDir = this.testUtils.getOutputDirectory();
-//		try {
-//			new CarrierPlanXmlWriterV2(carriers).write(outputDir + "/carriers.xml");
-//			Assert.fail("expected exception about missing vehicle type.");
-//		} catch (IllegalStateException e) {
-//			assertTrue(e.getMessage().contains("vehicleTypeId is missing"));
-//		}
-//
-//	}
-	// no longer possible. kai, jan'22
 
 }

--- a/contribs/freight/src/test/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlWriterV2_1Test.java
+++ b/contribs/freight/src/test/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlWriterV2_1Test.java
@@ -1,0 +1,141 @@
+package org.matsim.contrib.freight.carrier;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.contrib.freight.carrier.CarrierCapabilities.FleetSize;
+import org.matsim.testcases.MatsimTestUtils;
+import org.matsim.vehicles.Vehicle;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class CarrierPlanXmlWriterV2_1Test {
+
+	@Rule
+	public MatsimTestUtils testUtils = new MatsimTestUtils();
+
+	private Carrier testCarrier;
+
+	@Before
+	public void setUp() throws Exception{
+
+		CarrierVehicleTypes carrierVehicleTypes = new CarrierVehicleTypes();
+		new CarrierVehicleTypeReader( carrierVehicleTypes ).readFile( this.testUtils.getPackageInputDirectory() + "vehicleTypes_v2.xml" );
+
+		Carriers carriers = new Carriers();
+		new CarrierPlanXmlReader(carriers, carrierVehicleTypes ).readFile(this.testUtils.getClassInputDirectory() + "carrierPlansEquils.xml" );
+		new CarrierPlanXmlWriterV2_1(carriers).write(this.testUtils.getClassInputDirectory() + "carrierPlansEquilsWritten.xml");
+		carriers.getCarriers().clear();
+		new CarrierPlanXmlReader(carriers, carrierVehicleTypes ).readFile(this.testUtils.getClassInputDirectory() + "carrierPlansEquilsWritten.xml" );
+		testCarrier = carriers.getCarriers().get(Id.create("testCarrier", Carrier.class));
+	}
+
+	@Test
+	public void test_whenReadingServices_nuOfServicesIsCorrect(){
+		assertEquals(3,testCarrier.getServices().size());
+	}
+
+	@Test
+	public void test_whenReadingCarrier_itReadsTypeIdsCorrectly(){
+
+		CarrierVehicle light = CarrierUtils.getCarrierVehicle(testCarrier, Id.createVehicleId("lightVehicle"));
+		assertEquals("light",light.getVehicleTypeId().toString());
+
+		CarrierVehicle medium = CarrierUtils.getCarrierVehicle(testCarrier, Id.createVehicleId("mediumVehicle"));
+		assertEquals("medium",medium.getVehicleTypeId().toString());
+
+		CarrierVehicle heavy = CarrierUtils.getCarrierVehicle(testCarrier, Id.createVehicleId("heavyVehicle"));
+		assertEquals("heavy",heavy.getVehicleTypeId().toString());
+	}
+
+	@Test
+	public void test_whenReadingCarrier_itReadsVehiclesCorrectly(){
+		Map<Id<Vehicle>, CarrierVehicle> carrierVehicles = testCarrier.getCarrierCapabilities().getCarrierVehicles();
+		assertEquals(3,carrierVehicles.size());
+		assertTrue(exactlyTheseVehiclesAreInVehicleCollection(Arrays.asList(Id.create("lightVehicle", Vehicle.class),
+				Id.create("mediumVehicle", Vehicle.class),Id.create("heavyVehicle", Vehicle.class)),carrierVehicles.values()));
+	}
+
+	@Test
+	public void test_whenReadingCarrier_itReadsFleetSizeCorrectly(){
+		assertEquals(FleetSize.INFINITE, testCarrier.getCarrierCapabilities().getFleetSize());
+	}
+
+	@Test
+	public void test_whenReadingCarrier_itReadsShipmentsCorrectly(){
+		assertEquals(2, testCarrier.getShipments().size());
+	}
+
+	@Test
+	public void test_whenReadingCarrier_itReadsPlansCorrectly(){
+		assertEquals(3, testCarrier.getPlans().size());
+	}
+
+	@Test
+	public void test_whenReadingCarrier_itSelectsPlansCorrectly(){
+		assertNotNull(testCarrier.getSelectedPlan());
+	}
+
+	@Test
+	public void test_whenReadingPlans_nuOfToursIsCorrect(){
+		List<CarrierPlan> plans = new ArrayList<CarrierPlan>(testCarrier.getPlans());
+		assertEquals(1, plans.get(0).getScheduledTours().size());
+		assertEquals(1, plans.get(1).getScheduledTours().size());
+		assertEquals(1, plans.get(2).getScheduledTours().size());
+	}
+
+	@Test
+	public void test_whenReadingToursOfPlan1_nuOfActivitiesIsCorrect(){
+		List<CarrierPlan> plans = new ArrayList<CarrierPlan>(testCarrier.getPlans());
+		CarrierPlan plan1 = plans.get(0);
+		ScheduledTour tour1 = plan1.getScheduledTours().iterator().next();
+		assertEquals(5,tour1.getTour().getTourElements().size());
+	}
+
+	@Test
+	public void test_whenReadingToursOfPlan2_nuOfActivitiesIsCorrect(){
+		List<CarrierPlan> plans = new ArrayList<CarrierPlan>(testCarrier.getPlans());
+		CarrierPlan plan2 = plans.get(1);
+		ScheduledTour tour1 = plan2.getScheduledTours().iterator().next();
+		assertEquals(9,tour1.getTour().getTourElements().size());
+	}
+
+	@Test
+	public void test_whenReadingToursOfPlan3_nuOfActivitiesIsCorrect(){
+		List<CarrierPlan> plans = new ArrayList<CarrierPlan>(testCarrier.getPlans());
+		CarrierPlan plan3 = plans.get(2);
+		ScheduledTour tour1 = plan3.getScheduledTours().iterator().next();
+		assertEquals(9,tour1.getTour().getTourElements().size());
+	}
+
+
+	private boolean exactlyTheseVehiclesAreInVehicleCollection(List<Id<Vehicle>> asList, Collection<CarrierVehicle> carrierVehicles) {
+		List<CarrierVehicle> vehicles = new ArrayList<CarrierVehicle>(carrierVehicles);
+		for(CarrierVehicle type : carrierVehicles) if(asList.contains(type.getId() )) vehicles.remove(type );
+		return vehicles.isEmpty();
+	}
+
+	@Test
+	public void test_CarrierHasAttributes(){
+		assertEquals((TransportMode.drt),CarrierUtils.getCarrierMode(testCarrier));
+		assertEquals(50,CarrierUtils.getJspritIterations(testCarrier));
+	}
+
+	@Test
+	public void test_ServicesAndShipmentsHaveAttributes(){
+		Object serviceCustomerAtt = testCarrier.getServices().get(Id.create("serv1",CarrierService.class)).getAttributes().getAttribute("customer");
+		assertNotNull(serviceCustomerAtt);
+		assertEquals("someRandomCustomer", (String) serviceCustomerAtt);
+		Object shipmentCustomerAtt = testCarrier.getShipments().get(Id.create("s1",CarrierShipment.class)).getAttributes().getAttribute("customer");
+		assertNotNull(shipmentCustomerAtt);
+		assertEquals("someRandomCustomer", (String) shipmentCustomerAtt);
+	}
+	@Test
+	public void test_ReadWriteFilesAreEqual(){
+		MatsimTestUtils.assertEqualFilesLineByLine(this.testUtils.getClassInputDirectory() + "carrierPlansEquils.xml", this.testUtils.getClassInputDirectory() + "carrierPlansEquilsWritten.xml");
+	}
+}

--- a/contribs/freight/test/input/org/matsim/contrib/freight/carrier/CarrierPlanXmlWriterV2Test/carrierPlansEquils.xml
+++ b/contribs/freight/test/input/org/matsim/contrib/freight/carrier/CarrierPlanXmlWriterV2Test/carrierPlansEquils.xml
@@ -1,31 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-	<!--
-  ~ /* *********************************************************************** *
-  ~  * project: org.matsim.*
-  ~  * ${file_name}
-  ~  *                                                                         *
-  ~  * *********************************************************************** *
-  ~  *                                                                         *
-  ~  * copyright       : (C) ${year} by the members listed in the COPYING,        *
-  ~  *                   LICENSE and WARRANTY file.                            *
-  ~  * email           : info at matsim dot org                                *
-  ~  *                                                                         *
-  ~  * *********************************************************************** *
-  ~  *                                                                         *
-  ~  *   This program is free software; you can redistribute it and/or modify  *
-  ~  *   it under the terms of the GNU General Public License as published by  *
-  ~  *   the Free Software Foundation; either version 2 of the License, or     *
-  ~  *   (at your option) any later version.                                   *
-  ~  *   See also COPYING, LICENSE and WARRANTY file                           *
-  ~  *                                                                         *
-  ~  * *********************************************************************** */
-  ~
-  ~ ${filecomment}
-  ~ ${package_declaration}
-  ~
-  ~ ${typecomment}
-  ~ ${type_declaration}
-  -->
 
 <carriers>
 		<carrier id="testCarrier">
@@ -33,99 +6,99 @@
 				<attribute name="carrierMode" class="java.lang.String">drt</attribute>
 				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
 			</attributes>
-			<capabilities fleetSize="infinite">
+			<capabilities fleetSize="INFINITE">
 				<vehicles>
-					<vehicle id="lightVehicle" depotLinkId="1" typeId="light" earliestStart="21900" latestEnd="23:59:59"/>
-					<vehicle id="mediumVehicle" depotLinkId="1" typeId="medium" earliestStart="21900" latestEnd="23:59:59"/>
-					<vehicle id="heavyVehicle" depotLinkId="2" typeId="heavy" earliestStart="21900" latestEnd="23:59:59"/>
+					<vehicle id="lightVehicle" depotLinkId="1" typeId="light" earliestStart="06:05:00" latestEnd="23:59:59"/>
+					<vehicle id="mediumVehicle" depotLinkId="1" typeId="medium" earliestStart="06:05:00" latestEnd="23:59:59"/>
+					<vehicle id="heavyVehicle" depotLinkId="2" typeId="heavy" earliestStart="06:05:00" latestEnd="23:59:59"/>
 				</vehicles>
-				
+
 			</capabilities>
-			
-			<services>
-				<service id="serv1" to="22" capacityDemand="30" earliestStart="0.0" latestEnd="72000.0" serviceDuration="3600.0">
-				<attributes>
-					<attribute name="customer" class="java.lang.String">someRandomCustomer</attribute>
-				</attributes>
-				</service>
-				<service id="serv2" to="22" capacityDemand="30" earliestStart="0.0" latestEnd="72000.0" serviceDuration="3600.0"/>
-				<service id="serv3" to="22" capacityDemand="30" earliestStart="0.0" latestEnd="72000.0" serviceDuration="3600.0"/>
-			</services>
-			
+
 			<shipments>
-				<shipment id="s1" from="15" to="22" size="30" startPickup="21660.0" endPickup="28000.0" startDelivery="0.0" endDelivery="72000.0">
-				<attributes>
-					<attribute name="customer" class="java.lang.String">someRandomCustomer</attribute>
-				</attributes>
+				<shipment id="s1" from="15" to="22" size="30" startPickup="06:01:00" endPickup="07:46:40" startDelivery="00:00:00" endDelivery="20:00:00" pickupServiceTime="00:00:00" deliveryServiceTime="00:00:00">
+					<attributes>
+						<attribute name="customer" class="java.lang.String">someRandomCustomer</attribute>
+					</attributes>
 				</shipment>
-				<shipment id="s2" from="20" to="22" size="10" startPickup="21660.0" endPickup="28000.0" startDelivery="0.0" endDelivery="72000.0"/>
+				<shipment id="s2" from="20" to="22" size="10" startPickup="06:01:00" endPickup="07:46:40" startDelivery="00:00:00" endDelivery="20:00:00" pickupServiceTime="00:00:00" deliveryServiceTime="00:00:00"/>
 			</shipments>
-			
+
+			<services>
+				<service id="serv1" to="22" capacityDemand="30" earliestStart="00:00:00" latestEnd="20:00:00" serviceDuration="01:00:00">
+					<attributes>
+						<attribute name="customer" class="java.lang.String">someRandomCustomer</attribute>
+					</attributes>
+				</service>
+				<service id="serv2" to="22" capacityDemand="30" earliestStart="00:00:00" latestEnd="20:00:00" serviceDuration="01:00:00"/>
+				<service id="serv3" to="22" capacityDemand="30" earliestStart="00:00:00" latestEnd="20:00:00" serviceDuration="01:00:00"/>
+			</services>
+
 			<plans>
 				<plan score="-100.0" selected="false">
 					<tour vehicleId="lightVehicle">
 						<act type="start" end_time="07:00:00"/>
-						<leg dep_time="07:00:00" transp_time="00:30:00">
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:30:00">
 							<route>2 3 4</route>
 						</leg>
 						<act type="service" serviceId="serv1" end_time="07:30:00"/>
-						<leg dep_time="07:00:00" transp_time="00:00:00">
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
 							<route></route>
 						</leg>
 						<act type="service" serviceId="serv2" end_time="07:30:00"/>
-						<leg dep_time="07:00:00" transp_time="00:00:00">
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
 							<route></route>
 						</leg>
 						<act type="end"/>
 					</tour>
 				</plan>
-						
+
 				<plan score="-100.0" selected="true">
 					<tour vehicleId="lightVehicle">
 						<act type="start" end_time="07:00:00"/>
-						<leg dep_time="07:00:00" transp_time="00:30:00">
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:30:00">
 							<route>2 3 4</route>
 						</leg>
 						<act type="pickup" shipmentId="s1" end_time="07:00:00"/>
-						<leg dep_time="07:00:00" transp_time="00:00:00">
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
 							<route></route>
 						</leg>
 						<act type="delivery" shipmentId="s1" end_time="07:30:00"/>
-						<leg dep_time="07:00:00" transp_time="00:00:00">
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
 							<route></route>
 						</leg>
 						<act type="pickup" shipmentId="s2" end_time="07:30:00"/>
-						<leg dep_time="07:00:00" transp_time="00:00:00">
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
 							<route></route>
 						</leg>
 						<act type="delivery" shipmentId="s2" end_time="07:30:00"/>
-						<leg dep_time="07:00:00" transp_time="00:00:00">
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
 							<route></route>
 						</leg>
 						<act type="end"/>
 					</tour>
 				</plan>
-				
+
 				<plan score="-1000.0" selected="false">
 					<tour vehicleId="mediumVehicle">
 						<act type="start" end_time="07:00:00"/>
-						<leg dep_time="07:00:00" transp_time="00:30:00">
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:30:00">
 							<route>2 3 4</route>
 						</leg>
 						<act type="pickup" shipmentId="s1" end_time="07:00:00"/>
-						<leg dep_time="07:00:00" transp_time="00:00:00">
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
 							<route></route>
 						</leg>
 						<act type="delivery" shipmentId="s1" end_time="07:30:00"/>
-						<leg dep_time="07:00:00" transp_time="00:00:00">
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
 							<route></route>
 						</leg>
 						<act type="pickup" shipmentId="s2" end_time="07:30:00"/>
-						<leg dep_time="07:00:00" transp_time="00:00:00">
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
 							<route></route>
 						</leg>
 						<act type="delivery" shipmentId="s2" end_time="07:30:00"/>
-						<leg dep_time="07:00:00" transp_time="00:00:00">
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
 							<route></route>
 						</leg>
 						<act type="end"/>
@@ -133,6 +106,6 @@
 				</plan>
 			</plans>
 		</carrier>
+
 	</carriers>
-	
-	
+

--- a/contribs/freight/test/input/org/matsim/contrib/freight/carrier/CarrierPlanXmlWriterV2_1Test/carrierPlansEquils.xml
+++ b/contribs/freight/test/input/org/matsim/contrib/freight/carrier/CarrierPlanXmlWriterV2_1Test/carrierPlansEquils.xml
@@ -2,110 +2,111 @@
 
 <carriers xmlns="http://www.matsim.org/files/dtd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.matsim.org/files/dtd http://www.matsim.org/files/dtd/carriersDefinitions_v2.1.xsd">
 	<carrier id="testCarrier">
-			<attributes>
-				<attribute name="carrierMode" class="java.lang.String">drt</attribute>
-				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
-			</attributes>
-			<capabilities fleetSize="INFINITE">
-				<vehicles>
-					<vehicle id="lightVehicle" depotLinkId="1" typeId="light" earliestStart="06:05:00" latestEnd="23:59:59"/>
-					<vehicle id="mediumVehicle" depotLinkId="1" typeId="medium" earliestStart="06:05:00" latestEnd="23:59:59"/>
-					<vehicle id="heavyVehicle" depotLinkId="2" typeId="heavy" earliestStart="06:05:00" latestEnd="23:59:59"/>
-				</vehicles>
+		<attributes>
+			<attribute name="carrierMode" class="java.lang.String">drt</attribute>
+			<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+		</attributes>
+		<capabilities fleetSize="INFINITE">
+			<vehicles>
+				<vehicle id="lightVehicle" depotLinkId="1" typeId="light" earliestStart="06:05:00" latestEnd="23:59:59"/>
+				<vehicle id="mediumVehicle" depotLinkId="1" typeId="medium" earliestStart="06:05:00" latestEnd="23:59:59"/>
+				<vehicle id="heavyVehicle" depotLinkId="2" typeId="heavy" earliestStart="06:05:00" latestEnd="23:59:59"/>
+			</vehicles>
 
-			</capabilities>
+		</capabilities>
 
-			<services>
-				<service id="serv1" to="22" capacityDemand="30" earliestStart="00:00:00" latestEnd="20:00:00" serviceDuration="01:00:00">
-					<attributes>
-						<attribute name="customer" class="java.lang.String">someRandomCustomer</attribute>
-					</attributes>
-				</service>
-				<service id="serv2" to="22" capacityDemand="30" earliestStart="00:00:00" latestEnd="20:00:00" serviceDuration="01:00:00"/>
-				<service id="serv3" to="22" capacityDemand="30" earliestStart="00:00:00" latestEnd="20:00:00" serviceDuration="01:00:00"/>
-			</services>
+		<services>
+			<service id="serv1" to="22" capacityDemand="30" earliestStart="00:00:00" latestEnd="20:00:00" serviceDuration="01:00:00">
+				<attributes>
+					<attribute name="customer" class="java.lang.String">someRandomCustomer</attribute>
+				</attributes>
+			</service>
+			<service id="serv2" to="22" capacityDemand="30" earliestStart="00:00:00" latestEnd="20:00:00" serviceDuration="01:00:00"/>
+			<service id="serv3" to="22" capacityDemand="30" earliestStart="00:00:00" latestEnd="20:00:00" serviceDuration="01:00:00"/>
+		</services>
 
-			<shipments>
-				<shipment id="s1" from="15" to="22" size="30" startPickup="06:01:00" endPickup="07:46:40" startDelivery="00:00:00" endDelivery="20:00:00" pickupServiceTime="00:00:00" deliveryServiceTime="00:00:00">
-					<attributes>
-						<attribute name="customer" class="java.lang.String">someRandomCustomer</attribute>
-					</attributes>
-				</shipment>
-				<shipment id="s2" from="20" to="22" size="10" startPickup="06:01:00" endPickup="07:46:40" startDelivery="00:00:00" endDelivery="20:00:00" pickupServiceTime="00:00:00" deliveryServiceTime="00:00:00"/>
-			</shipments>
+		<shipments>
+			<shipment id="s1" from="15" to="22" size="30" startPickup="06:01:00" endPickup="07:46:40" startDelivery="00:00:00" endDelivery="20:00:00" pickupServiceTime="00:00:00" deliveryServiceTime="00:00:00">
+				<attributes>
+					<attribute name="customer" class="java.lang.String">someRandomCustomer</attribute>
+				</attributes>
+			</shipment>
+			<shipment id="s2" from="20" to="22" size="10" startPickup="06:01:00" endPickup="07:46:40" startDelivery="00:00:00" endDelivery="20:00:00" pickupServiceTime="00:00:00" deliveryServiceTime="00:00:00"/>
+		</shipments>
 
-			<plans>
-				<plan score="-100.0" selected="false">
-					<tour tourId="1" vehicleId="lightVehicle">
-						<act type="start" end_time="07:00:00"/>
-						<leg expected_dep_time="07:00:00" expected_transp_time="00:30:00">
-							<route>2 3 4</route>
-						</leg>
-						<act type="service" serviceId="serv1" end_time="07:30:00"/>
-						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
-							<route></route>
-						</leg>
-						<act type="service" serviceId="serv2" end_time="07:30:00"/>
-						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
-							<route></route>
-						</leg>
-						<act type="end"/>
-					</tour>
-				</plan>
+		<plans>
+			<plan score="-100.0" selected="false">
+				<tour tourId="1" vehicleId="lightVehicle">
+					<act type="start" end_time="07:00:00"/>
+					<leg expected_dep_time="07:00:00" expected_transp_time="00:30:00">
+						<route>2 3 4</route>
+					</leg>
+					<act type="service" serviceId="serv1"/>
+					<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
+						<route></route>
+					</leg>
+					<act type="service" serviceId="serv2"/>
+					<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
+						<route></route>
+					</leg>
+					<act type="end"/>
+				</tour>
+			</plan>
 
-				<plan score="-100.0" selected="true">
-					<tour tourId="42" vehicleId="lightVehicle">
-						<act type="start" end_time="07:00:00"/>
-						<leg expected_dep_time="07:00:00" expected_transp_time="00:30:00">
-							<route>2 3 4</route>
-						</leg>
-						<act type="pickup" shipmentId="s1" end_time="07:00:00"/>
-						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
-							<route></route>
-						</leg>
-						<act type="delivery" shipmentId="s1" end_time="07:30:00"/>
-						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
-							<route></route>
-						</leg>
-						<act type="pickup" shipmentId="s2" end_time="07:30:00"/>
-						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
-							<route></route>
-						</leg>
-						<act type="delivery" shipmentId="s2" end_time="07:30:00"/>
-						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
-							<route></route>
-						</leg>
-						<act type="end"/>
-					</tour>
-				</plan>
+			<plan score="-100.0" selected="true">
+				<tour tourId="42" vehicleId="lightVehicle">
+					<act type="start" end_time="07:00:00"/>
+					<leg expected_dep_time="07:00:00" expected_transp_time="00:30:00">
+						<route>2 3 4</route>
+					</leg>
+					<act type="pickup" shipmentId="s1"/>
+					<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
+						<route></route>
+					</leg>
+					<act type="delivery" shipmentId="s1"/>
+					<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
+						<route></route>
+					</leg>
+					<act type="pickup" shipmentId="s2"/>
+					<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
+						<route></route>
+					</leg>
+					<act type="delivery" shipmentId="s2"/>
+					<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
+						<route></route>
+					</leg>
+					<act type="end"/>
+				</tour>
+			</plan>
 
-				<plan score="-1000.0" selected="false">
-					<tour tourId="tour42" vehicleId="mediumVehicle">
-						<act type="start" end_time="07:00:00"/>
-						<leg expected_dep_time="07:00:00" expected_transp_time="00:30:00">
-							<route>2 3 4</route>
-						</leg>
-						<act type="pickup" shipmentId="s1" end_time="07:00:00"/>
-						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
-							<route></route>
-						</leg>
-						<act type="delivery" shipmentId="s1" end_time="07:30:00"/>
-						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
-							<route></route>
-						</leg>
-						<act type="pickup" shipmentId="s2" end_time="07:30:00"/>
-						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
-							<route></route>
-						</leg>
-						<act type="delivery" shipmentId="s2" end_time="07:30:00"/>
-						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
-							<route></route>
-						</leg>
-						<act type="end"/>
-					</tour>
-				</plan>
-			</plans>
-		</carrier>
+			<plan score="-1000.0" selected="false">
+				<tour tourId="tour42" vehicleId="mediumVehicle">
+					<act type="start" end_time="07:00:00"/>
+					<leg expected_dep_time="07:00:00" expected_transp_time="00:30:00">
+						<route>2 3 4</route>
+					</leg>
+					<act type="pickup" shipmentId="s1"/>
+					<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
+						<route></route>
+					</leg>
+					<act type="delivery" shipmentId="s1"/>
+					<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
+						<route></route>
+					</leg>
+					<act type="pickup" shipmentId="s2"/>
+					<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
+						<route></route>
+					</leg>
+					<act type="delivery" shipmentId="s2"/>
+					<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
+						<route></route>
+					</leg>
+					<act type="end"/>
+				</tour>
+			</plan>
 
-	</carriers>
+		</plans>
 
+	</carrier>
+
+</carriers>

--- a/contribs/freight/test/input/org/matsim/contrib/freight/carrier/CarrierPlanXmlWriterV2_1Test/carrierPlansEquils.xml
+++ b/contribs/freight/test/input/org/matsim/contrib/freight/carrier/CarrierPlanXmlWriterV2_1Test/carrierPlansEquils.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<carriers xmlns="http://www.matsim.org/files/dtd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.matsim.org/files/dtd http://www.matsim.org/files/dtd/carriersDefinitions_v2.0.xsd">		<carrier id="testCarrier">
+<carriers xmlns="http://www.matsim.org/files/dtd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.matsim.org/files/dtd http://www.matsim.org/files/dtd/carriersDefinitions_v2.1.xsd">
+	<carrier id="testCarrier">
 			<attributes>
 				<attribute name="carrierMode" class="java.lang.String">drt</attribute>
 				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
@@ -14,15 +15,6 @@
 
 			</capabilities>
 
-			<shipments>
-				<shipment id="s1" from="15" to="22" size="30" startPickup="06:01:00" endPickup="07:46:40" startDelivery="00:00:00" endDelivery="20:00:00" pickupServiceTime="00:00:00" deliveryServiceTime="00:00:00">
-					<attributes>
-						<attribute name="customer" class="java.lang.String">someRandomCustomer</attribute>
-					</attributes>
-				</shipment>
-				<shipment id="s2" from="20" to="22" size="10" startPickup="06:01:00" endPickup="07:46:40" startDelivery="00:00:00" endDelivery="20:00:00" pickupServiceTime="00:00:00" deliveryServiceTime="00:00:00"/>
-			</shipments>
-
 			<services>
 				<service id="serv1" to="22" capacityDemand="30" earliestStart="00:00:00" latestEnd="20:00:00" serviceDuration="01:00:00">
 					<attributes>
@@ -33,9 +25,18 @@
 				<service id="serv3" to="22" capacityDemand="30" earliestStart="00:00:00" latestEnd="20:00:00" serviceDuration="01:00:00"/>
 			</services>
 
+			<shipments>
+				<shipment id="s1" from="15" to="22" size="30" startPickup="06:01:00" endPickup="07:46:40" startDelivery="00:00:00" endDelivery="20:00:00" pickupServiceTime="00:00:00" deliveryServiceTime="00:00:00">
+					<attributes>
+						<attribute name="customer" class="java.lang.String">someRandomCustomer</attribute>
+					</attributes>
+				</shipment>
+				<shipment id="s2" from="20" to="22" size="10" startPickup="06:01:00" endPickup="07:46:40" startDelivery="00:00:00" endDelivery="20:00:00" pickupServiceTime="00:00:00" deliveryServiceTime="00:00:00"/>
+			</shipments>
+
 			<plans>
 				<plan score="-100.0" selected="false">
-					<tour vehicleId="lightVehicle">
+					<tour tourId="1" vehicleId="lightVehicle">
 						<act type="start" end_time="07:00:00"/>
 						<leg expected_dep_time="07:00:00" expected_transp_time="00:30:00">
 							<route>2 3 4</route>
@@ -53,7 +54,7 @@
 				</plan>
 
 				<plan score="-100.0" selected="true">
-					<tour vehicleId="lightVehicle">
+					<tour tourId="42" vehicleId="lightVehicle">
 						<act type="start" end_time="07:00:00"/>
 						<leg expected_dep_time="07:00:00" expected_transp_time="00:30:00">
 							<route>2 3 4</route>
@@ -79,7 +80,7 @@
 				</plan>
 
 				<plan score="-1000.0" selected="false">
-					<tour vehicleId="mediumVehicle">
+					<tour tourId="tour42" vehicleId="mediumVehicle">
 						<act type="start" end_time="07:00:00"/>
 						<leg expected_dep_time="07:00:00" expected_transp_time="00:30:00">
 							<route>2 3 4</route>

--- a/contribs/freight/test/input/org/matsim/contrib/freight/carrier/CarrierPlanXmlWriterV2_1Test/carrierPlansEquils.xml
+++ b/contribs/freight/test/input/org/matsim/contrib/freight/carrier/CarrierPlanXmlWriterV2_1Test/carrierPlansEquils.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<carriers xmlns="http://www.matsim.org/files/dtd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.matsim.org/files/dtd http://www.matsim.org/files/dtd/carriersDefinitions_v2.0.xsd">		<carrier id="testCarrier">
+			<attributes>
+				<attribute name="carrierMode" class="java.lang.String">drt</attribute>
+				<attribute name="jspritIterations" class="java.lang.Integer">50</attribute>
+			</attributes>
+			<capabilities fleetSize="INFINITE">
+				<vehicles>
+					<vehicle id="lightVehicle" depotLinkId="1" typeId="light" earliestStart="06:05:00" latestEnd="23:59:59"/>
+					<vehicle id="mediumVehicle" depotLinkId="1" typeId="medium" earliestStart="06:05:00" latestEnd="23:59:59"/>
+					<vehicle id="heavyVehicle" depotLinkId="2" typeId="heavy" earliestStart="06:05:00" latestEnd="23:59:59"/>
+				</vehicles>
+
+			</capabilities>
+
+			<shipments>
+				<shipment id="s1" from="15" to="22" size="30" startPickup="06:01:00" endPickup="07:46:40" startDelivery="00:00:00" endDelivery="20:00:00" pickupServiceTime="00:00:00" deliveryServiceTime="00:00:00">
+					<attributes>
+						<attribute name="customer" class="java.lang.String">someRandomCustomer</attribute>
+					</attributes>
+				</shipment>
+				<shipment id="s2" from="20" to="22" size="10" startPickup="06:01:00" endPickup="07:46:40" startDelivery="00:00:00" endDelivery="20:00:00" pickupServiceTime="00:00:00" deliveryServiceTime="00:00:00"/>
+			</shipments>
+
+			<services>
+				<service id="serv1" to="22" capacityDemand="30" earliestStart="00:00:00" latestEnd="20:00:00" serviceDuration="01:00:00">
+					<attributes>
+						<attribute name="customer" class="java.lang.String">someRandomCustomer</attribute>
+					</attributes>
+				</service>
+				<service id="serv2" to="22" capacityDemand="30" earliestStart="00:00:00" latestEnd="20:00:00" serviceDuration="01:00:00"/>
+				<service id="serv3" to="22" capacityDemand="30" earliestStart="00:00:00" latestEnd="20:00:00" serviceDuration="01:00:00"/>
+			</services>
+
+			<plans>
+				<plan score="-100.0" selected="false">
+					<tour vehicleId="lightVehicle">
+						<act type="start" end_time="07:00:00"/>
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:30:00">
+							<route>2 3 4</route>
+						</leg>
+						<act type="service" serviceId="serv1" end_time="07:30:00"/>
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
+							<route></route>
+						</leg>
+						<act type="service" serviceId="serv2" end_time="07:30:00"/>
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
+							<route></route>
+						</leg>
+						<act type="end"/>
+					</tour>
+				</plan>
+
+				<plan score="-100.0" selected="true">
+					<tour vehicleId="lightVehicle">
+						<act type="start" end_time="07:00:00"/>
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:30:00">
+							<route>2 3 4</route>
+						</leg>
+						<act type="pickup" shipmentId="s1" end_time="07:00:00"/>
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
+							<route></route>
+						</leg>
+						<act type="delivery" shipmentId="s1" end_time="07:30:00"/>
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
+							<route></route>
+						</leg>
+						<act type="pickup" shipmentId="s2" end_time="07:30:00"/>
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
+							<route></route>
+						</leg>
+						<act type="delivery" shipmentId="s2" end_time="07:30:00"/>
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
+							<route></route>
+						</leg>
+						<act type="end"/>
+					</tour>
+				</plan>
+
+				<plan score="-1000.0" selected="false">
+					<tour vehicleId="mediumVehicle">
+						<act type="start" end_time="07:00:00"/>
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:30:00">
+							<route>2 3 4</route>
+						</leg>
+						<act type="pickup" shipmentId="s1" end_time="07:00:00"/>
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
+							<route></route>
+						</leg>
+						<act type="delivery" shipmentId="s1" end_time="07:30:00"/>
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
+							<route></route>
+						</leg>
+						<act type="pickup" shipmentId="s2" end_time="07:30:00"/>
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
+							<route></route>
+						</leg>
+						<act type="delivery" shipmentId="s2" end_time="07:30:00"/>
+						<leg expected_dep_time="07:00:00" expected_transp_time="00:00:00">
+							<route></route>
+						</leg>
+						<act type="end"/>
+					</tour>
+				</plan>
+			</plans>
+		</carrier>
+
+	</carriers>
+

--- a/matsim/src/main/resources/dtd/carriersDefinitions_v2.1.xsd
+++ b/matsim/src/main/resources/dtd/carriersDefinitions_v2.1.xsd
@@ -1,131 +1,156 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="http://www.matsim.org/files/dtd" xmlns="http://www.matsim.org/files/dtd"
-           elementFormDefault="qualified"
-           xml:lang="en">
-  <!-- Editor: Kai Martins-Turner, VSP, Berlin Institute of Technology -->
-  <!-- This xml schema contains xml definitions for freight carriers information in the MATSim framework (freight contrib)  -->
+		   targetNamespace="http://www.matsim.org/files/dtd" xmlns="http://www.matsim.org/files/dtd"
+		   elementFormDefault="qualified"
+		   xml:lang="en">
+	<!-- Editor: Kai Martins-Turner, VSP, Berlin Institute of Technology -->
+	<!-- This xml schema contains xml definitions for freight carriers information in the MATSim framework (freight contrib)  -->
 
-  <xs:include schemaLocation="http://www.matsim.org/files/dtd/matsimCommon.xsd"/>
+	<xs:include schemaLocation="http://www.matsim.org/files/dtd/matsimCommon.xsd"/>
 
-  <xs:element name="carriers">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element name="carrier" type="carrierDefinition" maxOccurs="unbounded" />
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
+	<xs:element name="carriers">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="carrier" type="carrierDefinition" maxOccurs="unbounded" />
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
 
-  <xs:complexType name="carrierDefinition">
-    <xs:complexContent>
-      <xs:extension base="matsimObjectType">
-        <xs:sequence>
-          <xs:element name="description" type="xs:string" minOccurs="0"  />
-          <xs:element name="capabilities" >
-            <xs:complexType>
-              <xs:sequence>
-                <xs:element name="vehicles" type="VehicleType"/>
-              </xs:sequence>
-              <xs:attribute name="fleetSize" type="xs:string" use="required"/>
-            </xs:complexType>
-          </xs:element>
+	<xs:complexType name="carrierDefinition">
+		<xs:complexContent>
+			<xs:extension base="matsimObjectType">
+				<xs:sequence>
+					<xs:element name="attributes" minOccurs="0">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="attribute" type="attributeType" minOccurs="0" maxOccurs="unbounded"/>
+							</xs:sequence>
+						</xs:complexType>
+					</xs:element>
+					<xs:element name="description" type="xs:string" minOccurs="0"  />
+					<xs:element name="capabilities" >
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="vehicles" type="VehicleType"/>
+							</xs:sequence>
+							<xs:attribute name="fleetSize" type="xs:string" use="required"/>
+						</xs:complexType>
+					</xs:element>
 
-          <xs:element name="services" type="ServiceType" minOccurs="0" />
+					<xs:element name="services" type="ServiceType" minOccurs="0" />
 
-          <xs:element name="shipments" type="ShipmentType" minOccurs="0" />
+					<xs:element name="shipments" type="ShipmentType" minOccurs="0" />
 
-          <xs:element name="plans" type="PlanType" minOccurs="0" />
+					<xs:element name="plans" type="PlanType" minOccurs="0" />
 
-        </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
 
-  <xs:complexType name="VehicleType">
-    <xs:sequence>
-      <xs:element name="vehicle" maxOccurs="unbounded" >
-        <xs:complexType>
-          <xs:attribute name="id" type="xs:string" use="required"/>
-          <xs:attribute name="depotLinkId" type="xs:string" use="required"/>
-          <xs:attribute name="typeId" type="xs:string" use="required"/>
-          <xs:attribute name="earliestStart" />
-          <xs:attribute name="latestEnd" />
-        </xs:complexType>
-      </xs:element>
-    </xs:sequence>
-  </xs:complexType>
+	<xs:complexType name="VehicleType">
+		<xs:sequence>
+			<xs:element name="vehicle" maxOccurs="unbounded" >
+				<xs:complexType>
+					<xs:attribute name="id" type="xs:string" use="required"/>
+					<xs:attribute name="depotLinkId" type="xs:string" use="required"/>
+					<xs:attribute name="typeId" type="xs:string" use="required"/>
+					<xs:attribute name="earliestStart" />
+					<xs:attribute name="latestEnd" />
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
 
 
-  <xs:complexType name="ServiceType">
-    <xs:sequence>
-      <xs:element name="service" maxOccurs="unbounded" >
-        <xs:complexType>
-          <xs:attribute name="id" type="xs:string" use="required"/>
-          <xs:attribute name="to" type="xs:string" use="required"/>
-          <xs:attribute name="capacityDemand" type="xs:double" use="required"/>
-          <xs:attribute name="earliestStart" />
-          <xs:attribute name="latestEnd" />
-          <xs:attribute name="serviceDuration" />
-        </xs:complexType>
-      </xs:element>
-    </xs:sequence>
-  </xs:complexType>
+	<xs:complexType name="ServiceType">
+		<xs:sequence>
+			<xs:element name="service" maxOccurs="unbounded" >
+				<xs:complexType mixed="true">
+					<xs:sequence>
+						<xs:element name="attributes" minOccurs="0">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="attribute" type="attributeType" minOccurs="0" maxOccurs="unbounded"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="id" type="xs:string" use="required"/>
+					<xs:attribute name="to" type="xs:string" use="required"/>
+					<xs:attribute name="capacityDemand" type="xs:double" use="required"/>
+					<xs:attribute name="earliestStart" />
+					<xs:attribute name="latestEnd" />
+					<xs:attribute name="serviceDuration" />
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
 
-  <xs:complexType name="ShipmentType">
-    <xs:sequence>
-      <xs:element name="shipment" maxOccurs="unbounded" >
-        <xs:complexType>
-          <xs:attribute name="id" type="xs:string" use="required"/>
-          <xs:attribute name="from" type="xs:string" use="required"/>
-          <xs:attribute name="to" type="xs:string" use="required"/>
-          <xs:attribute name="size" type="xs:double" use="required"/>
-          <xs:attribute name="startPickup" />
-          <xs:attribute name="endPickup"/>
-          <xs:attribute name="pickupServiceTime" />
-          <xs:attribute name="startDelivery" />
-          <xs:attribute name="endDelivery" />
-          <xs:attribute name="deliveryServiceTime" />
-        </xs:complexType>
-      </xs:element>
-    </xs:sequence>
-  </xs:complexType>
+	<xs:complexType name="ShipmentType">
+		<xs:sequence>
+			<xs:element name="shipment" maxOccurs="unbounded" >
+				<xs:complexType mixed="true">
+					<xs:sequence>
+						<xs:element name="attributes" minOccurs="0">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="attribute" type="attributeType" minOccurs="0" maxOccurs="unbounded"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="id" type="xs:string" use="required"/>
+					<xs:attribute name="from" type="xs:string" use="required"/>
+					<xs:attribute name="to" type="xs:string" use="required"/>
+					<xs:attribute name="size" type="xs:double" use="required"/>
+					<xs:attribute name="startPickup" />
+					<xs:attribute name="endPickup"/>
+					<xs:attribute name="pickupServiceTime" />
+					<xs:attribute name="startDelivery" />
+					<xs:attribute name="endDelivery" />
+					<xs:attribute name="deliveryServiceTime" />
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
 
-  <xs:complexType name="PlanType">
-    <xs:sequence>
-      <xs:element name="plan" maxOccurs="unbounded">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:element name="tour" minOccurs="0">
-              <xs:complexType>
-                <xs:sequence maxOccurs="unbounded">
-                  <xs:element name="act" minOccurs="0" >
-                    <xs:complexType>
-                      <xs:attribute name="type" type="xs:string" />
-                      <xs:attribute name="serviceId" type="xs:string" />
-                      <xs:attribute name="shipmentId" type="xs:string" />
-                      <xs:attribute name="end_time"/>
-                    </xs:complexType>
-                  </xs:element>
-                  <xs:element name="leg" minOccurs="0" >
-                    <xs:complexType>
-                      <xs:sequence>
-                        <xs:element name="route" minOccurs="0" />
-                      </xs:sequence>
-                      <xs:attribute name="dep_time" />
-                      <xs:attribute name="transp_time"/>
-                    </xs:complexType>
-                  </xs:element>
-                </xs:sequence>
-                <xs:attribute name="tourId" type="xs:string" />
-                <xs:attribute name="vehicleId" type="xs:string" />
-              </xs:complexType>
-            </xs:element>
-          </xs:sequence>
-          <xs:attribute name="score" type="xs:double" />
-          <xs:attribute name="selected" type="xs:boolean" />
-        </xs:complexType>
-      </xs:element>
-    </xs:sequence>
-  </xs:complexType>
+	<xs:complexType name="PlanType">
+		<xs:sequence>
+			<xs:element name="plan" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="tour" minOccurs="0">
+							<xs:complexType>
+								<xs:sequence maxOccurs="unbounded">
+									<xs:element name="act" minOccurs="0" >
+										<xs:complexType>
+											<xs:attribute name="type" type="xs:string" />
+											<xs:attribute name="serviceId" type="xs:string" />
+											<xs:attribute name="shipmentId" type="xs:string" />
+											<xs:attribute name="end_time"/>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="leg" minOccurs="0" >
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="route" minOccurs="0" />
+											</xs:sequence>
+											<xs:attribute name="expected_dep_time" />
+											<xs:attribute name="expected_transp_time"/>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+								<xs:attribute name="tourId" type="xs:string" />
+								<xs:attribute name="vehicleId" type="xs:string" />
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="score" type="xs:double" />
+					<xs:attribute name="selected" type="xs:boolean" />
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
 
 </xs:schema>


### PR DESCRIPTION
The current version of the `CarrierPlanXmlWriterV2_1 `will now also write out
- the validation header
- the tourId
- tags <plans> </plans>: They were missing before :(

I also added a missing test for the current writer version, including a new checkFilesAreEqual (after read/write) (see #2196)

The XSD files has not had any information for `Attributes`, e.g. of the `Carrier` or the `Shipment`s or `Service`s -> I added those

Additionally, some small changes mostly regarding formating on the way, e.g. time format, indentation, etc. were done.

This PR closes #2421 for the current writer version.

