### PR TITLE
Add getter for totalWeight to WeightedRandomSelection

### DIFF
--- a/contribs/common/src/main/java/org/matsim/contrib/common/util/WeightedRandomSelection.java
+++ b/contribs/common/src/main/java/org/matsim/contrib/common/util/WeightedRandomSelection.java
@@ -67,6 +67,10 @@ public class WeightedRandomSelection<T> {
 		return entryList.size();
 	}
 
+	public double getTotalWeight() {
+		return totalWeight;
+	}
+
 	private record Entry<E>(E e, double cumulativeWeight) implements Comparable<Entry<E>> {
 		public int compareTo(Entry<E> o) {
 			double diff = this.cumulativeWeight - o.cumulativeWeight;


### PR DESCRIPTION
This adds a simple getter for the `totalWeight` property of the `WeightedRandomSelection` class. 

This is helpful in the case, where one receives a WRS object and does not know, whether calling `select()` will throw an exception if the total weight is 0. Now we can check this beforehand.