### PR TITLE
Add missing activity types in vsp contrib

### DIFF
--- a/contribs/vsp/src/main/java/org/matsim/contrib/vsp/scenario/SnzActivities.java
+++ b/contribs/vsp/src/main/java/org/matsim/contrib/vsp/scenario/SnzActivities.java
@@ -11,7 +11,8 @@ public enum SnzActivities {
 	home,
 	other,
 	visit,
-
+	accomp_other,
+	accomp_children,
 	educ_kiga(7, 17),
 	educ_primary(7, 16),
 	educ_secondary(7, 17),


### PR DESCRIPTION
Activity types accomp_other, accomp_children which are present in some vsp scenarios have been added.