### PR TITLE
feat: define which EV to charge during activities

### DIFF
--- a/contribs/vsp/src/main/java/playground/vsp/ev/README.md
+++ b/contribs/vsp/src/main/java/playground/vsp/ev/README.md
@@ -19,6 +19,8 @@ and if there is a charger on the home link, it does not search for a suitable ac
 The final SoC at the end of the iteration is maintained and transferred as the initial SoC to the next iteration. 
 
 For this to work, vehicles that represent an EV need to be attached to a vehicle type that is tagged as EV by providing a specific attribute (see `MATSimVehicleWrappingEVSpecificationProvider.class`).
+By default, _all_ of these (electric) vehicles are planned by to potentially get charged according to the above described logic.
+However, one can prevent this on the vehicle level by `UrbanEVUtils.setChargingDuringActivities(vehicle, false)` when defining the input. 
 
 ## A few notes to the current state of this package (and it's issues and TODOs)
 

--- a/contribs/vsp/src/main/java/playground/vsp/ev/UrbanEVModule.java
+++ b/contribs/vsp/src/main/java/playground/vsp/ev/UrbanEVModule.java
@@ -20,6 +20,8 @@
 
 package playground.vsp.ev;
 
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import org.matsim.contrib.ev.EvModule;
 import org.matsim.contrib.ev.charging.ChargingModule;
 import org.matsim.contrib.ev.discharging.DischargingModule;
@@ -31,9 +33,6 @@ import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.groups.ScoringConfigGroup;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
-
-import com.google.inject.Inject;
-import com.google.inject.Singleton;
 import org.matsim.core.mobsim.qsim.components.QSimComponentsConfigGroup;
 
 public class UrbanEVModule extends AbstractModule {
@@ -47,13 +46,6 @@ public class UrbanEVModule extends AbstractModule {
 		QSimComponentsConfigGroup qsimComponentsConfig = ConfigUtils.addOrGetModule( config, QSimComponentsConfigGroup.class );
 		qsimComponentsConfig.addActiveComponent( EvModule.EV_COMPONENT );
 
-//		UrbanEVConfigGroup urbanEVConfig = ConfigUtils.addOrGetModule( config, UrbanEVConfigGroup.class );
-
-//		if (urbanEVConfig == null)
-//			throw new IllegalArgumentException(
-//					"no config group of type " + UrbanEVConfigGroup.GROUP_NAME + " was specified in the config");
-		// was this meaningful?  I.e. do we want the code to fail if there is no such config group?  kai, apr'23
-
 		//standard EV stuff
 		install(new ChargingInfrastructureModule());
 		install(new ChargingModule());
@@ -62,7 +54,6 @@ public class UrbanEVModule extends AbstractModule {
 		install(new ElectricFleetModule());
 
 		//bind custom EVFleet stuff
-//		bind(ElectricFleetUpdater.class).in(Singleton.class);
 		addControlerListenerBinding().to(ElectricFleetUpdater.class).in( Singleton.class );
 		// (this takes the matsim modal vehicles for each leg and gives them to the ElectricFleetSpecification.  Don't know why it has to be in
 		// this ad-hoc way.  kai, apr'23)
@@ -74,20 +65,13 @@ public class UrbanEVModule extends AbstractModule {
 //				bind(UrbanVehicleChargingHandler.class);
 				addMobsimScopeEventHandlerBinding().to(UrbanVehicleChargingHandler.class);
 				// (I think that this takes the plugin/plugout activities, and actually initiates the charging.  kai, apr'23)
+				// yes it does, just like the regular VehicleChargingHandler in the ev contrib. schlenther, feb'24.
 			}
 		});
 
 		//bind urban ev planning stuff
 		addMobsimListenerBinding().to(UrbanEVTripsPlanner.class);
 		// (I think that this inserts the charging activities just before the mobsim starts (i.e. it is not in the plans).  kai, apr'23)
-
-		//TODO find a better solution for this yyyy yes.  We do not want automagic.  kai, apr'23  done.  kai, apr'23
-//		Collection<String> whileChargingActTypes = urbanEVConfig.getWhileChargingActivityTypes().isEmpty() ?
-//				config.planCalcScore().getActivityTypes() :
-//				urbanEVConfig.getWhileChargingActivityTypes();
-
-//		bind(ActivityWhileChargingFinder.class).toInstance(new ActivityWhileChargingFinder(whileChargingActTypes,
-//				urbanEVConfig.getMinWhileChargingActivityDuration_s()));
 
 		bind( ActivityWhileChargingFinder.class ).in( Singleton.class );
 
@@ -97,17 +81,5 @@ public class UrbanEVModule extends AbstractModule {
 		addEventHandlerBinding().to(ActsWhileChargingAnalyzer.class).in(Singleton.class);
 		addControlerListenerBinding().to(ActsWhileChargingAnalyzer.class);
 	}
-
-//	private Set<String> getOpenBerlinActivityTypes() {
-//		Set<String> activityTypes = new HashSet<>();
-//		for (long ii = 600; ii <= 97200; ii += 600) {
-//			activityTypes.add("home_" + ii + ".0");
-//			activityTypes.add("work_" + ii + ".0");
-//			activityTypes.add("leisure_" + ii + ".0");
-//			activityTypes.add("shopping_" + ii + ".0");
-//			activityTypes.add("other_" + ii + ".0");
-//		}
-//		return activityTypes;
-//	}
 
 }

--- a/contribs/vsp/src/main/java/playground/vsp/ev/UrbanEVUtils.java
+++ b/contribs/vsp/src/main/java/playground/vsp/ev/UrbanEVUtils.java
@@ -1,0 +1,67 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * Controler.java
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2007 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package playground.vsp.ev;
+
+import org.matsim.contrib.ev.fleet.ElectricVehicleSpecification;
+import org.matsim.vehicles.Vehicle;
+
+public final class UrbanEVUtils {
+
+	public static final String PLAN_CHARGING_DURING_ACTS_ATTRIBUTE_NAME = "planChargingDuringActivities";
+
+	/**
+	 * Checks whether {@code electricVehicleSpecification} should be charged during the drivers' activities. <br>
+	 * If this is the case, [@code {@link UrbanEVTripsPlanner} will pre-plan charging according to the driver's selected plan. <br>
+	 * <p>
+	 * Checks for the corresponding attribute with key={@code PLAN_CHARGING_DURING_ACTS_ATTRIBUTE_NAME} in the MATSim input vehicle.
+	 * <b>If the attribute was not provided, true is returned!</b>
+	 * This means that by default, <i>all</i> electricVehicleSpecifications are planned to get charged during activities and not during trips
+	 * (planning for the latter is done by {@code org.matsim.contrib.ev.routing.EVNetworkRoutingModule}.
+	 * </p>
+	 * @param electricVehicleSpecification
+	 * @return
+	 */
+	public static boolean isChargingDuringActivities(ElectricVehicleSpecification electricVehicleSpecification) {
+		Object attribute = electricVehicleSpecification.getMatsimVehicle().getAttributes().getAttribute(PLAN_CHARGING_DURING_ACTS_ATTRIBUTE_NAME);
+		return attribute == null ? true : (Boolean) attribute;
+	}
+
+	/**
+	 * see description for {@code setChargingDuringActivities(Vehicle vehicle, boolean value)}
+	 * @param electricVehicleSpecification
+	 * @param value
+	 */
+	public static void setChargingDuringActivities(ElectricVehicleSpecification electricVehicleSpecification, boolean value) {
+		setChargingDuringActivities(electricVehicleSpecification.getMatsimVehicle(), value);
+	}
+
+	/**
+	 * defines whether the vehicle shall be included for planning recharging during the driver's activities (with {@code UrbanEVTripsPlanner}, or not. <br>
+	 * In the latter case, recharging may be planned to take place during a trip, if the vehicle is taken for a trip with a mode that is
+	 * routed by {@code org.matsim.contrib.ev.routing.EVNetworkRoutingModule}.
+	 * @param vehicle
+	 * @param value
+	 */
+	public static void setChargingDuringActivities(Vehicle vehicle, boolean value) {
+		vehicle.getAttributes().putAttribute(PLAN_CHARGING_DURING_ACTS_ATTRIBUTE_NAME, value);
+	}
+
+}


### PR DESCRIPTION
This PR adds the feature to define for which EV pre-planning for charging _during_ the drivers' activities should take place (as opposed to charging during a trip like it's done by the `EVNetworkRoutingModule`).
The definition is simply added as an `Vehicle` attribute.
Corresponding setters and getters are provided in the newly introduced `UrbanEVUtils`.
By default, it is assumed that all EV shall be replanned by the `UrbanEVTripsPlanner`, i.e. all EV shall be charged during activities and not legs. This default is set as, this behavior needs to be enabled by configuring the `UrbanEVModule` in the first place.
A corresponding test is included in `UrbanEVTests`.