### PR TITLE
deps: stop grouping mvn dependencies version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    groups:
-      maven:
-        patterns: ["*"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
We need to manually ignore all dependencies that we cannot update in each PR like this: https://github.com/matsim-org/matsim-libs/pull/2836 (as they keep re-appearing in new PRs). This works much better when dependency bumps are not grouped (dependabot somehow remembers what we have already ignored and does not propose updates).