### PR TITLE
mvn: introduce osmosis.version property

### DIFF
--- a/contribs/accessibility/pom.xml
+++ b/contribs/accessibility/pom.xml
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.openstreetmap.osmosis</groupId>
 			<artifactId>osmosis-core</artifactId>
-			<version>0.48.3</version>
+			<version>${osmosis.version}</version>
 			<exclusions>
 				<!-- needed to compile in IntelliJ with Eclipse compiler -->
 				<!-- see: https://bugs.eclipse.org/bugs/show_bug.cgi?id=536928 -->
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>org.openstreetmap.osmosis</groupId>
 			<artifactId>osmosis-xml</artifactId>
-			<version>0.48.3</version>
+			<version>${osmosis.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>

--- a/contribs/noise/pom.xml
+++ b/contribs/noise/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
 			<groupId>org.openstreetmap.osmosis</groupId>
 			<artifactId>osmosis-xml</artifactId>
-			<version>0.48.3</version>
+			<version>${osmosis.version}</version>
 			<exclusions>
 				<!-- needed to compile in IntelliJ with Eclipse compiler -->
 				<!-- see: https://bugs.eclipse.org/bugs/show_bug.cgi?id=536928 -->

--- a/contribs/vsp/pom.xml
+++ b/contribs/vsp/pom.xml
@@ -102,7 +102,7 @@
 		<dependency>
 			<groupId>org.openstreetmap.osmosis</groupId>
 			<artifactId>osmosis-core</artifactId>
-			<version>0.48.3</version>
+			<version>${osmosis.version}</version>
 			<exclusions>
 				<!-- needed to compile in IntelliJ with Eclipse compiler -->
 				<!-- see: https://bugs.eclipse.org/bugs/show_bug.cgi?id=536928 -->
@@ -115,22 +115,22 @@
 		<dependency>
 			<groupId>org.openstreetmap.osmosis</groupId>
 			<artifactId>osmosis-xml</artifactId>
-			<version>0.48.3</version>
+			<version>${osmosis.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.openstreetmap.osmosis</groupId>
 			<artifactId>osmosis-tagfilter</artifactId>
-			<version>0.48.3</version>
+			<version>${osmosis.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.openstreetmap.osmosis</groupId>
 			<artifactId>osmosis-set</artifactId>
-			<version>0.48.3</version>
+			<version>${osmosis.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.openstreetmap.osmosis</groupId>
 			<artifactId>osmosis-areafilter</artifactId>
-			<version>0.48.3</version>
+			<version>${osmosis.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
 
         <log4j.version>2.21.1</log4j.version>
         <geotools.version>29.2</geotools.version>
+		<osmosis.version>0.48.3</osmosis.version>
         <jts.version>1.19.0</jts.version>
         <guice.version>7.0.0</guice.version>
         <jackson.version>2.15.3</jackson.version>


### PR DESCRIPTION
This is to keep all osmosis dependencies set to the same version and to get only one PR from dependabot when bumping osmosis.