### PR TITLE
fix: ensure landmarks count is not greater than number of nodes

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/core/router/speedy/SpeedyMultiSourceALTFactory.java
+++ b/contribs/dvrp/src/main/java/org/matsim/core/router/speedy/SpeedyMultiSourceALTFactory.java
@@ -40,8 +40,9 @@ public class SpeedyMultiSourceALTFactory {
 		SpeedyGraph graph = this.graphs.computeIfAbsent(network, SpeedyGraph::new);
 
 		var graphTravelCostsPair = Pair.of(graph, travelCosts);
+		int landmarksCount = Math.min(16, graph.nodeCount);
 		SpeedyALTData landmarks = this.landmarksData.computeIfAbsent(graphTravelCostsPair,
-				p -> new SpeedyALTData(p.getLeft(), 16, p.getRight()));
+				p -> new SpeedyALTData(p.getLeft(), landmarksCount, p.getRight()));
 
 		return new SpeedyMultiSourceALT(landmarks, travelTimes, travelCosts);
 	}

--- a/matsim/src/main/java/org/matsim/core/router/speedy/SpeedyALTFactory.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/SpeedyALTFactory.java
@@ -26,7 +26,8 @@ public class SpeedyALTFactory implements LeastCostPathCalculatorFactory {
 		}
 		SpeedyALTData landmarks = this.landmarksData.get(graph);
 		if (landmarks == null) {
-			landmarks = new SpeedyALTData(graph, 16, travelCosts);
+			int landmarksCount = Math.min(16, graph.nodeCount);
+			landmarks = new SpeedyALTData(graph, landmarksCount, travelCosts);
 			this.landmarksData.put(graph, landmarks);
 		}
 		return new SpeedyALT(landmarks, travelTimes, travelCosts);


### PR DESCRIPTION
By default, the number of landmarks is set to 16. This leads to errors if the number of nodes in the network is less than 16. See: https://github.com/matsim-org/matsim-maas/issues/105

This PR limits the number of landmarks so that it never exceeds the number of nodes.