### PR TITLE
Add CustomRebalancingStrategyParams

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/CustomRebalancingStrategyParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/CustomRebalancingStrategyParams.java
@@ -1,0 +1,33 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2023 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.drt.optimizer.rebalancing;
+
+import org.matsim.core.config.ReflectiveConfigGroup;
+
+/**
+ * Custom rebalancing strategy parameters. User is responsible for installing rebalancing module and parameters.
+ */
+public final class CustomRebalancingStrategyParams extends ReflectiveConfigGroup
+		implements RebalancingParams.RebalancingStrategyParams {
+	public static final String SET_NAME = "CustomRebalancingStrategy";
+
+	public CustomRebalancingStrategyParams() {
+		super(SET_NAME);
+	}
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/RebalancingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/RebalancingModule.java
@@ -54,6 +54,8 @@ public class RebalancingModule extends AbstractDvrpModeModule {
 				install(new DrtModePlusOneRebalanceModule(drtCfg));
 			} else if (rebalancingParams.getRebalancingStrategyParams() instanceof FeedforwardRebalancingStrategyParams) {
 				install(new DrtModeFeedforwardRebalanceModule(drtCfg));
+			} else if (rebalancingParams.getRebalancingStrategyParams() instanceof CustomRebalancingStrategyParams) {
+				// User is responsible for installing custom module
 			} else {
 				throw new RuntimeException(
 						"Unsupported rebalancingStrategyParams: " + rebalancingParams.getRebalancingStrategyParams());

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/RebalancingParams.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/RebalancingParams.java
@@ -79,6 +79,9 @@ public final class RebalancingParams extends ReflectiveConfigGroupWithConfigurab
 		addDefinition(PlusOneRebalancingStrategyParams.SET_NAME, PlusOneRebalancingStrategyParams::new,
 				() -> (ConfigGroup)rebalancingStrategyParams,
 				params -> rebalancingStrategyParams = (RebalancingStrategyParams)params);
+		addDefinition(CustomRebalancingStrategyParams.SET_NAME, CustomRebalancingStrategyParams::new,
+			() -> (ConfigGroup)rebalancingStrategyParams,
+			params -> rebalancingStrategyParams = (RebalancingStrategyParams)params);
 	}
 
 	@Override


### PR DESCRIPTION
Add CustomRebalancingStrategyParams that allow to bind arbitrary rebalancing modules with strategies not defined in the core. 