### PR TITLE
Add stop access and egress times

### DIFF
--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/DefaultRaptorStopFinder.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/DefaultRaptorStopFinder.java
@@ -207,24 +207,24 @@ public class DefaultRaptorStopFinder implements RaptorStopFinder {
                     // the router for the access/egress mode could not find a route, skip that access/egress mode
                     continue;
                 }
-                if (stopFacility != stop) {
-                    if (direction == Direction.ACCESS) {
-                        Leg transferLeg = PopulationUtils.createLeg(TransportMode.walk);
-                        Route transferRoute = RouteUtils.createGenericRouteImpl(stopFacility.getLinkId(), stop.getLinkId());
-						double accessTime = TransitScheduleUtils.getStopAccessTime(stop);
-                        transferRoute.setTravelTime(accessTime);
-                        transferRoute.setDistance(0);
-                        transferLeg.setRoute(transferRoute);
-                        transferLeg.setTravelTime(accessTime);
+				double accessTime = TransitScheduleUtils.getStopAccessTime(stop);
+				double egressTime = TransitScheduleUtils.getStopEgressTime(stop);
+				if ((stopFacility != stop) || accessTime>0.0 || egressTime>0.0) {
+					if (direction == Direction.ACCESS) {
+						Leg transferLeg = PopulationUtils.createLeg(TransportMode.walk);
+						Route transferRoute = RouteUtils.createGenericRouteImpl(stopFacility.getLinkId(), stop.getLinkId());
+						transferRoute.setTravelTime(accessTime);
+						transferRoute.setDistance(0);
+						transferLeg.setRoute(transferRoute);
+						transferLeg.setTravelTime(accessTime);
 
-                        List<PlanElement> tmp = new ArrayList<>(routeParts.size() + 1);
-                        tmp.addAll(routeParts);
-                        tmp.add(transferLeg);
-                        routeParts = tmp;
-                    } else {
-                        Leg transferLeg = PopulationUtils.createLeg(TransportMode.walk);
-                        Route transferRoute = RouteUtils.createGenericRouteImpl(stop.getLinkId(), stopFacility.getLinkId());
-						double egressTime = TransitScheduleUtils.getStopEgressTime(stop);
+						List<PlanElement> tmp = new ArrayList<>(routeParts.size() + 1);
+						tmp.addAll(routeParts);
+						tmp.add(transferLeg);
+						routeParts = tmp;
+					} else {
+						Leg transferLeg = PopulationUtils.createLeg(TransportMode.walk);
+						Route transferRoute = RouteUtils.createGenericRouteImpl(stop.getLinkId(), stopFacility.getLinkId());
                         transferRoute.setTravelTime(egressTime);
                         transferRoute.setDistance(0);
                         transferLeg.setRoute(transferRoute);

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleUtils.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleUtils.java
@@ -45,9 +45,21 @@ public final class TransitScheduleUtils {
 		return accessTime!=null?(double) accessTime:0.0;
 	}
 
+	public static void setStopAccessTime(TransitStopFacility stopFacility, double stopAccessTime){
+		stopFacility.getAttributes().putAttribute(ACCESSTIME_ATTRIBUTE,stopAccessTime);
+	}
+
 	public static double getStopEgressTime(TransitStopFacility stopFacility){
 		Object egressTime = stopFacility.getAttributes().getAttribute(EGRESSTIME_ATTRIBUTE);
 		return egressTime!=null?(double) egressTime:0.0;
+	}
+	public static void setStopEgressTime(TransitStopFacility stopFacility, double stopEgressTime){
+		stopFacility.getAttributes().putAttribute(EGRESSTIME_ATTRIBUTE,stopEgressTime);
+	}
+
+	public static void setSymmetricStopAccessEgressTime(TransitStopFacility stopFacility, double stopAccessEgressTime){
+		setStopAccessTime(stopFacility,stopAccessEgressTime);
+		setStopEgressTime(stopFacility,stopAccessEgressTime);
 	}
 
 	public static QuadTree<TransitStopFacility> createQuadTreeOfTransitStopFacilities(TransitSchedule transitSchedule) {

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleUtils.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleUtils.java
@@ -29,43 +29,20 @@ import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 
 /**
  * Helper class for commonly used operations on TransitSchedules
- * 
+ *
  * @author Thibaut Dubernet, gleich
  *
  */
 public final class TransitScheduleUtils {
-	// Logic gotten from PopulationUtils, but I am actually a bit unsure about the value of those methods now that
-	// attributable is the only way to get attributes...
 
-	public static Object getStopFacilityAttribute(TransitStopFacility facility, String key) {
-		return facility.getAttributes().getAttribute( key );
+	private TransitScheduleUtils() {
 	}
 
-	public static void putStopFacilityAttribute(TransitStopFacility facility, String key, Object value ) {
-		facility.getAttributes().putAttribute( key, value ) ;
-	}
-
-	public static Object removeStopFacilityAttribute( TransitStopFacility facility, String key ) {
-		return facility.getAttributes().removeAttribute( key );
-	}
-
-	public static Object getLineAttribute(TransitLine facility, String key) {
-		return facility.getAttributes().getAttribute( key );
-	}
-
-	public static void putLineAttribute(TransitLine facility, String key, Object value ) {
-		facility.getAttributes().putAttribute( key, value ) ;
-	}
-
-	public static Object removeLineAttribute( TransitLine facility, String key ) {
-		return facility.getAttributes().removeAttribute( key );
-	}
-	
-	public final static QuadTree<TransitStopFacility> createQuadTreeOfTransitStopFacilities(TransitSchedule transitSchedule) {
+	public static QuadTree<TransitStopFacility> createQuadTreeOfTransitStopFacilities(TransitSchedule transitSchedule) {
 		return createQuadTreeOfTransitStopFacilities(transitSchedule.getFacilities().values());
 	}
-	
-	public final static QuadTree<TransitStopFacility> createQuadTreeOfTransitStopFacilities(Collection<TransitStopFacility> transitStopFacilities) {
+
+	public static QuadTree<TransitStopFacility> createQuadTreeOfTransitStopFacilities(Collection<TransitStopFacility> transitStopFacilities) {
 		double minX = Double.POSITIVE_INFINITY;
 		double minY = Double.POSITIVE_INFINITY;
 		double maxX = Double.NEGATIVE_INFINITY;

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleUtils.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitScheduleUtils.java
@@ -35,7 +35,19 @@ import org.matsim.pt.transitSchedule.api.TransitStopFacility;
  */
 public final class TransitScheduleUtils {
 
+	public final static String ACCESSTIME_ATTRIBUTE = "accessTime";
+	public final static String EGRESSTIME_ATTRIBUTE = "egressTime";
 	private TransitScheduleUtils() {
+	}
+
+	public static double getStopAccessTime(TransitStopFacility stopFacility){
+		Object accessTime = stopFacility.getAttributes().getAttribute(ACCESSTIME_ATTRIBUTE);
+		return accessTime!=null?(double) accessTime:0.0;
+	}
+
+	public static double getStopEgressTime(TransitStopFacility stopFacility){
+		Object egressTime = stopFacility.getAttributes().getAttribute(EGRESSTIME_ATTRIBUTE);
+		return egressTime!=null?(double) egressTime:0.0;
 	}
 
 	public static QuadTree<TransitStopFacility> createQuadTreeOfTransitStopFacilities(TransitSchedule transitSchedule) {

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorTest.java
@@ -37,6 +37,7 @@ import org.matsim.facilities.ActivityFacilities;
 import org.matsim.facilities.ActivityFacility;
 import org.matsim.pt.router.TransitRouter;
 import org.matsim.pt.routes.TransitPassengerRoute;
+import org.matsim.pt.transitSchedule.TransitScheduleUtils;
 import org.matsim.pt.transitSchedule.api.Departure;
 import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
@@ -152,6 +153,28 @@ public class SwissRailRaptorTest {
         double expectedEgressWalkTime = CoordUtils.calcEuclideanDistance(f.schedule.getFacilities().get(Id.create("6", TransitStopFacility.class)).getCoord(), toCoord) / raptorParams.getBeelineWalkSpeed();
 		assertEquals(Math.ceil(expectedEgressWalkTime), ((Leg)legs.get(2)).getTravelTime().seconds(), MatsimTestUtils.EPSILON);
     }
+
+
+	@Test
+	public void testStationAccessEgressTimes() {
+		Fixture f = new Fixture();
+		f.init();
+		RaptorParameters raptorParams = RaptorUtils.createParameters(f.config);
+		f.schedule.getFacilities().values().forEach(facility-> TransitScheduleUtils.setSymmetricStopAccessEgressTime(facility,120.0));
+		TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
+		Coord fromCoord = new Coord(3800, 5100);
+		Coord toCoord = new Coord(16100, 5050);
+		List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 5.0*3600, null));
+		assertEquals(3, legs.size());
+		assertEquals(TransportMode.walk, ((Leg)legs.get(0)).getMode());
+		assertEquals(TransportMode.pt, ((Leg)legs.get(1)).getMode());
+		assertEquals(TransportMode.walk, ((Leg)legs.get(2)).getMode());
+
+		double expectedAccessWalkTime = 120.0 + CoordUtils.calcEuclideanDistance(f.schedule.getFacilities().get(Id.create("0", TransitStopFacility.class)).getCoord(), fromCoord) / raptorParams.getBeelineWalkSpeed();
+		assertEquals(Math.ceil(expectedAccessWalkTime), ((Leg)legs.get(0)).getTravelTime().seconds(), MatsimTestUtils.EPSILON);
+		double expectedEgressWalkTime = 120.0 + CoordUtils.calcEuclideanDistance(f.schedule.getFacilities().get(Id.create("6", TransitStopFacility.class)).getCoord(), toCoord) / raptorParams.getBeelineWalkSpeed();
+		assertEquals(Math.ceil(expectedEgressWalkTime), ((Leg)legs.get(2)).getTravelTime().seconds(), MatsimTestUtils.EPSILON);
+	}
 
     @Test
     public void testWalkDurations_range() {

--- a/matsim/src/test/java/org/matsim/core/scenario/ScenarioLoaderImplTest.java
+++ b/matsim/src/test/java/org/matsim/core/scenario/ScenarioLoaderImplTest.java
@@ -97,33 +97,6 @@ public class ScenarioLoaderImplTest {
 		Assert.assertTrue( caughtException );
 	}
 
-	@Test
-	public void testLoadScenario_loadTransitLinesAttributes() {
-		Config config = ConfigUtils.loadConfig(IOUtils.extendUrl(this.util.classInputResourcePath(), "transitConfig.xml"));
-		config.transit().setTransitLinesAttributesFile("transitLinesAttributes.xml");
-		config.transit().setInsistingOnUsingDeprecatedAttributeFiles(true);
-		Scenario scenario = ScenarioUtils.loadScenario(config);
-		Assert.assertEquals(
-				"unexpected attribute value",
-				"world",
-				TransitScheduleUtils.getLineAttribute(
-						scenario.getTransitSchedule().getTransitLines().get(Id.create("Blue Line", TransitLine.class)),
-						"hello"));
-	}
-
-	@Test
-	public void testLoadScenario_loadTransitStopsAttributes() {
-		Config config = ConfigUtils.loadConfig(IOUtils.extendUrl(this.util.classInputResourcePath(), "transitConfig.xml"));
-		config.transit().setTransitStopsAttributesFile("transitStopsAttributes.xml");
-		config.transit().setInsistingOnUsingDeprecatedAttributeFiles(true);
-		Scenario scenario = ScenarioUtils.loadScenario(config);
-		Assert.assertEquals(
-				"unexpected attribute value",
-				Boolean.TRUE,
-				TransitScheduleUtils.getStopFacilityAttribute(
-						scenario.getTransitSchedule().getFacilities().get(Id.create(1, TransitStopFacility.class)),
-						"hasP+R"));
-	}
 
 	@Test
 	public void testLoadScenario_loadFacilitiesAttributes() {


### PR DESCRIPTION
Some public transport stops are more accessible than others. 
One typical example: Accessing a metro stop is often much more cumbersome than accessing a tram stop, because one has to go down several metres. 
So far, accessing stops by usually teleported walk routes, this could not be taken into account. Thus we could see in our models that taking trains or metros for very short trips is more popular than it should be if there is competing ground level public transport. 
This PR allows the introduction of access and egress times for each stop facility (not including transfers between public transport, as these allow an explicit definition of a transfer time).

Depending on your pt data source this may or may not be useful. The Swiss GTFS essentially treats all stop points as single stops, the Berlin GTFS on the contrary does not, i.e., a combined tram and metro stop is treated as a single stop.

Access and egress times can be set to different values, which may be handy if one considers modeling long distance trains (e.g., TGV has a boarding time of 5 to 2 minutes) or even airplanes.

Access and egress times can be set via Attributes on the facility, some Convenience methods are provided in TransitScheduleUtilities. 
