### PR TITLE
fix: warn for parallell links in OneToManyPathCalculator

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/OneToManyPathCalculator.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/OneToManyPathCalculator.java
@@ -24,22 +24,26 @@ import static java.util.stream.Collectors.toList;
 import static org.matsim.contrib.dvrp.path.LeastCostPathTreeStopCriteria.allEndNodesReached;
 import static org.matsim.contrib.dvrp.path.LeastCostPathTreeStopCriteria.withMaxTravelTime;
 import static org.matsim.contrib.dvrp.path.VrpPaths.FIRST_LINK_TT;
-import static org.matsim.core.router.util.LeastCostPathCalculator.Path;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.IdMap;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch.PathData;
 import org.matsim.core.router.speedy.LeastCostPathTree;
+import org.matsim.core.router.util.LeastCostPathCalculator.Path;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.utils.misc.OptionalTime;
 
@@ -62,6 +66,8 @@ class OneToManyPathCalculator {
 		this.forwardSearch = forwardSearch;
 		this.fromLink = fromLink;
 		this.startTime = startTime;
+
+		verifyParallelLinks();
 	}
 
 	void calculateDijkstraTree(Collection<Link> toLinks) {
@@ -158,6 +164,7 @@ class OneToManyPathCalculator {
 			for (Link link : prevNode.getOutLinks().values()) {
 				//FIXME this method will not work properly if there are many prevNode -> nextNode links
 				//TODO save link idx in tree OR pre-check: at most 1 arc per each node pair OR choose faster/better link
+				// sh, 26/07/2023, added a check further below to increase awareness
 				if (link.getToNode() == nextNode) {
 					links.add(link);
 					break;
@@ -181,5 +188,31 @@ class OneToManyPathCalculator {
 				VrpPaths.getLastLinkTT(travelTime, toLink, time + pathTravelTime) :
 				VrpPaths.getLastLinkTT(travelTime, fromLink, time);
 		return FIRST_LINK_TT + lastLinkTT;
+	}
+
+	private final static Logger logger = LogManager.getLogger(OneToManyPathCalculator.class);
+	private static int parallelLinksWarningCount = 0;
+
+	private void verifyParallelLinks() {
+		if (parallelLinksWarningCount < 20) {
+			for (Node prevNode : nodeMap.values()) {
+				Set<Integer> candidates = new HashSet<>();
+
+				for (Link link : prevNode.getOutLinks().values()) {
+					if (!candidates.add(link.getToNode().getId().index())) {
+						logger.warn(
+								"Found parallel links between nodes {} and {}. This may lead to problems in path calculation.",
+								prevNode.getId().toString(), link.getToNode().getId().toString());
+
+						if (parallelLinksWarningCount > 20) {
+							logger.warn("Only showing 20 of these warnings ...");
+							return;
+						}
+
+						parallelLinksWarningCount++;
+					}
+				}
+			}
+		}
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/OneToManyPathCalculator.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/OneToManyPathCalculator.java
@@ -49,6 +49,7 @@ import org.matsim.core.utils.misc.OptionalTime;
 
 /**
  * @author Michal Maciejewski (michalm)
+ * @author Sebastian Hörl, IRT SystemX (sebhoerl)
  */
 class OneToManyPathCalculator {
 	private final IdMap<Node, Node> nodeMap;

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/OneToManyPathCalculator.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/OneToManyPathCalculator.java
@@ -206,6 +206,7 @@ class OneToManyPathCalculator {
 								prevNode.getId().toString(), link.getToNode().getId().toString());
 
 						if (parallelLinksWarningCount > 20) {
+							logger.warn("Consider using NetworkSegmentDoubleLinks.run on your network");
 							logger.warn("Only showing 20 of these warnings ...");
 							return;
 						}


### PR DESCRIPTION
Currently, there is a comment in `OneToManyPathCalculator` that already explains that having parallel links (same start and end node) may produce unexpected results when reconstructing the link sequence (see `constructLinkSequence`). 

Yesterday, I was debugging timing issues in DRT where I had a scenario in which I never managed to get the timing 100% congruent between insertion/scheduling and the simulation. After digging for several hours, I arrived at the comment in `OneToManyPathCalculator` so I thought it might be useful to have a check and a warning about the issue :)