### PR TITLE
Potential unconscious regression in WeightedRandomSelection after #2523

### DIFF
--- a/contribs/common/src/test/java/org/matsim/contrib/common/util/WeightedRandomSelectionIT.java
+++ b/contribs/common/src/test/java/org/matsim/contrib/common/util/WeightedRandomSelectionIT.java
@@ -1,0 +1,27 @@
+package org.matsim.contrib.common.util;
+
+import java.util.Random;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.matsim.core.gbl.MatsimRandom;
+
+public class WeightedRandomSelectionIT {
+
+    private WeightedRandomSelection<String> weightedRandomSelection;
+
+    @Before
+    public void init() {
+        Random random = MatsimRandom.getLocalInstance();
+        weightedRandomSelection = new WeightedRandomSelection<>(random);
+    }
+
+    @Test
+    public void testZeroCumulativeWeight() {
+        weightedRandomSelection.add("0", 0.);
+        weightedRandomSelection.add("1", 0.);
+        weightedRandomSelection.add("2", 0.);
+        weightedRandomSelection.select(); // throws exception now
+    }
+
+}


### PR DESCRIPTION
This pr - as illustration - adds a test for a use of [`WeightedRandomSelection`](https://github.com/matsim-org/matsim-libs/blob/e8a3e8853dbbd80c78b042807727fcf1bf92cdfb/contribs/common/src/main/java/org/matsim/contrib/common/util/WeightedRandomSelection.java) that did not throw an exception before #2523.

### Situation

Previously, `WeightedRandomSelection` was using [`UniformRandom`](https://github.com/matsim-org/matsim-libs/blob/9129efdf051a93f7ee9c084ae55c8398aafb74d1/contribs/common/src/main/java/org/matsim/contrib/common/util/random/UniformRandom.java) as the default RandomGenerator. `UniformRandom` had a `nextDouble(from, to)` method with a non-standard behavior, as it allowed `from == to` without throwing an exception - as most (if not all) other RandomGenerator do in that case.
https://github.com/matsim-org/matsim-libs/blob/9129efdf051a93f7ee9c084ae55c8398aafb74d1/contribs/common/src/main/java/org/matsim/contrib/common/util/random/UniformRandom.java#L31-L33

This results in the following code throwing an exception, as `Random.nextDouble(0., 0.)` is called in `WeightedRandomSelection.select()`.
```java
Random random = MatsimRandom.getLocalInstance();
WeightedRandomSelection<String> wrs = new WeightedRandomSelection<>(random);
wrs.add("0", 0.);
wrs.add("1", 0.);
wrs.select(); // throws exception now

// java.lang.IllegalArgumentException: bound must be greater than origin
//  at java.base/jdk.internal.util.random.RandomSupport.checkRange(RandomSupport.java:218)
//  at java.base/java.util.random.RandomGenerator.nextDouble(RandomGenerator.java:615)
//  at org.matsim.contrib.common.util.WeightedRandomSelection.select(WeightedRandomSelection.java:55)
//  at org.matsim.contrib.common.util.WeightedRandomSelectionIT.testZeroCumulativeWeight(WeightedRandomSelectionIT.java:28)
```
Previously, `wrs` would always (silently) return the first element in that case.

### Solu.. Options

I am thinking what would be the best behavior for `WeightedRandomSelection` in that case:

- return `null` as elements with zero weight should _never_ be selected, so comulativeWeight = 0 should be treated as empty list?
- return the first entry, as it was before?
- detect this case (all elements equal and zero weight) and uniformly select one entry?
- detect this case (all elements equal and zero weight) and assign every element a weight of 1/n and select then with the provided `random`?
- throw difficult to debug exception (current)?

@michalmac As you worked on #2523, do you have a preference?