### PR TITLE
Add group size and part information

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionUtils.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionUtils.java
@@ -21,6 +21,7 @@ package org.matsim.contrib.drt.extension.companions;
 
 import java.util.List;
 
+import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.common.util.WeightedRandomSelection;
 import org.matsim.core.gbl.MatsimRandom;
 
@@ -30,6 +31,8 @@ import org.matsim.core.gbl.MatsimRandom;
  *
  */
 public class DrtCompanionUtils {
+	public final static String ADDITIONAL_GROUP_SIZE_ATTRIBUTE = "additionalGroupSize";
+	public final static String ADDITIONAL_GROUP_PART_ATTRIBUTE = "additionalGroupPart";
 
 	public static WeightedRandomSelection<Integer> createIntegerSampler(final List<Double> distribution) {
 		WeightedRandomSelection<Integer> wrs = new WeightedRandomSelection<>(MatsimRandom.getLocalInstance());
@@ -38,4 +41,29 @@ public class DrtCompanionUtils {
 		}
 		return wrs;
 	}
+
+	public static Integer getAdditionalGroupSize(Person person) {
+		if (person.getAttributes().getAttribute(ADDITIONAL_GROUP_SIZE_ATTRIBUTE) == null) {
+			return null;
+		} else {
+			return Integer.parseInt(person.getAttributes().getAttribute(ADDITIONAL_GROUP_SIZE_ATTRIBUTE).toString());
+		}
+	}
+
+	public static Integer getAdditionalGroupPart(Person person) {
+		if (person.getAttributes().getAttribute(ADDITIONAL_GROUP_PART_ATTRIBUTE) == null) {
+			return null;
+		} else {
+			return Integer.parseInt(person.getAttributes().getAttribute(ADDITIONAL_GROUP_PART_ATTRIBUTE).toString());
+		}
+	}
+
+	public static void setAdditionalGroupSize(Person person, int additionalGroupSize) {
+		person.getAttributes().putAttribute(ADDITIONAL_GROUP_SIZE_ATTRIBUTE, additionalGroupSize);
+	}
+
+	public static void setAdditionalGroupPart(Person person, int additionalgroupPart) {
+		person.getAttributes().putAttribute(ADDITIONAL_GROUP_PART_ATTRIBUTE, additionalgroupPart);
+	}
+
 }


### PR DESCRIPTION
This PR adds some additional information to the companion agent person attributes. Might be required if one needs to deal with fare discounts for additional riders.

**Additional Group Size:** How many companions are additionally added.
**Additional Group Part:** Is the index of an additionally added companion.
