### PR TITLE
Run full integration on windows latest

### DIFF
--- a/.github/workflows/full-integration.yaml
+++ b/.github/workflows/full-integration.yaml
@@ -5,7 +5,7 @@ on:
     - cron: '30 0 * * *' # daily at 0:30 UTC
 
 jobs:
-  code-coverage:
+  run-full-integration:
     name: run full integration
 
     runs-on: ${{ matrix.os }}
@@ -37,3 +37,15 @@ jobs:
 
     env:
       MAVEN_OPTS: -Xmx2g
+
+  verify-full-integration-successful:
+    # always() - to ensure this job is executed (regardless of the status of the previous job)
+    # run if push or pull_requests from fork
+    if: always()
+    needs: run-full-integration
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: check if the whole job matrix is successful
+        if: needs.run-full-integration.result != 'success'
+        run: exit 1 # fail if "test" was not successful

--- a/.github/workflows/full-integration.yaml
+++ b/.github/workflows/full-integration.yaml
@@ -8,9 +8,18 @@ jobs:
   code-coverage:
     name: run full integration
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     steps:
+      - name: Prepare git
+        # turn off CRLF conversion (necessary on Windows)
+        run: git config --global core.autocrlf false
+
       - name: Checkout git repo
         uses: actions/checkout@v3
 
@@ -23,7 +32,8 @@ jobs:
 
       # Run unit and integration tests
       - name: Run verify - release profile
-        run: mvn verify -P release --batch-mode --fail-at-end -Dmaven.test.redirectTestOutputToFile -Dmatsim.preferLocalDtds=true
+        # arguments containing dots (.) need to be quoted ('') so that PowerShell (Windows) does not parse them
+        run: mvn verify -P release --batch-mode --fail-at-end -D'maven.test.redirectTestOutputToFile' -D'matsim.preferLocalDtds=true'
 
     env:
       MAVEN_OPTS: -Xmx2g


### PR DESCRIPTION
We have been recently experiencing lots of failing builds on AppVeyor. Most of the failures were caused by the 1-hour timeout, while a few of them by the differences in the testing environment (i.e. windows instead of linux).

This PR enables the windows builds to GitHub Actions that have much longer timeouts (6h). This also allows us to run integrations tests (right now we run only the "base" unit tests on AppVeyor).

See #2577 and #2580.