### PR TITLE
DRT: Bypass Fleet object in schedule interface

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/dispatcher/DefaultShiftScheduler.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/dispatcher/DefaultShiftScheduler.java
@@ -3,6 +3,7 @@ package org.matsim.contrib.drt.extension.operations.shifts.dispatcher;
 import com.google.common.collect.ImmutableMap;
 import org.matsim.api.core.v01.Id;
 import org.matsim.contrib.drt.extension.operations.shifts.shift.*;
+import org.matsim.contrib.dvrp.fleet.Fleet;
 
 import java.util.Collections;
 import java.util.List;
@@ -32,7 +33,7 @@ public final class DefaultShiftScheduler implements ShiftScheduler {
         this.shiftsSpecification = shiftsSpecification;
     }
     @Override
-    public List<DrtShift> schedule(double time) {
+    public List<DrtShift> schedule(double time, Fleet fleet) {
         return Collections.emptyList();
     }
 

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/dispatcher/DrtShiftDispatcherImpl.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/dispatcher/DrtShiftDispatcherImpl.java
@@ -141,7 +141,7 @@ public class DrtShiftDispatcherImpl implements DrtShiftDispatcher {
         if (timeStep % (drtShiftParams.updateShiftEndInterval) == 0) {
             updateShiftEnds(timeStep);
         }
-        scheduleShifts(timeStep);
+        scheduleShifts(timeStep, this.fleet);
         assignShifts(timeStep);
         startShifts(timeStep);
         checkBreaks();
@@ -172,8 +172,8 @@ public class DrtShiftDispatcherImpl implements DrtShiftDispatcher {
     }
 
 
-    private void scheduleShifts(double timeStep) {
-        List<DrtShift> scheduled = shiftScheduler.schedule(timeStep);
+    private void scheduleShifts(double timeStep, Fleet fleet) {
+        List<DrtShift> scheduled = shiftScheduler.schedule(timeStep, fleet);
         unAssignedShifts.addAll(scheduled);
     }
 

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/dispatcher/ShiftScheduler.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/dispatcher/ShiftScheduler.java
@@ -6,6 +6,8 @@ import org.matsim.contrib.drt.extension.operations.shifts.shift.DrtShift;
 import org.matsim.contrib.drt.extension.operations.shifts.shift.DrtShiftsSpecification;
 
 import jakarta.inject.Provider;
+import org.matsim.contrib.dvrp.fleet.Fleet;
+
 import java.util.List;
 
 /**
@@ -13,7 +15,7 @@ import java.util.List;
  */
 public interface ShiftScheduler extends Provider<DrtShiftsSpecification> {
 
-    List<DrtShift> schedule(double time);
+    List<DrtShift> schedule(double time, Fleet fleet);
     ImmutableMap<Id<DrtShift>, DrtShift> initialSchedule();
 
 }

--- a/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/operations/shifts/run/RunOnTheFlyShiftDrtScenarioIT.java
+++ b/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/operations/shifts/run/RunOnTheFlyShiftDrtScenarioIT.java
@@ -21,6 +21,7 @@ import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingParams;
 import org.matsim.contrib.drt.optimizer.rebalancing.mincostflow.MinCostFlowRebalancingStrategyParams;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
+import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.zone.skims.DvrpTravelTimeMatrixParams;
@@ -182,7 +183,7 @@ public class RunOnTheFlyShiftDrtScenarioIT {
         }
 
         @Override
-        public List<DrtShift> schedule(double time) {
+        public List<DrtShift> schedule(double time, Fleet fleet) {
             List<DrtShiftSpecification> shifts = new ArrayList<>();
             if (time > 4 * 3600 && time < 15 * 3600 && time % 3600 == 0) {
                 for (int i = 0; i < iteration + 1 ; i++) {


### PR DESCRIPTION
Bypass fleet object to allow usage of the Fleet instance without creating a qSimModule.