### PR TITLE
VSP: Update freight analysis 

### DIFF
--- a/contribs/vsp/src/main/java/org/matsim/contrib/freight/analysis/CarrierLoadAnalysis.java
+++ b/contribs/vsp/src/main/java/org/matsim/contrib/freight/analysis/CarrierLoadAnalysis.java
@@ -1,0 +1,111 @@
+package org.matsim.contrib.freight.analysis;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.events.Event;
+import org.matsim.contrib.freight.carrier.Carriers;
+import org.matsim.contrib.freight.events.FreightShipmentDeliveryStartEvent;
+import org.matsim.contrib.freight.events.FreightShipmentPickupStartEvent;
+import org.matsim.core.events.handler.BasicEventHandler;
+import org.matsim.vehicles.Vehicle;
+import org.matsim.vehicles.VehicleType;
+import org.matsim.vehicles.VehicleUtils;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.Map;
+
+import static org.matsim.contrib.freight.events.FreightEventAttributes.ATTRIBUTE_CAPACITYDEMAND;
+
+/**
+ * @author Kai Martins-Turner (kturner)
+ */
+public class CarrierLoadAnalysis implements BasicEventHandler {
+
+	private static final Logger log = LogManager.getLogger(CarrierLoadAnalysis.class);
+
+	Carriers carriers;
+
+	private final Map<Id<Vehicle>, LinkedList<Integer>> vehicle2Load = new LinkedHashMap<>();
+
+	public CarrierLoadAnalysis(Carriers carriers) {
+		this.carriers = carriers;
+	}
+
+	@Override public void handleEvent(Event event) {
+		if (event.getEventType().equals(FreightShipmentPickupStartEvent.EVENT_TYPE)) {
+			handlePickup( event);
+		} if (event.getEventType().equals(FreightShipmentDeliveryStartEvent.EVENT_TYPE)) {
+			handleDelivery(event);
+//		}  else if (event instanceof ActivityEndEvent activityEndEvent) {
+//			handleEvent(activityEndEvent);
+		}
+	}
+
+	private void handlePickup(Event event) {
+		Id<Vehicle> vehicleId = Id.createVehicleId(event.getAttributes().get("vehicle"));
+		Integer demand = Integer.valueOf(event.getAttributes().get(ATTRIBUTE_CAPACITYDEMAND));
+
+		LinkedList<Integer> list;
+		if (! vehicle2Load.containsKey(vehicleId)){
+			list = new LinkedList<>();
+			list.add(demand);
+		} else {
+			list = vehicle2Load.get(vehicleId);
+			list.add(list.getLast() + demand);
+		}
+		vehicle2Load.put(vehicleId, list);
+	}
+
+
+	private void handleDelivery(Event event) {
+		Id<Vehicle> vehicleId = Id.createVehicleId(event.getAttributes().get("vehicle"));
+		Integer demand = Integer.valueOf(event.getAttributes().get(ATTRIBUTE_CAPACITYDEMAND));
+
+		var list = vehicle2Load.get(vehicleId);
+		list.add(list.getLast() - demand);
+		vehicle2Load.put(vehicleId, list);
+	}
+
+	/*package-private*/ Map<Id<Vehicle>, LinkedList<Integer>> getVehicle2Load() {
+		return vehicle2Load;
+	}
+
+	static void writeLoadPerVehicle(String analysisOutputDirectory, Scenario scenario, CarrierLoadAnalysis carrierLoadAnalysis) throws IOException {
+		log.info("Writing out vehicle load analysis ...");
+		//Load per vehicle
+		String fileName = analysisOutputDirectory + "Load_perVehicle.tsv";
+
+		BufferedWriter bw1 = new BufferedWriter(new FileWriter(fileName));
+
+		//Write headline:
+		bw1.write("vehicleId \t capacity \t maxLoad \t load state during tour");
+		bw1.newLine();
+
+		var vehicle2Load = carrierLoadAnalysis.getVehicle2Load();
+
+		for (Id<Vehicle> vehicleId : vehicle2Load.keySet()) {
+
+			final LinkedList<Integer> load = vehicle2Load.get(vehicleId);
+			final Integer maxLoad = load.stream().max(Comparator.naturalOrder()).get();
+
+			final VehicleType vehicleType = VehicleUtils.findVehicle(vehicleId, scenario).getType();
+			final Double capacity = vehicleType.getCapacity().getOther();
+
+			bw1.write(vehicleId.toString());
+			bw1.write("\t" + capacity);
+			bw1.write("\t" + maxLoad);
+			bw1.write("\t" + load);
+			bw1.newLine();
+		}
+
+		bw1.close();
+		log.info("Output written to " + fileName);
+	}
+}

--- a/contribs/vsp/src/main/java/org/matsim/contrib/freight/analysis/FreightAnalysisEventHandler.java
+++ b/contribs/vsp/src/main/java/org/matsim/contrib/freight/analysis/FreightAnalysisEventHandler.java
@@ -58,6 +58,7 @@ import java.util.LinkedHashSet;
  * @author Jakob Harnisch (MATSim advanced class 2020/21)
  * */
 
+@Deprecated(since = "apr23")
 class FreightAnalysisEventHandler implements  ActivityStartEventHandler, LinkEnterEventHandler, LinkLeaveEventHandler, PersonEntersVehicleEventHandler, PersonLeavesVehicleEventHandler, FreightShipmentPickupEventHandler, FreightShipmentDeliveryEventHandler, FreightServiceStartEventHandler, FreightServiceEndEventHandler {
 
 	private final static Logger log = LogManager.getLogger(FreightAnalysisEventHandler.class);

--- a/contribs/vsp/src/main/java/org/matsim/contrib/freight/analysis/FreightAnalysisServiceTracking.java
+++ b/contribs/vsp/src/main/java/org/matsim/contrib/freight/analysis/FreightAnalysisServiceTracking.java
@@ -30,9 +30,14 @@ import org.matsim.contrib.freight.events.FreightServiceStartEvent;
 import java.util.LinkedHashMap;
 
 /**
+ *  @deprecated We have new event types now, allowing us to use a more straight forward analysis without guessing.
+ *  I will let this here for some time so we can have a look, what else should be moved over, but in the end, We will remove this here.
+ *  (kmt apr'23)
+ *
  * @author Jakob Harnisch (MATSim advanced class 2020/21)
  */
 
+@Deprecated(since = "apr23", forRemoval = true)
 class FreightAnalysisServiceTracking {
 
 	private final LinkedHashMap<Id<Carrier>, ServiceTracker.CarrierServiceTracker> carrierServiceTrackers = new LinkedHashMap<>();
@@ -128,6 +133,12 @@ class FreightAnalysisServiceTracking {
 	}
 }
 
+/**
+ *  @deprecated We have new event types now, allowing us to use a more straight forward analysis without guessing.
+ *  I will let this here for some time so we can have a look, what else should be moved over, but in the end, We will remove this here.
+ *  (kmt apr'23)
+ */
+@Deprecated(since = "apr23")
 class ServiceTracker {
 	public CarrierService service;
 	public Double calculatedArrival =0.0;

--- a/contribs/vsp/src/main/java/org/matsim/contrib/freight/analysis/FreightAnalysisShipmentTracking.java
+++ b/contribs/vsp/src/main/java/org/matsim/contrib/freight/analysis/FreightAnalysisShipmentTracking.java
@@ -33,9 +33,14 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 
 /**
+ *  @deprecated We have new event types now, allowing us to use a more straight forward analysis without guessing.
+ *  I will let this here for some time so we can have a look, what else should be moved over, but in the end, We will remove this here.
+ *  (kmt apr'23)
+ *
  * @author Jakob Harnisch (MATSim advanced class 2020/21)
  */
 
+@Deprecated(since = "apr23", forRemoval = true)
 class FreightAnalysisShipmentTracking {
 
 	private final LinkedHashMap<Id<CarrierShipment>, ShipmentTracker> shipments = new LinkedHashMap<>();
@@ -96,6 +101,13 @@ class FreightAnalysisShipmentTracking {
 	}
 }
 
+/**
+ *  @deprecated We have new event types now, allowing us to use a more straight forward analysis without guessing.
+ *  I will let this here for some time so we can have a look, what else should be moved over, but in the end, We will remove this here.
+ *  (kmt apr'23)
+ */
+
+@Deprecated(since = "apr23", forRemoval = true)
 class ShipmentTracker {
 	public Id<Person> driverIdGuess;
 	public double deliveryTimeGuess;

--- a/contribs/vsp/src/main/java/org/matsim/contrib/freight/analysis/FreightAnalysisVehicleTracking.java
+++ b/contribs/vsp/src/main/java/org/matsim/contrib/freight/analysis/FreightAnalysisVehicleTracking.java
@@ -36,9 +36,14 @@ import java.util.LinkedHashSet;
 import java.util.LinkedHashMap;
 
 /**
+ *  @deprecated We have new event types now, allowing us to use a more straight forward analysis without guessing.
+ *  I will let this here for some time so we can have a look, what else should be moved over, but in the end, We will remove this here.
+ *  (kmt apr'23)
+ *
  * @author Jakob Harnisch (MATSim advanced class 2020/21)
  */
 
+@Deprecated(since = "apr23", forRemoval = true)
 class FreightAnalysisVehicleTracking {
 
 	private static final  Logger log = LogManager.getLogger(FreightAnalysisVehicleTracking.class);
@@ -153,6 +158,13 @@ class FreightAnalysisVehicleTracking {
 
 }
 
+
+/**
+ *  @deprecated We have new event types now, allowing us to use a more straight forward analysis without guessing.
+ *  I will let this here for some time so we can have a look, what else should be moved over, but in the end, We will remove this here.
+ *  (kmt apr'23)
+ */
+@Deprecated(since = "apr23")
 class VehicleTracker {
 	public double lastExit;
 	public Id<Person> lastDriverId = Id.createPersonId(-1);

--- a/contribs/vsp/src/main/java/org/matsim/contrib/freight/analysis/FreightTimeAndDistanceAnalysisEventsHandler.java
+++ b/contribs/vsp/src/main/java/org/matsim/contrib/freight/analysis/FreightTimeAndDistanceAnalysisEventsHandler.java
@@ -1,0 +1,126 @@
+package org.matsim.contrib.freight.analysis;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.events.Event;
+import org.matsim.api.core.v01.events.LinkEnterEvent;
+import org.matsim.contrib.freight.events.FreightTourEndEvent;
+import org.matsim.contrib.freight.events.FreightTourStartEvent;
+import org.matsim.core.events.handler.BasicEventHandler;
+import org.matsim.vehicles.Vehicle;
+import org.matsim.vehicles.VehicleType;
+import org.matsim.vehicles.VehicleUtils;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * @author Kai Martins-Turner (kturner)
+ */
+public class FreightTimeAndDistanceAnalysisEventsHandler implements BasicEventHandler {
+
+	private final static Logger log = LogManager.getLogger(FreightTimeAndDistanceAnalysisEventsHandler.class);
+
+	private final Scenario scenario;
+
+
+	public Map<Id<Vehicle>, Double> getVehicle2TourDuration() {
+		return vehicle2TourDuration;
+	}
+
+	public Map<Id<Vehicle>, Double> getVehicle2TourLength() {
+		return vehicle2TourLength;
+	}
+
+	private final Map<Id<Vehicle>, Double> vehicle2TourDuration = new LinkedHashMap<>();
+	private final Map<Id<Vehicle>, Double> vehicle2TourLength = new LinkedHashMap<>();
+
+	private final Map<String, Double> tourStartTime = new LinkedHashMap<>();
+
+	public FreightTimeAndDistanceAnalysisEventsHandler(Scenario scenario) {
+		this.scenario = scenario;
+	}
+
+	private void handleEvent(FreightTourStartEvent event) {
+		// Save time of freight tour start
+		final String key = event.getCarrierId().toString() + "_" + event.getTourId().toString();
+		tourStartTime.put(key, event.getTime());
+	}
+
+	//Fix costs for vehicle usage
+	private void handleEvent(FreightTourEndEvent event) {
+		final String key = event.getCarrierId().toString() + "_" + event.getTourId().toString();
+		double tourDuration = event.getTime() - tourStartTime.get(key);
+		vehicle2TourDuration.put(event.getVehicleId(), tourDuration);
+
+	}
+
+	private void handleEvent(LinkEnterEvent event) {
+		final double distance = scenario.getNetwork().getLinks().get(event.getLinkId()).getLength();
+		vehicle2TourLength.merge(event.getVehicleId(), distance, Double::sum);
+	}
+
+
+	@Override public void handleEvent(Event event) {
+//		log.info(event + " ; " +event.getEventType());
+		if (event instanceof FreightTourStartEvent freightTourStartEvent) {
+			handleEvent(freightTourStartEvent);
+		} else if (event instanceof FreightTourEndEvent freightTourEndEvent) {
+			handleEvent(freightTourEndEvent);
+		} else if (event instanceof LinkEnterEvent linkEnterEvent) {
+			handleEvent(linkEnterEvent);
+		}
+	}
+
+
+	static void writeTravelTimeAndDistance(String analysisOutputDirectory, Scenario scenario, FreightTimeAndDistanceAnalysisEventsHandler freightTimeAndDistanceAnalysisEventsHandler) throws IOException {
+		log.info("Writing out Time & Distance & Costs ...");
+		//Travel time and distance per vehicle
+		String fileName = analysisOutputDirectory + "TimeDistance_perVehicle.tsv";
+
+		BufferedWriter bw1 = new BufferedWriter(new FileWriter(fileName));
+
+		//Write headline:
+		bw1.write("vehicleId \t tourDuration[s] \t travelDistance[m] \t " +
+				"costPerSecond[EUR/s] \t costPerMeter[EUR/m] \t fixedCosts[EUR] \t varCostsTime[EUR] \t varCostsDist[EUR] \t totalCosts[EUR]");
+		bw1.newLine();
+
+		var vehicle2Duration = freightTimeAndDistanceAnalysisEventsHandler.getVehicle2TourDuration();
+		var vehicle2Distance = freightTimeAndDistanceAnalysisEventsHandler.getVehicle2TourLength();
+
+		for (Id<Vehicle> vehicleId : vehicle2Duration.keySet()) {
+
+			final Double durationInSeconds = vehicle2Duration.get(vehicleId);
+			final Double distanceInMeters = vehicle2Distance.get(vehicleId);
+
+			final VehicleType vehicleType = VehicleUtils.findVehicle(vehicleId, scenario).getType();
+			final Double costsPerSecond = vehicleType.getCostInformation().getCostsPerSecond();
+			final Double costsPerMeter = vehicleType.getCostInformation().getCostsPerMeter();
+			final Double fixedCost = vehicleType.getCostInformation().getFixedCosts();
+
+			final double varCostsTime = durationInSeconds * costsPerSecond;
+			final double varCostsDist = distanceInMeters * costsPerMeter;
+			final double totalVehCosts = fixedCost + varCostsTime + varCostsDist;
+
+			bw1.write(vehicleId.toString());
+			bw1.write("\t" + durationInSeconds);
+			bw1.write("\t" + distanceInMeters);
+			bw1.write("\t" + costsPerSecond);
+			bw1.write("\t" + costsPerMeter);
+			bw1.write("\t" + fixedCost);
+			bw1.write("\t" + varCostsTime);
+			bw1.write("\t" + varCostsDist);
+			bw1.write("\t" + totalVehCosts);
+
+			bw1.newLine();
+		}
+
+		bw1.close();
+		log.info("Output written to " + fileName);
+	}
+}

--- a/contribs/vsp/src/main/java/org/matsim/contrib/freight/analysis/Readme.md
+++ b/contribs/vsp/src/main/java/org/matsim/contrib/freight/analysis/Readme.md
@@ -6,3 +6,13 @@ The content was created by Jakob Hanisch during the MATSim advanced class 2020/2
 
 **It is untested and needs some kind of review --> be very careful when using it!**
 (KMT, Sep 21)
+
+**Update April 2023 -> Event-based analysis (KMT)**
+We do now have an (unfortunately!!!) untested new approach:
+We now can base on freight events, that were introduce during the last year.
+This avoids the _guessing_ of some information, like vehicleType or carrierId.
+
+This analysis is of course not perfect and can/should be extended (and then moved over to the freight contrib.)
+Since I programmed it for the SimGV class, I believe it is a good option moving it to a more central place.
+
+I also deprecated the "old" guessing approach.

--- a/contribs/vsp/src/main/java/org/matsim/contrib/freight/analysis/RunFreightAnalysis.java
+++ b/contribs/vsp/src/main/java/org/matsim/contrib/freight/analysis/RunFreightAnalysis.java
@@ -37,9 +37,14 @@ import org.matsim.vehicles.Vehicles;
 import java.io.File;
 
 /**
+ *   @deprecated We have new event types now, allowing us to use a more straight forward analysis without guessing.
+ *  I will let this here for some time so we can have a look, what else should be moved over, but in the end, We will remove this here.
+ *  (kmt apr'23)
+ *
  * @author Jakob Harnisch (MATSim advanced class 2020/21)
  */
 
+@Deprecated(since = "apr '23", forRemoval = true)
 public class RunFreightAnalysis {
 
 	private final String inputPath;

--- a/contribs/vsp/src/main/java/org/matsim/contrib/freight/analysis/RunFreightAnalysisEventbased.java
+++ b/contribs/vsp/src/main/java/org/matsim/contrib/freight/analysis/RunFreightAnalysisEventbased.java
@@ -1,0 +1,107 @@
+/*
+ *   *********************************************************************** *
+ *   project: org.matsim.*
+ *   *********************************************************************** *
+ *                                                                           *
+ *   copyright       : (C) 2021 by the members listed in the COPYING,        *
+ *                     LICENSE and WARRANTY file.                            *
+ *   email           : info at matsim dot org                                *
+ *                                                                           *
+ *   *********************************************************************** *
+ *                                                                           *
+ *     This program is free software; you can redistribute it and/or modify  *
+ *     it under the terms of the GNU General Public License as published by  *
+ *     the Free Software Foundation; either version 2 of the License, or     *
+ *     (at your option) any later version.                                   *
+ *     See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                           *
+ *   ***********************************************************************
+ *
+ */
+
+package org.matsim.contrib.freight.analysis;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.contrib.freight.FreightConfigGroup;
+import org.matsim.contrib.freight.controler.FreightUtils;
+import org.matsim.contrib.freight.events.FreightEventsReaders;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.events.EventsUtils;
+import org.matsim.core.events.MatsimEventsReader;
+import org.matsim.core.scenario.ScenarioUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+
+/**
+ * A first approach for some analysis based on the freight events introduced in 2022/23.
+ * This class comes from teaching SimGV in the winter term 2022/23.
+ * <p>
+ * This class should get extended and prepared as a standadized analysis for freight output.
+ * This should also get aligned with the current development in simwrapper.
+ * Todo: Add some tests.
+ *
+ * @author kturner (Kai Martins-Turner)
+ */
+public class RunFreightAnalysisEventbased {
+
+	private static final Logger log = LogManager.getLogger(RunFreightAnalysisEventbased.class);
+
+	//Were is your simulation output, that should be analysed?
+	private static final String SIM_OUTPUT_PATH = "output/";
+
+	public static void main(String[] args) throws IOException {
+
+		Config config = ConfigUtils.createConfig();
+		config.vehicles().setVehiclesFile(SIM_OUTPUT_PATH + "output_allVehicles.xml.gz");
+		config.network().setInputFile(SIM_OUTPUT_PATH + "output_network.xml.gz");
+		config.plans().setInputFile(null);
+		config.parallelEventHandling().setNumberOfThreads(null);
+		config.parallelEventHandling().setEstimatedNumberOfEvents(null);
+		config.global().setNumberOfThreads(1);
+		//freight settings
+		FreightConfigGroup freightConfigGroup = ConfigUtils.addOrGetModule( config, FreightConfigGroup.class ) ;
+		freightConfigGroup.setCarriersFile( SIM_OUTPUT_PATH + "output_carriers.xml.gz");
+		freightConfigGroup.setCarriersVehicleTypesFile(SIM_OUTPUT_PATH + "output_carriersVehicleTypes.xml.gz");
+
+		//Were to store the analysis output?
+		String analysisOutputDirectory = SIM_OUTPUT_PATH + "Analysis/";
+		if (!analysisOutputDirectory.endsWith("/")) analysisOutputDirectory = analysisOutputDirectory + "/";
+
+		File folder = new File(analysisOutputDirectory);
+		folder.mkdirs();
+
+		final String eventsFile = SIM_OUTPUT_PATH + "output_events.xml.gz";
+
+		Scenario scenario = ScenarioUtils.loadScenario(config);
+
+		//load carriers according to freight config
+		FreightUtils.loadCarriersAccordingToFreightConfig( scenario );
+
+		// the following is copy paste from the example...
+		EventsManager eventsManager = EventsUtils.createEventsManager();
+
+		FreightTimeAndDistanceAnalysisEventsHandler freightTimeAndDistanceAnalysisEventsHandler = new FreightTimeAndDistanceAnalysisEventsHandler(scenario);
+		eventsManager.addHandler(freightTimeAndDistanceAnalysisEventsHandler);
+
+		CarrierLoadAnalysis carrierLoadAnalysis = new CarrierLoadAnalysis(FreightUtils.getCarriers(scenario));
+		eventsManager.addHandler(carrierLoadAnalysis);
+
+		eventsManager.initProcessing();
+		MatsimEventsReader matsimEventsReader = FreightEventsReaders.createEventsReader(eventsManager);
+
+		matsimEventsReader.readFile(eventsFile);
+		eventsManager.finishProcessing();
+
+		log.info("Analysis completed.");
+		log.info("Writing output...");
+		FreightTimeAndDistanceAnalysisEventsHandler.writeTravelTimeAndDistance(analysisOutputDirectory, scenario, freightTimeAndDistanceAnalysisEventsHandler);
+		CarrierLoadAnalysis.writeLoadPerVehicle(analysisOutputDirectory, scenario, carrierLoadAnalysis);
+	}
+
+}


### PR DESCRIPTION
Moving the new analysis used for teaching over to the vsp contrib.
The new analysis can directly access information from the freight events introduced in 2022/23.

At the same time, this PR deprecates the old analysis, which uses a lot of guessing due to missing information in the events.