### PR TITLE
Use global separator within ProfileWriter

### DIFF
--- a/contribs/common/src/main/java/org/matsim/contrib/common/timeprofile/ProfileWriter.java
+++ b/contribs/common/src/main/java/org/matsim/contrib/common/timeprofile/ProfileWriter.java
@@ -77,7 +77,8 @@ public class ProfileWriter implements IterationEndsListener {
 		String file = filename(outputFile);
 		String timeFormat = Time.TIMEFORMAT_HHMMSS;
 
-		try (CompactCSVWriter writer = new CompactCSVWriter(IOUtils.getBufferedWriter(file + ".txt"))) {
+		try (CompactCSVWriter writer = new CompactCSVWriter(IOUtils.getBufferedWriter(file + ".txt"),
+			matsimServices.getConfig().global().getDefaultDelimiter().charAt(0))) {
 			String[] profileHeader = profiles.keySet().toArray(new String[0]);
 			writer.writeNext(new CSVLineBuilder().add("time").addAll(profileHeader));
 			for (int i = 0; i < times.length; i++) {


### PR DESCRIPTION
Within latest drt refactoring, separators have been already adapted to the global separator, but the ProfileWriter that writes occupancy profiles has not been touched. This PR introduces now the usage of the global separator also in the ProfileWriter that is used in drt and taxi contrib. In my point of view, it would be useful, that csv and txt file writing is more harmonized in MATSim. 