### PR TITLE
account for group bookings in customer stats

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/dashboards/DrtAnalysisPostProcessing.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/dashboards/DrtAnalysisPostProcessing.java
@@ -119,7 +119,7 @@ public final class DrtAnalysisPostProcessing implements MATSimAppCommand {
 	}
 
 	private static void printDemandKPICSV(Table customerStats, Table tableSupplyKPI, Path output) throws IOException {
-		double rides = getLastDoubleValue(customerStats, "rides_requests");
+		double rides = getLastDoubleValue(customerStats, "rides");
 		double rejections = getLastDoubleValue(customerStats, "rejections");
 		double requests = rides + rejections;
 
@@ -180,7 +180,7 @@ public final class DrtAnalysisPostProcessing implements MATSimAppCommand {
 		Path customerStatsPath = ApplicationUtils.matchInput("drt_customer_stats_" + drtMode + ".csv", input.getRunDirectory());
 		Table customerStats = Table.read().csv(CsvReadOptions.builder(customerStatsPath.toFile())
 			.columnTypesPartial(Map.of(
-				"rides_requests", ColumnType.DOUBLE,
+				"rides", ColumnType.DOUBLE,
 				"wait_average", ColumnType.DOUBLE,
 				"wait_p95", ColumnType.DOUBLE,
 				"inVehicleTravelTime_mean", ColumnType.DOUBLE,

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/dashboards/DrtAnalysisPostProcessing.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/dashboards/DrtAnalysisPostProcessing.java
@@ -119,7 +119,7 @@ public final class DrtAnalysisPostProcessing implements MATSimAppCommand {
 	}
 
 	private static void printDemandKPICSV(Table customerStats, Table tableSupplyKPI, Path output) throws IOException {
-		double rides = getLastDoubleValue(customerStats, "rides");
+		double rides = getLastDoubleValue(customerStats, "rides_requests");
 		double rejections = getLastDoubleValue(customerStats, "rejections");
 		double requests = rides + rejections;
 
@@ -180,7 +180,7 @@ public final class DrtAnalysisPostProcessing implements MATSimAppCommand {
 		Path customerStatsPath = ApplicationUtils.matchInput("drt_customer_stats_" + drtMode + ".csv", input.getRunDirectory());
 		Table customerStats = Table.read().csv(CsvReadOptions.builder(customerStatsPath.toFile())
 			.columnTypesPartial(Map.of(
-				"rides", ColumnType.DOUBLE,
+				"rides_requests", ColumnType.DOUBLE,
 				"wait_average", ColumnType.DOUBLE,
 				"wait_p95", ColumnType.DOUBLE,
 				"inVehicleTravelTime_mean", ColumnType.DOUBLE,

--- a/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/companions/RunDrtWithCompanionExampleIT.java
+++ b/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/companions/RunDrtWithCompanionExampleIT.java
@@ -74,8 +74,13 @@ public class RunDrtWithCompanionExampleIT {
 		Controler controler = DrtCompanionControlerCreator.createControler(config);
 		controler.run();
 
-		int actualRides = getTotalNumberOfDrtRides();
-		Assertions.assertThat(actualRides).isEqualTo(706);
+		int actualRidesPax = getTotalNumberOfDrtRidesPax();
+		Assertions.assertThat(actualRidesPax).isEqualTo(706);
+
+		int actualRidesRequests = getTotalNumberOfDrtRides();
+		Assertions.assertThat(actualRidesRequests).isEqualTo(378);
+
+
 	}
 
 	@Test
@@ -101,8 +106,12 @@ public class RunDrtWithCompanionExampleIT {
 		Controler controler = DrtCompanionControlerCreator.createControler(config);
 		controler.run();
 
-		int actualRides = getTotalNumberOfDrtRides();
-		Assertions.assertThat(actualRides).isEqualTo(699);
+		int actualRidesPax = getTotalNumberOfDrtRidesPax();
+		Assertions.assertThat(actualRidesPax).isEqualTo(699);
+
+		int actualRidesRequests = getTotalNumberOfDrtRides();
+		Assertions.assertThat(actualRidesRequests).isEqualTo(375);
+
 	}
 
 	private int getTotalNumberOfDrtRides() {
@@ -119,8 +128,27 @@ public class RunDrtWithCompanionExampleIT {
 		List<String> keys = List.of(collect.get(0).split(";"));
 		List<String> lastIterationValues = List.of(collect.get(size - 1).split(";"));
 
-		int index = keys.indexOf("rides");
+		int index = keys.indexOf("rides_requests");
         String value = lastIterationValues.get(index);
+		return Integer.parseInt(value);
+	}
+
+	private int getTotalNumberOfDrtRidesPax() {
+		String filename = utils.getOutputDirectory() + "/drt_customer_stats_drt.csv";
+
+		final List<String> collect;
+		try {
+			collect = Files.lines(Paths.get(filename)).collect(Collectors.toList());
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+
+		int size = collect.size();
+		List<String> keys = List.of(collect.get(0).split(";"));
+		List<String> lastIterationValues = List.of(collect.get(size - 1).split(";"));
+
+		int index = keys.indexOf("rides_pax");
+		String value = lastIterationValues.get(index);
 		return Integer.parseInt(value);
 	}
 }

--- a/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/companions/RunDrtWithCompanionExampleIT.java
+++ b/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/companions/RunDrtWithCompanionExampleIT.java
@@ -121,7 +121,7 @@ public class RunDrtWithCompanionExampleIT {
 		List<String> keys = List.of(collect.get(0).split(";"));
 		List<String> lastIterationValues = List.of(collect.get(size - 1).split(";"));
 
-		int ridesRequestIndex = keys.indexOf("rides_requests");
+		int ridesRequestIndex = keys.indexOf("rides");
         int ridesRequest = Integer.parseInt(lastIterationValues.get(ridesRequestIndex));
 
 		int ridesPaxIndex = keys.indexOf("rides_pax");

--- a/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/companions/RunDrtWithCompanionExampleIT.java
+++ b/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/companions/RunDrtWithCompanionExampleIT.java
@@ -20,13 +20,6 @@
 package org.matsim.contrib.drt.extension.companions;
 
 
-import java.io.IOException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -43,6 +36,13 @@ import org.matsim.core.utils.io.IOUtils;
 import org.matsim.examples.ExamplesUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vis.otfvis.OTFVisConfigGroup;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * @author Steffen Axer
@@ -74,13 +74,9 @@ public class RunDrtWithCompanionExampleIT {
 		Controler controler = DrtCompanionControlerCreator.createControler(config);
 		controler.run();
 
-		int actualRidesPax = getTotalNumberOfDrtRidesPax();
-		Assertions.assertThat(actualRidesPax).isEqualTo(706);
-
-		int actualRidesRequests = getTotalNumberOfDrtRides();
-		Assertions.assertThat(actualRidesRequests).isEqualTo(378);
-
-
+		int[] actualRides = getTotalNumberOfDrtRides();
+		Assertions.assertThat(actualRides[0]).isEqualTo(378);
+		Assertions.assertThat(actualRides[1]).isEqualTo(706);
 	}
 
 	@Test
@@ -106,15 +102,12 @@ public class RunDrtWithCompanionExampleIT {
 		Controler controler = DrtCompanionControlerCreator.createControler(config);
 		controler.run();
 
-		int actualRidesPax = getTotalNumberOfDrtRidesPax();
-		Assertions.assertThat(actualRidesPax).isEqualTo(699);
-
-		int actualRidesRequests = getTotalNumberOfDrtRides();
-		Assertions.assertThat(actualRidesRequests).isEqualTo(375);
-
+		int[] actualRides = getTotalNumberOfDrtRides();
+		Assertions.assertThat(actualRides[0]).isEqualTo(375);
+		Assertions.assertThat(actualRides[1]).isEqualTo(699);
 	}
 
-	private int getTotalNumberOfDrtRides() {
+	private int[] getTotalNumberOfDrtRides() {
 		String filename = utils.getOutputDirectory() + "/drt_customer_stats_drt.csv";
 
 		final List<String> collect;
@@ -128,27 +121,12 @@ public class RunDrtWithCompanionExampleIT {
 		List<String> keys = List.of(collect.get(0).split(";"));
 		List<String> lastIterationValues = List.of(collect.get(size - 1).split(";"));
 
-		int index = keys.indexOf("rides_requests");
-        String value = lastIterationValues.get(index);
-		return Integer.parseInt(value);
-	}
+		int ridesRequestIndex = keys.indexOf("rides_requests");
+        int ridesRequest = Integer.parseInt(lastIterationValues.get(ridesRequestIndex));
 
-	private int getTotalNumberOfDrtRidesPax() {
-		String filename = utils.getOutputDirectory() + "/drt_customer_stats_drt.csv";
+		int ridesPaxIndex = keys.indexOf("rides_pax");
+		int ridesPax = Integer.parseInt(lastIterationValues.get(ridesPaxIndex));
 
-		final List<String> collect;
-		try {
-			collect = Files.lines(Paths.get(filename)).collect(Collectors.toList());
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-
-		int size = collect.size();
-		List<String> keys = List.of(collect.get(0).split(";"));
-		List<String> lastIterationValues = List.of(collect.get(size - 1).split(";"));
-
-		int index = keys.indexOf("rides_pax");
-		String value = lastIterationValues.get(index);
-		return Integer.parseInt(value);
+		return new int[]{ridesRequest, ridesPax};
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
@@ -334,7 +334,7 @@ public class DrtAnalysisControlerListener implements IterationEndsListener, Shut
 		try (var bw = getAppendingBufferedWriter("drt_customer_stats", ".csv")) {
 			if (!headerWritten) {
 				headerWritten = true;
-				bw.write(line("runId", "iteration", "rides_requests", "rides_pax", "groupSIze_mean", "wait_average", "wait_max", "wait_p95", "wait_p75", "wait_median",
+				bw.write(line("runId", "iteration", "rides_requests", "rides_pax", "groupSize_mean", "wait_average", "wait_max", "wait_p95", "wait_p75", "wait_median",
 						"percentage_WT_below_10", "percentage_WT_below_15", "inVehicleTravelTime_mean", "distance_m_mean", "directDistance_m_mean",
 						"totalTravelTime_mean", "fareAllReferences_mean", "rejections", "rejectionRate"));
 			}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
@@ -334,7 +334,7 @@ public class DrtAnalysisControlerListener implements IterationEndsListener, Shut
 		try (var bw = getAppendingBufferedWriter("drt_customer_stats", ".csv")) {
 			if (!headerWritten) {
 				headerWritten = true;
-				bw.write(line("runId", "iteration", "rides_requests", "rides_pax", "groupSize_mean", "wait_average", "wait_max", "wait_p95", "wait_p75", "wait_median",
+				bw.write(line("runId", "iteration", "rides", "rides_pax", "groupSize_mean", "wait_average", "wait_max", "wait_p95", "wait_p75", "wait_median",
 						"percentage_WT_below_10", "percentage_WT_below_15", "inVehicleTravelTime_mean", "distance_m_mean", "directDistance_m_mean",
 						"totalTravelTime_mean", "fareAllReferences_mean", "rejections", "rejectionRate"));
 			}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
@@ -20,6 +20,8 @@
 package org.matsim.contrib.drt.analysis;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.Multiset;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 import org.apache.logging.log4j.LogManager;
@@ -332,7 +334,7 @@ public class DrtAnalysisControlerListener implements IterationEndsListener, Shut
 		try (var bw = getAppendingBufferedWriter("drt_customer_stats", ".csv")) {
 			if (!headerWritten) {
 				headerWritten = true;
-				bw.write(line("runId", "iteration", "rides", "wait_average", "wait_max", "wait_p95", "wait_p75", "wait_median",
+				bw.write(line("runId", "iteration", "rides_requests", "rides_pax", "groupSIze_mean", "wait_average", "wait_max", "wait_p95", "wait_p75", "wait_median",
 						"percentage_WT_below_10", "percentage_WT_below_15", "inVehicleTravelTime_mean", "distance_m_mean", "directDistance_m_mean",
 						"totalTravelTime_mean", "fareAllReferences_mean", "rejections", "rejectionRate"));
 			}
@@ -569,10 +571,13 @@ public class DrtAnalysisControlerListener implements IterationEndsListener, Shut
 		format.setMaximumFractionDigits(2);
 		format.setGroupingUsed(false);
 
+		Multiset<Id<Request>> servedRides = HashMultiset.create();
+
 		for (DrtLeg leg : legs) {
 			if (leg.toLinkId == null) {
 				continue;
 			}
+			servedRides.add(leg.request);
 			waitStats.addValue(leg.waitTime);
 			rideStats.addValue(leg.arrivalTime - leg.departureTime - leg.waitTime);
 			distanceStats.addValue(travelDistances.get(leg.request));
@@ -580,7 +585,9 @@ public class DrtAnalysisControlerListener implements IterationEndsListener, Shut
 			traveltimes.addValue(leg.arrivalTime - leg.departureTime);
 		}
 
-		return String.join(delimiter, format.format(waitStats.getValues().length) + "",//
+		return String.join(delimiter, format.format(servedRides.entrySet().size()) + "",//
+				format.format(servedRides.size()) + "",//
+				format.format(((double) servedRides.size()) / servedRides.entrySet().size()) + "",//
 				format.format(waitStats.getMean()) + "",//
 				format.format(waitStats.getMax()) + "",//
 				format.format(waitStats.getPercentile(95)) + "",//


### PR DESCRIPTION
Since the introduction of group bookings in drt, the customer stats were a bit inconsistent.
-> the "rides" column would count every passenger
-> the "rejections" are counted per request

A proposal would be to fix the customer stats such that:
-> there is a column rides_request which counts the number of served rides at the request level (similar to rejections)
-> and an additional column rides_pax which counts the total number of served passengers
(optionally) -> groupSize_mean which is the average group size of served requests (the division of the former two variables)

Any feedback is welcome