### PR TITLE
core: accept TeleportedModeParams as arg in PlansCalcRouteConfigGroup.addTeleportedModeParams()

### DIFF
--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/examples/RunTeleportationBikesharing.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/examples/RunTeleportationBikesharing.java
@@ -19,7 +19,7 @@ import org.matsim.core.config.groups.PlansCalcRouteConfigGroup;
 import org.matsim.core.controler.Controler;
 
 /**
- * 
+ *
  * This is an example of a station-based bike-sharing service
  * siouxfalls-2014 can be used to run the simulation with the provided example
  * input file
@@ -37,13 +37,13 @@ public class RunTeleportationBikesharing {
 		PlansCalcRouteConfigGroup.TeleportedModeParams bikeRoutingParams = new PlansCalcRouteConfigGroup.TeleportedModeParams("bike");
 		bikeRoutingParams.setTeleportedModeSpeed(5.0);
 		bikeRoutingParams.setBeelineDistanceFactor(1.3);
-		config.plansCalcRoute().addModeRoutingParams(bikeRoutingParams);
+		config.plansCalcRoute().addTeleportedModeParams(bikeRoutingParams);
 
 		// Walk is deleted by adding bike here, we need to re-add it ...
 		PlansCalcRouteConfigGroup.TeleportedModeParams walkRoutingParams = new PlansCalcRouteConfigGroup.TeleportedModeParams("walk");
 		walkRoutingParams.setTeleportedModeSpeed(2.0);
 		walkRoutingParams.setBeelineDistanceFactor(1.3);
-		config.plansCalcRoute().addModeRoutingParams(walkRoutingParams);
+		config.plansCalcRoute().addTeleportedModeParams(walkRoutingParams);
 
 		// By default, "bike" will be simulated using teleportation.
 
@@ -84,7 +84,7 @@ public class RunTeleportationBikesharing {
 		ActivityParams dropoffParams = new ActivityParams(SharingUtils.DROPOFF_ACTIVITY);
 		dropoffParams.setScoringThisActivityAtAll(false);
 		config.planCalcScore().addActivityParams(dropoffParams);
-		
+
 		ActivityParams bookingParams = new ActivityParams(SharingUtils.BOOKING_ACTIVITY);
 		bookingParams.setScoringThisActivityAtAll(false);
 		config.planCalcScore().addActivityParams(bookingParams);

--- a/matsim/src/main/java/org/matsim/core/config/groups/PlansCalcRouteConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/PlansCalcRouteConfigGroup.java
@@ -418,15 +418,15 @@ public final class PlansCalcRouteConfigGroup extends ConfigGroup {
 		super.addParameterSet( set );
 	}
 
-	public void addTeleportedModeParams( final ModeRoutingParams pars ) {
-		this.addModeRoutingParams( pars );
-	}
-	/**
-	 * @deprecated -- use {@link #addTeleportedModeParams(ModeRoutingParams)} instead.
-	 */
-	public void addModeRoutingParams(final TeleportedModeParams pars ) {
+	public void addTeleportedModeParams( final TeleportedModeParams pars ) {
 		testForLocked() ;
 		addParameterSet( pars );
+	}
+	/**
+	 * @deprecated -- use {@link #addTeleportedModeParams(TeleportedModeParams)} instead.
+	 */
+	public void addModeRoutingParams(final TeleportedModeParams pars ) {
+		this.addTeleportedModeParams( pars );
 	}
 	public void removeTeleportedModeParams( String key ){
 		this.removeModeRoutingParams( key );


### PR DESCRIPTION
After recent refactorings (#2646), ModeRoutingParams is now a deprecated subclass of TeleportedModeParams.