### PR TITLE
ev: rename AuxDischargingHandler to IdleDischargingHandler

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/edrt/run/EDrtControlerCreator.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/edrt/run/EDrtControlerCreator.java
@@ -18,10 +18,6 @@
 
 package org.matsim.contrib.drt.extension.edrt.run;
 
-import static java.util.stream.Collectors.toList;
-
-import java.util.List;
-
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.run.DrtConfigs;
@@ -30,7 +26,7 @@ import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpModule;
 import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
 import org.matsim.contrib.ev.EvModule;
-import org.matsim.contrib.ev.discharging.AuxDischargingHandler;
+import org.matsim.contrib.ev.discharging.IdleDischargingHandler;
 import org.matsim.contrib.evrp.EvDvrpFleetQSimModule;
 import org.matsim.contrib.evrp.OperatingVehicleProvider;
 import org.matsim.contrib.otfvis.OTFVisLiveModule;
@@ -63,7 +59,7 @@ public class EDrtControlerCreator {
 		controler.addOverridingQSimModule(new AbstractQSimModule() {
 			@Override
 			protected void configureQSim() {
-				this.bind(AuxDischargingHandler.VehicleProvider.class).to(OperatingVehicleProvider.class);
+				this.bind(IdleDischargingHandler.VehicleProvider.class).to(OperatingVehicleProvider.class);
 			}
 		});
 

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/EDrtOperationsControlerCreator.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/EDrtOperationsControlerCreator.java
@@ -10,7 +10,7 @@ import org.matsim.contrib.drt.extension.operations.shifts.run.ShiftDrtModeOptimi
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.run.DrtModeQSimModule;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
-import org.matsim.contrib.ev.discharging.AuxDischargingHandler;
+import org.matsim.contrib.ev.discharging.IdleDischargingHandler;
 import org.matsim.core.config.Config;
 import org.matsim.core.controler.Controler;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
@@ -38,7 +38,7 @@ public class EDrtOperationsControlerCreator {
 		controler.addOverridingQSimModule(new AbstractQSimModule() {
 			@Override
 			protected void configureQSim() {
-				this.bind(AuxDischargingHandler.VehicleProvider.class).to(ShiftOperatingVehicleProvider.class);
+				this.bind(IdleDischargingHandler.VehicleProvider.class).to(ShiftOperatingVehicleProvider.class);
 			}
 		});
 

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/eshifts/charging/ShiftOperatingVehicleProvider.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/eshifts/charging/ShiftOperatingVehicleProvider.java
@@ -6,7 +6,7 @@ import org.matsim.api.core.v01.events.ActivityStartEvent;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicleLookup;
 import org.matsim.contrib.dvrp.schedule.Schedule;
-import org.matsim.contrib.ev.discharging.AuxDischargingHandler;
+import org.matsim.contrib.ev.discharging.IdleDischargingHandler;
 import org.matsim.contrib.ev.fleet.ElectricVehicle;
 import org.matsim.contrib.evrp.EvDvrpVehicle;
 import org.matsim.contrib.evrp.OperatingVehicleProvider;
@@ -15,10 +15,10 @@ import org.matsim.contrib.drt.extension.operations.shifts.schedule.OperationalSt
 /**
  * @author nkuehnel / MOIA
  */
-public class ShiftOperatingVehicleProvider implements AuxDischargingHandler.VehicleProvider {
+public class ShiftOperatingVehicleProvider implements IdleDischargingHandler.VehicleProvider {
 
     private final DvrpVehicleLookup dvrpVehicleLookup;
-    private final AuxDischargingHandler.VehicleProvider delegate;
+    private final IdleDischargingHandler.VehicleProvider delegate;
 
     @Inject
     public ShiftOperatingVehicleProvider(DvrpVehicleLookup dvrpVehicleLookup) {

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/evrp/OperatingVehicleProvider.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/evrp/OperatingVehicleProvider.java
@@ -25,7 +25,7 @@ import org.matsim.api.core.v01.events.ActivityStartEvent;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicleLookup;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
-import org.matsim.contrib.ev.discharging.AuxDischargingHandler;
+import org.matsim.contrib.ev.discharging.IdleDischargingHandler;
 import org.matsim.contrib.ev.fleet.ElectricVehicle;
 
 import com.google.inject.Inject;
@@ -33,7 +33,7 @@ import com.google.inject.Inject;
 /**
  * @author Michal Maciejewski (michalm)
  */
-public class OperatingVehicleProvider implements AuxDischargingHandler.VehicleProvider {
+public class OperatingVehicleProvider implements IdleDischargingHandler.VehicleProvider {
 	private final DvrpVehicleLookup dvrpVehicleLookup;
 
 	@Inject

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/AuxDischargingHandler.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/AuxDischargingHandler.java
@@ -22,8 +22,6 @@ package org.matsim.contrib.ev.discharging;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.events.ActivityEndEvent;
 import org.matsim.api.core.v01.events.ActivityStartEvent;
@@ -60,17 +58,8 @@ public class AuxDischargingHandler
 		ElectricVehicle getVehicle(ActivityStartEvent event);
 	}
 
-	private static final class VehicleAndLink {
-		private final ElectricVehicle vehicle;
-		private final Id<Link> linkId;
-
-		private VehicleAndLink(ElectricVehicle vehicle, Id<Link> linkId) {
-			this.vehicle = vehicle;
-			this.linkId = linkId;
-		}
+	private record VehicleAndLink(ElectricVehicle vehicle, Id<Link> linkId) {
 	}
-
-	private final static Logger log = LogManager.getLogger(AuxDischargingHandler.class );
 
 	private final VehicleProvider vehicleProvider;
 	private final int auxDischargeTimeStep;

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DischargingModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DischargingModule.java
@@ -43,12 +43,12 @@ public class DischargingModule extends AbstractModule {
 				addMobsimScopeEventHandlerBinding().to(DriveDischargingHandler.class);
 				// event handlers are not qsim components
 
-				this.bind(AuxDischargingHandler.class).in( Singleton.class );
-				addMobsimScopeEventHandlerBinding().to(AuxDischargingHandler.class);
-				this.addQSimComponentBinding(EvModule.EV_COMPONENT).to(AuxDischargingHandler.class);
+				this.bind(IdleDischargingHandler.class).in( Singleton.class );
+				addMobsimScopeEventHandlerBinding().to(IdleDischargingHandler.class);
+				this.addQSimComponentBinding(EvModule.EV_COMPONENT).to(IdleDischargingHandler.class);
 
 				//by default, no vehicle will be AUX-discharged when not moving
-				this.bind(AuxDischargingHandler.VehicleProvider.class).toInstance(event -> null);
+				this.bind(IdleDischargingHandler.VehicleProvider.class).toInstance(event -> null);
 			}
 		});
 	}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DriveDischargingHandler.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DriveDischargingHandler.java
@@ -40,9 +40,9 @@ import org.matsim.vehicles.Vehicle;
 import com.google.inject.Inject;
 
 /**
- * Because in QSim and JDEQSim vehicles enter and leave traffic at the end of links, we skip the first link when
+ * Because in QSim vehicles enter and leave traffic at the end of links, we skip the first link when
  * calculating the drive-related energy consumption. However, the time spent on the first link is used by the time-based
- * aux discharge process (see {@link AuxDischargingHandler}).
+ * idle discharge process (see {@link IdleDischargingHandler}).
  */
 public class DriveDischargingHandler
 		implements LinkLeaveEventHandler, VehicleEntersTrafficEventHandler, VehicleLeavesTrafficEventHandler, MobsimScopeEventHandler {

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/IdleDischargingHandler.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/IdleDischargingHandler.java
@@ -45,7 +45,7 @@ import com.google.inject.Inject;
  * VehicleProvider is responsible to decide if AUX discharging applies to a given vehicle based on information from
  * ActivityStartEvent.
  */
-public class AuxDischargingHandler
+public class IdleDischargingHandler
 		implements MobsimAfterSimStepListener, ActivityStartEventHandler, ActivityEndEventHandler, MobsimScopeEventHandler {
 	public interface VehicleProvider {
 		/**
@@ -68,7 +68,7 @@ public class AuxDischargingHandler
 	private final ConcurrentMap<Id<Person>, VehicleAndLink> vehicles = new ConcurrentHashMap<>();
 
 	@Inject
-	AuxDischargingHandler(VehicleProvider vehicleProvider, EvConfigGroup evCfg, EventsManager eventsManager) {
+	IdleDischargingHandler(VehicleProvider vehicleProvider, EvConfigGroup evCfg, EventsManager eventsManager) {
 		this.vehicleProvider = vehicleProvider;
 		this.auxDischargeTimeStep = evCfg.auxDischargeTimeStep;
 		this.eventsManager = eventsManager;

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/routing/EvNetworkRoutingModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/routing/EvNetworkRoutingModule.java
@@ -186,7 +186,6 @@ final class EvNetworkRoutingModule implements RoutingModule {
 				});
 		DriveEnergyConsumption driveEnergyConsumption = pseudoVehicle.getDriveEnergyConsumption();
 		AuxEnergyConsumption auxEnergyConsumption = pseudoVehicle.getAuxEnergyConsumption();
-		double lastCharge = pseudoVehicle.getBattery().getCharge();
 		double linkEnterTime = basicLeg.getDepartureTime().seconds();
 		for (Link l : links) {
 			double travelT = travelTime.getLinkTravelTime(l, basicLeg.getDepartureTime().seconds(), null, null);

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/RunETaxiBenchmark.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/RunETaxiBenchmark.java
@@ -21,9 +21,6 @@ package org.matsim.contrib.etaxi.run;
 
 import static org.matsim.contrib.drt.run.DrtControlerCreator.createScenarioWithDrtRouteFactory;
 
-import java.net.URL;
-import java.util.List;
-
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.dvrp.analysis.ExecutedScheduleCollector;
 import org.matsim.contrib.dvrp.benchmark.DvrpBenchmarks;
@@ -39,7 +36,7 @@ import org.matsim.contrib.ev.charging.ChargingLogic;
 import org.matsim.contrib.ev.charging.ChargingPower;
 import org.matsim.contrib.ev.charging.ChargingWithQueueingAndAssignmentLogic;
 import org.matsim.contrib.ev.charging.FixedSpeedCharging;
-import org.matsim.contrib.ev.discharging.AuxDischargingHandler;
+import org.matsim.contrib.ev.discharging.IdleDischargingHandler;
 import org.matsim.contrib.ev.temperature.TemperatureService;
 import org.matsim.contrib.evrp.EvDvrpFleetQSimModule;
 import org.matsim.contrib.evrp.OperatingVehicleProvider;
@@ -103,7 +100,7 @@ public class RunETaxiBenchmark {
 		controler.addOverridingQSimModule(new AbstractQSimModule() {
 			@Override
 			protected void configureQSim() {
-				this.bind(AuxDischargingHandler.VehicleProvider.class).to(OperatingVehicleProvider.class);
+				this.bind(IdleDischargingHandler.VehicleProvider.class).to(OperatingVehicleProvider.class);
 			}
 		});
 

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/RunETaxiScenario.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/run/RunETaxiScenario.java
@@ -19,12 +19,7 @@
 
 package org.matsim.contrib.etaxi.run;
 
-import static java.util.stream.Collectors.toList;
 import static org.matsim.contrib.drt.run.DrtControlerCreator.createScenarioWithDrtRouteFactory;
-
-import java.net.URL;
-import java.util.List;
-import java.util.stream.Collectors;
 
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
@@ -37,7 +32,7 @@ import org.matsim.contrib.ev.charging.ChargingLogic;
 import org.matsim.contrib.ev.charging.ChargingPower;
 import org.matsim.contrib.ev.charging.ChargingWithQueueingAndAssignmentLogic;
 import org.matsim.contrib.ev.charging.FixedSpeedCharging;
-import org.matsim.contrib.ev.discharging.AuxDischargingHandler;
+import org.matsim.contrib.ev.discharging.IdleDischargingHandler;
 import org.matsim.contrib.evrp.EvDvrpFleetQSimModule;
 import org.matsim.contrib.evrp.OperatingVehicleProvider;
 import org.matsim.contrib.ev.temperature.TemperatureService;
@@ -50,7 +45,6 @@ import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
-import org.matsim.core.mobsim.qsim.components.QSimComponentsConfigurator;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.vis.otfvis.OTFVisConfigGroup;
 
@@ -86,7 +80,7 @@ public class RunETaxiScenario {
 		controler.addOverridingQSimModule(new AbstractQSimModule() {
 			@Override
 			protected void configureQSim() {
-				this.bind(AuxDischargingHandler.VehicleProvider.class).to(OperatingVehicleProvider.class);
+				this.bind(IdleDischargingHandler.VehicleProvider.class).to(OperatingVehicleProvider.class);
 			}
 		});
 


### PR DESCRIPTION
To avoid confusion, because AUX energy consumption is also used in `DriveDischargingHandler`, that is:
- `DriveDischargingHandler` computes Drive+AUX energy consumption (simulated when a vehicle is moving)
- `IdleDischargingHandler` considers only AUX energy consumption (simulated when a vehicle is idle, e.g. a taxi at a rank)