### PR TITLE
Make TripsAndLegsWriter public again

### DIFF
--- a/matsim/src/main/java/org/matsim/analysis/TripsAndLegsWriter.java
+++ b/matsim/src/main/java/org/matsim/analysis/TripsAndLegsWriter.java
@@ -79,7 +79,7 @@ public class TripsAndLegsWriter {
     private static final Logger log = LogManager.getLogger(TripsAndLegsWriter.class);
 
 	@Inject
-	TripsAndLegsWriter(Scenario scenario, CustomTripsWriterExtension tripsWriterExtension, CustomLegsWriterExtension legWriterExtension,
+	public TripsAndLegsWriter(Scenario scenario, CustomTripsWriterExtension tripsWriterExtension, CustomLegsWriterExtension legWriterExtension,
 					   AnalysisMainModeIdentifier mainModeIdentifier, CustomTimeWriter customTimeWriter) {
 		this.scenario = scenario;
 		this.tripsWriterExtension = tripsWriterExtension;


### PR DESCRIPTION
#2955 removed the public constructor of the `TripsAndLegsWriter `. I would kindly ask to make this constructor again public. @jfbischoff developed this very valuable class, which is also a strong utility within post-processing tasks. 

However, post-processing would require the creation of a certain instance of this class. I observed in the recent past some changes that removed the visibility of classes and constructors. Maybe we require a general discussion about how to deal with this kind of an issue. Removing the visibility might be good in terms of code maintenance, however it pushes users/devs into the direction to make local code copies, which feels like a silent fork. In my eyes, MATSim is a framework that should allow users/devs to reuse code instead of making various replicas of the very same functionality. 
