### PR TITLE
Ensure deterministic depot selection

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/depot/Depots.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/depot/Depots.java
@@ -50,9 +50,9 @@ public class Depots {
 		if (!STAY.isBaseTypeOf(currentTask)) {
 			return false;
 		}
-		
+
 		// only if stay task is last task: with prebooking we may also idle during the day, but
-		// currently all the downstream relocation/charging logic assumes that we only stay at 
+		// currently all the downstream relocation/charging logic assumes that we only stay at
 		// the end of the schedule
 		if (currentTask.getTaskIdx() < schedule.getTaskCount() - 1) {
 			return false;
@@ -64,13 +64,15 @@ public class Depots {
 	}
 
 	public static Link findStraightLineNearestDepot(DvrpVehicle vehicle, Set<Link> links) {
-		Link currentLink = ((DrtStayTask)vehicle.getSchedule().getCurrentTask()).getLink();
+		Link currentLink = ((DrtStayTask) vehicle.getSchedule().getCurrentTask()).getLink();
 		return links.contains(currentLink) ?
-				null /* already at a depot*/ :
-				links.stream()
-						.min(Comparator.comparing(
-								l -> DistanceUtils.calculateSquaredDistance(currentLink.getToNode().getCoord(),
-										l.getFromNode().getCoord())))
-						.get();
+			null /* already at a depot*/ :
+			links.stream().map(l -> new DepotCandidates(l, DistanceUtils.calculateSquaredDistance(currentLink.getToNode().getCoord(),
+					l.getFromNode().getCoord())))
+				.sorted(Comparator.comparing(DepotCandidates::distance)
+					.thenComparing(h -> h.link.getId()))
+				.findFirst().get().link();
 	}
+
+	record DepotCandidates(Link link, double distance) {}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/depot/Depots.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/depot/Depots.java
@@ -69,9 +69,9 @@ public class Depots {
 			null /* already at a depot*/ :
 			links.stream().map(l -> new DepotCandidates(l, DistanceUtils.calculateSquaredDistance(currentLink.getToNode().getCoord(),
 					l.getFromNode().getCoord())))
-				.sorted(Comparator.comparing(DepotCandidates::distance)
+				.min(Comparator.comparing(DepotCandidates::distance)
 					.thenComparing(h -> h.link.getId()))
-				.findFirst().get().link();
+				.get().link();
 	}
 
 	record DepotCandidates(Link link, double distance) {}


### PR DESCRIPTION
This PR ensures a deterministic depot selection for eDrt in situation in which multiple depots are having the very same distance - unfortunately, yes this might happen 😓 and would cause a non-deterministic depot selection. Took me quite some time to narrow down this problem.