### PR TITLE
Provides a way to provide custom handling for unknown parameters in ReflectiveConfigGroup

### DIFF
--- a/matsim/src/main/java/org/matsim/core/config/ReflectiveConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/ReflectiveConfigGroup.java
@@ -285,14 +285,29 @@ public abstract class ReflectiveConfigGroup extends ConfigGroup implements Matsi
 			return;
 		}
 
-		Preconditions.checkArgument(storeUnknownParameters, "Module %s of type %s doesn't accept unknown parameters."
-						+ " Parameter %s is not part of the valid parameters: %s", getName(), getClass().getName(), param_name,
-				setters.keySet());
+		this.handleAddUnknownParam(param_name, value);
+	}
+
+	/**
+	 * This method is designed to be overwritten if a config group wants to provide
+	 * custom handling for unknown parameters, e.g. for improved backwards compatibility.
+	 * For example: It allows to convert (old-named) parameter values to different units and
+	 * store them with the new name (old parameter could be km/h, new parameter could be m/s).
+	 *
+	 * The default implementation in {@link ReflectiveConfigGroup} will either store the
+	 * unknown parameter or throw an exception, depending on the value of {@link #storeUnknownParameters}.
+	 *
+	 * If the method is overwritten, it might make sense to also overwrite {@link #handleGetUnknownValue(String)}.
+	 */
+	public void handleAddUnknownParam(final String paramName, final String value) {
+		Preconditions.checkArgument(this.storeUnknownParameters, "Module %s of type %s doesn't accept unknown parameters."
+				+ " Parameter %s is not part of the valid parameters: %s", getName(), getClass().getName(), paramName,
+			this.setters.keySet());
 
 		log.warn(
-				"Unknown parameter {} for group {}. Here are the valid parameter names: {}. Only the string value will be remembered.",
-				param_name, getName(), registeredParams);
-		super.addParam(param_name, value);
+			"Unknown parameter {} for group {}. Here are the valid parameter names: {}. Only the string value will be remembered.",
+			paramName, getName(), this.registeredParams);
+		super.addParam(paramName, value);
 	}
 
 	private void invokeSetter(final Method setter, final String value) {
@@ -438,13 +453,22 @@ public abstract class ReflectiveConfigGroup extends ConfigGroup implements Matsi
 		if (field != null) {
 			return getParamField(field);
 		}
+		return this.handleGetUnknownValue(param_name);
+	}
 
-		Preconditions.checkArgument(storeUnknownParameters, "Module %s of type %s doesn't store unknown parameters."
-						+ " Parameter %s is not part of the valid parameters: %s", getName(), getClass().getName(), param_name,
-				registeredParams);
+	/**
+	 * This method is designed to be overwritten if a config group wants to provide
+	 * custom handling for unknown parameters, e.g. for improved backwards compatibility.
+	 *
+	 * Also see {@link #handleAddUnknownParam(String, String)}
+	 */
+	public String handleGetUnknownValue(final String paramName) {
+		Preconditions.checkArgument(this.storeUnknownParameters, "Module %s of type %s doesn't store unknown parameters."
+						+ " Parameter %s is not part of the valid parameters: %s", getName(), getClass().getName(), paramName,
+				this.registeredParams);
 
-		log.warn("no getter found for param {}: trying parent method", param_name);
-		return super.getValue(param_name);
+		log.warn("no getter found for param {}: trying parent method", paramName);
+		return super.getValue(paramName);
 	}
 
 	private String invokeGetter(Method getter) {


### PR DESCRIPTION
If a ConfigGroup based on ReflectiveConfigGroup has to add an unmapped parameter, usually an exception is thrown.

In some cases, it could make sense to provide special handling in such cases, e.g. to implement backward compatibility to older parameter names, to support a migration from older to newer parameters, etc.

This PR adds two methods `handleAddUnknownParam(...)` and `handleGetUnknownValue(...)` (matching `addParam(...)` and `getValue(...)`) that are designed to be overwritten. The default implementation reuses the existing logic in ReflectiveConfigGroup. Custom config groups can overwrite the methods and add custom functionality to deal with unknown parameters.

Fixes #2960