### PR TITLE
Use IOUtils in MatsimXmlParser

### DIFF
--- a/matsim/src/main/java/org/matsim/core/utils/io/MatsimXmlParser.java
+++ b/matsim/src/main/java/org/matsim/core/utils/io/MatsimXmlParser.java
@@ -169,15 +169,7 @@ public abstract class MatsimXmlParser extends DefaultHandler implements MatsimRe
 		this.theSource = url.toString();
 		log.info("starting to parse xml from url " + this.theSource + " ...");
 		System.out.flush();
-		if (url.getFile().endsWith(".gz")) {
-			try {
-				parse(new InputSource(new GZIPInputStream(url.openStream())));
-			} catch (IOException e) {
-				throw new RuntimeException(e);
-			}
-		} else {
-			parse(new InputSource(url.toExternalForm()));
-		}
+		parse(new InputSource(IOUtils.getBufferedReader(this.theSource)));
 	}
 
 	public final void parse(final InputStream stream) throws UncheckedIOException {


### PR DESCRIPTION
Only parsing compressed GZip files (no ZSTD for example) was possible using the code path that `ScenarioUtils.loadScenario(Config)` used.

Now, also reading ZSTD file should be possible.