### PR TITLE
Configurable initial DRT estimators

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/estimator/DrtInitialEstimator.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/estimator/DrtInitialEstimator.java
@@ -1,0 +1,9 @@
+package org.matsim.contrib.drt.extension.estimator;
+
+/**
+ * This interface is used to provide an initial estimate for the drt service.
+ * Supposed to be used when no data is available from the simulation yet.
+ * The interface is exactly the same as {@link DrtEstimator}, but this class won't be called with update events.
+ */
+public interface DrtInitialEstimator extends DrtEstimator {
+}

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/estimator/impl/BasicDrtEstimator.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/estimator/impl/BasicDrtEstimator.java
@@ -1,4 +1,4 @@
-package org.matsim.contrib.drt.extension.estimator;
+package org.matsim.contrib.drt.extension.estimator.impl;
 
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 import org.apache.commons.math3.stat.regression.RegressionResults;
@@ -9,8 +9,9 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.events.PersonMoneyEvent;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.drt.analysis.DrtEventSequenceCollector;
+import org.matsim.contrib.drt.extension.estimator.DrtEstimator;
+import org.matsim.contrib.drt.extension.estimator.DrtInitialEstimator;
 import org.matsim.contrib.drt.extension.estimator.run.DrtEstimatorConfigGroup;
-import org.matsim.contrib.drt.fare.DrtFareParams;
 import org.matsim.contrib.drt.routing.DrtRoute;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.speedup.DrtSpeedUp;
@@ -32,6 +33,7 @@ public class BasicDrtEstimator implements DrtEstimator, IterationEndsListener {
 	private final DrtEventSequenceCollector collector;
 	private final DrtEstimatorConfigGroup config;
 	private final DrtConfigGroup drtConfig;
+	private final DrtInitialEstimator initial;
 
 	private final SplittableRandom rnd = new SplittableRandom();
 	/**
@@ -40,10 +42,11 @@ public class BasicDrtEstimator implements DrtEstimator, IterationEndsListener {
 	private GlobalEstimate currentEst;
 	private RegressionResults fare;
 
-	public BasicDrtEstimator(DrtEventSequenceCollector collector, DrtEstimatorConfigGroup config,
-							 DrtConfigGroup drtConfig) {
+	public BasicDrtEstimator(DrtEventSequenceCollector collector, DrtInitialEstimator initial,
+							 DrtEstimatorConfigGroup config, DrtConfigGroup drtConfig) {
 		//zones = injector.getModal(DrtZonalSystem.class);
 		this.collector = collector;
+		this.initial = initial;
 		this.config = config;
 		this.drtConfig = drtConfig;
 	}
@@ -64,6 +67,9 @@ public class BasicDrtEstimator implements DrtEstimator, IterationEndsListener {
 
 		int nRejections = collector.getRejectedRequestSequences().size();
 		int nSubmitted = collector.getRequestSubmissions().size();
+
+		// TODO: somehow configure initial estimates, probably behind interface and class
+		// TODO: optimistic, pessimistic initial etc
 
 		for (DrtEventSequenceCollector.EventSequence seq : collector.getPerformedRequestSequences().values()) {
 
@@ -115,23 +121,8 @@ public class BasicDrtEstimator implements DrtEstimator, IterationEndsListener {
 	public Estimate estimate(DrtRoute route, OptionalTime departureTime) {
 
 		if (currentEst == null) {
-			// If not estimates are present, use travel time alpha as detour
-			// beta is not used, because estimates are supposed to be minimums and not worst cases
-			double travelTime = Math.min(route.getDirectRideTime() + drtConfig.maxAbsoluteDetour,
-				route.getDirectRideTime() * drtConfig.maxTravelTimeAlpha);
-
-			double fare = 0;
-			if (drtConfig.getDrtFareParams().isPresent()) {
-				DrtFareParams fareParams = drtConfig.getDrtFareParams().get();
-				fare = fareParams.distanceFare_m * route.getDistance()
-					+ fareParams.timeFare_h * route.getDirectRideTime() / 3600.0
-					+ fareParams.baseFare;
-
-				fare = Math.max(fare, fareParams.minFarePerTrip);
-			}
-
-			// for distance, also use the max travel time alpha
-			return new Estimate(route.getDistance() * drtConfig.maxTravelTimeAlpha, travelTime, drtConfig.maxWaitTime, fare, 0);
+			// Same interface, just different binding
+			return initial.estimate(route, departureTime);
 		}
 
 		double fare = 0;

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/estimator/impl/BasicDrtEstimator.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/estimator/impl/BasicDrtEstimator.java
@@ -68,9 +68,6 @@ public class BasicDrtEstimator implements DrtEstimator, IterationEndsListener {
 		int nRejections = collector.getRejectedRequestSequences().size();
 		int nSubmitted = collector.getRequestSubmissions().size();
 
-		// TODO: somehow configure initial estimates, probably behind interface and class
-		// TODO: optimistic, pessimistic initial etc
-
 		for (DrtEventSequenceCollector.EventSequence seq : collector.getPerformedRequestSequences().values()) {
 
 			Map<Id<Person>, DrtEventSequenceCollector.EventSequence.PersonEvents> personEvents = seq.getPersonEvents();

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/estimator/impl/ConstantDrtEstimator.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/estimator/impl/ConstantDrtEstimator.java
@@ -1,0 +1,50 @@
+package org.matsim.contrib.drt.extension.estimator.impl;
+
+import org.matsim.contrib.drt.extension.estimator.DrtInitialEstimator;
+import org.matsim.contrib.drt.fare.DrtFareParams;
+import org.matsim.contrib.drt.routing.DrtRoute;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.core.utils.misc.OptionalTime;
+
+/**
+ * Estimates using a constant detour factor and waiting time.
+ */
+public class ConstantDrtEstimator implements DrtInitialEstimator {
+
+	private final DrtConfigGroup drtConfig;
+
+	/**
+	 * Detour factor for the estimate. 1.0 means no detour, 2.0 means twice the distance.
+	 */
+	private final double detourFactor;
+
+	/**
+	 * Constant waiting time estimate in seconds.
+	 */
+	private final double waitingTime;
+
+	public ConstantDrtEstimator(DrtConfigGroup drtConfig, double detourFactor, double waitingTime) {
+		this.drtConfig = drtConfig;
+		this.detourFactor = detourFactor;
+		this.waitingTime = waitingTime;
+	}
+
+	@Override
+	public Estimate estimate(DrtRoute route, OptionalTime departureTime) {
+
+		double distance = route.getDistance() * detourFactor;
+		double travelTime = route.getDirectRideTime() * detourFactor;
+
+		double fare = 0;
+		if (drtConfig.getDrtFareParams().isPresent()) {
+			DrtFareParams fareParams = drtConfig.getDrtFareParams().get();
+			fare = fareParams.distanceFare_m * distance
+				+ fareParams.timeFare_h * travelTime / 3600.0
+				+ fareParams.baseFare;
+
+			fare = Math.max(fare, fareParams.minFarePerTrip);
+		}
+
+		return new Estimate(distance, travelTime, waitingTime, fare, 0);
+	}
+}

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/estimator/impl/PessimisticDrtEstimator.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/estimator/impl/PessimisticDrtEstimator.java
@@ -1,0 +1,40 @@
+package org.matsim.contrib.drt.extension.estimator.impl;
+
+import org.matsim.contrib.drt.extension.estimator.DrtInitialEstimator;
+import org.matsim.contrib.drt.fare.DrtFareParams;
+import org.matsim.contrib.drt.routing.DrtRoute;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.core.utils.misc.OptionalTime;
+
+/**
+ * Uses the upper bounds from config for the initial estimate.
+ */
+public class PessimisticDrtEstimator implements DrtInitialEstimator {
+	private final DrtConfigGroup drtConfig;
+
+	public PessimisticDrtEstimator(DrtConfigGroup drtConfig) {
+		this.drtConfig = drtConfig;
+	}
+
+	@Override
+	public Estimate estimate(DrtRoute route, OptionalTime departureTime) {
+		// If not estimates are present, use travel time alpha as detour
+		// beta is not used, because estimates are supposed to be minimums and not worst cases
+		double travelTime = Math.min(route.getDirectRideTime() + drtConfig.maxAbsoluteDetour,
+			route.getDirectRideTime() * drtConfig.maxTravelTimeAlpha);
+
+		double fare = 0;
+		if (drtConfig.getDrtFareParams().isPresent()) {
+			DrtFareParams fareParams = drtConfig.getDrtFareParams().get();
+			fare = fareParams.distanceFare_m * route.getDistance()
+				+ fareParams.timeFare_h * route.getDirectRideTime() / 3600.0
+				+ fareParams.baseFare;
+
+			fare = Math.max(fare, fareParams.minFarePerTrip);
+		}
+
+		// for distance, also use the max travel time alpha
+		return new Estimate(route.getDistance() * drtConfig.maxTravelTimeAlpha, travelTime, drtConfig.maxWaitTime, fare, 0);
+	}
+
+}

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/estimator/run/DrtEstimatorConfigGroup.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/estimator/run/DrtEstimatorConfigGroup.java
@@ -17,6 +17,11 @@ public class DrtEstimatorConfigGroup extends ReflectiveConfigGroupWithConfigurab
 		BASIC,
 
 		/**
+		 * Will use the bound initial estimator, without any updates.
+		 */
+		INITIAL,
+
+		/**
 		 * Custom estimator, that needs to provided via binding.
 		 */
 		CUSTOM
@@ -56,6 +61,14 @@ public class DrtEstimatorConfigGroup extends ReflectiveConfigGroupWithConfigurab
 	@Override
 	public String getMode() {
 		return mode;
+	}
+
+	/**
+	 * Set estimator type and return same instance.
+	 */
+	public DrtEstimatorConfigGroup withEstimator(EstimatorType estimator) {
+		this.estimator = estimator;
+		return this;
 	}
 
 }

--- a/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/estimator/MultiModaFixedDrtLegEstimatorTest.java
+++ b/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/estimator/MultiModaFixedDrtLegEstimatorTest.java
@@ -1,0 +1,93 @@
+package org.matsim.contrib.drt.extension.estimator;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.matsim.application.MATSimApplication;
+import org.matsim.contrib.drt.extension.DrtTestScenario;
+import org.matsim.contrib.drt.extension.estimator.impl.ConstantDrtEstimator;
+import org.matsim.contrib.drt.extension.estimator.run.DrtEstimatorConfigGroup;
+import org.matsim.contrib.drt.extension.estimator.run.DrtEstimatorModule;
+import org.matsim.contrib.drt.extension.estimator.run.MultiModeDrtEstimatorConfigGroup;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.config.groups.ReplanningConfigGroup;
+import org.matsim.core.controler.Controler;
+import org.matsim.modechoice.InformedModeChoiceModule;
+import org.matsim.modechoice.ModeOptions;
+import org.matsim.modechoice.estimators.DefaultLegScoreEstimator;
+import org.matsim.modechoice.estimators.FixedCostsEstimator;
+import org.matsim.testcases.MatsimTestUtils;
+
+import java.io.File;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MultiModaFixedDrtLegEstimatorTest {
+
+	@Rule
+	public MatsimTestUtils utils = new MatsimTestUtils();
+
+	private Controler controler;
+
+	private static void prepare(Controler controler) {
+		InformedModeChoiceModule.Builder builder = InformedModeChoiceModule.newBuilder()
+			.withFixedCosts(FixedCostsEstimator.DailyConstant.class, "car")
+			.withLegEstimator(DefaultLegScoreEstimator.class, ModeOptions.AlwaysAvailable.class, "bike", "walk", "pt")
+			.withLegEstimator(DefaultLegScoreEstimator.class, ModeOptions.ConsiderYesAndNo.class, "car")
+			.withLegEstimator(MultiModalDrtLegEstimator.class, ModeOptions.AlwaysAvailable.class, "drt", "av");
+
+		controler.addOverridingModule(builder.build());
+		controler.addOverridingModule(new DrtEstimatorModule()
+			.withInitialEstimator(cfg -> new ConstantDrtEstimator(cfg, 1.05, 300), "drt", "av"));
+	}
+
+	private static void prepare(Config config) {
+
+		MultiModeDrtEstimatorConfigGroup estimators = ConfigUtils.addOrGetModule(config, MultiModeDrtEstimatorConfigGroup.class);
+
+		estimators.addParameterSet(new DrtEstimatorConfigGroup("drt")
+			.withEstimator(DrtEstimatorConfigGroup.EstimatorType.INITIAL));
+		estimators.addParameterSet(new DrtEstimatorConfigGroup("av"));
+
+		// Set subtour mode selection as strategy
+		List<ReplanningConfigGroup.StrategySettings> strategies = config.replanning().getStrategySettings().stream()
+			.filter(s -> !s.getStrategyName().toLowerCase().contains("mode")
+			).collect(Collectors.toList());
+
+		strategies.add(new ReplanningConfigGroup.StrategySettings()
+			.setStrategyName(InformedModeChoiceModule.SELECT_SUBTOUR_MODE_STRATEGY)
+			.setSubpopulation("person")
+			.setWeight(0.2));
+
+		config.replanning().clearStrategySettings();
+		strategies.forEach(s -> config.replanning().addStrategySettings(s));
+
+	}
+
+	@Before
+	public void setUp() throws Exception {
+
+		Config config = DrtTestScenario.loadConfig(utils);
+
+		config.controller().setLastIteration(3);
+
+		controler = MATSimApplication.prepare(new DrtTestScenario(MultiModaFixedDrtLegEstimatorTest::prepare, MultiModaFixedDrtLegEstimatorTest::prepare), config);
+	}
+
+	@Test
+	public void run() {
+
+		String out = utils.getOutputDirectory();
+
+		controler.run();
+
+		assertThat(new File(out, "kelheim-mini-drt.drt_estimates_drt.csv"))
+			.exists()
+			.isNotEmpty();
+
+
+	}
+}


### PR DESCRIPTION
This PR extends the DRT estimator module with an additional interface to provide estimates, when no data is available yet. This functionality can be used to try pessimistic, optimistic or even estimates based on real data.