### PR TITLE
Fix datatype error in TripAnalysis

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/analysis/population/TripAnalysis.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/population/TripAnalysis.java
@@ -92,6 +92,7 @@ public class TripAnalysis implements MATSimAppCommand {
 
 		Table persons = Table.read().csv(CsvReadOptions.builder(IOUtils.getBufferedReader(input.getPath("persons.csv")))
 			.columnTypesPartial(Map.of("person", ColumnType.TEXT))
+			.sample(false)
 			.separator(';').build());
 
 		int total = persons.rowCount();
@@ -132,6 +133,7 @@ public class TripAnalysis implements MATSimAppCommand {
 
 		Table trips = Table.read().csv(CsvReadOptions.builder(IOUtils.getBufferedReader(input.getPath("trips.csv")))
 			.columnTypesPartial(columnTypes)
+			.sample(false)
 			.separator(';').build());
 
 


### PR DESCRIPTION
Disables the sampling for detecting the data type in trips csv, which leads to a crash in case it is wrong.