### PR TITLE
add dependency for geotools-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,11 @@
                 <artifactId>gt-epsg-extension</artifactId>
                 <version>${geotools.version}</version>
             </dependency>
+			<dependency>
+				<groupId>org.geotools</groupId>
+				<artifactId>gt-api</artifactId>
+				<version>${geotools.version}</version>
+			</dependency>
             <dependency>
                 <groupId>org.geotools.jdbc</groupId>
                 <artifactId>gt-jdbc-postgis</artifactId>


### PR DESCRIPTION
the addition of some functionalities of getools-api caused errors in some scenarios, hence getools-api is added as a dependency, such that alle the necessary imports e.g. for matsim-libs class ShpOptions can be found.