### PR TITLE
Move method to PTWaitingTimeEstimator interface

### DIFF
--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/utils/NullWaitingTimeEstimator.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/utils/NullWaitingTimeEstimator.java
@@ -1,5 +1,8 @@
 package org.matsim.contribs.discrete_mode_choice.components.utils;
 
+import java.util.List;
+
+import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.pt.routes.TransitPassengerRoute;
 
 /**
@@ -9,8 +12,15 @@ import org.matsim.pt.routes.TransitPassengerRoute;
  * @author sebhoerl
  */
 public class NullWaitingTimeEstimator implements PTWaitingTimeEstimator {
+
 	@Override
 	public double estimateWaitingTime(double agentDepartureTime, TransitPassengerRoute route) {
 		return 0.0;
 	}
+
+	@Override
+	public double estimateWaitingTime(List<? extends PlanElement> elements) {
+		return 0.0;
+	}
+
 }

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/utils/PTWaitingTimeEstimator.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/utils/PTWaitingTimeEstimator.java
@@ -2,8 +2,6 @@ package org.matsim.contribs.discrete_mode_choice.components.utils;
 
 import java.util.List;
 
-import org.matsim.api.core.v01.TransportMode;
-import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.pt.routes.TransitPassengerRoute;
 
@@ -19,16 +17,6 @@ public interface PTWaitingTimeEstimator {
 
 	double estimateWaitingTime(double departureTime, TransitPassengerRoute route);
 
-	default double estimateWaitingTime(List<? extends PlanElement> elements) {
-		double totalWaitingTime = 0.0;
+	double estimateWaitingTime(List<? extends PlanElement> elements);
 
-		for (PlanElement element : elements) {
-			if (element instanceof Leg leg && leg.getMode().equals(TransportMode.pt)) {
-				TransitPassengerRoute route = (TransitPassengerRoute) leg.getRoute();
-				totalWaitingTime += this.estimateWaitingTime(leg.getDepartureTime().seconds(), route);
-			}
-		}
-
-		return totalWaitingTime;
-	}
 }

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/utils/PTWaitingTimeEstimator.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/utils/PTWaitingTimeEstimator.java
@@ -1,5 +1,10 @@
 package org.matsim.contribs.discrete_mode_choice.components.utils;
 
+import java.util.List;
+
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.pt.routes.TransitPassengerRoute;
 
 /**
@@ -11,5 +16,19 @@ import org.matsim.pt.routes.TransitPassengerRoute;
  * @author sebhoerl
  */
 public interface PTWaitingTimeEstimator {
+
 	double estimateWaitingTime(double departureTime, TransitPassengerRoute route);
+
+	default double estimateWaitingTime(List<? extends PlanElement> elements) {
+		double totalWaitingTime = 0.0;
+
+		for (PlanElement element : elements) {
+			if (element instanceof Leg leg && leg.getMode().equals(TransportMode.pt)) {
+				TransitPassengerRoute route = (TransitPassengerRoute) leg.getRoute();
+				totalWaitingTime += this.estimateWaitingTime(leg.getDepartureTime().seconds(), route);
+			}
+		}
+
+		return totalWaitingTime;
+	}
 }

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/utils/ScheduleWaitingTimeEstimator.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/utils/ScheduleWaitingTimeEstimator.java
@@ -8,6 +8,9 @@ import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.utils.collections.Tuple;
 import org.matsim.core.utils.misc.OptionalTime;
 import org.matsim.core.utils.misc.Time;
@@ -50,6 +53,20 @@ public class ScheduleWaitingTimeEstimator implements PTWaitingTimeEstimator {
 
 	private Tuple<Id<TransitLine>, Id<TransitRoute>> createId(TransitLine transitLine, TransitRoute transitRoute) {
 		return new Tuple<>(transitLine.getId(), transitRoute.getId());
+	}
+
+	@Override
+	public double estimateWaitingTime(List<? extends PlanElement> elements) {
+		double totalWaitingTime = 0.0;
+
+		for (PlanElement element : elements) {
+			if (element instanceof Leg leg && leg.getMode().equals(TransportMode.pt)) {
+				TransitPassengerRoute route = (TransitPassengerRoute) leg.getRoute();
+				totalWaitingTime += this.estimateWaitingTime(leg.getDepartureTime().seconds(), route);
+			}
+		}
+
+		return totalWaitingTime;
 	}
 
 	@Override

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/utils/ScheduleWaitingTimeEstimator.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/utils/ScheduleWaitingTimeEstimator.java
@@ -8,8 +8,6 @@ import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.population.Leg;
-import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.utils.collections.Tuple;
 import org.matsim.core.utils.misc.OptionalTime;
 import org.matsim.core.utils.misc.Time;
@@ -52,23 +50,6 @@ public class ScheduleWaitingTimeEstimator implements PTWaitingTimeEstimator {
 
 	private Tuple<Id<TransitLine>, Id<TransitRoute>> createId(TransitLine transitLine, TransitRoute transitRoute) {
 		return new Tuple<>(transitLine.getId(), transitRoute.getId());
-	}
-
-	public double estimateWaitingTime(List<? extends PlanElement> elements) {
-		double totalWaitingTime = 0.0;
-
-		for (PlanElement element : elements) {
-			if (element instanceof Leg) {
-				Leg leg = (Leg) element;
-
-				if (leg.getMode().equals("pt")) {
-					TransitPassengerRoute route = (TransitPassengerRoute) leg.getRoute();
-					totalWaitingTime += estimateWaitingTime(leg.getDepartureTime().seconds(), route);
-				}
-			}
-		}
-
-		return totalWaitingTime;
 	}
 
 	@Override


### PR DESCRIPTION
This change promotes the `double estimateWaitingTime(List<? extends PlanElement> elements)` method of the `ScheduleWaitingTimeEstimator` to its `PTWaitingTimeEstimator` interface as default implementation.

It was not part of the interface `PTWaitingTimeEstimator` before despite being public and being the most convenient way to use `ScheduleWaitingTimeEstimator`.

@sebhoerl Please let me know, if that is fine for you?