### PR TITLE
Fix pt fare config write to and read from config file

### DIFF
--- a/contribs/vsp/src/main/java/org/matsim/contrib/vsp/pt/fare/DistanceBasedPtFareParams.java
+++ b/contribs/vsp/src/main/java/org/matsim/contrib/vsp/pt/fare/DistanceBasedPtFareParams.java
@@ -2,6 +2,7 @@ package org.matsim.contrib.vsp.pt.fare;
 
 import jakarta.validation.constraints.PositiveOrZero;
 import org.apache.commons.math.stat.regression.SimpleRegression;
+import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ReflectiveConfigGroup;
 
 import java.util.*;
@@ -15,14 +16,14 @@ import java.util.*;
 public class DistanceBasedPtFareParams extends PtFareParams {
 	public static final DistanceBasedPtFareParams GERMAN_WIDE_FARE = germanWideFare();
 
-	public static final String SET_NAME = "ptFareCalculationDistanceBased";
+	public static final String SET_TYPE = "ptFareCalculationDistanceBased";
 	public static final String MIN_FARE = "minFare";
 
 	@PositiveOrZero
 	private double minFare = 2.0;
 
 	public DistanceBasedPtFareParams() {
-		super(SET_NAME);
+		super(SET_TYPE);
 	}
 
 	@Override
@@ -118,10 +119,20 @@ public class DistanceBasedPtFareParams extends PtFareParams {
 		return params;
 	}
 
+	@Override
+	public ConfigGroup createParameterSet(final String type) {
+		switch (type) {
+			case DistanceClassLinearFareFunctionParams.SET_TYPE:
+				return new DistanceClassLinearFareFunctionParams();
+			default:
+				throw new IllegalArgumentException(type);
+		}
+	}
+
 	public SortedMap<Double, DistanceClassLinearFareFunctionParams> getDistanceClassFareParams() {
 		@SuppressWarnings("unchecked")
 		final Collection<DistanceClassLinearFareFunctionParams> distanceClassFareParams =
-			(Collection<DistanceClassLinearFareFunctionParams>) getParameterSets(DistanceClassLinearFareFunctionParams.SET_NAME);
+			(Collection<DistanceClassLinearFareFunctionParams>) getParameterSets(DistanceClassLinearFareFunctionParams.SET_TYPE);
 		final SortedMap<Double, DistanceClassLinearFareFunctionParams> map = new TreeMap<>();
 
 		for (DistanceClassLinearFareFunctionParams pars : distanceClassFareParams) {
@@ -140,7 +151,8 @@ public class DistanceBasedPtFareParams extends PtFareParams {
 	public DistanceClassLinearFareFunctionParams getOrCreateDistanceClassFareParams(double maxDistance) {
 		DistanceClassLinearFareFunctionParams distanceClassFareParams = this.getDistanceClassFareParams().get(maxDistance);
 		if (distanceClassFareParams == null) {
-			distanceClassFareParams = new DistanceClassLinearFareFunctionParams(maxDistance);
+			distanceClassFareParams = new DistanceClassLinearFareFunctionParams();
+			distanceClassFareParams.setMaxDistance(maxDistance);
 			addParameterSet(distanceClassFareParams);
 		}
 		return distanceClassFareParams;
@@ -148,7 +160,7 @@ public class DistanceBasedPtFareParams extends PtFareParams {
 
 	public static class DistanceClassLinearFareFunctionParams extends ReflectiveConfigGroup {
 
-		public static final String SET_NAME = "distanceClassLinearFare";
+		public static final String SET_TYPE = "distanceClassLinearFare";
 		public static final String FARE_SLOPE = "fareSlope";
 		public static final String FARE_INTERCEPT = "fareIntercept";
 		public static final String MAX_DISTANCE = "maxDistance";
@@ -160,9 +172,8 @@ public class DistanceBasedPtFareParams extends PtFareParams {
 		@PositiveOrZero
 		private double maxDistance;
 
-		public DistanceClassLinearFareFunctionParams(double maxDistance) {
-			super(SET_NAME);
-			this.maxDistance = maxDistance;
+		public DistanceClassLinearFareFunctionParams() {
+			super(SET_TYPE);
 		}
 
 		@StringGetter(FARE_SLOPE)

--- a/contribs/vsp/src/main/java/org/matsim/contrib/vsp/pt/fare/FareZoneBasedPtFareParams.java
+++ b/contribs/vsp/src/main/java/org/matsim/contrib/vsp/pt/fare/FareZoneBasedPtFareParams.java
@@ -1,9 +1,9 @@
 package org.matsim.contrib.vsp.pt.fare;
 
 public class FareZoneBasedPtFareParams extends PtFareParams {
-	public static final String SET_NAME = "ptFareCalculationFareZoneBased";
+	public static final String SET_TYPE = "ptFareCalculationFareZoneBased";
 
 	public FareZoneBasedPtFareParams() {
-		super(SET_NAME);
+		super(SET_TYPE);
 	}
 }

--- a/contribs/vsp/src/main/java/org/matsim/contrib/vsp/pt/fare/PtFareConfigGroup.java
+++ b/contribs/vsp/src/main/java/org/matsim/contrib/vsp/pt/fare/PtFareConfigGroup.java
@@ -2,6 +2,7 @@ package org.matsim.contrib.vsp.pt.fare;
 
 import jakarta.validation.constraints.PositiveOrZero;
 import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ReflectiveConfigGroup;
 
 import java.util.Map;
@@ -58,11 +59,23 @@ public class PtFareConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	@Override
+	public ConfigGroup createParameterSet(final String type) {
+		switch (type) {
+			case DistanceBasedPtFareParams.SET_TYPE:
+				return new DistanceBasedPtFareParams();
+			case FareZoneBasedPtFareParams.SET_TYPE:
+				return new FareZoneBasedPtFareParams();
+			default:
+				throw new IllegalArgumentException(type);
+		}
+	}
+
+	@Override
 	protected void checkConsistency(Config config) {
 		super.checkConsistency(config);
 
-		var distanceBasedParameterSets = getParameterSets(DistanceBasedPtFareParams.SET_NAME);
-		var fareZoneBasedParameterSets = getParameterSets(FareZoneBasedPtFareParams.SET_NAME);
+		var distanceBasedParameterSets = getParameterSets(DistanceBasedPtFareParams.SET_TYPE);
+		var fareZoneBasedParameterSets = getParameterSets(FareZoneBasedPtFareParams.SET_TYPE);
 
 		if (distanceBasedParameterSets.isEmpty() && fareZoneBasedParameterSets.isEmpty()) {
 			throw new IllegalArgumentException("No parameter sets found for pt fare calculation. Please add at least one parameter set.");

--- a/contribs/vsp/src/main/java/org/matsim/contrib/vsp/pt/fare/PtFareModule.java
+++ b/contribs/vsp/src/main/java/org/matsim/contrib/vsp/pt/fare/PtFareModule.java
@@ -19,8 +19,8 @@ public class PtFareModule extends AbstractModule {
 		Multibinder<PtFareCalculator> ptFareCalculator = Multibinder.newSetBinder(binder(), PtFareCalculator.class);
 
 		PtFareConfigGroup ptFareConfigGroup = ConfigUtils.addOrGetModule(this.getConfig(), PtFareConfigGroup.class);
-		Collection<? extends ConfigGroup> fareZoneBased = ptFareConfigGroup.getParameterSets(FareZoneBasedPtFareParams.SET_NAME);
-		Collection<? extends ConfigGroup> distanceBased = ptFareConfigGroup.getParameterSets(DistanceBasedPtFareParams.SET_NAME);
+		Collection<? extends ConfigGroup> fareZoneBased = ptFareConfigGroup.getParameterSets(FareZoneBasedPtFareParams.SET_TYPE);
+		Collection<? extends ConfigGroup> distanceBased = ptFareConfigGroup.getParameterSets(DistanceBasedPtFareParams.SET_TYPE);
 
 		Stream.concat(fareZoneBased.stream(), distanceBased.stream())
 			  .map(c -> (PtFareParams) c)

--- a/contribs/vsp/src/main/java/org/matsim/contrib/vsp/pt/fare/PtTripWithDistanceBasedFareEstimator.java
+++ b/contribs/vsp/src/main/java/org/matsim/contrib/vsp/pt/fare/PtTripWithDistanceBasedFareEstimator.java
@@ -39,7 +39,7 @@ public class PtTripWithDistanceBasedFareEstimator extends PtTripEstimator {
 
 	private static DistanceBasedPtFareParams extractPtFare(PtFareConfigGroup config) {
 		//TODO
-		return config.getParameterSets(DistanceBasedPtFareParams.SET_NAME).stream()
+		return config.getParameterSets(DistanceBasedPtFareParams.SET_TYPE).stream()
 					 .map(DistanceBasedPtFareParams.class::cast)
 					 .findFirst()
 					 .orElseThrow(() -> new IllegalStateException("No distance based fare parameters found"));

--- a/contribs/vsp/src/test/java/org/matsim/contrib/vsp/pt/fare/FareZoneBasedPtFareHandlerTest.java
+++ b/contribs/vsp/src/test/java/org/matsim/contrib/vsp/pt/fare/FareZoneBasedPtFareHandlerTest.java
@@ -59,7 +59,14 @@ public class FareZoneBasedPtFareHandlerTest {
 		ptFareConfigGroup.addParameterSet(fareZoneBased);
 		ptFareConfigGroup.addParameterSet(distanceBased);
 
-		MutableScenario scenario = setUpScenario(config);
+		// write config to file and read in again to check config reading and writing
+		ConfigUtils.writeConfig(config, utils.getOutputDirectory() + "configFromCode.xml");
+		Config configFromFile = ConfigUtils.loadConfig(utils.getOutputDirectory() + "configFromCode.xml");
+		// re-direct to correct input directory
+		URL context = ExamplesUtils.getTestScenarioURL("kelheim");
+		configFromFile.setContext(context);
+
+		MutableScenario scenario = setUpScenario(configFromFile);
 
 		//Run
 		var fareAnalysis = new FareAnalysis();


### PR DESCRIPTION
Writing the PtFareConfigGroup to file and read in again gave errors. This PR adds a test and fixes the error.