### PR TITLE
Norm mode shares in TripAnalysis

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/CommandRunner.java
+++ b/contribs/application/src/main/java/org/matsim/application/CommandRunner.java
@@ -108,7 +108,7 @@ public final class CommandRunner {
 		MATSimAppCommand command = clazz.getDeclaredConstructor().newInstance();
 		String[] args = this.args.get(clazz);
 		args = ArrayUtils.addAll(args, createArgs(clazz, args, input));
-		log.info("Running {} with arguments: {}", clazz, Arrays.toString(args));
+		log.info("Running {} with arguments: {}", clazz, String.join(" ", args));
 
 		command.execute(args);
 	}

--- a/contribs/application/src/main/java/org/matsim/application/analysis/population/TripByGroupAnalysis.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/population/TripByGroupAnalysis.java
@@ -81,6 +81,22 @@ final class TripByGroupAnalysis {
 				}
 			}
 
+			// Norm shares per instance of each group to sum of 1
+			for (Group group : this.groups) {
+
+				String norm = group.columns.get(0);
+				if (group.columns.size() > 1)
+					throw new UnsupportedOperationException("Multiple columns not supported yet");
+
+				Table df = group.data;
+				for (String label : df.stringColumn(norm).asSet()) {
+					DoubleColumn dist_group = df.doubleColumn("share");
+					Selection sel = df.stringColumn(norm).isEqualTo(label);
+					double total = dist_group.where(sel).sum();
+					if (total > 0)
+						dist_group.set(sel, dist_group.divide(total));
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
The TripAnalysis for subgroups will now also work if the provided mode shares do not sum to 1 in each group.