### PR TITLE
add router binding for complex request unscheduling

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/prebooking/PrebookingModeQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/prebooking/PrebookingModeQSimModule.java
@@ -22,7 +22,9 @@ import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.mobsim.qsim.QSim;
+import org.matsim.core.router.speedy.SpeedyALTFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
+import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
 
 public class PrebookingModeQSimModule extends AbstractDvrpModeQSimModule {
@@ -97,6 +99,10 @@ public class PrebookingModeQSimModule extends AbstractDvrpModeQSimModule {
 			bindModal(RequestUnscheduler.class).to(modalKey(SimpleRequestUnscheduler.class));
 			break;
 		case Routing:
+			bindModal(LeastCostPathCalculator.class).toProvider(modalProvider(getter ->
+					new SpeedyALTFactory().createPathCalculator(getter.getModal(Network.class),
+                    getter.getModal(TravelDisutility.class), getter.getModal(TravelTime.class)
+            )));
 			bindModal(RequestUnscheduler.class).to(modalKey(ComplexRequestUnscheduler.class));
 			break;
 		default:

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/prebooking/PrebookingModeQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/prebooking/PrebookingModeQSimModule.java
@@ -17,6 +17,7 @@ import org.matsim.contrib.drt.vrpagent.DrtActionCreator;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicleLookup;
 import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
 import org.matsim.contrib.dvrp.passenger.*;
+import org.matsim.contrib.dvrp.router.TimeAsTravelDisutility;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
 import org.matsim.core.api.experimental.events.EventsManager;
@@ -101,7 +102,7 @@ public class PrebookingModeQSimModule extends AbstractDvrpModeQSimModule {
 		case Routing:
 			bindModal(LeastCostPathCalculator.class).toProvider(modalProvider(getter ->
 					new SpeedyALTFactory().createPathCalculator(getter.getModal(Network.class),
-                    getter.getModal(TravelDisutility.class), getter.getModal(TravelTime.class)
+                    new TimeAsTravelDisutility(getter.getModal(TravelTime.class)), getter.getModal(TravelTime.class)
             )));
 			bindModal(RequestUnscheduler.class).to(modalKey(ComplexRequestUnscheduler.class));
 			break;

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/prebooking/PrebookingTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/prebooking/PrebookingTest.java
@@ -12,7 +12,6 @@ import org.matsim.contrib.drt.stops.PassengerStopDurationProvider;
 import org.matsim.contrib.drt.stops.StaticPassengerStopDurationProvider;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
-import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.core.controler.Controler;
 import org.matsim.testcases.MatsimTestUtils;
 
@@ -57,12 +56,20 @@ public class PrebookingTest {
 	}
 
 	static PrebookingParams installPrebooking(Controler controller) {
-		return installPrebooking(controller, true);
+		return installPrebooking(controller, true, new PrebookingParams());
+	}
+
+	static PrebookingParams installPrebooking(Controler controller, PrebookingParams prebookingParams) {
+		return installPrebooking(controller, true, prebookingParams);
 	}
 
 	static PrebookingParams installPrebooking(Controler controller, boolean installLogic) {
+		return installPrebooking(controller, installLogic, new PrebookingParams());
+	}
+
+	static PrebookingParams installPrebooking(Controler controller, boolean installLogic, PrebookingParams prebookingParams) {
 		DrtConfigGroup drtConfig = DrtConfigGroup.getSingleModeDrtConfig(controller.getConfig());
-		drtConfig.addParameterSet(new PrebookingParams());
+		drtConfig.addParameterSet(prebookingParams);
 
 		if (installLogic) {
 			AttributeBasedPrebookingLogic.install(controller, drtConfig);


### PR DESCRIPTION
Hey @sebhoerl  I was playing around with the prebooking module - not sure if this was really missing or it was supposed to be bound elsewhere but when choosing the complex request unscheduler in prebooking there was a (modal) binding missing for the LeastCostPathCalculator

This also crashed when choosing this unscheduler in the matsim-code-example