### PR TITLE
Add support for LocalTime, LocalDate and LocalDateTime to ReflectiveConfigGroup

### DIFF
--- a/matsim/src/main/java/org/matsim/core/config/ReflectiveConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/ReflectiveConfigGroup.java
@@ -32,6 +32,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -234,10 +237,11 @@ public abstract class ReflectiveConfigGroup extends ConfigGroup implements Matsi
 
 	private static final Set<Class<?>> ALLOWED_PARAMETER_TYPES = Set.of(String.class, Float.class, Double.class,
 			Integer.class, Long.class, Boolean.class, Character.class, Byte.class, Short.class, Float.TYPE, Double.TYPE,
-			Integer.TYPE, Long.TYPE, Boolean.TYPE, Character.TYPE, Byte.TYPE, Short.TYPE);
+			Integer.TYPE, Long.TYPE, Boolean.TYPE, Character.TYPE, Byte.TYPE, Short.TYPE, LocalTime.class,
+			LocalDate.class, LocalDateTime.class);
 
 	private static final String HINT = " Valid types are String, primitive types and their wrapper classes,"
-			+ " enumerations, List<String> and Set<String>."
+			+ " enumerations, List<String> and Set<String>, LocalTime, LocalDate, LocalDateTime"
 			+ " Other types are fine as parameters, but you will need to implement conversion strategies"
 			+ " in corresponding StringGetters andStringSetters.";
 
@@ -342,6 +346,12 @@ public abstract class ReflectiveConfigGroup extends ConfigGroup implements Matsi
 			return null;
 		} else if (type.equals(String.class)) {
 			return value;
+		} else if (type.equals(LocalTime.class)) {
+			return LocalTime.parse(value);
+		} else if (type.equals(LocalDate.class)) {
+			return LocalDate.parse(value);
+		} else if (type.equals(LocalDateTime.class)) {
+			return LocalDateTime.parse(value);
 		} else if (type.equals(Float.class) || type.equals(Float.TYPE)) {
 			return Float.parseFloat(value);
 		} else if (type.equals(Double.class) || type.equals(Double.TYPE)) {

--- a/matsim/src/test/java/org/matsim/core/config/ReflectiveConfigGroupTest.java
+++ b/matsim/src/test/java/org/matsim/core/config/ReflectiveConfigGroupTest.java
@@ -22,6 +22,9 @@ package org.matsim.core.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -61,6 +64,9 @@ public class ReflectiveConfigGroupTest {
 		dumpedModule.charField = 'z';
 		dumpedModule.byteField = 78;
 		dumpedModule.booleanField = true;
+		dumpedModule.localTimeField = LocalTime.of(23, 59, 59);
+		dumpedModule.localDateField = LocalDate.of(2022, 12, 31);
+		dumpedModule.localDateTimeField = LocalDateTime.of(2022, 12, 31, 23, 59, 59);
 		dumpedModule.enumListField = List.of(MyEnum.VALUE1, MyEnum.VALUE2);
 		dumpedModule.enumSetField = Set.of(MyEnum.VALUE2);
 		dumpedModule.setField = ImmutableSet.of("a", "b", "c");
@@ -154,6 +160,9 @@ public class ReflectiveConfigGroupTest {
 		expectedComments.put("charField", "char");
 		expectedComments.put("byteField", "byte");
 		expectedComments.put("booleanField", "boolean");
+		expectedComments.put("localTimeField", "local time");
+		expectedComments.put("localDateField", "local date");
+		expectedComments.put("localDateTimeField", "local datetime");
 		expectedComments.put("enumField", "Possible values: VALUE1,VALUE2");
 		expectedComments.put("enumListField", "list of enum");
 		expectedComments.put("enumSetField", "set of enum");
@@ -438,6 +447,18 @@ public class ReflectiveConfigGroupTest {
 		@Comment("boolean")
 		@Parameter
 		private boolean booleanField;
+
+		@Comment("local time")
+		@Parameter
+		private LocalTime localTimeField;
+
+		@Comment("local date")
+		@Parameter
+		private LocalDate localDateField;
+
+		@Comment("local datetime")
+		@Parameter
+		private LocalDateTime localDateTimeField;
 
 		@Comment("set")
 		@Parameter


### PR DESCRIPTION
This change adds support for automatic conversion of `LocalTime`, `LocalDate` and `LocalDateTime` parameters in `ReflectiveConfigGroup`.