### PR TITLE
prepare poms for next release cycle

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>matsim-all</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<packaging>jar</packaging>
@@ -33,12 +33,12 @@
 		<dependency>
 			<groupId>org.matsim</groupId>
 			<artifactId>matsim</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim</groupId>
 			<artifactId>matsim-examples</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/contribs/accessibility/pom.xml
+++ b/contribs/accessibility/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>contrib</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.matsim.contrib</groupId>
@@ -37,12 +37,12 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>matrixbasedptrouter</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>roadpricing</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>net.sf.trove4j</groupId>
@@ -70,7 +70,7 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>analysis</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 <!--		<dependency>-->
 <!--			<groupId>org.matsim.contrib</groupId>-->

--- a/contribs/accidents/pom.xml
+++ b/contribs/accidents/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.matsim</groupId>
         <artifactId>contrib</artifactId>
-        <version>16.0-SNAPSHOT</version>
+        <version>25.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.matsim.contrib</groupId>

--- a/contribs/analysis/pom.xml
+++ b/contribs/analysis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.matsim</groupId>
         <artifactId>contrib</artifactId>
-        <version>16.0-SNAPSHOT</version>
+        <version>25.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.matsim.contrib</groupId>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>org.matsim.contrib</groupId>
             <artifactId>roadpricing</artifactId>
-            <version>16.0-SNAPSHOT</version>
+            <version>25.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.osgeo</groupId>

--- a/contribs/application/pom.xml
+++ b/contribs/application/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>contrib</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>
@@ -30,37 +30,37 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>otfvis</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>osm</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>sumo</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>analysis</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>emissions</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>noise</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>freight</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 			<exclusions>
 				<!-- Logging levels are all messed up without this exclusion -->
 				<exclusion>

--- a/contribs/av/pom.xml
+++ b/contribs/av/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>contrib</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.matsim.contrib</groupId>
@@ -16,19 +16,19 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>dvrp</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>taxi</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>drt</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/contribs/bicycle/pom.xml
+++ b/contribs/bicycle/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.matsim</groupId>
     <artifactId>contrib</artifactId>
-    <version>16.0-SNAPSHOT</version>
+    <version>25.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.matsim.contrib</groupId>
@@ -23,7 +23,7 @@
       <dependency>
           <groupId>org.matsim.contrib</groupId>
           <artifactId>osm</artifactId>
-          <version>16.0-SNAPSHOT</version>
+          <version>25.0-SNAPSHOT</version>
           <scope>compile</scope>
       </dependency>
   </dependencies>

--- a/contribs/cadytsIntegration/pom.xml
+++ b/contribs/cadytsIntegration/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.matsim</groupId>
     <artifactId>contrib</artifactId>
-    <version>16.0-SNAPSHOT</version>
+    <version>25.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.matsim.contrib</groupId>
@@ -17,7 +17,7 @@
   	<dependency>
   		<groupId>org.matsim.contrib</groupId>
   		<artifactId>analysis</artifactId>
-  		<version>16.0-SNAPSHOT</version>
+  		<version>25.0-SNAPSHOT</version>
   	</dependency>
   </dependencies>
   <inceptionYear>2012</inceptionYear>

--- a/contribs/carsharing/pom.xml
+++ b/contribs/carsharing/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.matsim</groupId>
     <artifactId>contrib</artifactId>
-    <version>16.0-SNAPSHOT</version>
+    <version>25.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.matsim.contrib</groupId>
@@ -12,7 +12,7 @@
   	<dependency>
   		<groupId>org.matsim.contrib</groupId>
   		<artifactId>dvrp</artifactId>
-  		<version>16.0-SNAPSHOT</version>
+  		<version>25.0-SNAPSHOT</version>
   	</dependency>
   </dependencies>
 </project>

--- a/contribs/commercialTrafficApplications/pom.xml
+++ b/contribs/commercialTrafficApplications/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>contrib</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.matsim.contrib</groupId>
@@ -14,13 +14,13 @@
         <dependency>
             <groupId>org.matsim.contrib</groupId>
             <artifactId>freight</artifactId>
-            <version>16.0-SNAPSHOT</version>
+            <version>25.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>org.matsim.contrib</groupId>
             <artifactId>drt</artifactId>
-            <version>16.0-SNAPSHOT</version>
+            <version>25.0-SNAPSHOT</version>
         </dependency>
 
     </dependencies>

--- a/contribs/common/pom.xml
+++ b/contribs/common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.matsim</groupId>
         <artifactId>contrib</artifactId>
-        <version>16.0-SNAPSHOT</version>
+        <version>25.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.matsim.contrib</groupId>

--- a/contribs/decongestion/pom.xml
+++ b/contribs/decongestion/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.matsim</groupId>
         <artifactId>contrib</artifactId>
-        <version>16.0-SNAPSHOT</version>
+        <version>25.0-SNAPSHOT</version>
     </parent>
 	<dependencies>
 		<dependency>

--- a/contribs/discrete_mode_choice/pom.xml
+++ b/contribs/discrete_mode_choice/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>contrib</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/contribs/drt-extensions/pom.xml
+++ b/contribs/drt-extensions/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>contrib</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.matsim.contrib</groupId>
@@ -15,25 +15,25 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>drt</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>ev</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>informed-mode-choice</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>simwrapper</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>vsp</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/contribs/drt/pom.xml
+++ b/contribs/drt/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>contrib</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.matsim.contrib</groupId>
@@ -15,19 +15,19 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>dvrp</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>otfvis</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>common</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/contribs/dvrp/pom.xml
+++ b/contribs/dvrp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>contrib</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.matsim.contrib</groupId>
@@ -24,17 +24,17 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>otfvis</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>common</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>ev</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/contribs/emissions/pom.xml
+++ b/contribs/emissions/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.matsim</groupId>
         <artifactId>contrib</artifactId>
-        <version>16.0-SNAPSHOT</version>
+        <version>25.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.matsim.contrib</groupId>
             <artifactId>analysis</artifactId>
-            <version>16.0-SNAPSHOT</version>
+            <version>25.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/contribs/ev/pom.xml
+++ b/contribs/ev/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>contrib</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.matsim.contrib</groupId>
@@ -14,7 +14,7 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>common</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/contribs/freight/pom.xml
+++ b/contribs/freight/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>contrib</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.matsim.contrib</groupId>
@@ -55,13 +55,13 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>roadpricing</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>otfvis</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>org.matsim</groupId>
 			<artifactId>matsim-examples</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 
 		<!-- This comes from jsprit, but is outdated there. Unclear, when the next release is coming.

--- a/contribs/freightreceiver/pom.xml
+++ b/contribs/freightreceiver/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>contrib</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.matsim.contrib</groupId>
@@ -28,13 +28,13 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>freight</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.matsim</groupId>
 			<artifactId>matsim-examples</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 
 	</dependencies>

--- a/contribs/hybridsim/pom.xml
+++ b/contribs/hybridsim/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.matsim</groupId>
     <artifactId>contrib</artifactId>
-    <version>16.0-SNAPSHOT</version>
+    <version>25.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.matsim.contrib</groupId>

--- a/contribs/informed-mode-choice/pom.xml
+++ b/contribs/informed-mode-choice/pom.xml
@@ -9,14 +9,14 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>contrib</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>application</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 			<exclusions>
 				<exclusion>
 					<groupId>xerces</groupId>

--- a/contribs/integration/pom.xml
+++ b/contribs/integration/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>contrib</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 
 	<build>
@@ -80,7 +80,7 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>accessibility</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.geotools.jdbc</groupId>
@@ -90,18 +90,18 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>analysis</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>dvrp</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>drt</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/contribs/locationchoice/pom.xml
+++ b/contribs/locationchoice/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.matsim</groupId>
     <artifactId>contrib</artifactId>
-    <version>16.0-SNAPSHOT</version>
+    <version>25.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.matsim.contrib</groupId>
@@ -24,12 +24,12 @@
         <dependency>
             <groupId>org.matsim.contrib</groupId>
             <artifactId>otfvis</artifactId>
-            <version>16.0-SNAPSHOT</version>
+            <version>25.0-SNAPSHOT</version>
         </dependency>
 	    <dependency>
 		    <groupId>org.matsim.contrib</groupId>
 		    <artifactId>analysis</artifactId>
-		    <version>16.0-SNAPSHOT</version>
+		    <version>25.0-SNAPSHOT</version>
 		    <scope>test</scope>
 	    </dependency>
     </dependencies>

--- a/contribs/matrixbasedptrouter/pom.xml
+++ b/contribs/matrixbasedptrouter/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.matsim</groupId>
     <artifactId>contrib</artifactId>
-    <version>16.0-SNAPSHOT</version>
+    <version>25.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.matsim.contrib</groupId>

--- a/contribs/minibus/pom.xml
+++ b/contribs/minibus/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.matsim</groupId>
     <artifactId>contrib</artifactId>
-    <version>16.0-SNAPSHOT</version>
+    <version>25.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.matsim.contrib</groupId>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.matsim</groupId>
       <artifactId>matsim</artifactId>
-      <version>16.0-SNAPSHOT</version>
+      <version>25.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <!-- only needed for external jar, no code dependency -->

--- a/contribs/multimodal/pom.xml
+++ b/contribs/multimodal/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.matsim</groupId>
     <artifactId>contrib</artifactId>
-    <version>16.0-SNAPSHOT</version>
+    <version>25.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.matsim.contrib</groupId>

--- a/contribs/noise/pom.xml
+++ b/contribs/noise/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.matsim</groupId>
         <artifactId>contrib</artifactId>
-        <version>16.0-SNAPSHOT</version>
+        <version>25.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.matsim.contrib</groupId>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>org.matsim.contrib</groupId>
             <artifactId>analysis</artifactId>
-            <version>16.0-SNAPSHOT</version>
+            <version>25.0-SNAPSHOT</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.geotools/gt-geojson -->
         <dependency>

--- a/contribs/osm/pom.xml
+++ b/contribs/osm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.matsim</groupId>
         <artifactId>contrib</artifactId>
-        <version>16.0-SNAPSHOT</version>
+        <version>25.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/contribs/otfvis/pom.xml
+++ b/contribs/otfvis/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>contrib</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/contribs/parking/pom.xml
+++ b/contribs/parking/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>contrib</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.matsim.contrib</groupId>
@@ -12,17 +12,17 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>multimodal</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>otfvis</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>dvrp</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/contribs/pom.xml
+++ b/contribs/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>matsim-all</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<packaging>pom</packaging>

--- a/contribs/protobuf/pom.xml
+++ b/contribs/protobuf/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.matsim</groupId>
         <artifactId>contrib</artifactId>
-        <version>16.0-SNAPSHOT</version>
+        <version>25.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.matsim.contrib</groupId>

--- a/contribs/pseudosimulation/pom.xml
+++ b/contribs/pseudosimulation/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.matsim</groupId>
     <artifactId>contrib</artifactId>
-    <version>16.0-SNAPSHOT</version>
+    <version>25.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.matsim.contrib</groupId>
@@ -13,7 +13,7 @@
     <dependency>
       <groupId>org.matsim.contrib</groupId>
       <artifactId>common</artifactId>
-      <version>16.0-SNAPSHOT</version>
+      <version>25.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/contribs/railsim/pom.xml
+++ b/contribs/railsim/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>contrib</artifactId>
 		<groupId>org.matsim</groupId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ch.sbb.matsim.contrib</groupId>

--- a/contribs/roadpricing/pom.xml
+++ b/contribs/roadpricing/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>contrib</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.matsim.contrib</groupId>

--- a/contribs/sbb-extensions/pom.xml
+++ b/contribs/sbb-extensions/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.matsim</groupId>
         <artifactId>contrib</artifactId>
-        <version>16.0-SNAPSHOT</version>
+        <version>25.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.matsim.contrib</groupId>

--- a/contribs/shared_mobility/pom.xml
+++ b/contribs/shared_mobility/pom.xml
@@ -9,19 +9,19 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>contrib</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.matsim</groupId>
 			<artifactId>matsim-examples</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>common</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/contribs/signals/pom.xml
+++ b/contribs/signals/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.matsim</groupId>
     <artifactId>contrib</artifactId>
-    <version>16.0-SNAPSHOT</version>
+    <version>25.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.matsim.contrib</groupId>
@@ -22,12 +22,12 @@
     <dependency>
       <groupId>org.matsim</groupId>
       <artifactId>matsim-examples</artifactId>
-      <version>16.0-SNAPSHOT</version>
+      <version>25.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.matsim.contrib</groupId>
       <artifactId>otfvis</artifactId>
-      <version>16.0-SNAPSHOT</version>
+      <version>25.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/contribs/simulatedannealing/pom.xml
+++ b/contribs/simulatedannealing/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>contrib</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>common</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/contribs/simwrapper/pom.xml
+++ b/contribs/simwrapper/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>contrib</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.matsim.contrib</groupId>
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>application</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 
 
@@ -55,7 +55,7 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>vsp</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/contribs/small-scale-traffic-generation/pom.xml
+++ b/contribs/small-scale-traffic-generation/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.matsim</groupId>
     <artifactId>contrib</artifactId>
-    <version>16.0-SNAPSHOT</version>
+    <version>25.0-SNAPSHOT</version>
   </parent>
 
     <dependencies>
@@ -15,13 +15,13 @@
         <dependency>
             <groupId>org.matsim.contrib</groupId>
             <artifactId>application</artifactId>
-            <version>16.0-SNAPSHOT</version>
+            <version>25.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>org.matsim.contrib</groupId>
             <artifactId>freight</artifactId>
-            <version>16.0-SNAPSHOT</version>
+            <version>25.0-SNAPSHOT</version>
         </dependency>
 
     </dependencies>

--- a/contribs/socnetsim/pom.xml
+++ b/contribs/socnetsim/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.matsim</groupId>
     <artifactId>contrib</artifactId>
-    <version>16.0-SNAPSHOT</version>
+    <version>25.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.matsim.contrib</groupId>

--- a/contribs/sumo/pom.xml
+++ b/contribs/sumo/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>contrib</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/contribs/taxi/pom.xml
+++ b/contribs/taxi/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>contrib</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.matsim.contrib</groupId>
@@ -28,17 +28,17 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>dvrp</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>drt</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>ev</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.assertj</groupId>

--- a/contribs/vsp/pom.xml
+++ b/contribs/vsp/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>contrib</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>
@@ -22,59 +22,59 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>multimodal</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>taxi</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>dvrp</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>parking</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>freight</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>accessibility</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>emissions</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>minibus</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>common</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>analysis</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>informed-mode-choice</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 <!--		<dependency>-->
 <!--			<groupId>org.processing</groupId>-->
@@ -97,17 +97,17 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>otfvis</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>noise</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>signals</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.openstreetmap.osmosis</groupId>
@@ -145,7 +145,7 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>cadyts-integration</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>
@@ -174,12 +174,12 @@
 		<dependency>
 			<groupId>org.matsim</groupId>
 			<artifactId>matsim-examples</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>drt</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.openjfx</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>matsim-all</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<packaging>jar</packaging>

--- a/matsim/pom.xml
+++ b/matsim/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.matsim</groupId>
 		<artifactId>matsim-all</artifactId>
-		<version>16.0-SNAPSHOT</version>
+		<version>25.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 
@@ -180,7 +180,7 @@
 		<dependency>
 			<groupId>org.matsim</groupId>
 			<artifactId>matsim-examples</artifactId>
-			<version>16.0-SNAPSHOT</version>
+			<version>25.0-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.matsim</groupId>
     <artifactId>matsim-all</artifactId>
     <packaging>pom</packaging>
-    <version>16.0-SNAPSHOT</version>
+    <version>25.0-SNAPSHOT</version>
     <name>MATSim-All</name>
     <modules>
         <module>matsim</module>


### PR DESCRIPTION
We will release version 24.0 next week. This commit prepares the master branch for the next release cycle. Effectively, everything which is merged into master after this commit will go into release 25. 

Changes from other branches can still be merged into the 24.x branch.

This corresponds to #2844 