### PR TITLE
fix: personMoney event reference lookup missing in EventsReader

### DIFF
--- a/matsim/src/main/java/org/matsim/core/events/EventsReaderXMLv1.java
+++ b/matsim/src/main/java/org/matsim/core/events/EventsReaderXMLv1.java
@@ -101,25 +101,25 @@ public final class EventsReaderXMLv1 extends MatsimXmlEventsParser {
 
 		// === material related to wait2link below here ===
 		if (LinkLeaveEvent.EVENT_TYPE.equals(eventType)) {
-			this.events.processEvent(new LinkLeaveEvent(time, 
-					Id.create(atts.getValue(LinkLeaveEvent.ATTRIBUTE_VEHICLE), Vehicle.class), 
+			this.events.processEvent(new LinkLeaveEvent(time,
+					Id.create(atts.getValue(LinkLeaveEvent.ATTRIBUTE_VEHICLE), Vehicle.class),
 					Id.create(atts.getValue(LinkLeaveEvent.ATTRIBUTE_LINK), Link.class)
 					// had driver id in previous version
 					));
 		} else if (LinkEnterEvent.EVENT_TYPE.equals(eventType)) {
-			this.events.processEvent(new LinkEnterEvent(time, 
-					Id.create(atts.getValue(LinkEnterEvent.ATTRIBUTE_VEHICLE), Vehicle.class), 
+			this.events.processEvent(new LinkEnterEvent(time,
+					Id.create(atts.getValue(LinkEnterEvent.ATTRIBUTE_VEHICLE), Vehicle.class),
 					Id.create(atts.getValue(LinkEnterEvent.ATTRIBUTE_LINK), Link.class)
 					// had driver id in previous version
 					));
 		} else if (VehicleEntersTrafficEvent.EVENT_TYPE.equals(eventType) ) {
 			// (this is the new version, marked by the new events name)
 
-			this.events.processEvent(new VehicleEntersTrafficEvent(time, 
+			this.events.processEvent(new VehicleEntersTrafficEvent(time,
 					Id.create(atts.getValue(HasPersonId.ATTRIBUTE_PERSON), Person.class),
-					Id.create(atts.getValue(VehicleEntersTrafficEvent.ATTRIBUTE_LINK), Link.class), 
+					Id.create(atts.getValue(VehicleEntersTrafficEvent.ATTRIBUTE_LINK), Link.class),
 					Id.create(atts.getValue(VehicleEntersTrafficEvent.ATTRIBUTE_VEHICLE), Vehicle.class),
-					atts.getValue(VehicleEntersTrafficEvent.ATTRIBUTE_NETWORKMODE), 
+					atts.getValue(VehicleEntersTrafficEvent.ATTRIBUTE_NETWORKMODE),
 					Double.parseDouble( atts.getValue( VehicleEntersTrafficEvent.ATTRIBUTE_POSITION) )
 					));
 		} else if ( "wait2link".equals(eventType) ) {
@@ -140,19 +140,19 @@ public final class EventsReaderXMLv1 extends MatsimXmlEventsParser {
 			} else {
 				position = 1.0 ;
 			}
-			this.events.processEvent(new VehicleEntersTrafficEvent(time, 
+			this.events.processEvent(new VehicleEntersTrafficEvent(time,
 					Id.create(atts.getValue(HasPersonId.ATTRIBUTE_PERSON), Person.class),
-					Id.create(atts.getValue(VehicleEntersTrafficEvent.ATTRIBUTE_LINK), Link.class), 
+					Id.create(atts.getValue(VehicleEntersTrafficEvent.ATTRIBUTE_LINK), Link.class),
 					vehicleId,
-					atts.getValue(VehicleEntersTrafficEvent.ATTRIBUTE_NETWORKMODE), 
+					atts.getValue(VehicleEntersTrafficEvent.ATTRIBUTE_NETWORKMODE),
 					position
 					));
 		} else if (VehicleLeavesTrafficEvent.EVENT_TYPE.equals(eventType)) {
-			this.events.processEvent(new VehicleLeavesTrafficEvent(time, 
-					Id.create(atts.getValue(VehicleLeavesTrafficEvent.ATTRIBUTE_DRIVER), Person.class), 
-					Id.create(atts.getValue(VehicleLeavesTrafficEvent.ATTRIBUTE_LINK), Link.class), 
-					atts.getValue(VehicleLeavesTrafficEvent.ATTRIBUTE_VEHICLE) == null ? null : Id.create(atts.getValue(VehicleLeavesTrafficEvent.ATTRIBUTE_VEHICLE), Vehicle.class), 
-					atts.getValue(VehicleLeavesTrafficEvent.ATTRIBUTE_NETWORKMODE), 
+			this.events.processEvent(new VehicleLeavesTrafficEvent(time,
+					Id.create(atts.getValue(VehicleLeavesTrafficEvent.ATTRIBUTE_DRIVER), Person.class),
+					Id.create(atts.getValue(VehicleLeavesTrafficEvent.ATTRIBUTE_LINK), Link.class),
+					atts.getValue(VehicleLeavesTrafficEvent.ATTRIBUTE_VEHICLE) == null ? null : Id.create(atts.getValue(VehicleLeavesTrafficEvent.ATTRIBUTE_VEHICLE), Vehicle.class),
+					atts.getValue(VehicleLeavesTrafficEvent.ATTRIBUTE_NETWORKMODE),
 					Double.parseDouble( atts.getValue( VehicleLeavesTrafficEvent.ATTRIBUTE_POSITION) )
 					));
 		}
@@ -165,7 +165,7 @@ public final class EventsReaderXMLv1 extends MatsimXmlEventsParser {
 				coord = new Coord( xx, yy ) ;
 			}
 			this.events.processEvent(new ActivityEndEvent(
-					time, 
+					time,
 					Id.create(atts.getValue(HasPersonId.ATTRIBUTE_PERSON), Person.class),
 					Id.create(atts.getValue(HasLinkId.ATTRIBUTE_LINK), Link.class),
 					atts.getValue(HasFacilityId.ATTRIBUTE_FACILITY) == null ? null : Id.create(atts.getValue(HasFacilityId.ATTRIBUTE_FACILITY),
@@ -208,7 +208,7 @@ public final class EventsReaderXMLv1 extends MatsimXmlEventsParser {
 			Id<Link> linkId = linkIdString == null ? null : Id.create(linkIdString, Link.class);
 			this.events.processEvent(new VehicleAbortsEvent(time, Id.create(atts.getValue(VehicleAbortsEvent.ATTRIBUTE_VEHICLE), Vehicle.class), linkId));
 		} else if (PersonMoneyEvent.EVENT_TYPE.equals(eventType) || "agentMoney".equals(eventType)) {
-			this.events.processEvent(new PersonMoneyEvent(time, Id.create(atts.getValue(PersonMoneyEvent.ATTRIBUTE_PERSON), Person.class), Double.parseDouble(atts.getValue(PersonMoneyEvent.ATTRIBUTE_AMOUNT)), atts.getValue(PersonMoneyEvent.ATTRIBUTE_PURPOSE), atts.getValue(PersonMoneyEvent.ATTRIBUTE_TRANSACTION_PARTNER)));
+			this.events.processEvent(new PersonMoneyEvent(time, Id.create(atts.getValue(PersonMoneyEvent.ATTRIBUTE_PERSON), Person.class), Double.parseDouble(atts.getValue(PersonMoneyEvent.ATTRIBUTE_AMOUNT)), atts.getValue(PersonMoneyEvent.ATTRIBUTE_PURPOSE), atts.getValue(PersonMoneyEvent.ATTRIBUTE_TRANSACTION_PARTNER), atts.getValue(PersonMoneyEvent.ATTRIBUTE_REFERENCE)));
 		} else if (PersonScoreEvent.EVENT_TYPE.equals(eventType) || "personScore".equals(eventType)) {
 			this.events.processEvent(new PersonScoreEvent(time, Id.create(atts.getValue(PersonScoreEvent.ATTRIBUTE_PERSON), Person.class), Double.parseDouble(atts.getValue(PersonScoreEvent.ATTRIBUTE_AMOUNT)), atts.getValue(PersonScoreEvent.ATTRIBUTE_KIND)));
 		} else if (PersonEntersVehicleEvent.EVENT_TYPE.equals(eventType)) {

--- a/matsim/src/test/java/org/matsim/core/events/EventsReadersTest.java
+++ b/matsim/src/test/java/org/matsim/core/events/EventsReadersTest.java
@@ -29,22 +29,9 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.matsim.api.core.v01.Id;
-import org.matsim.api.core.v01.events.ActivityEndEvent;
-import org.matsim.api.core.v01.events.ActivityStartEvent;
-import org.matsim.api.core.v01.events.LinkEnterEvent;
-import org.matsim.api.core.v01.events.LinkLeaveEvent;
-import org.matsim.api.core.v01.events.PersonArrivalEvent;
-import org.matsim.api.core.v01.events.PersonDepartureEvent;
-import org.matsim.api.core.v01.events.PersonStuckEvent;
-import org.matsim.api.core.v01.events.VehicleEntersTrafficEvent;
-import org.matsim.api.core.v01.events.handler.ActivityEndEventHandler;
-import org.matsim.api.core.v01.events.handler.ActivityStartEventHandler;
-import org.matsim.api.core.v01.events.handler.LinkEnterEventHandler;
-import org.matsim.api.core.v01.events.handler.LinkLeaveEventHandler;
-import org.matsim.api.core.v01.events.handler.PersonArrivalEventHandler;
-import org.matsim.api.core.v01.events.handler.PersonDepartureEventHandler;
-import org.matsim.api.core.v01.events.handler.PersonStuckEventHandler;
-import org.matsim.api.core.v01.events.handler.VehicleEntersTrafficEventHandler;
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.events.*;
+import org.matsim.api.core.v01.events.handler.*;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.testcases.MatsimTestUtils;
@@ -60,7 +47,7 @@ public class EventsReadersTest {
 
 	static class TestHandler implements ActivityEndEventHandler, PersonDepartureEventHandler, VehicleEntersTrafficEventHandler,
 			LinkLeaveEventHandler, LinkEnterEventHandler, PersonArrivalEventHandler, ActivityStartEventHandler,
-			PersonStuckEventHandler {
+			PersonStuckEventHandler, PersonMoneyEventHandler {
 
 		public int eventCounter = 0;
 
@@ -141,6 +128,17 @@ public class EventsReadersTest {
 			assertEquals("9", event.getLinkId().toString());
 		}
 
+		@Override
+		public void handleEvent(final PersonMoneyEvent event) {
+			this.eventCounter++;
+			assertEquals(9, this.eventCounter, "expected personMoney-Event to be event #9");
+			assertEquals(21690.0, event.getTime(), 0.0);
+			assertEquals("9", event.getPersonId().toString());
+			assertEquals("drtFare", event.getPurpose());
+			assertEquals(TransportMode.drt, event.getTransactionPartner());
+			assertEquals(-1.0, event.getAmount(), 0.0);
+			assertEquals("drt_0", event.getReference());
+		}
 	}
 
 	@Test
@@ -152,7 +150,7 @@ public class EventsReadersTest {
 		EventsReaderXMLv1 reader = new EventsReaderXMLv1(events);
 		reader.readFile(utils.getClassInputDirectory() + "events.xml");
 		events.finishProcessing();
-		assertEquals(8, handler.eventCounter, "number of read events");
+		assertEquals(9, handler.eventCounter, "number of read events");
 	}
 
 	@Test
@@ -164,6 +162,6 @@ public class EventsReadersTest {
 		MatsimEventsReader reader = new MatsimEventsReader(events);
 		reader.readFile(utils.getClassInputDirectory() + "events.xml");
 		events.finishProcessing();
-		assertEquals(8, handler.eventCounter, "number of read events");
+		assertEquals(9, handler.eventCounter, "number of read events");
 	}
 }

--- a/matsim/src/test/resources/test/input/org/matsim/core/events/EventsReadersTest/events.xml
+++ b/matsim/src/test/resources/test/input/org/matsim/core/events/EventsReadersTest/events.xml
@@ -9,4 +9,5 @@
 	<event time="21660" person="6" link="7" type="arrival"  />
 	<event time="21670" person="7" link="8" actType="" type="actstart"  />
 	<event time="21680" person="8" link="9" type="stuckAndAbort"  />
+	<event time="21690" person="9" type="personMoney" amount="-1.0" purpose="drtFare" transactionPartner="drt" reference="drt_0"  />
 </events>


### PR DESCRIPTION
We (Moia) discovered that the reference attribute for personMoney events was always null when parsed by the EventsReaderv1 class. I added a hopefully-appropriate unit test for it in EventsReadersTest, and adjusted the events.xml fixture accordingly. 

Feedback is more than welcome!  cc @nkuehnel  @fzwick 