### PR TITLE
Freight: Ignore plans-tags when reading carrierXML; add a small (VSP internal) analysis for carrier files

### DIFF
--- a/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlParserV2_1.java
+++ b/contribs/freight/src/main/java/org/matsim/contrib/freight/carrier/CarrierPlanXmlParserV2_1.java
@@ -123,7 +123,6 @@ class CarrierPlanXmlParserV2_1 extends MatsimXmlParser {
 				currentCarrier = CarrierUtils.createCarrier(Id.create(id, Carrier.class));
 				break;
 			}
-
 			//services
 			case SERVICES:
 				serviceMap = new HashMap<>();
@@ -207,13 +206,11 @@ class CarrierPlanXmlParserV2_1 extends MatsimXmlParser {
 			case "vehicleType", "engineInformation", "costInformation":
 				throw new RuntimeException(VEHICLE_TYPES_MSG);
 
-
 				//vehicle
 			case VEHICLES:
 				vehicles = new HashMap<>();
 				break;
 			case VEHICLE:
-
 				String vId = atts.getValue(ID);
 				if (vId == null) throw new IllegalStateException("vehicleId is missing.");
 
@@ -239,6 +236,9 @@ class CarrierPlanXmlParserV2_1 extends MatsimXmlParser {
 				break;
 
 			//plans
+			case "plans":
+				// do nothing
+				break ;
 			case "plan":
 				String score = atts.getValue("score");
 				if (score != null) currentScore = parseTimeToDouble(score);
@@ -345,6 +345,7 @@ class CarrierPlanXmlParserV2_1 extends MatsimXmlParser {
 				carriers.getCarriers().put(currentCarrier.getId(), currentCarrier);
 				currentCarrier = null;
 			}
+			case "plans" -> {} //do nothing
 			case "plan" -> {
 				CarrierPlan currentPlan = new CarrierPlan(currentCarrier, scheduledTours);
 				currentPlan.setScore(currentScore);

--- a/contribs/vsp/src/main/java/org/matsim/contrib/freight/analysis/CarrierPlanAnalysis.java
+++ b/contribs/vsp/src/main/java/org/matsim/contrib/freight/analysis/CarrierPlanAnalysis.java
@@ -1,0 +1,57 @@
+package org.matsim.contrib.freight.analysis;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.matsim.contrib.freight.carrier.Carrier;
+import org.matsim.contrib.freight.carrier.Carriers;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+
+/**
+ * Some basic analysis / data collection for {@link Carriers}(files)
+ * <p></p>
+ * For all carriers it writes out the:
+ * - score of the selected plan
+ * - number of tours (= vehicles) of the selected plan
+ * - number of Services (input)
+ * - number of shipments (input)
+ * to a tsv-file.
+ * @author Kai Martins-Turner (kturner)
+ */
+public class CarrierPlanAnalysis  {
+
+	private static final Logger log = LogManager.getLogger(CarrierPlanAnalysis.class);
+
+	Carriers carriers;
+
+	public CarrierPlanAnalysis(Carriers carriers) {
+		this.carriers = carriers;
+	}
+
+	public void runAnalysis(String analysisOutputDirectory) throws IOException {
+		log.info("Writing out carrier analysis ...");
+		//Load per vehicle
+		String fileName = analysisOutputDirectory + "Carrier_stats.tsv";
+
+		BufferedWriter bw1 = new BufferedWriter(new FileWriter(fileName));
+
+		//Write headline:
+		bw1.write("carrierId \t scoreOfSelectedPlan \t nuOfTours \t nuOfShipments(input) \t nuOfServices(input) ");
+		bw1.newLine();
+
+
+		for (Carrier carrier : carriers.getCarriers().values()) {
+			bw1.write(carrier.getId().toString());
+			bw1.write("\t" + carrier.getSelectedPlan().getScore());
+			bw1.write("\t" + carrier.getSelectedPlan().getScheduledTours().size());
+			bw1.write("\t" + carrier.getShipments().size());
+			bw1.write("\t" + carrier.getServices().size());
+			bw1.newLine();
+		}
+
+		bw1.close();
+		log.info("Output written to " + fileName);
+	}
+}


### PR DESCRIPTION
PlansXML-Tag: Actively "do nothing" when reading them in. This is done to avoid the warning, that an unknown tag was found (and ignored).
 
CarrierAnalysis: Add a small analysis, collecting some values (score, number of tours, number of jobs) from the `Carriers` and writing them out.