### PR TITLE
core: improve handling of absolute paths on windows

### DIFF
--- a/matsim/src/main/java/org/matsim/core/config/ConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/ConfigGroup.java
@@ -244,13 +244,15 @@ public class ConfigGroup implements MatsimExtensionPoint {
 	}
 
 	public static URL getInputFileURL(URL context, String filename) {
-		if (filename.startsWith("~" + File.separator)) {
+		if (filename.startsWith("~/")) {
 			filename = System.getProperty("user.home") + filename.substring(1);
 			return IOUtils.getFileUrl(filename) ;
 		}
-		if ( filename.startsWith( File.separator ) ) {
+		if ( filename.startsWith("/") ) {
 			// (= filename is absolute)
 			// (yyyy this may possibly fail on win systems. kai, sep.18)
+
+			// Absolute filename on Windows, when obtained through URL.toURI().getPath() starts with `/`, like on Unix.
 			return IOUtils.getFileUrl(filename) ;
 		}
 		return IOUtils.extendUrl(context, filename);


### PR DESCRIPTION
This fix allows running RunIT (in shared_mobility) on Windows CI machines.

RunIT mixes the input data from two sources: matsim-examples (where the config is) and test/resources (e.g. shared_vehicles_mobility.xml). This works on IDEs, but not in regular maven (eg. when running CI). As a result the following URL is constructed (GitHub Actions, windows-latest):
```
jar:file:/C:/Users/runneradmin/.m2/repository/org/matsim/matsim-examples/16.0-SNAPSHOT/matsim-examples-16.0-SNAPSHOT.jar!/D:/a/matsim-libs/matsim-libs/contribs/shared_mobility/target/test-classes/org/matsim/contrib/shared_mobility/shared_vehicles_mobility.xml
```
instead of
```
/D:/a/matsim-libs/matsim-libs/contribs/shared_mobility/target/test-classes/org/matsim/contrib/shared_mobility/shared_vehicles_mobility.xml
```