### PR TITLE
Pass person and vehicle to travel time query in FISS

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISS.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISS.java
@@ -15,6 +15,7 @@ import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.dynagent.DynAgent;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.controler.MatsimServices;
@@ -94,13 +95,16 @@ public class FISS implements DepartureHandler, MobsimEngine {
 						Leg currentLeg = (Leg) planAgent.getCurrentPlanElement();
 						Gbl.assertIf(this.fissConfigGroup.sampledModes.contains(currentLeg.getMode()));
 						NetworkRoute networkRoute = (NetworkRoute) currentLeg.getRoute();
+						Person person = planAgent.getCurrentPlan().getPerson();
+						Vehicle vehicle = this.matsimServices.getScenario().getVehicles().getVehicles()
+								.get(networkRoute.getVehicleId());
 
 						// update travel time with travel times of last iteration
 						double newTravelTime = 0.0;
 						// start and end link are not consideres in NetworkRoutingModule for travel time
 						for (Id<Link> routeLinkId : networkRoute.getLinkIds()) {
 							newTravelTime += this.travelTime.getLinkTravelTime(network.getLinks().get(routeLinkId),
-									now + newTravelTime, null, null);
+									now + newTravelTime, person, vehicle);
 						}
 						LOG.debug("New travelTime: {}, was {}", newTravelTime,
 								networkRoute.getTravelTime().orElseGet(() -> Double.NaN));

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISS.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISS.java
@@ -101,7 +101,7 @@ public class FISS implements DepartureHandler, MobsimEngine {
 
 						// update travel time with travel times of last iteration
 						double newTravelTime = 0.0;
-						// start and end link are not consideres in NetworkRoutingModule for travel time
+						// start and end link are not considered in NetworkRoutingModule for travel time
 						for (Id<Link> routeLinkId : networkRoute.getLinkIds()) {
 							newTravelTime += this.travelTime.getLinkTravelTime(network.getLinks().get(routeLinkId),
 									now + newTravelTime, person, vehicle);
@@ -112,8 +112,8 @@ public class FISS implements DepartureHandler, MobsimEngine {
 					}
 					// remove vehicle of teleported agent from parking spot
 					QVehicle removedVehicle = null;
-					if (agent instanceof MobsimDriverAgent) {
-						Id<Vehicle> vehicleId = ((MobsimDriverAgent) agent).getPlannedVehicleId();
+					if (agent instanceof MobsimDriverAgent driverAgent) {
+						Id<Vehicle> vehicleId = driverAgent.getPlannedVehicleId();
 						QVehicle vehicle = qNetsimEngine.getVehicles().get(vehicleId);
 						QLinkI qLinkI = (QLinkI) this.qNetsimEngine.getNetsimNetwork().getNetsimLink(linkId);
 						removedVehicle = qLinkI.removeParkedVehicle(vehicleId);


### PR DESCRIPTION
When teleporting agents and vehicles with FISS, the travel time is computed from the congested travel times of the links of the route of the previous iteration. When querying the links' travel times, the person and vehicle have not been passed to the `TravelTime` object for consideration, which they now are.