### PR TITLE
Parallel Streaming Population Reader

### DIFF
--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
@@ -78,12 +78,9 @@ import java.util.concurrent.LinkedBlockingQueue;
 		 * Check whether population streaming is activated
 		 */
 
-		if (scenario.getPopulation() instanceof StreamingPopulationReader.StreamingPopulation) {
-			// log.warn("Population streaming is activated - cannot use " + ParallelPopulationReaderMatsimV6.class.getName() + "!");
-			this.isPopulationStreaming = true;
-		} else {
-			isPopulationStreaming = false;
-		}
+		this.isPopulationStreaming = scenario.getPopulation() instanceof StreamingPopulationReader.StreamingPopulation;
+
+		// Set threads
 		if (scenario.getConfig().global().getNumberOfThreads() > 0) {
 			this.numThreads = Math.min(THREADS_LIMIT,scenario.getConfig().global().getNumberOfThreads());
 		} else this.numThreads = 1;

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
@@ -26,7 +26,6 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Population;
-import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.scenario.ProjectionUtils;
 import org.matsim.utils.objectattributes.AttributeConverter;
 import org.matsim.utils.objectattributes.ObjectAttributesConverter;
@@ -63,7 +62,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 	private boolean reachedPersons = false;
 
-	private BlockingQueue<CompletableFuture<Person>> personInsertionQueue = new LinkedBlockingQueue<>();
+	private final BlockingQueue<CompletableFuture<Person>> personInsertionQueue = new LinkedBlockingQueue<>();
 	private Thread personInsertionThread;
 
 	public ParallelPopulationReaderMatsimV6(
@@ -93,7 +92,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 	private static void initObjectAttributeConverters(ParallelPopulationReaderMatsimV6Runner runner, ObjectAttributesConverter converter)
 	{
 		Map<String, AttributeConverter<?>> targetConverter = runner.getObjectAttributesConverter().getConverters();
-		converter.getConverters().entrySet().forEach( e -> targetConverter.put(e.getKey(), e.getValue()));
+		targetConverter.putAll(converter.getConverters());
 	}
 
 	private void initThreads() {

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
@@ -106,7 +106,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 							this.targetCRS,
 							this.scenario,
 							this.tagQueue,
-							this.personInsertionQueue);
+							this.personInsertionQueue,
+							this.isPopulationStreaming);
 			initObjectAttributeConverters(runner,this.getObjectAttributesConverter());
 
 			Thread thread = new Thread(runner);
@@ -195,9 +196,12 @@ import java.util.concurrent.LinkedBlockingQueue;
 			for (int i = 0; i < this.numThreads; i++) {
 				this.tagQueue.add(List.of(new EndProcessingTag()));
 			}
-			CompletableFuture<Person> finishPerson = new CompletableFuture<>();
-			finishPerson.complete(null);
-			this.personInsertionQueue.add(finishPerson);
+			if(isPopulationStreaming)
+			{
+				CompletableFuture<Person> finishPerson = new CompletableFuture<>();
+				finishPerson.complete(null);
+				this.personInsertionQueue.add(finishPerson);
+			}
 
 			// wait for the threads to finish
 			try {

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
@@ -105,9 +105,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 							this.inputCRS,
 							this.targetCRS,
 							this.scenario,
-							this.tagQueue,
-							this.personInsertionQueue,
-							this.isPopulationStreaming);
+							this.tagQueue);
 			initObjectAttributeConverters(runner,this.getObjectAttributesConverter());
 
 			Thread thread = new Thread(runner);
@@ -145,7 +143,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 		// If it is a new person, create a new person and a list for its attributes.
 		if (PERSON.equals(name)) {
 			// Just create a person, but do not add it here!
-			Person person = PopulationUtils.getFactory().createPerson(Id.create(atts.getValue(ATTR_PERSON_ID), Person.class));
+			Person person = this.plans.getFactory().createPerson(Id.create(atts.getValue(ATTR_PERSON_ID), Person.class));
 			currentPersonXmlData = new ArrayList<>();
 			PersonTag personTag = new PersonTag();
 			personTag.person = person;
@@ -200,7 +198,11 @@ import java.util.concurrent.LinkedBlockingQueue;
 			{
 				CompletableFuture<Person> finishPerson = new CompletableFuture<>();
 				finishPerson.complete(null);
-				this.personInsertionQueue.add(finishPerson);
+				try {
+					this.personInsertionQueue.put(finishPerson);
+				} catch (InterruptedException e) {
+					throw new RuntimeException(e);
+				}
 			}
 
 			// wait for the threads to finish

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
@@ -101,8 +101,9 @@ import java.util.concurrent.LinkedBlockingQueue;
 							this.inputCRS,
 							this.targetCRS,
 							this.scenario,
-							this.tagQueue);
-			initObjectAttributeConverters(runner,this.getObjectAttributesConverter());
+							this.tagQueue,
+							this.isPopulationStreaming);
+			initObjectAttributeConverters(runner, this.getObjectAttributesConverter());
 
 			Thread thread = new Thread(runner);
 			thread.setDaemon(true);

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6.java
@@ -25,17 +25,18 @@ import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.scenario.ProjectionUtils;
 import org.matsim.utils.objectattributes.AttributeConverter;
 import org.matsim.utils.objectattributes.ObjectAttributesConverter;
 import org.xml.sax.Attributes;
 import org.xml.sax.helpers.AttributesImpl;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Stack;
+import java.util.*;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 
 /**
@@ -53,7 +54,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 	private static final int THREADS_LIMIT = 4;
 	private final boolean isPopulationStreaming;
 	private final int numThreads;
-	private final BlockingQueue<List<Tag>> queue;
+	private final BlockingQueue<List<Tag>> tagQueue;
 	private Thread[] threads;
 	private List<Tag> currentPersonXmlData;
 
@@ -62,6 +63,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 	private boolean reachedPersons = false;
 
+	private BlockingQueue<CompletableFuture<Person>> personInsertionQueue = new LinkedBlockingQueue<>();
+	private Thread personInsertionThread;
 
 	public ParallelPopulationReaderMatsimV6(
 			final String inputCRS,
@@ -70,27 +73,21 @@ import java.util.concurrent.LinkedBlockingQueue;
 		super(inputCRS, targetCRS, scenario);
 		this.inputCRS = inputCRS;
 		this.targetCRS = targetCRS;
+		this.tagQueue = new LinkedBlockingQueue<>();
 
 		/*
 		 * Check whether population streaming is activated
 		 */
 
 		if (scenario.getPopulation() instanceof StreamingPopulationReader.StreamingPopulation) {
-			log.warn("Population streaming is activated - cannot use " + ParallelPopulationReaderMatsimV6.class.getName() + "!");
-
+			// log.warn("Population streaming is activated - cannot use " + ParallelPopulationReaderMatsimV6.class.getName() + "!");
 			this.isPopulationStreaming = true;
-			this.numThreads = 1;
-			this.queue = null;
-
 		} else {
 			isPopulationStreaming = false;
-
-			if (scenario.getConfig().global().getNumberOfThreads() > 0) {
-				this.numThreads = Math.min(THREADS_LIMIT,scenario.getConfig().global().getNumberOfThreads());
-			} else this.numThreads = 1;
-
-			this.queue = new LinkedBlockingQueue<>();
 		}
+		if (scenario.getConfig().global().getNumberOfThreads() > 0) {
+			this.numThreads = Math.min(THREADS_LIMIT,scenario.getConfig().global().getNumberOfThreads());
+		} else this.numThreads = 1;
 	}
 
 	private static void initObjectAttributeConverters(ParallelPopulationReaderMatsimV6Runner runner, ObjectAttributesConverter converter)
@@ -108,7 +105,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 							this.inputCRS,
 							this.targetCRS,
 							this.scenario,
-							this.queue);
+							this.tagQueue,
+							this.personInsertionQueue);
 			initObjectAttributeConverters(runner,this.getObjectAttributesConverter());
 
 			Thread thread = new Thread(runner);
@@ -116,6 +114,11 @@ import java.util.concurrent.LinkedBlockingQueue;
 			thread.setName(ParallelPopulationReaderMatsimV6Runner.class.toString() + i);
 			threads[i] = thread;
 			thread.start();
+		}
+
+		if (this.scenario.getPopulation() instanceof StreamingPopulationReader.StreamingPopulation) {
+			this.personInsertionThread = new Thread(new PersonInserter(this.scenario.getPopulation(), this.personInsertionQueue));
+			this.personInsertionThread.start();
 		}
 	}
 
@@ -125,14 +128,14 @@ import java.util.concurrent.LinkedBlockingQueue;
 		if (PERSON.equals(name) && !this.reachedPersons) {
 			this.reachedPersons = true;
 
-			if (!isPopulationStreaming && this.threads == null) {
+			if (this.threads == null) {
 				log.info("Start parallel population reading...");
 				initThreads();
 			}
 		}
 
-		// if population streaming is activated, use non-parallel reader
-		if (isPopulationStreaming || !this.reachedPersons) {
+		// As long as we have not reached the persons in the xml, use super class
+		if (!this.reachedPersons) {
 			super.startTag(name, atts, context);
 			return;
 		}
@@ -140,14 +143,27 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 		// If it is a new person, create a new person and a list for its attributes.
 		if (PERSON.equals(name)) {
-			Person person = this.plans.getFactory().createPerson(Id.create(atts.getValue(ATTR_PERSON_ID), Person.class));
+			// Just create a person, but do not add it here!
+			Person person = PopulationUtils.getFactory().createPerson(Id.create(atts.getValue(ATTR_PERSON_ID), Person.class));
 			currentPersonXmlData = new ArrayList<>();
 			PersonTag personTag = new PersonTag();
 			personTag.person = person;
 			currentPersonXmlData.add(personTag);
-			this.plans.addPerson(person);
-		} else {
 
+			// If in streaming mode, we need later complete persons
+			if (isPopulationStreaming) {
+				personTag.futurePerson = new CompletableFuture<>();
+				try {
+					this.personInsertionQueue.put(personTag.futurePerson);
+				} catch (InterruptedException e) {
+					throw new RuntimeException(e);
+				}
+			} else {
+				// If not in streaming mode, we can work with a reference
+				// of an unfinished person and add it right now...
+				this.plans.addPerson(person);
+			}
+		} else {
 			// Create a new start tag and add it to the person data.
 			Stack<String> contextCopy = new Stack<>();
 			contextCopy.addAll(context);
@@ -168,7 +184,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 		// if population streaming is activated, use non-parallel reader
 		// or if not reached the persons in the xml
-		if (isPopulationStreaming || !this.reachedPersons) {
+		if (!this.reachedPersons) {
 			super.endTag(name, content, context);
 			return;
 		}
@@ -177,14 +193,22 @@ import java.util.concurrent.LinkedBlockingQueue;
 		if (POPULATION.equals(name)) {
 			// signal the threads that they should end parsing
 			for (int i = 0; i < this.numThreads; i++) {
-				this.queue.add(List.of(new EndProcessingTag()));
+				this.tagQueue.add(List.of(new EndProcessingTag()));
 			}
+			CompletableFuture<Person> finishPerson = new CompletableFuture<>();
+			finishPerson.complete(null);
+			this.personInsertionQueue.add(finishPerson);
 
 			// wait for the threads to finish
 			try {
 				for (Thread thread : threads) {
 					thread.join();
 				}
+				if(this.isPopulationStreaming)
+				{
+					this.personInsertionThread.join();
+				}
+
 			} catch (InterruptedException e) {
 				throw new RuntimeException(e);
 			}
@@ -204,7 +228,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 			// if it's a person end tag, add the persons xml data to the queue.
 			if (PERSON.equals(name)) {
-				queue.add(currentPersonXmlData);
+				tagQueue.add(currentPersonXmlData);
 			}
 		}
 	}
@@ -220,6 +244,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 	public final static class PersonTag extends Tag {
 		Person person;
+		CompletableFuture<Person> futurePerson;
 	}
 
 	public final static class EndTag extends Tag {
@@ -230,6 +255,36 @@ import java.util.concurrent.LinkedBlockingQueue;
 	 * Marker Tag to inform the threads that no further data has to be parsed.
 	 */
 	public final static class EndProcessingTag extends Tag {
+	}
+
+	// This class is used to feed the population step by step
+	// with new complete persons while being in streaming mode
+	public final static class PersonInserter implements Runnable {
+		Population population;
+		BlockingQueue<CompletableFuture<Person>> personInsertionQueue;
+
+		PersonInserter(Population population, BlockingQueue<CompletableFuture<Person>> personInsertionQueue)
+		{
+			this.population = population;
+			this.personInsertionQueue = personInsertionQueue;
+		}
+
+		@Override
+		public void run() {
+			while (true) {
+				try {
+					CompletableFuture<Person> finishedPerson = this.personInsertionQueue.take();
+					Person person = finishedPerson.get();
+					if (person == null) {
+						return;
+					}
+					this.population.addPerson(person);
+
+				} catch (InterruptedException | ExecutionException e) {
+					throw new RuntimeException(e);
+				}
+			}
+		}
 	}
 }
 

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6Runner.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6Runner.java
@@ -38,14 +38,17 @@ import java.util.concurrent.CompletableFuture;
 /* deliberately package */  class ParallelPopulationReaderMatsimV6Runner extends PopulationReaderMatsimV6 implements Runnable {
 
 	private final BlockingQueue<List<Tag>> queue;
+	private boolean isStreaming;
 
 	public ParallelPopulationReaderMatsimV6Runner(
 			final String inputCRS,
 			final String targetCRS,
 			final Scenario scenario,
-			final BlockingQueue<List<Tag>> tagQueue) {
+			final BlockingQueue<List<Tag>> tagQueue,
+			boolean isStreaming) {
 		super(inputCRS ,targetCRS, scenario);
 		this.queue = tagQueue;
+		this.isStreaming = isStreaming;
 	}
 
 	@Override
@@ -72,8 +75,12 @@ import java.util.concurrent.CompletableFuture;
 						 * to the population.
 						 */
 						if (PERSON.equals(tag.name)) {
-							CompletableFuture<Person> cf = currentPersonTag.futurePerson;
-							cf.complete(currentPersonTag.person);
+							if(isStreaming)
+							{
+								CompletableFuture<Person> cf = currentPersonTag.futurePerson;
+								cf.complete(currentPersonTag.person);
+							}
+
 							this.currperson = null;
 							currentPersonTag = null;
 						}

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6Runner.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6Runner.java
@@ -22,7 +22,6 @@ package org.matsim.core.population.io;
 
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.population.Person;
-import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.population.io.ParallelPopulationReaderMatsimV6.*;
 
 import java.util.List;
@@ -39,22 +38,14 @@ import java.util.concurrent.CompletableFuture;
 /* deliberately package */  class ParallelPopulationReaderMatsimV6Runner extends PopulationReaderMatsimV6 implements Runnable {
 
 	private final BlockingQueue<List<Tag>> queue;
-	private final BlockingQueue<CompletableFuture<Person>> finishedPersonsQueue;
-	private final boolean isStreaming;
 
 	public ParallelPopulationReaderMatsimV6Runner(
 			final String inputCRS,
 			final String targetCRS,
 			final Scenario scenario,
-			final BlockingQueue<List<Tag>> tagQueue,
-			final BlockingQueue<CompletableFuture<Person>> finishedPersonsQueue,
-			final boolean isStreaming) {
+			final BlockingQueue<List<Tag>> tagQueue) {
 		super(inputCRS ,targetCRS, scenario);
 		this.queue = tagQueue;
-		this.finishedPersonsQueue = finishedPersonsQueue;
-		this.isStreaming = isStreaming;
-
-
 	}
 
 	@Override
@@ -81,12 +72,8 @@ import java.util.concurrent.CompletableFuture;
 						 * to the population.
 						 */
 						if (PERSON.equals(tag.name)) {
-							if(isStreaming)
-							{
-								CompletableFuture<Person> cf = currentPersonTag.futurePerson;
-								cf.complete(currentPersonTag.person);
-								this.finishedPersonsQueue.put(cf);
-							}
+							CompletableFuture<Person> cf = currentPersonTag.futurePerson;
+							cf.complete(currentPersonTag.person);
 							this.currperson = null;
 							currentPersonTag = null;
 						}

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6Runner.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationReaderMatsimV6Runner.java
@@ -40,17 +40,20 @@ import java.util.concurrent.CompletableFuture;
 
 	private final BlockingQueue<List<Tag>> queue;
 	private final BlockingQueue<CompletableFuture<Person>> finishedPersonsQueue;
-
+	private final boolean isStreaming;
 
 	public ParallelPopulationReaderMatsimV6Runner(
 			final String inputCRS,
 			final String targetCRS,
 			final Scenario scenario,
 			final BlockingQueue<List<Tag>> tagQueue,
-			final BlockingQueue<CompletableFuture<Person>> finishedPersonsQueue) {
+			final BlockingQueue<CompletableFuture<Person>> finishedPersonsQueue,
+			final boolean isStreaming) {
 		super(inputCRS ,targetCRS, scenario);
 		this.queue = tagQueue;
 		this.finishedPersonsQueue = finishedPersonsQueue;
+		this.isStreaming = isStreaming;
+
 
 	}
 
@@ -78,9 +81,12 @@ import java.util.concurrent.CompletableFuture;
 						 * to the population.
 						 */
 						if (PERSON.equals(tag.name)) {
-							CompletableFuture<Person> cf = currentPersonTag.futurePerson;
-							cf.complete(currentPersonTag.person);
-							this.finishedPersonsQueue.put(cf);
+							if(isStreaming)
+							{
+								CompletableFuture<Person> cf = currentPersonTag.futurePerson;
+								cf.complete(currentPersonTag.person);
+								this.finishedPersonsQueue.put(cf);
+							}
 							this.currperson = null;
 							currentPersonTag = null;
 						}

--- a/matsim/src/test/java/org/matsim/core/population/io/StreamingPopulationAttributeConversionTest.java
+++ b/matsim/src/test/java/org/matsim/core/population/io/StreamingPopulationAttributeConversionTest.java
@@ -1,4 +1,3 @@
-
 /* *********************************************************************** *
  * project: org.matsim.*
  * PopulationAttributeConversionTest.java
@@ -62,11 +61,15 @@ public class StreamingPopulationAttributeConversionTest {
 		final Population population = scenario.getPopulation();
 		final PopulationFactory populationFactory = population.getFactory();
 
-		final Id<Person> personId = Id.createPersonId("Gaston");
-		final Person person = populationFactory.createPerson(personId);
+		final Id<Person> personId0 = Id.createPersonId("Gaston0");
 		final CustomClass attribute = new CustomClass("homme à tout faire");
-		person.getAttributes().putAttribute("job", attribute);
-		population.addPerson(person);
+		// create 10 test persons so we can actually test parallelism better
+		for (int i = 0; i < 10; i++) {
+			final Id<Person> personId = Id.createPersonId("Gaston" + i);
+			final Person person = populationFactory.createPerson(personId);
+			person.getAttributes().putAttribute("job", attribute);
+			population.addPerson(person);
+		}
 
 		final StreamingPopulationWriter writer = new StreamingPopulationWriter();
 		writer.putAttributeConverter(CustomClass.class, new CustomClassConverter());
@@ -79,7 +82,7 @@ public class StreamingPopulationAttributeConversionTest {
 		reader.putAttributeConverter(CustomClass.class, new CustomClassConverter());
 		readMethod.accept(reader);
 
-		final Person readPerson = readScenario.getPopulation().getPersons().get(personId);
+		final Person readPerson = readScenario.getPopulation().getPersons().get(personId0);
 		final Object readAttribute = readPerson.getAttributes().getAttribute("job");
 
 		Assert.assertEquals(


### PR DESCRIPTION
This PR adds now also the parallel reading functioanlity to the streaming population reader. Within an other PR I will add a new, much faster XML Parser that handels xml files with DTD validation. In the attached plot you can see the performance improvements. Benchmark reads for testing the hamburg-v3.0-25pct-base.output_plans.xml.gz
![grafik](https://github.com/matsim-org/matsim-libs/assets/26229392/ffaf4fa3-17c2-41cf-8664-99cb4022af98)

@mrieser thanks for supporting me! Great teamwork. 


