### PR TITLE
freight: stop transitively depending on junit 4

### DIFF
--- a/contribs/freight/pom.xml
+++ b/contribs/freight/pom.xml
@@ -44,6 +44,12 @@
 			<groupId>com.graphhopper</groupId>
 			<artifactId>jsprit-analysis</artifactId>
 			<version>${jsprit.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>junit</groupId>
+					<artifactId>junit</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/MatsimTransformerTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/MatsimTransformerTest.java
@@ -48,9 +48,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class MatsimTransformerTest {
@@ -78,7 +75,7 @@ public class MatsimTransformerTest {
 				.newInstance("myType").addCapacityDimension(0, 50).setCostPerDistance(10.0).setCostPerTransportTime(5.0)
 				.setFixedCost(100.0).build();
 		VehicleType matsimType = MatsimJspritFactory.createMatsimVehicleType(jspritType);
-		assertThat(matsimType, is(not(MatsimJspritFactory.createMatsimVehicleType(jspritType))));
+		assertNotEquals(matsimType, MatsimJspritFactory.createMatsimVehicleType(jspritType));
 	}
 
 	@Test


### PR DESCRIPTION
This is to make sure we do not accidently use junit 4 in freight or other depending contribs (junit 4 was not in the test scope, because graphstream declared it not in that scope, and therefore it was transitively available in so many places).