### PR TITLE
vsp: fix UrbanVehicleChargingHandler

### DIFF
--- a/contribs/vsp/src/main/java/playground/vsp/ev/UrbanVehicleChargingHandler.java
+++ b/contribs/vsp/src/main/java/playground/vsp/ev/UrbanVehicleChargingHandler.java
@@ -52,7 +52,7 @@ import java.util.*;
  */
 class UrbanVehicleChargingHandler
 		implements ActivityStartEventHandler, ActivityEndEventHandler, PersonLeavesVehicleEventHandler,
-		ChargingEndEventHandler, ChargingStartEventHandler, MobsimScopeEventHandler {
+		ChargingEndEventHandler, ChargingStartEventHandler, QueuedAtChargerEventHandler, MobsimScopeEventHandler {
 
 	private final Map<Id<Person>, Id<Vehicle>> lastVehicleUsed = new HashMap<>();
 	private final Map<Id<Vehicle>, Id<Charger>> vehiclesAtChargers = new HashMap<>();
@@ -142,5 +142,9 @@ class UrbanVehicleChargingHandler
 		//Charging has started
 	}
 
-
+	@Override
+	public void handleEvent(QueuedAtChargerEvent event) {
+		vehiclesAtChargers.put(event.getVehicleId(), event.getChargerId());
+		//Charging may start soon
+	}
 }


### PR DESCRIPTION
Add vehicles queued at the charger to the ongoing charging procedures.

Currently, we can observe the following issue:
- A vehicle gets queued at a charger (plugin interaction activity)
- A plugout interaction activity is executed while the vehicle is still in the queue
- Because the vehicle was not included in the ongoing charging procedures, it does not get removed from the charger logic
- The charging continues, often despite the vehicle moving somewhere in the network (!)
- At some point the vehicle gets fully charged and so the charging end event is triggered
- In response to this event, UrbanVehicleChargingHandler tries to remove the vehicle from the ongoing charging procedures, which causes an NPE (as the vehicle has not been registered there)