### PR TITLE
read first 5 lines of csv to check delimiter

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/options/CsvOptions.java
+++ b/contribs/application/src/main/java/org/matsim/application/options/CsvOptions.java
@@ -23,7 +23,7 @@ public final class CsvOptions {
 	@CommandLine.Option(names = "--csv-format", description = "CSV Format", defaultValue = "Default")
 	private CSVFormat.Predefined csvFormat;
 
-	@CommandLine.Option(names = "--csv-delimiter", description = "CSV Delimiter", required = false)
+	@CommandLine.Option(names = "--csv-delimiter", description = "CSV Delimiter")
 	private Character csvDelimiter;
 
 	@CommandLine.Option(names = "--csv-charset", description = "CSV input encoding", defaultValue = "UTF8")
@@ -56,24 +56,48 @@ public final class CsvOptions {
 	 */
 	public static Character detectDelimiter(String path) throws IOException {
         try (BufferedReader reader = IOUtils.getBufferedReader(path)) {
-			String firstLine = reader.readLine();
+			int[] comma = new int[5];
+			int[] semicolon = new int[5];
+			int[] tab = new int[5];
+			String[] lines = new String[5];
 
-			int comma = StringUtils.countMatches(firstLine, ",");
-			int semicolon = StringUtils.countMatches(firstLine, ";");
-			int tab = StringUtils.countMatches(firstLine, "\t");
-
-			if (comma == 0 && semicolon == 0 && tab == 0) {
-				throw new IllegalArgumentException("No delimiter found in the first line of the file.");
+//			check five first lines for separator chars. It might be that the csv file has additional info in the first x lines (e.g. EPSG)
+			for (int i = 0; i < 5; i++) {
+				lines[i] = reader.readLine();
+				if (lines[i] == null) {
+					comma[i] = 0;
+					semicolon[i] = 0;
+					tab[i] = 0;
+				} else {
+					comma[i] = StringUtils.countMatches(lines[i], ",");
+					semicolon[i] = StringUtils.countMatches(lines[i], ";");
+					tab[i] = StringUtils.countMatches(lines[i], "\t");
+				}
 			}
 
-			// Comma is preferred as the more likely format
-			if (comma >= semicolon && comma >= tab) {
-				return ',';
-			} else if (tab >= semicolon)
-				return '\t';
-			else
-				return ';';
-        }
+			Integer index = null;
+
+			for (int i = 0; i < comma.length - 1; i++) {
+//				only check next index if line with separators was not found
+				if (index == null) {
+					if (!(comma[i] == 0 && semicolon[i] == 0 && tab[i] == 0)) {
+						index = i;
+					}
+				}
+			}
+
+			if (index == null) {
+				throw new IllegalArgumentException("No delimiter found in the first line of the file.");
+			} else {
+				// Comma is preferred as the more likely format
+				if (comma[index] >= semicolon[index] && comma[index] >= tab[index]) {
+					return ',';
+				} else if (tab[index] >= semicolon[index])
+					return '\t';
+				else
+					return ';';
+			}
+		}
 	}
 
 	/**

--- a/contribs/application/src/test/java/org/matsim/application/options/CsvOptionsTest.java
+++ b/contribs/application/src/test/java/org/matsim/application/options/CsvOptionsTest.java
@@ -37,10 +37,12 @@ public class CsvOptionsTest {
 
 			printer.printRecord("header", "column");
 			printer.printRecord("1", "2");
+			printer.printRecord("3", "4");
+			printer.printRecord("5", "6");
 			printer.close();
 
 			assertThat(tmp)
-				.hasContent("header" + delimiter + "column\n1" + delimiter + "2");
+				.hasContent("header" + delimiter + "column\n1" + delimiter + "2" + "\n3" + delimiter + "4" + "\n5" + delimiter + "6");
 
 			assertThat(delimiter).isEqualTo(CsvOptions.detectDelimiter(tmp.toString()).toString());
 		}


### PR DESCRIPTION
When checking the delimiter by only reading the first csv line the method will fail for csv files with e.g. additional information like an EPSG (which is not in the delimiter separated format). Therefore, from now on the first 5 lines of the file will be read in to secure reading a line with delimiter separated data