### PR TITLE
ev: reduce default frequency of charging simulation (and of EnergyChargedEvents)

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/EvConfigGroup.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/EvConfigGroup.java
@@ -36,7 +36,7 @@ public final class EvConfigGroup extends ReflectiveConfigGroup {
 	@Comment("charging will be simulated every 'chargeTimeStep'-th time step")
 	// no need to simulate with 1-second time step
 	@Positive
-	public int chargeTimeStep = 5; // 5 s ==> 0.138% SOC when charging at 1C (i.e. full recharge in 1 hour)
+	public int chargeTimeStep = 15; // 15 s ==> 0.417% SOC when charging at 1C (i.e. full recharge in 1 hour)
 
 	@Parameter
 	@Comment("AUX discharging will be simulated every 'auxDischargeTimeStep'-th time step")


### PR DESCRIPTION
A 15-second interval is still high enough for good simulation accuracy and for online decision making (e.g. stopping charging when the target SOC is reached).