### PR TITLE
deps: group dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      maven:
+        patterns: ["*"]
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
This is to avoid having a lot of coexisting dependabot-triggered PRs (each addressing an individual version bump), which results in a lot of:
- CI builds (especially that we require PRs to be in sync with the master branch)
- PR-based releases deployed to our mvn repo