### PR TITLE
mvn: require mvn version 3.8+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
 							</excludes>
 						</requireReleaseDeps>
                         <requireMavenVersion>
-                            <version>3.6.3</version>
+                            <version>3.8</version>
                         </requireMavenVersion>
                     </rules>
                 </configuration>


### PR DESCRIPTION
This is to get more consistent build behaviour across different machines. Mvn 3.6.3 is now 4 years old and sometimes does not work well with newer JDKs (16+).