### PR TITLE
Pass AttributeConverters to HouseholdsWriter

### DIFF
--- a/matsim/src/main/java/org/matsim/core/controler/corelisteners/DumpDataAtEndImpl.java
+++ b/matsim/src/main/java/org/matsim/core/controler/corelisteners/DumpDataAtEndImpl.java
@@ -237,7 +237,9 @@ final class DumpDataAtEndImpl implements DumpDataAtEnd, ShutdownListener {
 
 	private void dumpHouseholds() {
 		try {
-			new HouseholdsWriterV10(this.households).writeFile(this.controlerIO.getOutputFilename(Controler.DefaultFiles.households));
+			HouseholdsWriterV10 writer = new HouseholdsWriterV10(this.households);
+			writer.putAttributeConverters(this.attributeConverters);
+			writer.writeFile(this.controlerIO.getOutputFilename(Controler.DefaultFiles.households));
 		} catch ( Exception ee ) {
 			log.error("Exception writing households.", ee);
 		}


### PR DESCRIPTION
This change passes registered AttributeConverters to the HousholdWriter when dumping at the end of the simulation.
Currently, custom AttributeConverters are not passed to the HousholdsWriter, but they are, for example, when writing the population.