### PR TITLE
Update deploy-on-pr-merge

### DIFF
--- a/.github/workflows/deploy-on-pr-merge.yaml
+++ b/.github/workflows/deploy-on-pr-merge.yaml
@@ -25,7 +25,7 @@ jobs:
           java-version: 17
           distribution: 'zulu'
           cache: 'maven'
-          server-id: ${{ github.event_name == 'push' && 'matsim-snapshots' || 'matsim-releases' }} #choose mvn repo
+          server-id: 'matsim-releases'
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
 

--- a/.github/workflows/deploy-on-pr-merge.yaml
+++ b/.github/workflows/deploy-on-pr-merge.yaml
@@ -10,8 +10,8 @@ on:
 jobs:
   deploy-snapshot:
     name: deploy PR-labelled version
-    # for PR-labelled deployment -- only if closed by merging
-    if: github.event_name == 'push' || github.event.pull_request.merged == true
+    # only if PR closed by merging
+    if: github.event.pull_request.merged == true
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Because we stopped deploying snapshots on push to master and now we only deploy proper (i.e. non-snapshot) releases.
