### PR TITLE
Full integration on macOS

### DIFF
--- a/.github/workflows/full-integration.yaml
+++ b/.github/workflows/full-integration.yaml
@@ -1,6 +1,7 @@
 name: full-integration
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '30 0 * * *' # daily at 0:30 UTC
 

--- a/.github/workflows/full-integration.yaml
+++ b/.github/workflows/full-integration.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - name: Prepare git


### PR DESCRIPTION
- support manually triggering of full-integration (useful if we do not want to wait for the scheduled build)
- run full-integration also on macos-latest