### PR TITLE
fix: order of drt discharge events

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DischargingModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DischargingModule.java
@@ -41,6 +41,7 @@ public final class DischargingModule extends AbstractModule {
 			protected void configureQSim() {
 				this.bind(DriveDischargingHandler.class).in( Singleton.class );
 				addMobsimScopeEventHandlerBinding().to(DriveDischargingHandler.class);
+				addMobsimListenerBinding().to(DriveDischargingHandler.class);
 				// event handlers are not qsim components
 
 				this.bind(IdleDischargingHandler.class).in( Singleton.class );


### PR DESCRIPTION
Relatively simple fix for #2925: All discharging events are collected and only fired at the end of the simstep.

If somebody who is more familar with the `edrt` code could take over, that would be great :)