### PR TITLE
(edrt) Allow multi. chargers per link

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/edrt/scheduler/EmptyVehicleChargingScheduler.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/edrt/scheduler/EmptyVehicleChargingScheduler.java
@@ -66,7 +66,7 @@ public class EmptyVehicleChargingScheduler {
 			Optional<Charger> freeCharger = chargers.stream().filter(c -> c.getLogic().getPluggedVehicles().isEmpty()).findFirst();
 
 			// Empty charger or at least smallest queue charger
-			Charger charger = freeCharger.orElseGet(() -> chargers.stream().min(Comparator.comparing(e -> e.getLogic().getQueuedVehicles().size())).orElseThrow());
+			Charger charger = freeCharger.orElseGet(() -> chargers.stream().min(Comparator.comparingInt(e -> e.getLogic().getQueuedVehicles().size())).orElseThrow());
 			ElectricVehicle ev = ((EvDvrpVehicle)vehicle).getElectricVehicle();
 			if (!charger.getLogic().getChargingStrategy().isChargingCompleted(ev)) {
 				chargeVehicleImpl(vehicle, charger);


### PR DESCRIPTION
The default EmptyVehicleChargingScheduler throws an error, if more than one charger has been deployed per link. If multiple chargers are available, a random charger is now selected in this PR.