### PR TITLE
Set standard validation feature for WoodStox parser

### DIFF
--- a/matsim/src/main/java/org/matsim/core/utils/io/MatsimXmlParser.java
+++ b/matsim/src/main/java/org/matsim/core/utils/io/MatsimXmlParser.java
@@ -201,7 +201,7 @@ public abstract class MatsimXmlParser extends DefaultHandler implements MatsimRe
 				factory.setFeature("http://xml.org/sax/features/external-general-entities", false); // prevent XEE attack: https://en.wikipedia.org/wiki/XML_external_entity_attack
 
 				if (validating) {
-					factory.setFeature("validation", true); // required to enable DTD validation in Woodstox
+					factory.setFeature("http://xml.org/sax/features/validation", true); // required to enable DTD validation in Woodstox
 					SAXParser parser = factory.newSAXParser();
 					XMLReader reader = parser.getXMLReader();
 					reader.setContentHandler(this);


### PR DESCRIPTION
This PR changes the setFeature method call to use standard feature. "http://xml.org/sax/features/validation". There were reports, that the usage of featureName "validation" is not working on every machine. So this should be now more robust.