### PR TITLE
install the drt zonalsystem module independently of the rebalancing module

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/RebalancingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/RebalancingModule.java
@@ -46,7 +46,6 @@ public class RebalancingModule extends AbstractDvrpModeModule {
 	public void install() {
 		if (drtCfg.getRebalancingParams().isPresent()) {
 			RebalancingParams rebalancingParams = drtCfg.getRebalancingParams().get();
-			install(new DrtModeZonalSystemModule(drtCfg));
 
 			if (rebalancingParams.getRebalancingStrategyParams() instanceof MinCostFlowRebalancingStrategyParams) {
 				install(new DrtModeMinCostFlowRebalancingModule(drtCfg));

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -25,6 +25,7 @@ import com.google.inject.Singleton;
 import com.google.inject.name.Names;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.analysis.DrtEventSequenceCollector;
+import org.matsim.contrib.drt.analysis.zonal.DrtModeZonalSystemModule;
 import org.matsim.contrib.drt.fare.DrtFareHandler;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingModule;
 import org.matsim.contrib.drt.prebooking.analysis.PrebookingModeAnalysisModule;
@@ -65,6 +66,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 				null :
 				ConfigGroup.getInputFileURL(getConfig().getContext(), drtCfg.vehiclesFile),
 				drtCfg.changeStartLinkToLastLinkInSchedule));
+		install(new DrtModeZonalSystemModule(drtCfg));
 		install(new RebalancingModule(drtCfg));
 		install(new DrtModeRoutingModule(drtCfg));
 


### PR DESCRIPTION
the zonal system is not only used for rebalancing but also for the zonal wait stats output (and possibly other analyses in the future)