### PR TITLE
Apply coordinate transformation in TrafficAnalysis class

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/analysis/population/TripAnalysis.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/population/TripAnalysis.java
@@ -101,7 +101,6 @@ public class TripAnalysis implements MATSimAppCommand {
 			persons = persons.where(persons.textColumn("person").matchesRegex(matchId));
 		}
 
-
 		// Home filter by standard attribute
 		if (shp.isDefined() && filter == LocationFilter.home) {
 			Geometry geometry = shp.getGeometry();

--- a/contribs/application/src/main/java/org/matsim/application/analysis/traffic/TrafficAnalysis.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/traffic/TrafficAnalysis.java
@@ -1,6 +1,5 @@
 package org.matsim.application.analysis.traffic;
 
-import org.locationtech.jts.geom.Geometry;
 import org.matsim.analysis.VolumesAnalyzer;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
@@ -15,8 +14,8 @@ import org.matsim.core.config.groups.NetworkConfigGroup;
 import org.matsim.core.events.EventsUtils;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.network.filter.NetworkFilterManager;
+import org.matsim.core.scenario.ProjectionUtils;
 import org.matsim.core.trafficmonitoring.TravelTimeCalculator;
-import org.matsim.core.utils.geometry.geotools.MGC;
 import picocli.CommandLine;
 import tech.tablesaw.api.*;
 import tech.tablesaw.columns.Column;
@@ -280,8 +279,9 @@ public class TrafficAnalysis implements MATSimAppCommand {
 		manager.addLinkFilter(l -> l.getAllowedModes().stream().anyMatch(s -> modes.contains(s)));
 
 		if (shp.isDefined()) {
-			Geometry geometry = shp.getGeometry();
-			manager.addLinkFilter(l -> geometry.covers(MGC.coord2Point(l.getCoord())));
+			String crs = ProjectionUtils.getCRS(unfiltered);
+			ShpOptions.Index index = shp.createIndex(crs != null ? crs : shp.getShapeCrs(), "_");
+			manager.addLinkFilter(l -> index.contains(l.getCoord()));
 		}
 
 		return manager.applyFilters();


### PR DESCRIPTION
When filtering with shp file, now the crs is respected to transform coordinates if necessary.