### PR TITLE
Remove the need of binding to use DRT detour constraints

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/edrt/run/EDrtModeOptimizerQSimModule.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/edrt/run/EDrtModeOptimizerQSimModule.java
@@ -44,6 +44,7 @@ import org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator;
 import org.matsim.contrib.drt.optimizer.insertion.UnplannedRequestInserter;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.drt.passenger.DrtOfferAcceptor;
+import org.matsim.contrib.drt.passenger.DefaultOfferAcceptor;
 import org.matsim.contrib.drt.prebooking.PrebookingActionCreator;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtTaskFactory;
@@ -178,7 +179,7 @@ public class EDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 								getter.getModal(StopTimeCalculator.class), scheduleWaitBeforeDrive)))
 				.asEagerSingleton();
 
-		bindModal(DrtOfferAcceptor.class).toInstance(DrtOfferAcceptor.DEFAULT_ACCEPTOR);
+		bindModal(DrtOfferAcceptor.class).toProvider(modalProvider(getter -> new DefaultOfferAcceptor(drtCfg.maxAllowedPickupDelay)));
 
 		bindModal(ScheduleTimingUpdater.class).toProvider(modalProvider(
 				getter -> new ScheduleTimingUpdater(getter.get(MobsimTimer.class),
@@ -187,11 +188,11 @@ public class EDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 		bindModal(VrpLegFactory.class).toProvider(modalProvider(getter -> {
 			DvrpConfigGroup dvrpCfg = getter.get(DvrpConfigGroup.class);
 			MobsimTimer timer = getter.get(MobsimTimer.class);
-			
+
 			// Makes basic DrtActionCreator create legs with consumption tracker
 			return v -> EDrtActionCreator.createLeg(dvrpCfg.mobsimMode, v, timer);
 		})).in(Singleton.class);
-		
+
 		bindModal(EDrtActionCreator.class).toProvider(modalProvider(getter -> {
 			VrpAgentLogic.DynActionCreator delegate = drtCfg.getPrebookingParams().isPresent()
 					? getter.getModal(PrebookingActionCreator.class)
@@ -201,9 +202,9 @@ public class EDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 			// + adds ChargingActivity
 			return new EDrtActionCreator(delegate, getter.get(MobsimTimer.class));
 		})).asEagerSingleton();
-		
+
 		bindModal(VrpAgentLogic.DynActionCreator.class).to(modalKey(EDrtActionCreator.class));
-		
+
 		bindModal(VrpOptimizer.class).to(modalKey(DrtOptimizer.class));
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtModeOptimizerQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtModeOptimizerQSimModule.java
@@ -37,6 +37,7 @@ import org.matsim.contrib.drt.optimizer.insertion.selective.SelectiveInsertionSe
 import org.matsim.contrib.drt.optimizer.insertion.selective.SelectiveInsertionSearchQSimModule;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.drt.passenger.DrtOfferAcceptor;
+import org.matsim.contrib.drt.passenger.DefaultOfferAcceptor;
 import org.matsim.contrib.drt.prebooking.PrebookingActionCreator;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtStayTaskEndTimeCalculator;
@@ -138,7 +139,7 @@ public class DrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 				}).asEagerSingleton();
 
 		bindModal(DrtScheduleInquiry.class).to(DrtScheduleInquiry.class).asEagerSingleton();
-		
+
 		boolean scheduleWaitBeforeDrive = drtCfg.getPrebookingParams().map(p -> p.scheduleWaitBeforeDrive).orElse(false);
 		bindModal(RequestInsertionScheduler.class).toProvider(modalProvider(
 						getter -> new DefaultRequestInsertionScheduler(getter.getModal(Fleet.class),
@@ -147,7 +148,7 @@ public class DrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 								getter.getModal(StopTimeCalculator.class), scheduleWaitBeforeDrive)))
 				.asEagerSingleton();
 
-		bindModal(DrtOfferAcceptor.class).toInstance(DrtOfferAcceptor.DEFAULT_ACCEPTOR);
+		bindModal(DrtOfferAcceptor.class).toProvider(modalProvider(getter -> new DefaultOfferAcceptor(drtCfg.maxAllowedPickupDelay)));
 
 		bindModal(ScheduleTimingUpdater.class).toProvider(modalProvider(
 				getter -> new ScheduleTimingUpdater(getter.get(MobsimTimer.class),
@@ -160,7 +161,7 @@ public class DrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 			return v -> VrpLegFactory.createWithOnlineTracker(dvrpCfg.mobsimMode, v, OnlineTrackerListener.NO_LISTENER,
 					timer);
 		})).in(Singleton.class);
-		
+
 		if (drtCfg.getPrebookingParams().isEmpty()) {
 			bindModal(VrpAgentLogic.DynActionCreator.class).to(modalKey(DrtActionCreator.class));
 		} else {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DefaultOfferAcceptor.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DefaultOfferAcceptor.java
@@ -2,11 +2,22 @@ package org.matsim.contrib.drt.passenger;
 
 import java.util.Optional;
 
-public class MaxDetourOfferAcceptor implements DrtOfferAcceptor{
+public class DefaultOfferAcceptor implements DrtOfferAcceptor{
 	private final double maxAllowedPickupDelay;
 
-	public MaxDetourOfferAcceptor(double maxAllowedPickupDelay) {
+	/**
+	 * Generate Default offer acceptor with max allowed pickup delay.
+	 * @param maxAllowedPickupDelay: maximum allowed delay since the initially assigned pickup time.
+	 */
+	public DefaultOfferAcceptor(double maxAllowedPickupDelay) {
 		this.maxAllowedPickupDelay = maxAllowedPickupDelay;
+	}
+
+	/**
+	 * Generate Default offer acceptor. 
+	 */
+	public DefaultOfferAcceptor() {
+		this.maxAllowedPickupDelay = Double.POSITIVE_INFINITY;
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DrtOfferAcceptor.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DrtOfferAcceptor.java
@@ -26,6 +26,7 @@ import java.util.Optional;
  * @author Michal Maciejewski (michalm)
  */
 public interface DrtOfferAcceptor {
+	@Deprecated
 	DrtOfferAcceptor DEFAULT_ACCEPTOR = (request, departureTime, arrivalTime) -> Optional.of(
 			AcceptedDrtRequest.createFromOriginalRequest(request));
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -133,7 +133,7 @@ public class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableParamet
 	@Comment(
 		"Defines the maximum delay allowed from the initial scheduled pick up time. Once the initial pickup time is offered, the latest promised"
 			+ "pickup time is calculated based on initial scheduled pickup time + maxAllowedPickupDelay. "
-			+ "By default, this limit is disabled. If enabled, a value between 120 and 240 is a good choice.")
+			+ "By default, this limit is disabled. If enabled, a value between 0 and 240 is a good choice.")
 	@PositiveOrZero
 	public double maxAllowedPickupDelay = Double.POSITIVE_INFINITY;// [s]
 
@@ -323,6 +323,12 @@ public class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableParamet
 		if (useModeFilteredSubnetwork) {
 			DvrpModeRoutingNetworkModule.checkUseModeFilteredSubnetworkAllowed(config, mode);
 		}
+
+		if ((maxDetourAlpha != Double.POSITIVE_INFINITY && maxDetourBeta != Double.POSITIVE_INFINITY) || maxAbsoluteDetour != Double.POSITIVE_INFINITY) {
+			Verify.verify(maxAllowedPickupDelay != Double.POSITIVE_INFINITY, "Detour constraints are activated, " +
+				"maxAllowedPickupDelay must be specified! A value between 0 and 240 seconds can be a good choice for maxAllowedPickupDelay.");
+		}
+
 	}
 
 	@Override

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/MaxDetourConstraintTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/MaxDetourConstraintTest.java
@@ -2,12 +2,9 @@ package org.matsim.contrib.drt.optimizer;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.matsim.contrib.drt.passenger.DrtOfferAcceptor;
-import org.matsim.contrib.drt.passenger.MaxDetourOfferAcceptor;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.run.DrtControlerCreator;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
-import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
@@ -29,7 +26,6 @@ public class MaxDetourConstraintTest {
 		URL configUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("mielec"), "mielec_drt_config.xml");
 		Config config = ConfigUtils.loadConfig(configUrl, new MultiModeDrtConfigGroup(), new DvrpConfigGroup(),
 			new OTFVisConfigGroup());
-		MultiModeDrtConfigGroup multiModeDrtConfigGroup = MultiModeDrtConfigGroup.get(config);
 		DrtConfigGroup drtConfigGroup = DrtConfigGroup.getSingleModeDrtConfig(config);
 
 		// Max wait time
@@ -49,15 +45,6 @@ public class MaxDetourConstraintTest {
 		config.controller().setOutputDirectory(utils.getOutputDirectory());
 
 		Controler controler = DrtControlerCreator.createControler(config, false);
-
-		for (DrtConfigGroup drtCfg : multiModeDrtConfigGroup.getModalElements()) {
-			controler.addOverridingQSimModule(new AbstractDvrpModeQSimModule(drtCfg.mode) {
-				@Override
-				protected void configureQSim() {
-					bindModal(DrtOfferAcceptor.class).toProvider(modalProvider(getter -> new MaxDetourOfferAcceptor(drtCfg.maxAllowedPickupDelay)));
-				}
-			});
-		}
 
 		controler.run();
 	}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserterTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserterTest.java
@@ -42,6 +42,7 @@ import org.matsim.contrib.drt.optimizer.DrtRequestInsertionRetryParams;
 import org.matsim.contrib.drt.optimizer.DrtRequestInsertionRetryQueue;
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
 import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
+import org.matsim.contrib.drt.passenger.DefaultOfferAcceptor;
 import org.matsim.contrib.drt.passenger.DrtOfferAcceptor;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
@@ -285,7 +286,7 @@ public class DefaultUnplannedRequestInserterTest {
 			VehicleEntry.EntryFactory vehicleEntryFactory, DrtRequestInsertionRetryQueue insertionRetryQueue,
 			DrtInsertionSearch insertionSearch, RequestInsertionScheduler insertionScheduler) {
 		return new DefaultUnplannedRequestInserter(mode, fleet, () -> now, eventsManager, insertionScheduler,
-				vehicleEntryFactory, insertionRetryQueue, insertionSearch, DrtOfferAcceptor.DEFAULT_ACCEPTOR,
+				vehicleEntryFactory, insertionRetryQueue, insertionSearch, new DefaultOfferAcceptor(),
 				forkJoinPoolExtension.forkJoinPool, StaticPassengerStopDurationProvider.of(10.0, 0.0));
 	}
 


### PR DESCRIPTION
The MaxDetourOfferAcceptor is now renamed as DefaultOfferAcceptor, which is now used as the default Offer Acceptor, as suggested by the name. The binding is, therefore, no longer required in order to use the max detour constraint. As long as the parameters related to detour constraints is properly set in the DRT config group (a simple check is also implemented), the detour constraints will be activated automatically. 

The maxAllowedPickupDelay is a new field in the new DefaultOfferAcceptor, compared to the previous anonymous DEFAULT_ACCEPTOR. To be backward compatible, two constructors are included in the DefaultOfferAcceptor: one with the maxAllowedPickupDelay as the input argument; the other one with maxAllowedPickupDelay set to Double.POSITIVE_INFINITY automatically (i.e., equivalent to not having the maxAllowedPickupDelay constraint). I am not sure if this is the best way to go. Perhaps @michalmac have some idea on this? 