### PR TITLE
Add VehicleUtils.hasVehicleId() method

### DIFF
--- a/matsim/src/main/java/org/matsim/vehicles/VehicleUtils.java
+++ b/matsim/src/main/java/org/matsim/vehicles/VehicleUtils.java
@@ -115,6 +115,21 @@ public final class VehicleUtils {
 	}
 
 	/**
+	 * Checks whether a person has a vehicle id for mode - without throwing an
+	 * exception if not.
+	 * 
+	 * @param person the person one wants to check for a vehicle id
+	 * @param mode   the mode for the vehicle id to check
+	 * @return whether person has a vehicle id for that mode
+	 * 
+	 * @see {@link VehicleUtils#getVehicleId(Person, String)}
+	 */
+	public static boolean hasVehicleId(Person person, String mode) {
+		PersonVehicles personVehicles = (PersonVehicles) person.getAttributes().getAttribute(VehicleUtils.VEHICLE_ATTRIBUTE_KEY);
+		return personVehicles != null && personVehicles.getVehicle(mode) != null;
+	}
+
+	/**
 	 * Retrieves vehicleIds of all vehicles that are assigned to the person.
 	 *
 	 * @param person the person one wants to retrieve vehicles for


### PR DESCRIPTION
This change adds the method `VehicleUtils.hasVehicleId(Person person, String mode)` that checks whether a person has a designated vehicle for a specific mode assigned - without throwing an exception.

Motivation for this method is, that
* the existing methods `getVehicleIds` and `getVehicleId` always throw an exception, if the `"vehicles"` attribute is not filled with a `PersonVehicles` object, and
* the attribute name `VehicleUtils.VEHICLE_ATTRIBUTE_KEY = "vehicles"` is private, so for checking it manually, a hard-coded copy of the `"vehicles"` string is required, which is ugly.