### PR TITLE
Remove (some) non-determinism from simulated annealing

### DIFF
--- a/contribs/simulatedannealing/src/main/java/org/matsim/contrib/simulatedannealing/perturbation/ChainedPerturbatorFactory.java
+++ b/contribs/simulatedannealing/src/main/java/org/matsim/contrib/simulatedannealing/perturbation/ChainedPerturbatorFactory.java
@@ -17,7 +17,7 @@ import java.util.*;
 /**
  * @author nkuehnel / MOIA
  */
-public class ChainedPeturbatorFactory<T> implements PerturbatorFactory<T> {
+public class ChainedPerturbatorFactory<T> implements PerturbatorFactory<T> {
 
 
 	private final List<PerturbatorFactory<T>> perturbatorFactories;
@@ -30,7 +30,7 @@ public class ChainedPeturbatorFactory<T> implements PerturbatorFactory<T> {
 
 	private final double initialTemperature;
 
-	private ChainedPeturbatorFactory(Map<PerturbatorFactory<T>, Double> perturbatorFactories,
+	private ChainedPerturbatorFactory(Map<PerturbatorFactory<T>, Double> perturbatorFactories,
 									 int minPerturbations,
 									 int maxPerturbations,
 									 double initialTemperature) {
@@ -100,8 +100,8 @@ public class ChainedPeturbatorFactory<T> implements PerturbatorFactory<T> {
 			return this;
 		}
 
-		public ChainedPeturbatorFactory<T> build() {
-			return new ChainedPeturbatorFactory<>(perturbatorFactories, minPerturbations, maxPerturbations, initialTemperature);
+		public ChainedPerturbatorFactory<T> build() {
+			return new ChainedPerturbatorFactory<>(perturbatorFactories, minPerturbations, maxPerturbations, initialTemperature);
 		}
 
 	}

--- a/contribs/simulatedannealing/src/main/java/org/matsim/contrib/simulatedannealing/perturbation/ChainedPerturbatorFactory.java
+++ b/contribs/simulatedannealing/src/main/java/org/matsim/contrib/simulatedannealing/perturbation/ChainedPerturbatorFactory.java
@@ -30,7 +30,7 @@ public class ChainedPerturbatorFactory<T> implements PerturbatorFactory<T> {
 
 	private final double initialTemperature;
 
-	private ChainedPerturbatorFactory(Map<PerturbatorFactory<T>, Double> perturbatorFactories,
+	private ChainedPerturbatorFactory(LinkedHashMap<PerturbatorFactory<T>, Double> perturbatorFactories,
 									 int minPerturbations,
 									 int maxPerturbations,
 									 double initialTemperature) {
@@ -72,7 +72,7 @@ public class ChainedPerturbatorFactory<T> implements PerturbatorFactory<T> {
 
 	public static class Builder<T> {
 
-		private final Map<PerturbatorFactory<T>, Double> perturbatorFactories = new HashMap<>();
+		private final LinkedHashMap<PerturbatorFactory<T>, Double> perturbatorFactories = new LinkedHashMap<>();
 
 		private int maxPerturbations = 10;
 

--- a/contribs/simulatedannealing/src/test/java/org/matsim/contrib/simulatedannealing/SimulatedAnnealingIT.java
+++ b/contribs/simulatedannealing/src/test/java/org/matsim/contrib/simulatedannealing/SimulatedAnnealingIT.java
@@ -19,7 +19,7 @@ import org.matsim.core.utils.io.IOUtils;
 import org.matsim.examples.ExamplesUtils;
 import org.matsim.contrib.simulatedannealing.acceptor.DefaultAnnealingAcceptor;
 import org.matsim.contrib.simulatedannealing.cost.CostCalculator;
-import org.matsim.contrib.simulatedannealing.perturbation.ChainedPeturbatorFactory;
+import org.matsim.contrib.simulatedannealing.perturbation.ChainedPerturbatorFactory;
 import org.matsim.contrib.simulatedannealing.perturbation.PerturbatorFactory;
 import org.matsim.testcases.MatsimTestUtils;
 
@@ -74,7 +74,7 @@ public class SimulatedAnnealingIT {
 				addEventHandlerBinding().toInstance(costCalculator);
 
 				bind(new TypeLiteral<PerturbatorFactory<VolumeEstimator>>(){}).toInstance(
-						new ChainedPeturbatorFactory.Builder<VolumeEstimator>()
+						new ChainedPerturbatorFactory.Builder<VolumeEstimator>()
 								.add((iteration, temperature) -> current -> {
 									return new VolumeEstimator((int) (current.estimation * MatsimRandom.getRandom().nextDouble(2.)));
 								}, 1)

--- a/contribs/simulatedannealing/src/test/java/org/matsim/contrib/simulatedannealing/SimulatedAnnealingTest.java
+++ b/contribs/simulatedannealing/src/test/java/org/matsim/contrib/simulatedannealing/SimulatedAnnealingTest.java
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.junit.Assert;
 import org.junit.Test;
+import org.matsim.contrib.common.util.random.RandomUtils;
 import org.matsim.core.controler.events.AfterMobsimEvent;
 import org.matsim.core.controler.events.BeforeMobsimEvent;
 import org.matsim.contrib.simulatedannealing.acceptor.Acceptor;
@@ -37,6 +38,7 @@ public class SimulatedAnnealingTest {
 
 	@Test
 	public void testSimulatedAnnealing() {
+		RandomUtils.reset();
 
 		LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
 		Configuration config = ctx.getConfiguration();


### PR DESCRIPTION
Remove non-deterministic behaviour from `ChainedPerturbatorFactory` and `SimulatedAnnealingTest`.