### PR TITLE
ev: fix ConcurrentModificationException in VehicleChargingHandler.notifyMobsimBeforeSimStep()

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/VehicleChargingHandler.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/charging/VehicleChargingHandler.java
@@ -53,6 +53,7 @@ import org.matsim.core.mobsim.qsim.agents.WithinDayAgentUtils;
 import org.matsim.vehicles.Vehicle;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This is an events based approach to trigger vehicle charging. Vehicles will be charged as soon as a person begins a charging activity.
@@ -71,7 +72,7 @@ public class VehicleChargingHandler
 	private final Map<Id<Person>, Id<Vehicle>> lastVehicleUsed = new HashMap<>();
 	private final Map<Id<Vehicle>, Id<Person>> lastDriver = new HashMap<>();
 	private final Map<Id<Vehicle>, Id<Charger>> vehiclesAtChargers = new HashMap<>();
-	private final Set<Id<Person>> agentsInChargerQueue = new HashSet<>();
+	private final Set<Id<Person>> agentsInChargerQueue = ConcurrentHashMap.newKeySet();
 
 	private final ChargingInfrastructure chargingInfrastructure;
 	private final ElectricFleet electricFleet;


### PR DESCRIPTION
Reported by Tobias Tietz:
```
java.util.ConcurrentModificationException: null
	at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1605) ~[?:?]
	at java.base/java.util.HashMap$KeyIterator.next(HashMap.java:1628) ~[?:?]
	at org.matsim.contrib.ev.charging.VehicleChargingHandler.notifyMobsimBeforeSimStep(VehicleChargingHandler.java:169) ~[classes/:?]
	at org.matsim.core.mobsim.qsim.MobsimListenerManager.fireQueueSimulationBeforeSimStepEvent(MobsimListenerManager.java:107) ~[classes/:?]
	at org.matsim.core.mobsim.qsim.QSim.doSimStep(QSim.java:390) ~[classes/:?]
	at org.matsim.core.mobsim.qsim.QSim.run(QSim.java:259) ~[classes/:?]
	at org.matsim.core.controler.NewControler.runMobSim(NewControler.java:125) ~[classes/:?]
	at org.matsim.core.controler.AbstractController$8.run(AbstractController.java:214) ~[classes/:?]
	at org.matsim.core.controler.AbstractController.iterationStep(AbstractController.java:246) ~[classes/:?]
	at org.matsim.core.controler.AbstractController.mobsim(AbstractController.java:210) ~[classes/:?]
	at org.matsim.core.controler.AbstractController.iteration(AbstractController.java:157) ~[classes/:?]
	at org.matsim.core.controler.AbstractController.doIterations(AbstractController.java:124) ~[classes/:?]
	at org.matsim.core.controler.AbstractController$1.run(AbstractController.java:84) ~[classes/:?]
	at org.matsim.core.controler.MatsimRuntimeModifications.run(MatsimRuntimeModifications.java:70) [classes/:?]
	at org.matsim.core.controler.MatsimRuntimeModifications.run(MatsimRuntimeModifications.java:53) [classes/:?]
	at org.matsim.core.controler.AbstractController.run(AbstractController.java:92) [classes/:?]
	at org.matsim.core.controler.NewControler.run(NewControler.java:83) [classes/:?]
	at org.matsim.core.controler.Controler.run(Controler.java:259) [classes/:?]
	at org.matsim.contrib.ev.eTruckTraffic.RunETruckTraffic.run(RunETruckTraffic.java:69) [classes/:?]
	at org.matsim.contrib.ev.eTruckTraffic.RunETruckTraffic.main(RunETruckTraffic.java:50) [classes/:?]
```