### PR TITLE
Support AttributeConverters in StreamingPopulationReader and Writer

### DIFF
--- a/matsim/src/main/java/org/matsim/core/population/io/StreamingPopulationReader.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/StreamingPopulationReader.java
@@ -32,11 +32,13 @@ import org.matsim.core.config.Config;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.population.algorithms.PersonAlgorithm;
 import org.matsim.core.scenario.MutableScenario;
+import org.matsim.utils.objectattributes.AttributeConverter;
 import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Map;
 
 public final class StreamingPopulationReader implements MatsimReader {
@@ -45,6 +47,7 @@ public final class StreamingPopulationReader implements MatsimReader {
 	private PopulationReader reader ;
 	private final StreamingPopulation pop ;
 	private int cnt;
+	private final Map<Class<?>, AttributeConverter<?>> attributeConverters = new HashMap<>();
 
 	// algorithms over plans
 	private final ArrayList<PersonAlgorithm> personAlgos = new ArrayList<>();
@@ -63,15 +66,26 @@ public final class StreamingPopulationReader implements MatsimReader {
 			throw new RuntimeException("scenario given into this class needs to be an instance of MutableScenario.") ;
 		}
 	}
+
+	public void putAttributeConverter(final Class<?> clazz, AttributeConverter<?> converter) {
+		this.attributeConverters.put(clazz, converter);
+	}
+
+	public void putAttributeConverters(final Map<Class<?>, AttributeConverter<?>> converters) {
+		this.attributeConverters.putAll(converters);
+	}
+
 	Population getStreamingPopulation() {
 		return pop ;
 	}
 	@Override public void readFile(String filename) {
+		reader.putAttributeConverters(this.attributeConverters);
 		reader.readFile(filename);
 	}
 
 	@Override
 	public void readURL( URL url ) {
+		reader.putAttributeConverters(this.attributeConverters);
 		reader.parse( url ) ;
 	}
 

--- a/matsim/src/main/java/org/matsim/core/population/io/StreamingPopulationWriter.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/StreamingPopulationWriter.java
@@ -33,11 +33,13 @@ import org.matsim.core.utils.geometry.transformations.IdentityTransformation;
 import org.matsim.core.utils.io.AbstractMatsimWriter;
 import org.matsim.core.utils.io.UncheckedIOException;
 import org.matsim.core.utils.misc.Counter;
+import org.matsim.utils.objectattributes.AttributeConverter;
 import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.utils.objectattributes.attributable.AttributesImpl;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 public final class StreamingPopulationWriter implements PersonAlgorithm {
@@ -47,6 +49,7 @@ public final class StreamingPopulationWriter implements PersonAlgorithm {
 
 	private PopulationWriterHandler handler = null;
 	private Counter counter = new Counter("[" + this.getClass().getSimpleName() + "] dumped person # ");
+	private final Map<Class<?>, AttributeConverter<?>> attributeConverters = new HashMap<>();
 
 	private static class DummyMatsimWriter extends AbstractMatsimWriter {
 		BufferedWriter getWriter() {
@@ -91,7 +94,13 @@ public final class StreamingPopulationWriter implements PersonAlgorithm {
 		this( new IdentityTransformation() , fraction );
 	}
 
+	public <T> void putAttributeConverter(Class<T> clazz, AttributeConverter<T> converter) {
+		this.attributeConverters.put(clazz, converter);
+	}
 
+	public void putAttributeConverters(final Map<Class<?>, AttributeConverter<?>> converters) {
+		this.attributeConverters.putAll(converters);
+	}
 
 	// implementation of PersonAlgorithm
 	// this is primarily to use the PlansWriter with filters and other algorithms.
@@ -153,6 +162,7 @@ public final class StreamingPopulationWriter implements PersonAlgorithm {
 		} ;
 		try {
 			matsimWriter.openHere(filename);
+			this.handler.putAttributeConverters(this.attributeConverters);
 			this.handler.writeHeaderAndStartElement(matsimWriter.getWriter());
 			this.handler.startPlans(fakepop, matsimWriter.getWriter());
 			this.handler.writeSeparator(matsimWriter.getWriter());

--- a/matsim/src/test/java/org/matsim/core/population/io/StreamingPopulationAttributeConversionTest.java
+++ b/matsim/src/test/java/org/matsim/core/population/io/StreamingPopulationAttributeConversionTest.java
@@ -1,0 +1,127 @@
+
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * PopulationAttributeConversionTest.java
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2019 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.core.population.io;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.api.core.v01.population.PopulationFactory;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.testcases.MatsimTestUtils;
+import org.matsim.utils.objectattributes.AttributeConverter;
+
+public class StreamingPopulationAttributeConversionTest {
+
+	@Rule
+	public final MatsimTestUtils utils = new MatsimTestUtils();
+
+	@Test
+	public void testDefaults() {
+		final String path = utils.getOutputDirectory() + "/plans.xml";
+
+		testWriteAndRereadStreaming((w, persons) -> {
+			w.startStreaming(path);
+			persons.forEach(w::writePerson);
+			w.closeStreaming();
+		}, r -> r.readFile(path));
+	}
+
+	public void testWriteAndRereadStreaming(
+			final BiConsumer<StreamingPopulationWriter, Collection<? extends Person>> writeMethod,
+			final Consumer<StreamingPopulationReader> readMethod) {
+		final Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+		final Population population = scenario.getPopulation();
+		final PopulationFactory populationFactory = population.getFactory();
+
+		final Id<Person> personId = Id.createPersonId("Gaston");
+		final Person person = populationFactory.createPerson(personId);
+		final CustomClass attribute = new CustomClass("homme à tout faire");
+		person.getAttributes().putAttribute("job", attribute);
+		population.addPerson(person);
+
+		final StreamingPopulationWriter writer = new StreamingPopulationWriter();
+		writer.putAttributeConverter(CustomClass.class, new CustomClassConverter());
+		writeMethod.accept(writer, population.getPersons().values());
+
+		final Scenario readScenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+		final Scenario streamingReadScenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+		final StreamingPopulationReader reader = new StreamingPopulationReader(streamingReadScenario);
+		reader.addAlgorithm(readScenario.getPopulation()::addPerson);
+		reader.putAttributeConverter(CustomClass.class, new CustomClassConverter());
+		readMethod.accept(reader);
+
+		final Person readPerson = readScenario.getPopulation().getPersons().get(personId);
+		final Object readAttribute = readPerson.getAttributes().getAttribute("job");
+
+		Assert.assertEquals(
+				"unexpected read attribute",
+				attribute,
+				readAttribute);
+	}
+
+	private static class CustomClass {
+
+		private final String value;
+
+		private CustomClass(String value) {
+			this.value = value;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o)
+				return true;
+			if (o == null || getClass() != o.getClass())
+				return false;
+			CustomClass that = (CustomClass) o;
+			return Objects.equals(value, that.value);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(value);
+		}
+	}
+
+	private static class CustomClassConverter implements AttributeConverter<CustomClass> {
+
+		@Override
+		public CustomClass convert(String value) {
+			return new CustomClass(value);
+		}
+
+		@Override
+		public String convertToString(Object o) {
+			return ((CustomClass) o).value;
+		}
+	}
+}


### PR DESCRIPTION
This change adds `putAttributeConverter`/`putAttributeConverters`-methods to both `StreamingPopulationReader` and `StreamingPopulationWriter` as well as a test for this new functionality.