### PR TITLE
Roadpring in Freight

### DIFF
--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/controler/CarrierVehicleReRouter.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/controler/CarrierVehicleReRouter.java
@@ -36,6 +36,7 @@ import com.graphhopper.jsprit.io.algorithm.AlgorithmConfig;
 import com.graphhopper.jsprit.io.algorithm.AlgorithmConfigXmlReader;
 import com.graphhopper.jsprit.io.algorithm.VehicleRoutingAlgorithms;
 import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.roadpricing.RoadPricingScheme;
 import org.matsim.core.replanning.ReplanningContext;
 import org.matsim.core.replanning.modules.GenericPlanStrategyModule;
 import org.matsim.core.router.util.TravelTime;
@@ -58,7 +59,7 @@ class CarrierVehicleReRouter implements GenericPlanStrategyModule<CarrierPlan>{
 
     private final VehicleRoutingActivityCosts vehicleRoutingActivityCosts;
 
-	public CarrierVehicleReRouter( Network network, CarrierVehicleTypes vehicleTypes, TravelTime travelTimes, String vrpAlgoConfigFile, VehicleTypeDependentRoadPricingCalculator roadPricing ) {
+	public CarrierVehicleReRouter( Network network, CarrierVehicleTypes vehicleTypes, TravelTime travelTimes, String vrpAlgoConfigFile, RoadPricingScheme roadPricing ) {
         this.network = network;
         vehicleRoutingTransportCosts = getNetworkBasedTransportCosts(network,vehicleTypes,travelTimes,roadPricing);
         vehicleRoutingActivityCosts = new VehicleRoutingActivityCosts() {
@@ -146,7 +147,7 @@ class CarrierVehicleReRouter implements GenericPlanStrategyModule<CarrierPlan>{
 
     }
 
-    private NetworkBasedTransportCosts getNetworkBasedTransportCosts(Network network, CarrierVehicleTypes vehicleTypes, TravelTime travelTimes, VehicleTypeDependentRoadPricingCalculator roadPricing) {
+    private NetworkBasedTransportCosts getNetworkBasedTransportCosts(Network network, CarrierVehicleTypes vehicleTypes, TravelTime travelTimes, RoadPricingScheme roadPricing ) {
         //******
         //Define transport-costs
         //******
@@ -157,7 +158,7 @@ class CarrierVehicleReRouter implements GenericPlanStrategyModule<CarrierPlan>{
         //sets time-dependent travelTimes
         tpcostsBuilder.setTravelTime(travelTimes);
 
-        if(roadPricing != null) tpcostsBuilder.setRoadPricingCalculator(roadPricing);
+        if(roadPricing != null) tpcostsBuilder.setRoadPricingScheme(roadPricing );
 
         //sets time-slice to build time-dependent tpcosts and travelTime matrices
         tpcostsBuilder.setTimeSliceWidth(900);

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/NetworkBasedTransportCosts.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/NetworkBasedTransportCosts.java
@@ -320,7 +320,6 @@ public class NetworkBasedTransportCosts implements VRPTransportCosts {
 	 */
 	static class VehicleTransportCostsIncludingToll implements TravelDisutility {
 
-//		private static Logger logger = LogManager.getLogger(VehicleTransportCostsIncludingToll.class);
 
 		private final TravelDisutility baseTransportDisutility;
 
@@ -331,26 +330,24 @@ public class NetworkBasedTransportCosts implements VRPTransportCosts {
 			super();
 			this.baseTransportDisutility = baseTransportDisutility;
 			this.roadPricingScheme = roadPricingScheme;
-//			System.out.println("huuuuuuuuuuuuuuuuuuuu - initialize transport costs with toll");
 		}
 
 		@Override
 		public double getLinkTravelDisutility(Link link, double time, Person person,
 				org.matsim.vehicles.Vehicle vehicle) {
 			double costs = baseTransportDisutility.getLinkTravelDisutility(link, time, person, vehicle);
-//			Id<org.matsim.vehicles.VehicleType> typeId = vehicle.getType().getId();
-//			double toll = roadPricingScheme.getTollAmount(typeId, link, time );
+
 			RoadPricingSchemeImpl.Cost costInfo;
 			if (person == null) {
 				costInfo = roadPricingScheme.getLinkCostInfo( link.getId(), time, null, vehicle.getId() );
 			} else {
 				costInfo = roadPricingScheme.getLinkCostInfo( link.getId(), time, person.getId(), vehicle.getId() );
 			}
-			double toll=0.;
+
+			double toll = 0.;
 			if ( costInfo != null ){
 				toll = costInfo.amount;
 			}
-//			System.out.println("huuuuuuuuuuuuuuuuuuuu - paid toll");
 			return costs + toll;
 		}
 
@@ -408,7 +405,7 @@ public class NetworkBasedTransportCosts implements VRPTransportCosts {
 		 * Creates the builder requiring {@link Network} and a collection of
 		 * {@link VehicleType}.
 		 *
-		 * @param network
+		 * @param network the MATSim network
 		 * @param vehicleTypes must be all vehicleTypes and their assigned
 		 *                     costInformation in the system.
 		 */
@@ -429,7 +426,7 @@ public class NetworkBasedTransportCosts implements VRPTransportCosts {
 		 * Sets the travelTime. By default, travelTime is based on
 		 * <code>link.getFreespeed();</code>.
 		 *
-		 * @param travelTime
+		 * @param travelTime the travelTime to set
 		 * @return this builder
 		 */
 		public Builder setTravelTime(TravelTime travelTime) {
@@ -478,7 +475,7 @@ public class NetworkBasedTransportCosts implements VRPTransportCosts {
 		 * <p>
 		 * By default, it use {@link SpeedyALTFactory}
 		 *
-		 * @param {@link {@link LeastCostPathCalculatorFactory}
+		 * @param  leastCostPathCalcFactory {@link LeastCostPathCalculatorFactory}
 		 * @return this builder
 		 */
 		public Builder setThreadSafeLeastCostPathCalculatorFactory(
@@ -526,10 +523,10 @@ public class NetworkBasedTransportCosts implements VRPTransportCosts {
 		 * Adds type-specific costs. If typeId already exists, existing entry is
 		 * overwritten.
 		 *
-		 * @param typeId
-		 * @param fix
-		 * @param perSecond
-		 * @param perMeter
+		 * @param typeId the vehicleType-id as String
+		 * @param fix fix costs for the vehicle
+		 * @param perSecond variable costs per second
+		 * @param perMeter variable costs per meter
 		 */
 		public void addVehicleTypeSpecificCosts(String typeId, double fix, double perSecond, double perMeter) {
 			typeSpecificCosts.put(typeId, new VehicleTypeVarCosts(perMeter, perSecond));
@@ -598,7 +595,7 @@ public class NetworkBasedTransportCosts implements VRPTransportCosts {
 	 * cached travel-time. If not, it computes and caches new values with the
 	 * leastCostPathCalc defined in here.
 	 *
-	 * @Throws {@link IllegalStateException} if vehicle is null
+	 * @exception  IllegalStateException if vehicle is null
 	 */
 	@Override
 	public double getTransportTime(Location fromId, Location toId, double departureTime, Driver driver,
@@ -679,7 +676,7 @@ public class NetworkBasedTransportCosts implements VRPTransportCosts {
 	 * cached travel-cost value. If not, it computes and caches new values with the
 	 * leastCostPathCalc defined in here.
 	 *
-	 * @Throws {@link IllegalStateException} if vehicle is null
+	 * @exception  IllegalStateException if vehicle is null
 	 */
 	@Override
 	public double getTransportCost(Location fromId, Location toId, double departureTime, Driver driver,
@@ -747,7 +744,7 @@ public class NetworkBasedTransportCosts implements VRPTransportCosts {
 	 * cached distance. If not, it computes and caches new values with the
 	 * leastCostPathCalc defined in here.
 	 *
-	 * @Throws {@link IllegalStateException} if vehicle is null
+	 * @exception  IllegalStateException if vehicle is null
 	 */
 	@Override
 	public double getDistance(Location fromId, Location toId, double departureTime, Vehicle vehicle) {
@@ -812,7 +809,7 @@ public class NetworkBasedTransportCosts implements VRPTransportCosts {
 	 * This is a rather bad approximation. If you require this, you should implement
 	 * another {@link VehicleRoutingTransportCosts}
 	 *
-	 * @Throws {@link IllegalStateException} if vehicle is null
+	 * @exception  IllegalStateException if vehicle is null
 	 */
 	@Override
 	public double getBackwardTransportCost(Location fromId, Location toId, double arrivalTime, Driver driver,
@@ -828,7 +825,7 @@ public class NetworkBasedTransportCosts implements VRPTransportCosts {
 	 * This is a rather bad approximation. If you require this, you should implement
 	 * another {@link VehicleRoutingTransportCosts}.
 	 *
-	 * @Throws {@link IllegalStateException} if vehicle is null
+	 * @exception  IllegalStateException if vehicle is null
 	 */
 	@Override
 	public double getBackwardTransportTime(Location fromId, Location toId, double arrivalTime, Driver driver,
@@ -875,7 +872,7 @@ public class NetworkBasedTransportCosts implements VRPTransportCosts {
 	/**
 	 * Gets the network the calculation is based on.
 	 *
-	 * @return
+	 * @return the network
 	 */
 	public Network getNetwork() {
 		return network;
@@ -889,14 +886,5 @@ public class NetworkBasedTransportCosts implements VRPTransportCosts {
 	public TravelTime getTravelTime() {
 		return travelTime;
 	}
-
-	/**
-	 * Gets the {@link VehicleTypeDependentRoadPricingCalculator}
-	 *
-	 * @return {@link VehicleTypeDependentRoadPricingCalculator}
-	 */
-//	public VehicleTypeDependentRoadPricingCalculator getRoadPricingCalculator() {
-//		return roadPricingCalc;
-//	}
 
 }

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/NetworkBasedTransportCosts.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/NetworkBasedTransportCosts.java
@@ -340,7 +340,12 @@ public class NetworkBasedTransportCosts implements VRPTransportCosts {
 			double costs = baseTransportDisutility.getLinkTravelDisutility(link, time, person, vehicle);
 //			Id<org.matsim.vehicles.VehicleType> typeId = vehicle.getType().getId();
 //			double toll = roadPricingScheme.getTollAmount(typeId, link, time );
-			RoadPricingSchemeImpl.Cost costInfo = roadPricingScheme.getLinkCostInfo( link.getId(), time, person.getId(), vehicle.getId() );
+			RoadPricingSchemeImpl.Cost costInfo;
+			if (person == null) {
+				costInfo = roadPricingScheme.getLinkCostInfo( link.getId(), time, null, vehicle.getId() );
+			} else {
+				costInfo = roadPricingScheme.getLinkCostInfo( link.getId(), time, person.getId(), vehicle.getId() );
+			}
 			double toll = costInfo.amount;
 //			System.out.println("huuuuuuuuuuuuuuuuuuuu - paid toll");
 			return costs + toll;

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/NetworkBasedTransportCosts.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/NetworkBasedTransportCosts.java
@@ -346,7 +346,10 @@ public class NetworkBasedTransportCosts implements VRPTransportCosts {
 			} else {
 				costInfo = roadPricingScheme.getLinkCostInfo( link.getId(), time, person.getId(), vehicle.getId() );
 			}
-			double toll = costInfo.amount;
+			double toll=0.;
+			if ( costInfo != null ){
+				toll = costInfo.amount;
+			}
 //			System.out.println("huuuuuuuuuuuuuuuuuuuu - paid toll");
 			return costs + toll;
 		}

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/VehicleTypeDependentRoadPricingCalculator.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/VehicleTypeDependentRoadPricingCalculator.java
@@ -35,6 +35,7 @@ import java.util.*;
  * @author stefan schröder
  *
  */
+@Deprecated // use RoadPricingScheme
 public class VehicleTypeDependentRoadPricingCalculator {
 
 	interface TollCalculator {

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/NetworkBasedTransportCostsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/NetworkBasedTransportCostsTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
@@ -38,10 +39,12 @@ import org.matsim.core.config.Config;
 import org.matsim.core.network.io.MatsimNetworkReader;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.utils.misc.Time;
+import org.matsim.freight.carriers.CarrierVehicle;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.CostInformation;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehicleUtils;
+import org.matsim.vehicles.VehiclesFactory;
 
 import java.util.Arrays;
 import java.util.List;
@@ -279,19 +282,38 @@ public class NetworkBasedTransportCostsTest {
 		builder.setRoadPricingScheme(schemeUsingTollFactor );
 		NetworkBasedTransportCosts c = builder.build();
 
-		Vehicle vehicle1 = mock(Vehicle.class);
-		com.graphhopper.jsprit.core.problem.vehicle.VehicleType type1 = mock( com.graphhopper.jsprit.core.problem.vehicle.VehicleType.class );
-		when(type1.getMaxVelocity()).thenReturn(5.0);
-		when(type1.getTypeId()).thenReturn(TYPE_1);
-		when(vehicle1.getType()).thenReturn(type1);
-		when(vehicle1.getId()).thenReturn("vehicle1");
+		VehiclesFactory vf = scenario.getVehicles().getFactory();
+		final Vehicle vehicle1;
+		{
+			VehicleType vehType1 = vf.createVehicleType( Id.create( TYPE_1, VehicleType.class ) );
+			scenario.getVehicles().addVehicleType( vehType1 );
+//		org.matsim.vehicles.Vehicle matsimVehicle1 = vf.createVehicle( Id.createVehicleId( "vehicle1" ), vehType1 );
+			CarrierVehicle matsimVehicle1 = CarrierVehicle.newInstance( Id.createVehicleId( "vehicle1" ), null, vehType1 );
+			scenario.getVehicles().addVehicle( matsimVehicle1 );
+			vehicle1 = MatsimJspritFactory.createJspritVehicle( matsimVehicle1, new Coord() );
+		}
+		VehicleType vehType2 = vf.createVehicleType( Id.create( TYPE_2, VehicleType.class ) );
+		scenario.getVehicles().addVehicleType( vehType2 );
+//		org.matsim.vehicles.Vehicle matsimVehicle2 = vf.createVehicle( Id.createVehicleId( "vehicle2" ), vehType2 );
+		CarrierVehicle matsimVehicle2 = CarrierVehicle.newInstance( Id.createVehicleId( "vehicle2" ), null, vehType2 );
+		scenario.getVehicles().addVehicle( matsimVehicle2 );
 
-		Vehicle vehicle2 = mock(Vehicle.class);
-		com.graphhopper.jsprit.core.problem.vehicle.VehicleType type2 = mock( com.graphhopper.jsprit.core.problem.vehicle.VehicleType.class );
-		when(type2.getMaxVelocity()).thenReturn(5.0);
-		when(type2.getTypeId()).thenReturn(TYPE_2);
-		when(vehicle2.getType()).thenReturn(type2);
-		when(vehicle2.getId()).thenReturn("vehicle2");
+		Vehicle vehicle2 = MatsimJspritFactory.createJspritVehicle( matsimVehicle2, new Coord() );
+
+//		// for the following rather use the MatsimJspritFactory#createCarrierVehicle
+//		Vehicle vehicle1 = mock(Vehicle.class);
+//		com.graphhopper.jsprit.core.problem.vehicle.VehicleType type1 = mock( com.graphhopper.jsprit.core.problem.vehicle.VehicleType.class );
+//		when(type1.getMaxVelocity()).thenReturn(5.0);
+//		when(type1.getTypeId()).thenReturn(TYPE_1);
+//		when(vehicle1.getType()).thenReturn(type1);
+//		when(vehicle1.getId()).thenReturn("vehicle1");
+//
+//		Vehicle vehicle2 = mock(Vehicle.class);
+//		com.graphhopper.jsprit.core.problem.vehicle.VehicleType type2 = mock( com.graphhopper.jsprit.core.problem.vehicle.VehicleType.class );
+//		when(type2.getMaxVelocity()).thenReturn(5.0);
+//		when(type2.getTypeId()).thenReturn(TYPE_2);
+//		when(vehicle2.getType()).thenReturn(type2);
+//		when(vehicle2.getId()).thenReturn("vehicle2");
 
 		//vehicle1: includes toll
 		Assertions.assertEquals(20099.99, c.getTransportCost(Location.newInstance("20"), Location.newInstance("21"), 0.0, mock(Driver.class), vehicle1), 0.01);

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/NetworkBasedTransportCostsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/NetworkBasedTransportCostsTest.java
@@ -30,10 +30,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.contrib.roadpricing.RoadPricingScheme;
-import org.matsim.contrib.roadpricing.RoadPricingSchemeImpl;
-import org.matsim.contrib.roadpricing.RoadPricingUtils;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contrib.roadpricing.*;
 import org.matsim.core.config.Config;
 import org.matsim.core.network.io.MatsimNetworkReader;
 import org.matsim.core.scenario.ScenarioUtils;
@@ -44,6 +44,9 @@ import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehicleUtils;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -194,14 +197,28 @@ public class NetworkBasedTransportCostsTest {
 		/* Create the rpCalculator based on the scheme.
 		* Here, only for one type, the see the vehicleType dependent work of it
 		* */
-		VehicleTypeDependentRoadPricingCalculator roadPricingCalculator = new VehicleTypeDependentRoadPricingCalculator();
-		roadPricingCalculator.addPricingScheme(TYPE_1, scheme);
+//		VehicleTypeDependentRoadPricingCalculator roadPricingScheme = new VehicleTypeDependentRoadPricingCalculator();
+//		roadPricingScheme.addPricingScheme(TYPE_1, scheme);
 		///___ End creating from Code
+
+		TollFactor tollFactor = new TollFactor(){
+			@Override public double getTollFactor( Id<Person> personId, Id<org.matsim.vehicles.Vehicle> vehicleId, Id<Link> linkId, double time ){
+				double tollFactor = 1.;
+				// find vehicle:
+				org.matsim.vehicles.Vehicle vehicle = scenario.getVehicles().getVehicles().get( vehicleId ); // das ist schlussendlich ziemlich dumm, aber so ist die Schnittstelle im Moment
+				VehicleType type = vehicle.getType();
+				if ( type......) {
+					tollFactor = 2.;
+				}
+				return tollFactor;
+			}
+		};
+		RoadPricingScheme schemeUsingTollFactor = new RoadPricingSchemeUsingTollFactor( scheme , tollFactor );
 
 		NetworkBasedTransportCosts.Builder builder = NetworkBasedTransportCosts.Builder.newInstance(scenario.getNetwork());
 		builder.addVehicleTypeSpecificCosts(TYPE_1, 10.0, 0.0, 2.0);
 		builder.addVehicleTypeSpecificCosts(TYPE_2, 20.0, 0.0, 4.0);
-		builder.setRoadPricingCalculator(roadPricingCalculator); //add the rpCalculator to activite the tolling.
+		builder.setRoadPricingScheme(schemeUsingTollFactor );
 		NetworkBasedTransportCosts c = builder.build();
 
 		Vehicle vehicle1 = mock(Vehicle.class);
@@ -284,7 +301,7 @@ public class NetworkBasedTransportCostsTest {
 		NetworkBasedTransportCosts.Builder builder = NetworkBasedTransportCosts.Builder.newInstance(scenario.getNetwork());
 		builder.addVehicleTypeSpecificCosts(TYPE_1, 10.0, 0.0, 2.0);
 		builder.addVehicleTypeSpecificCosts(TYPE_2, 20.0, 0.0, 4.0);
-		builder.setRoadPricingCalculator(roadPricingCalculator); //add the rpCalculator to activate the tolling.
+		builder.setRoadPricingScheme(roadPricingCalculator ); //add the rpCalculator to activate the tolling.
 		NetworkBasedTransportCosts c = builder.build();
 
 		Vehicle vehicle1 = mock(Vehicle.class);
@@ -348,7 +365,7 @@ public class NetworkBasedTransportCostsTest {
 		NetworkBasedTransportCosts.Builder builder = NetworkBasedTransportCosts.Builder.newInstance(scenario.getNetwork());
 		builder.addVehicleTypeSpecificCosts(TYPE_1, 10.0, 0.0, 2.0);
 		builder.addVehicleTypeSpecificCosts(TYPE_2, 20.0, 0.0, 4.0);
-		builder.setRoadPricingCalculator(roadPricingCalculator); //add the rpCalculator to activate the tolling.
+		builder.setRoadPricingScheme(roadPricingCalculator ); //add the rpCalculator to activate the tolling.
 		NetworkBasedTransportCosts c = builder.build();
 
 		Vehicle vehicle1 = mock(Vehicle.class);

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/NetworkBasedTransportCostsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/NetworkBasedTransportCostsTest.java
@@ -25,6 +25,7 @@ import com.graphhopper.jsprit.core.problem.Location;
 import com.graphhopper.jsprit.core.problem.driver.Driver;
 import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.matsim.api.core.v01.Id;
@@ -270,7 +271,6 @@ public class NetworkBasedTransportCostsTest {
 		RoadPricingUtils.addLink(scheme2, Id.createLinkId("21"));
 		RoadPricingUtils.createAndAddGeneralCost(scheme2, Time.parseTime("00:00:00"), Time.parseTime("72:00:00"), 42.42);
 
-
 		/* Create the rpCalculator based on the scheme.
 		 * Each vehicle type gets affected by a different tolling scheme.
 		 * */
@@ -308,6 +308,70 @@ public class NetworkBasedTransportCostsTest {
 		//vehicle 2: includes toll of 42.42 for entering the final link
 		//Fixme: This currently fails... see comments above.
 		Assertions.assertEquals(40042.42, c.getTransportCost(Location.newInstance("20"), Location.newInstance("21"), 0.0, mock(Driver.class), vehicle2), 0.01);
+		Assertions.assertEquals(20000.0, c.getDistance(Location.newInstance("6"), Location.newInstance("21"), 0.0, vehicle2), 0.01);
+	}
+
+	/**
+	 *  This test is a modified version of {@link #test_whenAddingTwoDifferentVehicleTypes_itMustAccountForThem}
+	 *  In addition, there is added a road pricing scheme.
+	 *  Two different schemes are created to toll the two different vehicle types differently.
+	 *  Here the approach using a factor is used to take into account the different types.
+	 *  //TODO: Write it completely
+	 */
+	@Test
+	@Disabled
+	void test_whenAddingTwoDifferentVehicleTypes_tollBothTypesDifferentlyWithFactor(){
+		Config config = new Config();
+		config.addCoreModules();
+		Scenario scenario = ScenarioUtils.createScenario(config);
+		new MatsimNetworkReader(scenario.getNetwork()).readFile(utils.getClassInputDirectory() + "network.xml");
+
+		//Create Rp Scheme from code.
+		RoadPricingSchemeImpl scheme1 = RoadPricingUtils.addOrGetMutableRoadPricingScheme(scenario );
+		/* Configure roadpricing scheme. */
+		RoadPricingUtils.setName(scheme1, "DemoToll4TestType1");
+		RoadPricingUtils.setType(scheme1, RoadPricingScheme.TOLL_TYPE_LINK);
+		RoadPricingUtils.setDescription(scheme1, "Tolling scheme for test.");
+
+		/* Add general link based toll for one link */
+		RoadPricingUtils.addLink(scheme1, Id.createLinkId("21"));
+		RoadPricingUtils.createAndAddGeneralCost(scheme1, Time.parseTime("00:00:00"), Time.parseTime("72:00:00"), 99.99);
+
+		//Use a factor to take into account the differnt types. type2 gehts tolled with 50% of the toll of type1
+		//TODO: Include factor
+
+		VehicleTypeDependentRoadPricingCalculator roadPricingCalculator = new VehicleTypeDependentRoadPricingCalculator();
+		roadPricingCalculator.addPricingScheme(TYPE_1, scheme1);
+
+		///___ End creating from Code
+
+		NetworkBasedTransportCosts.Builder builder = NetworkBasedTransportCosts.Builder.newInstance(scenario.getNetwork());
+		builder.addVehicleTypeSpecificCosts(TYPE_1, 10.0, 0.0, 2.0);
+		builder.addVehicleTypeSpecificCosts(TYPE_2, 20.0, 0.0, 4.0);
+		builder.setRoadPricingCalculator(roadPricingCalculator); //add the rpCalculator to activate the tolling.
+		NetworkBasedTransportCosts c = builder.build();
+
+		Vehicle vehicle1 = mock(Vehicle.class);
+		com.graphhopper.jsprit.core.problem.vehicle.VehicleType type1 = mock( com.graphhopper.jsprit.core.problem.vehicle.VehicleType.class );
+		when(type1.getMaxVelocity()).thenReturn(5.0);
+		when(type1.getTypeId()).thenReturn(TYPE_1);
+		when(vehicle1.getType()).thenReturn(type1);
+		when(vehicle1.getId()).thenReturn("vehicle1");
+
+		Vehicle vehicle2 = mock(Vehicle.class);
+		com.graphhopper.jsprit.core.problem.vehicle.VehicleType type2 = mock( com.graphhopper.jsprit.core.problem.vehicle.VehicleType.class );
+		when(type2.getMaxVelocity()).thenReturn(5.0);
+		when(type2.getTypeId()).thenReturn(TYPE_2);
+		when(vehicle2.getType()).thenReturn(type2);
+		when(vehicle2.getId()).thenReturn("vehicle2");
+
+		//vehicle1: includes toll of 99.99 for entering the final link
+		Assertions.assertEquals(20099.99, c.getTransportCost(Location.newInstance("20"), Location.newInstance("21"), 0.0, mock(Driver.class), vehicle1), 0.01);
+		Assertions.assertEquals(20000.0, c.getDistance(Location.newInstance("6"), Location.newInstance("21"), 0.0, vehicle1), 0.01);
+
+		//vehicle 2: includes toll of 49.995 (50% of 99.99) for entering the final link
+		//Fixme: This currently fails... see comments above.
+		Assertions.assertEquals(40049.995, c.getTransportCost(Location.newInstance("20"), Location.newInstance("21"), 0.0, mock(Driver.class), vehicle2), 0.01);
 		Assertions.assertEquals(20000.0, c.getDistance(Location.newInstance("6"), Location.newInstance("21"), 0.0, vehicle2), 0.01);
 	}
 

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/NetworkBasedTransportCostsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/NetworkBasedTransportCostsTest.java
@@ -40,6 +40,7 @@ import org.matsim.core.network.io.MatsimNetworkReader;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.utils.misc.Time;
 import org.matsim.freight.carriers.CarrierVehicle;
+import org.matsim.freight.carriers.CarriersUtils;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.CostInformation;
 import org.matsim.vehicles.VehicleType;
@@ -240,7 +241,7 @@ public class NetworkBasedTransportCostsTest {
 		Scenario scenario = ScenarioUtils.createScenario(config);
 		new MatsimNetworkReader(scenario.getNetwork()).readFile(utils.getClassInputDirectory() + "network.xml");
 
-		//Create Rp Scheme from code.
+		//Create RoadPricing Scheme from code.
 		RoadPricingSchemeImpl scheme = RoadPricingUtils.addOrGetMutableRoadPricingScheme(scenario );
 		/* Configure roadpricing scheme. */
 		RoadPricingUtils.setName(scheme, "DemoToll4Test");
@@ -251,69 +252,51 @@ public class NetworkBasedTransportCostsTest {
 		RoadPricingUtils.addLink(scheme, Id.createLinkId("21"));
 		RoadPricingUtils.createAndAddGeneralCost(scheme, Time.parseTime("00:00:00"), Time.parseTime("72:00:00"), 99.99);
 
-		/* Create the rpCalculator based on the scheme.
-		* Here, only for one type, the see the vehicleType dependent work of it
-		* */
-//		VehicleTypeDependentRoadPricingCalculator roadPricingScheme = new VehicleTypeDependentRoadPricingCalculator();
-//		roadPricingScheme.addPricingScheme(TYPE_1, scheme);
-		///___ End creating from Code
-
-		TollFactor tollFactor = new TollFactor(){
-			@Override public double getTollFactor( Id<Person> personId, Id<org.matsim.vehicles.Vehicle> vehicleId, Id<Link> linkId, double time ){
-				double tollFactor = 0.;
-
-				var vehTypeIdString = VehicleUtils.findVehicle(vehicleId, scenario).getType().getId().toString();
-
-//				// find vehicle:
-//				org.matsim.vehicles.Vehicle vehicle = scenario.getVehicles().getVehicles().get( vehicleId ); // das ist schlussendlich ziemlich dumm, aber so ist die Schnittstelle im Moment
-//				VehicleType type = vehicle.getType();
-//				if (TYPE_1.equals(type.getId().toString())) {
-				if (TYPE_1.equals(vehTypeIdString)) {
-					tollFactor = 1.;
-				}
-				return tollFactor;
+		//Use toll factor to only toll vehicles of type1.
+		TollFactor tollFactor = (personId, vehicleId, linkId, time) -> {
+			double tollFactor1 = 0.;
+			var vehTypeIdString = VehicleUtils.findVehicle(vehicleId, scenario).getType().getId().toString();
+			if (TYPE_1.equals(vehTypeIdString)) {
+				tollFactor1 = 1.;
 			}
+			return tollFactor1;
 		};
 		RoadPricingScheme schemeUsingTollFactor = new RoadPricingSchemeUsingTollFactor( scheme , tollFactor );
 
-		NetworkBasedTransportCosts.Builder builder = NetworkBasedTransportCosts.Builder.newInstance(scenario.getNetwork());
-		builder.addVehicleTypeSpecificCosts(TYPE_1, 10.0, 0.0, 2.0);
-		builder.addVehicleTypeSpecificCosts(TYPE_2, 20.0, 0.0, 4.0);
-		builder.setRoadPricingScheme(schemeUsingTollFactor );
-		NetworkBasedTransportCosts c = builder.build();
+		/// End creating roadPricing scheme from Code
 
+		//Build MATSim vehicles and convert them to jsprit Vehicles ... just to see, that this works across the whole chain and
+		//that we can filter/search by (MATSim) vehicle types in Toll Factor usage
 		VehiclesFactory vf = scenario.getVehicles().getFactory();
 		final Vehicle vehicle1;
 		{
 			VehicleType vehType1 = vf.createVehicleType( Id.create( TYPE_1, VehicleType.class ) );
+				vehType1.getCostInformation().setFixedCost(10.0);
+				vehType1.getCostInformation().setCostsPerSecond(0.0);
+				vehType1.getCostInformation().setCostsPerMeter(2.0);
 			scenario.getVehicles().addVehicleType( vehType1 );
-//		org.matsim.vehicles.Vehicle matsimVehicle1 = vf.createVehicle( Id.createVehicleId( "vehicle1" ), vehType1 );
-			CarrierVehicle matsimVehicle1 = CarrierVehicle.newInstance( Id.createVehicleId( "vehicle1" ), null, vehType1 );
+			CarrierVehicle matsimVehicle1 = CarrierVehicle.newInstance( Id.createVehicleId( "vehicle1" ), Id.createLinkId("20"), vehType1 );
 			scenario.getVehicles().addVehicle( matsimVehicle1 );
 			vehicle1 = MatsimJspritFactory.createJspritVehicle( matsimVehicle1, new Coord() );
 		}
-		VehicleType vehType2 = vf.createVehicleType( Id.create( TYPE_2, VehicleType.class ) );
-		scenario.getVehicles().addVehicleType( vehType2 );
-//		org.matsim.vehicles.Vehicle matsimVehicle2 = vf.createVehicle( Id.createVehicleId( "vehicle2" ), vehType2 );
-		CarrierVehicle matsimVehicle2 = CarrierVehicle.newInstance( Id.createVehicleId( "vehicle2" ), null, vehType2 );
-		scenario.getVehicles().addVehicle( matsimVehicle2 );
 
-		Vehicle vehicle2 = MatsimJspritFactory.createJspritVehicle( matsimVehicle2, new Coord() );
+		final Vehicle vehicle2;
+		{
+			VehicleType vehType2 = vf.createVehicleType(Id.create(TYPE_2, VehicleType.class));
+				vehType2.getCostInformation().setFixedCost(20.0);
+				vehType2.getCostInformation().setCostsPerSecond(0.0);
+				vehType2.getCostInformation().setCostsPerMeter(4.0);
+			scenario.getVehicles().addVehicleType(vehType2);
 
-//		// for the following rather use the MatsimJspritFactory#createCarrierVehicle
-//		Vehicle vehicle1 = mock(Vehicle.class);
-//		com.graphhopper.jsprit.core.problem.vehicle.VehicleType type1 = mock( com.graphhopper.jsprit.core.problem.vehicle.VehicleType.class );
-//		when(type1.getMaxVelocity()).thenReturn(5.0);
-//		when(type1.getTypeId()).thenReturn(TYPE_1);
-//		when(vehicle1.getType()).thenReturn(type1);
-//		when(vehicle1.getId()).thenReturn("vehicle1");
-//
-//		Vehicle vehicle2 = mock(Vehicle.class);
-//		com.graphhopper.jsprit.core.problem.vehicle.VehicleType type2 = mock( com.graphhopper.jsprit.core.problem.vehicle.VehicleType.class );
-//		when(type2.getMaxVelocity()).thenReturn(5.0);
-//		when(type2.getTypeId()).thenReturn(TYPE_2);
-//		when(vehicle2.getType()).thenReturn(type2);
-//		when(vehicle2.getId()).thenReturn("vehicle2");
+			CarrierVehicle matsimVehicle2 = CarrierVehicle.newInstance(Id.createVehicleId("vehicle2"), Id.createLinkId("20"), vehType2);
+			scenario.getVehicles().addVehicle(matsimVehicle2);
+			vehicle2 = MatsimJspritFactory.createJspritVehicle(matsimVehicle2, new Coord());
+		}
+
+		//Build the NetbasedTransportCosts opbejct with the roadpricing scheme.
+		NetworkBasedTransportCosts c = NetworkBasedTransportCosts.Builder.newInstance(scenario.getNetwork(), scenario.getVehicles().getVehicleTypes().values() )
+			.setRoadPricingScheme(schemeUsingTollFactor)
+			.build() ;
 
 		//vehicle1: includes toll
 		Assertions.assertEquals(20099.99, c.getTransportCost(Location.newInstance("20"), Location.newInstance("21"), 0.0, mock(Driver.class), vehicle1), 0.01);
@@ -324,89 +307,6 @@ public class NetworkBasedTransportCostsTest {
 		Assertions.assertEquals(20000.0, c.getDistance(Location.newInstance("6"), Location.newInstance("21"), 0.0, vehicle2), 0.01);
 	}
 
-//	/**
-//	 *  This test is a modified version of {@link #test_whenAddingTwoDifferentVehicleTypes_itMustAccountForThem}
-//	 *  In addition, there is added a road pricing scheme.
-//	 *  Two different schemes are created to toll the two different vehicle types differently.
-//	 */
-//	@Test
-//	void test_whenAddingTwoDifferentVehicleTypes_tollBothTypesDifferently(){
-//		Config config = new Config();
-//		config.addCoreModules();
-//		Scenario scenario = ScenarioUtils.createScenario(config);
-//		new MatsimNetworkReader(scenario.getNetwork()).readFile(utils.getClassInputDirectory() + "network.xml");
-//
-//		//Create Rp Scheme from code.
-//		RoadPricingSchemeImpl scheme1 = RoadPricingUtils.addOrGetMutableRoadPricingScheme(scenario );
-//		/* Configure roadpricing scheme. */
-//		RoadPricingUtils.setName(scheme1, "DemoToll4TestType1");
-//		RoadPricingUtils.setType(scheme1, RoadPricingScheme.TOLL_TYPE_LINK);
-//		RoadPricingUtils.setDescription(scheme1, "Tolling scheme for test.");
-//
-//		/* Add general link based toll for one link */
-//		RoadPricingUtils.addLink(scheme1, Id.createLinkId("21"));
-//		RoadPricingUtils.createAndAddGeneralCost(scheme1, Time.parseTime("00:00:00"), Time.parseTime("72:00:00"), 99.99);
-//
-//		//Create Rp Scheme from code.
-//		//Fixme: The following does not work as one may expect: In the end, both schemes are the same object.
-//		// --> It is just added a second entry to the costs, which is not taken into account anyways...
-//		// Questions:
-//		// 1.) How to build ab a second scheme, that is "independently" settable? Currently no new RoadPricingSchemeImpl() can be created without
-//		// the addOrGet methods provided in {@link RoadPricingUtils}.
-//		// 2.) Why does not both costs are summede up in the current behavior, so, the toll is 99.99 + 42.42 = 142.41?
-//		// --> Which one is choose? The first? The higher one?...???
-//		// One solution might be to use the "withTollFactor" approach. --> Todo write an additional test for it.
-//		// Nevertheless, the current approach leads IMO (KMT) easily to unintentional mistakes.
-//		//kmt, Aug'24
-//		RoadPricingSchemeImpl scheme2 = RoadPricingUtils.addOrGetMutableRoadPricingScheme(scenario );
-//		/* Configure roadpricing scheme. */
-//		RoadPricingUtils.setName(scheme2, "DemoToll4TestType1");
-//		RoadPricingUtils.setType(scheme2, RoadPricingScheme.TOLL_TYPE_LINK);
-//		RoadPricingUtils.setDescription(scheme2, "Tolling scheme for test.");
-//
-//		/* Add general link based toll for one link */
-//		RoadPricingUtils.addLink(scheme2, Id.createLinkId("21"));
-//		RoadPricingUtils.createAndAddGeneralCost(scheme2, Time.parseTime("00:00:00"), Time.parseTime("72:00:00"), 42.42);
-//
-//		/* Create the rpCalculator based on the scheme.
-//		 * Each vehicle type gets affected by a different tolling scheme.
-//		 * */
-//		//FIXME: See above/below: schem1 and scheme2 are the same object....
-//		VehicleTypeDependentRoadPricingCalculator roadPricingCalculator = new VehicleTypeDependentRoadPricingCalculator();
-//		roadPricingCalculator.addPricingScheme(TYPE_1, scheme1);
-//		roadPricingCalculator.addPricingScheme(TYPE_2, scheme2);
-//
-//		///___ End creating from Code
-//
-//		NetworkBasedTransportCosts.Builder builder = NetworkBasedTransportCosts.Builder.newInstance(scenario.getNetwork());
-//		builder.addVehicleTypeSpecificCosts(TYPE_1, 10.0, 0.0, 2.0);
-//		builder.addVehicleTypeSpecificCosts(TYPE_2, 20.0, 0.0, 4.0);
-//		builder.setRoadPricingScheme(roadPricingCalculator ); //add the rpCalculator to activate the tolling.
-//		NetworkBasedTransportCosts c = builder.build();
-//
-//		Vehicle vehicle1 = mock(Vehicle.class);
-//		com.graphhopper.jsprit.core.problem.vehicle.VehicleType type1 = mock( com.graphhopper.jsprit.core.problem.vehicle.VehicleType.class );
-//		when(type1.getMaxVelocity()).thenReturn(5.0);
-//		when(type1.getTypeId()).thenReturn(TYPE_1);
-//		when(vehicle1.getType()).thenReturn(type1);
-//		when(vehicle1.getId()).thenReturn("vehicle1");
-//
-//		Vehicle vehicle2 = mock(Vehicle.class);
-//		com.graphhopper.jsprit.core.problem.vehicle.VehicleType type2 = mock( com.graphhopper.jsprit.core.problem.vehicle.VehicleType.class );
-//		when(type2.getMaxVelocity()).thenReturn(5.0);
-//		when(type2.getTypeId()).thenReturn(TYPE_2);
-//		when(vehicle2.getType()).thenReturn(type2);
-//		when(vehicle2.getId()).thenReturn("vehicle2");
-//
-//		//vehicle1: includes toll of 99.99 for entering the final link
-//		Assertions.assertEquals(20099.99, c.getTransportCost(Location.newInstance("20"), Location.newInstance("21"), 0.0, mock(Driver.class), vehicle1), 0.01);
-//		Assertions.assertEquals(20000.0, c.getDistance(Location.newInstance("6"), Location.newInstance("21"), 0.0, vehicle1), 0.01);
-//
-//		//vehicle 2: includes toll of 42.42 for entering the final link
-//		//Fixme: This currently fails... see comments above.
-//		Assertions.assertEquals(40042.42, c.getTransportCost(Location.newInstance("20"), Location.newInstance("21"), 0.0, mock(Driver.class), vehicle2), 0.01);
-//		Assertions.assertEquals(20000.0, c.getDistance(Location.newInstance("6"), Location.newInstance("21"), 0.0, vehicle2), 0.01);
-//	}
 
 	/**
 	 *  This test is a modified version of {@link #test_whenAddingTwoDifferentVehicleTypes_itMustAccountForThem}


### PR DESCRIPTION
Use the official ` RoadPricingScheme` from the roadPrinciing contrib instead of a self-build `VehicleTypeDependentRoadPricingCalculator` for calculating the `NetworkBasedTransportCosts`.
The vehicleType-dependency can be achieved by using the `TollFactor`.

The `VehicleTypeDependentRoadPricingCalculator` is now deprecated.

Adding also some tests for running the  `NetworkBasedTransportCosts` calculation with tolls.