### PR TITLE
Add ObjectMapper Module for Id de-/serialization

### DIFF
--- a/matsim/src/main/java/org/matsim/api/core/v01/IdAnnotations.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/IdAnnotations.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.KeyDeserializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -82,6 +83,15 @@ public interface IdAnnotations {
 
 		}
 
+		static class PersonIdKeyDeserializer extends KeyDeserializer {
+
+			@Override
+			public Object deserializeKey(String key, DeserializationContext ctxt) throws IOException {
+				return Id.createPersonId(key);
+			}
+
+		}
+
 	}
 
 	@Retention(RetentionPolicy.RUNTIME)
@@ -125,6 +135,15 @@ public interface IdAnnotations {
 
 		}
 
+		static class LinkIdKeyDeserializer extends KeyDeserializer {
+
+			@Override
+			public Object deserializeKey(String key, DeserializationContext ctxt) throws IOException {
+				return Id.createLinkId(key);
+			}
+
+		}
+
 	}
 
 	@Retention(RetentionPolicy.RUNTIME)
@@ -164,6 +183,15 @@ public interface IdAnnotations {
 			public Id<Node> deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
 				JsonNode node = jp.getCodec().readTree(jp);
 				return Id.createNodeId(node.asText());
+			}
+
+		}
+
+		static class NodeIdKeyDeserializer extends KeyDeserializer {
+
+			@Override
+			public Object deserializeKey(String key, DeserializationContext ctxt) throws IOException {
+				return Id.createNodeId(key);
 			}
 
 		}

--- a/matsim/src/main/java/org/matsim/api/core/v01/IdDeSerializationModule.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/IdDeSerializationModule.java
@@ -1,0 +1,127 @@
+package org.matsim.api.core.v01;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.tuple.Triple;
+import org.matsim.api.core.v01.IdAnnotations.JsonLinkId;
+import org.matsim.api.core.v01.IdAnnotations.JsonNodeId;
+import org.matsim.api.core.v01.IdAnnotations.JsonPersonId;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.api.core.v01.population.Person;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.KeyDeserializer;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.deser.Deserializers;
+import com.fasterxml.jackson.databind.deser.KeyDeserializers;
+import com.fasterxml.jackson.databind.ser.Serializers;
+
+/**
+ * Use as follows with your {@link ObjectMapper} instance:
+ * 
+ * {@code objectMapper.registerModule(IdDeSerializationModule.getInstance());}
+ */
+public class IdDeSerializationModule extends Module {
+
+	private static final String NAME = IdDeSerializationModule.class.getSimpleName();
+	private static final Version VERSION = new Version(0, 1, 0, null, "org.matsim", "api.core.v01");
+	private static final Map<Class<?>, Triple<JsonSerializer<?>, JsonDeserializer<?>, KeyDeserializer>> DE_SERIALIZER_MAP;
+	static {
+		Map<Class<?>, Triple<JsonSerializer<?>, JsonDeserializer<?>, KeyDeserializer>> m = new HashMap<>();
+		m.put(Person.class, Triple.of(
+				new JsonPersonId.PersonIdSerializer(),
+				new JsonPersonId.PersonIdDeserializer(),
+				new JsonPersonId.PersonIdKeyDeserializer()));
+		m.put(Node.class, Triple.of(
+				new JsonNodeId.NodeIdSerializer(),
+				new JsonNodeId.NodeIdDeserializer(),
+				new JsonNodeId.NodeIdKeyDeserializer()));
+		m.put(Link.class, Triple.of(
+				new JsonLinkId.LinkIdSerializer(),
+				new JsonLinkId.LinkIdDeserializer(),
+				new JsonLinkId.LinkIdKeyDeserializer()));
+		// Add your own classes below here
+		DE_SERIALIZER_MAP = Collections.unmodifiableMap(m);
+	}
+
+	private static Module instance = null;
+
+	private IdDeSerializationModule() {
+		// nothing to do here
+	}
+
+	public static Module getInstance() {
+		if (instance == null) {
+			instance = new IdDeSerializationModule();
+		}
+		return instance;
+	}
+
+	@Override
+	public String getModuleName() {
+		return NAME;
+	}
+
+	@Override
+	public Version version() {
+		return VERSION;
+	}
+
+	@Override
+	public void setupModule(SetupContext context) {
+		context.addSerializers(new IdSerializers());
+		context.addDeserializers(new IdDeserializers());
+		context.addKeyDeserializers(new IdKeyDeserializers());
+	}
+
+	private static final class IdSerializers extends Serializers.Base {
+
+		@Override
+		public JsonSerializer<?> findSerializer(SerializationConfig config, JavaType type,
+				BeanDescription beanDesc) {
+			if (type.getRawClass().equals(Id.class) && type.containedTypeCount() == 1) {
+				return DE_SERIALIZER_MAP.get(type.containedType(0).getRawClass()).getLeft();
+			}
+			return null;
+		}
+
+	}
+
+	private static final class IdDeserializers extends Deserializers.Base {
+
+		@Override
+		public JsonDeserializer<?> findBeanDeserializer(JavaType type, DeserializationConfig config,
+				BeanDescription beanDesc) throws JsonMappingException {
+			if (type.getRawClass().equals(Id.class) && type.containedTypeCount() == 1) {
+				return DE_SERIALIZER_MAP.get(type.containedType(0).getRawClass()).getMiddle();
+			}
+			return null;
+		}
+
+	}
+
+	private static final class IdKeyDeserializers implements KeyDeserializers {
+
+		@Override
+		public KeyDeserializer findKeyDeserializer(JavaType type, DeserializationConfig config,
+				BeanDescription beanDesc) throws JsonMappingException {
+			if (type.getRawClass().equals(Id.class) && type.containedTypeCount() == 1) {
+				return DE_SERIALIZER_MAP.get(type.containedType(0).getRawClass()).getRight();
+			}
+			return null;
+		}
+
+	}
+
+}

--- a/matsim/src/test/java/org/matsim/api/core/v01/IdAnnotationsTest.java
+++ b/matsim/src/test/java/org/matsim/api/core/v01/IdAnnotationsTest.java
@@ -4,9 +4,7 @@ import java.util.Objects;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.matsim.api.core.v01.IdAnnotations.JsonLinkId;
-import org.matsim.api.core.v01.IdAnnotations.JsonNodeId;
-import org.matsim.api.core.v01.IdAnnotations.JsonPersonId;
+import org.matsim.api.core.v01.IdAnnotations.JsonId;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.api.core.v01.population.Person;
@@ -22,8 +20,9 @@ public class IdAnnotationsTest {
 
 	@Test
 	public void testRecordJsonIds() throws JsonProcessingException {
+		Id<Person> personId = Id.createPersonId("person");
 		RecordWithIds recordWithIds1 = new RecordWithIds(
-				Id.createPersonId("person"),
+				personId,
 				Id.createLinkId("link"),
 				Id.createNodeId("node"));
 
@@ -31,22 +30,28 @@ public class IdAnnotationsTest {
 		RecordWithIds recordWithIds2 = objectMapper.readValue(s, RecordWithIds.class);
 
 		Assert.assertEquals(recordWithIds1, recordWithIds2);
+		Assert.assertEquals(personId, recordWithIds2.personId);
+		Assert.assertSame(personId, recordWithIds2.personId);
 	}
 
 	@Test
 	public void testRecordJsonIdsWithNull() throws JsonProcessingException {
-		RecordWithIds recordWithIds1 = new RecordWithIds(null, null, null);
+		Id<Person> personId = null;
+		RecordWithIds recordWithIds1 = new RecordWithIds(personId, null, null);
 
 		String s = objectMapper.writeValueAsString(recordWithIds1);
 		RecordWithIds recordWithIds2 = objectMapper.readValue(s, RecordWithIds.class);
 
 		Assert.assertEquals(recordWithIds1, recordWithIds2);
+		Assert.assertEquals(personId, recordWithIds2.personId);
+		Assert.assertSame(personId, recordWithIds2.personId);
 	}
 
 	@Test
 	public void testClassJsonIds() throws JsonProcessingException {
+		Id<Person> personId = Id.createPersonId("person");
 		ClassWithIds classWithIds1 = new ClassWithIds(
-				Id.createPersonId("person"),
+				personId,
 				Id.createLinkId("link"),
 				Id.createNodeId("node"));
 
@@ -54,35 +59,40 @@ public class IdAnnotationsTest {
 		ClassWithIds classWithIds2 = objectMapper.readValue(s, ClassWithIds.class);
 
 		Assert.assertEquals(classWithIds1, classWithIds2);
+		Assert.assertEquals(personId, classWithIds2.personId);
+		Assert.assertSame(personId, classWithIds2.personId);
 	}
 
 	@Test
 	public void testClassJsonIdsWithNull() throws JsonProcessingException {
-		ClassWithIds classWithIds1 = new ClassWithIds(null, null, null);
+		Id<Person> personId = null;
+		ClassWithIds classWithIds1 = new ClassWithIds(personId, null, null);
 
 		String s = objectMapper.writeValueAsString(classWithIds1);
 		ClassWithIds classWithIds2 = objectMapper.readValue(s, ClassWithIds.class);
 
 		Assert.assertEquals(classWithIds1, classWithIds2);
+		Assert.assertEquals(personId, classWithIds2.personId);
+		Assert.assertSame(personId, classWithIds2.personId);
 	}
 
 	@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 	private static record RecordWithIds(
-			@JsonPersonId Id<Person> personId,
-			@JsonLinkId Id<Link> linkId,
-			@JsonNodeId Id<Node> nodeId) {
+			@JsonId Id<Person> personId,
+			@JsonId Id<Link> linkId,
+			@JsonId Id<Node> nodeId) {
 	};
 
 	@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 	private static class ClassWithIds {
 
-		@JsonPersonId
+		@JsonId
 		Id<Person> personId;
 
-		@JsonLinkId
+		@JsonId
 		Id<Link> linkId;
 
-		@JsonNodeId
+		@JsonId
 		Id<Node> nodeId;
 
 		ClassWithIds() {

--- a/matsim/src/test/java/org/matsim/api/core/v01/IdDeSerializationModuleTest.java
+++ b/matsim/src/test/java/org/matsim/api/core/v01/IdDeSerializationModuleTest.java
@@ -1,0 +1,94 @@
+package org.matsim.api.core.v01;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.matsim.api.core.v01.network.Link;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.type.MapType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+public class IdDeSerializationModuleTest {
+
+	private static final TypeFactory TYPE_FACTORY = TypeFactory.defaultInstance();
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Before
+	public void init() {
+		this.objectMapper.registerModule(IdDeSerializationModule.getInstance());
+	}
+
+	@Test
+	public void testMapKey() {
+
+		// create map with Id<T> as keys
+		Map<Id<Link>, String> map0 = new LinkedHashMap<>();
+		map0.put(Id.createLinkId("0"), "a");
+		map0.put(Id.createLinkId("1"), "b");
+
+		// build writer
+		JavaType linkIdType = TYPE_FACTORY.constructParametricType(Id.class, Link.class);
+		MapType mapType = TYPE_FACTORY.constructMapType(Map.class, linkIdType, TYPE_FACTORY.constructType(String.class));
+		ObjectWriter objectWriter = objectMapper.writerFor(mapType);
+
+		// serialize
+		String s;
+		try {
+			s = objectWriter.writeValueAsString(map0);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
+		System.out.println(s);
+		Assert.assertEquals("{\"0\":\"a\",\"1\":\"b\"}", s);
+
+		// deserialize
+		Map<Id<Link>, String> map1;
+		try {
+			map1 = objectMapper.readValue(s, mapType);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
+		Assert.assertEquals(map0, map1);
+	}
+
+	@Test
+	public void testMapValue() {
+
+		// create map with Id<T> as values
+		Map<String, Id<Link>> map0 = new LinkedHashMap<>();
+		map0.put("a", Id.createLinkId("0"));
+		map0.put("b", Id.createLinkId("1"));
+
+		// build writer
+		JavaType linkIdType = TYPE_FACTORY.constructParametricType(Id.class, Link.class);
+		MapType mapType = TypeFactory.defaultInstance().constructMapType(Map.class, TYPE_FACTORY.constructType(String.class), linkIdType);
+		ObjectWriter objectWriter = objectMapper.writerFor(mapType);
+
+		// serialize
+		String s;
+		try {
+			s = objectWriter.writeValueAsString(map0);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
+		System.out.println(s);
+		Assert.assertEquals("{\"a\":\"0\",\"b\":\"1\"}", s);
+
+		// deserialize
+		Map<String, Id<Link>> map1;
+		try {
+			map1 = objectMapper.readValue(s, mapType);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
+		Assert.assertEquals(map0, map1);
+	}
+
+}

--- a/matsim/src/test/java/org/matsim/api/core/v01/IdDeSerializationModuleTest.java
+++ b/matsim/src/test/java/org/matsim/api/core/v01/IdDeSerializationModuleTest.java
@@ -30,8 +30,10 @@ public class IdDeSerializationModuleTest {
 
 		// create map with Id<T> as keys
 		Map<Id<Link>, String> map0 = new LinkedHashMap<>();
-		map0.put(Id.createLinkId("0"), "a");
-		map0.put(Id.createLinkId("1"), "b");
+		Id<Link> linkId0 = Id.createLinkId("0");
+		Id<Link> linkId1 = Id.createLinkId("1");
+		map0.put(linkId0, "a");
+		map0.put(linkId1, "b");
 
 		// build writer
 		JavaType linkIdType = TYPE_FACTORY.constructParametricType(Id.class, Link.class);
@@ -56,6 +58,10 @@ public class IdDeSerializationModuleTest {
 			throw new RuntimeException(e);
 		}
 		Assert.assertEquals(map0, map1);
+		Assert.assertEquals(linkId0,
+				map1.keySet().stream().filter(lId -> lId.equals(linkId0)).findFirst().orElseThrow());
+		Assert.assertSame(linkId0,
+				map1.keySet().stream().filter(lId -> lId.equals(linkId0)).findFirst().orElseThrow());
 	}
 
 	@Test
@@ -63,7 +69,8 @@ public class IdDeSerializationModuleTest {
 
 		// create map with Id<T> as values
 		Map<String, Id<Link>> map0 = new LinkedHashMap<>();
-		map0.put("a", Id.createLinkId("0"));
+		Id<Link> linkId0 = Id.createLinkId("0");
+		map0.put("a", linkId0);
 		map0.put("b", Id.createLinkId("1"));
 
 		// build writer
@@ -89,6 +96,8 @@ public class IdDeSerializationModuleTest {
 			throw new RuntimeException(e);
 		}
 		Assert.assertEquals(map0, map1);
+		Assert.assertEquals(linkId0, map1.get("a"));
+		Assert.assertSame(linkId0, map1.get("a"));
 	}
 
 }


### PR DESCRIPTION
This change adds a Module, that configures a Jackson `ObjectMapper` such that it can natively de-/serialize `Id<T>` classes, even when nested in Lists or Maps.

This is a prerequisite for storing link ids in the network for enabling turn restrictions in #2829.

### Example

```java
Map<Id<Link>, String> map = new LinkedHashMap<>();
map.put(Id.createLinkId("0"), "a");
map.put(Id.createLinkId("1"), "b");

// create & configure ObjectMapper
ObjectMapper objectMapper = new ObjectMapper();
objectMapper.registerModule(IdDeSerializationModule.getInstance());

// create & configure ObjectWriter
TypeFactory typeFactory = TypeFactory.defaultInstance();
MapType mapType = typeFactory.constructMapType(
		Map.class, 
		typeFactory.constructParametricType(Id.class, Link.class),
 		typeFactory.constructType(String.class));
ObjectWriter objectWriter = objectMapper.writerFor(mapType);

// serialize
String s = objectWriter.writeValueAsString(map); // {"0":"a","1":"b"}

// deserialize
Map<Id<Link>, String> deserializedMap = objectMapper.readValue(s, mapType);
```

### Bonus Improvement

The `@JsonId` annotation from https://github.com/matsim-org/matsim-libs/pull/2667 also got generalized to work for any `Id<T>` class. 

```java
record RecordWithIds(
	@JsonId Id<Person> personId,
	@JsonId Id<Link> linkId
) {};
```

```java
class ClassWithIds {
	@JsonId
	public Id<Person> personId;
}
```

This code now is a blueprint for de-/serializing even parametrized classes. We should be able to write records with complex types that easily can be de-/serialized using Jackson.

Great thanks @mrieser for the support with the generalization!