### PR TITLE
Add drtCompanionType attribute

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionRideGenerator.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionRideGenerator.java
@@ -53,6 +53,7 @@ public final class DrtCompanionRideGenerator implements BeforeMobsimListener, Af
 
 	private static final Logger LOG = LogManager.getLogger(DrtCompanionRideGenerator.class);
 	public final static String DRT_COMPANION_AGENT_PREFIX = "COMPANION";
+	public static final String DRT_COMPANION_TYPE = "drtCompanion";
 
 	private final Scenario scenario;
 	private final String drtModes;
@@ -124,6 +125,7 @@ public final class DrtCompanionRideGenerator implements BeforeMobsimListener, Af
 		String prefix = getCompanionPrefix(drtMode);
 		String companionId = prefix + "_" + originalPerson.getId().toString() + "_" + UUID.randomUUID();
 		Person person = PopulationUtils.getFactory().createPerson(Id.createPersonId(companionId));
+		DrtCompanionUtils.setDRTCompanionType(person, DRT_COMPANION_TYPE);
 
 		// Copy attributes from person
 		AttributesUtils.copyAttributesFromTo(originalPerson, person);

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionUtils.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionUtils.java
@@ -21,7 +21,6 @@ package org.matsim.contrib.drt.extension.companions;
 
 import java.util.List;
 
-import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.common.util.WeightedRandomSelection;
 import org.matsim.core.gbl.MatsimRandom;
@@ -32,12 +31,30 @@ import org.matsim.core.gbl.MatsimRandom;
  *
  */
 public class DrtCompanionUtils {
+
 	public final static String ADDITIONAL_GROUP_SIZE_ATTRIBUTE = "additionalGroupSize";
 	public final static String ADDITIONAL_GROUP_PART_ATTRIBUTE = "additionalGroupPart";
+	public static final String COMPANION_TYPE_ATTRIBUTE = "companionType";
 
-    public static boolean isDrtCompanion(Id<Person> personId) {
-        return personId.toString().startsWith(DrtCompanionRideGenerator.DRT_COMPANION_AGENT_PREFIX);
-    }
+	private DrtCompanionUtils() {
+		throw new IllegalStateException("Utility class");
+	}
+
+	public static boolean isDrtCompanion(Person person) {
+		return getDRTCompanionType(person) != null;
+	}
+
+	public static void setDRTCompanionType(Person person, String drtCompanionType) {
+		if (drtCompanionType == null) {
+			person.getAttributes().removeAttribute(COMPANION_TYPE_ATTRIBUTE);
+		} else {
+			person.getAttributes().putAttribute(COMPANION_TYPE_ATTRIBUTE, drtCompanionType);
+		}
+	}
+
+	public static String getDRTCompanionType(Person person) {
+		return (String) person.getAttributes().getAttribute(COMPANION_TYPE_ATTRIBUTE);
+	}
 
 	public static WeightedRandomSelection<Integer> createIntegerSampler(final List<Double> distribution) {
 		WeightedRandomSelection<Integer> wrs = new WeightedRandomSelection<>(MatsimRandom.getLocalInstance());


### PR DESCRIPTION
This pr introduces a `drtCompanionType` attribute which gets attached to the created companion persons in `DrtCompanionRideGenerator` and responds to the comments from #2640. 