### PR TITLE
Extend Shp Index with query methods for other datatypes

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/options/ShpOptions.java
+++ b/contribs/application/src/main/java/org/matsim/application/options/ShpOptions.java
@@ -341,13 +341,27 @@ public final class ShpOptions {
 		}
 
 		/**
-		 * Query the index for first feature including a certain point.
+		 * Query the index for first feature including matching the coordinate and return specified attribute.
 		 *
 		 * @return null when no features was found that contains the point
 		 */
 		@Nullable
 		@SuppressWarnings("unchecked")
-		public String query(Coord coord) {
+		public <T> T query(Coord coord) {
+			SimpleFeature ft = queryFeature(coord);
+			if (ft != null)
+				return (T) ft.getAttribute(attr);
+
+			return null;
+			// throw new NoSuchElementException(String.format("No matching entry found for x:%f y:%f %s", x, y, p));
+		}
+
+		/**
+		 * Query the index and return the whole feature.
+		 */
+		@Nullable
+		@SuppressWarnings("unchecked")
+		public SimpleFeature queryFeature(Coord coord) {
 			// Because we can not easily transform the feature geometry with MATSim we have to do it the other way around...
 			Coordinate p = MGC.coord2Coordinate(ct.transform(coord));
 
@@ -355,16 +369,16 @@ public final class ShpOptions {
 			for (SimpleFeature ft : result) {
 				Geometry geom = (Geometry) ft.getDefaultGeometry();
 				if (geom.contains(MGC.coordinate2Point(p)))
-					return (String) ft.getAttribute(attr);
+					return ft;
 			}
 
 			return null;
-			// throw new NoSuchElementException(String.format("No matching entry found for x:%f y:%f %s", x, y, p));
 		}
 
 		/**
 		 * Checks whether a coordinate is contained in any of the features.
 		 */
+		@SuppressWarnings("unchecked")
 		public boolean contains(Coord coord) {
 
 			Coordinate p = MGC.coord2Coordinate(ct.transform(coord));

--- a/contribs/application/src/test/java/org/matsim/application/options/ShpOptionsTest.java
+++ b/contribs/application/src/test/java/org/matsim/application/options/ShpOptionsTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.locationtech.jts.geom.Geometry;
+import org.matsim.api.core.v01.Coord;
 import org.matsim.testcases.MatsimTestUtils;
 import org.opengis.feature.simple.SimpleFeature;
 
@@ -39,6 +40,30 @@ public class ShpOptionsTest {
 		assertThat(ft)
 				.isNotEmpty();
 
+	}
+
+	@Test
+	void get() {
+
+		Path input = Path.of(utils.getClassInputDirectory()
+				.replace("ShpOptionsTest", "CreateLandUseShpTest")
+				.replace("options", "prepare"))
+			.resolve("andorra-latest-free.shp.zip");
+
+		Assumptions.assumeTrue(Files.exists(input));
+
+		ShpOptions shp = new ShpOptions(input, null, null);
+
+		ShpOptions.Index index = shp.createIndex(shp.getShapeCrs(), "name");
+
+		SimpleFeature result = index.queryFeature(new Coord(1.5333461, 42.555388));
+
+		assertThat(result)
+			.isNotNull();
+
+		String name = index.query(new Coord(1.5333461, 42.555388));
+		assertThat(name)
+			.isEqualTo("Museu de la Miniatura");
 	}
 
 	@Test


### PR DESCRIPTION
Shp Index could only be queried for String attributes, now other datatypes are possible as well.