### PR TITLE
railsim: Test Scenario for a construction site between Lausanne and Geneva

### DIFF
--- a/contribs/railsim/src/test/java/ch/sbb/matsim/contrib/railsim/integration/RailsimIntegrationTest.java
+++ b/contribs/railsim/src/test/java/ch/sbb/matsim/contrib/railsim/integration/RailsimIntegrationTest.java
@@ -373,9 +373,9 @@ public class RailsimIntegrationTest {
 			type.setMaximumVelocity(30);
 			type.setLength(100);
 		}
-		
+
 		// simplify the activity types, e.g. home_3600 -> home
-		Set<String> activityTypes = new HashSet<>();	
+		Set<String> activityTypes = new HashSet<>();
 		for (Person person : scenario.getPopulation().getPersons().values()) {
 			for (Plan plan : person.getPlans()) {
 				for (PlanElement pE : plan.getPlanElements()) {
@@ -388,7 +388,7 @@ public class RailsimIntegrationTest {
 				}
 			}
 		}
-		
+
 		for (String type : activityTypes) {
 			config.scoring().addActivityParams(new ScoringConfigGroup.ActivityParams(type).setTypicalDuration(1234.));
 		}
@@ -403,6 +403,11 @@ public class RailsimIntegrationTest {
 	@Test
 	void testScenarioMicroMesoCombination() {
 		EventsCollector collector = runSimulation(new File(utils.getPackageInputDirectory(), "scenarioMicroMesoCombination"));
+	}
+
+	@Test
+	void testScenarioMicroMesoConstructionSiteLsGe() {
+		EventsCollector collector = runSimulation(new File(utils.getPackageInputDirectory(), "scenarioMicroMesoConstructionSiteLsGe"));
 	}
 
 	private EventsCollector runSimulation(File scenarioDir) {

--- a/contribs/railsim/test/input/ch/sbb/matsim/contrib/railsim/integration/scenarioMicroMesoConstructionSiteLsGe/config.xml
+++ b/contribs/railsim/test/input/ch/sbb/matsim/contrib/railsim/integration/scenarioMicroMesoConstructionSiteLsGe/config.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" ?>
+<!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
+<config>
+
+	<module name="global">
+		<param name="randomSeed" value="4711"/>
+		<param name="coordinateSystem" value="Atlantis"/>
+	</module>
+
+	<module name="controler">
+		<param name="runId" value="test"/>
+		<param name="firstIteration" value="0"/>
+	</module>
+
+	<module name="qsim">
+		<!-- "start/endTime" of MobSim (00:00:00 == take earliest activity time/ run as long as active vehicles exist) -->
+		<param name="startTime" value="00:00:00"/>
+		<param name="endTime" value="24:00:00"/>
+
+		<param name="snapshotperiod" value="00:00:00"/> <!-- 00:00:00 means NO snapshot writing -->
+		<param name="mainMode" value="car"/>
+
+		<!-- time in seconds.  Time after which the frontmost vehicle on a link is called `stuck' if it does not move. -->
+		<param name="stuckTime" value="999999."/>
+	</module>
+
+	<module name="transit">
+		<param name="routingAlgorithmType" value="SwissRailRaptor"/>
+		<param name="transitScheduleFile" value="transitSchedule.xml"/>
+		<param name="useTransit" value="true"/>
+		<param name="usingTransitInMobsim" value="true"/>
+		<param name="vehiclesFile" value="transitVehicles.xml"/>
+	</module>
+
+	<module name="network">
+		<param name="inputNetworkFile" value="trainNetwork.xml"/>
+	</module>
+
+</config>

--- a/contribs/railsim/test/input/ch/sbb/matsim/contrib/railsim/integration/scenarioMicroMesoConstructionSiteLsGe/trainNetwork.xml
+++ b/contribs/railsim/test/input/ch/sbb/matsim/contrib/railsim/integration/scenarioMicroMesoConstructionSiteLsGe/trainNetwork.xml
@@ -1,0 +1,319 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE network SYSTEM "http://www.matsim.org/files/dtd/network_v2.dtd">
+<network name="test network">
+
+	<!-- ====================================================================== -->
+
+	<!-- Network Lausanne - Genève, the whole line is mesoscopic except the portion between MOR and REN, where it is divided into two microscopic links.
+	All the stations are 400m long
+	The following convention applies to all stations : (Node : Station1) - (Stop : Station) - (Node : Station2)
+																																		            /<=1=>\
+	GE1 <=7=> GE2 <=3=> COP1 <=3=> COP2 <=2=> NY1 <=3=> NY2 <=2=> GLA1 <=2=> GLA2 <=2=> ROL1 <=2=> ROL2 <=2=> ALL1 <=3=> ALL2 <=2=> MOR1 <=4=> MOR2        REN1 <=5=> REN2 <=4=> LS1 <=7=> LS2
+																																					\<=1=>/
+
+	-->
+
+	<!-- ====================================================================== -->
+
+	<nodes>
+		<node id="GE1" x="-60660" y="0"></node>
+		<node id="GE2" x="-60260" y="0"></node>
+		<node id="COP1" x="-47200" y="0"></node>
+		<node id="COP2" x="-46800" y="0"></node>
+		<node id="NY1" x="-38730" y="0"></node>
+		<node id="NY2" x="-38330" y="0"></node>
+		<node id="GLA1" x="-33990" y="0"></node>
+		<node id="GLA2" x="-33590" y="0"></node>
+		<node id="ROL1" x="-26860" y="0"></node>
+		<node id="ROL2" x="-26460" y="0"></node>
+		<node id="ALL1" x="-21680" y="0"></node>
+		<node id="ALL2" x="-21280" y="0"></node>
+		<node id="MOR1" x="-12700" y="0"></node>
+		<node id="MOR2" x="-12300" y="0"></node>
+		<node id="REN1" x="-4710" y="0"></node>
+		<node id="REN2" x="-4310" y="0"></node>
+		<node id="LS1" x="0" y="0"></node>
+		<node id="LS2" x="400" y="0"></node>
+	</nodes>
+
+	<!-- ====================================================================== -->
+
+	<links capperiod="01:00:00" effectivecellsize="7.5" effectivelanewidth="3.75">
+		<link id="GE1-GE2" from="GE1" to="GE2" length="400" freespeed="32" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">GE1GE2</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">7</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+		<link id="GE2-GE1" from="GE2" to="GE1" length="400" freespeed="32" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">GE1GE2</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">7</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+
+		<link id="GE2-COP1" from="GE2" to="COP1" length="13060" freespeed="32" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">GE2COP1</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">3</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+		<link id="COP1-GE2" from="COP1" to="GE2" length="13060" freespeed="32" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">GE2COP1</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">3</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+
+		<link id="COP1-COP2" from="COP1" to="COP2" length="400" freespeed="38" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">COP1COP2</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">3</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+		<link id="COP2-COP1" from="COP2" to="COP1" length="400" freespeed="38" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">COP1COP2</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">3</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+
+
+		<link id="COP2-NY1" from="COP2" to="NY1" length="8070" freespeed="38" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">COP2NY1</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">2</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+		<link id="NY1-COP2" from="NY1" to="COP2" length="8070" freespeed="38" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">COP2NY1</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">2</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+
+		<link id="NY1-NY2" from="NY1" to="NY2" length="400" freespeed="38" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">NY1NY2</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">3</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+		<link id="NY2-NY1" from="NY2" to="NY1" length="400" freespeed="38" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">NY1NY2</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">3</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+
+		<link id="NY2-GLA1" from="NY2" to="GLA1" length="4340" freespeed="38" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">NY2GLA1</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">2</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+		<link id="GLA1-NY2" from="GLA1" to="NY2" length="4340" freespeed="38" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">NY2GLA1</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">2</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+
+		<link id="GLA1-GLA2" from="GLA1" to="GLA2" length="400" freespeed="38" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">GLA1GLA2</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">2</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+		<link id="GLA2-GLA1" from="GLA2" to="GLA1" length="400" freespeed="38" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">GLA1GLA2</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">2</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+
+		<link id="GLA2-ROL1" from="GLA2" to="ROL1" length="6730" freespeed="38" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">GLA2ROL1</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">2</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+		<link id="ROL1-GLA2" from="ROL1" to="GLA2" length="6730" freespeed="38" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">GLA2ROL1</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">2</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+
+
+		<link id="ROL1-ROL2" from="ROL1" to="ROL2" length="400" freespeed="29" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">ROL1ROL2</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">2</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+		<link id="ROL2-ROL1" from="ROL2" to="ROL1" length="400" freespeed="29" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">ROL1ROL2</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">2</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+
+		<link id="ROL2-ALL1" from="ROL2" to="ALL1" length="4780" freespeed="29" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">ROL2ALL1</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">2</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+		<link id="ALL1-ROL2" from="ALL1" to="ROL2" length="4780" freespeed="29" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">ROL2ALL1</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">2</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+
+		<link id="ALL1-ALL2" from="ALL1" to="ALL2" length="400" freespeed="29" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">ALL1ALL2</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">3</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+		<link id="ALL2-ALL1" from="ALL2" to="ALL1" length="400" freespeed="29" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">ALL1ALL2</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">3</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+
+		<link id="ALL2-MOR1" from="ALL2" to="MOR1" length="8580" freespeed="29" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">ALL2MOR1</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">2</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+		<link id="MOR1-ALL2" from="MOR1" to="ALL2" length="8580" freespeed="29" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">ALL2MOR1</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">2</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+
+		<link id="MOR1-MOR2" from="MOR1" to="MOR2" length="400" freespeed="29" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">MOR1MOR2</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">4</attribute>
+				<attribute name="railsimEntry" class="java.lang.Boolean">true</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+		<link id="MOR2-MOR1" from="MOR2" to="MOR1" length="400" freespeed="29" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">MOR1MOR2</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">4</attribute>
+				<attribute name="railsimExit" class="java.lang.Boolean">true</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+
+		<link id="MOR2_REN1-1" from="MOR2" to="REN1" length="7590" freespeed="29" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">MOR2REN1-1</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+		<link id="REN1-MOR2-1" from="REN1" to="MOR2" length="7590" freespeed="29" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">MOR2REN1-1</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+		<link id="MOR2_REN1-2" from="MOR2" to="REN1" length="7590" freespeed="29" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">MOR2REN1-2</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+		<link id="REN1-MOR2-2" from="REN1" to="MOR2" length="7590" freespeed="29" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">MOR2REN1-2</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+
+
+		<link id="REN1-REN2" from="REN1" to="REN2" length="400" freespeed="29" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">REN1REN2</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">5</attribute>
+				<attribute name="railsimExit" class="java.lang.Boolean">true</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+		<link id="REN2-REN1" from="REN2" to="REN1" length="400" freespeed="29" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">REN1REN2</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">5</attribute>
+				<attribute name="railsimEntry" class="java.lang.Boolean">true</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+
+		<link id="REN2-LS1" from="REN2" to="LS1" length="4310" freespeed="29" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">REN2LS1</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">4</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+		<link id="LS1-REN2" from="LS1" to="REN2" length="4310" freespeed="29" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">REN2LS1</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">4</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+
+		<link id="LS1-LS2" from="LS1" to="LS2" length="400" freespeed="29" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">LS1LS2</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">7</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+		<link id="LS2-LS1" from="LS2" to="LS1" length="400" freespeed="29" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimResourceId" class="java.lang.String">LS1LS2</attribute>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">7</attribute>
+				<attribute name="railsimResourceType" class="java.lang.String">fixedBlock</attribute>
+			</attributes>
+		</link>
+
+
+	</links>
+
+	<!-- ====================================================================== -->
+
+</network>

--- a/contribs/railsim/test/input/ch/sbb/matsim/contrib/railsim/integration/scenarioMicroMesoConstructionSiteLsGe/transitSchedule.xml
+++ b/contribs/railsim/test/input/ch/sbb/matsim/contrib/railsim/integration/scenarioMicroMesoConstructionSiteLsGe/transitSchedule.xml
@@ -1,0 +1,605 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE transitSchedule SYSTEM "http://www.matsim.org/files/dtd/transitSchedule_v2.dtd">
+
+<transitSchedule>
+
+	<!-- ====================================================================== -->
+
+	<!-- The schedule is taken from : https://network.sbb.ch/en/
+	Naming convention : Line-DepartureViaArrival-departure
+
+	In order to model a construction site between Morges and Renens, a new stop is created in the middle of the link, and a construction train stops there during the planned time, thus reducing the capacity of the link.
+
+	-->
+
+	<!-- ====================================================================== -->
+
+	<transitStops>
+		<stopFacility id="LS" x="0" y="0" linkRefId="LS1-LS2" stopAreaId="LS">
+		</stopFacility>
+		<stopFacility id="REN" x="-4510" y="0" linkRefId="REN1-REN2" stopAreaId="REN">
+		</stopFacility>
+		<stopFacility id="MOR" x="-12500" y="0" linkRefId="MOR1-MOR2" stopAreaId="MOR">
+		</stopFacility>
+		<stopFacility id="ALL" x="-21480" y="0" linkRefId="ALL1-ALL2" stopAreaId="ALL">
+		</stopFacility>
+		<stopFacility id="ROL" x="-26660" y="0" linkRefId="ROL1-ROL2" stopAreaId="ROL">
+		</stopFacility>
+		<stopFacility id="GLA" x="-33790" y="0" linkRefId="GLA1-GLA2" stopAreaId="GLA">
+		</stopFacility>
+		<stopFacility id="NY" x="-38530" y="0" linkRefId="NY1-NY2" stopAreaId="NY">
+		</stopFacility>
+		<stopFacility id="COP" x="-47000" y="0" linkRefId="COP1-COP2" stopAreaId="COP">
+		</stopFacility>
+		<stopFacility id="GE" x="-60260" y="0" linkRefId="GE1-GE2" stopAreaId="GE">
+		</stopFacility>
+		<stopFacility id="LS1" x="0" y="0" linkRefId="LS2-LS1" stopAreaId="LS">
+		</stopFacility>
+		<stopFacility id="REN1" x="-4510" y="0" linkRefId="REN2-REN1" stopAreaId="REN">
+		</stopFacility>
+		<stopFacility id="MOR1" x="-12500" y="0" linkRefId="MOR2-MOR1" stopAreaId="MOR">
+		</stopFacility>
+		<stopFacility id="ALL1" x="-21480" y="0" linkRefId="ALL2-ALL1" stopAreaId="ALL">
+		</stopFacility>
+		<stopFacility id="ROL1" x="-26660" y="0" linkRefId="ROL2-ROL1" stopAreaId="ROL">
+		</stopFacility>
+		<stopFacility id="GLA1" x="-33790" y="0" linkRefId="GLA2-GLA1" stopAreaId="GLA">
+		</stopFacility>
+		<stopFacility id="NY1" x="-38530" y="0" linkRefId="NY2-NY1" stopAreaId="NY">
+		</stopFacility>
+		<stopFacility id="COP1" x="-47000" y="0" linkRefId="COP2-COP1" stopAreaId="COP">
+		</stopFacility>
+		<stopFacility id="GE1" x="-60260" y="0" linkRefId="GE2-GE1" stopAreaId="GE">
+		</stopFacility>
+
+
+		<stopFacility id="Construction_Site_MOR_REN" x="-10000" y="0" linkRefId="MOR2_REN1-1" stopAreaId="BAU">
+		</stopFacility>
+		<stopFacility id="Construction_Site_MOR_REN2" x="-10000" y="0" linkRefId="MOR2_REN1-2" stopAreaId="BAU">
+		</stopFacility>
+
+	</transitStops>
+
+	<transitLine id="RE33">
+		<transitRoute id="RE33-ANNGELS">
+			<transportMode>rail</transportMode>
+			<routeProfile>
+				<stop refId="GE" arrivalOffset="00:00:00" departureOffset="00:03:00" awaitDeparture="true"/>
+				<stop refId="COP" arrivalOffset="00:12:00" departureOffset="00:13:00" awaitDeparture="true"/>
+				<stop refId="NY" arrivalOffset="00:18:00" departureOffset="00:19:00" awaitDeparture="true"/>
+				<stop refId="GLA" arrivalOffset="00:22:00" departureOffset="00:23:00" awaitDeparture="true"/>
+				<stop refId="ROL" arrivalOffset="00:27:00" departureOffset="00:28:00" awaitDeparture="true"/>
+				<stop refId="ALL" arrivalOffset="00:31:00" departureOffset="00:32:00" awaitDeparture="true"/>
+				<stop refId="MOR" arrivalOffset="00:37:00" departureOffset="00:38:00" awaitDeparture="true"/>
+				<stop refId="REN" arrivalOffset="00:44:00" departureOffset="00:45:00" awaitDeparture="true"/>
+				<stop refId="LS" arrivalOffset="00:51:00" departureOffset="00:54:00" awaitDeparture="true"/>
+			</routeProfile>
+			<route>
+				<link refId="GE1-GE2"/>
+				<link refId="GE2-COP1"/>
+				<link refId="COP1-COP2"/>
+				<link refId="COP2-NY1"/>
+				<link refId="NY1-NY2"/>
+				<link refId="NY2-GLA1"/>
+				<link refId="GLA1-GLA2"/>
+				<link refId="GLA2-ROL1"/>
+				<link refId="ROL1-ROL2"/>
+				<link refId="ROL2-ALL1"/>
+				<link refId="ALL1-ALL2"/>
+				<link refId="ALL2-MOR1"/>
+				<link refId="MOR1-MOR2"/>
+				<link refId="MOR2_REN1-1"/>
+				<link refId="REN1-REN2"/>
+				<link refId="REN2-LS1"/>
+				<link refId="LS1-LS2"/>
+			</route>
+			<departures>
+				<departure id="RE33-ANNGELS-8" departureTime="08:47:00" vehicleRefId="RE33-ANNGELS-8"/>
+				<departure id="RE33-ANNGELS-9" departureTime="09:47:00" vehicleRefId="RE33-ANNGELS-9"/>
+				<departure id="RE33-ANNGELS-10" departureTime="10:47:00" vehicleRefId="RE33-ANNGELS-10"/>
+				<departure id="RE33-ANNGELS-11" departureTime="11:47:00" vehicleRefId="RE33-ANNGELS-11"/>
+				<departure id="RE33-ANNGELS-12" departureTime="12:47:00" vehicleRefId="RE33-ANNGELS-12"/>
+			</departures>
+		</transitRoute>
+		<transitRoute id="RE33-ANNGESM">
+			<transportMode>rail</transportMode>
+			<routeProfile>
+				<stop refId="GE" arrivalOffset="00:00:00" departureOffset="00:03:00" awaitDeparture="true"/>
+				<stop refId="COP" arrivalOffset="00:12:00" departureOffset="00:13:00" awaitDeparture="true"/>
+				<stop refId="NY" arrivalOffset="00:18:00" departureOffset="00:19:00" awaitDeparture="true"/>
+				<stop refId="GLA" arrivalOffset="00:22:00" departureOffset="00:23:00" awaitDeparture="true"/>
+				<stop refId="ROL" arrivalOffset="00:27:00" departureOffset="00:28:00" awaitDeparture="true"/>
+				<stop refId="ALL" arrivalOffset="00:31:00" departureOffset="00:32:00" awaitDeparture="true"/>
+				<stop refId="MOR" arrivalOffset="00:37:00" departureOffset="00:38:00" awaitDeparture="true"/>
+				<stop refId="REN" arrivalOffset="00:44:00" departureOffset="00:45:00" awaitDeparture="true"/>
+				<stop refId="LS" arrivalOffset="00:51:00" departureOffset="00:54:00" awaitDeparture="true"/>
+			</routeProfile>
+			<route>
+				<link refId="GE1-GE2"/>
+				<link refId="GE2-COP1"/>
+				<link refId="COP1-COP2"/>
+				<link refId="COP2-NY1"/>
+				<link refId="NY1-NY2"/>
+				<link refId="NY2-GLA1"/>
+				<link refId="GLA1-GLA2"/>
+				<link refId="GLA2-ROL1"/>
+				<link refId="ROL1-ROL2"/>
+				<link refId="ROL2-ALL1"/>
+				<link refId="ALL1-ALL2"/>
+				<link refId="ALL2-MOR1"/>
+				<link refId="MOR1-MOR2"/>
+				<link refId="MOR2_REN1-1"/>
+				<link refId="REN1-REN2"/>
+				<link refId="REN2-LS1"/>
+				<link refId="LS1-LS2"/>
+			</route>
+			<departures>
+				<departure id="RE33-ANNGESM-8" departureTime="08:17:00" vehicleRefId="RE33-ANNGESM-8"/>
+				<departure id="RE33-ANNGESM-9" departureTime="09:17:00" vehicleRefId="RE33-ANNGESM-9"/>
+				<departure id="RE33-ANNGESM-10" departureTime="10:17:00" vehicleRefId="RE33-ANNGESM-10"/>
+				<departure id="RE33-ANNGESM-11" departureTime="11:17:00" vehicleRefId="RE33-ANNGESM-11"/>
+				<departure id="RE33-ANNGESM-12" departureTime="12:17:00" vehicleRefId="RE33-ANNGESM-12"/>
+			</departures>
+		</transitRoute>
+
+		<transitRoute id="RE33-VVGEANN">
+			<transportMode>rail</transportMode>
+			<routeProfile>
+				<stop refId="LS1" arrivalOffset="00:00:00" departureOffset="00:02:00" awaitDeparture="true"/>
+				<stop refId="REN1" arrivalOffset="00:08:00" departureOffset="00:08:00" awaitDeparture="true"/>
+				<stop refId="MOR1" arrivalOffset="00:15:00" departureOffset="00:16:00" awaitDeparture="true"/>
+				<stop refId="ALL1" arrivalOffset="00:21:00" departureOffset="00:22:00" awaitDeparture="true"/>
+				<stop refId="ROL1" arrivalOffset="00:25:00" departureOffset="00:26:00" awaitDeparture="true"/>
+				<stop refId="GLA1" arrivalOffset="00:31:00" departureOffset="00:32:00" awaitDeparture="true"/>
+				<stop refId="NY1" arrivalOffset="00:35:00" departureOffset="00:36:00" awaitDeparture="true"/>
+				<stop refId="COP1" arrivalOffset="00:41:00" departureOffset="00:42:00" awaitDeparture="true"/>
+				<stop refId="GE1" arrivalOffset="00:51:00" departureOffset="00:52:00" awaitDeparture="true"/>
+			</routeProfile>
+			<route>
+				<link refId="LS2-LS1"/>
+				<link refId="LS1-REN2"/>
+				<link refId="REN2-REN1"/>
+				<link refId="REN1-MOR2-2"/>
+				<link refId="MOR2-MOR1"/>
+				<link refId="MOR1-ALL2"/>
+				<link refId="ALL2-ALL1"/>
+				<link refId="ALL1-ROL2"/>
+				<link refId="ROL2-ROL1"/>
+				<link refId="ROL1-GLA2"/>
+				<link refId="GLA2-GLA1"/>
+				<link refId="GLA1-NY2"/>
+				<link refId="NY2-NY1"/>
+				<link refId="NY1-COP2"/>
+				<link refId="COP2-COP1"/>
+				<link refId="COP1-GE2"/>
+				<link refId="GE2-GE1"/>
+			</route>
+			<departures>
+				<departure id="RE33-VVGEANN-8" departureTime="08:19:00" vehicleRefId="RE33-VVGEANN-8"/>
+				<departure id="RE33-VVGEANN-9" departureTime="09:19:00" vehicleRefId="RE33-VVGEANN-9"/>
+				<departure id="RE33-VVGEANN-10" departureTime="10:19:00" vehicleRefId="RE33-VVGEANN-10"/>
+				<departure id="RE33-VVGEANN-11" departureTime="11:19:00" vehicleRefId="RE33-VVGEANN-11"/>
+				<departure id="RE33-VVGEANN-12" departureTime="12:19:00" vehicleRefId="RE33-VVGEANN-12"/>
+			</departures>
+		</transitRoute>
+
+		<transitRoute id="RE33-SMGEANN">
+			<transportMode>rail</transportMode>
+			<routeProfile>
+				<stop refId="LS1" arrivalOffset="00:00:00" departureOffset="00:03:00" awaitDeparture="true"/>
+				<stop refId="REN1" arrivalOffset="00:09:00" departureOffset="00:09:00" awaitDeparture="true"/>
+				<stop refId="MOR1" arrivalOffset="00:16:00" departureOffset="00:17:00" awaitDeparture="true"/>
+				<stop refId="ALL1" arrivalOffset="00:22:00" departureOffset="00:23:00" awaitDeparture="true"/>
+				<stop refId="ROL1" arrivalOffset="00:26:00" departureOffset="00:27:00" awaitDeparture="true"/>
+				<stop refId="GLA1" arrivalOffset="00:32:00" departureOffset="00:33:00" awaitDeparture="true"/>
+				<stop refId="NY1" arrivalOffset="00:36:00" departureOffset="00:37:00" awaitDeparture="true"/>
+				<stop refId="COP1" arrivalOffset="00:42:00" departureOffset="00:43:00" awaitDeparture="true"/>
+				<stop refId="GE1" arrivalOffset="00:52:00" departureOffset="00:54:00" awaitDeparture="true"/>
+			</routeProfile>
+			<route>
+				<link refId="LS2-LS1"/>
+				<link refId="LS1-REN2"/>
+				<link refId="REN2-REN1"/>
+				<link refId="REN1-MOR2-2"/>
+				<link refId="MOR2-MOR1"/>
+				<link refId="MOR1-ALL2"/>
+				<link refId="ALL2-ALL1"/>
+				<link refId="ALL1-ROL2"/>
+				<link refId="ROL2-ROL1"/>
+				<link refId="ROL1-GLA2"/>
+				<link refId="GLA2-GLA1"/>
+				<link refId="GLA1-NY2"/>
+				<link refId="NY2-NY1"/>
+				<link refId="NY1-COP2"/>
+				<link refId="COP2-COP1"/>
+				<link refId="COP1-GE2"/>
+				<link refId="GE2-GE1"/>
+			</route>
+			<departures>
+				<departure id="RE33-SMGEANN-8" departureTime="08:48:00" vehicleRefId="RE33-SMGEANN-8"/>
+				<departure id="RE33-SMGEANN-9" departureTime="09:48:00" vehicleRefId="RE33-SMGEANN-9"/>
+				<departure id="RE33-SMGEANN-10" departureTime="10:48:00" vehicleRefId="RE33-SMGEANN-10"/>
+				<departure id="RE33-SMGEANN-11" departureTime="11:48:00" vehicleRefId="RE33-SMGEANN-11"/>
+				<departure id="RE33-SMGEANN-12" departureTime="12:48:00" vehicleRefId="RE33-SMGEANN-12"/>
+			</departures>
+		</transitRoute>
+
+	</transitLine>
+
+	<transitLine id="IR90">
+		<transitRoute id="IR90-GEAPGEBR1">
+			<transportMode>rail</transportMode>
+			<routeProfile>
+				<stop refId="GE" arrivalOffset="00:00:00" departureOffset="00:02:00" awaitDeparture="true"/>
+				<stop refId="LS" arrivalOffset="00:39:00" departureOffset="00:42:00" awaitDeparture="true"/>
+			</routeProfile>
+			<route>
+				<link refId="GE1-GE2"/>
+				<link refId="GE2-COP1"/>
+				<link refId="COP1-COP2"/>
+				<link refId="COP2-NY1"/>
+				<link refId="NY1-NY2"/>
+				<link refId="NY2-GLA1"/>
+				<link refId="GLA1-GLA2"/>
+				<link refId="GLA2-ROL1"/>
+				<link refId="ROL1-ROL2"/>
+				<link refId="ROL2-ALL1"/>
+				<link refId="ALL1-ALL2"/>
+				<link refId="ALL2-MOR1"/>
+				<link refId="MOR1-MOR2"/>
+				<link refId="MOR2_REN1-1"/>
+				<link refId="REN1-REN2"/>
+				<link refId="REN2-LS1"/>
+				<link refId="LS1-LS2"/>
+			</route>
+			<departures>
+				<departure id="IR90-GEAPGEBR1-8" departureTime="08:08:00" vehicleRefId="IR90-GEAPGEBR1-8"/>
+				<departure id="IR90-GEAPGEBR1-9" departureTime="09:08:00" vehicleRefId="IR90-GEAPGEBR1-9"/>
+				<departure id="IR90-GEAPGEBR1-10" departureTime="10:08:00" vehicleRefId="IR90-GEAPGEBR1-10"/>
+				<departure id="IR90-GEAPGEBR1-11" departureTime="11:08:00" vehicleRefId="IR90-GEAPGEBR1-11"/>
+				<departure id="IR90-GEAPGEBR1-12" departureTime="12:08:00" vehicleRefId="IR90-GEAPGEBR1-12"/>
+			</departures>
+		</transitRoute>
+		<transitRoute id="IR90-GEAPGEBR2">
+			<transportMode>rail</transportMode>
+			<routeProfile>
+				<stop refId="GE" arrivalOffset="00:00:00" departureOffset="00:03:00" awaitDeparture="true"/>
+				<stop refId="NY" arrivalOffset="00:17:00" departureOffset="00:17:00" awaitDeparture="true"/>
+				<stop refId="MOR" arrivalOffset="00:34:00" departureOffset="00:34:00" awaitDeparture="true"/>
+				<stop refId="LS" arrivalOffset="00:45:00" departureOffset="00:55:00" awaitDeparture="true"/>
+			</routeProfile>
+			<route>
+				<link refId="GE1-GE2"/>
+				<link refId="GE2-COP1"/>
+				<link refId="COP1-COP2"/>
+				<link refId="COP2-NY1"/>
+				<link refId="NY1-NY2"/>
+				<link refId="NY2-GLA1"/>
+				<link refId="GLA1-GLA2"/>
+				<link refId="GLA2-ROL1"/>
+				<link refId="ROL1-ROL2"/>
+				<link refId="ROL2-ALL1"/>
+				<link refId="ALL1-ALL2"/>
+				<link refId="ALL2-MOR1"/>
+				<link refId="MOR1-MOR2"/>
+				<link refId="MOR2_REN1-1"/>
+				<link refId="REN1-REN2"/>
+				<link refId="REN2-LS1"/>
+				<link refId="LS1-LS2"/>
+			</route>
+			<departures>
+				<departure id="IR90-GEAPGEBR2-8" departureTime="08:26:00" vehicleRefId="IR90-GEAPGEBR2-8"/>
+				<departure id="IR90-GEAPGEBR2-9" departureTime="09:26:00" vehicleRefId="IR90-GEAPGEBR2-9"/>
+				<departure id="IR90-GEAPGEBR2-10" departureTime="10:26:00" vehicleRefId="IR90-GEAPGEBR2-10"/>
+				<departure id="IR90-GEAPGEBR2-11" departureTime="11:26:00" vehicleRefId="IR90-GEAPGEBR2-11"/>
+				<departure id="IR90-GEAPGEBR2-12" departureTime="12:26:00" vehicleRefId="IR90-GEAPGEBR2-12"/>
+			</departures>
+		</transitRoute>
+
+		<transitRoute id="IR90-BRGEGEAP1">
+			<transportMode>rail</transportMode>
+			<routeProfile>
+				<stop refId="LS1" arrivalOffset="00:00:00" departureOffset="00:03:00" awaitDeparture="true"/>
+				<stop refId="GE1" arrivalOffset="00:40:00" departureOffset="00:42:00" awaitDeparture="true"/>
+			</routeProfile>
+			<route>
+				<link refId="LS2-LS1"/>
+				<link refId="LS1-REN2"/>
+				<link refId="REN2-REN1"/>
+				<link refId="REN1-MOR2-2"/>
+				<link refId="MOR2-MOR1"/>
+				<link refId="MOR1-ALL2"/>
+				<link refId="ALL2-ALL1"/>
+				<link refId="ALL1-ROL2"/>
+				<link refId="ROL2-ROL1"/>
+				<link refId="ROL1-GLA2"/>
+				<link refId="GLA2-GLA1"/>
+				<link refId="GLA1-NY2"/>
+				<link refId="NY2-NY1"/>
+				<link refId="NY1-COP2"/>
+				<link refId="COP2-COP1"/>
+				<link refId="COP1-GE2"/>
+				<link refId="GE2-GE1"/>
+			</route>
+			<departures>
+				<departure id="IR90-BRGEGEAP1-8" departureTime="08:10:00" vehicleRefId="IR90-BRGEGEAP1-8"/>
+				<departure id="IR90-BRGEGEAP1-9" departureTime="09:10:00" vehicleRefId="IR90-BRGEGEAP1-9"/>
+				<departure id="IR90-BRGEGEAP1-10" departureTime="10:10:00" vehicleRefId="IR90-BRGEGEAP1-10"/>
+				<departure id="IR90-BRGEGEAP1-11" departureTime="11:10:00" vehicleRefId="IR90-BRGEGEAP1-11"/>
+				<departure id="IR90-BRGEGEAP1-12" departureTime="12:10:00" vehicleRefId="IR90-BRGEGEAP1-12"/>
+			</departures>
+		</transitRoute>
+		<transitRoute id="IR90-BRGEGEAP2">
+			<transportMode>rail</transportMode>
+			<routeProfile>
+				<stop refId="LS1" arrivalOffset="00:00:00" departureOffset="00:09:00" awaitDeparture="true"/>
+				<stop refId="MOR1" arrivalOffset="00:20:00" departureOffset="00:20:00" awaitDeparture="true"/>
+				<stop refId="NY1" arrivalOffset="00:36:00" departureOffset="00:37:00" awaitDeparture="true"/>
+				<stop refId="GE1" arrivalOffset="00:52:00" departureOffset="00:55:00" awaitDeparture="true"/>
+			</routeProfile>
+			<route>
+				<link refId="LS2-LS1"/>
+				<link refId="LS1-REN2"/>
+				<link refId="REN2-REN1"/>
+				<link refId="REN1-MOR2-2"/>
+				<link refId="MOR2-MOR1"/>
+				<link refId="MOR1-ALL2"/>
+				<link refId="ALL2-ALL1"/>
+				<link refId="ALL1-ROL2"/>
+				<link refId="ROL2-ROL1"/>
+				<link refId="ROL1-GLA2"/>
+				<link refId="GLA2-GLA1"/>
+				<link refId="GLA1-NY2"/>
+				<link refId="NY2-NY1"/>
+				<link refId="NY1-COP2"/>
+				<link refId="COP2-COP1"/>
+				<link refId="COP1-GE2"/>
+				<link refId="GE2-GE1"/>
+			</route>
+			<departures>
+				<departure id="IR90-BRGEGEAP2-8" departureTime="08:39:00" vehicleRefId="IR90-BRGEGEAP2-8"/>
+				<departure id="IR90-BRGEGEAP2-9" departureTime="09:39:00" vehicleRefId="IR90-BRGEGEAP2-9"/>
+				<departure id="IR90-BRGEGEAP2-10" departureTime="10:39:00" vehicleRefId="IR90-BRGEGEAP2-10"/>
+				<departure id="IR90-BRGEGEAP2-11" departureTime="11:39:00" vehicleRefId="IR90-BRGEGEAP2-11"/>
+				<departure id="IR90-BRGEGEAP2-12" departureTime="12:39:00" vehicleRefId="IR90-BRGEGEAP2-12"/>
+			</departures>
+		</transitRoute>
+
+	</transitLine>
+
+	<transitLine id="IR15">
+		<transitRoute id="IR15-GEAPGELZ">
+			<transportMode>rail</transportMode>
+			<routeProfile>
+				<stop refId="GE" arrivalOffset="00:00:00" departureOffset="00:03:00" awaitDeparture="true"/>
+				<stop refId="NY" arrivalOffset="00:17:00" departureOffset="00:17:00" awaitDeparture="true"/>
+				<stop refId="MOR" arrivalOffset="00:34:00" departureOffset="00:34:00" awaitDeparture="true"/>
+				<stop refId="LS" arrivalOffset="00:45:00" departureOffset="00:48:00" awaitDeparture="true"/>
+			</routeProfile>
+			<route>
+				<link refId="GE1-GE2"/>
+				<link refId="GE2-COP1"/>
+				<link refId="COP1-COP2"/>
+				<link refId="COP2-NY1"/>
+				<link refId="NY1-NY2"/>
+				<link refId="NY2-GLA1"/>
+				<link refId="GLA1-GLA2"/>
+				<link refId="GLA2-ROL1"/>
+				<link refId="ROL1-ROL2"/>
+				<link refId="ROL2-ALL1"/>
+				<link refId="ALL1-ALL2"/>
+				<link refId="ALL2-MOR1"/>
+				<link refId="MOR1-MOR2"/>
+				<link refId="MOR2_REN1-1"/>
+				<link refId="REN1-REN2"/>
+				<link refId="REN2-LS1"/>
+				<link refId="LS1-LS2"/>
+			</route>
+			<departures>
+				<departure id="IR15-GEAPGELZ-8" departureTime="08:56:00" vehicleRefId="IR15-GEAPGELZ-8"/>
+				<departure id="IR15-GEAPGELZ-9" departureTime="09:56:00" vehicleRefId="IR15-GEAPGELZ-9"/>
+				<departure id="IR15-GEAPGELZ-10" departureTime="10:56:00" vehicleRefId="IR15-GEAPGELZ-10"/>
+				<departure id="IR15-GEAPGELZ-11" departureTime="11:56:00" vehicleRefId="IR15-GEAPGELZ-11"/>
+				<departure id="IR15-GEAPGELZ-12" departureTime="12:56:00" vehicleRefId="IR15-GEAPGELZ-12"/>
+			</departures>
+		</transitRoute>
+
+		<transitRoute id="IR15-LZGEGEAP">
+			<transportMode>rail</transportMode>
+			<routeProfile>
+				<stop refId="LS1" arrivalOffset="00:00:00" departureOffset="00:03:00" awaitDeparture="true"/>
+				<stop refId="MOR1" arrivalOffset="00:13:00" departureOffset="00:13:00" awaitDeparture="true"/>
+				<stop refId="NY1" arrivalOffset="00:29:00" departureOffset="00:30:00" awaitDeparture="true"/>
+				<stop refId="GE1" arrivalOffset="00:45:00" departureOffset="00:48:00" awaitDeparture="true"/>
+			</routeProfile>
+			<route>
+				<link refId="LS2-LS1"/>
+				<link refId="LS1-REN2"/>
+				<link refId="REN2-REN1"/>
+				<link refId="REN1-MOR2-2"/>
+				<link refId="MOR2-MOR1"/>
+				<link refId="MOR1-ALL2"/>
+				<link refId="ALL2-ALL1"/>
+				<link refId="ALL1-ROL2"/>
+				<link refId="ROL2-ROL1"/>
+				<link refId="ROL1-GLA2"/>
+				<link refId="GLA2-GLA1"/>
+				<link refId="GLA1-NY2"/>
+				<link refId="NY2-NY1"/>
+				<link refId="NY1-COP2"/>
+				<link refId="COP2-COP1"/>
+				<link refId="COP1-GE2"/>
+				<link refId="GE2-GE1"/>
+			</route>
+			<departures>
+				<departure id="IR15-LZGEGEAP-8" departureTime="08:16:00" vehicleRefId="IR15-LZGEGEAP-8"/>
+				<departure id="IR15-LZGEGEAP-9" departureTime="09:16:00" vehicleRefId="IR15-LZGEGEAP-9"/>
+				<departure id="IR15-LZGEGEAP-10" departureTime="10:16:00" vehicleRefId="IR15-LZGEGEAP-10"/>
+				<departure id="IR15-LZGEGEAP-11" departureTime="11:16:00" vehicleRefId="IR15-LZGEGEAP-11"/>
+				<departure id="IR15-LZGEGEAP-12" departureTime="12:16:00" vehicleRefId="IR15-LZGEGEAP-12"/>
+			</departures>
+		</transitRoute>
+
+	</transitLine>
+
+	<transitLine id="IC1">
+		<transitRoute id="IC1-GEAPZUESG">
+			<transportMode>rail</transportMode>
+			<routeProfile>
+				<stop refId="GE" arrivalOffset="00:00:00" departureOffset="00:03:00" awaitDeparture="true"/>
+				<stop refId="LS" arrivalOffset="00:38:00" departureOffset="00:40:00" awaitDeparture="true"/>
+			</routeProfile>
+			<route>
+				<link refId="GE1-GE2"/>
+				<link refId="GE2-COP1"/>
+				<link refId="COP1-COP2"/>
+				<link refId="COP2-NY1"/>
+				<link refId="NY1-NY2"/>
+				<link refId="NY2-GLA1"/>
+				<link refId="GLA1-GLA2"/>
+				<link refId="GLA2-ROL1"/>
+				<link refId="ROL1-ROL2"/>
+				<link refId="ROL2-ALL1"/>
+				<link refId="ALL1-ALL2"/>
+				<link refId="ALL2-MOR1"/>
+				<link refId="MOR1-MOR2"/>
+				<link refId="MOR2_REN1-1"/>
+				<link refId="REN1-REN2"/>
+				<link refId="REN2-LS1"/>
+				<link refId="LS1-LS2"/>
+			</route>
+			<departures>
+				<departure id="IC1-GEAPZUESG-8" departureTime="08:39:00" vehicleRefId="IC1-GEAPZUESG-8"/>
+				<departure id="IC1-GEAPZUESG-9" departureTime="09:39:00" vehicleRefId="IC1-GEAPZUESG-9"/>
+				<departure id="IC1-GEAPZUESG-10" departureTime="10:39:00" vehicleRefId="IC1-GEAPZUESG-10"/>
+				<departure id="IC1-GEAPZUESG-11" departureTime="11:39:00" vehicleRefId="IC1-GEAPZUESG-11"/>
+				<departure id="IC1-GEAPZUESG-12" departureTime="12:39:00" vehicleRefId="IC1-GEAPZUESG-12"/>
+			</departures>
+		</transitRoute>
+
+		<transitRoute id="IC1-SGZUEGEAP">
+			<transportMode>rail</transportMode>
+			<routeProfile>
+				<stop refId="LS1" arrivalOffset="00:00:00" departureOffset="00:02:00" awaitDeparture="true"/>
+				<stop refId="GE1" arrivalOffset="00:37:00" departureOffset="00:39:00" awaitDeparture="true"/>
+			</routeProfile>
+			<route>
+				<link refId="LS2-LS1"/>
+				<link refId="LS1-REN2"/>
+				<link refId="REN2-REN1"/>
+				<link refId="REN1-MOR2-2"/>
+				<link refId="MOR2-MOR1"/>
+				<link refId="MOR1-ALL2"/>
+				<link refId="ALL2-ALL1"/>
+				<link refId="ALL1-ROL2"/>
+				<link refId="ROL2-ROL1"/>
+				<link refId="ROL1-GLA2"/>
+				<link refId="GLA2-GLA1"/>
+				<link refId="GLA1-NY2"/>
+				<link refId="NY2-NY1"/>
+				<link refId="NY1-COP2"/>
+				<link refId="COP2-COP1"/>
+				<link refId="COP1-GE2"/>
+				<link refId="GE2-GE1"/>
+			</route>
+			<departures>
+				<departure id="IC1-SGZUEGEAP-8" departureTime="08:41:00" vehicleRefId="IC1-SGZUEGEAP-8"/>
+				<departure id="IC1-SGZUEGEAP-9" departureTime="09:41:00" vehicleRefId="IC1-SGZUEGEAP-9"/>
+				<departure id="IC1-SGZUEGEAP-10" departureTime="10:41:00" vehicleRefId="IC1-SGZUEGEAP-10"/>
+				<departure id="IC1-SGZUEGEAP-11" departureTime="11:41:00" vehicleRefId="IC1-SGZUEGEAP-11"/>
+				<departure id="IC1-SGZUEGEAP-12" departureTime="12:41:00" vehicleRefId="IC1-SGZUEGEAP-12"/>
+			</departures>
+		</transitRoute>
+
+
+	</transitLine>
+
+	<transitLine id="IC5">
+		<transitRoute id="IC5-GEAPZUERS">
+			<transportMode>rail</transportMode>
+			<routeProfile>
+				<stop refId="GE" arrivalOffset="00:00:00" departureOffset="00:03:00" awaitDeparture="true"/>
+				<stop refId="MOR" arrivalOffset="00:29:00" departureOffset="00:30:00" awaitDeparture="true"/>
+				<stop refId="REN" arrivalOffset="00:37:00" awaitDeparture="false"/>
+			</routeProfile>
+			<route>
+				<link refId="GE1-GE2"/>
+				<link refId="GE2-COP1"/>
+				<link refId="COP1-COP2"/>
+				<link refId="COP2-NY1"/>
+				<link refId="NY1-NY2"/>
+				<link refId="NY2-GLA1"/>
+				<link refId="GLA1-GLA2"/>
+				<link refId="GLA2-ROL1"/>
+				<link refId="ROL1-ROL2"/>
+				<link refId="ROL2-ALL1"/>
+				<link refId="ALL1-ALL2"/>
+				<link refId="ALL2-MOR1"/>
+				<link refId="MOR1-MOR2"/>
+				<link refId="MOR2_REN1-1"/>
+				<link refId="REN1-REN2"/>
+			</route>
+			<departures>
+				<departure id="IC5-GEAPZUERS-8" departureTime="08:12:00" vehicleRefId="IC5-GEAPZUERS-8"/>
+				<departure id="IC5-GEAPZUERS-9" departureTime="09:12:00" vehicleRefId="IC5-GEAPZUERS-9"/>
+				<departure id="IC5-GEAPZUERS-10" departureTime="10:12:00" vehicleRefId="IC5-GEAPZUERS-10"/>
+				<departure id="IC5-GEAPZUERS-11" departureTime="11:12:00" vehicleRefId="IC5-GEAPZUERS-11"/>
+				<departure id="IC5-GEAPZUERS-12" departureTime="12:12:00" vehicleRefId="IC5-GEAPZUERS-12"/>
+			</departures>
+		</transitRoute>
+
+		<transitRoute id="IC5-RSZUEGEAP">
+			<transportMode>rail</transportMode>
+			<routeProfile>
+				<stop refId="REN1" arrivalOffset="00:00:00" departureOffset="00:00:00" awaitDeparture="true"/>
+				<stop refId="MOR1" arrivalOffset="00:07:00" departureOffset="00:09:00" awaitDeparture="true"/>
+				<stop refId="GE1" arrivalOffset="00:38:00" departureOffset="00:40:00" awaitDeparture="true"/>
+			</routeProfile>
+			<route>
+				<link refId="REN2-REN1"/>
+				<link refId="REN1-MOR2-2"/>
+				<link refId="MOR2-MOR1"/>
+				<link refId="MOR1-ALL2"/>
+				<link refId="ALL2-ALL1"/>
+				<link refId="ALL1-ROL2"/>
+				<link refId="ROL2-ROL1"/>
+				<link refId="ROL1-GLA2"/>
+				<link refId="GLA2-GLA1"/>
+				<link refId="GLA1-NY2"/>
+				<link refId="NY2-NY1"/>
+				<link refId="NY1-COP2"/>
+				<link refId="COP2-COP1"/>
+				<link refId="COP1-GE2"/>
+				<link refId="GE2-GE1"/>
+			</route>
+			<departures>
+				<departure id="IC5-RSZUEGEAP-8" departureTime="08:09:00" vehicleRefId="IC5-RSZUEGEAP-8"/>
+				<departure id="IC5-RSZUEGEAP-9" departureTime="09:09:00" vehicleRefId="IC5-RSZUEGEAP-9"/>
+				<departure id="IC5-RSZUEGEAP-10" departureTime="10:09:00" vehicleRefId="IC5-RSZUEGEAP-10"/>
+				<departure id="IC5-RSZUEGEAP-11" departureTime="11:09:00" vehicleRefId="IC5-RSZUEGEAP-11"/>
+				<departure id="IC5-RSZUEGEAP-12" departureTime="12:09:00" vehicleRefId="IC5-RSZUEGEAP-12"/>
+			</departures>
+		</transitRoute>
+
+		<transitRoute id="Construction_REN_LS">
+			<transportMode>rail</transportMode>
+			<routeProfile>
+				<stop refId="MOR" arrivalOffset="00:00:00" departureOffset="00:00:00" awaitDeparture="false"/>
+				<stop refId="Construction_Site_MOR_REN" arrivalOffset="00:00:00" departureOffset="01:00:00" awaitDeparture="true"/>
+				<stop refId="REN" arrivalOffset="01:00:00" departureOffset="01:00:00" awaitDeparture="false"/>
+			</routeProfile>
+			<route>
+				<link refId="MOR1-MOR2"/>
+				<link refId="MOR2_REN1-1"/>
+				<link refId="REN1-REN2"/>
+			</route>
+			<departures>
+				<departure id="Construction_MOR_REN_10" departureTime="10:00:00" vehicleRefId="Construction_Train1"/>
+			</departures>
+		</transitRoute>
+
+
+	</transitLine>
+
+
+</transitSchedule>

--- a/contribs/railsim/test/input/ch/sbb/matsim/contrib/railsim/integration/scenarioMicroMesoConstructionSiteLsGe/transitVehicles.xml
+++ b/contribs/railsim/test/input/ch/sbb/matsim/contrib/railsim/integration/scenarioMicroMesoConstructionSiteLsGe/transitVehicles.xml
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<vehicleDefinitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.matsim.org/files/dtd" xsi:schemaLocation="http://www.matsim.org/files/dtd http://www.matsim.org/files/dtd/vehicleDefinitions_v2.0.xsd">
+
+
+	<!-- ====================================================================== -->
+
+	<!-- Four types of vehicles are used for the different traffc types : Regional (RV160), InterRegio (FV200IR), InterCity (FV200IC), Construction (Construction_Train)
+	-->
+
+	<!-- ====================================================================== -->
+
+
+	<vehicleType id="RV160">
+		<attributes>
+			<attribute name="accessTimeInSecondsPerPerson" class="java.lang.Double">5.0</attribute>
+			<attribute name="doorOperationMode" class="org.matsim.vehicles.VehicleType$DoorOperationMode">serial</attribute>
+			<attribute name="egressTimeInSecondsPerPerson" class="java.lang.Double">5.0</attribute>
+			<attribute name="railsimAcceleration" class="java.lang.Double">1</attribute>
+			<attribute name="railsimDeceleration" class="java.lang.Double">1</attribute>
+		</attributes>
+		<capacity seats="200" standingRoomInPersons="0">
+
+		</capacity>
+		<length meter="150"/>
+		<width meter="2.85"/>
+		<maximumVelocity meterPerSecond="44"/>
+		<costInformation>
+
+		</costInformation>
+		<passengerCarEquivalents pce="1.0"/>
+		<networkMode networkMode="rail"/>
+		<flowEfficiencyFactor factor="1.0"/>
+	</vehicleType>
+
+	<vehicleType id="FV200IR">
+		<attributes>
+			<attribute name="accessTimeInSecondsPerPerson" class="java.lang.Double">5.0</attribute>
+			<attribute name="doorOperationMode" class="org.matsim.vehicles.VehicleType$DoorOperationMode">serial</attribute>
+			<attribute name="egressTimeInSecondsPerPerson" class="java.lang.Double">5.0</attribute>
+			<attribute name="railsimAcceleration" class="java.lang.Double">0.8</attribute>
+			<attribute name="railsimDeceleration" class="java.lang.Double">0.8</attribute>
+		</attributes>
+		<capacity seats="400" standingRoomInPersons="0">
+
+		</capacity>
+		<length meter="200"/>
+		<width meter="2.85"/>
+		<maximumVelocity meterPerSecond="55"/>
+		<costInformation>
+
+		</costInformation>
+		<passengerCarEquivalents pce="1.0"/>
+		<networkMode networkMode="rail"/>
+		<flowEfficiencyFactor factor="1.0"/>
+	</vehicleType>
+
+	<vehicleType id="FV200IC">
+		<attributes>
+			<attribute name="accessTimeInSecondsPerPerson" class="java.lang.Double">5.0</attribute>
+			<attribute name="doorOperationMode" class="org.matsim.vehicles.VehicleType$DoorOperationMode">serial</attribute>
+			<attribute name="egressTimeInSecondsPerPerson" class="java.lang.Double">5.0</attribute>
+			<attribute name="railsimAcceleration" class="java.lang.Double">0.8</attribute>
+			<attribute name="railsimDeceleration" class="java.lang.Double">0.8</attribute>
+		</attributes>
+		<capacity seats="400" standingRoomInPersons="0">
+
+		</capacity>
+		<length meter="200"/>
+		<width meter="2.85"/>
+		<maximumVelocity meterPerSecond="55"/>
+		<costInformation>
+
+		</costInformation>
+		<passengerCarEquivalents pce="1.0"/>
+		<networkMode networkMode="rail"/>
+		<flowEfficiencyFactor factor="1.0"/>
+	</vehicleType>
+
+	<vehicleType id="Construction_Train">
+		<attributes>
+			<attribute name="accessTimeInSecondsPerPerson" class="java.lang.Double">5.0</attribute>
+			<attribute name="doorOperationMode" class="org.matsim.vehicles.VehicleType$DoorOperationMode">serial</attribute>
+			<attribute name="egressTimeInSecondsPerPerson" class="java.lang.Double">5.0</attribute>
+			<attribute name="railsimAcceleration" class="java.lang.Double">0.8</attribute>
+			<attribute name="railsimDeceleration" class="java.lang.Double">0.8</attribute>
+		</attributes>
+		<capacity seats="1" standingRoomInPersons="0">
+
+		</capacity>
+		<length meter="200"/>
+		<width meter="2.85"/>
+		<maximumVelocity meterPerSecond="55"/>
+		<costInformation>
+
+		</costInformation>
+		<passengerCarEquivalents pce="1.0"/>
+		<networkMode networkMode="rail"/>
+		<flowEfficiencyFactor factor="1.0"/>
+	</vehicleType>
+
+
+	<vehicle id="RE33-ANNGELS-8" type="RV160"/>
+	<vehicle id="RE33-ANNGELS-9" type="RV160"/>
+	<vehicle id="RE33-ANNGELS-10" type="RV160"/>
+	<vehicle id="RE33-ANNGELS-11" type="RV160"/>
+	<vehicle id="RE33-ANNGELS-12" type="RV160"/>
+
+	<vehicle id="RE33-ANNGESM-8" type="RV160"/>
+	<vehicle id="RE33-ANNGESM-9" type="RV160"/>
+	<vehicle id="RE33-ANNGESM-10" type="RV160"/>
+	<vehicle id="RE33-ANNGESM-11" type="RV160"/>
+	<vehicle id="RE33-ANNGESM-12" type="RV160"/>
+
+	<vehicle id="RE33-VVGEANN-8" type="RV160"/>
+	<vehicle id="RE33-VVGEANN-9" type="RV160"/>
+	<vehicle id="RE33-VVGEANN-10" type="RV160"/>
+	<vehicle id="RE33-VVGEANN-11" type="RV160"/>
+	<vehicle id="RE33-VVGEANN-12" type="RV160"/>
+
+	<vehicle id="RE33-SMGEANN-8" type="RV160"/>
+	<vehicle id="RE33-SMGEANN-9" type="RV160"/>
+	<vehicle id="RE33-SMGEANN-10" type="RV160"/>
+	<vehicle id="RE33-SMGEANN-11" type="RV160"/>
+	<vehicle id="RE33-SMGEANN-12" type="RV160"/>
+
+	<vehicle id="IR90-GEAPGEBR1-8" type="FV200IR"/>
+	<vehicle id="IR90-GEAPGEBR1-9" type="FV200IR"/>
+	<vehicle id="IR90-GEAPGEBR1-10" type="FV200IR"/>
+	<vehicle id="IR90-GEAPGEBR1-11" type="FV200IR"/>
+	<vehicle id="IR90-GEAPGEBR1-12" type="FV200IR"/>
+
+	<vehicle id="IR90-GEAPGEBR2-8" type="FV200IR"/>
+	<vehicle id="IR90-GEAPGEBR2-9" type="FV200IR"/>
+	<vehicle id="IR90-GEAPGEBR2-10" type="FV200IR"/>
+	<vehicle id="IR90-GEAPGEBR2-11" type="FV200IR"/>
+	<vehicle id="IR90-GEAPGEBR2-12" type="FV200IR"/>
+
+	<vehicle id="IR90-BRGEGEAP1-8" type="FV200IR"/>
+	<vehicle id="IR90-BRGEGEAP1-9" type="FV200IR"/>
+	<vehicle id="IR90-BRGEGEAP1-10" type="FV200IR"/>
+	<vehicle id="IR90-BRGEGEAP1-11" type="FV200IR"/>
+	<vehicle id="IR90-BRGEGEAP1-12" type="FV200IR"/>
+
+	<vehicle id="IR90-BRGEGEAP2-8" type="FV200IR"/>
+	<vehicle id="IR90-BRGEGEAP2-9" type="FV200IR"/>
+	<vehicle id="IR90-BRGEGEAP2-10" type="FV200IR"/>
+	<vehicle id="IR90-BRGEGEAP2-11" type="FV200IR"/>
+	<vehicle id="IR90-BRGEGEAP2-12" type="FV200IR"/>
+
+	<vehicle id="IR15-GEAPGELZ-8" type="FV200IR"/>
+	<vehicle id="IR15-GEAPGELZ-9" type="FV200IR"/>
+	<vehicle id="IR15-GEAPGELZ-10" type="FV200IR"/>
+	<vehicle id="IR15-GEAPGELZ-11" type="FV200IR"/>
+	<vehicle id="IR15-GEAPGELZ-12" type="FV200IR"/>
+
+	<vehicle id="IR15-LZGEGEAP-8" type="FV200IR"/>
+	<vehicle id="IR15-LZGEGEAP-9" type="FV200IR"/>
+	<vehicle id="IR15-LZGEGEAP-10" type="FV200IR"/>
+	<vehicle id="IR15-LZGEGEAP-11" type="FV200IR"/>
+	<vehicle id="IR15-LZGEGEAP-12" type="FV200IR"/>
+
+	<vehicle id="IC1-GEAPZUESG-8" type="FV200IC"/>
+	<vehicle id="IC1-GEAPZUESG-9" type="FV200IC"/>
+	<vehicle id="IC1-GEAPZUESG-10" type="FV200IC"/>
+	<vehicle id="IC1-GEAPZUESG-11" type="FV200IC"/>
+	<vehicle id="IC1-GEAPZUESG-12" type="FV200IC"/>
+
+	<vehicle id="IC1-SGZUEGEAP-8" type="FV200IC"/>
+	<vehicle id="IC1-SGZUEGEAP-9" type="FV200IC"/>
+	<vehicle id="IC1-SGZUEGEAP-10" type="FV200IC"/>
+	<vehicle id="IC1-SGZUEGEAP-11" type="FV200IC"/>
+	<vehicle id="IC1-SGZUEGEAP-12" type="FV200IC"/>
+
+	<vehicle id="IC5-GEAPZUERS-8" type="FV200IC"/>
+	<vehicle id="IC5-GEAPZUERS-9" type="FV200IC"/>
+	<vehicle id="IC5-GEAPZUERS-10" type="FV200IC"/>
+	<vehicle id="IC5-GEAPZUERS-11" type="FV200IC"/>
+	<vehicle id="IC5-GEAPZUERS-12" type="FV200IC"/>
+
+	<vehicle id="IC5-RSZUEGEAP-8" type="FV200IC"/>
+	<vehicle id="IC5-RSZUEGEAP-9" type="FV200IC"/>
+	<vehicle id="IC5-RSZUEGEAP-10" type="FV200IC"/>
+	<vehicle id="IC5-RSZUEGEAP-11" type="FV200IC"/>
+	<vehicle id="IC5-RSZUEGEAP-12" type="FV200IC"/>
+
+
+	<vehicle id="Construction_Train1" type="Construction_Train"/>
+
+
+</vehicleDefinitions>


### PR DESCRIPTION
This PR adds a further integration test case for railsim

**Network**
Network based on the infrastructure between Lausanne and Geneva, only the stations needed for the long-distance trains have been modeled based on https://network.sbb.ch/en/
All links are mesoscopic, with tracks capacities following the reality. 
The portion of the line where the construction site happens is modelled in a microscopic manner between Morges (MOR) and Renens (REN).

**Schedule**
The schedule is built on the typical hour schedule available here : https://network.sbb.ch/en/ repeating itself every hour between 8am and 12pm (noon). 

**Construction site**
In order to model the capacity restriction on one track of the construction zone, a construction train is used, staying at at "construction Stop" for the duration wanted. In this case a construction train leaves Morges (MOR) at 10am and blocks one link (MOR2-REN1-1) for one hour, and then drives to Renens (REN).

This blocks the track and the trains therefore need to reroute if needed. The needed links in MOR and REN have been put to Entry and Exit to allow the rerouting. 


@rakow @ikaddoura @munterfi 