### PR TITLE
Moves PassengerGroupIdentifier for Drt Companions from Person to Leg

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionGroupIdentifier.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionGroupIdentifier.java
@@ -20,10 +20,11 @@
 package org.matsim.contrib.drt.extension.companions;
 
 import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.population.Person;
-import org.matsim.api.core.v01.population.Population;
+import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.contrib.dvrp.passenger.PassengerGroupIdentifier;
 import org.matsim.core.mobsim.framework.MobsimPassengerAgent;
+import org.matsim.core.mobsim.qsim.agents.WithinDayAgentUtils;
 
 import java.util.Optional;
 
@@ -31,21 +32,17 @@ import java.util.Optional;
  * @author steffenaxer
  */
 class DrtCompanionGroupIdentifier implements PassengerGroupIdentifier {
-	private final Population population;
-	DrtCompanionGroupIdentifier(final Population population)
-	{
-		this.population = population;
-	}
 
 	@Override
 	public Optional<Id<PassengerGroup>> getGroupId(MobsimPassengerAgent agent) {
-		Person person = wrapMobsimPassengerAgentToPerson(agent);
-		return DrtCompanionUtils.getPassengerGroupIdentifier(person);
-	}
 
-	private Person wrapMobsimPassengerAgentToPerson(MobsimPassengerAgent agent)
-	{
-		return this.population.getPersons().get(agent.getId());
+		PlanElement pe = WithinDayAgentUtils.getCurrentPlanElement(agent);
+
+		if (pe instanceof Leg leg) {
+			return DrtCompanionUtils.getPassengerGroupIdentifier(leg);
+		} else {
+			return Optional.empty();
+		}
 	}
 
 }

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionModule.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionModule.java
@@ -20,13 +20,11 @@
 package org.matsim.contrib.drt.extension.companions;
 
 import org.matsim.api.core.v01.Scenario;
-import org.matsim.api.core.v01.population.Population;
 import org.matsim.contrib.drt.extension.DrtWithExtensionsConfigGroup;
 import org.matsim.contrib.dvrp.fleet.FleetSpecification;
 import org.matsim.contrib.dvrp.passenger.PassengerGroupIdentifier;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
-import org.matsim.core.router.MainModeIdentifier;
 
 
 /**
@@ -48,7 +46,6 @@ public class DrtCompanionModule extends AbstractDvrpModeModule {
 		bindModal(DrtCompanionRideGenerator.class).toProvider(
 				modalProvider(getter -> new DrtCompanionRideGenerator(
 					getMode(), //
-					getter.get(MainModeIdentifier.class), //
 					getter.getModal(FleetSpecification.class), //
 					getter.get(Scenario.class), //
 					this.drtWithExtensionsConfigGroup)))
@@ -58,8 +55,7 @@ public class DrtCompanionModule extends AbstractDvrpModeModule {
 			@Override
 			protected void configureQSim() {
 				bindModal(PassengerGroupIdentifier.class).toProvider(
-					modalProvider(getter -> new DrtCompanionGroupIdentifier(
-					getter.get(Population.class))));
+					modalProvider(getter -> new DrtCompanionGroupIdentifier()));
 			}
 		});
 	}

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionRideGenerator.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionRideGenerator.java
@@ -26,6 +26,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Activity;
+import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Plan;
 import org.matsim.contrib.common.util.WeightedRandomSelection;
@@ -38,7 +39,6 @@ import org.matsim.core.controler.events.BeforeMobsimEvent;
 import org.matsim.core.controler.listener.AfterMobsimListener;
 import org.matsim.core.controler.listener.BeforeMobsimListener;
 import org.matsim.core.population.PopulationUtils;
-import org.matsim.core.router.MainModeIdentifier;
 import org.matsim.core.router.TripStructureUtils;
 import org.matsim.utils.objectattributes.attributable.AttributesUtils;
 
@@ -56,31 +56,29 @@ final class DrtCompanionRideGenerator implements BeforeMobsimListener, AfterMobs
 	public static final String DRT_COMPANION_TYPE = "drtCompanion";
 	private final Scenario scenario;
 	private final String drtMode;
-	private final MainModeIdentifier mainModeIdentifier;
 	private final int maxCapacity;
 
 	private final Set<Id<Person>> companionAgentIds = new HashSet<>();
 	private WeightedRandomSelection<Integer> sampler;
 
-	private final Map<Id<PassengerGroupIdentifier.PassengerGroup>,List<GroupTrip>> passengerGroups = new HashMap<>();
+	private final Map<Id<PassengerGroupIdentifier.PassengerGroup>, List<GroupLeg>> passengerGroups = new HashMap<>();
 
 	private int passengerGroupIdentifier = 0; // Should be unique over the entire simulation
 
 	private final AtomicInteger personIdentifierSuffix = new AtomicInteger(0);
 
-	DrtCompanionRideGenerator(final String drtMode, final MainModeIdentifier mainModeIdentifier,
+	DrtCompanionRideGenerator(final String drtMode,
 							  final FleetSpecification fleet,
 							  final Scenario scenario,
 							  final DrtWithExtensionsConfigGroup drtWithExtensionsConfigGroup) {
 		this.scenario = scenario;
-		this.mainModeIdentifier = mainModeIdentifier;
 		this.drtMode = drtMode;
 		this.maxCapacity = fleet.getVehicleSpecifications()
-				.values()
-				.stream()
-				.mapToInt(DvrpVehicleSpecification::getCapacity)
-				.max()
-				.orElse(0);;
+			.values()
+			.stream()
+			.mapToInt(DvrpVehicleSpecification::getCapacity)
+			.max()
+			.orElse(0);
 		installSampler(drtWithExtensionsConfigGroup);
 	}
 
@@ -100,48 +98,48 @@ final class DrtCompanionRideGenerator implements BeforeMobsimListener, AfterMobs
 		}
 	}
 
-	private Id<PassengerGroupIdentifier.PassengerGroup> getGroupIdentifier()
-	{
+	private Id<PassengerGroupIdentifier.PassengerGroup> getGroupIdentifier() {
 		return Id.create(this.passengerGroupIdentifier, PassengerGroupIdentifier.PassengerGroup.class);
 	}
 
-	record GroupTrip(TripStructureUtils.Trip trip, Id<Person> personId) {}
+	record GroupLeg(Leg leg, Id<Person> personId) {
+	}
 
 	private void addCompanionAgents() {
 		Collection<Person> companions = new ArrayList<>();
 		for (Person person : this.scenario.getPopulation().getPersons().values()) {
 			for (TripStructureUtils.Trip trip : TripStructureUtils.getTrips(person.getSelectedPlan())) {
-				String mainMode = mainModeIdentifier.identifyMainMode(trip.getTripElements());
-				if (this.drtMode.equals(mainMode)) {
-					int additionalCompanions = sampler.select();
+				int additionalCompanions = sampler.select();
 
-					// Initial person travels now in a group
-					Id<PassengerGroupIdentifier.PassengerGroup> currentGroupIdentifier = getGroupIdentifier();
-					DrtCompanionUtils.setPassengerGroupIdentifier(person, currentGroupIdentifier);
+				for (Leg leg : trip.getLegsOnly()) {
+					if (leg.getMode().equals(this.drtMode)) {
+						// Initial person travels now in a group
+						Id<PassengerGroupIdentifier.PassengerGroup> currentGroupIdentifier = getGroupIdentifier();
+						DrtCompanionUtils.setPassengerGroupIdentifier(leg, currentGroupIdentifier);
 
-					// Add person to group map
-					this.passengerGroups.computeIfAbsent(currentGroupIdentifier, k-> new ArrayList<>()).add(new GroupTrip(trip,person.getId()));
+						// Add person to group map
+						this.passengerGroups.computeIfAbsent(currentGroupIdentifier, k -> new ArrayList<>()).add(new GroupLeg(leg, person.getId()));
 
-					int groupSize = additionalCompanions + 1;
-					int currentGroupSize = 1; // Initial person
+						int groupSize = additionalCompanions + 1;
+						int currentGroupSize = 1; // Initial person
 
-					// Add companions
-					for (int i = 0; i < additionalCompanions; i++) {
+						// Add companions
+						for (int i = 0; i < additionalCompanions; i++) {
 
-						// currentGroupSize+1 exceeds maxCapacity, create a new passengerGroupIdentifier
-						if(currentGroupSize+1>this.maxCapacity)
-						{
-							passengerGroupIdentifier++; // increment due to vehicle capacity
-							currentGroupSize=0;
-							currentGroupIdentifier = getGroupIdentifier();
+							// currentGroupSize+1 exceeds maxCapacity, create a new passengerGroupIdentifier
+							if (currentGroupSize + 1 > this.maxCapacity) {
+								passengerGroupIdentifier++; // increment due to vehicle capacity
+								currentGroupSize = 0;
+								currentGroupIdentifier = getGroupIdentifier();
+							}
+
+							// Bypass passengerGroupIdentifierId to each group member
+							companions.add(createCompanionAgent(this.drtMode, person, leg, trip.getOriginActivity(),
+								trip.getDestinationActivity(), i, groupSize, personIdentifierSuffix.getAndIncrement(), currentGroupIdentifier));
+							currentGroupSize++;
 						}
-
-						// Bypass passengerGroupIdentifierId to each group member
-						companions.add(createCompanionAgent(mainMode, person, trip, trip.getOriginActivity(),
-							trip.getDestinationActivity(), i, groupSize, personIdentifierSuffix.getAndIncrement(), currentGroupIdentifier));
-						currentGroupSize++;
+						passengerGroupIdentifier++; // increment due to a new leg
 					}
-					passengerGroupIdentifier++; // increment due to a new trip
 				}
 			}
 		}
@@ -156,47 +154,46 @@ final class DrtCompanionRideGenerator implements BeforeMobsimListener, AfterMobs
 
 	private void validateGroups() {
 		this.passengerGroups.values().forEach(g -> {
-			GroupTrip representative = g.get(0);
+			GroupLeg representative = g.get(0);
 
-			Id<Link> fromLinkId = PopulationUtils.decideOnLinkIdForActivity(
-				representative.trip.getOriginActivity(),scenario);
-			Id<Link> toLinkId = PopulationUtils.decideOnLinkIdForActivity(
-				representative.trip.getDestinationActivity(),scenario);
+			Id<Link> fromLinkId = representative.leg.getRoute().getStartLinkId();
+			Id<Link> toLinkId = representative.leg.getRoute().getEndLinkId();
 
 			Preconditions.checkNotNull(fromLinkId);
 			Preconditions.checkNotNull(toLinkId);
 
 			Preconditions.checkArgument(g.stream().allMatch(
-				a -> PopulationUtils.decideOnLinkIdForActivity(
-				a.trip.getOriginActivity(),scenario).equals(fromLinkId)));
+				a -> a.leg.getRoute().getStartLinkId().equals(fromLinkId)));
 
 			Preconditions.checkArgument(g.stream().allMatch(
-				a -> PopulationUtils.decideOnLinkIdForActivity(
-				a.trip.getDestinationActivity(),scenario).equals(toLinkId)));
+				a -> a.leg.getRoute().getEndLinkId().equals(toLinkId)));
 
 			Preconditions.checkArgument(g.size() <= this.maxCapacity);
 		});
 	}
 
-	private Person createCompanionAgent(final String drtMode, final Person originalPerson, final TripStructureUtils.Trip trip,
+	private Person createCompanionAgent(final String drtMode, final Person originalPerson, final Leg leg,
 										final Activity fromActivity, final Activity toActivity, final int groupPart, final int groupSize, final int personIdentifier, final Id<PassengerGroupIdentifier.PassengerGroup> passengerGroupIdentifierId) {
 		String prefix = getCompanionPrefix(drtMode);
 		String companionId = prefix + "_" + originalPerson.getId().toString() + "_" + personIdentifier;
 		Person person = PopulationUtils.getFactory().createPerson(Id.createPersonId(companionId));
+		Leg legCopy = PopulationUtils.createLeg(leg);
+
 		DrtCompanionUtils.setDRTCompanionType(person, DRT_COMPANION_TYPE);
 
 		// Copy attributes from person
 		AttributesUtils.copyAttributesFromTo(originalPerson, person);
+		AttributesUtils.copyAttributesFromTo(leg, legCopy); // bypass all leg attributes
 
 		// Ensure that we have a timed end
 		Activity copyFromActivity = PopulationUtils.createActivity(fromActivity);
 		if (copyFromActivity.getEndTime().isUndefined()) {
-			copyFromActivity.setEndTime(trip.getLegsOnly().get(0).getDepartureTime().seconds());
+			copyFromActivity.setEndTime(leg.getDepartureTime().seconds());
 		}
 
 		Plan plan = PopulationUtils.createPlan();
 		plan.getPlanElements().add(copyFromActivity);
-		plan.getPlanElements().addAll(trip.getTripElements());
+		plan.getPlanElements().add(legCopy);
 		plan.getPlanElements().add(toActivity);
 
 		person.addPlan(plan);
@@ -204,10 +201,10 @@ final class DrtCompanionRideGenerator implements BeforeMobsimListener, AfterMobs
 		// Add group information to trip
 		DrtCompanionUtils.setAdditionalGroupPart(person, groupPart);
 		DrtCompanionUtils.setAdditionalGroupSize(person, groupSize);
-		DrtCompanionUtils.setPassengerGroupIdentifier(person, passengerGroupIdentifierId);
+		DrtCompanionUtils.setPassengerGroupIdentifier(legCopy, passengerGroupIdentifierId);
 
 		// Add companion to group map
-		this.passengerGroups.computeIfAbsent(passengerGroupIdentifierId, k-> new ArrayList<>()).add(new GroupTrip(trip,person.getId()));
+		this.passengerGroups.computeIfAbsent(passengerGroupIdentifierId, k -> new ArrayList<>()).add(new GroupLeg(legCopy, person.getId()));
 		return person;
 	}
 

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionUtils.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionUtils.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.common.util.WeightedRandomSelection;
 import org.matsim.contrib.dvrp.passenger.PassengerGroupIdentifier;
@@ -79,11 +80,11 @@ public class DrtCompanionUtils {
 		}
 	}
 
-	public static Optional<Id<PassengerGroupIdentifier.PassengerGroup>> getPassengerGroupIdentifier(Person person) {
-		if (person.getAttributes().getAttribute(GROUP_IDENTIFIER_ATTRIBUTE) == null) {
+	public static Optional<Id<PassengerGroupIdentifier.PassengerGroup>> getPassengerGroupIdentifier(Leg leg) {
+		if (leg.getAttributes().getAttribute(GROUP_IDENTIFIER_ATTRIBUTE) == null) {
 			return Optional.empty();
 		} else {
-			return Optional.of(Id.create(person.getAttributes()
+			return Optional.of(Id.create(leg.getAttributes()
 				.getAttribute(GROUP_IDENTIFIER_ATTRIBUTE).toString(), PassengerGroupIdentifier.PassengerGroup.class));
 		}
 	}
@@ -104,8 +105,8 @@ public class DrtCompanionUtils {
 		person.getAttributes().putAttribute(ADDITIONAL_GROUP_PART_ATTRIBUTE, additionalgroupPart);
 	}
 
-	public static void setPassengerGroupIdentifier(Person person, Id<PassengerGroupIdentifier.PassengerGroup> passengerGroupIdentifierId ) {
-		person.getAttributes().putAttribute(GROUP_IDENTIFIER_ATTRIBUTE, passengerGroupIdentifierId);
+	public static void setPassengerGroupIdentifier(Leg leg, Id<PassengerGroupIdentifier.PassengerGroup> passengerGroupIdentifierId ) {
+		leg.getAttributes().putAttribute(GROUP_IDENTIFIER_ATTRIBUTE, passengerGroupIdentifierId);
 	}
 
 }


### PR DESCRIPTION
This PR moves the PassengerGroupIdentifier information (stored in attributes) from the person level to the leg level. This is necessary, because an agent might travel with drt multiple times a day with different groups of companions. Each group needs to have its own PassengerGroupIdentifier.