### PR TITLE
Add method to remove DisallowedNextLinks attribute from link

### DIFF
--- a/matsim/src/main/java/org/matsim/core/network/NetworkUtils.java
+++ b/matsim/src/main/java/org/matsim/core/network/NetworkUtils.java
@@ -1018,4 +1018,8 @@ public final class NetworkUtils {
 		DisallowedNextLinks disallowedNextLinks = getOrCreateDisallowedNextLinks(link);
 		return disallowedNextLinks.addDisallowedLinkSequence(mode, linkIds);
 	}
+	
+	public static void removeDisallowedNextLinks(Link link) {
+		link.getAttributes().removeAttribute(DISALLOWED_NEXT_LINKS_ATTRIBUTE);
+	}
 }


### PR DESCRIPTION
There was no method to remove a `DisallowedNextLinks` attribute from a link. Now there is.