### PR TITLE
Create interface for different landuse/building input data types for small-scale commercial traffic

### DIFF
--- a/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/CreateDataDistributionOfStructureData.java
+++ b/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/CreateDataDistributionOfStructureData.java
@@ -71,7 +71,7 @@ public class CreateDataDistributionOfStructureData implements MATSimAppCommand {
 	@CommandLine.Option(names = "--pathToInvestigationAreaData", description = "Path to the investigation area data", defaultValue = "contribs/small-scale-traffic-generation/test/input/org/matsim/smallScaleCommercialTrafficGeneration/investigationAreaData.csv")
 	private Path pathToInvestigationAreaData;
 
-	private final Map<String, List<String>> landuseCategoriesAndDataConnection = new HashMap<>();
+	private Map<String, List<String>> landuseCategoriesAndDataConnection;
 	private final Map<String, Map<String, List<SimpleFeature>>> buildingsPerZone = new HashMap<>();
 
 	public CreateDataDistributionOfStructureData(LanduseDataConnectionCreator landuseDataConnectionCreator) {
@@ -115,7 +115,7 @@ public class CreateDataDistributionOfStructureData implements MATSimAppCommand {
 		if(Files.notExists(output))
 			new File(output.toString()).mkdir();
 
-		landuseDataConnectionCreator.createLanduseDataConnection(landuseCategoriesAndDataConnection);
+		landuseCategoriesAndDataConnection = landuseDataConnectionCreator.createLanduseDataConnection();
 
 		Map<String, Object2DoubleMap<String>> resultingDataPerZone = LanduseBuildingAnalysis
 			.createInputDataDistribution(output, landuseCategoriesAndDataConnection,

--- a/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/CreateDataDistributionOfStructureData.java
+++ b/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/CreateDataDistributionOfStructureData.java
@@ -29,6 +29,8 @@ public class CreateDataDistributionOfStructureData implements MATSimAppCommand {
 
 	private static final Logger log = LogManager.getLogger(CreateDataDistributionOfStructureData.class);
 
+	private static LanduseDataConnectionCreator landuseDataConnectionCreator;
+
 	private enum LanduseConfiguration {
 		useOnlyOSMLanduse, useOSMBuildingsAndLanduse
 	}
@@ -72,8 +74,17 @@ public class CreateDataDistributionOfStructureData implements MATSimAppCommand {
 	private final Map<String, List<String>> landuseCategoriesAndDataConnection = new HashMap<>();
 	private final Map<String, Map<String, List<SimpleFeature>>> buildingsPerZone = new HashMap<>();
 
+	public CreateDataDistributionOfStructureData(LanduseDataConnectionCreator landuseDataConnectionCreator) {
+		CreateDataDistributionOfStructureData.landuseDataConnectionCreator = landuseDataConnectionCreator;
+		log.info("Using LanduseDataConnectionCreator {} to connect the types of the landuse data to the categories of the small scale commercial traffic generation", landuseDataConnectionCreator.getClass().getSimpleName());
+	}
+	public CreateDataDistributionOfStructureData() {
+		landuseDataConnectionCreator = new LanduseDataConnectionCreatorForOSM_Data();
+		log.info("Using default LanduseDataConnectionCreatorForOSM_Data to connect the types of the landuse data to the categories of the small scale commercial traffic generation");
+	}
+
 	public static void main(String[] args) {
-		System.exit(new CommandLine(new CreateDataDistributionOfStructureData()).execute(args));
+		System.exit(new CommandLine(new CreateDataDistributionOfStructureData(landuseDataConnectionCreator)).execute(args));
 	}
 
 	@Override
@@ -104,7 +115,7 @@ public class CreateDataDistributionOfStructureData implements MATSimAppCommand {
 		if(Files.notExists(output))
 			new File(output.toString()).mkdir();
 
-		createDefaultDataConnectionForOSM(landuseCategoriesAndDataConnection); //TODO: find way to import this connection
+		landuseDataConnectionCreator.createLanduseDataConnection(landuseCategoriesAndDataConnection);
 
 		Map<String, Object2DoubleMap<String>> resultingDataPerZone = LanduseBuildingAnalysis
 			.createInputDataDistribution(output, landuseCategoriesAndDataConnection,

--- a/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/LanduseBuildingAnalysis.java
+++ b/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/LanduseBuildingAnalysis.java
@@ -120,10 +120,8 @@ public class LanduseBuildingAnalysis {
 					resultingDataPerZone.get(zoneId).mergeDouble(categoryData, 0., Double::sum);
 					if (landuseCategoriesAndDataConnection.get(categoryData).contains(categoryLanduse)) {
 						double additionalArea = landuseCategoriesPerZone.get(zoneId).getDouble(categoryLanduse);
-						// because the category commercial is in two categories (traffic/parcels and
-						// Tertiary Sector Rest
-						if (categoryLanduse.equals("commercial"))
-							additionalArea = additionalArea * 0.5;
+//						// because the categoryLanduse can be in two categories (e.g., traffic/parcels and Tertiary Sector Rest
+						additionalArea = additionalArea / LanduseDataConnectionCreator.getNumberOfEmployeeCategoriesOfThisTyp(landuseCategoriesAndDataConnection, categoryLanduse);
 						resultingDataPerZone.get(zoneId).mergeDouble(categoryData, additionalArea, Double::sum);
 						totalSquareMetersPerCategory.get(regionOfZone).mergeDouble(categoryData, additionalArea,
 								Double::sum);

--- a/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/LanduseBuildingAnalysis.java
+++ b/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/LanduseBuildingAnalysis.java
@@ -253,21 +253,31 @@ public class LanduseBuildingAnalysis {
 	 *
 	 * @param building      the building to be analyzed
 	 * @param buildingTypes the types of the building
-	 * @return
+	 * @return the area of the building for each category
 	 */
 	public static int calculateAreaPerBuildingCategory(SimpleFeature building, String[] buildingTypes) {
 		double buildingLevels;
+		double buildingLevelsPerType;
 		if (building.getAttribute("levels") == null)
 			buildingLevels = 1;
-		else
-			buildingLevels = (long) building.getAttribute("levels")
-				/ (double) buildingTypes.length;
+		else {
+			Object levelsAttribute = building.getAttribute("levels");
+			if (levelsAttribute instanceof String) {
+				buildingLevels = Double.parseDouble((String) levelsAttribute);
+			} else if (levelsAttribute instanceof Long) {
+				buildingLevels = (long) levelsAttribute;
+			} else {
+				throw new RuntimeException("The attribute 'levels' of the building shape is not a string or a long.");
+			}
+		}
+		buildingLevelsPerType = buildingLevels / (double) buildingTypes.length;
+
 		double groundArea;
 		if (building.getAttribute("area") != null)
 			groundArea = (int) (long) building.getAttribute("area");
 		else
 			groundArea = ((Geometry) building.getDefaultGeometry()).getArea();
-		double area = groundArea * buildingLevels;
+		double area = groundArea * buildingLevelsPerType;
 		return (int) Math.round(area);
 	}
 

--- a/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/LanduseBuildingAnalysis.java
+++ b/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/LanduseBuildingAnalysis.java
@@ -90,24 +90,6 @@ public class LanduseBuildingAnalysis {
 		return resultingDataPerZone;
 	}
 
-	public static void createDefaultDataConnectionForOSM(Map<String, List<String>> landuseCategoriesAndDataConnection) {
-		landuseCategoriesAndDataConnection.put("Inhabitants",
-                new ArrayList<>(Arrays.asList("residential", "apartments", "dormitory", "dwelling_house", "house",
-                        "retirement_home", "semidetached_house", "detached")));
-		landuseCategoriesAndDataConnection.put("Employee Primary Sector", new ArrayList<>(
-                Arrays.asList("farmyard", "farmland", "farm", "farm_auxiliary", "greenhouse", "agricultural")));
-		landuseCategoriesAndDataConnection.put("Employee Construction",
-                new ArrayList<>(List.of("construction")));
-		landuseCategoriesAndDataConnection.put("Employee Secondary Sector Rest",
-                new ArrayList<>(Arrays.asList("industrial", "factory", "manufacture", "bakehouse")));
-		landuseCategoriesAndDataConnection.put("Employee Retail",
-                new ArrayList<>(Arrays.asList("retail", "kiosk", "mall", "shop", "supermarket")));
-		landuseCategoriesAndDataConnection.put("Employee Traffic/Parcels", new ArrayList<>(
-                Arrays.asList("commercial", "post_office", "storage", "storage_tank", "warehouse")));
-		landuseCategoriesAndDataConnection.put("Employee Tertiary Sector Rest", new ArrayList<>(
-                Arrays.asList("commercial", "embassy", "foundation", "government", "office", "townhall")));
-	}
-
 	/**
 	 * Creates the resulting data for each zone based on the landuse distribution
 	 * and the original data.

--- a/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/LanduseDataConnectionCreator.java
+++ b/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/LanduseDataConnectionCreator.java
@@ -1,0 +1,13 @@
+package org.matsim.smallScaleCommercialTrafficGeneration.prepare;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Interface for creating the connection between landuse categories and the employee data.
+ *
+ * @author Ricardo Ewert
+ */
+public interface LanduseDataConnectionCreator {
+	void createLanduseDataConnection(Map<String, List<String>> landuseCategoriesAndDataConnection);
+}

--- a/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/LanduseDataConnectionCreator.java
+++ b/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/LanduseDataConnectionCreator.java
@@ -2,6 +2,7 @@ package org.matsim.smallScaleCommercialTrafficGeneration.prepare;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Interface for creating the connection between landuse categories and the employee data.
@@ -10,4 +11,21 @@ import java.util.Map;
  */
 public interface LanduseDataConnectionCreator {
 	Map<String, List<String>> createLanduseDataConnection();
+
+	/**
+	 * Counts the number of employee categories in which a type is represented.
+	 *
+	 * @return
+	 */
+	static int getNumberOfEmployeeCategoriesOfThisTyp(Map<String, List<String>> landuseCategoriesAndDataConnection, String type) {
+		AtomicInteger count = new AtomicInteger();
+		landuseCategoriesAndDataConnection.values().forEach(list -> {
+			if (list.contains(type)) {
+				count.getAndIncrement();
+			}
+		});
+		return count.get();
+	}
+
+	;
 }

--- a/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/LanduseDataConnectionCreator.java
+++ b/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/LanduseDataConnectionCreator.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Interface for creating the connection between landuse categories and the employee data.
+ * Interface for creating the connection between landuse or building categories and the required employee data categories for the simulation.
  *
  * @author Ricardo Ewert
  */

--- a/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/LanduseDataConnectionCreator.java
+++ b/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/LanduseDataConnectionCreator.java
@@ -9,5 +9,5 @@ import java.util.Map;
  * @author Ricardo Ewert
  */
 public interface LanduseDataConnectionCreator {
-	void createLanduseDataConnection(Map<String, List<String>> landuseCategoriesAndDataConnection);
+	Map<String, List<String>> createLanduseDataConnection();
 }

--- a/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/LanduseDataConnectionCreatorForOSM_Data.java
+++ b/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/LanduseDataConnectionCreatorForOSM_Data.java
@@ -1,0 +1,33 @@
+package org.matsim.smallScaleCommercialTrafficGeneration.prepare;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class creates the connection between the landuse categories of the OSM landuse data and the employee data.
+ *
+ * @author Ricardo Ewert
+ */
+public class LanduseDataConnectionCreatorForOSM_Data implements LanduseDataConnectionCreator{
+
+	@Override
+	public void createLanduseDataConnection(Map<String, List<String>> landuseCategoriesAndDataConnection) {
+		landuseCategoriesAndDataConnection.put("Inhabitants",
+			new ArrayList<>(Arrays.asList("residential", "apartments", "dormitory", "dwelling_house", "house",
+				"retirement_home", "semidetached_house", "detached")));
+		landuseCategoriesAndDataConnection.put("Employee Primary Sector", new ArrayList<>(
+			Arrays.asList("farmyard", "farmland", "farm", "farm_auxiliary", "greenhouse", "agricultural")));
+		landuseCategoriesAndDataConnection.put("Employee Construction",
+			new ArrayList<>(List.of("construction")));
+		landuseCategoriesAndDataConnection.put("Employee Secondary Sector Rest",
+			new ArrayList<>(Arrays.asList("industrial", "factory", "manufacture", "bakehouse")));
+		landuseCategoriesAndDataConnection.put("Employee Retail",
+			new ArrayList<>(Arrays.asList("retail", "kiosk", "mall", "shop", "supermarket")));
+		landuseCategoriesAndDataConnection.put("Employee Traffic/Parcels", new ArrayList<>(
+			Arrays.asList("commercial", "post_office", "storage", "storage_tank", "warehouse")));
+		landuseCategoriesAndDataConnection.put("Employee Tertiary Sector Rest", new ArrayList<>(
+			Arrays.asList("commercial", "embassy", "foundation", "government", "office", "townhall")));
+	}
+}

--- a/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/LanduseDataConnectionCreatorForOSM_Data.java
+++ b/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/LanduseDataConnectionCreatorForOSM_Data.java
@@ -1,9 +1,6 @@
 package org.matsim.smallScaleCommercialTrafficGeneration.prepare;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * This class creates the connection between the landuse categories of the OSM landuse data and the employee data.
@@ -13,7 +10,8 @@ import java.util.Map;
 public class LanduseDataConnectionCreatorForOSM_Data implements LanduseDataConnectionCreator{
 
 	@Override
-	public void createLanduseDataConnection(Map<String, List<String>> landuseCategoriesAndDataConnection) {
+	public Map<String, List<String>> createLanduseDataConnection() {
+		Map<String, List<String>> landuseCategoriesAndDataConnection = new HashMap<>();
 		landuseCategoriesAndDataConnection.put("Inhabitants",
 			new ArrayList<>(Arrays.asList("residential", "apartments", "dormitory", "dwelling_house", "house",
 				"retirement_home", "semidetached_house", "detached")));
@@ -29,5 +27,6 @@ public class LanduseDataConnectionCreatorForOSM_Data implements LanduseDataConne
 			Arrays.asList("commercial", "post_office", "storage", "storage_tank", "warehouse")));
 		landuseCategoriesAndDataConnection.put("Employee Tertiary Sector Rest", new ArrayList<>(
 			Arrays.asList("commercial", "embassy", "foundation", "government", "office", "townhall")));
+		return landuseCategoriesAndDataConnection;
 	}
 }

--- a/contribs/small-scale-traffic-generation/src/test/java/org/matsim/smallScaleCommercialTrafficGeneration/TrafficVolumeGenerationTest.java
+++ b/contribs/small-scale-traffic-generation/src/test/java/org/matsim/smallScaleCommercialTrafficGeneration/TrafficVolumeGenerationTest.java
@@ -35,6 +35,8 @@ import org.matsim.freight.carriers.CarrierCapabilities.FleetSize;
 import org.matsim.freight.carriers.CarriersUtils;
 import org.matsim.smallScaleCommercialTrafficGeneration.TrafficVolumeGeneration.TrafficVolumeKey;
 import org.matsim.smallScaleCommercialTrafficGeneration.prepare.LanduseBuildingAnalysis;
+import org.matsim.smallScaleCommercialTrafficGeneration.prepare.LanduseDataConnectionCreator;
+import org.matsim.smallScaleCommercialTrafficGeneration.prepare.LanduseDataConnectionCreatorForOSM_Data;
 import org.matsim.testcases.MatsimTestUtils;
 import org.opengis.feature.simple.SimpleFeature;
 
@@ -42,8 +44,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
-
-import static org.matsim.smallScaleCommercialTrafficGeneration.prepare.LanduseBuildingAnalysis.createDefaultDataConnectionForOSM;
 
 /**
  * @author Ricardo Ewert
@@ -67,7 +67,8 @@ public class TrafficVolumeGenerationTest {
 		String shapeFileZoneNameColumn = "name";
 		String shapeFileBuildingTypeColumn = "type";
 		Path pathToInvestigationAreaData = Path.of(utils.getPackageInputDirectory()).resolve("investigationAreaData.csv");
-		createDefaultDataConnectionForOSM(landuseCategoriesAndDataConnection);
+		LanduseDataConnectionCreator landuseDataConnectionCreator = new LanduseDataConnectionCreatorForOSM_Data();
+		landuseDataConnectionCreator.createLanduseDataConnection(landuseCategoriesAndDataConnection);
 
 		Map<String, Object2DoubleMap<String>> resultingDataPerZone = LanduseBuildingAnalysis
 				.createInputDataDistribution(output, landuseCategoriesAndDataConnection,
@@ -198,7 +199,8 @@ public class TrafficVolumeGenerationTest {
 		String shapeFileZoneNameColumn = "name";
 		String shapeFileBuildingTypeColumn = "type";
 		Path pathToInvestigationAreaData = Path.of(utils.getPackageInputDirectory()).resolve("investigationAreaData.csv");
-		createDefaultDataConnectionForOSM(landuseCategoriesAndDataConnection);
+		LanduseDataConnectionCreator landuseDataConnectionCreator = new LanduseDataConnectionCreatorForOSM_Data();
+		landuseDataConnectionCreator.createLanduseDataConnection(landuseCategoriesAndDataConnection);
 
 		Map<String, Object2DoubleMap<String>> resultingDataPerZone = LanduseBuildingAnalysis
 				.createInputDataDistribution(output, landuseCategoriesAndDataConnection,
@@ -523,7 +525,8 @@ public class TrafficVolumeGenerationTest {
 		String shapeFileZoneNameColumn = "name";
 		String shapeFileBuildingTypeColumn = "type";
 		Path pathToInvestigationAreaData = Path.of(utils.getPackageInputDirectory()).resolve("investigationAreaData.csv");
-		createDefaultDataConnectionForOSM(landuseCategoriesAndDataConnection);
+		LanduseDataConnectionCreator landuseDataConnectionCreator = new LanduseDataConnectionCreatorForOSM_Data();
+		landuseDataConnectionCreator.createLanduseDataConnection(landuseCategoriesAndDataConnection);
 
 		ArrayList<String> modesORvehTypes = new ArrayList<>(
 				Arrays.asList("vehTyp1", "vehTyp2", "vehTyp3", "vehTyp4", "vehTyp5"));
@@ -697,7 +700,9 @@ public class TrafficVolumeGenerationTest {
 		Scenario scenario = ScenarioUtils.loadScenario(config);
 		TrafficVolumeGeneration.setInputParameters(usedTrafficType);
 
-		createDefaultDataConnectionForOSM(landuseCategoriesAndDataConnection);
+		LanduseDataConnectionCreator landuseDataConnectionCreator = new LanduseDataConnectionCreatorForOSM_Data();
+		landuseDataConnectionCreator.createLanduseDataConnection(landuseCategoriesAndDataConnection);
+
 		Map<String, Object2DoubleMap<String>> resultingDataPerZone = LanduseBuildingAnalysis
 				.createInputDataDistribution(output, landuseCategoriesAndDataConnection,
 					usedLanduseConfiguration,

--- a/contribs/small-scale-traffic-generation/src/test/java/org/matsim/smallScaleCommercialTrafficGeneration/TrafficVolumeGenerationTest.java
+++ b/contribs/small-scale-traffic-generation/src/test/java/org/matsim/smallScaleCommercialTrafficGeneration/TrafficVolumeGenerationTest.java
@@ -57,7 +57,6 @@ public class TrafficVolumeGenerationTest {
 	@Test
 	void testTrafficVolumeGenerationCommercialPersonTraffic() throws IOException {
 
-		Map<String, List<String>> landuseCategoriesAndDataConnection = new HashMap<>();
 		Map<String, Map<String, List<SimpleFeature>>> buildingsPerZone = new HashMap<>();
 
 		Path output = Path.of(utils.getOutputDirectory());
@@ -68,7 +67,7 @@ public class TrafficVolumeGenerationTest {
 		String shapeFileBuildingTypeColumn = "type";
 		Path pathToInvestigationAreaData = Path.of(utils.getPackageInputDirectory()).resolve("investigationAreaData.csv");
 		LanduseDataConnectionCreator landuseDataConnectionCreator = new LanduseDataConnectionCreatorForOSM_Data();
-		landuseDataConnectionCreator.createLanduseDataConnection(landuseCategoriesAndDataConnection);
+		Map<String, List<String>> landuseCategoriesAndDataConnection = landuseDataConnectionCreator.createLanduseDataConnection();
 
 		Map<String, Object2DoubleMap<String>> resultingDataPerZone = LanduseBuildingAnalysis
 				.createInputDataDistribution(output, landuseCategoriesAndDataConnection,
@@ -189,7 +188,6 @@ public class TrafficVolumeGenerationTest {
 	@Test
 	void testTrafficVolumeGenerationGoodsTraffic() throws IOException {
 
-		Map<String, List<String>> landuseCategoriesAndDataConnection = new HashMap<>();
 		Map<String, Map<String, List<SimpleFeature>>> buildingsPerZone = new HashMap<>();
 
 		Path output = Path.of(utils.getOutputDirectory());
@@ -200,7 +198,7 @@ public class TrafficVolumeGenerationTest {
 		String shapeFileBuildingTypeColumn = "type";
 		Path pathToInvestigationAreaData = Path.of(utils.getPackageInputDirectory()).resolve("investigationAreaData.csv");
 		LanduseDataConnectionCreator landuseDataConnectionCreator = new LanduseDataConnectionCreatorForOSM_Data();
-		landuseDataConnectionCreator.createLanduseDataConnection(landuseCategoriesAndDataConnection);
+		Map<String, List<String>> landuseCategoriesAndDataConnection = landuseDataConnectionCreator.createLanduseDataConnection();
 
 		Map<String, Object2DoubleMap<String>> resultingDataPerZone = LanduseBuildingAnalysis
 				.createInputDataDistribution(output, landuseCategoriesAndDataConnection,
@@ -512,7 +510,6 @@ public class TrafficVolumeGenerationTest {
 
 	@Test
 	void testReducingDemandAfterAddingExistingScenarios_goods() throws Exception {
-		Map<String, List<String>> landuseCategoriesAndDataConnection = new HashMap<>();
 		Map<String, Map<String, List<SimpleFeature>>> buildingsPerZone = new HashMap<>();
 
 		Path output = Path.of(utils.getOutputDirectory());
@@ -526,7 +523,7 @@ public class TrafficVolumeGenerationTest {
 		String shapeFileBuildingTypeColumn = "type";
 		Path pathToInvestigationAreaData = Path.of(utils.getPackageInputDirectory()).resolve("investigationAreaData.csv");
 		LanduseDataConnectionCreator landuseDataConnectionCreator = new LanduseDataConnectionCreatorForOSM_Data();
-		landuseDataConnectionCreator.createLanduseDataConnection(landuseCategoriesAndDataConnection);
+		Map<String, List<String>> landuseCategoriesAndDataConnection = landuseDataConnectionCreator.createLanduseDataConnection();
 
 		ArrayList<String> modesORvehTypes = new ArrayList<>(
 				Arrays.asList("vehTyp1", "vehTyp2", "vehTyp3", "vehTyp4", "vehTyp5"));
@@ -675,7 +672,6 @@ public class TrafficVolumeGenerationTest {
 
 	@Test
 	void testReducingDemandAfterAddingExistingScenarios_commercialPersonTraffic() throws Exception {
-		Map<String, List<String>> landuseCategoriesAndDataConnection = new HashMap<>();
 		Map<String, Map<String, List<SimpleFeature>>> buildingsPerZone = new HashMap<>();
 		Map<String, Map<String, List<ActivityFacility>>> facilitiesPerZone = new HashMap<>();
 
@@ -701,7 +697,7 @@ public class TrafficVolumeGenerationTest {
 		TrafficVolumeGeneration.setInputParameters(usedTrafficType);
 
 		LanduseDataConnectionCreator landuseDataConnectionCreator = new LanduseDataConnectionCreatorForOSM_Data();
-		landuseDataConnectionCreator.createLanduseDataConnection(landuseCategoriesAndDataConnection);
+		Map<String, List<String>> landuseCategoriesAndDataConnection = landuseDataConnectionCreator.createLanduseDataConnection();
 
 		Map<String, Object2DoubleMap<String>> resultingDataPerZone = LanduseBuildingAnalysis
 				.createInputDataDistribution(output, landuseCategoriesAndDataConnection,

--- a/contribs/small-scale-traffic-generation/src/test/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/LanduseBuildingAnalysisTest.java
+++ b/contribs/small-scale-traffic-generation/src/test/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/LanduseBuildingAnalysisTest.java
@@ -45,7 +45,6 @@ public class LanduseBuildingAnalysisTest {
 
 	@Test
 	void testReadOfDataDistributionPerZoneAndBuildingAnalysis() throws IOException {
-		Map<String, List<String>> landuseCategoriesAndDataConnection = new HashMap<>();
 		Map<String, Map<String, List<SimpleFeature>>> buildingsPerZone = new HashMap<>();
 
 		Path output = Path.of(utils.getOutputDirectory());
@@ -56,7 +55,7 @@ public class LanduseBuildingAnalysisTest {
 		String shapeFileBuildingTypeColumn = "type";
 		Path pathToInvestigationAreaData = Path.of(utils.getPackageInputDirectory()).getParent().resolve("investigationAreaData.csv");
 		LanduseDataConnectionCreator landuseDataConnectionCreator = new LanduseDataConnectionCreatorForOSM_Data();
-		landuseDataConnectionCreator.createLanduseDataConnection(landuseCategoriesAndDataConnection);
+		Map<String, List<String>> landuseCategoriesAndDataConnection = landuseDataConnectionCreator.createLanduseDataConnection();
 		// Test if the reading of the existing data distribution works correctly
 
 		Map<String, Object2DoubleMap<String>> resultingDataPerZone = LanduseBuildingAnalysis
@@ -240,7 +239,6 @@ public class LanduseBuildingAnalysisTest {
 
 	@Test
 	void testLanduseDistribution() throws IOException {
-		Map<String, List<String>> landuseCategoriesAndDataConnection = new HashMap<>();
 		Map<String, Map<String, List<SimpleFeature>>> buildingsPerZone = new HashMap<>();
 
 		Path output = Path.of(utils.getOutputDirectory());
@@ -251,7 +249,7 @@ public class LanduseBuildingAnalysisTest {
 		String shapeFileBuildingTypeColumn = "type";
 		Path pathToInvestigationAreaData = Path.of(utils.getPackageInputDirectory()).getParent().resolve("investigationAreaData.csv");
 		LanduseDataConnectionCreator landuseDataConnectionCreator = new LanduseDataConnectionCreatorForOSM_Data();
-		landuseDataConnectionCreator.createLanduseDataConnection(landuseCategoriesAndDataConnection);
+		Map<String, List<String>> landuseCategoriesAndDataConnection = landuseDataConnectionCreator.createLanduseDataConnection();
 
 		// Analyze resultingData per zone
 		Map<String, Object2DoubleMap<String>> resultingDataPerZone = LanduseBuildingAnalysis

--- a/contribs/small-scale-traffic-generation/src/test/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/LanduseBuildingAnalysisTest.java
+++ b/contribs/small-scale-traffic-generation/src/test/java/org/matsim/smallScaleCommercialTrafficGeneration/prepare/LanduseBuildingAnalysisTest.java
@@ -34,8 +34,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.matsim.smallScaleCommercialTrafficGeneration.prepare.LanduseBuildingAnalysis.createDefaultDataConnectionForOSM;
-
 /**
  * @author Ricardo Ewert
  *
@@ -57,9 +55,9 @@ public class LanduseBuildingAnalysisTest {
 		String shapeFileZoneNameColumn = "name";
 		String shapeFileBuildingTypeColumn = "type";
 		Path pathToInvestigationAreaData = Path.of(utils.getPackageInputDirectory()).getParent().resolve("investigationAreaData.csv");
+		LanduseDataConnectionCreator landuseDataConnectionCreator = new LanduseDataConnectionCreatorForOSM_Data();
+		landuseDataConnectionCreator.createLanduseDataConnection(landuseCategoriesAndDataConnection);
 		// Test if the reading of the existing data distribution works correctly
-
-		createDefaultDataConnectionForOSM(landuseCategoriesAndDataConnection);
 
 		Map<String, Object2DoubleMap<String>> resultingDataPerZone = LanduseBuildingAnalysis
 				.createInputDataDistribution(output, landuseCategoriesAndDataConnection,
@@ -252,7 +250,8 @@ public class LanduseBuildingAnalysisTest {
 		String shapeFileZoneNameColumn = "name";
 		String shapeFileBuildingTypeColumn = "type";
 		Path pathToInvestigationAreaData = Path.of(utils.getPackageInputDirectory()).getParent().resolve("investigationAreaData.csv");
-		createDefaultDataConnectionForOSM(landuseCategoriesAndDataConnection);
+		LanduseDataConnectionCreator landuseDataConnectionCreator = new LanduseDataConnectionCreatorForOSM_Data();
+		landuseDataConnectionCreator.createLanduseDataConnection(landuseCategoriesAndDataConnection);
 
 		// Analyze resultingData per zone
 		Map<String, Object2DoubleMap<String>> resultingDataPerZone = LanduseBuildingAnalysis


### PR DESCRIPTION
- now it is possible to use different data sources because the assignment of the data categories of the input data and the used categories in the simulation can be set by the implementation