### PR TITLE
Round randomly generated coordinates

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/prepare/population/AdjustActivityToLinkDistances.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/population/AdjustActivityToLinkDistances.java
@@ -134,6 +134,7 @@ public class AdjustActivityToLinkDistances implements MATSimAppCommand {
 							v = new Coord(coord.getX() - y * m, coord.getY() + x * m);
 						}
 
+						v = CoordUtils.round(v);
 
 						mapping.put(act.getCoord(), v);
 					}

--- a/contribs/application/src/main/java/org/matsim/application/prepare/population/ResolveGridCoordinates.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/population/ResolveGridCoordinates.java
@@ -14,6 +14,7 @@ import org.matsim.application.options.LanduseOptions;
 import org.matsim.application.options.ShpOptions;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.population.PopulationUtils;
+import org.matsim.core.utils.geometry.CoordUtils;
 import org.matsim.core.utils.geometry.geotools.MGC;
 import picocli.CommandLine;
 
@@ -93,7 +94,7 @@ public class ResolveGridCoordinates implements MATSimAppCommand {
 
 						Coord newCoord = mapping.getOrDefault(coord, null);
 						if (newCoord == null) {
-							newCoord = landuse.select(crs.getInputCRS(),
+							newCoord = CoordUtils.round(landuse.select(crs.getInputCRS(),
 									() -> {
 										double x = rnd.nextDouble(-gridResolution / 2, gridResolution / 2);
 										double y = rnd.nextDouble(-gridResolution / 2, gridResolution / 2);
@@ -103,7 +104,7 @@ public class ResolveGridCoordinates implements MATSimAppCommand {
 										else
 											return new Coord(coord.getX() + x, coord.getY() + y);
 									}
-							);
+							));
 							mapping.put(coord, newCoord);
 						}
 


### PR DESCRIPTION
Make use of `CoordUtils.round` in some classes that generate coordinates. Keeping all digits makes population files unnecessarily large.