### PR TITLE
Add PopulationUtils.removeSubpopulation()

### DIFF
--- a/matsim/src/main/java/org/matsim/core/population/PopulationUtils.java
+++ b/matsim/src/main/java/org/matsim/core/population/PopulationUtils.java
@@ -1184,15 +1184,16 @@ public final class PopulationUtils {
 		person.getAttributes().clear();
 	}
 
-        public static String getSubpopulation( HasPlansAndId<?,?> person ){
+	public static String getSubpopulation( HasPlansAndId<?,?> person ){
 		if ( person==null ) {
 			return null;
 		}
 		// (This originally delegated to getPersonAttribute.  See comment there.  kai, jul'22)
 
 		return (String) person.getAttributes().getAttribute( SUBPOPULATION_ATTRIBUTE_NAME );
-        }
-        public static void putSubpopulation( HasPlansAndId<?,?> person, String subpopulation ) {
+	}
+
+	public static void putSubpopulation( HasPlansAndId<?,?> person, String subpopulation ) {
 		putPersonAttribute( person, SUBPOPULATION_ATTRIBUTE_NAME, subpopulation );
 	}
 

--- a/matsim/src/main/java/org/matsim/core/population/PopulationUtils.java
+++ b/matsim/src/main/java/org/matsim/core/population/PopulationUtils.java
@@ -1196,6 +1196,10 @@ public final class PopulationUtils {
 		putPersonAttribute( person, SUBPOPULATION_ATTRIBUTE_NAME, subpopulation );
 	}
 
+	public static void removeSubpopulation(Person person) {
+		person.getAttributes().removeAttribute(SUBPOPULATION_ATTRIBUTE_NAME);
+	}
+
 	public static Population getOrCreateAllpersons( Scenario  scenario ) {
 		Population map = (Population) scenario.getScenarioElement( "allpersons" );
 		if ( map==null ) {


### PR DESCRIPTION
This adds a simple helper method `PopulationUtils.removeSubpopulation()`, that removes the `PopulationUtils.SUBPOPULATION_ATTRIBUTE_NAME` from a person. 

Adding this (trivial) helper helps to avoid using the `SUBPOPULATION_ATTRIBUTE_NAME` attribute directly, as its comment states, it should not be public.

https://github.com/matsim-org/matsim-libs/blob/f3d59d70fcec7f675f2e32d415862afed5e1c9b1/matsim/src/main/java/org/matsim/core/population/PopulationUtils.java#L88-L92

Bonus: Converted some spaces to tabs for indentation