### PR TITLE
Migrate from Java 17 to 21

### DIFF
--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'zulu'
           cache: 'maven'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'zulu'
           cache: 'maven'
 

--- a/.github/workflows/deploy-on-pr-merge.yaml
+++ b/.github/workflows/deploy-on-pr-merge.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'zulu'
           cache: 'maven'
           server-id: 'matsim-releases'

--- a/.github/workflows/deploy-on-release-created.yaml
+++ b/.github/workflows/deploy-on-release-created.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'zulu'
           cache: 'maven'
           server-id: matsim-releases

--- a/.github/workflows/deploy-weekly.yaml
+++ b/.github/workflows/deploy-weekly.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'zulu'
           cache: 'maven'
           server-id: 'matsim-releases'

--- a/.github/workflows/full-integration.yaml
+++ b/.github/workflows/full-integration.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'zulu'
           cache: 'maven'
 

--- a/.github/workflows/verify-push.yaml
+++ b/.github/workflows/verify-push.yaml
@@ -86,7 +86,7 @@ jobs:
         if: ${{matrix.module != 'matsim' || steps.detect-changes.outputs.outside-contribs == 'true'}}
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'zulu'
           cache: 'maven'
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
         <argLine></argLine>
 
         <log4j.version>2.23.0</log4j.version>


### PR DESCRIPTION
Java 21 LTS has now been release for 6 months, which may be a good time to see if we can start upgrading to Java 21. This PR tests that by updating the `pom.xml` and the GitHub Actions workflows to use Java 21 LTS instead of Java 17 LTS.

The previous Java upgrade was done and discussed here:
- #2043

Potentially interesting articles:

- [Upgrading From Java 17 To 21: All You Need To Know](https://nipafx.dev/road-to-21-upgrade/)
- [What’s New Between Java 17 and Java 21?](https://mydeveloperplanet.com/2023/11/01/whats-new-between-java-17-and-java-21/)

New features in JDK 18, 19, 20 and 21 are:

> #### [JDK 18](https://openjdk.org/projects/jdk/18/)
> - 400:	[UTF-8 by Default](https://openjdk.org/jeps/400)
> - 408:	[Simple Web Server](https://openjdk.org/jeps/408)
> - 413:	[Code Snippets in Java API Documentation](https://openjdk.org/jeps/413)
> - 416:	[Reimplement Core Reflection with Method Handles](https://openjdk.org/jeps/416)
> - 417:	[Vector API (Third Incubator)](https://openjdk.org/jeps/417)
> - 418:	[Internet-Address Resolution SPI](https://openjdk.org/jeps/418)
> - 419:	[Foreign Function & Memory API (Second Incubator)](https://openjdk.org/jeps/419)
> - 420:	[Pattern Matching for switch (Second Preview)](https://openjdk.org/jeps/420)
> - 421:	[Deprecate Finalization for Removal](https://openjdk.org/jeps/421)
> 
> #### [JDK 19](https://openjdk.org/projects/jdk/19)
> - 405:	[Record Patterns (Preview)](https://openjdk.org/jeps/405)
> - 422:	[Linux/RISC-V Port](https://openjdk.org/jeps/422)
> - 424:	[Foreign Function & Memory API (Preview)](https://openjdk.org/jeps/424)
> - 425:	[Virtual Threads (Preview)](https://openjdk.org/jeps/425)
> - 426:	[Vector API (Fourth Incubator)](https://openjdk.org/jeps/426)
> - 427:	[Pattern Matching for switch (Third Preview)](https://openjdk.org/jeps/427)
> - 428:	[Structured Concurrency (Incubator)](https://openjdk.org/jeps/428)
> 
> #### [JDK 20](https://openjdk.org/projects/jdk/20)
> - 429:	[Scoped Values (Incubator)](https://openjdk.org/jeps/429)
> - 432:	[Record Patterns (Second Preview)](https://openjdk.org/jeps/432)
> - 433:	[Pattern Matching for switch (Fourth Preview)](https://openjdk.org/jeps/433)
> - 434:	[Foreign Function & Memory API (Second Preview)](https://openjdk.org/jeps/434)
> - 436:	[Virtual Threads (Second Preview)](https://openjdk.org/jeps/436)
> - 437:	[Structured Concurrency (Second Incubator)](https://openjdk.org/jeps/437)
> - 438:	[Vector API (Fifth Incubator)](https://openjdk.org/jeps/438)
> 
> #### [JDK 21](https://openjdk.org/projects/jdk/21/)
> - 430:	[String Templates (Preview)](https://openjdk.org/jeps/430)
> - 431:	[Sequenced Collections](https://openjdk.org/jeps/431)
> - 439:	[Generational ZGC](https://openjdk.org/jeps/439)
> - 440:	[Record Patterns](https://openjdk.org/jeps/440)
> - 441:	[Pattern Matching for switch](https://openjdk.org/jeps/441)
> - 442:	[Foreign Function & Memory API (Third Preview)](https://openjdk.org/jeps/442)
> - 443:	[Unnamed Patterns and Variables (Preview)](https://openjdk.org/jeps/443)
> - 444:	[Virtual Threads](https://openjdk.org/jeps/444)
> - 445:	[Unnamed Classes and Instance Main Methods (Preview)](https://openjdk.org/jeps/445)
> - 446:	[Scoped Values (Preview)](https://openjdk.org/jeps/446)
> - 448:	[Vector API (Sixth Incubator)](https://openjdk.org/jeps/448)
> - 449:	[Deprecate the Windows 32-bit x86 Port for Removal](https://openjdk.org/jeps/449)
> - 451:	[Prepare to Disallow the Dynamic Loading of Agents](https://openjdk.org/jeps/451)
> - 452:	[Key Encapsulation Mechanism API](https://openjdk.org/jeps/452)
> - 453:	[Structured Concurrency (Preview)](https://openjdk.org/jeps/453)