### PR TITLE
Fix weighted random selection

### DIFF
--- a/contribs/common/src/main/java/org/matsim/contrib/common/util/WeightedRandomSelection.java
+++ b/contribs/common/src/main/java/org/matsim/contrib/common/util/WeightedRandomSelection.java
@@ -25,6 +25,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.random.RandomGenerator;
 
+import com.google.common.base.Preconditions;
+
 public class WeightedRandomSelection<T> {
 	private final List<Entry<T>> entryList = new ArrayList<>();
 	private double totalWeight = 0;
@@ -48,9 +50,8 @@ public class WeightedRandomSelection<T> {
 	}
 
 	public T select() {
-		if (entryList.size() == 0) {
-			throw new IllegalStateException("No entries in the list to select from");
-		}
+		Preconditions.checkState(!entryList.isEmpty(), "No entries in the list to select from");
+		Preconditions.checkState(totalWeight > 0, "Total weight is not positive");
 
 		double rnd = random.nextDouble(0, totalWeight);
 		int idx = Collections.binarySearch(entryList, new Entry<>(null, rnd));

--- a/contribs/common/src/main/java/org/matsim/contrib/common/util/WeightedRandomSelection.java
+++ b/contribs/common/src/main/java/org/matsim/contrib/common/util/WeightedRandomSelection.java
@@ -67,15 +67,7 @@ public class WeightedRandomSelection<T> {
 		return entryList.size();
 	}
 
-	private static class Entry<E> implements Comparable<Entry<E>> {
-		final private E e;
-		final private double cumulativeWeight;
-
-		private Entry(E e, double cumulativeWeight) {
-			this.e = e;
-			this.cumulativeWeight = cumulativeWeight;
-		}
-
+	private record Entry<E>(E e, double cumulativeWeight) implements Comparable<Entry<E>> {
 		public int compareTo(Entry<E> o) {
 			double diff = this.cumulativeWeight - o.cumulativeWeight;
 			return diff == 0 ? 0 : (diff > 0 ? 1 : -1);

--- a/contribs/common/src/test/java/org/matsim/contrib/common/util/WeightedRandomSelectionTest.java
+++ b/contribs/common/src/test/java/org/matsim/contrib/common/util/WeightedRandomSelectionTest.java
@@ -79,6 +79,15 @@ public class WeightedRandomSelectionTest {
 	}
 
 	@Test
+	public void testZeroTotalWeight() {
+		weightedRandomSelection.add("A", 0.);
+		weightedRandomSelection.add("B", 0.);
+		assertThatThrownBy(() -> weightedRandomSelection.select())//
+				.isExactlyInstanceOf(IllegalStateException.class)//
+				.hasMessage("Total weight is not positive");
+	}
+
+	@Test
 	public void testSingleValueList() {
 		weightedRandomSelection.add("A", 1);
 		assertThat(weightedRandomSelection.size()).isEqualTo(1);


### PR DESCRIPTION
Fixes issue reported in #2537 by throwing a more meaningful exception when the total weight is not positive.