### PR TITLE
Explicitly define dependencies in drt pom.xml

### DIFF
--- a/contribs/drt/pom.xml
+++ b/contribs/drt/pom.xml
@@ -19,8 +19,75 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.matsim.contrib</groupId>
+			<artifactId>otfvis</artifactId>
+			<version>16.0-SNAPSHOT</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.matsim.contrib</groupId>
+			<artifactId>common</artifactId>
+			<version>16.0-SNAPSHOT</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-math3</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.opencsv</groupId>
+			<artifactId>opencsv</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.geotools</groupId>
+			<artifactId>gt-main</artifactId>
+			<version>${geotools.version}</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.geotools</groupId>
+			<artifactId>gt-opengis</artifactId>
+			<version>${geotools.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>one.util</groupId>
+			<artifactId>streamex</artifactId>
+			<version>0.8.1</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.locationtech.jts</groupId>
+			<artifactId>jts-core</artifactId>
+			<version>${jts.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jfree</groupId>
+			<artifactId>jfreechart</artifactId>
+			<version>1.5.4</version>
 		</dependency>
 
 		<!-- test dependencies -->


### PR DESCRIPTION
Ths change defines drt's dependencies explicitly in its pom.

I might have run into an issue using the drt contrib due to some dependencies not defined explicitly. These issues remain largely undetected depending on the surrounding dependencies used and their requirements. Thus, it is usually considered best practice, to define every package's dependencies explicitly in its pom. 

These "Used undeclared" dependencies can be shown with the [Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/analyze-mojo.html) using `mvn org.apache.maven.plugins:maven-dependency-plugin:3.6.0:analyze`. I added all dependencies for which I could find obvious references in the code, which fixed most of these used undeclared warnings - fortunately my issue.

```log
[INFO] -----------------------< org.matsim.contrib:drt >-----------------------
[INFO] Building drt 16.0-SNAPSHOT                                       [21/48]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 

...

[INFO] 
[INFO] --- maven-dependency-plugin:3.6.0:analyze (default-cli) @ drt ---
[WARNING] Used undeclared dependencies found:
[WARNING]    com.google.code.findbugs:jsr305:jar:3.0.2:compile
[WARNING]    org.apache.commons:commons-math3:jar:3.6.1:compile
[WARNING]    com.opencsv:opencsv:jar:5.8:compile
[WARNING]    com.google.guava:guava:jar:32.1.2-jre:compile
[WARNING]    org.geotools:gt-main:jar:29.2:compile
[WARNING]    one.util:streamex:jar:0.8.1:compile
[WARNING]    org.locationtech.jts:jts-core:jar:1.19.0:compile
[WARNING]    org.geotools:gt-opengis:jar:29.2:compile
[WARNING]    com.fasterxml.jackson.core:jackson-databind:jar:2.15.2:compile
[WARNING]    com.google.inject:guice:jar:7.0.0:compile
[WARNING]    org.matsim.contrib:otfvis:jar:16.0-SNAPSHOT:compile
[WARNING]    com.fasterxml.jackson.core:jackson-annotations:jar:2.15.2:compile
[WARNING]    com.fasterxml.jackson.core:jackson-core:jar:2.15.2:compile
[WARNING]    jakarta.inject:jakarta.inject-api:jar:2.0.1:compile
[WARNING]    org.jfree:jfreechart:jar:1.5.4:compile
[WARNING]    org.matsim.contrib:common:jar:16.0-SNAPSHOT:compile
[WARNING]    jakarta.validation:jakarta.validation-api:jar:3.0.2:compile
[WARNING] Unused declared dependencies found:
[WARNING]    commons-logging:commons-logging:jar:1.2:compile
[WARNING]    org.apache.logging.log4j:log4j-core:jar:2.20.0:compile
```

A chore for future PRs might be to do this to the other contribs as well and to identify dependencies used in multiple projects and define a common version in their parent pom.