### PR TITLE
Small fixes for analysis (simwrapper)

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/prepare/network/CreateGeoJsonNetwork.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/network/CreateGeoJsonNetwork.java
@@ -45,7 +45,7 @@ public class CreateGeoJsonNetwork implements MATSimAppCommand {
 	@CommandLine.Option(names = "--match-id", description = "Pattern to filter links by id")
 	private String matchId;
 
-	@CommandLine.Option(names = "--mode-filter", split = ",", defaultValue = "car",
+	@CommandLine.Option(names = "--mode-filter", split = ",", defaultValue = "car,freight,drt",
 		description = "Only keep links if they have one of the specified modes. Specify 'none' to disable.")
 	private Set<String> modes;
 

--- a/contribs/simwrapper/src/main/java/org/matsim/simwrapper/SimWrapperListener.java
+++ b/contribs/simwrapper/src/main/java/org/matsim/simwrapper/SimWrapperListener.java
@@ -109,7 +109,7 @@ public class SimWrapperListener implements StartupListener, ShutdownListener {
 		List<DashboardProvider> result = new ArrayList<>();
 		for (ClassPath.ClassInfo info : classes) {
 			Class<?> clazz = info.load();
-			if (clazz.isAssignableFrom(DashboardProvider.class)) {
+			if (DashboardProvider.class.isAssignableFrom(clazz)) {
 				try {
 					Constructor<?> c = clazz.getDeclaredConstructor();
 					DashboardProvider o = (DashboardProvider) c.newInstance();

--- a/contribs/simwrapper/src/main/java/org/matsim/simwrapper/SimWrapperRunner.java
+++ b/contribs/simwrapper/src/main/java/org/matsim/simwrapper/SimWrapperRunner.java
@@ -30,6 +30,10 @@ public class SimWrapperRunner implements MATSimAppCommand {
 	@CommandLine.Option(names = "--exclude", split = ",", description = "Exclusion that will be added to the config.")
 	private Set<String> exclude;
 
+	public static void main(String[] args) {
+		new SimWrapperRunner().execute(args);
+	}
+
 	@Override
 	public Integer call() throws Exception {
 		for (Path input : inputPaths) {


### PR DESCRIPTION
1) include freight and drt in the mode filter when writing out geojson network. Otherwise, links that have no cars allowed, but drt, are not included for visualization
2) fix the lookup of implementations of `DashboardProvider`
3) (main method for SimWrapperRunner)