### PR TITLE
Repeated selective insertion search

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtModeOptimizerQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtModeOptimizerQSimModule.java
@@ -31,6 +31,8 @@ import org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator;
 import org.matsim.contrib.drt.optimizer.insertion.UnplannedRequestInserter;
 import org.matsim.contrib.drt.optimizer.insertion.extensive.ExtensiveInsertionSearchParams;
 import org.matsim.contrib.drt.optimizer.insertion.extensive.ExtensiveInsertionSearchQSimModule;
+import org.matsim.contrib.drt.optimizer.insertion.repeatedselective.RepeatedSelectiveInsertionSearchParams;
+import org.matsim.contrib.drt.optimizer.insertion.repeatedselective.RepeatedSelectiveInsertionSearchQSimModule;
 import org.matsim.contrib.drt.optimizer.insertion.selective.SelectiveInsertionSearchParams;
 import org.matsim.contrib.drt.optimizer.insertion.selective.SelectiveInsertionSearchQSimModule;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
@@ -157,6 +159,9 @@ public class DrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 
 			case SelectiveInsertionSearchParams.SET_NAME:
 				return new SelectiveInsertionSearchQSimModule(drtCfg);
+
+			case RepeatedSelectiveInsertionSearchParams.SET_NAME:
+				return new RepeatedSelectiveInsertionSearchQSimModule(drtCfg);
 
 			default:
 				throw new RuntimeException(

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/DetourTimeEstimatorWithAdaptiveTravelTimes.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/DetourTimeEstimatorWithAdaptiveTravelTimes.java
@@ -1,0 +1,50 @@
+package org.matsim.contrib.drt.optimizer.insertion.repeatedselective;
+
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.contrib.drt.optimizer.insertion.DetourTimeEstimator;
+import org.matsim.contrib.dvrp.path.VrpPaths;
+import org.matsim.contrib.zone.skims.AdaptiveTravelTimeMatrix;
+import org.matsim.core.router.util.TravelTime;
+
+import static org.matsim.contrib.dvrp.path.VrpPaths.FIRST_LINK_TT;
+
+/**
+ * @author steffenaxer
+ */
+public class DetourTimeEstimatorWithAdaptiveTravelTimes implements DetourTimeEstimator {
+
+	private final TravelTime travelTime;
+	private final AdaptiveTravelTimeMatrix adaptiveTravelTimeMatrix;
+	private final double speedFactor;
+
+	DetourTimeEstimatorWithAdaptiveTravelTimes(double speedFactor, AdaptiveTravelTimeMatrix adaptiveTravelTimeMatrix,
+											   TravelTime travelTime) {
+		this.speedFactor = speedFactor;
+		this.adaptiveTravelTimeMatrix = adaptiveTravelTimeMatrix;
+		this.travelTime = travelTime;
+	}
+
+	public static DetourTimeEstimatorWithAdaptiveTravelTimes create(double speedFactor, AdaptiveTravelTimeMatrix updatableTravelTimeMatrix,
+																	TravelTime travelTime) {
+		return new DetourTimeEstimatorWithAdaptiveTravelTimes(speedFactor, updatableTravelTimeMatrix, travelTime);
+	}
+
+	@Override
+	public double estimateTime(Link from, Link to, double departureTime) {
+
+		if (from == to) {
+			return 0;
+		}
+
+		double duration = FIRST_LINK_TT;
+		duration += this.getTravelTime(from.getToNode(), to.getFromNode(), departureTime + duration);
+		duration += VrpPaths.getLastLinkTT(travelTime, to, departureTime + duration);
+		return duration / speedFactor;
+	}
+
+	double getTravelTime(Node fromNode, Node toNode, double departureTime) {
+		return this.adaptiveTravelTimeMatrix.getTravelTime(fromNode, toNode, departureTime);
+	}
+
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/DetourTimeEstimatorWithAdaptiveTravelTimes.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/DetourTimeEstimatorWithAdaptiveTravelTimes.java
@@ -1,3 +1,22 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2023 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
 package org.matsim.contrib.drt.optimizer.insertion.repeatedselective;
 
 import org.matsim.api.core.v01.network.Link;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/RepeatedSelectiveInsertionProvider.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/RepeatedSelectiveInsertionProvider.java
@@ -1,0 +1,89 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.optimizer.insertion.repeatedselective;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.matsim.contrib.drt.optimizer.VehicleEntry;
+import org.matsim.contrib.drt.optimizer.insertion.*;
+import org.matsim.contrib.drt.optimizer.insertion.BestInsertionFinder.InsertionWithCost;
+import static org.matsim.contrib.drt.optimizer.insertion.BestInsertionFinder.INSERTION_WITH_COST_COMPARATOR;
+import org.matsim.contrib.drt.passenger.DrtRequest;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.zone.skims.AdaptiveTravelTimeMatrix;
+import org.matsim.core.router.util.TravelTime;
+
+import static org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ForkJoinPool;
+import java.util.stream.Collectors;
+
+/**
+ * @author steffenaxer
+ */
+class RepeatedSelectiveInsertionProvider {
+    private static final double SPEED_FACTOR = 1.;
+    private final InsertionCostCalculator insertionCostCalculator;
+    private final InsertionGenerator insertionGenerator;
+    private final ForkJoinPool forkJoinPool;
+    @VisibleForTesting
+	RepeatedSelectiveInsertionProvider(InsertionCostCalculator insertionCostCalculator,
+									   InsertionGenerator insertionGenerator,
+									   ForkJoinPool forkJoinPool) {
+        this.insertionCostCalculator = insertionCostCalculator;
+        this.insertionGenerator = insertionGenerator;
+        this.forkJoinPool = forkJoinPool;
+    }
+
+    public static RepeatedSelectiveInsertionProvider create( InsertionCostCalculator insertionCostCalculator, AdaptiveTravelTimeMatrix updatableTravelTimeMatrix,
+															TravelTime travelTime,
+															ForkJoinPool forkJoinPool, IncrementalStopDurationEstimator incrementalStopDurationEstimator) {
+        var detourTimeEstimatorWithUpdatedTravelTimes = DetourTimeEstimatorWithAdaptiveTravelTimes.create(
+                SPEED_FACTOR, updatableTravelTimeMatrix, travelTime);
+        return new RepeatedSelectiveInsertionProvider(insertionCostCalculator,
+                new InsertionGenerator(incrementalStopDurationEstimator, detourTimeEstimatorWithUpdatedTravelTimes), forkJoinPool);
+    }
+
+    public List<InsertionWithDetourData> getInsertions(DrtRequest drtRequest, Collection<VehicleEntry> vehicleEntries) {
+        // Parallel outer stream over vehicle entries. The inner stream (flatmap) is
+        // sequential.
+        List<InsertionWithDetourData> preFilteredInsertions = forkJoinPool.submit(() -> vehicleEntries.parallelStream()
+                // generate feasible insertions (wrt occupancy limits) with admissible detour
+                // times
+                .flatMap(e -> insertionGenerator.generateInsertions(drtRequest, e).stream())
+                .map(i -> new InsertionWithCost(i,
+                        this.insertionCostCalculator.calculate(drtRequest, i.insertion, i.detourTimeInfo)))
+                // optimistic pre-filtering wrt admissible cost function (SPEED_FACTOR 1.0)
+                .filter(iWithCost -> iWithCost.cost < INFEASIBLE_SOLUTION_COST)
+                // sort all found insertions
+                .sorted(INSERTION_WITH_COST_COMPARATOR)
+                .map(iWithCost -> iWithCost.insertionWithDetourData)
+                // collect
+                .collect(Collectors.toList())).join();
+
+        if (preFilteredInsertions.isEmpty()) {
+            return List.of();
+        }
+
+        return preFilteredInsertions;
+    }
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/RepeatedSelectiveInsertionProvider.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/RepeatedSelectiveInsertionProvider.java
@@ -1,9 +1,9 @@
-/*
- * *********************************************************************** *
+/* *********************************************************************** *
  * project: org.matsim.*
+ *                                                                         *
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ * copyright       : (C) 2023 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -15,8 +15,7 @@
  *   (at your option) any later version.                                   *
  *   See also COPYING, LICENSE and WARRANTY file                           *
  *                                                                         *
- * *********************************************************************** *
- */
+ * *********************************************************************** */
 
 package org.matsim.contrib.drt.optimizer.insertion.repeatedselective;
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/RepeatedSelectiveInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/RepeatedSelectiveInsertionSearch.java
@@ -1,0 +1,171 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2023 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.drt.optimizer.insertion.repeatedselective;
+
+import com.opencsv.CSVWriter;
+import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
+import org.matsim.contrib.drt.optimizer.VehicleEntry;
+import org.matsim.contrib.drt.optimizer.insertion.*;
+import org.matsim.contrib.drt.optimizer.insertion.selective.SingleInsertionDetourPathCalculator;
+import org.matsim.contrib.drt.passenger.DrtRequest;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.dvrp.path.OneToManyPathSearch;
+import org.matsim.contrib.zone.skims.AdaptiveTravelTimeMatrix;
+import org.matsim.contrib.zone.skims.TravelTimeMatrix;
+import org.matsim.core.controler.MatsimServices;
+import org.matsim.core.mobsim.framework.events.MobsimBeforeCleanupEvent;
+import org.matsim.core.mobsim.framework.listeners.MobsimBeforeCleanupListener;
+import org.matsim.core.router.util.LeastCostPathCalculator;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
+import static org.matsim.contrib.drt.optimizer.insertion.InsertionDetourTimeCalculator.DetourTimeInfo;
+
+/**
+ * @author steffenaxer
+ */
+final class RepeatedSelectiveInsertionSearch implements DrtInsertionSearch, MobsimBeforeCleanupListener {
+	private final RepeatedSelectiveInsertionProvider insertionProvider;
+	private final SingleInsertionDetourPathCalculator detourPathCalculator;
+	private final InsertionDetourTimeCalculator detourTimeCalculator;
+	private final InsertionCostCalculator insertionCostCalculator;
+	private final MatsimServices matsimServices;
+	private final String mode;
+	private final TravelTimeMatrix travelTimeMatrix;
+	private final AdaptiveTravelTimeMatrix adaptiveTravelTimeMatrix;
+	private final RepeatedSelectiveInsertionSearchParams insertionSearchParams;
+
+	public RepeatedSelectiveInsertionSearch(RepeatedSelectiveInsertionProvider insertionProvider,
+											SingleInsertionDetourPathCalculator detourPathCalculator, InsertionCostCalculator insertionCostCalculator,
+											DrtConfigGroup drtCfg, MatsimServices matsimServices, IncrementalStopDurationEstimator incrementalStopDurationEstimator, TravelTimeMatrix travelTimeMatrix, AdaptiveTravelTimeMatrix adaptiveTravelTimeMatrix) {
+		this.insertionSearchParams = (RepeatedSelectiveInsertionSearchParams) drtCfg.getDrtInsertionSearchParams();
+		this.insertionProvider = insertionProvider;
+		this.detourPathCalculator = detourPathCalculator;
+		this.insertionCostCalculator = insertionCostCalculator;
+		this.detourTimeCalculator = new InsertionDetourTimeCalculator(incrementalStopDurationEstimator, null);
+		this.matsimServices = matsimServices;
+		this.mode = drtCfg.getMode();
+		this.travelTimeMatrix = travelTimeMatrix;
+		this.adaptiveTravelTimeMatrix = adaptiveTravelTimeMatrix;
+	}
+
+	@Override
+	public Optional<InsertionWithDetourData> findBestInsertion(DrtRequest drtRequest,
+			Collection<VehicleEntry> vehicleEntries) {
+	      List<InsertionWithDetourData> sortedInsertions = insertionProvider.getInsertions(drtRequest, vehicleEntries);
+		if (sortedInsertions.isEmpty()) {
+			return Optional.empty();
+		}
+        return validateInsertionWithPathCalculation(sortedInsertions, drtRequest, insertionSearchParams.retryInsertion);
+	}
+
+    Optional<InsertionWithDetourData> validateInsertionWithPathCalculation(List<InsertionWithDetourData> selectedInsertionList,
+            DrtRequest drtRequest, int tryKBest) {
+        int n = Math.min(selectedInsertionList.size(), tryKBest);
+        for (int i = 0; i < n; i++) {
+            var selectedInsertion = selectedInsertionList.get(i);
+            var insertion = selectedInsertion.insertion;
+            var insertionDetourData = detourPathCalculator.calculatePaths(drtRequest, insertion);
+            var insertionWithDetourData = new InsertionWithDetourData(insertion, insertionDetourData,
+                    detourTimeCalculator.calculateDetourTimeInfo(insertion, insertionDetourData, drtRequest));
+
+            collectDifferences(drtRequest, selectedInsertion.detourTimeInfo, insertionWithDetourData.detourTimeInfo);
+
+            double insertionCost = insertionCostCalculator.calculate(drtRequest, insertion,
+                    insertionWithDetourData.detourTimeInfo);
+
+            // For each realized routing, we update lazily a correction matrix
+            updateMatrix(drtRequest, travelTimeMatrix, adaptiveTravelTimeMatrix, insertionWithDetourData);
+
+            Optional<InsertionWithDetourData> solution = insertionCost >= INFEASIBLE_SOLUTION_COST ? Optional.empty()
+                    : Optional.of(insertionWithDetourData);
+            if (solution.isPresent()) {
+                return solution;
+            }
+        }
+        return Optional.empty();
+    }
+
+	private final Map<Integer, SummaryStatistics> pickupTimeLossStats = new LinkedHashMap<>();
+	private final Map<Integer, SummaryStatistics> dropoffTimeLossStats = new LinkedHashMap<>();
+
+	private void collectDifferences(DrtRequest request, DetourTimeInfo matrixTimeInfo, DetourTimeInfo networkTimeInfo) {
+		addRelativeDiff(matrixTimeInfo.pickupDetourInfo.pickupTimeLoss, networkTimeInfo.pickupDetourInfo.pickupTimeLoss,
+				networkTimeInfo.pickupDetourInfo.departureTime, pickupTimeLossStats);
+		addRelativeDiff(matrixTimeInfo.dropoffDetourInfo.dropoffTimeLoss,
+				networkTimeInfo.dropoffDetourInfo.dropoffTimeLoss, networkTimeInfo.dropoffDetourInfo.arrivalTime,
+				dropoffTimeLossStats);
+	}
+
+	private void updateMatrix(DrtRequest request, TravelTimeMatrix travelTimeMatrix, AdaptiveTravelTimeMatrix updatableTravelTimeMatrix, InsertionWithDetourData insertionWithDetourData) {
+		updateMatrix(request, travelTimeMatrix, updatableTravelTimeMatrix, insertionWithDetourData.detourData.detourToPickup);
+		updateMatrix(request, travelTimeMatrix, updatableTravelTimeMatrix, insertionWithDetourData.detourData.detourFromPickup);
+		updateMatrix(request, travelTimeMatrix, updatableTravelTimeMatrix, insertionWithDetourData.detourData.detourToDropoff);
+		updateMatrix(request, travelTimeMatrix, updatableTravelTimeMatrix, insertionWithDetourData.detourData.detourFromDropoff);
+	}
+
+	private static void updateMatrix(DrtRequest request, TravelTimeMatrix travelTimeMatrix, AdaptiveTravelTimeMatrix updatableTravelTimeMatrix, OneToManyPathSearch.PathData pathData) {
+		if(pathData!=null && pathData.getPath().links!=null)
+		{
+			LeastCostPathCalculator.Path path = pathData.getPath();
+			double ttRoutedEstimate = pathData.getTravelTime();
+			updatableTravelTimeMatrix.setTravelTime(path.getFromNode(), path.getToNode(), ttRoutedEstimate, request.getEarliestStartTime());
+		}
+	}
+
+
+	private void addRelativeDiff(double matrixVal, double networkVal, double eventTime,
+			Map<Integer, SummaryStatistics> summaryStatsMap) {
+		int timeBin = (int)(eventTime / 3600);
+		var stats = summaryStatsMap.computeIfAbsent(timeBin, b -> new SummaryStatistics());
+		if (matrixVal == 0 && networkVal == 0) {
+			stats.addValue(0);
+		} else if (networkVal != 0) {
+			stats.addValue((matrixVal - networkVal) / networkVal);
+		}
+	}
+
+	@Override
+	public void notifyMobsimBeforeCleanup(@SuppressWarnings("rawtypes") MobsimBeforeCleanupEvent event) {
+		String filename = matsimServices.getControlerIO()
+				.getIterationFilename(matsimServices.getIterationNumber(),
+						mode + "_selective_insertion_detour_time_estimation_errors.csv");
+		try (CSVWriter writer = new CSVWriter(Files.newBufferedWriter(Paths.get(filename)), ';', '"', '"', "\n");) {
+			writer.writeNext(new String[] { "type", "hour", "count", "mean", "std_dev", "min", "max" }, false);
+			pickupTimeLossStats.forEach((hour, stats) -> printStats(writer, "pickup", hour, stats));
+			dropoffTimeLossStats.forEach((hour, stats) -> printStats(writer, "dropoff", hour, stats));
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	private void printStats(CSVWriter writer, String type, int hour, SummaryStatistics stats) {
+		writer.writeNext(new String[] { type, hour + "", stats.getN() + "", stats.getMean() + "",
+				stats.getStandardDeviation() + "", stats.getMin() + "", stats.getMax() + "" }, false);
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/RepeatedSelectiveInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/RepeatedSelectiveInsertionSearch.java
@@ -99,7 +99,8 @@ final class RepeatedSelectiveInsertionSearch implements DrtInsertionSearch, Mobs
             double insertionCost = insertionCostCalculator.calculate(drtRequest, insertion,
                     insertionWithDetourData.detourTimeInfo);
 
-            // For each realized routing, we update lazily a correction matrix
+            // For each realized routing, we update the adaptiveTravelTimeMatrix
+			// The idea is to get a passively updated travel time estimation, without additional routing costs
             updateMatrix(drtRequest, travelTimeMatrix, adaptiveTravelTimeMatrix, insertionWithDetourData);
 
             Optional<InsertionWithDetourData> solution = insertionCost >= INFEASIBLE_SOLUTION_COST ? Optional.empty()

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/RepeatedSelectiveInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/RepeatedSelectiveInsertionSearch.java
@@ -103,10 +103,8 @@ final class RepeatedSelectiveInsertionSearch implements DrtInsertionSearch, Mobs
 			// The idea is to get a passively updated travel time estimation, without additional routing costs
             updateMatrix(drtRequest, travelTimeMatrix, adaptiveTravelTimeMatrix, insertionWithDetourData);
 
-            Optional<InsertionWithDetourData> solution = insertionCost >= INFEASIBLE_SOLUTION_COST ? Optional.empty()
-                    : Optional.of(insertionWithDetourData);
-            if (solution.isPresent()) {
-                return solution;
+            if (insertionCost < INFEASIBLE_SOLUTION_COST) {
+                return Optional.of(insertionWithDetourData);
             }
         }
         return Optional.empty();

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/RepeatedSelectiveInsertionSearchParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/RepeatedSelectiveInsertionSearchParams.java
@@ -1,9 +1,9 @@
-/*
- * *********************************************************************** *
+/* *********************************************************************** *
  * project: org.matsim.*
+ *                                                                         *
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ * copyright       : (C) 2023 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -15,8 +15,8 @@
  *   (at your option) any later version.                                   *
  *   See also COPYING, LICENSE and WARRANTY file                           *
  *                                                                         *
- * *********************************************************************** *
- */
+ * *********************************************************************** */
+
 
 package org.matsim.contrib.drt.optimizer.insertion.repeatedselective;
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/RepeatedSelectiveInsertionSearchParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/RepeatedSelectiveInsertionSearchParams.java
@@ -1,0 +1,39 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.optimizer.insertion.repeatedselective;
+
+import jakarta.validation.constraints.Positive;
+import org.matsim.contrib.drt.optimizer.insertion.DrtInsertionSearchParams;
+
+/**
+ * @author steffenaxer
+ */
+public class RepeatedSelectiveInsertionSearchParams extends DrtInsertionSearchParams {
+	public static final String SET_NAME = "RepeatedSelectiveInsertionSearch";
+
+	@Parameter
+	@Positive
+	public int retryInsertion = 5;
+
+	public RepeatedSelectiveInsertionSearchParams() {
+		super(SET_NAME);
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/RepeatedSelectiveInsertionSearchQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/RepeatedSelectiveInsertionSearchQSimModule.java
@@ -1,9 +1,9 @@
-/*
- * *********************************************************************** *
+/* *********************************************************************** *
  * project: org.matsim.*
+ *                                                                         *
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ * copyright       : (C) 2023 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -15,8 +15,8 @@
  *   (at your option) any later version.                                   *
  *   See also COPYING, LICENSE and WARRANTY file                           *
  *                                                                         *
- * *********************************************************************** *
- */
+ * *********************************************************************** */
+
 
 package org.matsim.contrib.drt.optimizer.insertion.repeatedselective;
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/RepeatedSelectiveInsertionSearchQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/RepeatedSelectiveInsertionSearchQSimModule.java
@@ -1,0 +1,79 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2022 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.drt.optimizer.insertion.repeatedselective;
+
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.drt.optimizer.QSimScopeForkJoinPoolHolder;
+import org.matsim.contrib.drt.optimizer.insertion.DrtInsertionSearch;
+import org.matsim.contrib.drt.optimizer.insertion.IncrementalStopDurationEstimator;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator;
+import org.matsim.contrib.drt.optimizer.insertion.selective.SingleInsertionDetourPathCalculator;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
+import org.matsim.contrib.dvrp.run.DvrpModes;
+import org.matsim.contrib.zone.skims.AdaptiveTravelTimeMatrix;
+import org.matsim.contrib.zone.skims.TravelTimeMatrix;
+import org.matsim.core.controler.MatsimServices;
+import org.matsim.core.modal.ModalProviders;
+import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
+import org.matsim.core.router.util.TravelDisutility;
+import org.matsim.core.router.util.TravelTime;
+
+/**
+ * @author steffenaxer
+ */
+public class RepeatedSelectiveInsertionSearchQSimModule extends AbstractDvrpModeQSimModule {
+    private final DrtConfigGroup drtCfg;
+
+    public RepeatedSelectiveInsertionSearchQSimModule(DrtConfigGroup drtCfg) {
+        super(drtCfg.getMode());
+        this.drtCfg = drtCfg;
+    }
+
+    @Override
+    protected void configureQSim() {
+        addModalComponent(RepeatedSelectiveInsertionSearch.class, modalProvider(getter -> {
+            RepeatedSelectiveInsertionProvider provider = RepeatedSelectiveInsertionProvider.create(
+                    getter.getModal(InsertionCostCalculator.class), getter.getModal(AdaptiveTravelTimeMatrix.class),
+                    getter.getModal(TravelTime.class), getter.getModal(QSimScopeForkJoinPoolHolder.class).getPool(),
+                    getter.getModal(IncrementalStopDurationEstimator.class));
+            var insertionCostCalculator = getter.getModal(InsertionCostCalculator.class);
+            return new RepeatedSelectiveInsertionSearch(provider,
+                    getter.getModal(SingleInsertionDetourPathCalculator.class),
+                    insertionCostCalculator, drtCfg, getter.get(MatsimServices.class),
+                    getter.getModal(IncrementalStopDurationEstimator.class), getter.getModal(TravelTimeMatrix.class),
+                    getter.getModal(AdaptiveTravelTimeMatrix.class));
+        }));
+        bindModal(DrtInsertionSearch.class).to(modalKey(RepeatedSelectiveInsertionSearch.class));
+
+        addModalComponent(SingleInsertionDetourPathCalculator.class,
+                new ModalProviders.AbstractProvider<>(getMode(), DvrpModes::mode) {
+                    @Override
+                    public SingleInsertionDetourPathCalculator get() {
+                        var travelTime = getModalInstance(TravelTime.class);
+                        Network network = getModalInstance(Network.class);
+                        TravelDisutility travelDisutility = getModalInstance(
+                                TravelDisutilityFactory.class).createTravelDisutility(travelTime);
+                        return new SingleInsertionDetourPathCalculator(network, travelTime, travelDisutility, drtCfg);
+                    }
+                });
+    }
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/selective/SingleInsertionDetourPathCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/selective/SingleInsertionDetourPathCalculator.java
@@ -51,7 +51,7 @@ import com.google.common.util.concurrent.Futures;
 /**
  * @author Michal Maciejewski (michalm)
  */
-class SingleInsertionDetourPathCalculator implements MobsimBeforeCleanupListener {
+public class SingleInsertionDetourPathCalculator implements MobsimBeforeCleanupListener {
 
 	public static final int MAX_THREADS = 4;
 
@@ -64,8 +64,8 @@ class SingleInsertionDetourPathCalculator implements MobsimBeforeCleanupListener
 
 	private final ExecutorService executorService;
 
-	SingleInsertionDetourPathCalculator(Network network, TravelTime travelTime,
-			TravelDisutility travelDisutility, DrtConfigGroup drtCfg) {
+	public SingleInsertionDetourPathCalculator(Network network, TravelTime travelTime,
+											   TravelDisutility travelDisutility, DrtConfigGroup drtCfg) {
 		this(network, travelTime, travelDisutility, drtCfg.numberOfThreads, new SpeedyALTFactory());
 	}
 
@@ -81,7 +81,7 @@ class SingleInsertionDetourPathCalculator implements MobsimBeforeCleanupListener
 		executorService = Executors.newFixedThreadPool(Math.min(numberOfThreads, MAX_THREADS));
 	}
 
-	InsertionDetourData calculatePaths(DrtRequest drtRequest, Insertion insertion) {
+	public InsertionDetourData calculatePaths(DrtRequest drtRequest, Insertion insertion) {
 		Link pickup = drtRequest.getFromLink();
 		Link dropoff = drtRequest.getToLink();
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -34,6 +34,7 @@ import org.matsim.contrib.drt.fare.DrtFareParams;
 import org.matsim.contrib.drt.optimizer.DrtRequestInsertionRetryParams;
 import org.matsim.contrib.drt.optimizer.insertion.DrtInsertionSearchParams;
 import org.matsim.contrib.drt.optimizer.insertion.extensive.ExtensiveInsertionSearchParams;
+import org.matsim.contrib.drt.optimizer.insertion.repeatedselective.RepeatedSelectiveInsertionSearchParams;
 import org.matsim.contrib.drt.optimizer.insertion.selective.SelectiveInsertionSearchParams;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingParams;
 import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingStrategyParams;
@@ -216,13 +217,16 @@ public class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableParamet
 		addDefinition(DrtZonalSystemParams.SET_NAME, DrtZonalSystemParams::new, () -> zonalSystemParams,
 				params -> zonalSystemParams = (DrtZonalSystemParams)params);
 
-		//insertion search params (one of: extensive, selective)
+		//insertion search params (one of: extensive, selective, repeated selective)
 		addDefinition(ExtensiveInsertionSearchParams.SET_NAME, ExtensiveInsertionSearchParams::new,
 				() -> drtInsertionSearchParams,
 				params -> drtInsertionSearchParams = (ExtensiveInsertionSearchParams)params);
 		addDefinition(SelectiveInsertionSearchParams.SET_NAME, SelectiveInsertionSearchParams::new,
 				() -> drtInsertionSearchParams,
 				params -> drtInsertionSearchParams = (SelectiveInsertionSearchParams)params);
+		addDefinition(RepeatedSelectiveInsertionSearchParams.SET_NAME, RepeatedSelectiveInsertionSearchParams::new,
+				() -> drtInsertionSearchParams,
+				params -> drtInsertionSearchParams = (RepeatedSelectiveInsertionSearchParams)params);
 
 		//drt fare (optional)
 		addDefinition(DrtFareParams.SET_NAME, DrtFareParams::new, () -> drtFareParams,

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -35,6 +35,7 @@ import org.matsim.contrib.dvrp.router.TimeAsTravelDisutility;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.DvrpModes;
 import org.matsim.contrib.dvrp.trafficmonitoring.DvrpTravelTimeModule;
+import org.matsim.contrib.zone.skims.AdaptiveTravelTimeMatrixModule;
 import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.router.costcalculators.TravelDisutilityFactory;
 import org.matsim.core.router.util.TravelTime;
@@ -86,5 +87,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 				(vehicle, dropoffRequests, pickupRequests) -> drtCfg.stopDuration);
 		bindModal(IncrementalStopDurationEstimator.class).toInstance(
 				new DefaultIncrementalStopDurationEstimator(drtCfg.stopDuration));
+
+		install(new AdaptiveTravelTimeMatrixModule(drtCfg.mode));
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/OneToManyPathSearch.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/OneToManyPathSearch.java
@@ -61,7 +61,7 @@ public class OneToManyPathSearch {
 
 		public PathData(Path path, double firstAndLastLinkTT) {
 			this.pathSupplier = null;
-			this.path = new Path(null, ImmutableList.copyOf(path.links), path.travelTime, path.travelCost);
+			this.path = new Path(ImmutableList.copyOf(path.nodes), ImmutableList.copyOf(path.links), path.travelTime, path.travelCost);
 			this.travelTime = path.travelTime + firstAndLastLinkTT;
 		}
 
@@ -75,7 +75,7 @@ public class OneToManyPathSearch {
 		}
 
 		//package visibility only (path.nodes is null)
-		Path getPath() {
+		public Path getPath() {
 			if (path == null) {
 				path = pathSupplier.get();
 			}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/OneToManyPathSearch.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/path/OneToManyPathSearch.java
@@ -61,7 +61,7 @@ public class OneToManyPathSearch {
 
 		public PathData(Path path, double firstAndLastLinkTT) {
 			this.pathSupplier = null;
-			this.path = new Path(ImmutableList.copyOf(path.nodes), ImmutableList.copyOf(path.links), path.travelTime, path.travelCost);
+			this.path = new Path(path.nodes!= null ? ImmutableList.copyOf(path.nodes) : null, ImmutableList.copyOf(path.links), path.travelTime, path.travelCost);
 			this.travelTime = path.travelTime + firstAndLastLinkTT;
 		}
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/AdaptiveTravelTimeMatrix.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/AdaptiveTravelTimeMatrix.java
@@ -1,0 +1,11 @@
+package org.matsim.contrib.zone.skims;
+
+import org.matsim.api.core.v01.network.Node;
+
+/**
+ * @author steffenaxer
+ */
+public interface AdaptiveTravelTimeMatrix {
+	 double getTravelTime(Node fromNode, Node toNode, double departureTime);
+	 void setTravelTime(Node fromNode, Node toNode, double travelTime, double departureTime);
+}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/AdaptiveTravelTimeMatrix.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/AdaptiveTravelTimeMatrix.java
@@ -1,3 +1,23 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2023 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+
 package org.matsim.contrib.zone.skims;
 
 import org.matsim.api.core.v01.network.Node;

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/AdaptiveTravelTimeMatrixImpl.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/AdaptiveTravelTimeMatrixImpl.java
@@ -1,0 +1,129 @@
+package org.matsim.contrib.zone.skims;
+
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.contrib.common.util.DistanceUtils;
+import org.matsim.contrib.zone.SquareGridSystem;
+import org.matsim.contrib.zone.ZonalSystems;
+import org.matsim.contrib.zone.Zone;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.IntStream;
+
+/**
+ * @author steffenaxer
+ */
+public class AdaptiveTravelTimeMatrixImpl implements AdaptiveTravelTimeMatrix {
+	private final double TIME_INTERVAL = 3600.;
+	private final List<Matrix> timeDependentMatrix;
+	private final SquareGridSystem gridSystem;
+	private final double alpha;
+	private final Map<Zone, Node> centralNodes;
+	private final int numberOfBins;
+	private final DvrpTravelTimeMatrixParams params;
+	private final Map<SparseTravelTimeKey, Double> sparseTravelTimeCache = new ConcurrentHashMap<>();
+
+	public AdaptiveTravelTimeMatrixImpl(double maxTime, Network dvrpNetwork, DvrpTravelTimeMatrixParams params,
+										TravelTimeMatrix freeSpeedMatrix, double alpha) {
+		this.alpha = alpha;
+		this.numberOfBins = numberOfBins(maxTime);
+		this.gridSystem = new SquareGridSystem(dvrpNetwork.getNodes().values(), params.cellSize);
+		this.centralNodes = ZonalSystems.computeMostCentralNodes(dvrpNetwork.getNodes().values(), this.gridSystem);
+		this.timeDependentMatrix = IntStream.range(0, numberOfBins).mapToObj(i -> new Matrix(centralNodes.keySet()))
+				.toList();
+		this.params = params;
+		this.initializeRegularMatrix(freeSpeedMatrix);
+		this.initializeSparseTravelTimeCache(freeSpeedMatrix);
+	}
+
+	record SparseTravelTimeKey(Node fromNode, Node toNode, double timeBin) {
+	}
+
+	int numberOfBins(double maxTime) {
+		return (int) (maxTime / TIME_INTERVAL);
+	}
+
+	// SparseTravelTimeCache is a poor man's version of the SparseMatrix
+	// Much less code, but probably not so memory efficient?
+	void initializeSparseTravelTimeCache(TravelTimeMatrix freeSpeedMatrix) {
+		for (int i = 0; i < numberOfBins; i++) {
+			int bin = i;
+			centralNodes.entrySet().stream().parallel().forEach(originZoneEntry -> {
+				for (Entry<Zone, Node> destinationZoneEntry : centralNodes.entrySet()) {
+					Node originNode = originZoneEntry.getValue();
+					Node destinationNode = destinationZoneEntry.getValue();
+					if (DistanceUtils.calculateSquaredDistance(originNode.getCoord(),
+							destinationNode.getCoord()) < (params.maxNeighborDistance * params.maxNeighborDistance)) {
+						SparseTravelTimeKey key = getSparseTravelTimeKey(originNode, destinationNode, bin);
+						double freeSpeedTravelTime = freeSpeedMatrix.getTravelTime(originNode, destinationNode, Double.NaN);
+						this.sparseTravelTimeCache.computeIfAbsent(key, k -> freeSpeedTravelTime);
+					}
+				}
+			});
+		}
+	}
+
+	SparseTravelTimeKey getSparseTravelTimeKey(Node originNode, Node destinationNode, int bin) {
+		return new SparseTravelTimeKey(originNode, destinationNode, bin);
+	}
+
+	// Matrix needs to be filled otherwise we have -1 exceptions
+	// We fill the matrix with already calculated free speed travel times
+	void initializeRegularMatrix(TravelTimeMatrix freeSpeedMatrix) {
+		for (int i = 0; i < numberOfBins; i++) {
+			int bin = i;
+			centralNodes.entrySet().stream().parallel().forEach(originZoneEntry -> {
+				for (Entry<Zone, Node> destinationZoneEntry : centralNodes.entrySet()) {
+					Node originNode = originZoneEntry.getValue();
+					Node destinationNode = destinationZoneEntry.getValue();
+					double freeSpeedTravelTime = freeSpeedMatrix.getTravelTime(originNode, destinationNode, Double.NaN);
+					this.timeDependentMatrix.get(bin).set(originZoneEntry.getKey(), destinationZoneEntry.getKey(),
+							freeSpeedTravelTime);
+				}
+			});
+		}
+	}
+
+	@Override
+	public double getTravelTime(Node fromNode, Node toNode, double departureTime) {
+		int bin = this.getBin(departureTime);
+		Double sparseValue = this.sparseTravelTimeCache.get(this.getSparseTravelTimeKey(fromNode, toNode, bin));
+		if (sparseValue != null) {
+			return sparseValue;
+		}
+		return this.timeDependentMatrix.get(bin).get(this.gridSystem.getZone(fromNode), this.gridSystem.getZone(toNode));
+	}
+
+	int getBin(double departureTime) {
+		return Math.min((int) (departureTime / TIME_INTERVAL), this.numberOfBins);
+	}
+
+	@Override
+	public void setTravelTime(Node fromNode, Node toNode, double routeEstimate, double departureTime) {
+		int bin = this.getBin(departureTime);
+		SparseTravelTimeKey key = this.getSparseTravelTimeKey(fromNode, toNode, bin);
+		Double sparseValue = this.sparseTravelTimeCache.get(this.getSparseTravelTimeKey(fromNode, toNode, bin));
+
+		// Update sparseTravelTimeCache
+		if (sparseValue != null) {
+			double value = getUpdatedValue(sparseValue, routeEstimate, this.alpha);
+			this.sparseTravelTimeCache.put(key, value);
+
+			// Update regular matrix for long distances
+		} else {
+			double currentTravelTimeEstimate = this.getTravelTime(fromNode, toNode, departureTime);
+			double value = getUpdatedValue(currentTravelTimeEstimate, routeEstimate, this.alpha);
+			this.timeDependentMatrix.get(bin).set(this.gridSystem.getZone(fromNode), this.gridSystem.getZone(toNode),
+					value);
+		}
+
+	}
+
+	static double getUpdatedValue(double currentValue, double newValue, double alpha) {
+		return currentValue * (1 - alpha) + alpha * newValue;
+	}
+
+}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/AdaptiveTravelTimeMatrixImpl.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/AdaptiveTravelTimeMatrixImpl.java
@@ -1,3 +1,22 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2023 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
 package org.matsim.contrib.zone.skims;
 
 import org.matsim.api.core.v01.network.Network;

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/AdaptiveTravelTimeMatrixModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/AdaptiveTravelTimeMatrixModule.java
@@ -1,3 +1,22 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2023 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
 package org.matsim.contrib.zone.skims;
 
 import com.google.inject.Inject;

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/AdaptiveTravelTimeMatrixModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/AdaptiveTravelTimeMatrixModule.java
@@ -1,0 +1,36 @@
+package org.matsim.contrib.zone.skims;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
+import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.core.config.groups.QSimConfigGroup;
+
+/**
+ * @author steffenaxer
+ */
+public class AdaptiveTravelTimeMatrixModule extends AbstractDvrpModeModule {
+    private final double ALTERNATIVE_ENDTIME = 30*3600;
+    private final static double SMOOTHING_ALPHA = 0.75; // High weight to new values
+
+    @Inject
+    private QSimConfigGroup qsimConfig;
+
+    @Inject
+    private DvrpConfigGroup dvrpConfigGroup;
+
+    public AdaptiveTravelTimeMatrixModule(String mode) {
+        super(mode);
+    }
+
+    @Override
+    public void install() {
+        bindModal(AdaptiveTravelTimeMatrix.class).toProvider(modalProvider(
+                getter -> new AdaptiveTravelTimeMatrixImpl(qsimConfig.getEndTime().orElse(ALTERNATIVE_ENDTIME),
+                        getter.getModal(Network.class),
+                        dvrpConfigGroup.getTravelTimeMatrixParams(),
+                        getter.getModal(TravelTimeMatrix.class),SMOOTHING_ALPHA)))
+                .in(Singleton.class);
+    }
+}


### PR DESCRIPTION
This PR provides a novel insertion search implementation that is a blend between extensive and selective search. In a nutshell:

-	Introduction of a time dependent travel time cache (see AdaptiveTravelTimeMatrix) to get most accurate detour time estimates. First, I played around and developed a straightforward time dependent TravelTimeMatrix, but the initialization and updating is painful slow when having 30-time bins. Second, I developed an AdaptiveTravelTimeMatrix that gets initialized from the existing FreeSpeedMatrix but it is updated lazily within the insertion search whenever a regular calculatePaths method is called. As we have multiple millions routing calls over the iterations one can produce passively a travel time matrix that is quite accurate without addition runtime burden. 
-	In addition, I implemented a repeated selective search approach, in which insertions are firstly estimated (speedfactor is 1.0) via the AdaptiveTravelTimeMatrix. Second, insertions are sorted according to their costs. Third, the n-cheapest insertion (config switch, retryInsertion) candidates are than routed and validated according to the travel time constrains. If a valid candidate is found, the validation stops. In many cases only 1-3 trials of different insertions are needed. I found out that 5 candidates are a good tradeoff between performance and rejection rate. 

With this novel approach, the rejection rate is up to 2 % worse than the extensive insertion but likewise 4x faster. Approx. 73 % of the requests can be inserted with the first trial. Which reveals the main reason, why selective search insertion is much faster than extensive search. However, to reach a nearly similar rejection rate, additional trials are needed.
<p align="center">
<img width="400" alt="grafik" src="https://github.com/matsim-org/matsim-libs/assets/26229392/249149e9-8634-42cd-8fbb-22d7ada54e86">
</p>

