### PR TITLE
feat: customizable distance calculators for drt constraints

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/constraints/VehicleRangeConstraint.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/constraints/VehicleRangeConstraint.java
@@ -3,6 +3,7 @@ package org.matsim.contrib.drt.extension.insertion.constraints;
 import javax.annotation.Nullable;
 
 import org.matsim.contrib.drt.extension.insertion.DrtInsertionConstraint;
+import org.matsim.contrib.drt.extension.insertion.distances.DistanceApproximator;
 import org.matsim.contrib.drt.extension.insertion.distances.DistanceCalculator;
 import org.matsim.contrib.drt.extension.insertion.distances.InsertionDistanceCalculator;
 import org.matsim.contrib.drt.extension.insertion.distances.InsertionDistanceCalculator.VehicleDistance;
@@ -16,10 +17,10 @@ public class VehicleRangeConstraint implements DrtInsertionConstraint {
 
 	private final VehicleRangeSupplier rangeSupplier;
 	private final DistanceCalculator distanceCalculator;
-	private final DistanceCalculator distanceApproximator;
+	private final DistanceApproximator distanceApproximator;
 
 	public VehicleRangeConstraint(VehicleRangeSupplier rangeSupplier, DistanceCalculator distanceEstimator,
-			@Nullable DistanceCalculator distanceApproximator) {
+			@Nullable DistanceApproximator distanceApproximator) {
 		this.rangeSupplier = rangeSupplier;
 		this.distanceCalculator = distanceEstimator;
 		this.distanceApproximator = distanceApproximator;

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/distances/DistanceApproximator.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/distances/DistanceApproximator.java
@@ -1,0 +1,8 @@
+package org.matsim.contrib.drt.extension.insertion.distances;
+
+public interface DistanceApproximator extends DistanceCalculator {
+	static public DistanceApproximator NULL = (departureTime, fromLink, toLink) -> {
+		throw new IllegalStateException(
+				"The NULL DistanceApproximator is only used as a tag for not using any approximation.");
+	};
+}

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/distances/DistanceCalculator.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/distances/DistanceCalculator.java
@@ -3,5 +3,5 @@ package org.matsim.contrib.drt.extension.insertion.distances;
 import org.matsim.api.core.v01.network.Link;
 
 public interface DistanceCalculator {
-	double estimateDistance(double departureTime, Link fromLink, Link toLink);
+	double calculateDistance(double departureTime, Link fromLink, Link toLink);
 }

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/distances/EuclideanDistanceApproximator.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/distances/EuclideanDistanceApproximator.java
@@ -3,15 +3,15 @@ package org.matsim.contrib.drt.extension.insertion.distances;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.core.utils.geometry.CoordUtils;
 
-public class ApproximateDistanceCalculator implements DistanceCalculator {
+public class EuclideanDistanceApproximator implements DistanceApproximator {
 	private final double distanceEstimationFactor;
 
-	public ApproximateDistanceCalculator(double distanceEstimationFactor) {
+	public EuclideanDistanceApproximator(double distanceEstimationFactor) {
 		this.distanceEstimationFactor = distanceEstimationFactor;
 	}
 
 	@Override
-	public double estimateDistance(double departureTime, Link fromLink, Link toLink) {
+	public double calculateDistance(double departureTime, Link fromLink, Link toLink) {
 		return distanceEstimationFactor
 				* CoordUtils.calcEuclideanDistance(fromLink.getFromNode().getCoord(), toLink.getFromNode().getCoord());
 	}

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/distances/InsertionDistanceCalculator.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/distances/InsertionDistanceCalculator.java
@@ -68,9 +68,9 @@ public class InsertionDistanceCalculator {
 		int beforePickupOccupancy = insertion.pickup.previousWaypoint.getOutgoingOccupancy();
 
 		double beforePickupDistance = distanceEstimator
-				.estimateDistance(insertion.pickup.previousWaypoint.getDepartureTime(), pickupFromLink, pickupNewLink);
+				.calculateDistance(insertion.pickup.previousWaypoint.getDepartureTime(), pickupFromLink, pickupNewLink);
 
-		double afterPickupDistance = distanceEstimator.estimateDistance(detourTimeInfo.pickupDetourInfo.departureTime,
+		double afterPickupDistance = distanceEstimator.calculateDistance(detourTimeInfo.pickupDetourInfo.departureTime,
 				pickupNewLink, pickupToLink);
 
 		addedDistances.add(new DistanceEntry(beforePickupDistance, beforePickupOccupancy));
@@ -128,7 +128,7 @@ public class InsertionDistanceCalculator {
 		final int beforeDropoffOccupancy;
 		if (insertion.dropoff.index > insertion.pickup.index) {
 			beforeDropoffOccupancy = insertion.dropoff.previousWaypoint.getOutgoingOccupancy() + 1;
-			double beforeDropoffDistance = distanceEstimator.estimateDistance(
+			double beforeDropoffDistance = distanceEstimator.calculateDistance(
 					insertion.dropoff.previousWaypoint.getDepartureTime(), dropoffFromLink, dropoffNewLink);
 
 			addedDistances.add(new DistanceEntry(beforeDropoffDistance, beforeDropoffOccupancy));
@@ -136,7 +136,7 @@ public class InsertionDistanceCalculator {
 			beforeDropoffOccupancy = beforePickupOccupancy + 1;
 		}
 
-		double afterDropoffDistance = distanceEstimator.estimateDistance(detourTimeInfo.dropoffDetourInfo.arrivalTime,
+		double afterDropoffDistance = distanceEstimator.calculateDistance(detourTimeInfo.dropoffDetourInfo.arrivalTime,
 				dropoffNewLink, dropoffToLink);
 		addedDistances.add(new DistanceEntry(afterDropoffDistance, beforeDropoffOccupancy - 1));
 

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/distances/RoutingDistanceCalculator.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/distances/RoutingDistanceCalculator.java
@@ -19,7 +19,7 @@ public class RoutingDistanceCalculator implements DistanceCalculator {
 	// set this up in a more intelligent way, I'm not sure, but I guess that the
 	// constraints are accesses in parallel by DRT. /sh nov'23
 	@Override
-	public synchronized double estimateDistance(double departureTime, Link fromLink, Link toLink) {
+	public synchronized double calculateDistance(double departureTime, Link fromLink, Link toLink) {
 		VrpPathWithTravelData path = VrpPaths.calcAndCreatePath(fromLink, toLink, departureTime, router, travelTime);
 		return VrpPaths.calcDistance(path);
 	}


### PR DESCRIPTION
This PR makes it easy to further experiment with the distance objective and range constraint that comes with `drt-extensions/insertion`. It is now possible to flexibly configure the distance calculator with a custom logic. Furthermore, the distance approximator can be defined. While the calculator is used in the distance objective, both of them are used in the range constraint: If an approximator is defined (but it is optional), the range constraint is first evaluated with the approximator, which should be pessimistic. Only if a violation of the constraint is detected using this pessmistic (i.e. overestimating) setting, the more exact calculator is used that will perform a direct network routing by default. Both elements can now be configured by:

```java
DrtInsertionModule insertionModule = new DrtInsertionModule(drtConfig) //
  .withVehicleRange(100.0 * 1e3) //
  .withDistanceCalculator(distanceCalculator) //
  .withDistanceApproximator(distanceApproximator);
```

The values passed can either be an instance of `DistanceCalculator` and `DistanceApproximator`, or they can be a class name, then a modal binding needs to be provided somewhere (see example in the unit tests).