### PR TITLE
fix: repair treatment of extended stop durations in drt task scheduling

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
 import org.matsim.contrib.drt.optimizer.Waypoint;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator.Insertion;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionWithDetourData;
 import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
 import org.matsim.contrib.drt.schedule.*;
@@ -90,8 +91,24 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 		var dropoffTask = insertDropoff(request, insertion, pickupTask);
 		verifyTimes("Inconsistent dropoff arrival time", insertion.detourTimeInfo.dropoffDetourInfo.arrivalTime,
 				dropoffTask.getBeginTime());
-
+		
+		verifyTaskContinuity(insertion);
 		return new PickupDropoffTaskPair(pickupTask, dropoffTask);
+	}
+	
+	private void verifyTaskContinuity(InsertionWithDetourData insertion) {
+		/*
+		 * During insertion of tasks the common sanity checks that happen when appending
+		 * to the schedule (next start time = previous end time) are not evaluated. This
+		 * method verifies that the timing remains intact after insertion.
+		 */
+		
+		Schedule schedule = insertion.insertion.vehicleEntry.vehicle.getSchedule();
+		for (int i = 1; i < schedule.getTaskCount(); i++) {
+			Task first = schedule.getTasks().get(i - 1);
+			Task second = schedule.getTasks().get(i);
+			Verify.verify(first.getEndTime() == second.getBeginTime());
+		}
 	}
 
 	private void verifyTimes(String messageStart, double timeFromInsertionData, double timeFromScheduler) {
@@ -191,6 +208,9 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 					scheduleTimingUpdater.updateTimingsStartingFromTaskIdx(vehicleEntry.vehicle,
 							stopTask.getTaskIdx() + 2, driveFromPickupTask.getEndTime());
 					///////
+				} else {
+					scheduleTimingUpdater.updateTimingsStartingFromTaskIdx(vehicleEntry.vehicle,
+							stopTask.getTaskIdx() + 1, stopTask.getEndTime());
 				}
 
 				return stopTask;
@@ -272,6 +292,8 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 				stopTask.addDropoffRequest(request);
 				double updatedStopDuration = stopDurationEstimator.calcDuration(vehicleEntry.vehicle, stopTask.getDropoffRequests().values(), stopTask.getPickupRequests().values());
 				stopTask.setEndTime(stopTask.getBeginTime() + updatedStopDuration);
+				scheduleTimingUpdater.updateTimingsStartingFromTaskIdx(vehicleEntry.vehicle,
+						stopTask.getTaskIdx() + 1, stopTask.getEndTime());
 				return stopTask;
 			} else { // add drive task to dropoff location
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
@@ -54,6 +54,7 @@ import com.google.common.base.Verify;
 
 /**
  * @author michalm
+ * @author Sebastian Hörl, IRT SystemX (sebhoerl)
  */
 public class DefaultRequestInsertionScheduler implements RequestInsertionScheduler {
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/run/examples/RunDrtExampleIT.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/run/examples/RunDrtExampleIT.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,11 +35,21 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.contrib.drt.optimizer.DrtRequestInsertionRetryParams;
+import org.matsim.contrib.drt.optimizer.insertion.IncrementalStopDurationEstimator;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionDetourTimeCalculatorWithVariableDurationTest;
 import org.matsim.contrib.drt.optimizer.insertion.selective.SelectiveInsertionSearchParams;
+import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
+import org.matsim.contrib.drt.passenger.DrtRequest;
+import org.matsim.contrib.drt.run.DrtControlerCreator;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
+import org.matsim.contrib.drt.schedule.DrtStopTask;
+import org.matsim.contrib.drt.schedule.StopDurationEstimator;
+import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
+import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
 import org.matsim.core.utils.io.IOUtils;
 import org.matsim.examples.ExamplesUtils;
@@ -186,6 +197,59 @@ public class RunDrtExampleIT {
 				.waitAverage(223.86)
 				.inVehicleTravelTimeMean(389.57)
 				.totalTravelTimeMean(613.44)
+				.build();
+
+		verifyDrtCustomerStatsCloseToExpectedStats(utils.getOutputDirectory(), expectedStats);
+	}
+	
+	@Test
+	public void testRunDrtExampleWithIncrementalStopDuration() {
+		Id.resetCaches();
+		URL configUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("mielec"), "mielec_drt_config.xml");
+		Config config = ConfigUtils.loadConfig(configUrl, new MultiModeDrtConfigGroup(), new DvrpConfigGroup(),
+				new OTFVisConfigGroup());
+
+		config.controler().setOverwriteFileSetting(OverwriteFileSetting.deleteDirectoryIfExists);
+		config.controler().setOutputDirectory(utils.getOutputDirectory());
+		
+		Controler controller = DrtControlerCreator.createControler(config, false);
+		
+		StopDurationEstimator stopDurationEstimator = new StopDurationEstimator() {
+			@Override
+			public double calcDuration(DvrpVehicle vehicle, Collection<AcceptedDrtRequest> dropoffRequests,
+					Collection<AcceptedDrtRequest> pickupRequests) {
+				return Math.max(60.0, pickupRequests.size() * 60.0 + dropoffRequests.size() * 5.0);
+			}
+		};
+		
+		IncrementalStopDurationEstimator incrementalStopDurationEstimator = new IncrementalStopDurationEstimator() {
+			@Override
+			public double calcForPickup(DvrpVehicle vehicle, DrtStopTask stopTask, DrtRequest pickupRequest) {
+				return 60.0;
+			}
+			
+			@Override
+			public double calcForDropoff(DvrpVehicle vehicle, DrtStopTask stopTask, DrtRequest dropoffRequest) {
+				return stopTask == null ? 65.0 : 5.0;
+			}
+		};
+		
+		controller.addOverridingModule(new AbstractDvrpModeModule("drt") {
+			@Override
+			public void install() {
+				bindModal(StopDurationEstimator.class).toInstance(stopDurationEstimator);
+				bindModal(IncrementalStopDurationEstimator.class).toInstance(incrementalStopDurationEstimator);
+			}
+		});
+		
+		controller.run();
+
+		var expectedStats = Stats.newBuilder()
+				.rejectionRate(0.04)
+				.rejections(16)
+				.waitAverage(276.78)
+				.inVehicleTravelTimeMean(383.47)
+				.totalTravelTimeMean(660.25)
 				.build();
 
 		verifyDrtCustomerStatsCloseToExpectedStats(utils.getOutputDirectory(), expectedStats);

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/run/examples/RunDrtExampleIT.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/run/examples/RunDrtExampleIT.java
@@ -60,6 +60,7 @@ import com.google.common.base.MoreObjects;
 
 /**
  * @author jbischoff
+ * @author Sebastian Hörl, IRT SystemX (sebhoerl)
  */
 public class RunDrtExampleIT {
 


### PR DESCRIPTION
Currently, there is an issue when using varying stop durations (`StopDurationEstimator` + `IncrementalStopDurationEstimator`) in the scheduling of the DRT tasks. Everything works well in the case when new tasks are created, but for stops to which pickups or dropoffs are added, only their own duration is updated and the scheduling finishes. This is fine if the `stopDuration` stays constant (e.g. 60s), but if the stop duration increases, this has an impact on the following tasks. So whenever the stop duration is updated during scheduling, we should use `ScheduleTimingUpdater` to repair the following start and end times. Otherwise, we have an inconsistent schedule. It may be repaired eventually somewhere, but if we have subsequent insertions in one iteration, this may lead to confusion. 

- Added an integration test with varying stop duration
- Added a verification in `DefaultRequestInsertionScheduler` that detects inconsistent schedules and fails without further intervention
- Added fixes in `DefaultRequestInsertionScheduler` that repair the schedule timing