### PR TITLE
Preserve the working directory when gui is run from cli

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/MATSimApplication.java
+++ b/contribs/application/src/main/java/org/matsim/application/MATSimApplication.java
@@ -413,6 +413,8 @@ public abstract class MATSimApplication implements Callable<Integer>, CommandLin
 
 		if (ApplicationUtils.isRunFromDesktop() && args.length == 0) {
 
+			System.setProperty("MATSIM_GUI_DESKTOP", "true");
+
 			if (defaultArgs.length > 0) {
 				String value = String.join(ARGS_DELIMITER, defaultArgs);
 				System.setProperty("MATSIM_GUI_ARGS", value);

--- a/contribs/application/src/main/java/org/matsim/application/ShowGUI.java
+++ b/contribs/application/src/main/java/org/matsim/application/ShowGUI.java
@@ -40,6 +40,13 @@ class ShowGUI implements Callable<Integer> {
 
         Gui gui = f.get();
 
+		// Set the current working directory to be used in the gui, when run from the command line
+		// If the gui is run from desktop, the working directory is not overwritten
+
+		// Assumption is that starting something from command line, the user expects that the working directory remains the same
+		if (!System.getProperty("MATSIM_GUI_DESKTOP", "false").equals("true"))
+			gui.setWorkingDirectory(new File(""));
+
         while (gui.isShowing())
             Thread.sleep(250);
 

--- a/matsim/src/main/java/org/matsim/run/gui/Gui.java
+++ b/matsim/src/main/java/org/matsim/run/gui/Gui.java
@@ -91,6 +91,11 @@ public class Gui extends JFrame {
 
 	private File configFile;
 	private File lastUsedDirectory;
+
+	/**
+	 * This is the working directory for the simulation. If it is null, the working directory is the directory of the config file.
+	 */
+	private File workingDirectory = null;
 	private ConfigEditor editor = null;
 	private ScheduleValidatorWindow transitValidator = null;
 
@@ -439,6 +444,8 @@ public class Gui extends JFrame {
 		textStdOut.setText("");
 		textErrOut.setText("");
 
+		String cwd = workingDirectory == null ? new File(txtConfigfilename.getText()).getParent() : workingDirectory.getAbsolutePath();
+
 		new Thread(() -> {
 			String classpath = System.getProperty("java.class.path");
 			String[] cpParts = classpath.split(File.pathSeparator);
@@ -457,8 +464,7 @@ public class Gui extends JFrame {
 					"--add-exports", "java.desktop/sun.java2d=ALL-UNNAMED",
 					mainClass, txtConfigfilename.getText() };
 			// see https://jogamp.org/bugzilla/show_bug.cgi?id=1317#c21 and/or https://github.com/matsim-org/matsim-libs/pull/2940
-			exeRunner = ExeRunner.run(cmdArgs, textStdOut, textErrOut,
-					new File(txtConfigfilename.getText()).getParent());
+			exeRunner = ExeRunner.run(cmdArgs, textStdOut, textErrOut, cwd);
 			int exitcode = exeRunner.waitForFinish();
 			exeRunner = null;
 
@@ -573,6 +579,10 @@ public class Gui extends JFrame {
 	public static void main(String[] args) {
 		Preconditions.checkArgument(args.length < 2);
 		Gui.show("MATSim", RunMatsim.class, args.length == 1 ? new File(args[0]) : null);
+	}
+
+	public void setWorkingDirectory(File cwd) {
+		this.workingDirectory = cwd;
 	}
 
 	// Is it a problem to make the following available to the outside?  If so, why?  Would it


### PR DESCRIPTION
The MATSim GUI always starts the matsim process in the directory where the config is.
This leads to confusing behavior when run from the command line via matsim application contrib. 

This PR adds a function so that the default working directory in the gui can be changed. 