### PR TITLE
dvrp: skip computing sparse TT matrix when not needed

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/FreeSpeedTravelTimeMatrix.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/FreeSpeedTravelTimeMatrix.java
@@ -33,7 +33,7 @@ import org.matsim.core.router.util.TravelTime;
  */
 public class FreeSpeedTravelTimeMatrix implements TravelTimeMatrix {
 	public static FreeSpeedTravelTimeMatrix createFreeSpeedMatrix(Network dvrpNetwork, DvrpTravelTimeMatrixParams params, int numberOfThreads,
-			double qSimTimeStepSize) {
+		double qSimTimeStepSize) {
 		return new FreeSpeedTravelTimeMatrix(dvrpNetwork, params, numberOfThreads, new QSimFreeSpeedTravelTime(qSimTimeStepSize));
 	}
 
@@ -48,7 +48,7 @@ public class FreeSpeedTravelTimeMatrix implements TravelTimeMatrix {
 		var routingParams = new TravelTimeMatrices.RoutingParams(dvrpNetwork, travelTime, travelDisutility, numberOfThreads);
 		freeSpeedTravelTimeMatrix = TravelTimeMatrices.calculateTravelTimeMatrix(routingParams, centralNodes, 0);
 		freeSpeedTravelTimeSparseMatrix = TravelTimeMatrices.calculateTravelTimeSparseMatrix(routingParams, params.maxNeighborDistance,
-				params.maxNeighborTravelTime, 0);
+			params.maxNeighborTravelTime, 0).orElse(null);
 	}
 
 	@Override
@@ -56,9 +56,11 @@ public class FreeSpeedTravelTimeMatrix implements TravelTimeMatrix {
 		if (fromNode == toNode) {
 			return 0;
 		}
-		int time = freeSpeedTravelTimeSparseMatrix.get(fromNode, toNode);
-		if (time >= 0) {// value is present
-			return time;
+		if (freeSpeedTravelTimeSparseMatrix != null) {
+			int time = freeSpeedTravelTimeSparseMatrix.get(fromNode, toNode);
+			if (time >= 0) {// value is present
+				return time;
+			}
 		}
 		return freeSpeedTravelTimeMatrix.get(gridSystem.getZone(fromNode), gridSystem.getZone(toNode));
 	}

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/zone/skims/TravelTimeMatricesTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/zone/skims/TravelTimeMatricesTest.java
@@ -69,7 +69,7 @@ public class TravelTimeMatricesTest {
 		NetworkUtils.createAndAddLink(network, Id.createLinkId("CA"), nodeC, nodeA, 600, 15, 80, 1);
 
 		double maxDistance = 300;// B->A->C and C->A->B are pruned by  the limit
-		var matrix = TravelTimeMatrices.calculateTravelTimeSparseMatrix(routingParams(network), maxDistance, 0, 0);
+		var matrix = TravelTimeMatrices.calculateTravelTimeSparseMatrix(routingParams(network), maxDistance, 0, 0).orElseThrow();
 
 		assertThat(matrix.get(nodeA, nodeA)).isEqualTo(0);
 		assertThat(matrix.get(nodeA, nodeB)).isEqualTo(10);
@@ -97,7 +97,7 @@ public class TravelTimeMatricesTest {
 
 		// 20 s (max TT) corresponds to 300 m (max distance) in another test (see: travelTimeSparseMatrix_maxDistance())
 		double maxTravelTime = 20;// B->A->C and C->A->B are pruned by  the limit
-		var matrix = TravelTimeMatrices.calculateTravelTimeSparseMatrix(routingParams(network), 0, maxTravelTime, 0);
+		var matrix = TravelTimeMatrices.calculateTravelTimeSparseMatrix(routingParams(network), 0, maxTravelTime, 0).orElseThrow();
 
 		assertThat(matrix.get(nodeA, nodeA)).isEqualTo(0);
 		assertThat(matrix.get(nodeA, nodeB)).isEqualTo(10);


### PR DESCRIPTION
When max duration and distance are set to zero, there is no point in computing the sparce matrix, which may be very time consuming for very large networks.