### PR TITLE
Debug noise analysis

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/analysis/noise/NoiseAnalysis.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/noise/NoiseAnalysis.java
@@ -110,7 +110,8 @@ public class NoiseAnalysis implements MATSimAppCommand {
 	private Config prepareConfig() {
 		Config config = ConfigUtils.loadConfig(ApplicationUtils.matchInput("config.xml", input.getRunDirectory()).toAbsolutePath().toString(), new NoiseConfigGroup());
 
-		config.vehicles().setVehiclesFile(ApplicationUtils.matchInput("vehicles", input.getRunDirectory()).toAbsolutePath().toString());
+		//it is important to match "output_vehicles" because otherwise dvrpVehicle files might be matched and the code crashes later
+		config.vehicles().setVehiclesFile(ApplicationUtils.matchInput("output_vehicles", input.getRunDirectory()).toAbsolutePath().toString());
 		config.network().setInputFile(ApplicationUtils.matchInput("network", input.getRunDirectory()).toAbsolutePath().toString());
 		config.transit().setTransitScheduleFile(null);
 		config.transit().setVehiclesFile(null);

--- a/matsim/src/main/java/org/matsim/vehicles/MatsimVehicleReader.java
+++ b/matsim/src/main/java/org/matsim/vehicles/MatsimVehicleReader.java
@@ -83,6 +83,11 @@ public final class MatsimVehicleReader implements MatsimReader{
 					throw new RuntimeException("no reader found for " + str ) ;
 				}
 			} else{
+				if (this.delegate == null) {
+					log.error("found no valid. vehicle definition file. this may happen if you try to parse a dvrp vehicles file for example or if no vehicle definition file is provided.\n" +
+						"Valid vehicle definitions are at http://www.matsim.org/files/dtd/vehicleDefinitions_v2.0.xsd and http://www.matsim.org/files/dtd/vehicleDefinitions_v1.0.xsd\n" +
+						"The code will crash with a NullPointerException.");
+				}
 				this.delegate.startTag( name, atts, context );
 			}
 		}


### PR DESCRIPTION
`NoiseAnalysis` matched `vehicles` from the run directory. In case of runs with dvrp, there are multiple of files matching that pattern. We need to make sure that the one, complete `output_vehicles` file is read.