### PR TITLE
NoiseAnalysis

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/analysis/noise/NoiseAnalysis.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/noise/NoiseAnalysis.java
@@ -110,8 +110,8 @@ public class NoiseAnalysis implements MATSimAppCommand {
 	private Config prepareConfig() {
 		Config config = ConfigUtils.loadConfig(ApplicationUtils.matchInput("config.xml", input.getRunDirectory()).toAbsolutePath().toString(), new NoiseConfigGroup());
 
-		//it is important to match "output_vehicles" because otherwise dvrpVehicle files might be matched and the code crashes later
-		config.vehicles().setVehiclesFile(ApplicationUtils.matchInput("output_vehicles", input.getRunDirectory()).toAbsolutePath().toString());
+		//it is important to match "output_vehicles.xml.gz" specifically, because otherwise dvrpVehicle files might be matched and the code crashes later
+		config.vehicles().setVehiclesFile(ApplicationUtils.matchInput("output_vehicles.xml.gz", input.getRunDirectory()).toAbsolutePath().toString());
 		config.network().setInputFile(ApplicationUtils.matchInput("network", input.getRunDirectory()).toAbsolutePath().toString());
 		config.transit().setTransitScheduleFile(null);
 		config.transit().setVehiclesFile(null);

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/dashboards/CreateDrtDashboard.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/dashboards/CreateDrtDashboard.java
@@ -42,7 +42,7 @@ final class CreateDrtDashboard implements MATSimAppCommand {
 
 	private static final Logger log = LogManager.getLogger(CreateDrtDashboard.class);
 
-	@CommandLine.Parameters(arity = "1..*", description = "Path to run output directories for which emission dashboards are to be generated.")
+	@CommandLine.Parameters(arity = "1..*", description = "Path to run output directories for which DRT dashboards are to be generated.")
 	private List<Path> inputPaths;
 
 	private CreateDrtDashboard(){

--- a/contribs/simwrapper/src/test/java/org/matsim/simwrapper/dashboard/NoiseDashboardTests.java
+++ b/contribs/simwrapper/src/test/java/org/matsim/simwrapper/dashboard/NoiseDashboardTests.java
@@ -1,5 +1,6 @@
 package org.matsim.simwrapper.dashboard;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.matsim.application.MATSimApplication;
@@ -15,6 +16,7 @@ import org.matsim.testcases.MatsimTestUtils;
 
 
 import java.net.URL;
+import java.nio.file.Path;
 
 public class NoiseDashboardTests {
 
@@ -24,6 +26,8 @@ public class NoiseDashboardTests {
 
 	@Test
 	void generate() {
+		Path out = Path.of(utils.getOutputDirectory(), "analysis", "noise");
+
 		Config config = TestScenario.loadConfig(utils);
 
 		config.global().setCoordinateSystem("EPSG:25832");
@@ -34,11 +38,14 @@ public class NoiseDashboardTests {
 
 		simWrapperConfigGroup.defaultParams().shp = IOUtils.extendUrl(kelheim, "area/area.shp").toString();
 
-
 		SimWrapper sw = SimWrapper.create(config).addDashboard(new NoiseDashboard());
 		Controler controler = MATSimApplication.prepare(new TestScenario(sw), config);
 
-
 		controler.run();
+
+		Assertions.assertThat(out)
+			.isDirectoryContaining("glob:**emission_per_day.csv")
+			.isDirectoryContaining("glob:**immission_per_day.avro")
+			.isDirectoryContaining("glob:**immission_per_hour.avro");
 	}
 }


### PR DESCRIPTION
couldn't identify the correct *output_vehicles.xml.gz and there was no proper testing in `NoiseDashboardTests`.
Meanwhile fixed a typo in CreateDrtDashboard.

Tested with a proper Kelheim run. There, the noise link plot fails, but the GridMaps are correctly shown. Further debugging potentially comes with a new PR