### PR TITLE
add VM arguments to second Java call from within the Gui to circumvent module encapsulation which breaks jogl on windows

### DIFF
--- a/matsim/src/main/java/org/matsim/run/gui/Gui.java
+++ b/matsim/src/main/java/org/matsim/run/gui/Gui.java
@@ -449,8 +449,14 @@ public class Gui extends JFrame {
 				}
 				absoluteClasspath.append(new File(cpPart).getAbsolutePath());
 			}
-			String[] cmdArgs = new String[] { txtJvmlocation.getText(), "-cp", absoluteClasspath.toString(),
-					"-Xmx" + txtRam.getText() + "m", mainClass, txtConfigfilename.getText() };
+			String[] cmdArgs = new String[] { txtJvmlocation.getText(),
+					"-cp", absoluteClasspath.toString(),
+					"-Xmx" + txtRam.getText() + "m",
+					"--add-exports", "java.base/java.lang=ALL-UNNAMED",
+					"--add-exports", "java.desktop/sun.awt=ALL-UNNAMED",
+					"--add-exports", "java.desktop/sun.java2d=ALL-UNNAMED",
+					mainClass, txtConfigfilename.getText() };
+			// see https://jogamp.org/bugzilla/show_bug.cgi?id=1317#c21 and/or https://github.com/matsim-org/matsim-libs/pull/2940
 			exeRunner = ExeRunner.run(cmdArgs, textStdOut, textErrOut,
 					new File(txtConfigfilename.getText()).getParent());
 			int exitcode = exeRunner.waitForFinish();


### PR DESCRIPTION
Our java gui internally calls java a second time in order to be able to add a larger memory request as VM argument.  I am now additionally adding the arguments

					"--add-exports", "java.base/java.lang=ALL-UNNAMED",
					"--add-exports", "java.desktop/sun.awt=ALL-UNNAMED",
					"--add-exports", "java.desktop/sun.java2d=ALL-UNNAMED",
because this seems to be needed to make jogl work on windows.