### PR TITLE
build: stop deploying SNAPSHOT versions on merging to master

### DIFF
--- a/.github/workflows/deploy-on-pr-merge.yaml
+++ b/.github/workflows/deploy-on-pr-merge.yaml
@@ -1,9 +1,6 @@
 name: deploy-on-pr-merge
 
 on:
-  push: # snapshot deployment
-    branches:
-      - master
   pull_request_target: # pr-labelled deployment
     branches:
       - master
@@ -12,7 +9,7 @@ on:
 
 jobs:
   deploy-snapshot:
-    name: deploy snapshot/PR-labelled version
+    name: deploy PR-labelled version
     # for PR-labelled deployment -- only if closed by merging
     if: github.event_name == 'push' || github.event.pull_request.merged == true
 
@@ -32,8 +29,7 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
 
-      - name: Set MATSim version (if PR-labelled version)
-        if: github.event_name == 'pull_request_target'
+      - name: Set MATSim version
         run: mvn versions:set --batch-mode -DnewVersion=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | sed 's/SNAPSHOT//')PR${{ github.event.pull_request.number }} -DgenerateBackupPoms=false
 
       # Build and publish are separated so we start deploying only after all jars are built successfully


### PR DESCRIPTION
After discussions with some of you, it seems that stopping deploying SNAPSHOT versions is a good step towards increasing the maintainability and reproducibly.

Now the idea is to merge this PR shortly before we bump to `16.0-SNAPSHOT` on master, so `16.0-SNAPSHOT` will never get deployed.

Ping @Janekdererste (related to #2491 and #2492 )