### PR TITLE
Bug fix regarding multiple plug in

### DIFF
--- a/contribs/vsp/src/main/java/playground/vsp/ev/UrbanVehicleChargingHandler.java
+++ b/contribs/vsp/src/main/java/playground/vsp/ev/UrbanVehicleChargingHandler.java
@@ -115,9 +115,14 @@ class UrbanVehicleChargingHandler
 			if (tuple != null) {
 				Id<Vehicle> evId = Id.create(tuple.getFirst(), Vehicle.class);
 				if(vehiclesAtChargers.remove(evId) != null){ //if null, vehicle is fully charged and de-plugged already (see handleEvent(ChargingEndedEvent) )
+					//this is not necessarily true as vehicles can be also queued and waiting for plug in Nov23 Ashraf
 					Id<Charger> chargerId = tuple.getSecond();
 					Charger c = chargingInfrastructure.getChargers().get(chargerId);
 					c.getLogic().removeVehicle(electricFleet.getElectricVehicles().get(evId), event.getTime());
+				}else {
+					Id<Charger> chargerId = tuple.getSecond();
+					Charger c = chargingInfrastructure.getChargers().get(chargerId);
+					if(c.getLogic().getQueuedVehicles().contains(electricFleet.getElectricVehicles().get(evId)))c.getLogic().removeVehicle(electricFleet.getElectricVehicles().get(evId), event.getTime());// so it is important to remove the vehicle from queue as well.
 				}
 			} else {
 				throw new RuntimeException("there is something wrong with the charging procedure of person=" + event.getPersonId() + " on link= " + event.getLinkId());
@@ -134,6 +139,7 @@ class UrbanVehicleChargingHandler
 	public void handleEvent(ChargingEndEvent event) {
 		vehiclesAtChargers.remove(event.getVehicleId());
 		//Charging has ended before activity ends
+		// again this will only fire if the vehicle is picked from queue and plugged in//ashraf Nov2023
 	}
 
 	@Override

--- a/contribs/vsp/src/main/java/playground/vsp/ev/UrbanVehicleChargingHandler.java
+++ b/contribs/vsp/src/main/java/playground/vsp/ev/UrbanVehicleChargingHandler.java
@@ -114,15 +114,16 @@ class UrbanVehicleChargingHandler
 			Tuple<Id<Vehicle>, Id<Charger>> tuple = chargingProcedures.get(event.getLinkId()).remove(event.getPersonId());
 			if (tuple != null) {
 				Id<Vehicle> evId = Id.create(tuple.getFirst(), Vehicle.class);
+				ElectricVehicle ev = electricFleet.getElectricVehicles().get(evId);
 				if(vehiclesAtChargers.remove(evId) != null){ //if null, vehicle is fully charged and de-plugged already (see handleEvent(ChargingEndedEvent) )
 					//this is not necessarily true as vehicles can be also queued and waiting for plug in Nov23 Ashraf
 					Id<Charger> chargerId = tuple.getSecond();
 					Charger c = chargingInfrastructure.getChargers().get(chargerId);
-					c.getLogic().removeVehicle(electricFleet.getElectricVehicles().get(evId), event.getTime());
+					c.getLogic().removeVehicle(ev, event.getTime());
 				}else {
 					Id<Charger> chargerId = tuple.getSecond();
 					Charger c = chargingInfrastructure.getChargers().get(chargerId);
-					if(c.getLogic().getQueuedVehicles().contains(electricFleet.getElectricVehicles().get(evId)))c.getLogic().removeVehicle(electricFleet.getElectricVehicles().get(evId), event.getTime());// so it is important to remove the vehicle from queue as well.
+					if(c.getLogic().getQueuedVehicles().contains(ev))c.getLogic().removeVehicle(ev, event.getTime());// so it is important to remove the vehicle from queue as well.
 				}
 			} else {
 				throw new RuntimeException("there is something wrong with the charging procedure of person=" + event.getPersonId() + " on link= " + event.getLinkId());


### PR DESCRIPTION
I have added necessary comments in he file for a smooth understanding. Basically, when the charging end event happens the vehicles are removed from the vehiclesAtCharger map. But if the charging is not started, they are never put into the map in the first place. So, assuming if the vehicles are not there they are full charge is not right as they might be still in the queue and was never plugged in the first place. As a result, the queue in the charging logic is not cleaned and they still await for plug in. The car can then be put into the logic of another charger and gets plugged in simultaneously in two chargers, hence the bug. 

