### PR TITLE
remove snapshot deployment badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![deploy-on-pr-merge](https://github.com/matsim-org/matsim-libs/actions/workflows/deploy-on-pr-merge.yaml/badge.svg?event=push "snapshot release")](https://github.com/matsim-org/matsim-libs/actions/workflows/deploy-on-pr-merge.yaml)
 [![deploy-on-pr-merge](https://github.com/matsim-org/matsim-libs/actions/workflows/deploy-on-pr-merge.yaml/badge.svg?event=pull_request_target&branch= "PR-merge release")](https://github.com/matsim-org/matsim-libs/actions/workflows/deploy-on-pr-merge.yaml)
 [![deploy-weekly](https://github.com/matsim-org/matsim-libs/actions/workflows/deploy-weekly.yaml/badge.svg "weekly release")](https://github.com/matsim-org/matsim-libs/actions/workflows/deploy-weekly.yaml)
 [![full-integration](https://github.com/matsim-org/matsim-libs/actions/workflows/full-integration.yaml/badge.svg "daily release-like build")](https://github.com/matsim-org/matsim-libs/actions/workflows/full-integration.yaml)


### PR DESCRIPTION
Since we stopped deploying snapshots in #2493.