### PR TITLE
NoiseAnalysis: use asterisk for act type default

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/analysis/noise/NoiseAnalysis.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/noise/NoiseAnalysis.java
@@ -46,7 +46,8 @@ public class NoiseAnalysis implements MATSimAppCommand {
 	@CommandLine.Mixin
 	private final ShpOptions shp = new ShpOptions();
 
-	@CommandLine.Option(names = "--consider-activities", split = ",", description = "Considered activities for noise calculation", defaultValue = "h,w,home,work")
+	@CommandLine.Option(names = "--consider-activities", split = ",", description = "Considered activities for noise calculation." +
+		" Use asterisk ('*') for acttype prefixes, if all such acts shall be considered.", defaultValue = "h,w,home*,work*")
 	private Set<String> considerActivities;
 
 	@CommandLine.Option(names = "--noise-barrier", description = "Path to the noise barrier File", defaultValue = "")


### PR DESCRIPTION
.. such that all subtypes of `work` and `home` are considered by default (we typically split activities into act types with typical durations, see `SnzActivities`) 