### PR TITLE
fix(drt): bugs with variable stop duration and prebooking stop logic

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/prebooking/PrebookingActionCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/prebooking/PrebookingActionCreator.java
@@ -2,6 +2,9 @@ package org.matsim.contrib.drt.prebooking;
 
 import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.getBaseTypeOrElseThrow;
 
+import java.util.List;
+
+import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
 import org.matsim.contrib.drt.prebooking.abandon.AbandonVoter;
 import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.drt.schedule.DrtTaskBaseType;
@@ -47,11 +50,42 @@ public class PrebookingActionCreator implements VrpAgentLogic.DynActionCreator {
 
 		if (getBaseTypeOrElseThrow(task).equals(DrtTaskBaseType.STOP)) {
 			DrtStopTask stopTask = (DrtStopTask) task;
+			int incomingCapacity = getIncomingOccupancy(vehicle, stopTask);
+
 			return new PrebookingStopActivity(passengerHandler, dynAgent, stopTask, stopTask.getDropoffRequests(),
 					stopTask.getPickupRequests(), DrtActionCreator.DRT_STOP_NAME, () -> stopTask.getEndTime(),
-					stopDurationProvider, vehicle, prebookingManager, abandonVoter);
+					stopDurationProvider, vehicle, prebookingManager, abandonVoter, incomingCapacity);
 		}
 
 		return delegate.createAction(dynAgent, vehicle, now);
+	}
+
+	private int getIncomingOccupancy(DvrpVehicle vehicle, DrtStopTask referenceTask) {
+		int incomingOccupancy = 0;
+
+		List<? extends Task> tasks = vehicle.getSchedule().getTasks();
+
+		int index = tasks.size() - 1;
+		while (index >= 0) {
+			Task task = tasks.get(index);
+
+			if (task instanceof DrtStopTask) {
+				DrtStopTask stopTask = (DrtStopTask) task;
+
+				incomingOccupancy += stopTask.getDropoffRequests().values().stream()
+						.mapToInt(AcceptedDrtRequest::getPassengerCount).sum();
+
+				incomingOccupancy -= stopTask.getPickupRequests().values().stream()
+						.mapToInt(AcceptedDrtRequest::getPassengerCount).sum();
+
+				if (task == referenceTask) {
+					return incomingOccupancy;
+				}
+			}
+			
+			index--;
+		}
+
+		throw new IllegalStateException();
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/prebooking/PrebookingTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/prebooking/PrebookingTest.java
@@ -4,12 +4,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.prebooking.PrebookingTestEnvironment.RequestInfo;
 import org.matsim.contrib.drt.prebooking.logic.AttributeBasedPrebookingLogic;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.stops.PassengerStopDurationProvider;
 import org.matsim.contrib.drt.stops.StaticPassengerStopDurationProvider;
+import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
+import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.core.controler.Controler;
 import org.matsim.testcases.MatsimTestUtils;
 
@@ -566,7 +569,7 @@ public class PrebookingTest {
 			assertEquals(8000.0 + 60.0 + 1.0, requestInfo.pickupTime, 1e-3);
 			assertEquals(8230.0, requestInfo.dropoffTime, 1e-3);
 		}
-		
+
 		{
 			RequestInfo requestInfo = environment.getRequestInfo().get("requestC");
 			assertEquals(2.0, requestInfo.submissionTime, 1e-3);
@@ -576,7 +579,7 @@ public class PrebookingTest {
 
 		assertEquals(4, environment.getTaskInfo().get("vehicleA").stream().filter(t -> t.type.equals("STOP")).count());
 	}
-	
+
 	@Test
 	void destinationEqualsPrebookedOrigin_oneRequest() {
 		/*-
@@ -613,5 +616,148 @@ public class PrebookingTest {
 		}
 
 		assertEquals(4, environment.getTaskInfo().get("vehicleA").stream().filter(t -> t.type.equals("STOP")).count());
+	}
+
+	@Test
+	void intraStopTiming_pickupTooEarly() {
+		/*-
+		 * In this test, we cover the intra stop timing when we use customizable stop
+		 * durations. Before the fix, there was a bug described by the following
+		 * situation: 
+		 * 
+		 * - We look for an insertion for a pickup
+		 * - We find an existing stop that already contains some dropoffs
+		 * - Inserting the pickup overall will fit (assuming that the persons are dropped off, then picked up)
+		 * - But because of variable stop durations, the pickup happens *before* the dropoffs
+		 * - Leading to a few seconds in which the occupancy is higher than the vehicle capacity
+		 * 
+		 * This test led to a VerifyException in VehicleOccupancyProfileCalculator.processOccupancyChange
+		 */
+
+		PrebookingTestEnvironment environment = new PrebookingTestEnvironment(utils) //
+				.addVehicle("vehicleA", 1, 1) //
+				.setVehicleCapacity(2) //
+				.addRequest("requestA1", 1, 1, 8, 8, 2000.0, 1.0) // forward
+				.addRequest("requestA2", 1, 1, 8, 8, 2000.0, 2.0) // forward
+				.addRequest("requestB1", 8, 8, 1, 1, 2356.0, 3.0) // backward
+				.configure(300.0, 2.0, 1800.0, 60.0) // 
+				.endTime(12.0 * 3600.0);
+
+		Controler controller = environment.build();
+		installPrebooking(controller);
+		
+		controller.addOverridingModule(new AbstractDvrpModeModule("drt") {
+			@Override
+			public void install() {
+				bindModal(PassengerStopDurationProvider.class).toInstance(new PassengerStopDurationProvider() {
+					@Override
+					public double calcPickupDuration(DvrpVehicle vehicle, DrtRequest request) {
+						if (request.getId().toString().startsWith("requestA")) {
+							return 60.0;
+						} else {
+							return 30.0; // shorter than the dropoff duration (see below)
+						}
+					}
+					
+					@Override
+					public double calcDropoffDuration(DvrpVehicle vehicle, DrtRequest request) {
+						return 60.0;
+					}
+				});
+			}
+		});
+		
+		controller.run();
+
+		{
+			RequestInfo requestInfo = environment.getRequestInfo().get("requestA1");
+			assertEquals(1.0, requestInfo.submissionTime, 1e-3);
+			assertEquals(2000.0 + 60.0 + 1.0, requestInfo.pickupTime, 1e-3);
+			assertEquals(2356.0, requestInfo.dropoffTime, 1e-3);
+		}
+
+		{
+			RequestInfo requestInfo = environment.getRequestInfo().get("requestA2");
+			assertEquals(2.0, requestInfo.submissionTime, 1e-3);
+			assertEquals(2000.0 + 60.0 + 1.0, requestInfo.pickupTime, 1e-3);
+			assertEquals(2356.0, requestInfo.dropoffTime, 1e-3);
+		}
+
+		{
+			RequestInfo requestInfo = environment.getRequestInfo().get("requestB1");
+			assertEquals(3.0, requestInfo.submissionTime, 1e-3);
+			assertEquals(2356.0 + 60.0, requestInfo.pickupTime, 1e-3);
+			assertEquals(2753.0, requestInfo.dropoffTime, 1e-3);
+		}
+
+		assertEquals(3, environment.getTaskInfo().get("vehicleA").stream().filter(t -> t.type.equals("STOP")).count());
+	}
+	
+	@Test
+	void intraStopTiming_dropoffTooLate() {
+		/*-
+		 * Inverse situation of the previous test: A new request is inserted, but the dropoff 
+		 * happens too late compared to the pickups in the following stop task.
+		 * 
+		 * This test led to a VerifyException in VehicleOccupancyProfileCalculator.processOccupancyChange
+		 */
+
+		PrebookingTestEnvironment environment = new PrebookingTestEnvironment(utils) //
+				.addVehicle("vehicleA", 1, 1) //
+				.setVehicleCapacity(2) //
+				.addRequest("requestA", 1, 1, 8, 8, 2000.0, 1.0) // forward
+				.addRequest("requestB1", 8, 8, 1, 1, 2356.0, 2.0) // backward
+				.addRequest("requestB2", 8, 8, 1, 1, 2356.0, 3.0) // backward
+				.configure(300.0, 2.0, 1800.0, 60.0) // 
+				.endTime(12.0 * 3600.0);
+
+		Controler controller = environment.build();
+		installPrebooking(controller);
+		
+		controller.addOverridingModule(new AbstractDvrpModeModule("drt") {
+			@Override
+			public void install() {
+				bindModal(PassengerStopDurationProvider.class).toInstance(new PassengerStopDurationProvider() {
+					@Override
+					public double calcPickupDuration(DvrpVehicle vehicle, DrtRequest request) {
+						return 60.0;
+					}
+					
+					@Override
+					public double calcDropoffDuration(DvrpVehicle vehicle, DrtRequest request) {
+						if (request.getId().toString().equals("requestA")) {
+							return 90.0; // longer than the pickups
+						} else {
+							return 60.0;
+						}
+					}
+				});
+			}
+		});
+		
+		controller.run();
+
+		{
+			RequestInfo requestInfo = environment.getRequestInfo().get("requestA");
+			assertEquals(1.0, requestInfo.submissionTime, 1e-3);
+			assertEquals(2000.0 + 60.0 + 1.0, requestInfo.pickupTime, 1e-3);
+			assertEquals(2356.0, requestInfo.dropoffTime, 1e-3);
+		}
+
+		{
+			RequestInfo requestInfo = environment.getRequestInfo().get("requestB1");
+			assertEquals(2.0, requestInfo.submissionTime, 1e-3);
+			assertEquals(2356.0 + 60.0, requestInfo.pickupTime, 1e-3);
+			assertEquals(2753.0, requestInfo.dropoffTime, 1e-3);
+		}
+		
+		{
+			RequestInfo requestInfo = environment.getRequestInfo().get("requestB2");
+			assertEquals(3.0, requestInfo.submissionTime, 1e-3);
+			assertEquals(2356.0 + 60.0, requestInfo.pickupTime, 1e-3);
+			assertEquals(2753.0, requestInfo.dropoffTime, 1e-3);
+		}
+
+		assertEquals(3, environment.getTaskInfo().get("vehicleA").stream().filter(t -> t.type.equals("STOP")).count());
 	}
 }


### PR DESCRIPTION
Since recently, we have the option to define pickup and dropoff durations per request using the `PassengerStopDurationProvider`. The stop logic with *prebooking* activated is that all persons enter the vehicle in parallel, taking into account the values obtained from that provider. The non-*prebooking* implementation does not make use of the interface yet (all dropoffs happen at the beginning of a stop with a fixed duration, all pickups happen at the end). So the following only affects simulations where *prebooking* is activated.

The following situation can arise:
- We have found a valid insertion for a new request
- The pickup is inserted into an existing stop in which 4 persons leave the vehicle (with capacity 4)
- The 4 persons will need 60s to leave the vehicle (from the stop duration provider)
- The new request will need 30s to enter the vehicle
- This means that the vehicle stops, the occupancy rises to 5 after 30s and goes down to 1 after 60s
- But for 30s we have exceeded the capacity of the vehicle, which rightfully raises an exception in `VehicleOccupancyProfileCalculator`

To solve the problem, the `PassengerStopActivity` has been adjusted: A person can only enter the vehicle if occupancy is not already at the maximum. This means that before another person can enter, a dropoff person must leave before.

Note that this fix solves the problem in simulation, but since pickups need to wait for an additional few seconds, there might be edge cases where their maximum wait time, for instance, is exceeded, and, hence, this should not have been a valid insertion. This is probably of very little relevance in simulations with congestion and everything, but may lead to deviations when running exact free-flow simulations.

To solve the problem also on the side of the insertion algorithm, I think it would make sense to change generally the logic how stops work in prebooking. I would propose the dropoffs, as in non-prebooking, happen first (so we first let everybody leave the vehicle), and then we start with the pickups. This allows to provide relatively straight-forward calculations in `StopTimeCalculator` while they would become quite complex if everything happens in parallel. This, however, has not been implemented here and should be a future PR.