### PR TITLE
Parallel Population Reader

### DIFF
--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
@@ -1,0 +1,343 @@
+package org.matsim.core.population.io;
+
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * ParallelPlansReaderMatsimV4.java
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2012 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.api.core.v01.population.PopulationFactory;
+import org.matsim.core.config.Config;
+import org.matsim.facilities.ActivityFacilities;
+import org.matsim.households.Households;
+import org.matsim.lanes.Lanes;
+import org.matsim.pt.transitSchedule.api.TransitSchedule;
+import org.matsim.vehicles.Vehicles;
+import org.xml.sax.Attributes;
+import org.xml.sax.helpers.AttributesImpl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+/**
+ * Parallel implementation of the PopulationReaderMatsimV6. The main thread only reads
+ * the file and creates empty person objects which are added to the population to ensure
+ * that their order is not changed. Note that this approach is not compatible with
+ * population streaming. When this feature is activated, the non-parallel reader is used.
+ * The parallel threads interpret the xml data for each person.
+ *
+ * @author cdobler, steffenaxer
+ */
+/* deliberately package */  class ParallelPopulationReaderMatsimV6 extends PopulationReaderMatsimV6 {
+
+	static final Logger log = LogManager.getLogger(ParallelPopulationReaderMatsimV6.class);
+
+	private final boolean isPopulationStreaming;
+	private final int numThreads;
+	private final BlockingQueue<List<Tag>> queue;
+	private final CollectorScenario collectorScenario;
+	private final CollectorPopulation collectorPopulation;
+
+	private Thread[] threads;
+	private List<Tag> currentPersonXmlData;
+
+	private final String inputCRS;
+	private final String targetCRS;
+
+	private boolean reachedPersons = false;
+
+	public ParallelPopulationReaderMatsimV6(
+			final String inputCRS,
+			final String targetCRS,
+			final Scenario scenario) {
+		super(inputCRS, targetCRS, scenario);
+		this.inputCRS = inputCRS;
+		this.targetCRS = targetCRS;
+
+		/*
+		 * Check whether population streaming is activated
+		 */
+
+		if (scenario.getPopulation() instanceof StreamingPopulationReader.StreamingPopulation) {
+			log.warn("Population streaming is activated - cannot use " + ParallelPopulationReaderMatsimV4.class.getName() + "!");
+
+			this.isPopulationStreaming = true;
+			this.numThreads = 1;
+			this.queue = null;
+			this.collectorPopulation = null;
+			this.collectorScenario = null;
+		} else {
+			isPopulationStreaming = false;
+
+			if (scenario.getConfig().global().getNumberOfThreads() > 0) {
+				this.numThreads = scenario.getConfig().global().getNumberOfThreads();
+			} else this.numThreads = 1;
+
+			this.queue = new LinkedBlockingQueue<>();
+			this.collectorPopulation = new CollectorPopulation(this.plans);
+			this.collectorScenario = new CollectorScenario(scenario, collectorPopulation);
+		}
+	}
+
+	private void initThreads() {
+		threads = new Thread[numThreads];
+		for (int i = 0; i < numThreads; i++) {
+
+			ParallelPopulationReaderMatsimV6Runner runner =
+					new ParallelPopulationReaderMatsimV6Runner(
+							this.inputCRS,
+							this.targetCRS,
+							this.collectorScenario,
+							this.queue);
+
+			Thread thread = new Thread(runner);
+			thread.setDaemon(true);
+			thread.setName(ParallelPopulationReaderMatsimV6Runner.class.toString() + i);
+			threads[i] = thread;
+			thread.start();
+		}
+	}
+
+	@Override
+	public void startTag(String name, Attributes atts, Stack<String> context) {
+		// if population streaming is activated, use non-parallel reader
+		if (isPopulationStreaming || this.reachedPersons == false) {
+			super.startTag(name, atts, context);
+			return;
+		}
+
+		if (POPULATION.equals(name)) {
+			super.startTag(name, atts, context);
+			log.info("Start parallel population reading...");
+			initThreads();
+		} else {
+			// If it is an new person, create a new person and a list for its attributes.
+			if (PERSON.equals(name)) {
+				this.reachedPersons = true;
+				Person person = this.plans.getFactory().createPerson(Id.create(atts.getValue("id"), Person.class));
+				currentPersonXmlData = new ArrayList<>();
+				PersonTag personTag = new PersonTag();
+				personTag.person = person;
+				currentPersonXmlData.add(personTag);
+				this.plans.addPerson(person);
+			}
+
+
+			// Create a new start tag and add it to the person data.
+			Stack<String> contextCopy = new Stack<>();
+			contextCopy.addAll(context);
+			StartTag tag = new StartTag();
+			tag.name = name;
+			tag.context = contextCopy;
+			tag.atts = new AttributesImpl(atts);    // We have to create copies of the attributes because the object is re-used by the parser!
+			currentPersonXmlData.add(tag);
+		}
+	}
+
+	@Override
+	public void endTag(String name, String content, Stack<String> context) {
+
+		// if population streaming is activated, use non-parallel reader
+		// or if not reached the persons in the xml
+		if (isPopulationStreaming || this.reachedPersons == false) {
+			super.endTag(name, content, context);
+			return;
+		}
+
+		// End of population reached
+		if (POPULATION.equals(name)) {
+			// signal the threads that they should end parsing
+			for (int i = 0; i < this.numThreads; i++) {
+				List<Tag> list = new ArrayList<>();
+				list.add(new EndProcessingTag());
+				this.queue.add(list);
+			}
+
+			// wait for the threads to finish
+			try {
+				for (Thread thread : threads) {
+					thread.join();
+				}
+			} catch (InterruptedException e) {
+				throw new RuntimeException(e);
+			}
+
+			super.endTag(name, content, context);
+			log.info("Finished parallel population reading...");
+			// Till parsing population
+		} else {
+			// Create a new end tag and add it to the person data.
+			EndTag tag = new EndTag();
+			tag.name = name;
+			tag.content = content;
+			tag.context = context;
+			currentPersonXmlData.add(tag);
+
+			// if its a person end tag, add the persons xml data to the queue.
+			if (PERSON.equals(name)) {
+				queue.add(currentPersonXmlData);
+			}
+		}
+	}
+
+	private static class CollectorScenario implements Scenario {
+		// yyyy Why is this necessary at all?  Could you please explain your design decisions?  The same instance is passed to all threads, so
+		// what is the difference to using the underlying population directly?
+
+		private final Scenario delegate;
+		private final CollectorPopulation population;
+
+		public CollectorScenario(Scenario scenario, CollectorPopulation population) {
+			this.delegate = scenario;
+			this.population = population;
+		}
+
+		@Override
+		public Network getNetwork() {
+			return this.delegate.getNetwork();
+		}
+
+		@Override
+		public Population getPopulation() {
+			return this.population;    // return collector population
+		}
+
+		@Override
+		public ActivityFacilities getActivityFacilities() {
+			return this.delegate.getActivityFacilities();
+		}
+
+		@Override
+		public TransitSchedule getTransitSchedule() {
+			return this.delegate.getTransitSchedule();
+		}
+
+		@Override
+		public Config getConfig() {
+			return this.delegate.getConfig();
+		}
+
+		@Override
+		public void addScenarioElement(String name, Object o) {
+			this.delegate.addScenarioElement(name, o);
+		}
+
+		@Override
+		public Object getScenarioElement(String name) {
+			return this.delegate.getScenarioElement(name);
+		}
+
+		@Override
+		public Vehicles getTransitVehicles() {
+			return this.delegate.getTransitVehicles();
+		}
+
+		@Override
+		public Households getHouseholds() {
+			return this.delegate.getHouseholds();
+		}
+
+		@Override
+		public Lanes getLanes() {
+			return this.delegate.getLanes();
+		}
+
+		@Override
+		public Vehicles getVehicles() {
+			return this.delegate.getVehicles();
+		}
+	}
+
+	private static class CollectorPopulation implements Population {
+
+		private final Population population;
+
+		public CollectorPopulation(Population population) {
+			this.population = population;
+		}
+
+		@Override
+		public PopulationFactory getFactory() {
+			return population.getFactory();
+		}
+
+		@Override
+		public String getName() {
+			throw new RuntimeException("Calls to this method are not expected to happen...");
+		}
+
+		@Override
+		public void setName(String name) {
+			throw new RuntimeException("Calls to this method are not expected to happen...");
+		}
+
+		@Override
+		public Map<Id<Person>, ? extends Person> getPersons() {
+			throw new RuntimeException("Calls to this method are not expected to happen...");
+		}
+
+		@Override
+		public void addPerson(Person p) {
+			throw new RuntimeException("Calls to this method are not expected to happen...");
+		}
+
+		@Override
+		public Person removePerson(Id<Person> personId) {
+			throw new RuntimeException("not implemented");
+		}
+
+		@Override
+		public org.matsim.utils.objectattributes.attributable.Attributes getAttributes() {
+			throw new RuntimeException("Calls to this method are not expected to happen...");
+		}
+	}
+
+	public abstract static class Tag {
+		String name;
+		Stack<String> context = null;    // not used by the PopulationReader
+	}
+
+	public final class StartTag extends Tag {
+		Attributes atts;
+	}
+
+	public final class PersonTag extends Tag {
+		Person person;
+	}
+
+	public final class EndTag extends Tag {
+		String content;
+	}
+
+	/*
+	 * Marker Tag to inform the threads that no further data has to be parsed.
+	 */
+	public final class EndProcessingTag extends Tag {
+	}
+}
+

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
@@ -25,11 +25,14 @@ import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.population.Person;
+import org.matsim.utils.objectattributes.AttributeConverter;
+import org.matsim.utils.objectattributes.ObjectAttributesConverter;
 import org.xml.sax.Attributes;
 import org.xml.sax.helpers.AttributesImpl;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Stack;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -89,6 +92,12 @@ import java.util.concurrent.LinkedBlockingQueue;
 		}
 	}
 
+	private static void initObjectAttributeConverters(ParallelPopulationReaderMatsimV6Runner runner, ObjectAttributesConverter converter)
+	{
+		Map<String, AttributeConverter<?>> targetConverter = runner.getObjectAttributesConverter().getConverters();
+		converter.getConverters().entrySet().forEach( e -> targetConverter.put(e.getKey(), e.getValue()));
+	}
+
 	private void initThreads() {
 		threads = new Thread[numThreads];
 		for (int i = 0; i < numThreads; i++) {
@@ -99,6 +108,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 							this.targetCRS,
 							this.scenario,
 							this.queue);
+			initObjectAttributeConverters(runner,this.getObjectAttributesConverter());
 
 			Thread thread = new Thread(runner);
 			thread.setDaemon(true);

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
@@ -110,9 +110,14 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 	@Override
 	public void startTag(String name, Attributes atts, Stack<String> context) {
-		if (PERSON.equals(name))
-		{
+		//Reached first time a person
+		if (PERSON.equals(name) && !this.reachedPersons) {
 			this.reachedPersons = true;
+
+			if (!isPopulationStreaming && this.threads == null) {
+				log.info("Start parallel population reading...");
+				initThreads();
+			}
 		}
 
 		// if population streaming is activated, use non-parallel reader
@@ -121,20 +126,16 @@ import java.util.concurrent.LinkedBlockingQueue;
 			return;
 		}
 
-		if (this.threads==null) {
-			log.info("Start parallel population reading...");
-			initThreads();
-		}
 
-			// If it is a new person, create a new person and a list for its attributes.
-			if (PERSON.equals(name)) {
-				Person person = this.plans.getFactory().createPerson(Id.create(atts.getValue(ATTR_PERSON_ID), Person.class));
-				currentPersonXmlData = new ArrayList<>();
-				PersonTag personTag = new PersonTag();
-				personTag.person = person;
-				currentPersonXmlData.add(personTag);
-				this.plans.addPerson(person);
-			} else {
+		// If it is a new person, create a new person and a list for its attributes.
+		if (PERSON.equals(name)) {
+			Person person = this.plans.getFactory().createPerson(Id.create(atts.getValue(ATTR_PERSON_ID), Person.class));
+			currentPersonXmlData = new ArrayList<>();
+			PersonTag personTag = new PersonTag();
+			personTag.person = person;
+			currentPersonXmlData.add(personTag);
+			this.plans.addPerson(person);
+		} else {
 
 			// Create a new start tag and add it to the person data.
 			Stack<String> contextCopy = new Stack<>();

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
@@ -138,9 +138,11 @@ import java.util.concurrent.LinkedBlockingQueue;
 		} else {
 
 			// Create a new start tag and add it to the person data.
+			Stack<String> contextCopy = new Stack<>();
+			contextCopy.addAll(context);
 			StartTag tag = new StartTag();
 			tag.name = name;
-			tag.context = (Stack<String>) context.clone();
+			tag.context = contextCopy;
 			tag.atts = new AttributesImpl(atts);    // We have to create copies of the attributes because the object is re-used by the parser!
 			currentPersonXmlData.add(tag);
 		}
@@ -179,10 +181,12 @@ import java.util.concurrent.LinkedBlockingQueue;
 			// Till parsing population
 		} else {
 			// Create a new end tag and add it to the person data.
+			Stack<String> contextCopy = new Stack<>();
+			contextCopy.addAll(context);
 			EndTag tag = new EndTag();
 			tag.name = name;
 			tag.content = content;
-			tag.context = (Stack<String>) context.clone();
+			tag.context = contextCopy;
 			currentPersonXmlData.add(tag);
 
 			// if it's a person end tag, add the persons xml data to the queue.

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
@@ -2,11 +2,11 @@ package org.matsim.core.population.io;
 
 /* *********************************************************************** *
  * project: org.matsim.*
- * ParallelPlansReaderMatsimV4.java
+ * ParallelPlansReaderMatsimV6.java
  *                                                                         *
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2012 by the members listed in the COPYING,        *
+ * copyright       : (C) 2023 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -121,10 +121,10 @@ import java.util.concurrent.LinkedBlockingQueue;
 			log.info("Start parallel population reading...");
 			initThreads();
 		} else {
-			// If it is an new person, create a new person and a list for its attributes.
+			// If it is a new person, create a new person and a list for its attributes.
 			if (PERSON.equals(name)) {
 				this.reachedPersons = true;
-				Person person = this.plans.getFactory().createPerson(Id.create(atts.getValue("id"), Person.class));
+				Person person = this.plans.getFactory().createPerson(Id.create(atts.getValue(ATTR_PERSON_ID), Person.class));
 				currentPersonXmlData = new ArrayList<>();
 				PersonTag personTag = new PersonTag();
 				personTag.person = person;
@@ -192,25 +192,25 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 	public abstract static class Tag {
 		String name;
-		Stack<String> context = null;    // not used by the PopulationReader
+		Stack<String> context;
 	}
 
-	public final class StartTag extends Tag {
+	public final static class StartTag extends Tag {
 		Attributes atts;
 	}
 
-	public final class PersonTag extends Tag {
+	public final static class PersonTag extends Tag {
 		Person person;
 	}
 
-	public final class EndTag extends Tag {
+	public final static class EndTag extends Tag {
 		String content;
 	}
 
 	/*
 	 * Marker Tag to inform the threads that no further data has to be parsed.
 	 */
-	public final class EndProcessingTag extends Tag {
+	public final static class EndProcessingTag extends Tag {
 	}
 }
 

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
@@ -162,9 +162,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 		if (POPULATION.equals(name)) {
 			// signal the threads that they should end parsing
 			for (int i = 0; i < this.numThreads; i++) {
-				List<Tag> list = new ArrayList<>();
-				list.add(new EndProcessingTag());
-				this.queue.add(list);
+				this.queue.add(List.of(new EndProcessingTag()));
 			}
 
 			// wait for the threads to finish

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
@@ -2,7 +2,7 @@ package org.matsim.core.population.io;
 
 /* *********************************************************************** *
  * project: org.matsim.*
- * ParallelPlansReaderMatsimV6.java
+ * ParallelPopulationReaderMatsimV6.java
  *                                                                         *
  * *********************************************************************** *
  *                                                                         *

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
@@ -138,11 +138,9 @@ import java.util.concurrent.LinkedBlockingQueue;
 		} else {
 
 			// Create a new start tag and add it to the person data.
-			Stack<String> contextCopy = new Stack<>();
-			contextCopy.addAll(context);
 			StartTag tag = new StartTag();
 			tag.name = name;
-			tag.context = contextCopy;
+			tag.context = (Stack<String>) context.clone();
 			tag.atts = new AttributesImpl(atts);    // We have to create copies of the attributes because the object is re-used by the parser!
 			currentPersonXmlData.add(tag);
 		}
@@ -181,12 +179,10 @@ import java.util.concurrent.LinkedBlockingQueue;
 			// Till parsing population
 		} else {
 			// Create a new end tag and add it to the person data.
-			Stack<String> contextCopy = new Stack<>();
-			contextCopy.addAll(context);
 			EndTag tag = new EndTag();
 			tag.name = name;
 			tag.content = content;
-			tag.context = contextCopy;
+			tag.context = (Stack<String>) context.clone();
 			currentPersonXmlData.add(tag);
 
 			// if it's a person end tag, add the persons xml data to the queue.

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
@@ -46,7 +46,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 /* deliberately package */  class ParallelPopulationReaderMatsimV6 extends PopulationReaderMatsimV6 {
 
 	static final Logger log = LogManager.getLogger(ParallelPopulationReaderMatsimV6.class);
-
+	private static int THREADS_LIMIT = 4;
 	private final boolean isPopulationStreaming;
 	private final int numThreads;
 	private final BlockingQueue<List<Tag>> queue;
@@ -82,7 +82,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 			isPopulationStreaming = false;
 
 			if (scenario.getConfig().global().getNumberOfThreads() > 0) {
-				this.numThreads = scenario.getConfig().global().getNumberOfThreads();
+				this.numThreads = Math.min(THREADS_LIMIT,scenario.getConfig().global().getNumberOfThreads());
 			} else this.numThreads = 1;
 
 			this.queue = new LinkedBlockingQueue<>();

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
@@ -72,7 +72,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 		 */
 
 		if (scenario.getPopulation() instanceof StreamingPopulationReader.StreamingPopulation) {
-			log.warn("Population streaming is activated - cannot use " + ParallelPopulationReaderMatsimV4.class.getName() + "!");
+			log.warn("Population streaming is activated - cannot use " + ParallelPopulationReaderMatsimV6.class.getName() + "!");
 
 			this.isPopulationStreaming = true;
 			this.numThreads = 1;

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
@@ -111,7 +111,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 	@Override
 	public void startTag(String name, Attributes atts, Stack<String> context) {
 		// if population streaming is activated, use non-parallel reader
-		if (isPopulationStreaming || this.reachedPersons == false) {
+		if (isPopulationStreaming || !this.reachedPersons) {
 			super.startTag(name, atts, context);
 			return;
 		}
@@ -149,7 +149,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 		// if population streaming is activated, use non-parallel reader
 		// or if not reached the persons in the xml
-		if (isPopulationStreaming || this.reachedPersons == false) {
+		if (isPopulationStreaming || !this.reachedPersons) {
 			super.endTag(name, content, context);
 			return;
 		}

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
@@ -110,28 +110,31 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 	@Override
 	public void startTag(String name, Attributes atts, Stack<String> context) {
+		if (PERSON.equals(name))
+		{
+			this.reachedPersons = true;
+		}
+
 		// if population streaming is activated, use non-parallel reader
 		if (isPopulationStreaming || !this.reachedPersons) {
 			super.startTag(name, atts, context);
 			return;
 		}
 
-		if (POPULATION.equals(name)) {
-			super.startTag(name, atts, context);
+		if (this.threads==null) {
 			log.info("Start parallel population reading...");
 			initThreads();
-		} else {
+		}
+
 			// If it is a new person, create a new person and a list for its attributes.
 			if (PERSON.equals(name)) {
-				this.reachedPersons = true;
 				Person person = this.plans.getFactory().createPerson(Id.create(atts.getValue(ATTR_PERSON_ID), Person.class));
 				currentPersonXmlData = new ArrayList<>();
 				PersonTag personTag = new PersonTag();
 				personTag.person = person;
 				currentPersonXmlData.add(personTag);
 				this.plans.addPerson(person);
-			}
-
+			} else {
 
 			// Create a new start tag and add it to the person data.
 			Stack<String> contextCopy = new Stack<>();
@@ -177,10 +180,12 @@ import java.util.concurrent.LinkedBlockingQueue;
 			// Till parsing population
 		} else {
 			// Create a new end tag and add it to the person data.
+			Stack<String> contextCopy = new Stack<>();
+			contextCopy.addAll(context);
 			EndTag tag = new EndTag();
 			tag.name = name;
 			tag.content = content;
-			tag.context = context;
+			tag.context = contextCopy;
 			currentPersonXmlData.add(tag);
 
 			// if its a person end tag, add the persons xml data to the queue.

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
@@ -189,7 +189,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 			tag.context = contextCopy;
 			currentPersonXmlData.add(tag);
 
-			// if its a person end tag, add the persons xml data to the queue.
+			// if it's a person end tag, add the persons xml data to the queue.
 			if (PERSON.equals(name)) {
 				queue.add(currentPersonXmlData);
 			}

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6Runner.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6Runner.java
@@ -20,17 +20,11 @@
 
 package org.matsim.core.population.io;
 
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.core.population.io.ParallelPopulationReaderMatsimV6.*;
+
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
-
-import org.matsim.api.core.v01.Scenario;
-import org.matsim.core.population.PersonUtils;
-import org.matsim.core.population.io.ParallelPopulationReaderMatsimV6.EndProcessingTag;
-import org.matsim.core.population.io.ParallelPopulationReaderMatsimV6.EndTag;
-import org.matsim.core.population.io.ParallelPopulationReaderMatsimV6.PersonTag;
-import org.matsim.core.population.io.ParallelPopulationReaderMatsimV6.StartTag;
-import org.matsim.core.population.io.ParallelPopulationReaderMatsimV6.Tag;
-import org.xml.sax.Attributes;
 
 /**
  * Runnable used by ParallelPopulationReaderMatsimV6.
@@ -62,19 +56,11 @@ import org.xml.sax.Attributes;
 			try {
 				List<Tag> tags;
 				tags = queue.take();
-
 				for (Tag tag : tags) {
 					if (tag instanceof PersonTag) {
 						this.currperson = ((PersonTag) tag).person;
 					} else if (tag instanceof StartTag) {
-						// if its is a person tag, we use the startPerson method from this class
-						if (PERSON.equals(tag.name)) {
-							//startPerson(((ParallelPopulationReaderMatsimV6.StartTag) tag).atts);
-						}
-						// otherwise hand the tag over to the super class
-						else {
-							this.startTag(tag.name, ((ParallelPopulationReaderMatsimV6.StartTag) tag).atts, tag.context);
-						}
+						this.startTag(tag.name, ((ParallelPopulationReaderMatsimV6.StartTag) tag).atts, tag.context);
 					} else if (tag instanceof EndTag) {
 						/*
 						 * If its is a person tag, we reset the current person. We do not hand the
@@ -95,23 +81,6 @@ import org.xml.sax.Attributes;
 			} catch (InterruptedException e) {
 				throw new RuntimeException(e);
 			}
-		}
-	}
-
-	private void startPerson(final Attributes atts) {
-		String ageString = atts.getValue("age");
-//		int age = Integer.MIN_VALUE;
-		Integer age = null ;
-		if (ageString != null) age = Integer.parseInt(ageString);
-		PersonUtils.setAge(this.currperson, age);
-		PersonUtils.setSex(this.currperson, atts.getValue("sex"));
-		PersonUtils.setLicence(this.currperson, atts.getValue("license"));
-		PersonUtils.setCarAvail(this.currperson, atts.getValue("car_avail"));
-		String employed = atts.getValue("employed");
-		if (employed == null) {
-			PersonUtils.setEmployed(this.currperson, null);
-		} else {
-			PersonUtils.setEmployed(this.currperson, "yes".equals(employed));
 		}
 	}
 }

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6Runner.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6Runner.java
@@ -1,10 +1,10 @@
 /* *********************************************************************** *
  * project: org.matsim.*
- * ParallelPopulationReaderMatsimV4Runner.java
+ * ParallelPopulationReaderMatsimV6Runner.java
  *                                                                         *
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2012 by the members listed in the COPYING,        *
+ * copyright       : (C) 2023 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6Runner.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6Runner.java
@@ -57,11 +57,11 @@ import java.util.concurrent.BlockingQueue;
 				List<Tag> tags;
 				tags = queue.take();
 				for (Tag tag : tags) {
-					if (tag instanceof PersonTag) {
-						this.currperson = ((PersonTag) tag).person;
-					} else if (tag instanceof StartTag) {
-						this.startTag(tag.name, ((ParallelPopulationReaderMatsimV6.StartTag) tag).atts, tag.context);
-					} else if (tag instanceof EndTag) {
+					if (tag instanceof PersonTag personTag) {
+						this.currperson = personTag.person;
+					} else if (tag instanceof StartTag startTag) {
+						this.startTag(tag.name, startTag.atts, tag.context);
+					} else if (tag instanceof EndTag endTag) {
 						/*
 						 * If its is a person tag, we reset the current person. We do not hand the
 						 * tag over to the superclass because the person has already been added
@@ -72,7 +72,7 @@ import java.util.concurrent.BlockingQueue;
 						}
 						// otherwise hand the tag over to the super class
 						else {
-							this.endTag(tag.name, ((EndTag) tag).content, tag.context);
+							this.endTag(tag.name, endTag.content, tag.context);
 						}
 					} else if (tag instanceof EndProcessingTag) {
 						return;

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6Runner.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6Runner.java
@@ -1,0 +1,117 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * ParallelPopulationReaderMatsimV4Runner.java
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2012 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.core.population.io;
+
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.core.population.PersonUtils;
+import org.matsim.core.population.io.ParallelPopulationReaderMatsimV6.EndProcessingTag;
+import org.matsim.core.population.io.ParallelPopulationReaderMatsimV6.EndTag;
+import org.matsim.core.population.io.ParallelPopulationReaderMatsimV6.PersonTag;
+import org.matsim.core.population.io.ParallelPopulationReaderMatsimV6.StartTag;
+import org.matsim.core.population.io.ParallelPopulationReaderMatsimV6.Tag;
+import org.xml.sax.Attributes;
+
+/**
+ * Runnable used by ParallelPopulationReaderMatsimV6.
+ * Processes xml data taken from a BlockingQueue which is filled
+ * in the main class.
+ *
+ * @author cdobler, steffenaxer
+ */
+/* deliberately package */  class ParallelPopulationReaderMatsimV6Runner extends PopulationReaderMatsimV6 implements Runnable {
+
+	private final BlockingQueue<List<Tag>> queue;
+
+	public ParallelPopulationReaderMatsimV6Runner(
+			final String inputCRS,
+			final String targetCRS,
+			final Scenario scenario,
+			final BlockingQueue<List<Tag>> queue) {
+		super(inputCRS ,targetCRS, scenario);
+		this.queue = queue;
+	}
+
+	@Override
+	public void run() {
+		/*
+		 * The thread will go on with the parsing until an EndProcessingTag is found,
+		 * which calls "return".
+		 */
+		while (true) {
+			try {
+				List<Tag> tags;
+				tags = queue.take();
+
+				for (Tag tag : tags) {
+					if (tag instanceof PersonTag) {
+						this.currperson = ((PersonTag) tag).person;
+					} else if (tag instanceof StartTag) {
+						// if its is a person tag, we use the startPerson method from this class
+						if (PERSON.equals(tag.name)) {
+							//startPerson(((ParallelPopulationReaderMatsimV6.StartTag) tag).atts);
+						}
+						// otherwise hand the tag over to the super class
+						else {
+							this.startTag(tag.name, ((ParallelPopulationReaderMatsimV6.StartTag) tag).atts, tag.context);
+						}
+					} else if (tag instanceof EndTag) {
+						/*
+						 * If its is a person tag, we reset the current person. We do not hand the
+						 * tag over to the superclass because the person has already been added
+						 * to the population.
+						 */
+						if (PERSON.equals(tag.name)) {
+							this.currperson = null;
+						}
+						// otherwise hand the tag over to the super class
+						else {
+							this.endTag(tag.name, ((EndTag) tag).content, tag.context);
+						}
+					} else if (tag instanceof EndProcessingTag) {
+						return;
+					}
+				}
+			} catch (InterruptedException e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+
+	private void startPerson(final Attributes atts) {
+		String ageString = atts.getValue("age");
+//		int age = Integer.MIN_VALUE;
+		Integer age = null ;
+		if (ageString != null) age = Integer.parseInt(ageString);
+		PersonUtils.setAge(this.currperson, age);
+		PersonUtils.setSex(this.currperson, atts.getValue("sex"));
+		PersonUtils.setLicence(this.currperson, atts.getValue("license"));
+		PersonUtils.setCarAvail(this.currperson, atts.getValue("car_avail"));
+		String employed = atts.getValue("employed");
+		if (employed == null) {
+			PersonUtils.setEmployed(this.currperson, null);
+		} else {
+			PersonUtils.setEmployed(this.currperson, "yes".equals(employed));
+		}
+	}
+}

--- a/matsim/src/main/java/org/matsim/core/population/io/PopulationReader.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/PopulationReader.java
@@ -116,7 +116,7 @@ public final class PopulationReader extends MatsimXmlParser {
 		switch ( doctype ) {
 			case POPULATION_V6:
 				this.delegate =
-						new PopulationReaderMatsimV6(
+						new ParallelPopulationReaderMatsimV6(
 						        inputCRS,
 						        targetCRS,
 								this.scenario);

--- a/matsim/src/main/java/org/matsim/core/population/io/PopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/PopulationReaderMatsimV6.java
@@ -71,8 +71,8 @@ import com.google.inject.Inject;
 /* deliberately package */ class PopulationReaderMatsimV6 extends MatsimXmlParser implements MatsimReader {
     private static final Logger log = LogManager.getLogger(PopulationReaderMatsimV6.class);
 
-	private final static String POPULATION = "population";
-	private final static String PERSON = "person";
+	/* package */ final static String POPULATION = "population";
+	/* package */ final static String PERSON = "person";
 	private final static String ATTRIBUTES = "attributes";
 	private final static String ATTRIBUTE = "attribute";
 	private final static String PLAN = "plan";
@@ -109,10 +109,10 @@ import com.google.inject.Inject;
 	private final AttributesXmlReaderDelegate attributesReader = new AttributesXmlReaderDelegate();
 
 	private final Scenario scenario;
-	private final Population plans;
+	final Population plans;
 	private final String externalInputCRS;
 
-	private Person currperson = null;
+	Person currperson = null;
 	private Plan currplan = null;
 	private Activity curract = null;
 	private Leg currleg = null;
@@ -448,7 +448,7 @@ import com.google.inject.Inject;
 		String startLinkId = atts.getValue(ATTR_ROUTE_STARTLINK);
 		String endLinkId = atts.getValue(ATTR_ROUTE_ENDLINK);
 		String routeType = atts.getValue("type");
-		
+
 		if (routeType == null) {
 			String legMode = this.currleg.getMode();
 			if ("pt".equals(legMode)) {
@@ -459,10 +459,10 @@ import com.google.inject.Inject;
 				routeType = "generic";
 			}
 		}
-		
+
 		RouteFactories factory = this.scenario.getPopulation().getFactory().getRouteFactories();
 		Class<? extends Route> routeClass = factory.getRouteClassForType(routeType);
-		
+
 		this.currRoute = this.scenario.getPopulation().getFactory().getRouteFactories().createRoute(routeClass, startLinkId == null ? null : Id.create(startLinkId, Link.class), endLinkId == null ? null : Id.create(endLinkId, Link.class));
 		this.currleg.setRoute(this.currRoute);
 
@@ -488,7 +488,7 @@ import com.google.inject.Inject;
 		this.currRoute.setStartLinkId(startLinkId);
 		this.currRoute.setEndLinkId(endLinkId);
 		this.currRoute.setRouteDescription(this.routeDescription.trim());
-		
+
 		// yy I think that my intuition would be to put the following into prepareForSim. kai, dec'16
 		if (Double.isNaN(this.currRoute.getDistance())) {
 			if (this.currRoute instanceof NetworkRoute) {

--- a/matsim/src/main/java/org/matsim/core/population/io/PopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/PopulationReaderMatsimV6.java
@@ -81,7 +81,7 @@ import com.google.inject.Inject;
 	private final static String ROUTE = "route";
 
 	private final static String ATTR_POPULATION_DESC = "desc";
-	private final static String ATTR_PERSON_ID = "id";
+	/* package */ final static String ATTR_PERSON_ID = "id";
 	private final static String ATTR_PLAN_SCORE = "score";
 	private final static String ATTR_PLAN_TYPE = "type";
 	private final static String ATTR_PLAN_SELECTED = "selected";

--- a/matsim/src/main/java/org/matsim/core/population/io/PopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/PopulationReaderMatsimV6.java
@@ -108,7 +108,7 @@ import com.google.inject.Inject;
 	// TODO: infrastructure to configure converters
 	private final AttributesXmlReaderDelegate attributesReader = new AttributesXmlReaderDelegate();
 
-	private final Scenario scenario;
+	final Scenario scenario;
 	final Population plans;
 	private final String externalInputCRS;
 

--- a/matsim/src/main/java/org/matsim/core/population/io/PopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/PopulationReaderMatsimV6.java
@@ -54,6 +54,7 @@ import org.matsim.core.utils.misc.OptionalTime;
 import org.matsim.core.utils.misc.Time;
 import org.matsim.facilities.ActivityFacility;
 import org.matsim.utils.objectattributes.AttributeConverter;
+import org.matsim.utils.objectattributes.ObjectAttributesConverter;
 import org.matsim.utils.objectattributes.attributable.AttributesUtils;
 import org.matsim.utils.objectattributes.attributable.AttributesXmlReaderDelegate;
 import org.matsim.vehicles.Vehicle;
@@ -138,6 +139,11 @@ import com.google.inject.Inject;
 		    this.coordinateTransformation = TransformationFactory.getCoordinateTransformation(externalInputCRS, targetCRS);
 		    ProjectionUtils.putCRS(this.plans, targetCRS);
 	    }
+	}
+
+	public ObjectAttributesConverter getObjectAttributesConverter()
+	{
+		return attributesReader.getObjectAttributesConverter();
 	}
 
 	public void putAttributeConverter( final Class<?> clazz , AttributeConverter<?> converter ) {

--- a/matsim/src/main/java/org/matsim/utils/objectattributes/ObjectAttributesConverter.java
+++ b/matsim/src/main/java/org/matsim/utils/objectattributes/ObjectAttributesConverter.java
@@ -68,6 +68,11 @@ public class ObjectAttributesConverter {
 		return converter == null ? null : converter.convert(value);
 	}
 
+	public Map<String, AttributeConverter<?>> getConverters()
+	{
+		return this.converters;
+	}
+
 	private AttributeConverter getConverter(String className) {
 		if (converters.containsKey(className)) return converters.get(className);
 		try {

--- a/matsim/src/main/java/org/matsim/utils/objectattributes/attributable/AttributesXmlReaderDelegate.java
+++ b/matsim/src/main/java/org/matsim/utils/objectattributes/attributable/AttributesXmlReaderDelegate.java
@@ -47,6 +47,11 @@ public class AttributesXmlReaderDelegate {
 	/*package*/ final static String ATTR_ATTRIBUTENAME = "name";
 	/*package*/ final static String ATTR_ATTRIBUTECLASS = "class";
 
+	public ObjectAttributesConverter getObjectAttributesConverter()
+	{
+		return this.converter;
+	}
+
 	public void startTag(String name,
 						 org.xml.sax.Attributes atts,
 						 Stack<String> context,


### PR DESCRIPTION
This PR reactives an idea from @cdobler, who developed the `ParallelPopulationReaderMatsimV4`. The basic idea was, to have one read thread an one or many processing threads. I reactivated this idea and cleaned the code. I even benchmarked this approach and the loading runtime of a population can be saved by approx. 40 %, which is in my eyes quite significant. 