### PR TITLE
fix(drt): missing insertions for prebooking

### DIFF
--- a/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/insertion/DrtInsertionExtensionIT.java
+++ b/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/insertion/DrtInsertionExtensionIT.java
@@ -283,7 +283,7 @@ public class DrtInsertionExtensionIT {
 		}
 
 		assertEquals(1470, distanceCalculator.calculatedDistances);
-		assertEquals(5288, distanceApproximator.calculatedDistances);
+		assertEquals(5280, distanceApproximator.calculatedDistances);
 	}
 
 	@Test
@@ -319,7 +319,7 @@ public class DrtInsertionExtensionIT {
 		}
 
 		assertEquals(1470, distanceCalculator.calculatedDistances);
-		assertEquals(5288, distanceApproximator.calculatedDistances);
+		assertEquals(5280, distanceApproximator.calculatedDistances);
 	}
 
 	static class CustomDistanceCalculator extends CustomCalculator {
@@ -464,9 +464,9 @@ public class DrtInsertionExtensionIT {
 		controller.run();
 
 		assertEquals(22, handler.rejectedRequests);
-		assertEquals(2066658.0, handler.fleetDistance, 1e-3);
-		assertEquals(694149.0, handler.activeTime(), 1e-3);
-		assertEquals(280.61475, handler.meanWaitTime(), 1e-3);
+		assertEquals(2070663.0, handler.fleetDistance, 1e-3);
+		assertEquals(699076.0, handler.activeTime(), 1e-3);
+		assertEquals(279.37704, handler.meanWaitTime(), 1e-3);
 	}
 
 	@Test

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGenerator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGenerator.java
@@ -186,7 +186,8 @@ public class InsertionGenerator {
 					// task here on the same link (maybe a pickup followed by its dropoff) but much
 					// earlier. In that case it is actually a valid insertion.
 
-					if (drtRequest.getEarliestStartTime() < nextStop.getArrivalTime()) {
+					boolean viableSameLink = vEntry.getPrecedingStayTime(i) > 0.0;
+					if (viableSameLink && drtRequest.getEarliestStartTime() < nextStop.getArrivalTime()) {
 						// the new request wants to depart before the start of the next stop, which may
 						// be a viable insertion. Note that if the requested wanted to depart after the
 						// start of the next stop, but before its end, this is a special case that is
@@ -235,6 +236,16 @@ public class InsertionGenerator {
 				addInsertion(insertions,
 						createInsertionWithDetourData(request, vEntry, pickupInsertion, fromPickupTT, pickupDetourInfo,
 								j));
+			} else {
+				// special case: inserting dropoff before prebooked task on the same link
+				// see the reasoning in generateInsertions
+				
+				boolean viableSameLink = vEntry.getPrecedingStayTime(j) > 0.0;
+				if (viableSameLink && earliestPickupStartTime + fromPickupTT < nextStop(vEntry, j).getArrivalTime()) {
+					addInsertion(insertions,
+							createInsertionWithDetourData(request, vEntry, pickupInsertion, fromPickupTT, pickupDetourInfo,
+									j));
+				}
 			}
 		}
 
@@ -274,6 +285,16 @@ public class InsertionGenerator {
 				addInsertion(insertions,
 						createInsertionWithDetourData(request, vEntry, pickupInsertion, fromPickupTT, pickupDetourInfo,
 								j));
+			} else {
+				// special case: inserting dropoff before prebooked task on the same link
+				// see the reasoning in generateInsertions
+				
+				boolean viableSameLink = vEntry.getPrecedingStayTime(j) > 0.0;
+				if (viableSameLink && earliestPickupStartTime + fromPickupTT < nextStop(vEntry, j).getArrivalTime()) {
+					addInsertion(insertions,
+							createInsertionWithDetourData(request, vEntry, pickupInsertion, fromPickupTT, pickupDetourInfo,
+									j));
+				}
 			}
 		}
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
@@ -378,7 +378,8 @@ public class InsertionGeneratorTest {
 		Waypoint.Start start = new Waypoint.Start(null, link("start"), 0, 0);
 		Waypoint.Stop stop0 = stop(200, fromLink, 1);
 		Waypoint.Stop stop1 = stop(400, link("stop"), 0);
-		VehicleEntry entry = entry(start, stop0, stop1);
+		List<Double> precedingStayTimes = Arrays.asList(100.0, 0.0);
+		VehicleEntry entry = entry(start, precedingStayTimes, stop0, stop1);
 		assertInsertionsOnly(drtRequest, entry,
 			new Insertion(drtRequest, entry, 0, 0),
 			new Insertion(drtRequest, entry, 0, 1),
@@ -524,9 +525,13 @@ public class InsertionGeneratorTest {
 	}
 
 	private VehicleEntry entry(Waypoint.Start start, Waypoint.Stop... stops) {
+		List<Double> precedingStayTimes = Collections.nCopies(stops.length, 0.0);
+		return entry(start, precedingStayTimes, stops);
+	}
+	
+	private VehicleEntry entry(Waypoint.Start start, List<Double> precedingStayTimes, Waypoint.Stop... stops) {
 		var slackTimes = new double[stops.length + 2];
 		Arrays.fill(slackTimes, Double.POSITIVE_INFINITY);
-		List<Double> precedingStayTimes = Collections.nCopies(stops.length, 0.0);
 		return new VehicleEntry(vehicle, start, ImmutableList.copyOf(stops), slackTimes, precedingStayTimes, 0);
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/run/examples/RunDrtExampleIT.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/run/examples/RunDrtExampleIT.java
@@ -304,16 +304,12 @@ public class RunDrtExampleIT {
 
 		controller.run();
 
-		// sh, 11/08/2023: updated after introducing prebookg, basically we generate a
-		// new feasible insertion (see InsertionGenerator) that previously did not
-		// exist, but has the same cost (pickup loss + drop-off loss) as the original
-		// one
 		var expectedStats = Stats.newBuilder()
 				.rejectionRate(0.04)
 				.rejections(16)
-				.waitAverage(278.76)
-				.inVehicleTravelTimeMean(384.93)
-				.totalTravelTimeMean(663.68)
+				.waitAverage(278.92)
+				.inVehicleTravelTimeMean(384.6)
+				.totalTravelTimeMean(663.52)
 				.build();
 
 		verifyDrtCustomerStatsCloseToExpectedStats(utils.getOutputDirectory(), expectedStats);
@@ -350,9 +346,9 @@ public class RunDrtExampleIT {
 		var expectedStats = Stats.newBuilder()
 				.rejectionRate(0.04)
 				.rejections(14)
-				.waitAverage(232.45)
-				.inVehicleTravelTimeMean(388.99)
-				.totalTravelTimeMean(621.44)
+				.waitAverage(232.47)
+				.inVehicleTravelTimeMean(389.16)
+				.totalTravelTimeMean(621.63)
 				.build();
 
 		verifyDrtCustomerStatsCloseToExpectedStats(utils.getOutputDirectory(), expectedStats);


### PR DESCRIPTION
Some rare insertions were missing when working with prebooking. These are insertions in which a request would be integrated in the stop sequence and where the *destination* of the new request equals the *origin* of a prebooked request before which it is supposed to be inserted. See `PrebookingTest::destinationEqualsPrebookedOrigin_*`.