### PR TITLE
Clear PassengerGroupIdentifier (DrtCompanion)

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionRideGenerator.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionRideGenerator.java
@@ -57,8 +57,8 @@ final class DrtCompanionRideGenerator implements BeforeMobsimListener, AfterMobs
 	private final Scenario scenario;
 	private final String drtMode;
 	private final int maxCapacity;
-
 	private final Set<Id<Person>> companionAgentIds = new HashSet<>();
+	private final Set<Leg> drtLegs = new HashSet<>();
 	private WeightedRandomSelection<Integer> sampler;
 
 	private final Map<Id<PassengerGroupIdentifier.PassengerGroup>, List<GroupLeg>> passengerGroups = new HashMap<>();
@@ -113,6 +113,7 @@ final class DrtCompanionRideGenerator implements BeforeMobsimListener, AfterMobs
 
 				for (Leg leg : trip.getLegsOnly()) {
 					if (leg.getMode().equals(this.drtMode)) {
+						this.drtLegs.add(leg);
 						// Initial person travels now in a group
 						Id<PassengerGroupIdentifier.PassengerGroup> currentGroupIdentifier = getGroupIdentifier();
 						DrtCompanionUtils.setPassengerGroupIdentifier(leg, currentGroupIdentifier);
@@ -221,6 +222,10 @@ final class DrtCompanionRideGenerator implements BeforeMobsimListener, AfterMobs
 		passengerGroups.clear();
 		personIdentifierSuffix.set(0);
 		LOG.info("Removed # {} drt companion agents", counter);
+
+		// Remove attribute from legs of initial drt riders
+		this.drtLegs.stream().forEach(DrtCompanionUtils::removePassengerGroupIdentifier);
+		this.drtLegs.clear();
 	}
 
 	@Override

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionUtils.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/companions/DrtCompanionUtils.java
@@ -109,4 +109,9 @@ public class DrtCompanionUtils {
 		leg.getAttributes().putAttribute(GROUP_IDENTIFIER_ATTRIBUTE, passengerGroupIdentifierId);
 	}
 
+	public static void removePassengerGroupIdentifier(Leg leg)
+	{
+		leg.getAttributes().removeAttribute(GROUP_IDENTIFIER_ATTRIBUTE);
+	}
+
 }


### PR DESCRIPTION
PR ensures that old PassengerGroupIdentifiers of initial rider legs are cleaned after each simulation.