### PR TITLE
fix(drt): scheduling a same-index insertion before a prebooked request

### DIFF
--- a/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/edrt/run/RunEDrtScenarioIT.java
+++ b/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/edrt/run/RunEDrtScenarioIT.java
@@ -109,10 +109,10 @@ public class RunEDrtScenarioIT {
 
 		controller.run();
 
-		assertEquals(74, tracker.immediateScheduled);
-		assertEquals(198, tracker.prebookedScheduled);
-		assertEquals(116, tracker.immediateRejected);
-		assertEquals(7, tracker.prebookedRejected);
+		assertEquals(112, tracker.immediateScheduled);
+		assertEquals(182, tracker.prebookedScheduled);
+		assertEquals(94, tracker.immediateRejected);
+		assertEquals(23, tracker.prebookedRejected);
 	}
 
 	static private class PassengerPickUpTracker implements PassengerPickedUpEventHandler {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
@@ -313,8 +313,13 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 			// prebooking case when we are already at the stop location, but next stop task happens in the future
 			Task afterPickupTask = insertWait(vehicleEntry.vehicle, pickupStopTask, nextBeginTime);
 
-			scheduleTimingUpdater.updateTimingsStartingFromTaskIdx(vehicleEntry.vehicle, afterPickupTask.getTaskIdx() + 1,
-					afterPickupTask.getEndTime());
+			// update timings
+			if (pickupIdx != dropoffIdx) {
+				// update schedule when inserting the dropoff, otherwise we will illegally shift
+				// the begin time of a following prebooked stop if there is one
+				scheduleTimingUpdater.updateTimingsStartingFromTaskIdx(vehicleEntry.vehicle, afterPickupTask.getTaskIdx() + 1,
+						afterPickupTask.getEndTime());
+			}
 		} else {
 			VrpPathWithTravelData vrpPath = VrpPaths.createPath(request.getFromLink(), toLink, pickupStopTask.getEndTime(),
 					detourData.detourFromPickup, travelTime);
@@ -323,9 +328,12 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 			Task afterPickupTask = insertDriveWithWait(vehicleEntry.vehicle, pickupStopTask, vrpPath, nextBeginTime);
 
 			// update timings
-			// TODO should be enough to update the timeline only till dropoffIdx...
-			scheduleTimingUpdater.updateTimingsStartingFromTaskIdx(vehicleEntry.vehicle, afterPickupTask.getTaskIdx() + 1,
-					afterPickupTask.getEndTime());
+			if (pickupIdx != dropoffIdx) {
+				// update schedule when inserting the dropoff, otherwise we will illegally shift
+				// the begin time of a following prebooked stop if there is one
+				scheduleTimingUpdater.updateTimingsStartingFromTaskIdx(vehicleEntry.vehicle, afterPickupTask.getTaskIdx() + 1,
+						afterPickupTask.getEndTime());
+			}
 		}
 
 		return pickupStopTask;

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/prebooking/PrebookingTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/prebooking/PrebookingTest.java
@@ -207,8 +207,8 @@ public class PrebookingTest {
 		{
 			RequestInfo requestInfo = environment.getRequestInfo().get("lateRequest");
 			assertEquals(0.0, requestInfo.submissionTime, 1e-3);
-			assertEquals(4000.0 + 60.0, requestInfo.pickupTime, 1e-3);
-			assertEquals(4103.0, requestInfo.dropoffTime, 1e-3);
+			assertEquals(4000.0 + 60.0 + 1.0, requestInfo.pickupTime, 1e-3);
+			assertEquals(4104.0, requestInfo.dropoffTime, 1e-3);
 		}
 	}
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/run/examples/RunDrtExampleIT.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/run/examples/RunDrtExampleIT.java
@@ -342,17 +342,17 @@ public class RunDrtExampleIT {
 
 		controller.run();
 
-		assertEquals(157, tracker.immediateScheduled);
+		assertEquals(169, tracker.immediateScheduled);
 		assertEquals(205, tracker.prebookedScheduled);
-		assertEquals(26, tracker.immediateRejected);
+		assertEquals(14, tracker.immediateRejected);
 		assertEquals(0, tracker.prebookedRejected);
 
 		var expectedStats = Stats.newBuilder()
-				.rejectionRate(0.07)
-				.rejections(26)
-				.waitAverage(232.76)
-				.inVehicleTravelTimeMean(389.09)
-				.totalTravelTimeMean(621.85)
+				.rejectionRate(0.04)
+				.rejections(14)
+				.waitAverage(232.45)
+				.inVehicleTravelTimeMean(388.99)
+				.totalTravelTimeMean(621.44)
 				.build();
 
 		verifyDrtCustomerStatsCloseToExpectedStats(utils.getOutputDirectory(), expectedStats);


### PR DESCRIPTION
There has been a bug when scheduling an insertion that has the same pickup and dropoff index (new dropoff directly following the new pickup along the stop sequence) just before a task with a prebooked pick-up. In that case, the *begin time* of the following pick-up task was illegally shifted to the past, or otherwise put, the fixed begin time of the prebooked task was not kept constant, thus blocking the vehicle for an unnecessary long time in a stop task. This PR fixes this issue, the performance of the prebooking scenario improves in the tests. 