### PR TITLE
Support Maps in ReflectiveConfigGroup

### DIFF
--- a/matsim/pom.xml
+++ b/matsim/pom.xml
@@ -258,6 +258,10 @@
 			<artifactId>jackson-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 		</dependency>

--- a/matsim/src/main/java/org/matsim/core/config/ReflectiveConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/ReflectiveConfigGroup.java
@@ -433,8 +433,9 @@ public abstract class ReflectiveConfigGroup extends ConfigGroup implements Matsi
 			} else if (paramField != null && paramField.getGenericType() instanceof ParameterizedType pType) {
 				Class<?> keyClass = TypeFactory.rawClass(pType.getActualTypeArguments()[0]);
 				Class<?> valueClass = TypeFactory.rawClass(pType.getActualTypeArguments()[1]);
-				JavaType mapType = OBJECT_MAPPER.getTypeFactory().constructMapType(
-						LinkedHashMap.class, keyClass, valueClass);
+				Class<? extends Map> mapClass = keyClass.isEnum() ? EnumMap.class : LinkedHashMap.class;
+				JavaType mapType = OBJECT_MAPPER.getTypeFactory().constructMapType(mapClass, keyClass,
+						valueClass);
 				try {
 					return OBJECT_MAPPER.readValue(value, mapType);
 				} catch (JsonProcessingException e) {

--- a/matsim/src/test/java/org/matsim/core/config/ReflectiveConfigGroupTest.java
+++ b/matsim/src/test/java/org/matsim/core/config/ReflectiveConfigGroupTest.java
@@ -27,6 +27,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -74,6 +75,8 @@ public class ReflectiveConfigGroupTest {
 		dumpedModule.integerMapField = Map.of("a\"b", 1, "b", 2);
 		dumpedModule.localDateMapField = Map.of('d', LocalDate.of(2023, 10, 9));
 		dumpedModule.booleanMapField = Map.of(0.1, true);
+		dumpedModule.enumMapField = new EnumMap<>(MyEnum.class);
+		dumpedModule.enumMapField.put(MyEnum.VALUE1, "abc");
 		dumpedModule.setField = ImmutableSet.of("a", "b", "c");
 		dumpedModule.listField = List.of("1", "2", "3");
 		assertEqualAfterDumpAndRead(dumpedModule);
@@ -198,6 +201,7 @@ public class ReflectiveConfigGroupTest {
 		expectedComments.put("integerMapField", "map of Integer");
 		expectedComments.put("localDateMapField", "map of LocalDate");
 		expectedComments.put("booleanMapField", "map of Boolean");
+		expectedComments.put("enumMapField", "map of Enum");
 
 		assertThat(new MyModule().getComments()).isEqualTo(expectedComments);
 	}
@@ -514,6 +518,10 @@ public class ReflectiveConfigGroupTest {
 		@Comment("map of Boolean")
 		@Parameter
 		private Map<Double, Boolean> booleanMapField;
+
+		@Comment("map of Enum")
+		@Parameter
+		private Map<MyEnum, String> enumMapField;
 
 		// Object fields:
 		// Id: string representation is toString


### PR DESCRIPTION
This change allows to store Maps of primitive Java types within `ReflectiveConfigGroup` using the `@Parameter` annotation and closes #2815 

Keys will always be quoted and properly XML-excaped when written to the config file.

### Example

```java
@Comment("map of LocalDate")
@Parameter
public Map<Character, LocalDate> localDateMapField = Map.of('d', LocalDate.of(2023, 10, 9));
```

 will result in 

```xml
<!-- map of LocalDate -->
<param name="localDateMapField" value="{&quot;d&quot;:[2023,10,9]}" />
```
