### PR TITLE
Towards grades in emissions

### DIFF
--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/EmissionUtils.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/EmissionUtils.java
@@ -187,18 +187,19 @@ public abstract class EmissionUtils {
 		Tuple<HbefaVehicleCategory, HbefaVehicleAttributes> vehicleInformationTuple;
 
 		Gbl.assertNotNull(vehicleType);
-		Gbl.assertNotNull(vehicleType.getEngineInformation());
-		Gbl.assertNotNull(VehicleUtils.getHbefaVehicleCategory(vehicleType.getEngineInformation()));
+		final EngineInformation engineInformation = vehicleType.getEngineInformation();
+		Gbl.assertNotNull( engineInformation );
+		Gbl.assertNotNull(VehicleUtils.getHbefaVehicleCategory( engineInformation ) );
 
-		HbefaVehicleCategory hbefaVehicleCategory = mapString2HbefaVehicleCategory( VehicleUtils.getHbefaVehicleCategory( vehicleType.getEngineInformation() ) ) ;
+		HbefaVehicleCategory hbefaVehicleCategory = mapString2HbefaVehicleCategory( VehicleUtils.getHbefaVehicleCategory( engineInformation ) ) ;
 
 		HbefaVehicleAttributes hbefaVehicleAttributes = new HbefaVehicleAttributes();
 
-		final String hbefaTechnology = VehicleUtils.getHbefaTechnology( vehicleType.getEngineInformation() );
+		final String hbefaTechnology = VehicleUtils.getHbefaTechnology( engineInformation );
 		if ( hbefaTechnology!=null ){
 			hbefaVehicleAttributes.setHbefaTechnology( hbefaTechnology );
-			hbefaVehicleAttributes.setHbefaSizeClass( VehicleUtils.getHbefaSizeClass( vehicleType.getEngineInformation() ) );
-			hbefaVehicleAttributes.setHbefaEmConcept( VehicleUtils.getHbefaEmissionsConcept( vehicleType.getEngineInformation() ) );
+			hbefaVehicleAttributes.setHbefaSizeClass( VehicleUtils.getHbefaSizeClass( engineInformation ) );
+			hbefaVehicleAttributes.setHbefaEmConcept( VehicleUtils.getHbefaEmissionsConcept( engineInformation ) );
 		}
 		// yyyy we are as of now not catching the case where the information is not there. kai/kai, sep'19
 

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/EmissionUtils.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/EmissionUtils.java
@@ -49,6 +49,8 @@ public abstract class EmissionUtils {
 
 	public static final String HBEFA_ROAD_TYPE = "hbefa_road_type";
 
+	public static final String HBEFA_ROAD_GRADIENT = "hbefa_road_gradient";
+
 	public static void setHbefaRoadType(Link link, String type) {
 		link.getAttributes().putAttribute(HBEFA_ROAD_TYPE, type);
 	}
@@ -56,6 +58,10 @@ public abstract class EmissionUtils {
 	public static String getHbefaRoadType(Link link) {
 		return (String) link.getAttributes().getAttribute(HBEFA_ROAD_TYPE);
 	}
+
+	public static void setHbefaRoadGradient(Link link, String type) { link.getAttributes().putAttribute(HBEFA_ROAD_GRADIENT, type); } // implement the setHbefaRoadGradient-Method here but it is not callable in the exmaple project then...
+
+	public static String getHbefaRoadGradient(Link link) { return (String) link.getAttributes().getAttribute(HBEFA_ROAD_GRADIENT); }
 
 	public static Map<Pollutant, Double> sumUpEmissions(Map<Pollutant, Double> warmEmissions, Map<Pollutant, Double> coldEmissions) {
 
@@ -97,7 +103,7 @@ public abstract class EmissionUtils {
 				for (Pollutant pollutant : pollutants) {
 					emissionType2Value.put(pollutant, 0.0);
 				}
-			} else { // person in map, but some emissions are not set; setting these to 0.0 
+			} else { // person in map, but some emissions are not set; setting these to 0.0
 				emissionType2Value = totalEmissions.get(personId);
 				for (Pollutant pollutant : emissionType2Value.keySet()) {
 					// else do nothing

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/EmissionUtils.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/EmissionUtils.java
@@ -59,9 +59,9 @@ public abstract class EmissionUtils {
 		return (String) link.getAttributes().getAttribute(HBEFA_ROAD_TYPE);
 	}
 
-	public static void setHbefaRoadGradient(Link link, String type) { link.getAttributes().putAttribute(HBEFA_ROAD_GRADIENT, type); } // implement the setHbefaRoadGradient-Method here but it is not callable in the exmaple project then...
+	public static void setHbefaRoadGradient(Link link, String gradient) { link.getAttributes().putAttribute(String.valueOf(HBEFA_ROAD_GRADIENT), gradient); } // implement the setHbefaRoadGradient-Method here but it is not callable in the exmaple project then...
 
-	public static String getHbefaRoadGradient(Link link) { return (String) link.getAttributes().getAttribute(HBEFA_ROAD_GRADIENT); }
+	public static String getHbefaRoadGradient(Link link) { return (String) link.getAttributes().getAttribute(String.valueOf(HBEFA_ROAD_GRADIENT)); }
 
 	public static Map<Pollutant, Double> sumUpEmissions(Map<Pollutant, Double> warmEmissions, Map<Pollutant, Double> coldEmissions) {
 

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaEmissionFactorKey.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaEmissionFactorKey.java
@@ -37,7 +37,7 @@ abstract class HbefaEmissionFactorKey {
 		this.vehicleCategory = copyFrom.getVehicleCategory();
 		this.vehicleAttributes = copyFrom.getVehicleAttributes();
 		this.component = copyFrom.getComponent();
-		this.roadGradient = copyFrom.getRoadGradient();
+//		this.roadGradient = copyFrom.getRoadGradient();
 	}
 
 	HbefaEmissionFactorKey() {
@@ -72,7 +72,7 @@ abstract class HbefaEmissionFactorKey {
 		return roadGradient;
 	}
 
-	public void setRoadGradient(String roadGradient) { this.roadGradient = roadGradient; }
+//	public void setRoadGradient(String roadGradient) { this.roadGradient = roadGradient; }
 
 	@Override
 	public boolean equals(Object o) {

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaEmissionFactorKey.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaEmissionFactorKey.java
@@ -31,7 +31,8 @@ abstract class HbefaEmissionFactorKey {
 
 
 
-	private String roadGradient;
+//	private String roadGradient;
+	// this is, in the end, added in the WARMEmissionFactorKey, where it probably belongs.  kai, apr'23
 
 	HbefaEmissionFactorKey(HbefaEmissionFactorKey copyFrom) {
 		this.vehicleCategory = copyFrom.getVehicleCategory();
@@ -68,9 +69,9 @@ abstract class HbefaEmissionFactorKey {
 		this.component = component;
 	}
 
-	public String getRoadGradient() {
-		return roadGradient;
-	}
+//	public String getRoadGradient() {
+//		return roadGradient;
+//	}
 
 //	public void setRoadGradient(String roadGradient) { this.roadGradient = roadGradient; }
 

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaEmissionFactorKey.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaEmissionFactorKey.java
@@ -72,9 +72,7 @@ abstract class HbefaEmissionFactorKey {
 		return roadGradient;
 	}
 
-	public void setRoadGradient(String roadGradient) {
-		this.roadGradient = roadGradient;
-	}
+	public void setRoadGradient(String roadGradient) { this.roadGradient = roadGradient; }
 
 	@Override
 	public boolean equals(Object o) {

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaEmissionFactorKey.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaEmissionFactorKey.java
@@ -29,10 +29,15 @@ abstract class HbefaEmissionFactorKey {
 	private HbefaVehicleAttributes vehicleAttributes = new HbefaVehicleAttributes();
 	private Pollutant component;
 
+
+
+	private HbefaRoadGradient roadGradient;
+
 	HbefaEmissionFactorKey(HbefaEmissionFactorKey copyFrom) {
 		this.vehicleCategory = copyFrom.getVehicleCategory();
 		this.vehicleAttributes = copyFrom.getVehicleAttributes();
 		this.component = copyFrom.getComponent();
+		this.roadGradient = copyFrom.getRoadGradient();
 	}
 
 	HbefaEmissionFactorKey() {
@@ -61,6 +66,14 @@ abstract class HbefaEmissionFactorKey {
 
 	public void setComponent(Pollutant component) {
 		this.component = component;
+	}
+
+	public HbefaRoadGradient getRoadGradient() {
+		return roadGradient;
+	}
+
+	public void setRoadGradient(HbefaRoadGradient roadGradient) {
+		this.roadGradient = roadGradient;
 	}
 
 	@Override

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaEmissionFactorKey.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaEmissionFactorKey.java
@@ -31,7 +31,7 @@ abstract class HbefaEmissionFactorKey {
 
 
 
-	private HbefaRoadGradient roadGradient;
+	private String roadGradient;
 
 	HbefaEmissionFactorKey(HbefaEmissionFactorKey copyFrom) {
 		this.vehicleCategory = copyFrom.getVehicleCategory();
@@ -68,11 +68,11 @@ abstract class HbefaEmissionFactorKey {
 		this.component = component;
 	}
 
-	public HbefaRoadGradient getRoadGradient() {
+	public String getRoadGradient() {
 		return roadGradient;
 	}
 
-	public void setRoadGradient(HbefaRoadGradient roadGradient) {
+	public void setRoadGradient(String roadGradient) {
 		this.roadGradient = roadGradient;
 	}
 

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaRoadGradient.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaRoadGradient.java
@@ -1,0 +1,20 @@
+package org.matsim.contrib.emissions;
+
+/**
+ * @author Tim Kirschbaum
+ * */
+public enum HbefaRoadGradient {
+	ZERO,
+	PLUS_TWO,
+	PLUS_FOUR,
+	PLUS_SIX,
+	MINUS_2,
+	MINUS_4,
+	MINUS_6,
+	PLUS_MINUS_2,
+	PLUS_MINUS_4,
+	PLUS_MINUS_6;
+
+	HbefaRoadGradient() {
+	}
+}

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaRoadGradient.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaRoadGradient.java
@@ -5,9 +5,9 @@ package org.matsim.contrib.emissions;
  * */
 public enum HbefaRoadGradient {
 	ZERO,
-	PLUS_TWO,
-	PLUS_FOUR,
-	PLUS_SIX,
+	PLUS_2,
+	PLUS_4,
+	PLUS_6,
 	MINUS_2,
 	MINUS_4,
 	MINUS_6,

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaTables.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaTables.java
@@ -44,7 +44,8 @@ public abstract class HbefaTables {
         return load(file, HbefaTables::createWarmKey, record -> {
             var factor = Double.parseDouble(record.get("EFA_weighted"));
             var speed = Double.parseDouble(record.get("V_weighted"));
-            return new HbefaWarmEmissionFactor(factor, speed);
+			var roadGradient = record.get("Gradient");
+            return new HbefaWarmEmissionFactor(factor, speed, roadGradient);
         });
     }
 
@@ -53,7 +54,7 @@ public abstract class HbefaTables {
             var key = createWarmKey(record);
             setCommonDetailedParametersOnKey(key, record);
             return key;
-        }, record -> new HbefaWarmEmissionFactor(Double.parseDouble(record.get("EFA")), Double.parseDouble(record.get("V"))));
+        }, record -> new HbefaWarmEmissionFactor(Double.parseDouble(record.get("EFA")), Double.parseDouble(record.get("V")), record.get("Gradient")));
     }
 
     static Map<HbefaColdEmissionFactorKey, HbefaColdEmissionFactor> loadAverageCold(URL file) {
@@ -90,8 +91,10 @@ public abstract class HbefaTables {
         var key = new HbefaWarmEmissionFactorKey();
         setCommonParametersOnKey(key, record);
         var trafficSit = record.get("TrafficSit");
+		var roadGradient = record.get("Gradient");
         key.setRoadCategory(trafficSit.substring(0, trafficSit.lastIndexOf('/')));
         key.setTrafficSituation(mapString2HbefaTrafficSituation(trafficSit));
+		key.setRoadGradient(roadGradient);
         key.setVehicleAttributes(new HbefaVehicleAttributes());
         return key;
     }
@@ -129,6 +132,25 @@ public abstract class HbefaTables {
             throw new RuntimeException();
         }
     }
+//TODO	to use when enum functionality is implemented. also use it furtherup
+	private static HbefaRoadGradient mapString2HbefaRoadGradient(String string) {
+
+		if (string.equals("0%")) return HbefaRoadGradient.ZERO;
+		else if (string.equals("+2%")) return HbefaRoadGradient.PLUS_2;
+		else if (string.equals("+4%")) return HbefaRoadGradient.PLUS_4;
+		else if (string.equals("+6%")) return HbefaRoadGradient.PLUS_6;
+		else if (string.equals("-2%")) return HbefaRoadGradient.MINUS_2;
+		else if (string.equals("-4%")) return HbefaRoadGradient.MINUS_4;
+		else if (string.equals("-6%")) return HbefaRoadGradient.MINUS_6;
+		else if (string.equals("+/-2%")) return HbefaRoadGradient.PLUS_MINUS_2;
+		else if (string.equals("+/-4%")) return HbefaRoadGradient.PLUS_MINUS_4;
+		else if (string.equals("+/-6%")) return HbefaRoadGradient.PLUS_MINUS_6;
+
+		else {
+			logger.warn("Could not map String " + string + " to any HbefaRoadGradient; please check syntax in hbefa input file.");
+			throw new RuntimeException();
+		}
+	}
 
     private static int mapAmbientCondPattern2Distance(String string) {
         String distanceString = string.split(",")[2];

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaTables.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaTables.java
@@ -44,8 +44,9 @@ public abstract class HbefaTables {
         return load(file, HbefaTables::createWarmKey, record -> {
             var factor = Double.parseDouble(record.get("EFA_weighted"));
             var speed = Double.parseDouble(record.get("V_weighted"));
-			var roadGradient = record.get("Gradient");
-            return new HbefaWarmEmissionFactor(factor, speed, roadGradient);
+//            var roadGradient = record.get("Gradient");
+//            return new HbefaWarmEmissionFactor(factor, speed, roadGradient);
+            return new HbefaWarmEmissionFactor(factor, speed );
         });
     }
 
@@ -54,7 +55,10 @@ public abstract class HbefaTables {
             var key = createWarmKey(record);
             setCommonDetailedParametersOnKey(key, record);
             return key;
-        }, record -> new HbefaWarmEmissionFactor(Double.parseDouble(record.get("EFA")), Double.parseDouble(record.get("V")), record.get("Gradient")));
+        }, record -> new HbefaWarmEmissionFactor(Double.parseDouble(record.get("EFA"))
+                        , Double.parseDouble(record.get("V"))
+//                        , record.get("Gradient")
+        ));
     }
 
     static Map<HbefaColdEmissionFactorKey, HbefaColdEmissionFactor> loadAverageCold(URL file) {
@@ -133,7 +137,8 @@ public abstract class HbefaTables {
         }
     }
 //TODO	to use when enum functionality is implemented. also use it furtherup
-	private static HbefaRoadGradient mapString2HbefaRoadGradient(String string) {
+private static HbefaRoadGradient mapString2HbefaRoadGradient(String string) {
+        // I cannot say if and how this is needed.  Currently, it is never called.  kai, apr'23
 
 		if (string.equals("0%")) return HbefaRoadGradient.ZERO;
 		else if (string.equals("+2%")) return HbefaRoadGradient.PLUS_2;

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaWarmEmissionFactor.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaWarmEmissionFactor.java
@@ -27,9 +27,16 @@ class HbefaWarmEmissionFactor extends HbefaEmissionFactor {
 
 	private final double speed;
 
-	/*package-private*/ HbefaWarmEmissionFactor(double factor, double speed) {
+	public String getRoadGradient() {
+		return roadGradient;
+	}
+
+	private final String roadGradient;
+
+	/*package-private*/ HbefaWarmEmissionFactor(double factor, double speed, String roadGradient) {
 		super(factor);
 		this.speed = speed;
+		this.roadGradient = roadGradient;
 	}
 
 	public double getSpeed() {
@@ -40,6 +47,7 @@ class HbefaWarmEmissionFactor extends HbefaEmissionFactor {
 	public String toString() {
 		return "HbefaWarmEmissionFactor{" +
 				"speed=" + speed +
+				", roadGradient=" + roadGradient +
 				", warmEmissionFactor=" + getFactor() +
 				'}';
 	}

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaWarmEmissionFactor.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaWarmEmissionFactor.java
@@ -27,16 +27,22 @@ class HbefaWarmEmissionFactor extends HbefaEmissionFactor {
 
 	private final double speed;
 
-	public String getRoadGradient() {
-		return roadGradient;
-	}
+//	public String getRoadGradient() {
+//		return roadGradient;
+//	}
+//
+//	private final String roadGradient;
 
-	private final String roadGradient;
+//	/*package-private*/ HbefaWarmEmissionFactor(double factor, double speed, @Deprecated String roadGradient) {
 
-	/*package-private*/ HbefaWarmEmissionFactor(double factor, double speed, String roadGradient) {
+//	 My strong intuition is that roadGradient does <i>not</i> belong into the emission factor.  Since the emissions factor is output,
+//	 not input.  For this, one has to note that for HBEFA speed is output, for a certain traffic state on a certain road category.  This is
+//	 nonwithstanding the fact that for some versions of the emission calculation it is then used as input.  kai, apr'23
+
+	/*package-private*/ HbefaWarmEmissionFactor(double factor, double speed ) {
 		super(factor);
 		this.speed = speed;
-		this.roadGradient = roadGradient;
+//		this.roadGradient = roadGradient;
 	}
 
 	public double getSpeed() {
@@ -47,7 +53,7 @@ class HbefaWarmEmissionFactor extends HbefaEmissionFactor {
 	public String toString() {
 		return "HbefaWarmEmissionFactor{" +
 				"speed=" + speed +
-				", roadGradient=" + roadGradient +
+//				", roadGradient=" + roadGradient +
 				", warmEmissionFactor=" + getFactor() +
 				'}';
 	}

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaWarmEmissionFactorKey.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaWarmEmissionFactorKey.java
@@ -27,6 +27,15 @@ class HbefaWarmEmissionFactorKey extends HbefaEmissionFactorKey {
 	private String roadCategory;
 	private HbefaTrafficSituation trafficSituation;
 	private String roadGradient; // added var roadGradient
+	// It is most probably correct to add roadGradient here.  However, the way it is done right now it is far from complete.  Including that it is
+	// not used in equals and in HashCode.  kai, apr'23
+
+	// What is also missing in general is some wildcard syntax.  This now comes in as a problem here since it makes retrofitting the non-grade
+	// code more difficult.  So far an easy solution for wildcards did not come to mind, and for a complicated solution we
+	// did not have the patience.  Maybe there is a library?  In the meantime, we have operated with the fallbacks in the config.  So one could
+	// now include something there either fall back to zero grade if grade is not available in the link.  Or abort.  (I find the latter more
+	// plausible; one can add a grade to each individual link in the pre-processing.)  kai, apr'23
+
 
 	/*package-private*/ HbefaWarmEmissionFactorKey() {
 	}

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaWarmEmissionFactorKey.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaWarmEmissionFactorKey.java
@@ -26,6 +26,7 @@ class HbefaWarmEmissionFactorKey extends HbefaEmissionFactorKey {
 
 	private String roadCategory;
 	private HbefaTrafficSituation trafficSituation;
+	private HbefaRoadGradient roadGradient; // added var roadGradient
 
 	/*package-private*/ HbefaWarmEmissionFactorKey() {
 	}
@@ -34,11 +35,14 @@ class HbefaWarmEmissionFactorKey extends HbefaEmissionFactorKey {
 		super(key);
 		this.roadCategory = key.roadCategory;
 		this.trafficSituation = key.trafficSituation;
+		this.roadGradient = key.roadGradient; // roadGradient in constructor
 	}
 
 	String getRoadCategory() {
 		return this.roadCategory;
 	}
+
+
 
 	/*package-private*/ void setRoadCategory(String roadCategory) {
 		this.roadCategory = roadCategory;

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaWarmEmissionFactorKey.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaWarmEmissionFactorKey.java
@@ -26,7 +26,7 @@ class HbefaWarmEmissionFactorKey extends HbefaEmissionFactorKey {
 
 	private String roadCategory;
 	private HbefaTrafficSituation trafficSituation;
-	private HbefaRoadGradient roadGradient; // added var roadGradient
+	private String roadGradient; // added var roadGradient
 
 	/*package-private*/ HbefaWarmEmissionFactorKey() {
 	}

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaWarmEmissionFactorKey.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaWarmEmissionFactorKey.java
@@ -35,7 +35,7 @@ class HbefaWarmEmissionFactorKey extends HbefaEmissionFactorKey {
 		super(key);
 		this.roadCategory = key.roadCategory;
 		this.trafficSituation = key.trafficSituation;
-		this.roadGradient = key.roadGradient; // roadGradient in constructor
+		this.roadGradient = key.roadGradient;
 	}
 
 	String getRoadCategory() {

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaWarmEmissionFactorKey.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/HbefaWarmEmissionFactorKey.java
@@ -56,6 +56,10 @@ class HbefaWarmEmissionFactorKey extends HbefaEmissionFactorKey {
 		this.trafficSituation = trafficSituation;
 	}
 
+	/*package-private*/ void setRoadGradient(String roadGradient) {
+		this.roadGradient = roadGradient;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
@@ -73,6 +77,7 @@ class HbefaWarmEmissionFactorKey extends HbefaEmissionFactorKey {
 		int result = super.hashCode();
 		result = 31 * result + trafficSituation.hashCode();
 		result = 31 * result + roadCategory.hashCode();
+		result = 31 * result + roadGradient.hashCode();
 		return result;
 	}
 
@@ -84,6 +89,7 @@ class HbefaWarmEmissionFactorKey extends HbefaEmissionFactorKey {
 						+ getComponent() + "; "
 						+ roadCategory + "; "
 						+ trafficSituation + "; "
+						+ roadGradient + "; "
 						+ getVehicleAttributes();
 	}
 }

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/PositionEmissionsModule.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/PositionEmissionsModule.java
@@ -100,7 +100,7 @@ public class PositionEmissionsModule extends AbstractModule {
 
 			var vehicleAttributes = getVehicleAttributes(vehicle);
 			var roadType = EmissionUtils.getHbefaRoadType(link);
-			String roadGradient = EmissionUtils.getHbefaRoadGradient(link);
+			var roadGradient = EmissionUtils.getHbefaRoadGradient(link);
 			return emissionModule.getWarmEmissionAnalysisModule().calculateWarmEmissions(time, roadType, roadGradient,link.getFreespeed(), distance, vehicleAttributes);
 		}
 

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/PositionEmissionsModule.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/PositionEmissionsModule.java
@@ -100,7 +100,8 @@ public class PositionEmissionsModule extends AbstractModule {
 
 			var vehicleAttributes = getVehicleAttributes(vehicle);
 			var roadType = EmissionUtils.getHbefaRoadType(link);
-			return emissionModule.getWarmEmissionAnalysisModule().calculateWarmEmissions(time, roadType, link.getFreespeed(), distance, vehicleAttributes);
+			String roadGradient = EmissionUtils.getHbefaRoadGradient(link);
+			return emissionModule.getWarmEmissionAnalysisModule().calculateWarmEmissions(time, roadType, roadGradient,link.getFreespeed(), distance, vehicleAttributes);
 		}
 
 		Map<Pollutant, Double> calculateColdEmissions(Vehicle vehicle, double parkingDuration, int distance) {

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/PositionEmissionsModule.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/PositionEmissionsModule.java
@@ -97,11 +97,13 @@ public class PositionEmissionsModule extends AbstractModule {
 		private EmissionModule emissionModule;
 
 		Map<Pollutant, Double> calculateWarmEmissions(Vehicle vehicle, Link link, double distance, double time) {
-
 			var vehicleAttributes = getVehicleAttributes(vehicle);
 			var roadType = EmissionUtils.getHbefaRoadType(link);
 			var roadGradient = EmissionUtils.getHbefaRoadGradient(link);
 			return emissionModule.getWarmEmissionAnalysisModule().calculateWarmEmissions(time, roadType, roadGradient,link.getFreespeed(), distance, vehicleAttributes);
+			// The above is plausible as the adapter method which takes matsim objects (vehicle, link), and converts them into plain
+			// lookup tables.  HOWEVER, then one should either resolve vehicleAttributes into individual entries.  Or combine the link attributes into
+			// linkAttributes.  (This may not be so much a problem as long as (all the) calculateWarmEmissions are not public.)  kai, apr'23
 		}
 
 		Map<Pollutant, Double> calculateColdEmissions(Vehicle vehicle, double parkingDuration, int distance) {

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/WarmEmissionAnalysisModule.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/WarmEmissionAnalysisModule.java
@@ -228,10 +228,10 @@ public final class WarmEmissionAnalysisModule implements LinkEmissionsCalculator
 
 		double freeVelocity = link.getFreespeed(); //TODO: what about time dependence
 
-		return calculateWarmEmissions(travelTime, EmissionUtils.getHbefaRoadType(link), freeVelocity, link.getLength(), vehicleInformationTuple);
+		return calculateWarmEmissions(travelTime, EmissionUtils.getHbefaRoadType(link),EmissionUtils.getHbefaRoadGradient(link),freeVelocity, link.getLength(), vehicleInformationTuple);
 	}
 
-	Map<Pollutant, Double> calculateWarmEmissions(double travelTime_sec, String roadType, double freeVelocity_ms,
+	Map<Pollutant, Double> calculateWarmEmissions(double travelTime_sec, String roadType, String roadGradient, double freeVelocity_ms,
 												  double linkLength_m, Tuple<HbefaVehicleCategory, HbefaVehicleAttributes> vehicleInformationTuple) {
 
 		Map<Pollutant, Double> warmEmissionsOfEvent = new EnumMap<>(Pollutant.class);
@@ -257,7 +257,7 @@ public final class WarmEmissionAnalysisModule implements LinkEmissionsCalculator
 		HbefaWarmEmissionFactorKey efkey = new HbefaWarmEmissionFactorKey();
 		efkey.setVehicleCategory(vehicleInformationTuple.getFirst());
 		efkey.setRoadCategory(roadType);
-		//efkey.setRoadGradient(roadGradient); //TODO how to add the args roadGradient to the function() above?!
+		efkey.setRoadGradient(roadGradient); //TODO how to add the args roadGradient to the function() above?!
 		if (this.detailedHbefaWarmTable != null) {
 			HbefaVehicleAttributes hbefaVehicleAttributes = new HbefaVehicleAttributes();
 			hbefaVehicleAttributes.setHbefaTechnology(vehicleInformationTuple.getSecond().getHbefaTechnology());
@@ -333,6 +333,7 @@ public final class WarmEmissionAnalysisModule implements LinkEmissionsCalculator
 			double generatedEmissions = (linkLength_m / 1000) * ef_gpkm;
 			warmEmissionsOfEvent.put(warmPollutant, generatedEmissions);
 		}
+		System.out.println("you are correct");
 
 		// update counters:
 		// yy I don't now what this is good for; I would base downstream analysis rather on events.  kai, jan'20

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/WarmEmissionAnalysisModule.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/WarmEmissionAnalysisModule.java
@@ -128,7 +128,7 @@ public final class WarmEmissionAnalysisModule implements LinkEmissionsCalculator
 										key.setTrafficSituation(trafficSituation);
 										key.setVehicleCategory(vehicleCategory);
 										key.setVehicleAttributes(vehicleAttribute);
-										key.setComponent(pollutant);
+										key.setComponent(pollutant); //TODO add key.setroadGradient here later kerseboom,jan'23
 										HbefaWarmEmissionFactor result = detailedHbefaWarmTable.get(key);
 										if (result == null) {
 											throw new RuntimeException("emissions factor for key=" + key + " is missing." +
@@ -257,7 +257,7 @@ public final class WarmEmissionAnalysisModule implements LinkEmissionsCalculator
 		HbefaWarmEmissionFactorKey efkey = new HbefaWarmEmissionFactorKey();
 		efkey.setVehicleCategory(vehicleInformationTuple.getFirst());
 		efkey.setRoadCategory(roadType);
-		efkey.setRoadGradient(roadGradient); //TODO how to add the args roadGradient to the function() above?!
+		efkey.setRoadGradient(roadGradient); //TODO make it work and then change and use the enum kerseboom, jan'23
 		if (this.detailedHbefaWarmTable != null) {
 			HbefaVehicleAttributes hbefaVehicleAttributes = new HbefaVehicleAttributes();
 			hbefaVehicleAttributes.setHbefaTechnology(vehicleInformationTuple.getSecond().getHbefaTechnology());

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/WarmEmissionAnalysisModule.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/WarmEmissionAnalysisModule.java
@@ -333,7 +333,6 @@ public final class WarmEmissionAnalysisModule implements LinkEmissionsCalculator
 			double generatedEmissions = (linkLength_m / 1000) * ef_gpkm;
 			warmEmissionsOfEvent.put(warmPollutant, generatedEmissions);
 		}
-		System.out.println("you are correct");
 
 		// update counters:
 		// yy I don't now what this is good for; I would base downstream analysis rather on events.  kai, jan'20

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/WarmEmissionAnalysisModule.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/WarmEmissionAnalysisModule.java
@@ -257,6 +257,7 @@ public final class WarmEmissionAnalysisModule implements LinkEmissionsCalculator
 		HbefaWarmEmissionFactorKey efkey = new HbefaWarmEmissionFactorKey();
 		efkey.setVehicleCategory(vehicleInformationTuple.getFirst());
 		efkey.setRoadCategory(roadType);
+		//efkey.setRoadGradient(roadGradient); //TODO how to add the args roadGradient to the function() above?!
 		if (this.detailedHbefaWarmTable != null) {
 			HbefaVehicleAttributes hbefaVehicleAttributes = new HbefaVehicleAttributes();
 			hbefaVehicleAttributes.setHbefaTechnology(vehicleInformationTuple.getSecond().getHbefaTechnology());

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/WarmEmissionHandler.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/WarmEmissionHandler.java
@@ -71,9 +71,9 @@ class WarmEmissionHandler implements LinkEnterEventHandler, LinkLeaveEventHandle
 	private final Map<Id<Vehicle>, Tuple<Id<Link>, Double>> vehicleEntersTrafficMap = new HashMap<>();
 
 	/*package-private*/ WarmEmissionHandler( Scenario scenario, Map<HbefaWarmEmissionFactorKey, HbefaWarmEmissionFactor> avgHbefaWarmTable,
-											 Map<HbefaWarmEmissionFactorKey, HbefaWarmEmissionFactor> detailedHbefaWarmTable,
-											 Map<HbefaRoadVehicleCategoryKey, Map<HbefaTrafficSituation, Double>> hbefaRoadTrafficSpeeds, Set<Pollutant> warmPollutants,
-											 EventsManager eventsManager ){
+						 Map<HbefaWarmEmissionFactorKey, HbefaWarmEmissionFactor> detailedHbefaWarmTable,
+						 Map<HbefaRoadVehicleCategoryKey, Map<HbefaTrafficSituation, Double>> hbefaRoadTrafficSpeeds, Set<Pollutant> warmPollutants,
+						 EventsManager eventsManager ){
 
 		this.scenario = scenario;
 		this.emissionsConfigGroup = ConfigUtils.addOrGetModule( scenario.getConfig(), EmissionsConfigGroup.class );
@@ -107,15 +107,15 @@ class WarmEmissionHandler implements LinkEnterEventHandler, LinkLeaveEventHandle
 		Link link = this.scenario.getNetwork().getLinks().get(event.getLinkId());
 		if ( linkLengthIsZero( link.getId(), link.getLength() ) ) { trafficLeaveCnt++; }
 
-		final double leaveTime = event.getTime();
+		final double now = event.getTime();
 		final Id<Vehicle> vehicleId = event.getVehicleId();
 		if ( this.linkEnterMap.containsKey( vehicleId ) ) {
-			double travelTime = leaveTime - this.linkEnterMap.get(vehicleId).getSecond() + 1.0;
+			double travelTime = now - this.linkEnterMap.get(vehicleId).getSecond() + 1.0;
 			// this extra second added to travelTime is needed because the vehicleLeavesTrafficEvent
 			// is thrown one second earlier (by design) ~kn,kmt,rjg 08.22
 			Vehicle vehicle = VehicleUtils.findVehicle(vehicleId, scenario);
 			if (vehicle != null) {
-				emissionsCalculation( vehicleId, vehicle, link, leaveTime, travelTime );
+				emissionsCalculation( vehicleId, vehicle, link, now, travelTime );
 				this.vehicleEntersTrafficMap.remove( vehicleId );
 				this.linkEnterMap.remove( vehicleId );
 				// clearing these maps so that no second emission event is computed for travel from parking to link leave
@@ -182,10 +182,10 @@ class WarmEmissionHandler implements LinkEnterEventHandler, LinkLeaveEventHandle
 
 	}
 
-	private void emissionsCalculation(Id<Vehicle> vehicleId, Vehicle vehicle, Link link, double leaveTime, double travelTime) {
+	private void emissionsCalculation(Id<Vehicle> vehicleId, Vehicle vehicle, Link link, double now, double travelTime) {
 		VehicleType vehicleType = vehicle.getType();
 		Map<Pollutant, Double> warmEmissions = warmEmissionAnalysisModule.checkVehicleInfoAndCalculateWarmEmissions(vehicleType, vehicleId, link, travelTime);
-		warmEmissionAnalysisModule.throwWarmEmissionEvent(leaveTime, link.getId(), vehicleId, warmEmissions);
+		warmEmissionAnalysisModule.throwWarmEmissionEvent(now, link.getId(), vehicleId, warmEmissions);
 	}
 
 	private boolean linkLengthIsZero( Id<Link> linkId, double linkLength) {

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/example/RunAverageEmissionToolOfflineExample.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/example/RunAverageEmissionToolOfflineExample.java
@@ -26,9 +26,7 @@ import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.AbstractModule;
-import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.Injector;
-import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.core.events.EventsUtils;
 import org.matsim.core.events.MatsimEventsReader;
 import org.matsim.core.events.algorithms.EventWriterXML;
@@ -47,12 +45,6 @@ import org.matsim.vehicles.MatsimVehicleWriter;
  */
 public final class RunAverageEmissionToolOfflineExample{
 
-//	private static final String configFile = "./scenarios/sampleScenario/testv2_Vehv1/config_average.xml";
-
-	public static final String emissionEventsFilename = "emission.events.offline.xml.gz";
-
-	// (remove dependency of one test/execution path from other. kai/ihab, nov'18)
-
 	private Config config;
 
 	// =======================================================================================================		
@@ -60,16 +52,9 @@ public final class RunAverageEmissionToolOfflineExample{
 	public static void main (String[] args){
 		RunAverageEmissionToolOfflineExample emissionToolOfflineExampleV2 = new RunAverageEmissionToolOfflineExample();
 		emissionToolOfflineExampleV2.run();
+		// yyyy I think that this will fail (since config is null, see under run).  kai, apr'23
 	}
 
-//	public Config prepareConfig() {
-//		config = ConfigUtils.loadConfig(configFile, new EmissionsConfigGroup());
-//		return config;
-//	}
-
-	public Config prepareConfig(String args){
-		throw new RuntimeException("execution path no longer exists");
-	}
 	public Config prepareConfig(String [] args) {
 		config = ConfigUtils.loadConfig(args, new EmissionsConfigGroup());
 		EmissionsConfigGroup ecg = ConfigUtils.addOrGetModule( config, EmissionsConfigGroup.class );
@@ -106,7 +91,7 @@ public final class RunAverageEmissionToolOfflineExample{
 //		OutputDirectoryHierarchy outputDirectoryHierarchy = injector.getInstance( OutputDirectoryHierarchy.class );
 
 		final String outputDirectory = scenario.getConfig().controler().getOutputDirectory();
-		EventWriterXML emissionEventWriter = new EventWriterXML( outputDirectory + emissionEventsFilename );
+		EventWriterXML emissionEventWriter = new EventWriterXML( outputDirectory + "emission.events.offline.xml.gz" );
 		emissionModule.getEmissionEventsManager().addHandler(emissionEventWriter);
 
 		eventsManager.initProcessing();

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/example/RunDetailedEmissionToolOfflineExample.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/example/RunDetailedEmissionToolOfflineExample.java
@@ -29,7 +29,6 @@ import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.Injector;
 import org.matsim.core.events.EventsUtils;
 import org.matsim.core.events.MatsimEventsReader;
-import org.matsim.core.events.ParallelEventsManager;
 import org.matsim.core.events.algorithms.EventWriterXML;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.utils.io.IOUtils;
@@ -97,7 +96,7 @@ public final class RunDetailedEmissionToolOfflineExample{
 		EmissionModule emissionModule = injector.getInstance(EmissionModule.class);
 
 		final String outputDirectory = scenario.getConfig().controler().getOutputDirectory();
-		EventWriterXML emissionEventWriter = new EventWriterXML( outputDirectory + RunAverageEmissionToolOfflineExample.emissionEventsFilename ) ;
+		EventWriterXML emissionEventWriter = new EventWriterXML( outputDirectory + "emission.events.offline.xml.gz" ) ;
 		emissionModule.getEmissionEventsManager().addHandler(emissionEventWriter);
 
 		eventsManager.initProcessing();

--- a/contribs/emissions/src/test/java/org/matsim/contrib/emissions/example/RunAverageEmissionToolOfflineExampleIT.java
+++ b/contribs/emissions/src/test/java/org/matsim/contrib/emissions/example/RunAverageEmissionToolOfflineExampleIT.java
@@ -30,7 +30,6 @@ import org.matsim.core.events.EventsUtils;
 import org.matsim.core.utils.io.IOUtils;
 import org.matsim.examples.ExamplesUtils;
 import org.matsim.testcases.MatsimTestUtils;
-import org.matsim.utils.eventsfilecomparison.EventsFileComparator;
 import org.matsim.utils.eventsfilecomparison.EventsFileComparator.Result;
 
 import java.net.URL;
@@ -57,8 +56,8 @@ public class RunAverageEmissionToolOfflineExampleIT{
 
 		offlineExample.run();
 
-		String expected = utils.getInputDirectory() + RunAverageEmissionToolOfflineExample.emissionEventsFilename;
-		String actual = utils.getOutputDirectory() + RunAverageEmissionToolOfflineExample.emissionEventsFilename;
+		String expected = utils.getInputDirectory() + "emission.events.offline.xml.gz";
+		String actual = utils.getOutputDirectory() + "emission.events.offline.xml.gz";
 		Result result = EventsUtils.compareEventsFiles( expected, actual );
 		Assert.assertEquals( Result.FILES_ARE_EQUAL, result);
 	}
@@ -79,8 +78,8 @@ public class RunAverageEmissionToolOfflineExampleIT{
 
 		offlineExample.run();
 
-		String expected = utils.getInputDirectory() + RunAverageEmissionToolOfflineExample.emissionEventsFilename;
-		String actual = utils.getOutputDirectory() + RunAverageEmissionToolOfflineExample.emissionEventsFilename;
+		String expected = utils.getInputDirectory() + "emission.events.offline.xml.gz";
+		String actual = utils.getOutputDirectory() + "emission.events.offline.xml.gz";
 		Result result = EventsUtils.compareEventsFiles( expected, actual );
 		Assert.assertEquals( Result.FILES_ARE_EQUAL, result);
 	}
@@ -105,8 +104,8 @@ public class RunAverageEmissionToolOfflineExampleIT{
 
 		offlineExample.run();
 
-		String expected = utils.getInputDirectory() + RunAverageEmissionToolOfflineExample.emissionEventsFilename;
-		String actual = utils.getOutputDirectory() + RunAverageEmissionToolOfflineExample.emissionEventsFilename;
+		String expected = utils.getInputDirectory() + "emission.events.offline.xml.gz";
+		String actual = utils.getOutputDirectory() + "emission.events.offline.xml.gz";
 		Result result = EventsUtils.compareEventsFiles( expected, actual );
 		Assert.assertEquals( Result.FILES_ARE_EQUAL, result);
 
@@ -129,8 +128,8 @@ public class RunAverageEmissionToolOfflineExampleIT{
 
 		offlineExample.run();
 
-		String expected = utils.getInputDirectory() + RunAverageEmissionToolOfflineExample.emissionEventsFilename;
-		String actual = utils.getOutputDirectory() + RunAverageEmissionToolOfflineExample.emissionEventsFilename;
+		String expected = utils.getInputDirectory() + "emission.events.offline.xml.gz";
+		String actual = utils.getOutputDirectory() + "emission.events.offline.xml.gz";
 		Result result = EventsUtils.compareEventsFiles( expected, actual );
 		Assert.assertEquals( Result.FILES_ARE_EQUAL, result);
 	}

--- a/examples/scenarios/emissions-sampleScenario/sample_41_EFA_HOT_vehcat_2020average_withHGVetc_allGradients.csv
+++ b/examples/scenarios/emissions-sampleScenario/sample_41_EFA_HOT_vehcat_2020average_withHGVetc_allGradients.csv
@@ -1,0 +1,4141 @@
+Case;VehCat;Year;TrafficScenario;Component;RoadCat;TrafficSit;Gradient;V_weighted;EFA_weighted;AmbientCondPattern;EFA_WTT_weighted;EFA_WTW_weighted
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;0%;79.04334259;0.007471068;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04331207;0.008247676;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04321289;0.010871409;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.04324341;0.014738609;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;-6%;79.04334259;0.003527788;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;-4%;79.04334259;0.003903835;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;-2%;79.04334259;0.005025127;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;+2%;79.04328156;0.011470225;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;+4%;79.04309082;0.017838987;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;+6%;79.04311371;0.025949432;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;0%;15.47643852;0.022391768;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;+/-2%;15.4724884;0.022778807;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;+/-4%;15.46883678;0.024144957;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45297337;0.026229559;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;-6%;15.48051739;0.014797023;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;-4%;15.48048592;0.016614862;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;-2%;15.47820568;0.019177606;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;+2%;15.46677399;0.026379995;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;+4%;15.45718384;0.031675041;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;+6%;15.42543221;0.037662089;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;0%;6.128380299;0.039759863;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1273489;0.03990633;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124416351;0.040441472;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.124890327;0.041414864;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;-6%;6.125377178;0.032898355;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;-4%;6.128029346;0.034645393;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;-2%;6.127646923;0.036718946;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;+2%;6.127052784;0.043093722;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;+4%;6.120803833;0.046237566;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;+6%;6.124405384;0.049931362;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;0%;41.66275787;0.010469965;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;+/-2%;41.66275787;0.010849499;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;+/-4%;41.66275787;0.012192441;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;+/-6%;41.66162491;0.014168913;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;-6%;41.66275787;0.006284647;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;-4%;41.66275787;0.007048326;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;-2%;41.66275787;0.008234367;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;+2%;41.66275787;0.013464625;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;+4%;41.66275787;0.017336557;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;+6%;41.66048813;0.022053177;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;0%;12.48863316;0.022639077;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;+/-2%;12.48870945;0.02284834;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;+/-4%;12.48709679;0.023695972;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;+/-6%;12.48793888;0.0250331;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;-6%;12.48871803;0.017243378;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;-4%;12.48871803;0.018577164;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;-2%;12.48871803;0.020345228;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;+2%;12.48870087;0.025351457;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;+4%;12.48547554;0.028814768;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;+6%;12.48715973;0.032822832;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;0%;5.839771271;0.035918243;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;+/-2%;5.838320255;0.036106501;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;+/-4%;5.839328766;0.036871441;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;+/-6%;5.839369297;0.037960984;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;-6%;5.839882851;0.031624548;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;-4%;5.83987093;0.032862853;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;-2%;5.839808464;0.034178697;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;+2%;5.836833;0.038034331;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;+4%;5.838788986;0.040880002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;+6%;5.838853836;0.044297412;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;0%;79.04334259;0.155700698;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04331207;0.187708259;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04321289;0.276817709;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.04324341;0.438112259;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;-6%;79.04334259;0.065814242;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;-4%;79.04334259;0.073849775;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;-2%;79.04334259;0.101325832;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;+2%;79.04328156;0.274090618;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;+4%;79.04309082;0.479785502;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;+6%;79.04311371;0.810410142;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;0%;15.47643852;0.60593462;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;+/-2%;15.4724884;0.644346356;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;+/-4%;15.46883678;0.884164453;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45297337;1.234271169;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;-6%;15.48051739;0.210351512;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;-4%;15.48048592;0.261826664;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;-2%;15.47820568;0.350611031;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;+2%;15.46677399;0.938081563;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;+4%;15.45718384;1.506501913;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;+6%;15.42543221;2.258190393;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;0%;6.128380299;0.931938529;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1273489;0.898894906;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124416351;1.058894753;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.124890327;1.142214656;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;-6%;6.125377178;0.439053804;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;-4%;6.128029346;0.485251963;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;-2%;6.127646923;0.565994143;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;+2%;6.127052784;1.231795311;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;+4%;6.120803833;1.632537127;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;+6%;6.124405384;1.845374942;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;0%;41.66275787;0.19335942;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;+/-2%;41.66275787;0.201266199;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;+/-4%;41.66275787;0.239351422;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;+/-6%;41.66162491;0.30140239;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;-6%;41.66275787;0.107380435;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;-4%;41.66275787;0.120274;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;-2%;41.66275787;0.144802779;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;+2%;41.66275787;0.25772965;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;+4%;41.66275787;0.358428717;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;+6%;41.66048813;0.49542442;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;0%;12.48863316;0.3382034;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;+/-2%;12.48870945;0.3417207;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;+/-4%;12.48709679;0.37524116;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;+/-6%;12.48793888;0.426966697;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;-6%;12.48871803;0.220885143;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;-4%;12.48871803;0.244979158;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;-2%;12.48871803;0.278052539;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;+2%;12.48870087;0.405388802;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;+4%;12.48547554;0.50550282;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;+6%;12.48715973;0.633048296;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;0%;5.839771271;0.449499577;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;+/-2%;5.838320255;0.450300694;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;+/-4%;5.839328766;0.469701886;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;+/-6%;5.839369297;0.567529738;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;-6%;5.839882851;0.349514663;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;-4%;5.83987093;0.375656545;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;-2%;5.839808464;0.40956986;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;+2%;5.836833;0.491031468;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;+4%;5.838788986;0.563747227;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;+6%;5.838853836;0.785544932;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;0%;79.04334259;0.230366305;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04331207;0.257593334;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04321289;0.345990628;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.04324341;0.475752741;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;-6%;79.04334259;0.075047567;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;-4%;79.04334259;0.092987724;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;-2%;79.04334259;0.144747987;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;+2%;79.04328156;0.370438665;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;+4%;79.04309082;0.59899354;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;+6%;79.04311371;0.876457989;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;0%;15.47643852;0.556553245;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;+/-2%;15.4724884;0.571052611;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;+/-4%;15.46883678;0.614735305;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45297337;0.695089698;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;-6%;15.48051739;0.317459315;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;-4%;15.48048592;0.370216668;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;-2%;15.47820568;0.452619791;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;+2%;15.46677399;0.689485371;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;+4%;15.45718384;0.859254241;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;+6%;15.42543221;1.072720051;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;0%;6.128380299;0.874101758;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1273489;0.876322567;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124416351;0.896731436;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.124890327;0.92975688;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;-6%;6.125377178;0.662282467;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;-4%;6.128029346;0.715723634;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;-2%;6.127646923;0.777205169;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;+2%;6.127052784;0.975439668;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;+4%;6.120803833;1.077739;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;+6%;6.124405384;1.197231054;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;0%;41.66275787;0.299246997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;+/-2%;41.66275787;0.309403718;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;+/-4%;41.66275787;0.350685656;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;+/-6%;41.66162491;0.418845206;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;-6%;41.66275787;0.147379756;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;-4%;41.66275787;0.173779353;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;-2%;41.66275787;0.222237185;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;+2%;41.66275787;0.396570235;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;+4%;41.66275787;0.527592003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;+6%;41.66048813;0.690310717;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;0%;12.48863316;0.548087835;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;+/-2%;12.48870945;0.556457758;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;+/-4%;12.48709679;0.58335197;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;+/-6%;12.48793888;0.628213227;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;-6%;12.48871803;0.374539554;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;-4%;12.48871803;0.413621664;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;-2%;12.48871803;0.472825557;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;+2%;12.48870087;0.640089929;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;+4%;12.48547554;0.753082097;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;+6%;12.48715973;0.88188684;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;0%;5.839771271;0.782463789;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;+/-2%;5.838320255;0.779575646;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;+/-4%;5.839328766;0.797314525;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;+/-6%;5.839369297;0.827128053;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;-6%;5.839882851;0.62502563;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;-4%;5.83987093;0.664056778;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;-2%;5.839808464;0.709603965;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;+2%;5.836833;0.849547982;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;+4%;5.838788986;0.930572331;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;+6%;5.838853836;1.029230356;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;0%;79.04334259;43.61745453;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04331207;44.19202805;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04321289;45.58287048;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.04324341;50.91514969;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;-6%;79.04334259;2.362139225;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;-4%;79.04334259;10.3219614;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;-2%;79.04334259;26.21108627;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;+2%;79.04328156;62.17295837;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;+4%;79.04309082;80.84376526;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;+6%;79.04311371;99.46817017;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;0%;15.47643852;85.38336182;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;+/-2%;15.4724884;86.41178894;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;+/-4%;15.46883678;88.4006958;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45297337;92.45957184;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;-6%;15.48051739;47.63288498;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;-4%;15.48048592;58.09821701;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;-2%;15.47820568;71.22841644;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;+2%;15.46677399;101.5951996;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;+4%;15.45718384;118.7032394;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;+6%;15.42543221;137.2862701;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;0%;6.128380299;146.554306;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1273489;147.9854279;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124416351;150.3182068;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.124890327;153.4543457;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;-6%;6.125377178;107.2036896;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;-4%;6.128029346;118.8101578;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;-2%;6.127646923;131.9870605;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;+2%;6.127052784;163.9838104;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;+4%;6.120803833;181.8262939;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;+6%;6.124405384;199.7050018;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;0%;41.66275787;50.59958649;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;+/-2%;41.66275787;50.77656174;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;+/-4%;41.66275787;52.63883591;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;+/-6%;41.66162491;57.54747391;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;-6%;41.66275787;11.71959972;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;-4%;41.66275787;19.91292763;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;-2%;41.66275787;33.85700989;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;+2%;41.66275787;67.69610596;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;+4%;41.66275787;85.36473083;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;+6%;41.66048813;103.3753281;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;0%;12.48863316;91.26190948;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;+/-2%;12.48870945;91.70667267;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;+/-4%;12.48709679;93.55104828;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;+/-6%;12.48793888;96.88349152;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;-6%;12.48871803;52.75648117;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;-4%;12.48871803;63.57430267;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;-2%;12.48871803;76.64977264;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;+2%;12.48870087;106.763588;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;+4%;12.48547554;123.5278168;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;+6%;12.48715973;141.0104828;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;0%;5.839771271;148.1355591;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;+/-2%;5.838320255;148.9516907;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;+/-4%;5.839328766;150.6094208;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;+/-6%;5.839369297;153.7845306;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;-6%;5.839882851;105.2366867;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;-4%;5.83987093;118.4103622;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;-2%;5.839808464;132.6305695;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;+2%;5.836833;165.2727966;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;+4%;5.838788986;182.8084106;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;+6%;5.838853836;202.3322906;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;0%;79.04334259;1.847706676;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04331207;1.87211895;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04321289;1.931505322;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.04324341;2.15785718;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;-6%;79.04334259;0.098335527;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;-4%;79.04334259;0.435925573;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;-2%;79.04334259;1.109289289;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;+2%;79.04328156;2.6349473;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;+4%;79.04309082;3.427083492;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;+6%;79.04311371;4.217377663;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;0%;15.47643852;3.614514828;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;+/-2%;15.4724884;3.658075094;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;+/-4%;15.46883678;3.742539406;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45297337;3.914617062;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;-6%;15.48051739;2.012830973;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;-4%;15.48048592;2.456912994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;-2%;15.47820568;3.013854742;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;+2%;15.46677399;4.302297115;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;+4%;15.45718384;5.02816534;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;+6%;15.42543221;5.816401482;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;0%;6.128380299;6.2008605;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1273489;6.261471748;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124416351;6.360631466;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.124890327;6.494012833;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;-6%;6.125377178;4.532316685;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;-4%;6.128029346;5.024346352;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;-2%;6.127646923;5.582980633;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;+2%;6.127052784;6.939963818;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;+4%;6.120803833;7.696913719;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;+6%;6.124405384;8.455710411;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;0%;41.66275787;2.142549992;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;+/-2%;41.66275787;2.150361061;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;+/-4%;41.66275787;2.229771376;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;+/-6%;41.66162491;2.437911034;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;-6%;41.66275787;0.493102312;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;-4%;41.66275787;0.841350257;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;-2%;41.66275787;1.432547808;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;+2%;41.66275787;2.868173122;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;+4%;41.66275787;3.618191004;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;+6%;41.66048813;4.38272047;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;0%;12.48863316;3.863288879;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;+/-2%;12.48870945;3.882261515;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;+/-4%;12.48709679;3.960582495;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;+/-6%;12.48793888;4.101946354;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;-6%;12.48871803;2.229130507;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;-4%;12.48871803;2.688379049;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;-2%;12.48871803;3.243253469;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;+2%;12.48870087;4.521270275;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;+4%;12.48547554;5.232786655;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;+6%;12.48715973;5.974765301;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;0%;5.839771271;6.268201828;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;+/-2%;5.838320255;6.302828789;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;+/-4%;5.839328766;6.373448849;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;+/-6%;5.839369297;6.508283138;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;-6%;5.839882851;4.448592663;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;-4%;5.83987093;5.007211208;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;-2%;5.839808464;5.610331059;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;+2%;5.836833;6.995322227;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;+4%;5.838788986;7.73968935;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;+6%;5.838853836;8.567974091;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;0%;79.04334259;0.002212082;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04331207;0.002355713;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04321289;0.002784067;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.04324341;0.003445194;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;-6%;79.04334259;0.000971403;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;-4%;79.04334259;0.0011216;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;-2%;79.04334259;0.001534945;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;+2%;79.04328156;0.00317648;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;+4%;79.04309082;0.004446534;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;+6%;79.04311371;0.005918987;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;0%;15.47643852;0.004919721;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;+/-2%;15.4724884;0.005070788;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;+/-4%;15.46883678;0.005369526;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45297337;0.006129978;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;-6%;15.48051739;0.003257784;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;-4%;15.48048592;0.003629417;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;-2%;15.47820568;0.004198469;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;+2%;15.46677399;0.005943111;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;+4%;15.45718384;0.007109633;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;+6%;15.42543221;0.009002172;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;0%;6.128380299;0.008970035;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1273489;0.008958289;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124416351;0.009224014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.124890327;0.009481507;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;-6%;6.125377178;0.007347886;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;-4%;6.128029346;0.007772332;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;-2%;6.127646923;0.008224605;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;+2%;6.127052784;0.009691968;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;+4%;6.120803833;0.0106757;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;+6%;6.124405384;0.011615128;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;0%;41.66275787;0.002823106;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;+/-2%;41.66275787;0.002872864;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;+/-4%;41.66275787;0.00305747;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;+/-6%;41.66162491;0.003336358;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;-6%;41.66275787;0.001653985;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;-4%;41.66275787;0.001874306;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;-2%;41.66275787;0.002251556;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;+2%;41.66275787;0.003494174;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;+4%;41.66275787;0.004240633;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;+6%;41.66048813;0.00501873;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;0%;12.48863316;0.005200097;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;+/-2%;12.48870945;0.005230729;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;+/-4%;12.48709679;0.005362137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;+/-6%;12.48793888;0.005608299;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;-6%;12.48871803;0.004049799;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;-4%;12.48871803;0.004338864;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;-2%;12.48871803;0.004721954;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;+2%;12.48870087;0.005739508;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;+4%;12.48547554;0.00638541;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;+6%;12.48715973;0.0071668;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;0%;5.839771271;0.008105308;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;+/-2%;5.838320255;0.008073921;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;+/-4%;5.839328766;0.008220837;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;+/-6%;5.839369297;0.008438217;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;-6%;5.839882851;0.006940253;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;-4%;5.83987093;0.007313492;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;-2%;5.839808464;0.007631677;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;+2%;5.836833;0.008516167;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;+4%;5.838788986;0.009128183;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;+6%;5.838853836;0.009936186;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;0%;79.04334259;2.19146E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04331207;2.27917E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04321289;2.57346E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.04324341;2.91931E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;-6%;79.04334259;1.18208E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;-4%;79.04334259;1.3315E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;-2%;79.04334259;1.62238E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;+2%;79.04328156;2.93597E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;+4%;79.04309082;3.81542E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;+6%;79.04311371;4.65655E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;0%;15.47643852;4.12925E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;+/-2%;15.4724884;4.20585E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;+/-4%;15.46883678;4.32853E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45297337;4.59889E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;-6%;15.48051739;2.96761E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;-4%;15.48048592;3.26535E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;-2%;15.47820568;3.65621E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;+2%;15.46677399;4.75549E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;+4%;15.45718384;5.39171E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;+6%;15.42543221;6.23017E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;0%;6.128380299;7.27485E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1273489;7.26571E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124416351;7.31714E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.124890327;7.44144E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;-6%;6.125377178;6.21247E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;-4%;6.128029346;6.4994E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;-2%;6.127646923;6.79847E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;+2%;6.127052784;7.73294E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;+4%;6.120803833;8.13489E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;+6%;6.124405384;8.67041E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;0%;41.66275787;2.83881E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;+/-2%;41.66275787;2.87647E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;+/-4%;41.66275787;3.00655E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;+/-6%;41.66162491;3.17861E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;-6%;41.66275787;1.88869E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;-4%;41.66275787;2.09156E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;-2%;41.66275787;2.37107E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;+2%;41.66275787;3.38187E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;+4%;41.66275787;3.92153E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;+6%;41.66048813;4.46853E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;0%;12.48863316;4.73836E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;+/-2%;12.48870945;4.76262E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;+/-4%;12.48709679;4.83945E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;+/-6%;12.48793888;4.99815E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;-6%;12.48871803;3.87942E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;-4%;12.48871803;4.10288E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;-2%;12.48871803;4.39321E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;+2%;12.48870087;5.13204E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;+4%;12.48547554;5.57603E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;+6%;12.48715973;6.11687E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;0%;5.839771271;6.86545E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;+/-2%;5.838320255;6.80217E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;+/-4%;5.839328766;6.86981E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;+/-6%;5.839369297;6.99575E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;-6%;5.839882851;5.9735E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;-4%;5.83987093;6.20143E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;-2%;5.839808464;6.44709E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;+2%;5.836833;7.15725E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;+4%;5.838788986;7.5382E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;+6%;5.838853836;8.018E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;0%;79.04334259;126.1807938;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04331207;127.8451691;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04321289;131.9027405;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;+/-6%;79.04324341;147.3922272;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;-6%;79.04334259;6.821579456;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;-4%;79.04334259;29.79043388;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;-2%;79.04334259;75.7506485;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;+2%;79.04328156;179.9396973;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;+4%;79.04309082;234.0150146;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;+6%;79.04311371;287.9628906;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;0%;15.47643852;246.9307404;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;+/-2%;15.4724884;249.9079742;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;+/-4%;15.46883678;255.6811981;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;+/-6%;15.45297337;267.4471741;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;-6%;15.48051739;137.6791992;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;-4%;15.48048592;167.9529419;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;-2%;15.47820568;205.9490814;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;+2%;15.46677399;293.8668518;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;+4%;15.45718384;343.4093628;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;+6%;15.42543221;397.2150574;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;0%;6.128380299;423.6157837;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1273489;427.7537842;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124416351;434.5220032;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;+/-6%;6.124890327;443.6333618;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;-6%;6.125377178;309.7861023;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;-4%;6.128029346;343.3486938;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;-2%;6.127646923;381.4589539;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;+2%;6.127052784;474.0484314;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;+4%;6.120803833;525.6951294;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;+6%;6.124405384;577.4806519;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;0%;41.66275787;146.3571472;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;+/-2%;41.66275787;146.8895111;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;+/-4%;41.66275787;152.3243713;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;+/-6%;41.66162491;166.5646515;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;-6%;41.66275787;33.87506866;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;-4%;41.66275787;57.57506943;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;-2%;41.66275787;97.89755249;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;+2%;41.66275787;195.8814392;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;+4%;41.66275787;247.0735626;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;+6%;41.66048813;299.254303;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;0%;12.48863316;263.9105225;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;+/-2%;12.48870945;265.2076111;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;+/-4%;12.48709679;270.5618896;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;+/-6%;12.48793888;280.2255859;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;-6%;12.48871803;152.4709473;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;-4%;12.48871803;183.77565;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;-2%;12.48871803;221.6164856;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;+2%;12.48870087;308.798584;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;+4%;12.48547554;357.348053;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;+6%;12.48715973;407.9802551;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;0%;5.839771271;428.1163025;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;+/-2%;5.838320255;430.4833374;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;+/-4%;5.839328766;435.306366;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;+/-6%;5.839369297;444.5160828;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;-6%;5.839882851;304.0184937;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;-4%;5.83987093;342.1191711;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;-2%;5.839808464;383.2513428;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;+2%;5.836833;477.7153625;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;+4%;5.838788986;528.4935303;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;+6%;5.838853836;585.0136108;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;0%;79.04334259;134.471817;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04331207;136.2454834;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04321289;140.5734558;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;+/-6%;79.04324341;157.0885468;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;-6%;79.04334259;7.268063068;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;-4%;79.04334259;31.7389698;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;-2%;79.04334259;80.71927643;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;+2%;79.04328156;191.7717133;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;+4%;79.04309082;249.4079132;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;+6%;79.04311371;306.9089661;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;0%;15.47643852;263.1363525;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;+/-2%;15.4724884;266.3093872;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;+/-4%;15.46883678;272.464386;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;+/-6%;15.45297337;285.0050049;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;-6%;15.48051739;146.701355;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;-4%;15.48048592;178.9644775;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;-2%;15.47820568;219.4582367;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;+2%;15.46677399;313.1605835;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;+4%;15.45718384;365.9641724;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;+6%;15.42543221;423.3087769;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;0%;6.128380299;451.3781738;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1273489;455.7890015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124416351;463.0028076;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;+/-6%;6.124890327;472.7178345;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;-6%;6.125377178;330.0704956;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;-4%;6.128029346;365.836792;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;-2%;6.127646923;406.4508362;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;+2%;6.127052784;505.1270447;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;+4%;6.120803833;560.1687622;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;+6%;6.124405384;615.3652344;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;0%;41.66275787;155.973587;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;+/-2%;41.66275787;156.5430298;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;+/-4%;41.66275787;162.3402863;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;+/-6%;41.66162491;177.5209961;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;-6%;41.66275787;36.09796143;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;-4%;41.66275787;61.35552979;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;-2%;41.66275787;104.3262177;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;+2%;41.66275787;208.759903;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;+4%;41.66275787;263.3250427;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;+6%;41.66048813;318.9441223;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;0%;12.48863316;281.2261963;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;+/-2%;12.48870945;282.610321;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;+/-4%;12.48709679;288.3186646;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;+/-6%;12.48793888;298.619873;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;-6%;12.48871803;162.4586639;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;-4%;12.48871803;195.8216858;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;-2%;12.48871803;236.1512299;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;+2%;12.48870087;329.0695801;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;+4%;12.48547554;380.8156738;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;+6%;12.48715973;434.7810974;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;0%;5.839771271;456.1771851;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;+/-2%;5.838320255;458.7007141;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;+/-4%;5.839328766;463.8436584;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;+/-6%;5.839369297;473.6596985;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;-6%;5.839882851;323.9248047;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;-4%;5.83987093;364.5284424;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;-2%;5.839808464;408.363739;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;+2%;5.836833;509.0377197;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;+4%;5.838788986;563.1589966;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;+6%;5.838853836;623.3947144;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;0%;79.04334259;0.072544985;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04331207;0.081857271;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04321289;0.112278953;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.04324341;0.155373901;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;-6%;79.04334259;0.022670835;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;-4%;79.04334259;0.028412413;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;-2%;79.04334259;0.044961926;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;+2%;79.04328156;0.118752606;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;+4%;79.04309082;0.19614549;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;+6%;79.04311371;0.288076997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;0%;15.47643852;0.180003434;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;+/-2%;15.4724884;0.184747979;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;+/-4%;15.46883678;0.199802339;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45297337;0.226858199;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;-6%;15.48051739;0.101972468;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;-4%;15.48048592;0.118762776;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;-2%;15.47820568;0.145811632;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;+2%;15.46677399;0.223684266;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;+4%;15.45718384;0.280841827;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;+6%;15.42543221;0.351743907;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;0%;6.128380299;0.287501514;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1273489;0.288062423;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124416351;0.294332653;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.124890327;0.305807829;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;-6%;6.125377178;0.218704328;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;-4%;6.128029346;0.235835671;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;-2%;6.127646923;0.255620718;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;+2%;6.127052784;0.320504159;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;+4%;6.120803833;0.352829665;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;+6%;6.124405384;0.392911404;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;0%;41.66275787;0.093356177;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;+/-2%;41.66275787;0.096793145;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;+/-4%;41.66275787;0.11083208;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;+/-6%;41.66162491;0.133666515;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;-6%;41.66275787;0.045259647;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;-4%;41.66275787;0.053514209;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;-2%;41.66275787;0.068582103;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;+2%;41.66275787;0.125004187;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;+4%;41.66275787;0.168149963;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;+6%;41.66048813;0.222073346;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;0%;12.48863316;0.17424117;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;+/-2%;12.48870945;0.177090198;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;+/-4%;12.48709679;0.186029077;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;+/-6%;12.48793888;0.20062466;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;-6%;12.48871803;0.119463809;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;-4%;12.48871803;0.131529212;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;-2%;12.48871803;0.150255844;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;+2%;12.48870087;0.203924537;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;+4%;12.48547554;0.240529045;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;+6%;12.48715973;0.281785637;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;0%;5.839771271;0.253808528;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;+/-2%;5.838320255;0.253070116;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;+/-4%;5.839328766;0.258911848;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;+/-6%;5.839369297;0.268357664;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;-6%;5.839882851;0.205472976;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;-4%;5.83987093;0.217649326;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;-2%;5.839808464;0.231418833;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;+2%;5.836833;0.274721384;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;+4%;5.838788986;0.300174475;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;+6%;5.838853836;0.331242234;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;0%;79.04334259;0.003628947;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04331207;0.004035513;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04321289;0.005277974;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.04324341;0.006855291;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;-6%;79.04334259;0.001588107;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;-4%;79.04334259;0.001763246;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;-2%;79.04334259;0.002334316;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;+2%;79.04328156;0.005736711;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;+4%;79.04309082;0.008792705;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;+6%;79.04311371;0.012122475;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;0%;15.47643852;0.009496894;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;+/-2%;15.4724884;0.009619053;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;+/-4%;15.46883678;0.010125743;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45297337;0.010986142;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;-6%;15.48051739;0.005879446;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;-4%;15.48048592;0.006714098;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;-2%;15.47820568;0.007948159;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;+2%;15.46677399;0.011289949;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;+4%;15.45718384;0.013537391;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;+6%;15.42543221;0.016092829;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;0%;6.128380299;0.015090682;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1273489;0.01504936;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124416351;0.015300735;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.124890327;0.015778685;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;-6%;6.125377178;0.011799105;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;-4%;6.128029346;0.012651425;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;-2%;6.127646923;0.013588662;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;+2%;6.127052784;0.016510058;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;+4%;6.120803833;0.017950052;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;+6%;6.124405384;0.019758273;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;0%;41.66275787;0.005049523;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;+/-2%;41.66275787;0.005292743;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;+/-4%;41.66275787;0.006026095;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;+/-6%;41.66162491;0.007033586;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;-6%;41.66275787;0.002916233;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;-4%;41.66275787;0.003300504;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;-2%;41.66275787;0.003875504;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;+2%;41.66275787;0.006709983;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;+4%;41.66275787;0.008751687;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;+6%;41.66048813;0.011150938;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;0%;12.48863316;0.009582363;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;+/-2%;12.48870945;0.009701175;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;+/-4%;12.48709679;0.01008235;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;+/-6%;12.48793888;0.01076326;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;-6%;12.48871803;0.00682473;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;-4%;12.48871803;0.007481182;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;-2%;12.48871803;0.008419458;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;+2%;12.48870087;0.010982893;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;+4%;12.48547554;0.012683522;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;+6%;12.48715973;0.01470179;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;0%;5.839771271;0.013339235;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;+/-2%;5.838320255;0.013384132;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;+/-4%;5.839328766;0.013721064;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;+/-6%;5.839369297;0.014311767;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;-6%;5.839882851;0.011249896;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;-4%;5.83987093;0.011835089;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;-2%;5.839808464;0.012433498;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;+2%;5.836833;0.014334762;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;+4%;5.838788986;0.015607039;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;+6%;5.838853836;0.017373646;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;0%;79.04334259;0.003842121;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04331207;0.004212162;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04321289;0.005593436;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.04324341;0.007883319;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;-6%;79.04334259;0.001939681;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;-4%;79.04334259;0.00214059;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;-2%;79.04334259;0.002690811;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;+2%;79.04328156;0.005733512;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;+4%;79.04309082;0.009046281;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;+6%;79.04311371;0.013826955;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;0%;15.47643852;0.012894871;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;+/-2%;15.4724884;0.013159747;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;+/-4%;15.46883678;0.014019214;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45297337;0.015243417;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;-6%;15.48051739;0.008917577;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;-4%;15.48048592;0.00990077;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;-2%;15.47820568;0.011229453;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;+2%;15.46677399;0.015090051;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;+4%;15.45718384;0.018137658;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;+6%;15.42543221;0.021569259;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;0%;6.128380299;0.024669182;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1273489;0.024856979;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124416351;0.02514074;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.124890327;0.025636181;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;-6%;6.125377178;0.021099258;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;-4%;6.128029346;0.021993961;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;-2%;6.127646923;0.02313029;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;+2%;6.127052784;0.026583655;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;+4%;6.120803833;0.028287508;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;+6%;6.124405384;0.030173106;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;0%;41.66275787;0.00542044;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;+/-2%;41.66275787;0.005556755;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;+/-4%;41.66275787;0.006166344;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;+/-6%;41.66162491;0.007135328;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;-6%;41.66275787;0.003368414;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;-4%;41.66275787;0.003747821;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;-2%;41.66275787;0.004358865;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;+2%;41.66275787;0.006754648;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;+4%;41.66275787;0.008584869;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;+6%;41.66048813;0.010902241;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;0%;12.48863316;0.01305672;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;+/-2%;12.48870945;0.013147171;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;+/-4%;12.48709679;0.013613612;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;+/-6%;12.48793888;0.014269844;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;-6%;12.48871803;0.010418648;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;-4%;12.48871803;0.011095983;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;-2%;12.48871803;0.01192577;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;+2%;12.48870087;0.014368568;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;+4%;12.48547554;0.016131248;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;+6%;12.48715973;0.018121041;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;0%;5.839771271;0.022579009;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;+/-2%;5.838320255;0.022722386;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;+/-4%;5.839328766;0.02315037;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;+/-6%;5.839369297;0.023649221;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;-6%;5.839882851;0.020374656;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;-4%;5.83987093;0.021027766;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;-2%;5.839808464;0.02174519;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;+2%;5.836833;0.02369957;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;+4%;5.838788986;0.025272969;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;+6%;5.838853836;0.026923779;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;0%;79.04334259;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04331207;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04321289;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.04324341;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;-6%;79.04334259;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;-4%;79.04334259;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;-2%;79.04334259;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;+2%;79.04328156;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;+4%;79.04309082;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;+6%;79.04311371;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;0%;15.47643852;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;+/-2%;15.4724884;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;+/-4%;15.46883678;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45297337;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;-6%;15.48051739;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;-4%;15.48048592;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;-2%;15.47820568;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;+2%;15.46677399;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;+4%;15.45718384;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;+6%;15.42543221;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;0%;6.128380299;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1273489;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124416351;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.124890327;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;-6%;6.125377178;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;-4%;6.128029346;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;-2%;6.127646923;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;+2%;6.127052784;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;+4%;6.120803833;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;+6%;6.124405384;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;0%;41.66275787;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;+/-2%;41.66275787;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;+/-4%;41.66275787;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;+/-6%;41.66162491;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;-6%;41.66275787;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;-4%;41.66275787;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;-2%;41.66275787;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;+2%;41.66275787;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;+4%;41.66275787;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;+6%;41.66048813;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;0%;12.48863316;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;+/-2%;12.48870945;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;+/-4%;12.48709679;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;+/-6%;12.48793888;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;-6%;12.48871803;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;-4%;12.48871803;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;-2%;12.48871803;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;+2%;12.48870087;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;+4%;12.48547554;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;+6%;12.48715973;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;0%;5.839771271;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;+/-2%;5.838320255;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;+/-4%;5.839328766;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;+/-6%;5.839369297;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;-6%;5.839882851;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;-4%;5.83987093;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;-2%;5.839808464;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;+2%;5.836833;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;+4%;5.838788986;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;+6%;5.838853836;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;0%;79.04334259;0.000653764;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04331207;0.000662442;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04321289;0.000684396;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.04324341;0.000766477;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;-6%;79.04334259;3.49898E-05;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;-4%;79.04334259;0.000152323;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;-2%;79.04334259;0.000390336;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;+2%;79.04328156;0.000934549;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;+4%;79.04309082;0.001216469;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;+6%;79.04311371;0.001497965;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;0%;15.47643852;0.001276621;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;+/-2%;15.4724884;0.001292124;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;+/-4%;15.46883678;0.001322589;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45297337;0.001384152;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;-6%;15.48051739;0.000709326;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;-4%;15.48048592;0.000866185;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;-2%;15.47820568;0.001063396;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;+2%;15.46677399;0.001520851;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;+4%;15.45718384;0.001778992;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;+6%;15.42543221;0.002058978;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;0%;6.128380299;0.002182997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1273489;0.002204554;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124416351;0.002240134;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.124890327;0.002288448;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;-6%;6.125377178;0.001593504;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;-4%;6.128029346;0.001767079;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;-2%;6.127646923;0.001964325;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;+2%;6.127052784;0.002444782;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;+4%;6.120803833;0.002713189;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;+6%;6.124405384;0.002983394;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;0%;41.66275787;0.000757755;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;+/-2%;41.66275787;0.000761072;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;+/-4%;41.66275787;0.00079058;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;+/-6%;41.66162491;0.000865476;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;-6%;41.66275787;0.000174699;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;-4%;41.66275787;0.000297477;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;-2%;41.66275787;0.000505926;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;+2%;41.66275787;0.001016218;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;+4%;41.66275787;0.001283684;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;+6%;41.66048813;0.001556253;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;0%;12.48863316;0.001363682;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;+/-2%;12.48870945;0.001370746;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;+/-4%;12.48709679;0.001398999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;+/-6%;12.48793888;0.001449734;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;-6%;12.48871803;0.000784935;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;-4%;12.48871803;0.000947409;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;-2%;12.48871803;0.001143958;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;+2%;12.48870087;0.001597535;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;+4%;12.48547554;0.00185059;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;+6%;12.48715973;0.002114533;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;0%;5.839771271;0.00220478;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;+/-2%;5.838320255;0.002217368;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;+/-4%;5.839328766;0.00224313;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;+/-6%;5.839369297;0.002291444;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;-6%;5.839882851;0.001561951;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;-4%;5.83987093;0.001759177;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;-2%;5.839808464;0.001972206;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;+2%;5.836833;0.00246253;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;+4%;5.838788986;0.002727085;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;+6%;5.838853836;0.003020936;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;0%;78.50055695;0.00272062;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;+/-2%;78.50054169;0.00272062;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;+/-4%;78.50050354;0.00272062;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;+/-6%;78.5005188;0.00272062;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;-6%;78.50055695;0.00272062;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;-4%;78.50055695;0.00272062;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;-2%;78.50055695;0.00272062;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;+2%;78.50053406;0.00272062;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;+4%;78.50045776;0.00272062;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;+6%;78.50046539;0.00272062;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;0%;15.37024593;0.007770275;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;+/-2%;15.3662529;0.007770275;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;+/-4%;15.3626585;0.007770275;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;+/-6%;15.34680939;0.007770275;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;-6%;15.37421322;0.007770275;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;-4%;15.37418175;0.007770275;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;-2%;15.371912;0.007770275;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;+2%;15.36059475;0.007770275;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;+4%;15.35113239;0.007770275;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;+6%;15.31940842;0.007770275;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;0%;6.086312294;0.007770275;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.085287571;0.007770275;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.082342148;0.007770275;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.082809448;0.007770275;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;-6%;6.083298206;0.007770275;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;-4%;6.08595562;0.007770275;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;-2%;6.085594654;0.007770275;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;+2%;6.084982395;0.007770275;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;+4%;6.078728676;0.007770275;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;+6%;6.082324028;0.007770275;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;0%;41.34796906;0.004822957;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;+/-2%;41.34796906;0.004822957;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;+/-4%;41.34796906;0.004822957;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;+/-6%;41.34701538;0.004822957;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;-6%;41.34796906;0.004822957;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;-4%;41.34796906;0.004822957;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;-2%;41.34796906;0.004822957;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;+2%;41.34796906;0.004822957;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;+4%;41.34796906;0.004822957;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;+6%;41.34605789;0.004822957;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;0%;12.39430141;0.007768795;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;+/-2%;12.3943491;0.007768795;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;+/-4%;12.3927393;0.007768795;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;+/-6%;12.39365864;0.007768795;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;-6%;12.39435673;0.007768795;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;-4%;12.39435673;0.007768795;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;-2%;12.39435673;0.007768795;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;+2%;12.39434052;0.007768795;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;+4%;12.39112091;0.007768795;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;+6%;12.3929615;0.007768795;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;0%;5.79566431;0.007768795;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;+/-2%;5.794224262;0.007768795;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;+/-4%;5.795262814;0.007768795;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;+/-6%;5.795278549;0.007768795;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;-6%;5.795759201;0.007768795;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;-4%;5.795755863;0.007768795;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;-2%;5.795699596;0.007768795;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;+2%;5.792750359;0.007768795;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;+4%;5.794772625;0.007768795;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;+6%;5.794796467;0.007768795;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;0%;78.50055695;0.023063309;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;+/-2%;78.50054169;0.023063309;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;+/-4%;78.50050354;0.023063309;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;+/-6%;78.5005188;0.023063309;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;-6%;78.50055695;0.023063309;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;-4%;78.50055695;0.023063309;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;-2%;78.50055695;0.023063309;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;+2%;78.50053406;0.023063309;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;+4%;78.50045776;0.023063309;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;+6%;78.50046539;0.023063309;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;0%;15.37024593;0.01078383;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;+/-2%;15.3662529;0.01078383;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;+/-4%;15.3626585;0.01078383;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;+/-6%;15.34680939;0.01078383;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;-6%;15.37421322;0.01078383;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;-4%;15.37418175;0.01078383;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;-2%;15.371912;0.01078383;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;+2%;15.36059475;0.01078383;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;+4%;15.35113239;0.01078383;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;+6%;15.31940842;0.01078383;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;0%;6.086312294;0.01078383;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.085287571;0.01078383;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.082342148;0.01078383;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.082809448;0.01078383;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;-6%;6.083298206;0.01078383;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;-4%;6.08595562;0.01078383;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;-2%;6.085594654;0.01078383;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;+2%;6.084982395;0.01078383;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;+4%;6.078728676;0.01078383;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;+6%;6.082324028;0.01078383;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;0%;41.34796906;0.014256096;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;+/-2%;41.34796906;0.014256096;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;+/-4%;41.34796906;0.014256096;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;+/-6%;41.34701538;0.014256096;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;-6%;41.34796906;0.014256096;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;-4%;41.34796906;0.014256096;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;-2%;41.34796906;0.014256096;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;+2%;41.34796906;0.014256096;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;+4%;41.34796906;0.014256096;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;+6%;41.34605789;0.014256096;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;0%;12.39430141;0.01076703;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;+/-2%;12.3943491;0.01076703;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;+/-4%;12.3927393;0.01076703;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;+/-6%;12.39365864;0.01076703;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;-6%;12.39435673;0.01076703;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;-4%;12.39435673;0.01076703;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;-2%;12.39435673;0.01076703;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;+2%;12.39434052;0.01076703;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;+4%;12.39112091;0.01076703;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;+6%;12.3929615;0.01076703;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;0%;5.79566431;0.01076703;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;+/-2%;5.794224262;0.01076703;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;+/-4%;5.795262814;0.01076703;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;+/-6%;5.795278549;0.01076703;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;-6%;5.795759201;0.01076703;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;-4%;5.795755863;0.01076703;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;-2%;5.795699596;0.01076703;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;+2%;5.792750359;0.01076703;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;+4%;5.794772625;0.01076703;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;+6%;5.794796467;0.01076703;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;0%;79.04334259;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04331207;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04321289;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-6%;79.04324341;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-6%;79.04334259;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-4%;79.04334259;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-2%;79.04334259;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+2%;79.04328156;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+4%;79.04309082;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+6%;79.04311371;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;0%;15.47643852;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-2%;15.4724884;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-4%;15.46883678;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-6%;15.45297337;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;-6%;15.48051739;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;-4%;15.48048592;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;-2%;15.47820568;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;+2%;15.46677399;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;+4%;15.45718384;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;+6%;15.42543221;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;0%;6.128380299;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1273489;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124416351;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-6%;6.124890327;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-6%;6.125377178;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-4%;6.128029346;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-2%;6.127646923;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+2%;6.127052784;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+4%;6.120803833;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+6%;6.124405384;0.029999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;0%;41.66275787;0.025999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;+/-2%;41.66275787;0.025999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;+/-4%;41.66275787;0.025999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;+/-6%;41.66162491;0.025999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;-6%;41.66275787;0.025999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;-4%;41.66275787;0.025999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;-2%;41.66275787;0.025999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;+2%;41.66275787;0.025999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;+4%;41.66275787;0.025999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;+6%;41.66048813;0.025999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;0%;12.48863316;0.044999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;+/-2%;12.48870945;0.044999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;+/-4%;12.48709679;0.044999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;+/-6%;12.48793888;0.044999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;-6%;12.48871803;0.044999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;-4%;12.48871803;0.044999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;-2%;12.48871803;0.044999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;+2%;12.48870087;0.044999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;+4%;12.48547554;0.044999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;+6%;12.48715973;0.044999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;0%;5.839771271;0.044999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;+/-2%;5.838320255;0.044999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;+/-4%;5.839328766;0.044999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;+/-6%;5.839369297;0.044999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;-6%;5.839882851;0.044999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;-4%;5.83987093;0.044999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;-2%;5.839808464;0.044999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;+2%;5.836833;0.044999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;+4%;5.838788986;0.044999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;+6%;5.838853836;0.044999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;0%;79.04334259;0.00022951;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04331207;0.000271268;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04321289;0.000407174;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.04324341;0.000633621;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;-6%;79.04334259;7.10892E-05;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;-4%;79.04334259;8.40852E-05;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;-2%;79.04334259;0.000129188;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;+2%;79.04328156;0.000413347;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;+4%;79.04309082;0.000730263;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;+6%;79.04311371;0.001196152;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;0%;15.47643852;0.000995737;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;+/-2%;15.4724884;0.00102337;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;+/-4%;15.46883678;0.001089178;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45297337;0.001168645;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;-6%;15.48051739;0.000649925;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;-4%;15.48048592;0.00074482;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;-2%;15.47820568;0.00086702;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;+2%;15.46677399;0.00117972;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;+4%;15.45718384;0.001433535;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;+6%;15.42543221;0.001687366;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;0%;6.128380299;0.001926883;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1273489;0.001963843;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124416351;0.001974099;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.124890327;0.002020499;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;-6%;6.125377178;0.001644756;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;-4%;6.128029346;0.001728742;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;-2%;6.127646923;0.00183485;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;+2%;6.127052784;0.002092836;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;+4%;6.120803833;0.002219456;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;+6%;6.124405384;0.002396242;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;0%;41.66275787;0.000317855;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;+/-2%;41.66275787;0.000331212;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;+/-4%;41.66275787;0.000388377;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;+/-6%;41.66162491;0.00048791;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;-6%;41.66275787;0.000148134;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;-4%;41.66275787;0.000177956;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;-2%;41.66275787;0.000231713;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;+2%;41.66275787;0.000430711;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;+4%;41.66275787;0.000598797;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;+6%;41.66048813;0.000827686;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;0%;12.48863316;0.000944885;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;+/-2%;12.48870945;0.000954845;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;+/-4%;12.48709679;0.001006913;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;+/-6%;12.48793888;0.001074454;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;-6%;12.48871803;0.000713554;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;-4%;12.48871803;0.000775291;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;-2%;12.48871803;0.000845196;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;+2%;12.48870087;0.001064493;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;+4%;12.48547554;0.001238536;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;+6%;12.48715973;0.001435354;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;0%;5.839771271;0.001725703;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;+/-2%;5.838320255;0.001751521;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;+/-4%;5.839328766;0.00180424;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;+/-6%;5.839369297;0.001835312;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;-6%;5.839882851;0.001554483;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;-4%;5.83987093;0.001609867;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;-2%;5.839808464;0.001670981;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;+2%;5.836833;0.001832061;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;+4%;5.838788986;0.001998613;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;+6%;5.838853836;0.002116142;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;0%;79.04334259;0.002212082;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04331207;0.002355713;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04321289;0.002784067;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.04324341;0.003445194;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;-6%;79.04334259;0.000971403;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;-4%;79.04334259;0.0011216;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;-2%;79.04334259;0.001534945;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;+2%;79.04328156;0.00317648;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;+4%;79.04309082;0.004446534;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;+6%;79.04311371;0.005918987;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;0%;15.47643852;0.004919721;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;+/-2%;15.4724884;0.005070788;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;+/-4%;15.46883678;0.005369526;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45297337;0.006129978;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;-6%;15.48051739;0.003257784;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;-4%;15.48048592;0.003629417;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;-2%;15.47820568;0.004198469;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;+2%;15.46677399;0.005943111;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;+4%;15.45718384;0.007109633;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;+6%;15.42543221;0.009002172;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;0%;6.128380299;0.008970035;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1273489;0.008958289;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124416351;0.009224014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.124890327;0.009481507;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;-6%;6.125377178;0.007347886;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;-4%;6.128029346;0.007772332;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;-2%;6.127646923;0.008224605;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;+2%;6.127052784;0.009691968;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;+4%;6.120803833;0.0106757;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;+6%;6.124405384;0.011615128;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;0%;41.66275787;0.002823106;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;+/-2%;41.66275787;0.002872864;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;+/-4%;41.66275787;0.00305747;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;+/-6%;41.66162491;0.003336358;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;-6%;41.66275787;0.001653985;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;-4%;41.66275787;0.001874306;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;-2%;41.66275787;0.002251556;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;+2%;41.66275787;0.003494174;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;+4%;41.66275787;0.004240633;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;+6%;41.66048813;0.00501873;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;0%;12.48863316;0.005200097;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;+/-2%;12.48870945;0.005230729;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;+/-4%;12.48709679;0.005362137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;+/-6%;12.48793888;0.005608299;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;-6%;12.48871803;0.004049799;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;-4%;12.48871803;0.004338864;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;-2%;12.48871803;0.004721954;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;+2%;12.48870087;0.005739508;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;+4%;12.48547554;0.00638541;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;+6%;12.48715973;0.0071668;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;0%;5.839771271;0.008105308;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;+/-2%;5.838320255;0.008073921;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;+/-4%;5.839328766;0.008220837;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;+/-6%;5.839369297;0.008438217;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;-6%;5.839882851;0.006940253;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;-4%;5.83987093;0.007313492;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;-2%;5.839808464;0.007631677;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;+2%;5.836833;0.008516167;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;+4%;5.838788986;0.009128183;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;+6%;5.838853836;0.009936186;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;0%;79.04334259;0.001314051;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04331207;0.001374817;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04321289;0.001562056;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;+/-6%;79.04324341;0.001830154;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;-6%;79.04334259;0.000496425;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;-4%;79.04334259;0.000596663;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;-2%;79.04334259;0.000883124;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;+2%;79.04328156;0.001866511;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;+4%;79.04309082;0.00252745;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;+6%;79.04311371;0.003163884;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;0%;15.47643852;0.002646777;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;+/-2%;15.4724884;0.002699409;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;+/-4%;15.46883678;0.002788891;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;+/-6%;15.45297337;0.003040042;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;-6%;15.48051739;0.001764787;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;-4%;15.48048592;0.00197988;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;-2%;15.47820568;0.002284013;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;+2%;15.46677399;0.003114804;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;+4%;15.45718384;0.003597904;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;+6%;15.42543221;0.004315298;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;0%;6.128380299;0.004758554;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1273489;0.004758417;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124416351;0.004840542;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;+/-6%;6.124890327;0.004927353;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;-6%;6.125377178;0.00390158;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;-4%;6.128029346;0.004166837;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;-2%;6.127646923;0.004422491;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;+2%;6.127052784;0.005094343;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;+4%;6.120803833;0.005514243;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;+6%;6.124405384;0.005953125;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;0%;41.66275787;0.001651847;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;+/-2%;41.66275787;0.001681663;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;+/-4%;41.66275787;0.001763724;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;+/-6%;41.66162491;0.001899661;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;-6%;41.66275787;0.000868419;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;-4%;41.66275787;0.00101601;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;-2%;41.66275787;0.001282364;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;+2%;41.66275787;0.002080961;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;+4%;41.66275787;0.002511439;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;+6%;41.66048813;0.002930905;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;0%;12.48863316;0.002941421;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;+/-2%;12.48870945;0.002962179;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;+/-4%;12.48709679;0.003029755;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;+/-6%;12.48793888;0.00314678;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;-6%;12.48871803;0.002204194;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;-4%;12.48871803;0.002396773;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;-2%;12.48871803;0.002646699;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;+2%;12.48870087;0.003277659;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;+4%;12.48547554;0.003662737;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;+6%;12.48715973;0.004089365;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;0%;5.839771271;0.004474191;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;+/-2%;5.838320255;0.004445123;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;+/-4%;5.839328766;0.004522225;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;+/-6%;5.839369297;0.004588198;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;-6%;5.839882851;0.003710487;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;-4%;5.83987093;0.003954934;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;-2%;5.839808464;0.004160217;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;+2%;5.836833;0.004730032;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;+4%;5.838788986;0.005089519;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;+6%;5.838853836;0.005465907;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;0%;79.04334259;0.010000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04331207;0.010000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04321289;0.010000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-6%;79.04324341;0.010000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-6%;79.04334259;0.010000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-4%;79.04334259;0.010000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-2%;79.04334259;0.010000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+2%;79.04328156;0.010000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+4%;79.04309082;0.010000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+6%;79.04311371;0.010000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;0%;15.47643852;0.014999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-2%;15.4724884;0.014999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-4%;15.46883678;0.014999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-6%;15.45297337;0.014999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;-6%;15.48051739;0.014999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;-4%;15.48048592;0.014999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;-2%;15.47820568;0.014999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;+2%;15.46677399;0.014999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;+4%;15.45718384;0.014999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;+6%;15.42543221;0.014999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;0%;6.128380299;0.014999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1273489;0.014999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124416351;0.014999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-6%;6.124890327;0.014999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-6%;6.125377178;0.014999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-4%;6.128029346;0.014999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-2%;6.127646923;0.014999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+2%;6.127052784;0.014999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+4%;6.120803833;0.014999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+6%;6.124405384;0.014999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;0%;41.66275787;0.014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;+/-2%;41.66275787;0.014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;+/-4%;41.66275787;0.014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;+/-6%;41.66162491;0.014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;-6%;41.66275787;0.014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;-4%;41.66275787;0.014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;-2%;41.66275787;0.014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;+2%;41.66275787;0.014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;+4%;41.66275787;0.014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;+6%;41.66048813;0.014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;0%;12.48863316;0.015000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;+/-2%;12.48870945;0.015000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;+/-4%;12.48709679;0.015000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;+/-6%;12.48793888;0.015000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;-6%;12.48871803;0.015000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;-4%;12.48871803;0.015000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;-2%;12.48871803;0.015000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;+2%;12.48870087;0.015000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;+4%;12.48547554;0.015000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;+6%;12.48715973;0.015000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;0%;5.839771271;0.015000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;+/-2%;5.838320255;0.015000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;+/-4%;5.839328766;0.015000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;+/-6%;5.839369297;0.015000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;-6%;5.839882851;0.015000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;-4%;5.83987093;0.015000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;-2%;5.839808464;0.015000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;+2%;5.836833;0.015000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;+4%;5.838788986;0.015000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;+6%;5.838853836;0.015000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;0%;79.04334259;0.001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04331207;0.001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04321289;0.001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-6%;79.04324341;0.001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-6%;79.04334259;0.001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-4%;79.04334259;0.001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-2%;79.04334259;0.001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+2%;79.04328156;0.001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+4%;79.04309082;0.001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+6%;79.04311371;0.001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;0%;15.47643852;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-2%;15.4724884;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-4%;15.46883678;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-6%;15.45297337;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;-6%;15.48051739;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;-4%;15.48048592;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;-2%;15.47820568;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;+2%;15.46677399;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;+4%;15.45718384;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;+6%;15.42543221;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;0%;6.128380299;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1273489;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124416351;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-6%;6.124890327;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-6%;6.125377178;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-4%;6.128029346;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-2%;6.127646923;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+2%;6.127052784;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+4%;6.120803833;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+6%;6.124405384;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;0%;41.66275787;0.0014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;+/-2%;41.66275787;0.0014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;+/-4%;41.66275787;0.0014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;+/-6%;41.66162491;0.0014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;-6%;41.66275787;0.0014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;-4%;41.66275787;0.0014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;-2%;41.66275787;0.0014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;+2%;41.66275787;0.0014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;+4%;41.66275787;0.0014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;+6%;41.66048813;0.0014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;0%;12.48863316;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;+/-2%;12.48870945;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;+/-4%;12.48709679;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;+/-6%;12.48793888;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;-6%;12.48871803;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;-4%;12.48871803;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;-2%;12.48871803;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;+2%;12.48870087;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;+4%;12.48547554;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;+6%;12.48715973;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;0%;5.839771271;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;+/-2%;5.838320255;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;+/-4%;5.839328766;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;+/-6%;5.839369297;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;-6%;5.839882851;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;-4%;5.83987093;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;-2%;5.839808464;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;+2%;5.836833;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;+4%;5.838788986;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;+6%;5.838853836;0.0015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;0%;79.04334259;127.0822678;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04331207;128.7567749;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04321289;132.8453979;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.04324341;148.3743439;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;-6%;79.04334259;7.672025204;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;-4%;79.04334259;30.64525604;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;-2%;79.04334259;76.61973572;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;+2%;79.04328156;180.8938751;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;+4%;79.04309082;235.0455627;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;+6%;79.04311371;289.0767212;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;0%;15.47643852;249.4837036;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;+/-2%;15.4724884;252.4640198;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;+/-4%;15.46883678;258.2498779;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45297337;270.0373535;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;-6%;15.48051739;140.1417084;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;-4%;15.48048592;170.4363556;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;-2%;15.47820568;208.4633179;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;+2%;15.46677399;296.4646912;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;+4%;15.45718384;346.0635071;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;+6%;15.42543221;399.9329529;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;0%;6.128380299;426.3085938;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1273489;430.4454651;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124416351;437.2200623;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.124890327;446.3434448;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;-6%;6.125377178;312.3965149;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;-4%;6.128029346;345.9805298;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;-2%;6.127646923;384.1141052;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;+2%;6.127052784;476.7768555;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;+4%;6.120803833;528.4597778;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;+6%;6.124405384;580.2903442;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;0%;41.66275787;147.9206543;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;+/-2%;41.66275787;148.4590607;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;+/-4%;41.66275787;153.9122772;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;+/-6%;41.66162491;168.1777344;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;-6%;41.66275787;35.38520432;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;-4%;41.66275787;59.0948143;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;-2%;41.66275787;99.43170929;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;+2%;41.66275787;197.4864044;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;+4%;41.66275787;248.72966;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;+6%;41.66048813;300.9702148;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;0%;12.48863316;266.4651184;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;+/-2%;12.48870945;267.7652588;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;+/-4%;12.48709679;273.1289673;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;+/-6%;12.48793888;282.8097534;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;-6%;12.48871803;154.9566345;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;-4%;12.48871803;186.2778625;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;-2%;12.48871803;224.1420898;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;+2%;12.48870087;311.3883057;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;+4%;12.48547554;359.9802551;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;+6%;12.48715973;410.6629639;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;0%;5.839771271;430.7648315;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;+/-2%;5.838320255;433.1331177;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;+/-4%;5.839328766;437.9645081;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;+/-6%;5.839369297;447.1888733;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;-6%;5.839882851;306.6148071;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;-4%;5.83987093;344.7301025;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;-2%;5.839808464;385.8773193;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;+2%;5.836833;480.388916;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;+4%;5.838788986;531.1988525;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];pass. car;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;+6%;5.838853836;587.7630615;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;0%;79.04335022;0.007199587;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04335022;0.00695121;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04286957;0.00780956;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.03543091;0.011176444;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;-6%;79.04335022;0.002782972;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;-4%;79.04335022;0.003504114;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;-2%;79.04335022;0.005096347;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;+2%;79.04335022;0.008806077;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;+4%;79.04238129;0.012115015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;+6%;79.02753448;0.019569915;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;0%;15.47837925;0.016313499;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;+/-2%;15.46831226;0.016523601;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;+/-4%;15.47038269;0.016585002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45549774;0.017212603;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;-6%;15.48045063;0.011535334;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;-4%;15.47970295;0.012925983;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;-2%;15.47945595;0.014534568;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;+2%;15.45716667;0.018512625;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;+4%;15.46105671;0.020244012;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;+6%;15.43054295;0.022889886;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;0%;6.126023769;0.028860126;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1227355;0.02896888;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124218941;0.0289835;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.126291752;0.029179929;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;-6%;6.127859116;0.024155462;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;-4%;6.126489639;0.025793789;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;-2%;6.125799179;0.027409965;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;+2%;6.119670868;0.030527811;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;+4%;6.12195015;0.032173183;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;+6%;6.124723434;0.034204405;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;0%;41.66257095;0.009070513;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;+/-2%;41.66205597;0.009247571;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;+/-4%;41.66094589;0.009699645;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;+/-6%;41.66074371;0.010745397;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;-6%;41.6627655;0.005092954;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;-4%;41.6627655;0.005816339;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;-2%;41.6627655;0.00722227;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;+2%;41.66133881;0.011272874;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;+4%;41.65912247;0.01358295;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;+6%;41.65872955;0.016397832;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;0%;12.48837757;0.018195948;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;+/-2%;12.48783493;0.018207014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;+/-4%;12.48834038;0.018558173;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;+/-6%;12.48767376;0.019380856;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;-6%;12.48871517;0.013836162;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;-4%;12.48871517;0.014931821;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;-2%;12.48864937;0.016336087;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;+2%;12.48702335;0.020077938;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;+4%;12.48796558;0.022184515;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;+6%;12.48662758;0.024925556;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;0%;5.839619637;0.029286748;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;+/-2%;5.839772701;0.029370476;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;+/-4%;5.839612007;0.029642664;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;+/-6%;5.839401722;0.030037176;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;-6%;5.839708805;0.024965907;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;-4%;5.839848042;0.026152801;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;-2%;5.839827061;0.027547771;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;+2%;5.839718819;0.031193187;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;+4%;5.839376926;0.03313252;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;+6%;5.839095116;0.03510844;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;0%;79.04335022;0.13730517;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04335022;0.116929159;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04286957;0.150516614;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.03543091;0.320650965;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;-6%;79.04335022;0.033332035;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;-4%;79.04335022;0.042848535;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;-2%;79.04335022;0.076264642;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;+2%;79.04335022;0.157593668;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;+4%;79.04238129;0.258184642;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;+6%;79.02753448;0.607969761;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;0%;15.47837925;0.372286856;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;+/-2%;15.46831226;0.365839452;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;+/-4%;15.47038269;0.425975174;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45549774;0.536555111;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;-6%;15.48045063;0.143906921;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;-4%;15.47970295;0.180247188;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;-2%;15.47945595;0.239146322;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;+2%;15.45716667;0.492532581;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;+4%;15.46105671;0.6717031;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;+6%;15.43054295;0.929203391;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;0%;6.126023769;0.494474649;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1227355;0.493171573;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124218941;0.473734021;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.126291752;0.501706898;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;-6%;6.127859116;0.26232034;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;-4%;6.126489639;0.302280486;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;-2%;6.125799179;0.420568734;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;+2%;6.119670868;0.56577456;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;+4%;6.12195015;0.645187676;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;+6%;6.124723434;0.741093099;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;0%;41.66257095;0.147537246;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;+/-2%;41.66205597;0.161122903;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;+/-4%;41.66094589;0.190748155;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;+/-6%;41.66074371;0.232357427;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;-6%;41.6627655;0.062072895;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;-4%;41.6627655;0.080431312;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;-2%;41.6627655;0.10842225;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;+2%;41.66133881;0.213823661;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;+4%;41.65912247;0.301065058;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;+6%;41.65872955;0.402641863;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;0%;12.48837757;0.274742216;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;+/-2%;12.48783493;0.289202183;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;+/-4%;12.48834038;0.290897816;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;+/-6%;12.48767376;0.336687446;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;-6%;12.48871517;0.161028132;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;-4%;12.48871517;0.189022854;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;-2%;12.48864937;0.223600313;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;+2%;12.48702335;0.354803979;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;+4%;12.48796558;0.392772734;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;+6%;12.48662758;0.512346745;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;0%;5.839619637;0.40932411;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;+/-2%;5.839772701;0.41415748;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;+/-4%;5.839612007;0.404391408;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;+/-6%;5.839401722;0.405780882;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;-6%;5.839708805;0.255219996;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;-4%;5.839848042;0.303925425;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;-2%;5.839827061;0.366076738;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;+2%;5.839718819;0.462238222;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;+4%;5.839376926;0.504857361;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;+6%;5.839095116;0.556341887;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;0%;79.04335022;0.628602564;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04335022;0.69813031;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04286957;0.857043505;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.03543091;1.150188804;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;-6%;79.04335022;0.094286248;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;-4%;79.04335022;0.156594098;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;-2%;79.04335022;0.329025;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;+2%;79.04335022;1.067234516;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;+4%;79.04238129;1.557492852;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;+6%;79.02753448;2.206091881;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;0%;15.47837925;1.148685098;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;+/-2%;15.46831226;1.181485057;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;+/-4%;15.47038269;1.27234292;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45549774;1.432487607;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;-6%;15.48045063;0.537477195;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;-4%;15.47970295;0.678551018;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;-2%;15.47945595;0.880891323;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;+2%;15.45716667;1.482078791;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;+4%;15.46105671;1.866135001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;+6%;15.43054295;2.327497482;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;0%;6.126023769;1.419524908;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1227355;1.440610886;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124218941;1.484125137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.126291752;1.542218208;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;-6%;6.127859116;0.939698935;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;-4%;6.126489639;1.082524538;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;-2%;6.125799179;1.236020327;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;+2%;6.119670868;1.645201921;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;+4%;6.12195015;1.885725737;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;+6%;6.124723434;2.144737005;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;0%;41.66257095;0.601670265;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;+/-2%;41.66205597;0.634771228;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;+/-4%;41.66094589;0.733015358;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;+/-6%;41.66074371;0.906392395;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;-6%;41.6627655;0.197463691;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;-4%;41.6627655;0.261344969;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;-2%;41.6627655;0.396492541;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;+2%;41.66133881;0.873049974;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;+4%;41.65912247;1.204685807;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;+6%;41.65872955;1.615320921;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;0%;12.48837757;0.998800278;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;+/-2%;12.48783493;1.017985225;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;+/-4%;12.48834038;1.086898565;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;+/-6%;12.48767376;1.203758955;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;-6%;12.48871517;0.557070792;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;-4%;12.48871517;0.653976738;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;-2%;12.48864937;0.801792622;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;+2%;12.48702335;1.234176755;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;+4%;12.48796558;1.519820333;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;+6%;12.48662758;1.850448132;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;0%;5.839619637;1.254162431;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;+/-2%;5.839772701;1.271355867;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;+/-4%;5.839612007;1.317425609;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;+/-6%;5.839401722;1.393576026;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;-6%;5.839708805;0.876600385;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;-4%;5.839848042;0.95955205;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;-2%;5.839827061;1.074762464;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;+2%;5.839718819;1.467950106;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;+4%;5.839376926;1.675299168;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;+6%;5.839095116;1.910551548;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;0%;79.04335022;61.15639496;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04335022;61.36819839;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04286957;64.01105499;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.03543091;72.87140656;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;-6%;79.04335022;2.97970295;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;-4%;79.04335022;13.5818367;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;-2%;79.04335022;35.60063553;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;+2%;79.04335022;87.13575745;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;+4%;79.04238129;114.4402542;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;+6%;79.02753448;142.7631073;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;0%;15.47837925;98.9093399;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;+/-2%;15.46831226;100.3073959;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;+/-4%;15.47038269;103.8329239;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45549774;110.276413;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;-6%;15.48045063;48.86800766;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;-4%;15.47970295;62.32527161;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;-2%;15.47945595;79.25489807;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;+2%;15.45716667;121.3598862;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;+4%;15.46105671;145.3406677;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;+6%;15.43054295;171.6847839;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;0%;6.126023769;145.7751617;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1227355;147.6549683;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124218941;151.2046814;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.126291752;155.8862457;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;-6%;6.127859116;97.12470245;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;-4%;6.126489639;111.6924744;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;-2%;6.125799179;127.7218704;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;+2%;6.119670868;167.5880737;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;+4%;6.12195015;190.7168732;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;+6%;6.124723434;214.6477966;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;0%;41.66257095;60.14077759;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;+/-2%;41.66205597;61.24600601;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;+/-4%;41.66094589;65.11524963;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;+/-6%;41.66074371;73.2468338;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;-6%;41.6627655;11.6329813;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;-4%;41.6627655;20.71165276;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;-2%;41.6627655;37.84972382;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;+2%;41.66133881;84.64230347;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;+4%;41.65912247;109.5188141;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;+6%;41.65872955;134.8607483;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;0%;12.48837757;98.17988586;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;+/-2%;12.48783493;99.1497879;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;+/-4%;12.48834038;102.5639038;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;+/-6%;12.48767376;108.3943176;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;-6%;12.48871517;49.48101425;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;-4%;12.48871517;62.5348053;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;-2%;12.48864937;78.80818176;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;+2%;12.48702335;119.4913483;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;+4%;12.48796558;142.5929565;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;+6%;12.48662758;167.3076324;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;0%;5.839619637;144.0187073;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;+/-2%;5.839772701;145.5462494;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;+/-4%;5.839612007;149.2095642;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;+/-6%;5.839401722;154.3576965;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;-6%;5.839708805;93.00523376;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;-4%;5.839848042;107.3824768;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;-2%;5.839827061;124.1237564;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;+2%;5.839718819;166.9688873;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;+4%;5.839376926;191.0366669;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;+6%;5.839095116;215.7102203;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;0%;79.04335022;2.604921341;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04335022;2.614087582;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04286957;2.726878166;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.03543091;3.104238749;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;-6%;79.04335022;0.125818282;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;-4%;79.04335022;0.578112245;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;-2%;79.04335022;1.516151309;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;+2%;79.04335022;3.712025881;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;+4%;79.04238129;4.875645161;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;+6%;79.02753448;6.082659245;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;0%;15.47837925;4.211947441;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;+/-2%;15.46831226;4.271486759;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;+/-4%;15.47038269;4.42164135;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45549774;4.69598484;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;-6%;15.48045063;2.078077555;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;-4%;15.47970295;2.65215683;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;-2%;15.47945595;3.374024391;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;+2%;15.45716667;5.168952465;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;+4%;15.46105671;6.191127777;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;+6%;15.43054295;7.313889503;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;0%;6.126023769;6.207334518;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1227355;6.287443161;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124218941;6.438871861;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.126291752;6.638404846;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;-6%;6.127859116;4.132966995;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;-4%;6.126489639;4.754127026;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;-2%;6.125799179;5.43752861;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;+2%;6.119670868;7.137355804;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;+4%;6.12195015;8.123620987;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;+6%;6.124723434;9.143838882;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;0%;41.66257095;2.560918808;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;+/-2%;41.66205597;2.608066559;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;+/-4%;41.66094589;2.772903681;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;+/-6%;41.66074371;3.118999481;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;-6%;41.6627655;0.492577195;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;-4%;41.6627655;0.880473197;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;-2%;41.6627655;1.611047983;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;+2%;41.66133881;3.605086565;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;+4%;41.65912247;4.665332794;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;+6%;41.65872955;5.74542141;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;0%;12.48837757;4.180572033;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;+/-2%;12.48783493;4.221886635;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;+/-4%;12.48834038;4.367245197;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;+/-6%;12.48767376;4.615413666;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;-6%;12.48871517;2.103645325;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;-4%;12.48871517;2.660671711;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;-2%;12.48864937;3.354694843;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;+2%;12.48702335;5.089078903;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;+4%;12.48796558;6.073814869;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;+6%;12.48662758;7.127182961;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;0%;5.839619637;6.132795334;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;+/-2%;5.839772701;6.197898388;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;+/-4%;5.839612007;6.353995323;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;+/-6%;5.839401722;6.573313236;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;-6%;5.839708805;3.957393408;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;-4%;5.839848042;4.570592403;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;-2%;5.839827061;5.284537315;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;+2%;5.839718819;7.111254692;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;+4%;5.839376926;8.137393951;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;+6%;5.839095116;9.189229965;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;0%;79.04335022;0.010680032;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04335022;0.012308198;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04286957;0.013287968;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.03543091;0.014904844;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;-6%;79.04335022;0.004977524;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;-4%;79.04335022;0.005778007;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;-2%;79.04335022;0.007561798;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;+2%;79.04335022;0.017054603;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;+4%;79.04238129;0.020797933;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;+6%;79.02753448;0.024832169;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;0%;15.47837925;0.020840727;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;+/-2%;15.46831226;0.021289533;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;+/-4%;15.47038269;0.022025201;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45549774;0.024077615;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;-6%;15.48045063;0.014001874;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;-4%;15.47970295;0.015571965;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;-2%;15.47945595;0.017670196;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;+2%;15.45716667;0.024908872;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;+4%;15.46105671;0.028478445;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;+6%;15.43054295;0.03415335;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;0%;6.126023769;0.034060121;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1227355;0.034357283;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124218941;0.036390927;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.126291752;0.034642905;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;-6%;6.127859116;0.027690023;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;-4%;6.126489639;0.029569829;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;-2%;6.125799179;0.031378463;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;+2%;6.119670868;0.037336107;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;+4%;6.12195015;0.043212015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;+6%;6.124723434;0.041595809;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;0%;41.66257095;0.011360387;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;+/-2%;41.66205597;0.011831703;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;+/-4%;41.66094589;0.012672739;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;+/-6%;41.66074371;0.014460005;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;-6%;41.6627655;0.006268911;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;-4%;41.6627655;0.007143422;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;-2%;41.6627655;0.00893067;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;+2%;41.66133881;0.014732736;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;+4%;41.65912247;0.018202063;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;+6%;41.65872955;0.022651106;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;0%;12.48837757;0.021714726;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;+/-2%;12.48783493;0.022005577;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;+/-4%;12.48834038;0.023086024;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;+/-6%;12.48767376;0.024497349;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;-6%;12.48871517;0.016469045;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;-4%;12.48871517;0.017851092;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;-2%;12.48864937;0.019507729;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;+2%;12.48702335;0.024503427;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;+4%;12.48796558;0.028320951;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;+6%;12.48662758;0.032525659;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;0%;5.839619637;0.033467274;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;+/-2%;5.839772701;0.033863455;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;+/-4%;5.839612007;0.033974349;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;+/-6%;5.839401722;0.034788948;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;-6%;5.839708805;0.027563011;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;-4%;5.839848042;0.028906856;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;-2%;5.839827061;0.030885071;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;+2%;5.839718819;0.036841847;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;+4%;5.839376926;0.039041825;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;+6%;5.839095116;0.042014882;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;0%;79.04335022;1.30038E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04335022;1.33817E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04286957;1.31205E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.03543091;1.29349E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;-6%;79.04335022;8.17185E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;-4%;79.04335022;8.77204E+12;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;-2%;79.04335022;1.03057E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;+2%;79.04335022;1.64576E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;+4%;79.04238129;1.74689E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;+6%;79.02753448;1.7698E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;0%;15.47837925;2.50956E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;+/-2%;15.46831226;2.53915E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;+/-4%;15.47038269;2.55879E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45549774;2.64295E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;-6%;15.48045063;2.0707E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;-4%;15.47970295;2.18921E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;-2%;15.47945595;2.33079E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;+2%;15.45716667;2.74752E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;+4%;15.46105671;2.92837E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;+6%;15.43054295;3.2152E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;0%;6.126023769;4.5772E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1227355;4.61628E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124218941;4.62053E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.126291752;4.62217E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;-6%;6.127859116;4.08155E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;-4%;6.126489639;4.22139E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;-2%;6.125799179;4.3634E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;+2%;6.119670868;4.86915E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;+4%;6.12195015;5.01966E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;+6%;6.124723434;5.1628E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;0%;41.66257095;1.58943E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;+/-2%;41.66205597;1.62521E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;+/-4%;41.66094589;1.66018E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;+/-6%;41.66074371;1.76213E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;-6%;41.6627655;1.10998E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;-4%;41.6627655;1.18992E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;-2%;41.6627655;1.35457E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;+2%;41.66133881;1.89586E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;+4%;41.65912247;2.13043E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;+6%;41.65872955;2.41429E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;0%;12.48837757;3.0681E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;+/-2%;12.48783493;3.07992E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;+/-4%;12.48834038;3.16588E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;+/-6%;12.48767376;3.25095E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;-6%;12.48871517;2.5705E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;-4%;12.48871517;2.69468E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;-2%;12.48864937;2.84569E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;+2%;12.48702335;3.31415E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;+4%;12.48796558;3.63708E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;+6%;12.48662758;3.9314E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;0%;5.839619637;4.89481E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;+/-2%;5.839772701;4.91644E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;+/-4%;5.839612007;4.9071E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;+/-6%;5.839401722;4.94736E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;-6%;5.839708805;4.28049E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;-4%;5.839848042;4.41052E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;-2%;5.839827061;4.62001E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;+2%;5.839718819;5.21287E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;+4%;5.839376926;5.40369E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;+6%;5.839095116;5.61423E+13;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;0%;79.04335022;178.4647369;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04335022;179.0762939;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04286957;186.7931671;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;+/-6%;79.03543091;212.655426;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;-6%;79.04335022;8.693336487;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;-4%;79.04335022;39.62102127;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;-2%;79.04335022;103.8730621;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;+2%;79.04335022;254.2796631;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;+4%;79.04238129;333.9652405;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;+6%;79.02753448;416.6174316;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;0%;15.47837925;288.5895996;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;+/-2%;15.46831226;292.6740723;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;+/-4%;15.47038269;302.9649048;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;+/-6%;15.45549774;321.7703552;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;-6%;15.48045063;142.5656128;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;-4%;15.47970295;181.8312988;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;-2%;15.47945595;231.2345428;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;+2%;15.45716667;354.113678;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;+4%;15.46105671;424.0983582;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;+6%;15.43054295;500.9751282;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;0%;6.126023769;425.2729797;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1227355;430.756073;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124218941;441.1262512;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;+/-6%;6.126291752;454.7976379;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;-6%;6.127859116;283.3015442;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;-4%;6.126489639;325.8112488;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;-2%;6.125799179;372.572052;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;+2%;6.119670868;488.9401245;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;+4%;6.12195015;556.4411621;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;+6%;6.124723434;626.2938843;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;0%;41.66257095;175.4877167;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;+/-2%;41.66205597;178.719223;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;+/-4%;41.66094589;190.0199432;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;+/-6%;41.66074371;213.7512665;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;-6%;41.6627655;33.94158936;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;-4%;41.6627655;60.43698502;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;-2%;41.6627655;110.442749;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;+2%;41.66133881;246.9956818;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;+4%;41.65912247;319.6028137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;+6%;41.65872955;393.5609741;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;0%;12.48837757;286.4405212;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;+/-2%;12.48783493;289.2736511;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;+/-4%;12.48834038;299.2467346;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;+/-6%;12.48767376;316.2589722;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;-6%;12.48871517;144.3342743;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;-4%;12.48871517;182.4260712;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;-2%;12.48864937;229.911911;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;+2%;12.48702335;348.6354065;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;+4%;12.48796558;416.0673828;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;+6%;12.48662758;488.1837769;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;0%;5.839619637;420.158844;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;+/-2%;5.839772701;424.6197815;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;+/-4%;5.839612007;435.3119202;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;+/-6%;5.839401722;450.3463135;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;-6%;5.839708805;271.2845154;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;-4%;5.839848042;313.2316284;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;-2%;5.839827061;362.089325;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;+2%;5.839718819;487.1502686;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;+4%;5.839376926;557.3921509;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;+6%;5.839095116;629.40802;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;0%;79.04335022;190.5485535;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04335022;191.2048187;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04286957;199.4420013;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;+/-6%;79.03543091;227.0523224;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;-6%;79.04335022;9.28285408;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;-4%;79.04335022;42.3099823;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;-2%;79.04335022;110.9139099;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;+2%;79.04335022;271.495697;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;+4%;79.04238129;356.5739441;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;+6%;79.02753448;444.8218384;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;0%;15.47837925;308.1515808;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;+/-2%;15.46831226;312.5100708;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;+/-4%;15.47038269;323.4963684;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;+/-6%;15.45549774;343.5741272;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;-6%;15.48045063;152.2375488;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;-4%;15.47970295;194.1643372;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;-2%;15.47945595;246.9128113;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;+2%;15.45716667;378.1073914;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;+4%;15.46105671;452.8283081;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;+6%;15.43054295;534.9106445;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;0%;6.126023769;454.1271362;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1227355;459.9825134;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124218941;471.04953;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;+/-6%;6.126291752;485.6419678;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;-6%;6.127859116;302.5437622;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;-4%;6.126489639;347.932251;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;-2%;6.125799179;397.866272;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;+2%;6.119670868;522.0987549;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;+4%;6.12195015;594.166626;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;+6%;6.124723434;668.7401123;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;0%;41.66257095;187.3769379;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;+/-2%;41.66205597;190.8243866;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;+/-4%;41.66094589;202.8855743;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;+/-6%;41.66074371;228.2230682;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;-6%;41.6627655;36.24242783;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;-4%;41.6627655;64.53083801;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;-2%;41.6627655;117.9256668;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;+2%;41.66133881;263.7232056;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;+4%;41.65912247;341.2402954;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;+6%;41.65872955;420.2037354;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;0%;12.48837757;305.8674927;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;+/-2%;12.48783493;308.8914795;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;+/-4%;12.48834038;319.5347595;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;+/-6%;12.48767376;337.7002258;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;-6%;12.48871517;154.1364288;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;-4%;12.48871517;194.8081818;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;-2%;12.48864937;245.5107269;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;+2%;12.48702335;372.2723389;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;+4%;12.48796558;444.2612;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;+6%;12.48662758;521.263916;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;0%;5.839619637;448.6631775;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;+/-2%;5.839772701;453.4247742;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;+/-4%;5.839612007;464.8400269;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;+/-6%;5.839401722;480.8872375;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;-6%;5.839708805;289.7124023;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;-4%;5.839848042;334.503479;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;-2%;5.839827061;386.6678467;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;+2%;5.839718819;520.1817627;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;+4%;5.839376926;595.1764526;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;+6%;5.839095116;672.0621338;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;0%;79.04335022;0.220089406;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04335022;0.245372251;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04286957;0.301394939;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.03543091;0.404233009;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;-6%;79.04335022;0.033252329;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;-4%;79.04335022;0.054810487;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;-2%;79.04335022;0.114633478;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;+2%;79.04335022;0.37611118;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;+4%;79.04238129;0.547979176;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;+6%;79.02753448;0.775213838;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;0%;15.47837925;0.402838171;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;+/-2%;15.46831226;0.414518505;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;+/-4%;15.47038269;0.446418673;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45549774;0.503283858;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;-6%;15.48045063;0.188963205;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;-4%;15.47970295;0.23822549;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;-2%;15.47945595;0.309077471;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;+2%;15.45716667;0.519959629;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;+4%;15.46105671;0.654611886;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;+6%;15.43054295;0.817604423;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;0%;6.126023769;0.498695552;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1227355;0.50652504;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124218941;0.521760285;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.126291752;0.541612446;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;-6%;6.127859116;0.331313878;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;-4%;6.126489639;0.381247222;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;-2%;6.125799179;0.434715867;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;+2%;6.119670868;0.578334153;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;+4%;6.12195015;0.662273526;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;+6%;6.124723434;0.751910746;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;0%;41.66257095;0.209664434;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;+/-2%;41.66205597;0.221532345;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;+/-4%;41.66094589;0.256194443;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;+/-6%;41.66074371;0.317550749;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;-6%;41.6627655;0.069316678;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;-4%;41.6627655;0.091338515;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;-2%;41.6627655;0.138173908;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;+2%;41.66133881;0.304890662;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;+4%;41.65912247;0.4210504;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;+6%;41.65872955;0.565784633;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;0%;12.48837757;0.349439651;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;+/-2%;12.48783493;0.356213063;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;+/-4%;12.48834038;0.380786151;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;+/-6%;12.48767376;0.422359645;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;-6%;12.48871517;0.195761219;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;-4%;12.48871517;0.229295045;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;-2%;12.48864937;0.280673295;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;+2%;12.48702335;0.43175289;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;+4%;12.48796558;0.532277465;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;+6%;12.48662758;0.648957968;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;0%;5.839619637;0.439677477;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;+/-2%;5.839772701;0.445916176;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;+/-4%;5.839612007;0.462024063;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;+/-6%;5.839401722;0.488591194;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;-6%;5.839708805;0.308849305;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;-4%;5.839848042;0.337459207;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;-2%;5.839827061;0.377306044;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;+2%;5.839718819;0.514526248;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;+4%;5.839376926;0.58658874;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;+6%;5.839095116;0.668333232;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;0%;79.04335022;0.004490115;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04335022;0.004215121;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04286957;0.004895607;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.03543091;0.00748348;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;-6%;79.04335022;0.00128233;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;-4%;79.04335022;0.001699455;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;-2%;79.04335022;0.002811532;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;+2%;79.04335022;0.005618708;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;+4%;79.04238129;0.008091761;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;+6%;79.02753448;0.01368463;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;0%;15.47837925;0.00851005;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;+/-2%;15.46831226;0.008664168;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;+/-4%;15.47038269;0.008577678;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45549774;0.008886621;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;-6%;15.48045063;0.005336934;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;-4%;15.47970295;0.006260613;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;-2%;15.47945595;0.007347268;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;+2%;15.45716667;0.009981075;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;+4%;15.46105671;0.010894745;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;+6%;15.43054295;0.012436303;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;0%;6.126023769;0.013015613;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1227355;0.013078887;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124218941;0.013121124;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.126291752;0.013287405;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;-6%;6.127859116;0.010080975;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;-4%;6.126489639;0.01114201;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;-2%;6.125799179;0.012095748;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;+2%;6.119670868;0.01406202;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;+4%;6.12195015;0.015100233;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;+6%;6.124723434;0.016493836;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;0%;41.66257095;0.005191395;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;+/-2%;41.66205597;0.005368461;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;+/-4%;41.66094589;0.005818166;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;+/-6%;41.66074371;0.006676068;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;-6%;41.6627655;0.002477515;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;-4%;41.6627655;0.002947246;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;-2%;41.6627655;0.003877489;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;+2%;41.66133881;0.006859432;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;+4%;41.65912247;0.008689083;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;+6%;41.65872955;0.010874622;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;0%;12.48837757;0.009258484;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;+/-2%;12.48783493;0.009254045;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;+/-4%;12.48834038;0.009516899;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;+/-6%;12.48767376;0.010108716;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;-6%;12.48871517;0.006235796;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;-4%;12.48871517;0.006971837;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;-2%;12.48864937;0.007940076;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;+2%;12.48702335;0.010568009;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;+4%;12.48796558;0.012061956;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;+6%;12.48662758;0.013981637;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;0%;5.839619637;0.013027991;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;+/-2%;5.839772701;0.013080023;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;+/-4%;5.839612007;0.013311861;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;+/-6%;5.839401722;0.013694575;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;-6%;5.839708805;0.010330216;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;-4%;5.839848042;0.010993034;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;-2%;5.839827061;0.011875272;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;+2%;5.839718819;0.014284777;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;+4%;5.839376926;0.015630689;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;+6%;5.839095116;0.017058939;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;0%;79.04335022;0.002709473;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04335022;0.00273609;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04286957;0.002913953;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.03543091;0.003692965;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;-6%;79.04335022;0.001500643;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;-4%;79.04335022;0.001804658;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;-2%;79.04335022;0.002284815;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;+2%;79.04335022;0.003187366;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;+4%;79.04238129;0.004023248;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;+6%;79.02753448;0.005885288;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;0%;15.47837925;0.007803446;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;+/-2%;15.46831226;0.007859427;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;+/-4%;15.47038269;0.008007322;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45549774;0.008325989;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;-6%;15.48045063;0.006198401;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;-4%;15.47970295;0.006665371;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;-2%;15.47945595;0.007187301;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;+2%;15.45716667;0.008531554;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;+4%;15.46105671;0.009349269;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;+6%;15.43054295;0.010453584;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;0%;6.126023769;0.015844509;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1227355;0.01589;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124218941;0.015862374;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.126291752;0.015892526;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;-6%;6.127859116;0.014074481;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;-4%;6.126489639;0.01465178;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;-2%;6.125799179;0.015314216;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;+2%;6.119670868;0.016465785;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;+4%;6.12195015;0.017072979;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;+6%;6.124723434;0.017710572;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;0%;41.66257095;0.003879121;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;+/-2%;41.66205597;0.003879111;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;+/-4%;41.66094589;0.003881479;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;+/-6%;41.66074371;0.004069325;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;-6%;41.6627655;0.00261544;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;-4%;41.6627655;0.002869094;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;-2%;41.6627655;0.003344781;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;+2%;41.66133881;0.00441344;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;+4%;41.65912247;0.004893865;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;+6%;41.65872955;0.005523211;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;0%;12.48837757;0.008937459;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;+/-2%;12.48783493;0.008952967;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;+/-4%;12.48834038;0.009041274;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;+/-6%;12.48767376;0.009272146;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;-6%;12.48871517;0.007600368;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;-4%;12.48871517;0.007959981;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;-2%;12.48864937;0.008396014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;+2%;12.48702335;0.009509929;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;+4%;12.48796558;0.010122562;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;+6%;12.48662758;0.010943918;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;0%;5.839619637;0.016258746;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;+/-2%;5.839772701;0.016290447;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;+/-4%;5.839612007;0.016330801;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;+/-6%;5.839401722;0.016342599;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;-6%;5.839708805;0.014635696;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;-4%;5.839848042;0.015159764;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;-2%;5.839827061;0.015672497;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;+2%;5.839718819;0.016908405;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;+4%;5.839376926;0.017501848;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;+6%;5.839095116;0.018049503;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;0%;79.04335022;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04335022;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04286957;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.03543091;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;-6%;79.04335022;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;-4%;79.04335022;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;-2%;79.04335022;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;+2%;79.04335022;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;+4%;79.04238129;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;+6%;79.02753448;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;0%;15.47837925;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;+/-2%;15.46831226;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;+/-4%;15.47038269;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45549774;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;-6%;15.48045063;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;-4%;15.47970295;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;-2%;15.47945595;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;+2%;15.45716667;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;+4%;15.46105671;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;+6%;15.43054295;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;0%;6.126023769;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1227355;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124218941;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.126291752;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;-6%;6.127859116;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;-4%;6.126489639;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;-2%;6.125799179;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;+2%;6.119670868;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;+4%;6.12195015;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;+6%;6.124723434;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;0%;41.66257095;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;+/-2%;41.66205597;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;+/-4%;41.66094589;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;+/-6%;41.66074371;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;-6%;41.6627655;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;-4%;41.6627655;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;-2%;41.6627655;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;+2%;41.66133881;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;+4%;41.65912247;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;+6%;41.65872955;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;0%;12.48837757;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;+/-2%;12.48783493;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;+/-4%;12.48834038;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;+/-6%;12.48767376;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;-6%;12.48871517;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;-4%;12.48871517;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;-2%;12.48864937;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;+2%;12.48702335;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;+4%;12.48796558;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;+6%;12.48662758;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;0%;5.839619637;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;+/-2%;5.839772701;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;+/-4%;5.839612007;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;+/-6%;5.839401722;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;-6%;5.839708805;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;-4%;5.839848042;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;-2%;5.839827061;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;+2%;5.839718819;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;+4%;5.839376926;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;+6%;5.839095116;0;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;0%;79.04335022;0.000972298;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04335022;0.00097552;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04286957;0.001017639;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.03543091;0.001158644;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;-6%;79.04335022;4.73291E-05;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;-4%;79.04335022;0.000215639;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;-2%;79.04335022;0.000565649;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;+2%;79.04335022;0.001385391;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;+4%;79.04238129;0.001819638;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;+6%;79.02753448;0.002269959;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;0%;15.47837925;0.001571516;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;+/-2%;15.46831226;0.001593848;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;+/-4%;15.47038269;0.001649957;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45549774;0.001752453;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;-6%;15.48045063;0.000776046;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;-4%;15.47970295;0.000989888;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;-2%;15.47945595;0.001259037;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;+2%;15.45716667;0.00192866;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;+4%;15.46105671;0.002310025;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;+6%;15.43054295;0.00272886;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;0%;6.126023769;0.002314843;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1227355;0.002344674;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124218941;0.002401366;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.126291752;0.002476016;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;-6%;6.127859116;0.001541353;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;-4%;6.126489639;0.001772923;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;-2%;6.125799179;0.002027411;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;+2%;6.119670868;0.002661937;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;+4%;6.12195015;0.00302981;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;+6%;6.124723434;0.003410679;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;0%;41.66257095;0.000955858;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;+/-2%;41.66205597;0.00097357;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;+/-4%;41.66094589;0.0010353;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;+/-6%;41.66074371;0.001164625;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;-6%;41.6627655;0.000184827;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;-4%;41.6627655;0.000329216;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;-2%;41.6627655;0.000601553;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;+2%;41.66133881;0.001345587;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;+4%;41.65912247;0.001741385;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;+6%;41.65872955;0.002144424;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;0%;12.48837757;0.001559469;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;+/-2%;12.48783493;0.001574958;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;+/-4%;12.48834038;0.001629458;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;+/-6%;12.48767376;0.001722115;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;-6%;12.48871517;0.000785347;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;-4%;12.48871517;0.000992852;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;-2%;12.48864937;0.001251518;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;+2%;12.48702335;0.001898397;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;+4%;12.48796558;0.002266064;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;+6%;12.48662758;0.002658883;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;0%;5.839619637;0.002287192;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;+/-2%;5.839772701;0.002311553;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;+/-4%;5.839612007;0.002369841;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;+/-6%;5.839401722;0.002451939;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;-6%;5.839708805;0.001475969;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;-4%;5.839848042;0.001704361;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;-2%;5.839827061;0.00197061;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;+2%;5.839718819;0.002652494;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;+4%;5.839376926;0.00303532;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;+6%;5.839095116;0.003427908;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;0%;78.73399353;0.005276851;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;+/-2%;78.73399353;0.005276851;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;+/-4%;78.73351288;0.005276851;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;+/-6%;78.72608948;0.005276851;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;-6%;78.73399353;0.005276851;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;-4%;78.73399353;0.005276851;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;-2%;78.73399353;0.005276851;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;+2%;78.73399353;0.005276851;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;+4%;78.73303223;0.005276851;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;+6%;78.71820068;0.005276851;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;0%;15.41779804;0.013475136;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;+/-2%;15.40773106;0.013475136;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;+/-4%;15.40980434;0.013475136;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;+/-6%;15.39496422;0.013475136;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;-6%;15.4198637;0.013475136;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;-4%;15.41911697;0.013475136;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;-2%;15.41887093;0.013475136;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;+2%;15.39658928;0.013475136;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;+4%;15.40048599;0.013475136;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;+6%;15.37006283;0.013475136;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;0%;6.102042675;0.013475136;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.098754406;0.013475136;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.100236416;0.013475136;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.102311134;0.013475136;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;-6%;6.103877068;0.013475136;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;-4%;6.102507591;0.013475136;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;-2%;6.101817608;0.013475136;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;+2%;6.09569025;0.013475136;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;+4%;6.097966671;0.013475136;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;+6%;6.100744724;0.013475136;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;0%;41.49657822;0.009530302;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;+/-2%;41.49606323;0.009530302;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;+/-4%;41.49496078;0.009530302;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;+/-6%;41.49477005;0.009530302;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;-6%;41.49677277;0.009530302;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;-4%;41.49677277;0.009530302;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;-2%;41.49677277;0.009530302;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;+2%;41.49534607;0.009530302;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;+4%;41.4931488;0.009530302;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;+6%;41.49277496;0.009530302;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;0%;12.43862343;0.013477137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;+/-2%;12.43808079;0.013477137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;+/-4%;12.438591;0.013477137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;+/-6%;12.43793392;0.013477137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;-6%;12.43895721;0.013477137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;-4%;12.43895721;0.013477137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;-2%;12.43889236;0.013477137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;+2%;12.43727207;0.013477137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;+4%;12.43822384;0.013477137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;+6%;12.43690777;0.013477137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;0%;5.816351891;0.013477137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;+/-2%;5.816505432;0.013477137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;+/-4%;5.816344261;0.013477137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;+/-6%;5.816135406;0.013477137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;-6%;5.816440582;0.013477137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;-4%;5.816580296;0.013477137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;-2%;5.816560745;0.013477137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;+2%;5.816450596;0.013477137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;+4%;5.816108704;0.013477137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;+6%;5.815830231;0.013477137;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;0%;78.73399353;0.005373255;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;+/-2%;78.73399353;0.005373255;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;+/-4%;78.73351288;0.005373255;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;+/-6%;78.72608948;0.005373255;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;-6%;78.73399353;0.005373255;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;-4%;78.73399353;0.005373255;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;-2%;78.73399353;0.005373255;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;+2%;78.73399353;0.005373255;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;+4%;78.73303223;0.005373255;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;+6%;78.71820068;0.005373255;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;0%;15.41779804;0.002761103;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;+/-2%;15.40773106;0.002761103;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;+/-4%;15.40980434;0.002761103;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;+/-6%;15.39496422;0.002761103;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;-6%;15.4198637;0.002761103;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;-4%;15.41911697;0.002761103;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;-2%;15.41887093;0.002761103;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;+2%;15.39658928;0.002761103;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;+4%;15.40048599;0.002761103;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;+6%;15.37006283;0.002761103;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;0%;6.102042675;0.002761103;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.098754406;0.002761103;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.100236416;0.002761103;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.102311134;0.002761103;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;-6%;6.103877068;0.002761103;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;-4%;6.102507591;0.002761103;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;-2%;6.101817608;0.002761103;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;+2%;6.09569025;0.002761103;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;+4%;6.097966671;0.002761103;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;+6%;6.100744724;0.002761103;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;0%;41.49657822;0.004833834;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;+/-2%;41.49606323;0.004833834;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;+/-4%;41.49496078;0.004833834;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;+/-6%;41.49477005;0.004833834;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;-6%;41.49677277;0.004833834;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;-4%;41.49677277;0.004833834;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;-2%;41.49677277;0.004833834;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;+2%;41.49534607;0.004833834;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;+4%;41.4931488;0.004833834;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;+6%;41.49277496;0.004833834;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;0%;12.43862343;0.002753695;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;+/-2%;12.43808079;0.002753695;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;+/-4%;12.438591;0.002753695;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;+/-6%;12.43793392;0.002753695;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;-6%;12.43895721;0.002753695;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;-4%;12.43895721;0.002753695;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;-2%;12.43889236;0.002753695;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;+2%;12.43727207;0.002753695;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;+4%;12.43822384;0.002753695;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;+6%;12.43690777;0.002753695;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;0%;5.816351891;0.002753695;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;+/-2%;5.816505432;0.002753695;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;+/-4%;5.816344261;0.002753695;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;+/-6%;5.816135406;0.002753695;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;-6%;5.816440582;0.002753695;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;-4%;5.816580296;0.002753695;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;-2%;5.816560745;0.002753695;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;+2%;5.816450596;0.002753695;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;+4%;5.816108704;0.002753695;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;+6%;5.815830231;0.002753695;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;0%;79.04335022;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04335022;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04286957;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-6%;79.03543091;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-6%;79.04335022;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-4%;79.04335022;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-2%;79.04335022;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+2%;79.04335022;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+4%;79.04238129;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+6%;79.02753448;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;0%;15.47837925;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-2%;15.46831226;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-4%;15.47038269;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-6%;15.45549774;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;-6%;15.48045063;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;-4%;15.47970295;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;-2%;15.47945595;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;+2%;15.45716667;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;+4%;15.46105671;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;+6%;15.43054295;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;0%;6.126023769;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1227355;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124218941;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-6%;6.126291752;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-6%;6.127859116;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-4%;6.126489639;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-2%;6.125799179;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+2%;6.119670868;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+4%;6.12195015;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+6%;6.124723434;0.030000003;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;0%;41.66257095;0.025999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;+/-2%;41.66205597;0.025999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;+/-4%;41.66094589;0.025999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;+/-6%;41.66074371;0.025999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;-6%;41.6627655;0.025999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;-4%;41.6627655;0.025999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;-2%;41.6627655;0.025999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;+2%;41.66133881;0.025999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;+4%;41.65912247;0.025999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;+6%;41.65872955;0.025999997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;0%;12.48837757;0.045000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;+/-2%;12.48783493;0.045000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;+/-4%;12.48834038;0.045000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;+/-6%;12.48767376;0.045000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;-6%;12.48871517;0.045000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;-4%;12.48871517;0.045000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;-2%;12.48864937;0.045000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;+2%;12.48702335;0.045000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;+4%;12.48796558;0.045000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;+6%;12.48662758;0.045000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;0%;5.839619637;0.045000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;+/-2%;5.839772701;0.045000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;+/-4%;5.839612007;0.045000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;+/-6%;5.839401722;0.045000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;-6%;5.839708805;0.045000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;-4%;5.839848042;0.045000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;-2%;5.839827061;0.045000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;+2%;5.839718819;0.045000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;+4%;5.839376926;0.045000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;+6%;5.839095116;0.045000002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;0%;79.04335022;0.000106546;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04335022;0.000106877;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04286957;0.000122009;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.03543091;0.000180407;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;-6%;79.04335022;4.15515E-05;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;-4%;79.04335022;5.23953E-05;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;-2%;79.04335022;7.52961E-05;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;+2%;79.04335022;0.000138458;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;+4%;79.04238129;0.000191624;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;+6%;79.02753448;0.000319263;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;0%;15.47837925;0.000306883;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;+/-2%;15.46831226;0.000310318;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;+/-4%;15.47038269;0.000320323;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45549774;0.00033635;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;-6%;15.48045063;0.000219472;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;-4%;15.47970295;0.000244891;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;-2%;15.47945595;0.000273379;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;+2%;15.45716667;0.000347257;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;+4%;15.46105671;0.000395755;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;+6%;15.43054295;0.000453228;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;0%;6.126023769;0.000585178;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1227355;0.000585752;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124218941;0.000588197;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.126291752;0.00059075;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;-6%;6.127859116;0.000505774;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;-4%;6.126489639;0.000535181;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;-2%;6.125799179;0.000562087;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;+2%;6.119670868;0.000609417;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;+4%;6.12195015;0.000641213;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;+6%;6.124723434;0.000675727;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;0%;41.66257095;0.00013377;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;+/-2%;41.66205597;0.000136838;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;+/-4%;41.66094589;0.000145576;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;+/-6%;41.66074371;0.00016317;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;-6%;41.6627655;7.8893E-05;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;-4%;41.6627655;8.93045E-05;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;-2%;41.6627655;0.000108683;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;+2%;41.66133881;0.000164992;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;+4%;41.65912247;0.000201847;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;+6%;41.65872955;0.000247446;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;0%;12.48837757;0.000316127;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;+/-2%;12.48783493;0.000318246;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;+/-4%;12.48834038;0.000325928;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;+/-6%;12.48767376;0.000342463;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;-6%;12.48871517;0.000256133;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;-4%;12.48871517;0.000270922;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;-2%;12.48864937;0.000290978;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;+2%;12.48702335;0.000345514;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;+4%;12.48796558;0.000380933;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;+6%;12.48662758;0.000428792;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;0%;5.839619637;0.000567462;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;+/-2%;5.839772701;0.000570099;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;+/-4%;5.839612007;0.000574832;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;+/-6%;5.839401722;0.00057671;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;-6%;5.839708805;0.000510028;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;-4%;5.839848042;0.000532074;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;-2%;5.839827061;0.000548909;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;+2%;5.839718819;0.000591289;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;+4%;5.839376926;0.000617589;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;+6%;5.839095116;0.000643391;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;0%;79.04335022;0.010680032;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04335022;0.012308198;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04286957;0.013287968;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.03543091;0.014904844;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;-6%;79.04335022;0.004977524;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;-4%;79.04335022;0.005778007;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;-2%;79.04335022;0.007561798;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;+2%;79.04335022;0.017054603;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;+4%;79.04238129;0.020797933;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;+6%;79.02753448;0.024832169;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;0%;15.47837925;0.020840727;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;+/-2%;15.46831226;0.021289533;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;+/-4%;15.47038269;0.022025201;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45549774;0.024077615;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;-6%;15.48045063;0.014001874;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;-4%;15.47970295;0.015571965;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;-2%;15.47945595;0.017670196;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;+2%;15.45716667;0.024908872;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;+4%;15.46105671;0.028478445;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;+6%;15.43054295;0.03415335;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;0%;6.126023769;0.034060121;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1227355;0.034357283;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124218941;0.036390927;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.126291752;0.034642905;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;-6%;6.127859116;0.027690023;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;-4%;6.126489639;0.029569829;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;-2%;6.125799179;0.031378463;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;+2%;6.119670868;0.037336107;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;+4%;6.12195015;0.043212015;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;+6%;6.124723434;0.041595809;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;0%;41.66257095;0.011360387;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;+/-2%;41.66205597;0.011831703;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;+/-4%;41.66094589;0.012672739;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;+/-6%;41.66074371;0.014460005;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;-6%;41.6627655;0.006268911;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;-4%;41.6627655;0.007143422;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;-2%;41.6627655;0.00893067;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;+2%;41.66133881;0.014732736;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;+4%;41.65912247;0.018202063;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;+6%;41.65872955;0.022651106;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;0%;12.48837757;0.021714726;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;+/-2%;12.48783493;0.022005577;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;+/-4%;12.48834038;0.023086024;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;+/-6%;12.48767376;0.024497349;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;-6%;12.48871517;0.016469045;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;-4%;12.48871517;0.017851092;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;-2%;12.48864937;0.019507729;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;+2%;12.48702335;0.024503427;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;+4%;12.48796558;0.028320951;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;+6%;12.48662758;0.032525659;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;0%;5.839619637;0.033467274;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;+/-2%;5.839772701;0.033863455;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;+/-4%;5.839612007;0.033974349;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;+/-6%;5.839401722;0.034788948;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;-6%;5.839708805;0.027563011;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;-4%;5.839848042;0.028906856;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;-2%;5.839827061;0.030885071;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;+2%;5.839718819;0.036841847;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;+4%;5.839376926;0.039041825;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;+6%;5.839095116;0.042014882;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;0%;79.04335022;0.007849866;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04335022;0.009099423;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04286957;0.009630171;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;+/-6%;79.03543091;0.010368752;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;-6%;79.04335022;0.00360962;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;-4%;79.04335022;0.004235078;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;-2%;79.04335022;0.005568447;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;+2%;79.04335022;0.012630394;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;+4%;79.04238129;0.015025261;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;+6%;79.02753448;0.017127886;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;0%;15.47837925;0.014396915;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;+/-2%;15.46831226;0.014685677;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;+/-4%;15.47038269;0.015188999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;+/-6%;15.45549774;0.016279571;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;-6%;15.48045063;0.009831822;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;-4%;15.47970295;0.010969036;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;-2%;15.47945595;0.01243664;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;+2%;15.45716667;0.01693473;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;+4%;15.46105671;0.01940896;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;+6%;15.43054295;0.022727324;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;0%;6.126023769;0.02343609;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1227355;0.02383659;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124218941;0.024205096;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;+/-6%;6.126291752;0.023942107;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;-6%;6.127859116;0.019105669;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;-4%;6.126489639;0.020509647;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;-2%;6.125799179;0.021776931;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;+2%;6.119670868;0.02589624;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;+4%;6.12195015;0.027900545;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;+6%;6.124723434;0.028778538;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;0%;41.66257095;0.008290866;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;+/-2%;41.66205597;0.008623732;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;+/-4%;41.66094589;0.009182165;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;+/-6%;41.66074371;0.010432246;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;-6%;41.6627655;0.004471804;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;-4%;41.6627655;0.005135642;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;-2%;41.6627655;0.00648567;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;+2%;41.66133881;0.010761796;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;+4%;41.65912247;0.013228687;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;+6%;41.65872955;0.016392689;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;0%;12.48837757;0.015554335;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;+/-2%;12.48783493;0.015748862;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;+/-4%;12.48834038;0.01652508;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;+/-6%;12.48767376;0.017449193;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;-6%;12.48871517;0.011614707;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;-4%;12.48871517;0.012656178;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;-2%;12.48864937;0.013922298;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;+2%;12.48702335;0.017575426;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;+4%;12.48796558;0.020393997;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;+6%;12.48662758;0.023283672;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;0%;5.839619637;0.023388172;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;+/-2%;5.839772701;0.023660436;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;+/-4%;5.839612007;0.023733566;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;+/-6%;5.839401722;0.024249241;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;-6%;5.839708805;0.018943012;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;-4%;5.839848042;0.019967342;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;-2%;5.839827061;0.021484101;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;+2%;5.839718819;0.025836769;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;+4%;5.839376926;0.027499801;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;+6%;5.839095116;0.029555473;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;0%;79.04335022;0.013999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04335022;0.013999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04286957;0.013999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-6%;79.03543091;0.013999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-6%;79.04335022;0.013999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-4%;79.04335022;0.013999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-2%;79.04335022;0.013999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+2%;79.04335022;0.013999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+4%;79.04238129;0.013999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+6%;79.02753448;0.013999999;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;0%;15.47837925;0.021999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-2%;15.46831226;0.021999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-4%;15.47038269;0.021999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-6%;15.45549774;0.021999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;-6%;15.48045063;0.021999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;-4%;15.47970295;0.021999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;-2%;15.47945595;0.021999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;+2%;15.45716667;0.021999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;+4%;15.46105671;0.021999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;+6%;15.43054295;0.021999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;0%;6.126023769;0.021999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1227355;0.021999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124218941;0.021999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-6%;6.126291752;0.021999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-6%;6.127859116;0.021999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-4%;6.126489639;0.021999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-2%;6.125799179;0.021999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+2%;6.119670868;0.021999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+4%;6.12195015;0.021999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+6%;6.124723434;0.021999994;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;0%;41.66257095;0.019999998;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;+/-2%;41.66205597;0.019999998;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;+/-4%;41.66094589;0.019999998;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;+/-6%;41.66074371;0.019999998;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;-6%;41.6627655;0.019999998;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;-4%;41.6627655;0.019999998;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;-2%;41.6627655;0.019999998;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;+2%;41.66133881;0.019999998;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;+4%;41.65912247;0.019999998;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;+6%;41.65872955;0.019999998;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;0%;12.48837757;0.022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;+/-2%;12.48783493;0.022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;+/-4%;12.48834038;0.022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;+/-6%;12.48767376;0.022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;-6%;12.48871517;0.022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;-4%;12.48871517;0.022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;-2%;12.48864937;0.022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;+2%;12.48702335;0.022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;+4%;12.48796558;0.022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;+6%;12.48662758;0.022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;0%;5.839619637;0.022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;+/-2%;5.839772701;0.022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;+/-4%;5.839612007;0.022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;+/-6%;5.839401722;0.022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;-6%;5.839708805;0.022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;-4%;5.839848042;0.022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;-2%;5.839827061;0.022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;+2%;5.839718819;0.022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;+4%;5.839376926;0.022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;+6%;5.839095116;0.022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;0%;79.04335022;0.0014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04335022;0.0014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04286957;0.0014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-6%;79.03543091;0.0014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-6%;79.04335022;0.0014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-4%;79.04335022;0.0014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-2%;79.04335022;0.0014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+2%;79.04335022;0.0014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+4%;79.04238129;0.0014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+6%;79.02753448;0.0014;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;0%;15.47837925;0.0022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-2%;15.46831226;0.0022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-4%;15.47038269;0.0022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-6%;15.45549774;0.0022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;-6%;15.48045063;0.0022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;-4%;15.47970295;0.0022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;-2%;15.47945595;0.0022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;+2%;15.45716667;0.0022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;+4%;15.46105671;0.0022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;+6%;15.43054295;0.0022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;0%;6.126023769;0.0022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1227355;0.0022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124218941;0.0022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-6%;6.126291752;0.0022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-6%;6.127859116;0.0022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-4%;6.126489639;0.0022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-2%;6.125799179;0.0022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+2%;6.119670868;0.0022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+4%;6.12195015;0.0022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+6%;6.124723434;0.0022;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;0%;41.66257095;0.002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;+/-2%;41.66205597;0.002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;+/-4%;41.66094589;0.002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;+/-6%;41.66074371;0.002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;-6%;41.6627655;0.002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;-4%;41.6627655;0.002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;-2%;41.6627655;0.002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;+2%;41.66133881;0.002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;+4%;41.65912247;0.002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;+6%;41.65872955;0.002;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;0%;12.48837757;0.002200001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;+/-2%;12.48783493;0.002200001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;+/-4%;12.48834038;0.002200001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;+/-6%;12.48767376;0.002200001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;-6%;12.48871517;0.002200001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;-4%;12.48871517;0.002200001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;-2%;12.48864937;0.002200001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;+2%;12.48702335;0.002200001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;+4%;12.48796558;0.002200001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;+6%;12.48662758;0.002200001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;0%;5.839619637;0.002200001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;+/-2%;5.839772701;0.002200001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;+/-4%;5.839612007;0.002200001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;+/-6%;5.839401722;0.002200001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;-6%;5.839708805;0.002200001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;-4%;5.839848042;0.002200001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;-2%;5.839827061;0.002200001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;+2%;5.839718819;0.002200001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;+4%;5.839376926;0.002200001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;+6%;5.839095116;0.002200001;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;0%;79.04335022;180.1495361;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;+/-2%;79.04335022;180.7542114;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;+/-4%;79.04286957;188.4880829;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;+/-6%;79.03543091;214.4149628;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;-6%;79.04335022;10.29789639;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;-4%;79.04335022;41.23600769;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;-2%;79.04335022;105.5158234;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;+2%;79.04335022;255.9926147;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;+4%;79.04238129;335.7401428;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;+6%;79.02753448;418.532074;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;0%;15.47837925;292.8178101;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;+/-2%;15.46831226;296.90625;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;+/-4%;15.47038269;307.1949158;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;+/-6%;15.45549774;326.0080872;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;-6%;15.48045063;146.7145691;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;-4%;15.47970295;186.0034485;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;-2%;15.47945595;235.4337921;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;+2%;15.45716667;358.3788757;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;+4%;15.46105671;428.3862915;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;+6%;15.43054295;505.3016663;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;0%;6.126023769;429.6139832;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;+/-2%;6.1227355;435.0986633;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;+/-4%;6.124218941;445.4698486;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;+/-6%;6.126291752;459.1454468;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;-6%;6.127859116;287.5691528;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;-4%;6.126489639;330.1054077;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;-2%;6.125799179;376.8899536;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;+2%;6.119670868;493.3071594;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;+4%;6.12195015;560.8342896;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;+6%;6.124723434;630.7216187;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;0%;41.66257095;178.4575195;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;+/-2%;41.66205597;181.6934814;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;+/-4%;41.66094589;193.0053864;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;+/-6%;41.66074371;216.758255;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;-6%;41.6627655;36.84355545;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;-4%;41.6627655;63.35068512;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;-2%;41.6627655;113.3797455;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;+2%;41.66133881;250.0072632;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;+4%;41.65912247;322.6600342;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;+6%;41.65872955;396.6727905;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;0%;12.48837757;290.6881714;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;+/-2%;12.48783493;293.5212402;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;+/-4%;12.48834038;303.500824;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;+/-6%;12.48767376;320.5279236;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;-6%;12.48871517;148.5063324;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;-4%;12.48871517;186.6165771;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;-2%;12.48864937;234.1265717;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;+2%;12.48702335;352.9158325;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;+4%;12.48796558;420.3851929;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;+6%;12.48662758;492.549469;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;0%;5.839619637;424.5007019;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;+/-2%;5.839772701;428.9630432;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;+/-4%;5.839612007;439.6608887;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;+/-6%;5.839401722;454.704834;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;-6%;5.839708805;275.55896;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;-4%;5.839848042;317.5227051;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;-2%;5.839827061;366.4024658;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;+2%;5.839718819;491.5235596;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;+4%;5.839376926;561.7990723;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];LCV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;+6%;5.839095116;633.8508301;ØGermany;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;0%;76.98996735;0.02731877;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;+/-2%;76.83776855;0.028433854;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;+/-4%;72.06789398;0.035577893;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;+/-6%;68.70932007;0.045659114;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;-6%;76.99573517;0.009545479;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;-4%;76.99573517;0.012035565;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;-2%;76.99564362;0.01762085;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;+2%;76.67988586;0.039246865;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;+4%;67.14006805;0.059120212;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/Freeflow;+6%;60.42288208;0.081772752;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;0%;14.96282387;0.097063199;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;+/-2%;14.9279213;0.097249039;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;+/-4%;14.87481022;0.10017392;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;+/-6%;14.68308735;0.104263902;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;-6%;15.10646343;0.071556933;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;-4%;15.10005188;0.077774681;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;-2%;15.04090786;0.086285733;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;+2%;14.81493187;0.108212337;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;+4%;14.64956856;0.122573175;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go;+6%;14.2597065;0.136970863;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;0%;5.922516346;0.199832052;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;+/-2%;5.949680805;0.199000806;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;+/-4%;5.933505058;0.200328618;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;+/-6%;5.920527935;0.202587351;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;-6%;5.946077347;0.166993961;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;-4%;5.942987442;0.175765246;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;-2%;5.955795765;0.185799897;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;+2%;5.943564415;0.2122017;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;+4%;5.924026489;0.22489202;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Rural;RUR/Trunk/80/St+Go2;+6%;5.894978046;0.238180727;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;0%;38.16640472;0.048620749;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;+/-2%;38.15972137;0.047779445;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;+/-4%;38.05031204;0.048574511;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;+/-6%;37.58854294;0.053053901;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;-6%;38.18581009;0.021822253;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;-4%;38.18580246;0.026506031;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;-2%;38.18279648;0.036214296;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;+2%;38.1366539;0.059344608;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;+4%;37.91482925;0.070642978;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/Freeflow;+6%;36.99126434;0.084285565;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;0%;12.30854416;0.115925066;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;+/-2%;12.3304491;0.116190135;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;+/-4%;12.29303265;0.118019804;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;+/-6%;12.25161839;0.120800242;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;-6%;12.36960888;0.090561166;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;-4%;12.35750484;0.097448699;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;-2%;12.35688972;0.105599262;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;+2%;12.30400658;0.126781002;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;+4%;12.22855568;0.138590917;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go;+6%;12.13362694;0.151039302;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;0%;5.82649374;0.217582226;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;+/-2%;5.820070744;0.216503829;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;+/-4%;5.820352077;0.217025071;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;+/-6%;5.818859577;0.218028471;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;-6%;5.827131748;0.183195338;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;-4%;5.826894283;0.193618253;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;-2%;5.825897217;0.203670561;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;+2%;5.814248085;0.229336992;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;+4%;5.813810825;0.240431845;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;HC;Urban;URB/Local/50/St+Go2;+6%;5.81058836;0.252861559;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;0%;76.98996735;0.526756048;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;+/-2%;76.83776855;0.461078376;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;+/-4%;72.06789398;0.490539789;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;+/-6%;68.70932007;0.451333463;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;-6%;76.99573517;0.07323546;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;-4%;76.99573517;0.095936313;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;-2%;76.99564362;0.19870308;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;+2%;76.67988586;0.72345376;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;+4%;67.14006805;0.88514322;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/Freeflow;+6%;60.42288208;0.829431474;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;0%;14.96282387;1.065484881;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;+/-2%;14.9279213;1.069570899;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;+/-4%;14.87481022;1.087009788;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;+/-6%;14.68308735;1.147313952;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;-6%;15.10646343;0.672157288;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;-4%;15.10005188;0.761480331;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;-2%;15.04090786;0.902514279;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;+2%;14.81493187;1.236627698;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;+4%;14.64956856;1.412539363;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go;+6%;14.2597065;1.622471333;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;0%;5.922516346;2.05407691;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;+/-2%;5.949680805;2.069652081;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;+/-4%;5.933505058;2.144563437;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;+/-6%;5.920527935;2.258215904;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;-6%;5.946077347;1.47299087;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;-4%;5.942987442;1.622608662;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;-2%;5.955795765;1.797603726;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;+2%;5.943564415;2.341701269;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;+4%;5.924026489;2.666517496;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Rural;RUR/Trunk/80/St+Go2;+6%;5.894978046;3.043439627;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;0%;38.16640472;0.67141211;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;+/-2%;38.15972137;0.712645113;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;+/-4%;38.05031204;0.763980925;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;+/-6%;37.58854294;0.799663842;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;-6%;38.18581009;0.174534991;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;-4%;38.18580246;0.227895811;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;-2%;38.18279648;0.368326962;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;+2%;38.1366539;1.056963325;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;+4%;37.91482925;1.300066113;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/Freeflow;+6%;36.99126434;1.424792767;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;0%;12.30854416;1.383059025;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;+/-2%;12.3304491;1.389686942;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;+/-4%;12.29303265;1.416908741;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;+/-6%;12.25161839;1.46267736;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;-6%;12.36960888;0.860643446;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;-4%;12.35750484;0.996880591;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;-2%;12.35688972;1.170276046;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;+2%;12.30400658;1.609097838;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;+4%;12.22855568;1.836936831;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go;+6%;12.13362694;2.064710379;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;0%;5.82649374;2.278458357;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;+/-2%;5.820070744;2.286205292;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;+/-4%;5.820352077;2.349547863;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;+/-6%;5.818859577;2.451084852;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;-6%;5.827131748;1.529366374;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;-4%;5.826894283;1.729562044;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;-2%;5.825897217;1.964179754;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;+2%;5.814248085;2.608229399;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;+4%;5.813810825;2.969532251;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO;Urban;URB/Local/50/St+Go2;+6%;5.81058836;3.372803211;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;0%;76.98996735;0.955763876;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;+/-2%;76.83776855;1.23482132;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;+/-4%;72.06789398;1.113695264;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;+/-6%;68.70932007;1.272716045;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;-6%;76.99573517;0.276280791;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;-4%;76.99573517;0.38742882;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;-2%;76.99564362;1.157349467;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;+2%;76.67988586;1.312293649;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;+4%;67.14006805;1.839961052;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/Freeflow;+6%;60.42288208;2.269150257;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;0%;14.96282387;6.091925144;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;+/-2%;14.9279213;6.592739582;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;+/-4%;14.87481022;6.333334446;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;+/-6%;14.68308735;5.908323288;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;-6%;15.10646343;5.800094604;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;-4%;15.10005188;6.783541203;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;-2%;15.04090786;7.397286892;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;+2%;14.81493187;5.788191795;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;+4%;14.64956856;5.883129597;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go;+6%;14.2597065;6.016550064;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;0%;5.922516346;9.394060135;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;+/-2%;5.949680805;9.673859596;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;+/-4%;5.933505058;9.758140564;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;+/-6%;5.920527935;9.588884354;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;-6%;5.946077347;10.1997633;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;-4%;5.942987442;10.74781895;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;-2%;5.955795765;10.4187479;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;+2%;5.943564415;8.928971291;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;+4%;5.924026489;8.768465996;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Rural;RUR/Trunk/80/St+Go2;+6%;5.894978046;8.978004456;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;0%;38.16640472;2.29156208;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;+/-2%;38.15972137;2.318653107;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;+/-4%;38.05031204;1.676610708;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;+/-6%;37.58854294;1.681372046;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;-6%;38.18581009;0.714254081;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;-4%;38.18580246;1.118885398;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;-2%;38.18279648;2.665282488;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;+2%;38.1366539;1.972025275;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;+4%;37.91482925;2.234335661;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/Freeflow;+6%;36.99126434;2.648489475;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;0%;12.30854416;6.721096516;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;+/-2%;12.3304491;6.575528622;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;+/-4%;12.29303265;6.311663628;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;+/-6%;12.25161839;5.902778149;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;-6%;12.36960888;5.18112421;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;-4%;12.35750484;6.152830601;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;-2%;12.35688972;6.677828312;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;+2%;12.30400658;6.473227978;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;+4%;12.22855568;6.470496655;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go;+6%;12.13362694;6.624433041;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;0%;5.82649374;10.06217289;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;+/-2%;5.820070744;10.08262062;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;+/-4%;5.820352077;9.895298004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;+/-6%;5.818859577;9.687541008;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;-6%;5.827131748;8.145251274;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;-4%;5.826894283;8.852661133;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;-2%;5.825897217;9.590029716;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;+2%;5.814248085;10.5752182;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;+4%;5.813810825;10.93793583;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NOx;Urban;URB/Local/50/St+Go2;+6%;5.81058836;11.22983265;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;0%;76.98996735;199.8915863;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;+/-2%;76.83776855;237.96315;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;+/-4%;72.06789398;338.2887878;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;+/-6%;68.70932007;456.0582886;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;-6%;76.99573517;0.998302341;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;-4%;76.99573517;6.040926456;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;-2%;76.99564362;42.35586166;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;+2%;76.67988586;433.5704346;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;+4%;67.14006805;670.5365601;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/Freeflow;+6%;60.42288208;911.1183472;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;0%;14.96282387;520.5753784;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;+/-2%;14.9279213;531.7247314;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;+/-4%;14.87481022;573.0325928;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;+/-6%;14.68308735;637.6595459;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;-6%;15.10646343;222.2549744;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;-4%;15.10005188;290.7480164;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;-2%;15.04090786;386.3559875;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;+2%;14.81493187;677.093689;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;+4%;14.64956856;855.3172607;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go;+6%;14.2597065;1053.064331;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;0%;5.922516346;694.8359375;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;+/-2%;5.949680805;708.2736816;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;+/-4%;5.933505058;746.8925781;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;+/-6%;5.920527935;804.5263672;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;-6%;5.946077347;389.5814819;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;-4%;5.942987442;474.7330017;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;-2%;5.955795765;573.0280762;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;+2%;5.943564415;843.5192871;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;+4%;5.924026489;1019.052002;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Rural;RUR/Trunk/80/St+Go2;+6%;5.894978046;1219.471558;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;0%;38.16640472;207.2973328;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;+/-2%;38.15972137;235.7642365;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;+/-4%;38.05031204;311.3813477;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;+/-6%;37.58854294;408.8731384;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;-6%;38.18581009;11.56706142;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;-4%;38.18580246;29.71734428;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;-2%;38.18279648;82.80996704;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;+2%;38.1366539;388.7186584;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;+4%;37.91482925;593.0453491;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/Freeflow;+6%;36.99126434;806.1791992;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;0%;12.30854416;489.4849548;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;+/-2%;12.3304491;501.1528931;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;+/-4%;12.29303265;538.4013672;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;+/-6%;12.25161839;591.590271;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;-6%;12.36960888;206.0619354;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;-4%;12.35750484;277.4344177;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;-2%;12.35688972;369.7815247;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;+2%;12.30400658;632.524353;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;+4%;12.22855568;799.3684082;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go;+6%;12.13362694;977.1184082;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;0%;5.82649374;596.0463867;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;+/-2%;5.820070744;609.0921631;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;+/-4%;5.820352077;645.1156006;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;+/-6%;5.818859577;701.1573486;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;-6%;5.827131748;299.3801575;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;-4%;5.826894283;374.7991943;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;-2%;5.825897217;472.9034729;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;+2%;5.814248085;745.2808838;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;+4%;5.813810825;915.4319458;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC;Urban;URB/Local/50/St+Go2;+6%;5.81058836;1102.934448;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;0%;76.98996735;8.506083488;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;+/-2%;76.83776855;10.12555313;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;+/-4%;72.06789398;14.39326;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;+/-6%;68.70932007;19.40324402;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;-6%;76.99573517;0.039716374;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;-4%;76.99573517;0.255722672;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;-2%;76.99564362;1.802517295;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;+2%;76.67988586;18.44858742;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;+4%;67.14006805;28.53079414;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/Freeflow;+6%;60.42288208;38.76677322;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;0%;14.96282387;22.14816284;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;+/-2%;14.9279213;22.62240982;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;+/-4%;14.87481022;24.37975311;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;+/-6%;14.68308735;27.12934303;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;-6%;15.10646343;9.453556061;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;-4%;15.10005188;12.36842728;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;-2%;15.04090786;16.43699837;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;+2%;14.81493187;28.8078289;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;+4%;14.64956856;36.39110184;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go;+6%;14.2597065;44.80513;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;0%;5.922516346;29.56092262;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;+/-2%;5.949680805;30.13255692;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;+/-4%;5.933505058;31.77571487;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;+/-6%;5.920527935;34.22796631;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;-6%;5.946077347;16.57191086;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;-4%;5.942987442;20.19516182;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;-2%;5.955795765;24.37774086;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;+2%;5.943564415;35.88736343;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;+4%;5.924026489;43.35626221;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Rural;RUR/Trunk/80/St+Go2;+6%;5.894978046;51.8840332;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;0%;38.16640472;8.820799828;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;+/-2%;38.15972137;10.03181744;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;+/-4%;38.05031204;13.24877453;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;+/-6%;37.58854294;17.39661789;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;-6%;38.18581009;0.488363355;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;-4%;38.18580246;1.262102246;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;-2%;38.18279648;3.522736549;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;+2%;38.1366539;16.54090118;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;+4%;37.91482925;25.23544693;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/Freeflow;+6%;36.99126434;34.30487442;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;0%;12.30854416;20.82605171;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;+/-2%;12.3304491;21.32246399;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;+/-4%;12.29303265;22.90725327;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;+/-6%;12.25161839;25.17035484;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;-6%;12.36960888;8.764014244;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;-4%;12.35750484;11.80172539;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;-2%;12.35688972;15.73195934;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;+2%;12.30400658;26.91296959;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;+4%;12.22855568;34.01278305;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go;+6%;12.13362694;41.5766983;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;0%;5.82649374;25.35904312;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;+/-2%;5.820070744;25.91402435;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;+/-4%;5.820352077;27.44678307;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;+/-6%;5.818859577;29.83145523;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;-6%;5.827131748;12.7336483;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;-4%;5.826894283;15.9432745;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;-2%;5.825897217;20.11841774;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;+2%;5.814248085;31.70963478;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;+4%;5.813810825;38.95027161;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;FC_MJ;Urban;URB/Local/50/St+Go2;+6%;5.81058836;46.92927551;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;0%;76.98996735;0.020343527;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;+/-2%;76.83776855;0.01730044;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;+/-4%;72.06789398;0.017447293;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;+/-6%;68.70932007;0.018676752;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;-6%;76.99573517;0.003283858;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;-4%;76.99573517;0.004329456;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;-2%;76.99564362;0.008864681;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;+2%;76.67988586;0.025736194;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;+4%;67.14006805;0.030565124;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/Freeflow;+6%;60.42288208;0.034069642;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;0%;14.96282387;0.051620524;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;+/-2%;14.9279213;0.051826097;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;+/-4%;14.87481022;0.053031277;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;+/-6%;14.68308735;0.054383278;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;-6%;15.10646343;0.033145681;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;-4%;15.10005188;0.039100971;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;-2%;15.04090786;0.044920407;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;+2%;14.81493187;0.058731791;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;+4%;14.64956856;0.066961572;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go;+6%;14.2597065;0.075620867;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;0%;5.922516346;0.106180668;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;+/-2%;5.949680805;0.106712684;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;+/-4%;5.933505058;0.108092502;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;+/-6%;5.920527935;0.111677282;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;-6%;5.946077347;0.077790417;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;-4%;5.942987442;0.085929744;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;-2%;5.955795765;0.094273433;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;+2%;5.943564415;0.11915192;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;+4%;5.924026489;0.130255222;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Rural;RUR/Trunk/80/St+Go2;+6%;5.894978046;0.145564064;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;0%;38.16640472;0.02732794;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;+/-2%;38.15972137;0.027866151;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;+/-4%;38.05031204;0.02856797;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;+/-6%;37.58854294;0.029820791;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;-6%;38.18581009;0.008985499;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;-4%;38.18580246;0.011513454;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;-2%;38.18279648;0.017342249;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;+2%;38.1366539;0.038390052;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;+4%;37.91482925;0.045622483;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/Freeflow;+6%;36.99126434;0.050656073;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;0%;12.30854416;0.071998134;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;+/-2%;12.3304491;0.07137569;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;+/-4%;12.29303265;0.071814992;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;+/-6%;12.25161839;0.071961574;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;-6%;12.36960888;0.044866778;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;-4%;12.35750484;0.052602001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;-2%;12.35688972;0.061678577;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;+2%;12.30400658;0.08107277;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;+4%;12.22855568;0.09102796;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go;+6%;12.13362694;0.099056363;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;0%;5.82649374;0.113061935;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;+/-2%;5.820070744;0.114979327;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;+/-4%;5.820352077;0.116552077;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;+/-6%;5.818859577;0.119422428;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;-6%;5.827131748;0.074267514;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;-4%;5.826894283;0.083613321;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;-2%;5.825897217;0.098184042;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;+2%;5.814248085;0.131774634;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;+4%;5.813810825;0.149490848;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM;Urban;URB/Local/50/St+Go2;+6%;5.81058836;0.16457729;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;0%;76.98996735;1.11361E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;+/-2%;76.83776855;1.04983E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;+/-4%;72.06789398;1.109E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;+/-6%;68.70932007;1.18801E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;-6%;76.99573517;2.0846E+12;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;-4%;76.99573517;2.90942E+12;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;-2%;76.99564362;5.67112E+12;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;+2%;76.67988586;1.53255E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;+4%;67.14006805;1.92707E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/Freeflow;+6%;60.42288208;2.16756E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;0%;14.96282387;2.48716E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;+/-2%;14.9279213;2.47978E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;+/-4%;14.87481022;2.52011E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;+/-6%;14.68308735;2.59901E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;-6%;15.10646343;1.55201E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;-4%;15.10005188;1.80018E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;-2%;15.04090786;2.10445E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;+2%;14.81493187;2.85511E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;+4%;14.64956856;3.24004E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go;+6%;14.2597065;3.646E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;0%;5.922516346;4.34777E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;+/-2%;5.949680805;4.35459E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;+/-4%;5.933505058;4.43622E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;+/-6%;5.920527935;4.55048E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;-6%;5.946077347;3.13564E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;-4%;5.942987442;3.46392E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;-2%;5.955795765;3.84373E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;+2%;5.943564415;4.86545E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;+4%;5.924026489;5.40852E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Rural;RUR/Trunk/80/St+Go2;+6%;5.894978046;5.96532E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;0%;38.16640472;1.60308E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;+/-2%;38.15972137;1.62223E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;+/-4%;38.05031204;1.70166E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;+/-6%;37.58854294;1.83132E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;-6%;38.18581009;5.2201E+12;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;-4%;38.18580246;6.8109E+12;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;-2%;38.18279648;1.03986E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;+2%;38.1366539;2.20459E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;+4%;37.91482925;2.72222E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/Freeflow;+6%;36.99126434;3.14064E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;0%;12.30854416;3.33335E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;+/-2%;12.3304491;3.33732E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;+/-4%;12.29303265;3.38043E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;+/-6%;12.25161839;3.46433E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;-6%;12.36960888;2.15685E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;-4%;12.35750484;2.48343E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;-2%;12.35688972;2.87695E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;+2%;12.30400658;3.79769E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;+4%;12.22855568;4.27743E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go;+6%;12.13362694;4.77181E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;0%;5.82649374;5.20874E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;+/-2%;5.820070744;5.20271E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;+/-4%;5.820352077;5.2546E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;+/-6%;5.818859577;5.34569E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;-6%;5.827131748;3.46416E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;-4%;5.826894283;3.91531E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;-2%;5.825897217;4.49671E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;+2%;5.814248085;5.90872E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;+4%;5.813810825;6.59389E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PN;Urban;URB/Local/50/St+Go2;+6%;5.81058836;7.22723E+13;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;0%;76.98996735;584.0648193;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;+/-2%;76.83776855;695.3063965;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;+/-4%;72.06789398;988.4500732;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;+/-6%;68.70932007;1332.563965;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;-6%;76.99573517;2.916579485;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;-4%;76.99573517;17.64890862;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;-2%;76.99564362;123.7574768;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;+2%;76.67988586;1266.855225;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;+4%;67.14006805;1959.251343;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/Freeflow;+6%;60.42288208;2662.211426;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;0%;14.96282387;1521.080322;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;+/-2%;14.9279213;1553.657959;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;+/-4%;14.87481022;1674.355469;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;+/-6%;14.68308735;1863.190674;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;-6%;15.10646343;649.4118652;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;-4%;15.10005188;849.5428467;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;-2%;15.04090786;1128.901489;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;+2%;14.81493187;1978.413818;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;+4%;14.64956856;2499.168213;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go;+6%;14.2597065;3076.969482;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;0%;5.922516346;2030.258911;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;+/-2%;5.949680805;2069.522461;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;+/-4%;5.933505058;2182.363525;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;+/-6%;5.920527935;2350.764404;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;-6%;5.946077347;1138.328735;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;-4%;5.942987442;1387.13501;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;-2%;5.955795765;1674.345825;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;+2%;5.943564415;2464.699707;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;+4%;5.924026489;2977.591797;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Rural;RUR/Trunk/80/St+Go2;+6%;5.894978046;3563.200195;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;0%;38.16640472;605.7132568;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;+/-2%;38.15972137;688.8930054;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;+/-4%;38.05031204;909.8445435;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;+/-6%;37.58854294;1194.713013;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;-6%;38.18581009;33.79818726;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;-4%;38.18580246;86.83175659;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;-2%;38.18279648;241.9654236;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;+2%;38.1366539;1135.820313;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;+4%;37.91482925;1732.857788;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/Freeflow;+6%;36.99126434;2355.627686;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;0%;12.30854416;1430.256348;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;+/-2%;12.3304491;1464.349854;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;+/-4%;12.29303265;1573.188965;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;+/-6%;12.25161839;1728.605225;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;-6%;12.36960888;602.1034546;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;-4%;12.35750484;810.6515503;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;-2%;12.35688972;1080.487061;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;+2%;12.30400658;1848.213135;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;+4%;12.22855568;2335.726563;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go;+6%;12.13362694;2855.107666;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;0%;5.82649374;1741.624634;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;+/-2%;5.820070744;1779.743164;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;+/-4%;5.820352077;1885.002808;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;+/-6%;5.818859577;2048.755127;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;-6%;5.827131748;874.7750244;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;-4%;5.826894283;1095.146484;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;-2%;5.825897217;1381.803833;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;+2%;5.814248085;2177.68335;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;+4%;5.813810825;2674.859375;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(rep);Urban;URB/Local/50/St+Go2;+6%;5.81058836;3222.736084;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;0%;76.98996735;623.312439;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;+/-2%;76.83776855;742.0291748;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;+/-4%;72.06789398;1054.870361;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;+/-6%;68.70932007;1422.105713;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;-6%;76.99573517;3.112864494;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;-4%;76.99573517;18.83660316;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;-2%;76.99564362;132.0756378;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;+2%;76.67988586;1351.983032;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;+4%;67.14006805;2090.90332;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/Freeflow;+6%;60.42288208;2841.098389;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;0%;14.96282387;1623.287598;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;+/-2%;14.9279213;1658.053955;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;+/-4%;14.87481022;1786.862549;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;+/-6%;14.68308735;1988.385742;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;-6%;15.10646343;693.0481567;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;-4%;15.10005188;906.6268311;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;-2%;15.04090786;1204.756714;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;+2%;14.81493187;2111.351318;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;+4%;14.64956856;2667.097656;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go;+6%;14.2597065;3283.723389;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;0%;5.922516346;2166.676758;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;+/-2%;5.949680805;2208.579346;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;+/-4%;5.933505058;2329.00293;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;+/-6%;5.920527935;2508.719727;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;-6%;5.946077347;1214.815552;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;-4%;5.942987442;1480.339966;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;-2%;5.955795765;1786.849365;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;+2%;5.943564415;2630.30957;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;+4%;5.924026489;3177.666016;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Rural;RUR/Trunk/80/St+Go2;+6%;5.894978046;3802.624023;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;0%;38.16640472;646.4078979;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;+/-2%;38.15972137;735.1754761;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;+/-4%;38.05031204;970.9700317;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;+/-6%;37.58854294;1274.97583;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;-6%;38.18581009;36.0690918;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;-4%;38.18580246;92.66630554;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;-2%;38.18279648;258.223053;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;+2%;38.1366539;1212.12793;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;+4%;37.91482925;1849.274048;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/Freeflow;+6%;36.99126434;2513.88208;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;0%;12.30854416;1526.344604;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;+/-2%;12.3304491;1562.728394;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;+/-4%;12.29303265;1678.878784;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;+/-6%;12.25161839;1844.736206;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;-6%;12.36960888;642.555603;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;-4%;12.35750484;865.1140747;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;-2%;12.35688972;1153.077271;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;+2%;12.30400658;1972.379761;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;+4%;12.22855568;2492.644531;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go;+6%;12.13362694;3046.916748;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;0%;5.82649374;1858.631104;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;+/-2%;5.820070744;1899.311523;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;+/-4%;5.820352077;2011.642334;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;+/-6%;5.818859577;2186.395508;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;-6%;5.827131748;933.5466919;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;-4%;5.826894283;1168.723022;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;-2%;5.825897217;1474.638428;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;+2%;5.814248085;2323.984863;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;+4%;5.813810825;2854.561035;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2(total);Urban;URB/Local/50/St+Go2;+6%;5.81058836;3439.244629;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;0%;76.98996735;0.173341751;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;+/-2%;76.83776855;0.23085767;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;+/-4%;72.06789398;0.179227591;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;+/-6%;68.70932007;0.197698861;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;-6%;76.99573517;0.055973455;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;-4%;76.99573517;0.074978203;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;-2%;76.99564362;0.252260834;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;+2%;76.67988586;0.209454492;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;+4%;67.14006805;0.283476949;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/Freeflow;+6%;60.42288208;0.339424342;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;0%;14.96282387;1.296055794;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;+/-2%;14.9279213;1.417335391;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;+/-4%;14.87481022;1.362146497;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;+/-6%;14.68308735;1.254148483;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;-6%;15.10646343;1.303208828;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;-4%;15.10005188;1.517406344;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;-2%;15.04090786;1.628636599;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;+2%;14.81493187;1.206033945;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;+4%;14.64956856;1.206886888;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go;+6%;14.2597065;1.205087543;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;0%;5.922516346;1.9256742;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;+/-2%;5.949680805;1.985776424;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;+/-4%;5.933505058;1.999235392;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;+/-6%;5.920527935;1.96008718;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;-6%;5.946077347;2.223111868;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;-4%;5.942987442;2.310803413;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;-2%;5.955795765;2.192746401;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;+2%;5.943564415;1.778806448;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;+4%;5.924026489;1.687667489;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Rural;RUR/Trunk/80/St+Go2;+6%;5.894978046;1.697062731;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;0%;38.16640472;0.425829202;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;+/-2%;38.15972137;0.469330221;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;+/-4%;38.05031204;0.301421225;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;+/-6%;37.58854294;0.278875977;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;-6%;38.18581009;0.139986828;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;-4%;38.18580246;0.22747767;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;-2%;38.18279648;0.590499699;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;+2%;38.1366539;0.348160833;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;+4%;37.91482925;0.375364661;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/Freeflow;+6%;36.99126434;0.417764992;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;0%;12.30854416;1.337840796;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;+/-2%;12.3304491;1.305039883;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;+/-4%;12.29303265;1.25616014;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;+/-6%;12.25161839;1.1644696;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;-6%;12.36960888;1.06823504;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;-4%;12.35750484;1.266121268;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;-2%;12.35688972;1.349487185;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;+2%;12.30400658;1.260592222;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;+4%;12.22855568;1.246198773;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go;+6%;12.13362694;1.260704279;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;0%;5.82649374;1.92364049;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;+/-2%;5.820070744;1.935098052;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;+/-4%;5.820352077;1.897200584;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;+/-6%;5.818859577;1.857321858;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;-6%;5.827131748;1.630464077;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;-4%;5.826894283;1.74945569;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;-2%;5.825897217;1.869556069;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;+2%;5.814248085;2.000640631;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;+4%;5.813810825;2.044944763;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NO2;Urban;URB/Local/50/St+Go2;+6%;5.81058836;2.084178686;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;0%;76.98996735;0.000898376;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;+/-2%;76.83776855;0.000977403;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;+/-4%;72.06789398;0.001280039;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;+/-6%;68.70932007;0.00167496;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;-6%;76.99573517;0.000233608;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;-4%;76.99573517;0.00029968;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;-2%;76.99564362;0.000470189;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;+2%;76.67988586;0.001484616;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;+4%;67.14006805;0.002260397;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/Freeflow;+6%;60.42288208;0.003116311;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;0%;14.96282387;0.002941786;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;+/-2%;14.9279213;0.002961834;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;+/-4%;14.87481022;0.00308941;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;+/-6%;14.68308735;0.003274123;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;-6%;15.10646343;0.001968294;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;-4%;15.10005188;0.00219785;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;-2%;15.04090786;0.002516413;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;+2%;14.81493187;0.003407256;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;+4%;14.64956856;0.00398097;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go;+6%;14.2597065;0.004579952;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;0%;5.922516346;0.005545871;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;+/-2%;5.949680805;0.005547435;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;+/-4%;5.933505058;0.005637354;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;+/-6%;5.920527935;0.005773545;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;-6%;5.946077347;0.004410313;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;-4%;5.942987442;0.004714166;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;-2%;5.955795765;0.005065951;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;+2%;5.943564415;0.006028919;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;+4%;5.924026489;0.006560542;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Rural;RUR/Trunk/80/St+Go2;+6%;5.894978046;0.007136774;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;0%;38.16640472;0.001376602;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;+/-2%;38.15972137;0.001388682;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;+/-4%;38.05031204;0.001489955;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;+/-6%;37.58854294;0.001701155;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;-6%;38.18581009;0.00053768;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;-4%;38.18580246;0.000667743;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;-2%;38.18279648;0.000952078;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;+2%;38.1366539;0.001825287;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;+4%;37.91482925;0.002312166;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/Freeflow;+6%;36.99126434;0.002864629;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;0%;12.30854416;0.003263844;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;+/-2%;12.3304491;0.003283804;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;+/-4%;12.29303265;0.003368108;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;+/-6%;12.25161839;0.003492496;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;-6%;12.36960888;0.002367745;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;-4%;12.35750484;0.00260471;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;-2%;12.35688972;0.002893771;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;+2%;12.30400658;0.003673836;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;+4%;12.22855568;0.004131506;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go;+6%;12.13362694;0.004617248;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;0%;5.82649374;0.005763322;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;+/-2%;5.820070744;0.00575443;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;+/-4%;5.820352077;0.005809368;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;+/-6%;5.818859577;0.005898294;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;-6%;5.827131748;0.004654169;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;-4%;5.826894283;0.004972758;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;-2%;5.825897217;0.005308161;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;+2%;5.814248085;0.006200699;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;+4%;5.813810825;0.006645976;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CH4;Urban;URB/Local/50/St+Go2;+6%;5.81058836;0.007142421;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;0%;76.98996735;0.026420388;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;+/-2%;76.83776855;0.027456455;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;+/-4%;72.06789398;0.034297854;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;+/-6%;68.70932007;0.043984149;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;-6%;76.99573517;0.009311871;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;-4%;76.99573517;0.011735885;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;-2%;76.99564362;0.017150667;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;+2%;76.67988586;0.037762236;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;+4%;67.14006805;0.056859832;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/Freeflow;+6%;60.42288208;0.078656442;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;0%;14.96282387;0.094121404;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;+/-2%;14.9279213;0.094287179;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;+/-4%;14.87481022;0.097084545;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;+/-6%;14.68308735;0.100989789;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;-6%;15.10646343;0.069588661;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;-4%;15.10005188;0.075576834;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;-2%;15.04090786;0.083769344;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;+2%;14.81493187;0.104805097;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;+4%;14.64956856;0.11859218;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go;+6%;14.2597065;0.132390901;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;0%;5.922516346;0.194286197;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;+/-2%;5.949680805;0.193453372;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;+/-4%;5.933505058;0.194691315;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;+/-6%;5.920527935;0.196813807;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;-6%;5.946077347;0.162583649;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;-4%;5.942987442;0.171051115;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;-2%;5.955795765;0.180733934;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;+2%;5.943564415;0.206172824;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;+4%;5.924026489;0.218331426;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Rural;RUR/Trunk/80/St+Go2;+6%;5.894978046;0.231043935;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;0%;38.16640472;0.04724415;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;+/-2%;38.15972137;0.046390764;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;+/-4%;38.05031204;0.047084566;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;+/-6%;37.58854294;0.051352765;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;-6%;38.18581009;0.021284573;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;-4%;38.18580246;0.025838288;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;-2%;38.18279648;0.035262231;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;+2%;38.1366539;0.057519313;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;+4%;37.91482925;0.068330809;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/Freeflow;+6%;36.99126434;0.081420943;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;0%;12.30854416;0.112661213;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;+/-2%;12.3304491;0.112906307;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;+/-4%;12.29303265;0.114651717;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;+/-6%;12.25161839;0.117307775;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;-6%;12.36960888;0.088193431;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;-4%;12.35750484;0.094843991;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;-2%;12.35688972;0.102705494;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;+2%;12.30400658;0.12310718;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;+4%;12.22855568;0.134459406;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go;+6%;12.13362694;0.146422073;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;0%;5.82649374;0.211818829;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;+/-2%;5.820070744;0.210749373;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;+/-4%;5.820352077;0.21121569;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;+/-6%;5.818859577;0.212130204;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;-6%;5.827131748;0.178541154;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;-4%;5.826894283;0.188645542;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;-2%;5.825897217;0.198362425;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;+2%;5.814248085;0.223136306;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;+4%;5.813810825;0.233785912;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NMHC;Urban;URB/Local/50/St+Go2;+6%;5.81058836;0.245719194;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;0%;76.98996735;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;+/-2%;76.83776855;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;+/-4%;72.06789398;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;+/-6%;68.70932007;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;-6%;76.99573517;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;-4%;76.99573517;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;-2%;76.99564362;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;+2%;76.67988586;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;+4%;67.14006805;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/Freeflow;+6%;60.42288208;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;0%;14.96282387;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;+/-2%;14.9279213;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;+/-4%;14.87481022;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;+/-6%;14.68308735;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;-6%;15.10646343;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;-4%;15.10005188;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;-2%;15.04090786;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;+2%;14.81493187;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;+4%;14.64956856;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go;+6%;14.2597065;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;0%;5.922516346;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;+/-2%;5.949680805;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;+/-4%;5.933505058;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;+/-6%;5.920527935;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;-6%;5.946077347;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;-4%;5.942987442;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;-2%;5.955795765;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;+2%;5.943564415;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;+4%;5.924026489;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Rural;RUR/Trunk/80/St+Go2;+6%;5.894978046;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;0%;38.16640472;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;+/-2%;38.15972137;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;+/-4%;38.05031204;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;+/-6%;37.58854294;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;-6%;38.18581009;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;-4%;38.18580246;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;-2%;38.18279648;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;+2%;38.1366539;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;+4%;37.91482925;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/Freeflow;+6%;36.99126434;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;0%;12.30854416;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;+/-2%;12.3304491;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;+/-4%;12.29303265;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;+/-6%;12.25161839;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;-6%;12.36960888;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;-4%;12.35750484;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;-2%;12.35688972;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;+2%;12.30400658;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;+4%;12.22855568;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go;+6%;12.13362694;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;0%;5.82649374;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;+/-2%;5.820070744;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;+/-4%;5.820352077;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;+/-6%;5.818859577;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;-6%;5.827131748;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;-4%;5.826894283;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;-2%;5.825897217;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;+2%;5.814248085;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;+4%;5.813810825;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Pb;Urban;URB/Local/50/St+Go2;+6%;5.81058836;0;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;0%;76.98996735;0.003195159;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;+/-2%;76.83776855;0.003803713;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;+/-4%;72.06789398;0.005407394;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;+/-6%;68.70932007;0.007289926;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;-6%;76.99573517;1.59502E-05;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;-4%;76.99573517;9.65197E-05;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;-2%;76.99564362;0.000676989;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;+2%;76.67988586;0.006930437;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;+4%;67.14006805;0.01071827;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/Freeflow;+6%;60.42288208;0.014563901;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;0%;14.96282387;0.008321254;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;+/-2%;14.9279213;0.008499474;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;+/-4%;14.87481022;0.009159762;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;+/-6%;14.68308735;0.010192806;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;-6%;15.10646343;0.003552694;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;-4%;15.10005188;0.004647532;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;-2%;15.04090786;0.006175795;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;+2%;14.81493187;0.010823153;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;+4%;14.64956856;0.013671995;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go;+6%;14.2597065;0.016832918;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;0%;5.922516346;0.011106825;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;+/-2%;5.949680805;0.011321622;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;+/-4%;5.933505058;0.011938926;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;+/-6%;5.920527935;0.012860175;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;-6%;5.946077347;0.006227403;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;-4%;5.942987442;0.007588534;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;-2%;5.955795765;0.009159758;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;+2%;5.943564415;0.013483487;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;+4%;5.924026489;0.016289318;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Rural;RUR/Trunk/80/St+Go2;+6%;5.894978046;0.019492948;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;0%;38.16640472;0.003313724;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;+/-2%;38.15972137;0.003768791;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;+/-4%;38.05031204;0.004977596;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;+/-6%;37.58854294;0.00653608;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;-6%;38.18581009;0.000184899;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;-4%;38.18580246;0.000475024;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;-2%;38.18279648;0.001323719;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;+2%;38.1366539;0.006213862;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;+4%;37.91482925;0.009480166;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/Freeflow;+6%;36.99126434;0.012887259;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;0%;12.30854416;0.007824671;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;+/-2%;12.3304491;0.008011198;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;+/-4%;12.29303265;0.00860664;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;+/-6%;12.25161839;0.009456906;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;-6%;12.36960888;0.003293979;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;-4%;12.35750484;0.004434911;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;-2%;12.35688972;0.005911138;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;+2%;12.30400658;0.010111257;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;+4%;12.22855568;0.01277837;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go;+6%;12.13362694;0.015619831;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;0%;5.82649374;0.009528109;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;+/-2%;5.820070744;0.009736646;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;+/-4%;5.820352077;0.010312504;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;+/-6%;5.818859577;0.011208376;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;-6%;5.827131748;0.004785702;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;-4%;5.826894283;0.005991313;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;-2%;5.825897217;0.007559572;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;+2%;5.814248085;0.01191372;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;+4%;5.813810825;0.014633697;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;SO2;Urban;URB/Local/50/St+Go2;+6%;5.81058836;0.017631048;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;0%;76.84284973;0.039884981;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;+/-2%;76.69287109;0.039884981;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;+/-4%;71.93149567;0.039884981;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;+/-6%;68.58207703;0.039884981;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;-6%;76.84860992;0.039884981;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;-4%;76.84860992;0.039884981;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;-2%;76.84851837;0.039884981;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;+2%;76.53723145;0.039884981;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;+4%;67.01438141;0.039884981;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/Freeflow;+6%;60.3155365;0.039884981;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;0%;14.93427086;0.04806618;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;+/-2%;14.89946556;0.04806618;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;+/-4%;14.84657001;0.04806618;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;+/-6%;14.65561867;0.04806618;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;-6%;15.0776186;0.04806618;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;-4%;15.07121658;0.04806618;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;-2%;15.01217651;0.04806618;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;+2%;14.78675461;0.04806618;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;+4%;14.62192154;0.04806618;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go;+6%;14.23361492;0.04806618;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;0%;5.911186218;0.04806618;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;+/-2%;5.938327312;0.04806618;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;+/-4%;5.922170162;0.04806618;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;+/-6%;5.90925169;0.04806618;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;-6%;5.934707165;0.04806618;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;-4%;5.931613445;0.04806618;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;-2%;5.944426537;0.04806618;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;+2%;5.932228088;0.04806618;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;+4%;5.91272831;0.04806618;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Rural;RUR/Trunk/80/St+Go2;+6%;5.883796692;0.04806618;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;0%;38.081604;0.047037929;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;+/-2%;38.07510376;0.047037929;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;+/-4%;37.96611404;0.047037929;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;+/-6%;37.50867462;0.047037929;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;-6%;38.10093307;0.047037929;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;-4%;38.10092926;0.047037929;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;-2%;38.09793854;0.047037929;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;+2%;38.05228043;0.047037929;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;+4%;37.83129501;0.047037929;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/Freeflow;+6%;36.91640854;0.047037929;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;0%;12.28125668;0.04313051;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;+/-2%;12.30315208;0.04313051;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;+/-4%;12.26583481;0.04313051;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;+/-6%;12.2247839;0.04313051;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;-6%;12.34212399;0.04313051;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;-4%;12.33006191;0.04313051;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;-2%;12.32950783;0.04313051;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;+2%;12.27679443;0.04313051;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;+4%;12.20160484;0.04313051;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go;+6%;12.10743999;0.04313051;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;0%;5.813541889;0.04313051;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;+/-2%;5.807134151;0.04313051;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;+/-4%;5.807433605;0.04313051;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;+/-6%;5.806009293;0.04313051;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;-6%;5.81417799;0.04313051;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;-4%;5.813941002;0.04313051;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;-2%;5.812946796;0.04313051;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;+2%;5.801323891;0.04313051;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;+4%;5.800927162;0.04313051;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;N2O;Urban;URB/Local/50/St+Go2;+6%;5.797841549;0.04313051;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;0%;76.84284973;0.012130267;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;+/-2%;76.69287109;0.012130267;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;+/-4%;71.93149567;0.012130267;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;+/-6%;68.58207703;0.012130267;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;-6%;76.84860992;0.012130267;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;-4%;76.84860992;0.012130267;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;-2%;76.84851837;0.012130267;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;+2%;76.53723145;0.012130267;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;+4%;67.01438141;0.012130267;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/Freeflow;+6%;60.3155365;0.012130267;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;0%;14.93427086;0.01616185;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;+/-2%;14.89946556;0.01616185;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;+/-4%;14.84657001;0.01616185;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;+/-6%;14.65561867;0.01616185;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;-6%;15.0776186;0.01616185;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;-4%;15.07121658;0.01616185;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;-2%;15.01217651;0.01616185;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;+2%;14.78675461;0.01616185;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;+4%;14.62192154;0.01616185;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go;+6%;14.23361492;0.01616185;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;0%;5.911186218;0.01616185;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;+/-2%;5.938327312;0.01616185;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;+/-4%;5.922170162;0.01616185;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;+/-6%;5.90925169;0.01616185;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;-6%;5.934707165;0.01616185;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;-4%;5.931613445;0.01616185;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;-2%;5.944426537;0.01616185;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;+2%;5.932228088;0.01616185;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;+4%;5.91272831;0.01616185;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Rural;RUR/Trunk/80/St+Go2;+6%;5.883796692;0.01616185;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;0%;38.081604;0.011355663;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;+/-2%;38.07510376;0.011355663;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;+/-4%;37.96611404;0.011355663;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;+/-6%;37.50867462;0.011355663;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;-6%;38.10093307;0.011355663;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;-4%;38.10092926;0.011355663;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;-2%;38.09793854;0.011355663;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;+2%;38.05228043;0.011355663;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;+4%;37.83129501;0.011355663;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/Freeflow;+6%;36.91640854;0.011355663;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;0%;12.28125668;0.014842311;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;+/-2%;12.30315208;0.014842311;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;+/-4%;12.26583481;0.014842311;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;+/-6%;12.2247839;0.014842311;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;-6%;12.34212399;0.014842311;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;-4%;12.33006191;0.014842311;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;-2%;12.32950783;0.014842311;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;+2%;12.27679443;0.014842311;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;+4%;12.20160484;0.014842311;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go;+6%;12.10743999;0.014842311;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;0%;5.813541889;0.014842311;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;+/-2%;5.807134151;0.014842311;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;+/-4%;5.807433605;0.014842311;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;+/-6%;5.806009293;0.014842311;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;-6%;5.81417799;0.014842311;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;-4%;5.813941002;0.014842311;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;-2%;5.812946796;0.014842311;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;+2%;5.801323891;0.014842311;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;+4%;5.800927162;0.014842311;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;NH3;Urban;URB/Local/50/St+Go2;+6%;5.797841549;0.014842311;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;0%;76.98996735;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-2%;76.83776855;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-4%;72.06789398;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-6%;68.70932007;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-6%;76.99573517;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-4%;76.99573517;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-2%;76.99564362;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+2%;76.67988586;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+4%;67.14006805;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+6%;60.42288208;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;0%;14.96282387;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-2%;14.9279213;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-4%;14.87481022;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-6%;14.68308735;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;-6%;15.10646343;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;-4%;15.10005188;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;-2%;15.04090786;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;+2%;14.81493187;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;+4%;14.64956856;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go;+6%;14.2597065;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;0%;5.922516346;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-2%;5.949680805;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-4%;5.933505058;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-6%;5.920527935;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-6%;5.946077347;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-4%;5.942987442;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-2%;5.955795765;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+2%;5.943564415;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+4%;5.924026489;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+6%;5.894978046;0.13000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;0%;38.16640472;0.099999994;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;+/-2%;38.15972137;0.099999994;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;+/-4%;38.05031204;0.099999994;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;+/-6%;37.58854294;0.099999994;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;-6%;38.18581009;0.099999994;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;-4%;38.18580246;0.099999994;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;-2%;38.18279648;0.099999994;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;+2%;38.1366539;0.099999994;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;+4%;37.91482925;0.099999994;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/Freeflow;+6%;36.99126434;0.099999994;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;0%;12.30854416;1.200000048;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;+/-2%;12.3304491;1.200000048;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;+/-4%;12.29303265;1.200000048;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;+/-6%;12.25161839;1.200000048;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;-6%;12.36960888;1.200000048;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;-4%;12.35750484;1.200000048;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;-2%;12.35688972;1.200000048;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;+2%;12.30400658;1.200000048;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;+4%;12.22855568;1.200000048;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go;+6%;12.13362694;1.200000048;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;0%;5.82649374;1.200000048;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;+/-2%;5.820070744;1.200000048;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;+/-4%;5.820352077;1.200000048;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;+/-6%;5.818859577;1.200000048;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;-6%;5.827131748;1.200000048;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;-4%;5.826894283;1.200000048;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;-2%;5.825897217;1.200000048;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;+2%;5.814248085;1.200000048;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;+4%;5.813810825;1.200000048;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM (non-exhaust);Urban;URB/Local/50/St+Go2;+6%;5.81058836;1.200000048;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;0%;76.98996735;0.000451699;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;+/-2%;76.83776855;0.000469347;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;+/-4%;72.06789398;0.000586208;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;+/-6%;68.70932007;0.000751713;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;-6%;76.99573517;0.000159325;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;-4%;76.99573517;0.000200792;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;-2%;76.99564362;0.000293387;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;+2%;76.67988586;0.000645308;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;+4%;67.14006805;0.000971623;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/Freeflow;+6%;60.42288208;0.0013441;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;0%;14.96282387;0.001609544;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;+/-2%;14.9279213;0.001612357;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;+/-4%;14.87481022;0.001660133;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;+/-6%;14.68308735;0.001726822;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;-6%;15.10646343;0.001190324;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;-4%;15.10005188;0.001292663;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;-2%;15.04090786;0.001432667;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;+2%;14.81493187;0.001792046;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;+4%;14.64956856;0.002027602;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go;+6%;14.2597065;0.00226332;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;0%;5.922516346;0.003323219;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;+/-2%;5.949680805;0.003308936;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;+/-4%;5.933505058;0.003330028;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;+/-6%;5.920527935;0.00336622;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;-6%;5.946077347;0.002781298;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;-4%;5.942987442;0.002926039;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;-2%;5.955795765;0.003091549;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;+2%;5.943564415;0.003526322;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;+4%;5.924026489;0.003734017;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Rural;RUR/Trunk/80/St+Go2;+6%;5.894978046;0.003951143;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;0%;38.16640472;0.000808058;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;+/-2%;38.15972137;0.000793407;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;+/-4%;38.05031204;0.000805153;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;+/-6%;37.58854294;0.000878026;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;-6%;38.18581009;0.000364172;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;-4%;38.18580246;0.000442062;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;-2%;38.18279648;0.000603233;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;+2%;38.1366539;0.000983581;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;+4%;37.91482925;0.001168243;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/Freeflow;+6%;36.99126434;0.00139188;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;0%;12.30854416;0.001926972;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;+/-2%;12.3304491;0.001931145;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;+/-4%;12.29303265;0.001960947;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;+/-6%;12.25161839;0.002006306;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;-6%;12.36960888;0.00150875;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;-4%;12.35750484;0.001622436;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;-2%;12.35688972;0.001756809;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;+2%;12.30400658;0.00210548;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;+4%;12.22855568;0.002299458;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go;+6%;12.13362694;0.002503862;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;0%;5.82649374;0.003623533;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;+/-2%;5.820070744;0.003605206;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;+/-4%;5.820352077;0.003613121;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;+/-6%;5.818859577;0.00362867;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;-6%;5.827131748;0.003054563;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;-4%;5.826894283;0.003227351;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;-2%;5.825897217;0.00339347;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;+2%;5.814248085;0.003816943;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;+4%;5.813810825;0.003998892;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;Benzene;Urban;URB/Local/50/St+Go2;+6%;5.81058836;0.004202776;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;0%;76.98996735;0.020343527;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;+/-2%;76.83776855;0.01730044;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;+/-4%;72.06789398;0.017447293;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;+/-6%;68.70932007;0.018676752;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;-6%;76.99573517;0.003283858;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;-4%;76.99573517;0.004329456;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;-2%;76.99564362;0.008864681;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;+2%;76.67988586;0.025736194;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;+4%;67.14006805;0.030565124;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/Freeflow;+6%;60.42288208;0.034069642;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;0%;14.96282387;0.051620524;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;+/-2%;14.9279213;0.051826097;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;+/-4%;14.87481022;0.053031277;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;+/-6%;14.68308735;0.054383278;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;-6%;15.10646343;0.033145681;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;-4%;15.10005188;0.039100971;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;-2%;15.04090786;0.044920407;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;+2%;14.81493187;0.058731791;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;+4%;14.64956856;0.066961572;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go;+6%;14.2597065;0.075620867;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;0%;5.922516346;0.106180668;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;+/-2%;5.949680805;0.106712684;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;+/-4%;5.933505058;0.108092502;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;+/-6%;5.920527935;0.111677282;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;-6%;5.946077347;0.077790417;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;-4%;5.942987442;0.085929744;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;-2%;5.955795765;0.094273433;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;+2%;5.943564415;0.11915192;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;+4%;5.924026489;0.130255222;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Rural;RUR/Trunk/80/St+Go2;+6%;5.894978046;0.145564064;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;0%;38.16640472;0.02732794;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;+/-2%;38.15972137;0.027866151;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;+/-4%;38.05031204;0.02856797;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;+/-6%;37.58854294;0.029820791;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;-6%;38.18581009;0.008985499;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;-4%;38.18580246;0.011513454;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;-2%;38.18279648;0.017342249;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;+2%;38.1366539;0.038390052;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;+4%;37.91482925;0.045622483;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/Freeflow;+6%;36.99126434;0.050656073;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;0%;12.30854416;0.071998134;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;+/-2%;12.3304491;0.07137569;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;+/-4%;12.29303265;0.071814992;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;+/-6%;12.25161839;0.071961574;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;-6%;12.36960888;0.044866778;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;-4%;12.35750484;0.052602001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;-2%;12.35688972;0.061678577;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;+2%;12.30400658;0.08107277;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;+4%;12.22855568;0.09102796;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go;+6%;12.13362694;0.099056363;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;0%;5.82649374;0.113061935;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;+/-2%;5.820070744;0.114979327;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;+/-4%;5.820352077;0.116552077;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;+/-6%;5.818859577;0.119422428;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;-6%;5.827131748;0.074267514;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;-4%;5.826894283;0.083613321;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;-2%;5.825897217;0.098184042;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;+2%;5.814248085;0.131774634;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;+4%;5.813810825;0.149490848;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5;Urban;URB/Local/50/St+Go2;+6%;5.81058836;0.16457729;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;0%;76.98996735;0.010258011;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;+/-2%;76.83776855;0.009133951;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;+/-4%;72.06789398;0.009322239;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;+/-6%;68.70932007;0.009791275;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;-6%;76.99573517;0.001768928;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;-4%;76.99573517;0.00236314;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;-2%;76.99564362;0.004619936;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;+2%;76.67988586;0.013647966;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;+4%;67.14006805;0.016281338;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/Freeflow;+6%;60.42288208;0.017813625;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;0%;14.96282387;0.023227409;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;+/-2%;14.9279213;0.023254432;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;+/-4%;14.87481022;0.023645684;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;+/-6%;14.68308735;0.024422906;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;-6%;15.10646343;0.015146908;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;-4%;15.10005188;0.017362189;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;-2%;15.04090786;0.020055221;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;+2%;14.81493187;0.02645364;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;+4%;14.64956856;0.029929176;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go;+6%;14.2597065;0.033698916;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;0%;5.922516346;0.044403289;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;+/-2%;5.949680805;0.044615183;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;+/-4%;5.933505058;0.045313139;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;+/-6%;5.920527935;0.04663584;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;-6%;5.946077347;0.033293951;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;-4%;5.942987442;0.036466561;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;-2%;5.955795765;0.039857317;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;+2%;5.943564415;0.049373042;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;+4%;5.924026489;0.054159731;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Rural;RUR/Trunk/80/St+Go2;+6%;5.894978046;0.05997771;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;0%;38.16640472;0.013995224;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;+/-2%;38.15972137;0.014506298;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;+/-4%;38.05031204;0.015268178;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;+/-6%;37.58854294;0.016241975;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;-6%;38.18581009;0.004925126;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;-4%;38.18580246;0.006211485;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;-2%;38.18279648;0.009137794;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;+2%;38.1366539;0.019874798;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;+4%;37.91482925;0.024324872;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/Freeflow;+6%;36.99126434;0.02755883;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;0%;12.30854416;0.032724172;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;+/-2%;12.3304491;0.032700699;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;+/-4%;12.29303265;0.033091456;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;+/-6%;12.25161839;0.033652775;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;-6%;12.36960888;0.021605218;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;-4%;12.35750484;0.024733355;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;-2%;12.35688972;0.028441096;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;+2%;12.30400658;0.036960296;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;+4%;12.22855568;0.041449577;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go;+6%;12.13362694;0.045700338;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;0%;5.82649374;0.051548038;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;+/-2%;5.820070744;0.051831305;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;+/-4%;5.820352077;0.052394889;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;+/-6%;5.818859577;0.05351451;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;-6%;5.827131748;0.035932079;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;-4%;5.826894283;0.039970696;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;-2%;5.825897217;0.045354199;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;+2%;5.814248085;0.058308408;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;+4%;5.813810825;0.064819068;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (exhaust);Urban;URB/Local/50/St+Go2;+6%;5.81058836;0.071096949;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;0%;76.98996735;0.048999995;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-2%;76.83776855;0.048999995;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-4%;72.06789398;0.048999995;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-6%;68.70932007;0.048999995;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-6%;76.99573517;0.048999995;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-4%;76.99573517;0.048999995;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-2%;76.99564362;0.048999995;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+2%;76.67988586;0.048999995;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+4%;67.14006805;0.048999995;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+6%;60.42288208;0.048999995;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;0%;14.96282387;0.068000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-2%;14.9279213;0.068000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-4%;14.87481022;0.068000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-6%;14.68308735;0.068000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;-6%;15.10646343;0.068000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;-4%;15.10005188;0.068000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;-2%;15.04090786;0.068000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;+2%;14.81493187;0.068000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;+4%;14.64956856;0.068000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go;+6%;14.2597065;0.068000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;0%;5.922516346;0.068000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-2%;5.949680805;0.068000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-4%;5.933505058;0.068000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-6%;5.920527935;0.068000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-6%;5.946077347;0.068000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-4%;5.942987442;0.068000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-2%;5.955795765;0.068000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+2%;5.943564415;0.068000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+4%;5.924026489;0.068000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+6%;5.894978046;0.068000004;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;0%;38.16640472;0.067000002;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;+/-2%;38.15972137;0.067000002;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;+/-4%;38.05031204;0.067000002;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;+/-6%;37.58854294;0.067000002;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;-6%;38.18581009;0.067000002;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;-4%;38.18580246;0.067000002;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;-2%;38.18279648;0.067000002;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;+2%;38.1366539;0.067000002;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;+4%;37.91482925;0.067000002;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/Freeflow;+6%;36.99126434;0.067000002;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;0%;12.30854416;0.068000019;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;+/-2%;12.3304491;0.068000019;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;+/-4%;12.29303265;0.068000019;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;+/-6%;12.25161839;0.068000019;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;-6%;12.36960888;0.068000019;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;-4%;12.35750484;0.068000019;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;-2%;12.35688972;0.068000019;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;+2%;12.30400658;0.068000019;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;+4%;12.22855568;0.068000019;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go;+6%;12.13362694;0.068000019;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;0%;5.82649374;0.068000019;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;+/-2%;5.820070744;0.068000019;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;+/-4%;5.820352077;0.068000019;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;+/-6%;5.818859577;0.068000019;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;-6%;5.827131748;0.068000019;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;-4%;5.826894283;0.068000019;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;-2%;5.825897217;0.068000019;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;+2%;5.814248085;0.068000019;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;+4%;5.813810825;0.068000019;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;PM2.5 (non-exhaust);Urban;URB/Local/50/St+Go2;+6%;5.81058836;0.068000019;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;0%;76.98996735;0.004900001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-2%;76.83776855;0.004900001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-4%;72.06789398;0.004900001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+/-6%;68.70932007;0.004900001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-6%;76.99573517;0.004900001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-4%;76.99573517;0.004900001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;-2%;76.99564362;0.004900001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+2%;76.67988586;0.004900001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+4%;67.14006805;0.004900001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/Freeflow;+6%;60.42288208;0.004900001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;0%;14.96282387;0.0068;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-2%;14.9279213;0.0068;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-4%;14.87481022;0.0068;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;+/-6%;14.68308735;0.0068;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;-6%;15.10646343;0.0068;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;-4%;15.10005188;0.0068;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;-2%;15.04090786;0.0068;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;+2%;14.81493187;0.0068;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;+4%;14.64956856;0.0068;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go;+6%;14.2597065;0.0068;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;0%;5.922516346;0.0068;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-2%;5.949680805;0.0068;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-4%;5.933505058;0.0068;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+/-6%;5.920527935;0.0068;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-6%;5.946077347;0.0068;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-4%;5.942987442;0.0068;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;-2%;5.955795765;0.0068;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+2%;5.943564415;0.0068;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+4%;5.924026489;0.0068;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Rural;RUR/Trunk/80/St+Go2;+6%;5.894978046;0.0068;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;0%;38.16640472;0.006700001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;+/-2%;38.15972137;0.006700001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;+/-4%;38.05031204;0.006700001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;+/-6%;37.58854294;0.006700001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;-6%;38.18581009;0.006700001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;-4%;38.18580246;0.006700001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;-2%;38.18279648;0.006700001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;+2%;38.1366539;0.006700001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;+4%;37.91482925;0.006700001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/Freeflow;+6%;36.99126434;0.006700001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;0%;12.30854416;0.006800001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;+/-2%;12.3304491;0.006800001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;+/-4%;12.29303265;0.006800001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;+/-6%;12.25161839;0.006800001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;-6%;12.36960888;0.006800001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;-4%;12.35750484;0.006800001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;-2%;12.35688972;0.006800001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;+2%;12.30400658;0.006800001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;+4%;12.22855568;0.006800001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go;+6%;12.13362694;0.006800001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;0%;5.82649374;0.006800001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;+/-2%;5.820070744;0.006800001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;+/-4%;5.820352077;0.006800001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;+/-6%;5.818859577;0.006800001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;-6%;5.827131748;0.006800001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;-4%;5.826894283;0.006800001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;-2%;5.825897217;0.006800001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;+2%;5.814248085;0.006800001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;+4%;5.813810825;0.006800001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;BC (non-exhaust);Urban;URB/Local/50/St+Go2;+6%;5.81058836;0.006800001;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;0%;76.98996735;595.9727783;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;+/-2%;76.83776855;707.2164307;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;+/-4%;72.06789398;1000.367859;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;+/-6%;68.70932007;1344.491455;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;-6%;76.99573517;14.80814457;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;-4%;76.99573517;29.54213142;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;-2%;76.99564362;135.654953;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;+2%;76.67988586;1278.777954;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;+4%;67.14006805;1971.193481;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/Freeflow;+6%;60.42288208;2674.175293;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;0%;14.96282387;1535.477417;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;+/-2%;14.9279213;1568.05542;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;+/-4%;14.87481022;1688.756348;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;+/-6%;14.68308735;1877.596313;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;-6%;15.10646343;663.78479;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;-4%;15.10005188;863.9216309;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;-2%;15.04090786;1143.288208;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;+2%;14.81493187;1992.822876;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;+4%;14.64956856;2513.591309;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go;+6%;14.2597065;3091.407227;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;0%;5.922516346;2044.721313;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;+/-2%;5.949680805;2083.984619;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;+/-4%;5.933505058;2196.828369;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;+/-6%;5.920527935;2365.232666;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;-6%;5.946077347;1152.762817;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;-4%;5.942987442;1401.57666;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;-2%;5.955795765;1688.796387;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;+2%;5.943564415;2479.174805;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;+4%;5.924026489;2992.080078;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Rural;RUR/Trunk/80/St+Go2;+6%;5.894978046;3577.702881;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;0%;38.16640472;619.7648926;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;+/-2%;38.15972137;702.9449463;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;+/-4%;38.05031204;923.899231;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;+/-6%;37.58854294;1208.772949;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;-6%;38.18581009;47.82892227;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;-4%;38.18580246;100.8657532;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;-2%;38.18279648;256.0065308;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;+2%;38.1366539;1149.883423;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;+4%;37.91482925;1746.932739;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/Freeflow;+6%;36.99126434;2369.716553;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;0%;12.30854416;1443.19104;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;+/-2%;12.3304491;1477.285156;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;+/-4%;12.29303265;1586.126221;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;+/-6%;12.25161839;1741.545654;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;-6%;12.36960888;615.015625;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;-4%;12.35750484;823.569519;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;-2%;12.35688972;1093.412598;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;+2%;12.30400658;1861.157471;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;+4%;12.22855568;2348.682861;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go;+6%;12.13362694;2868.075928;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;0%;5.82649374;1754.621704;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;+/-2%;5.820070744;1792.740356;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;+/-4%;5.820352077;1898.00061;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;+/-6%;5.818859577;2061.755615;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;-6%;5.827131748;887.7445679;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;-4%;5.826894283;1108.123901;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;-2%;5.825897217;1394.789307;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;+2%;5.814248085;2190.691162;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;+4%;5.813810825;2687.878174;;NA;NA
+avg_demo_all_gradients[4.1];HGV;2020;REF D HB41;CO2e;Urban;URB/Local/50/St+Go2;+6%;5.81058836;3235.767334;;NA;NA


### PR DESCRIPTION
This is an attempt to rescue what was done during a matsim advanced class.  Main things to observe IMO:
* Grade is a hbefa input, not a hbefa output.  In consequence, it does not belong into the emission factor class.  (In contrast to speed, which for hbefa is an output, based on traffic state and road category as input.)
* There are NO tests.  There may have been a test if it runs without errors, but that was so incomplete that I did not rescue it.
* There is, I think, nothing in the config or elsewhere to switch back and forth between grades and no grades.  There are also no thoughts about possible fallback.  (Maybe these two are the same: We could say that we want grades, and in that case also want to have grades an all links plus the corresponding complete tables.)