### PR TITLE
Fix a (severe) bug in MSA scoring

### DIFF
--- a/matsim/src/main/java/org/matsim/core/scoring/PlansScoringImpl.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/PlansScoringImpl.java
@@ -52,11 +52,11 @@ final class PlansScoringImpl implements PlansScoring, ScoringListener, Iteration
 	@Inject private OutputDirectoryHierarchy controlerIO;
 	@Inject private ScoringFunctionsForPopulation scoringFunctionsForPopulation;
 	@Inject private ExperiencedPlansService experiencedPlansService;
+	@Inject private NewScoreAssigner newScoreAssigner;
 
 	@Override
 	public void notifyScoring(final ScoringEvent event) {
 		scoringFunctionsForPopulation.finishScoringFunctions();
-		NewScoreAssignerImpl newScoreAssigner = new NewScoreAssignerImpl(this.scoringConfigGroup, this.controllerConfigGroup);
 		newScoreAssigner.assignNewScores(event.getIteration(), this.scoringFunctionsForPopulation, this.population);
 	}
 

--- a/matsim/src/main/java/org/matsim/core/scoring/PlansScoringModule.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/PlansScoringModule.java
@@ -32,5 +32,6 @@ public final class PlansScoringModule extends AbstractModule {
 		bind(ScoringFunctionsForPopulation.class).asEagerSingleton();
 		bind(PlansScoring.class).to(PlansScoringImpl.class);
 		bind(ExperiencedPlansService.class).to(ExperiencedPlansServiceImpl.class).asEagerSingleton();
+		bind(NewScoreAssigner.class).to(NewScoreAssignerImpl.class).asEagerSingleton();
 	}
 }

--- a/matsim/src/test/java/org/matsim/core/scoring/EventsToScoreTest.java
+++ b/matsim/src/test/java/org/matsim/core/scoring/EventsToScoreTest.java
@@ -23,17 +23,39 @@ package org.matsim.core.scoring;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.events.PersonDepartureEvent;
 import org.matsim.api.core.v01.events.PersonMoneyEvent;
+import org.matsim.api.core.v01.events.handler.PersonDepartureEventHandler;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Plan;
 import org.matsim.api.core.v01.population.Population;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.config.groups.ReplanningConfigGroup;
+import org.matsim.core.config.groups.RoutingConfigGroup;
+import org.matsim.core.config.groups.ScoringConfigGroup;
+import org.matsim.core.controler.AbstractModule;
+import org.matsim.core.controler.Controler;
+import org.matsim.core.controler.OutputDirectoryHierarchy;
+import org.matsim.core.controler.events.IterationEndsEvent;
+import org.matsim.core.controler.events.IterationStartsEvent;
+import org.matsim.core.controler.listener.IterationEndsListener;
+import org.matsim.core.controler.listener.IterationStartsListener;
 import org.matsim.core.events.EventsUtils;
+import org.matsim.core.mobsim.framework.events.MobsimBeforeCleanupEvent;
+import org.matsim.core.mobsim.framework.events.MobsimInitializedEvent;
+import org.matsim.core.mobsim.framework.listeners.MobsimBeforeCleanupListener;
+import org.matsim.core.mobsim.framework.listeners.MobsimInitializedListener;
+import org.matsim.core.mobsim.qsim.AbstractQSimModule;
 import org.matsim.core.population.PopulationUtils;
+import org.matsim.core.replanning.strategies.DefaultPlanStrategiesModule;
 import org.matsim.core.scenario.MutableScenario;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.scoring.functions.CharyparNagelScoringFunctionFactory;
@@ -156,6 +178,119 @@ public class EventsToScoreTest {
 			}
 
 		}
+	}
+
+	@Test
+	void testMsaAveragingWithController() {
+		Config config = ConfigUtils.createConfig() ;
+		config.controller().setOverwriteFileSetting(OutputDirectoryHierarchy.OverwriteFileSetting.overwriteExistingFiles);
+
+		config.controller().setFirstIteration(10);
+		config.controller().setLastIteration(110);
+
+		config.scoring().setMarginalUtilityOfMoney(1.);
+		config.scoring().setFractionOfIterationsToStartScoreMSA(0.9);
+
+		ReplanningConfigGroup.StrategySettings strat = new ReplanningConfigGroup.StrategySettings();
+		strat.setStrategyName(DefaultPlanStrategiesModule.DefaultSelector.KeepLastSelected);
+		strat.setWeight(1.);
+		config.replanning().addStrategySettings(strat);
+
+		config.routing().setNetworkRouteConsistencyCheck(RoutingConfigGroup.NetworkRouteConsistencyCheck.disable);
+
+		Scenario scenario = ScenarioUtils.createScenario(config);
+
+		Network network = scenario.getNetwork();
+		Node node0 = network.getFactory().createNode(Id.createNodeId(0), new Coord(0, 0));
+		Node node1 = network.getFactory().createNode(Id.createNodeId(1), new Coord(1, 0));
+		network.addNode(node0);
+		network.addNode(node1);
+		Link link01 = network.getFactory().createLink(Id.createLinkId("0_1"), node0, node1);
+		network.addLink(link01);
+
+		Population population = scenario.getPopulation();
+		Person person = PopulationUtils.getFactory().createPerson(Id.create(1, Person.class));
+		population.addPerson(person);
+		Plan plan = PopulationUtils.createPlan() ;
+		plan.addActivity(population.getFactory().createActivityFromLinkId("dummy", link01.getId()));
+		person.addPlan(plan);
+
+		ScoringConfigGroup.ActivityParams dummyAct = new ScoringConfigGroup.ActivityParams("dummy");
+		dummyAct.setScoringThisActivityAtAll(false);
+		config.scoring().addActivityParams(dummyAct);
+
+		Controler controler = new Controler(scenario);
+		EventsManager events = controler.getEvents();
+		controler.addOverridingModule(new AbstractModule() {
+			@Override
+			public void install() {
+				final int[] iteration = new int[1];
+				this.addControlerListenerBinding().toInstance(new IterationStartsListener() {
+					@Override
+					public void notifyIterationStarts(IterationStartsEvent event) {
+						iteration[0] = event.getIteration();
+					}
+				});
+				this.addMobsimListenerBinding().toInstance(new MobsimInitializedListener() {
+					@Override
+					public void notifyMobsimInitialized(MobsimInitializedEvent e) {
+						events.processEvent(new PersonMoneyEvent(3600.0, person.getId(), iteration[0] -98, "bribe", "contractor" ));
+					}
+				});
+			}
+		});
+		controler.addControlerListener(new IterationEndsListener() {
+			@Override
+			public void notifyIterationEnds(IterationEndsEvent event) {
+				System.out.println( "score: " + person.getSelectedPlan().getScore() ) ;
+
+				switch(event.getIteration()){
+					case 99:
+						Assertions.assertEquals(1.0, person.getSelectedPlan().getScore(), 0);
+						break ;
+					case 100:
+						// first MSA iteration; plain score should be ok:
+						Assertions.assertEquals(2.0, person.getSelectedPlan().getScore(), 0);
+						break ;
+					case 101:
+						// second MSA iteration
+						// (2+3)/2 = 2.5
+						Assertions.assertEquals(2.5, person.getSelectedPlan().getScore(), 0);
+						break ;
+					case 102:
+						// 3rd MSA iteration
+						// (2+3+4)/3 = 3
+						Assertions.assertEquals(3.0, person.getSelectedPlan().getScore(), 0);
+						break ;
+					case 103:
+						// (2+3+4+5)/4 = 3.5
+						Assertions.assertEquals(3.5, person.getSelectedPlan().getScore(), 0);
+						break ;
+					case 104:
+						Assertions.assertEquals(4.0, person.getSelectedPlan().getScore(), 0);
+						break ;
+					case 105:
+						Assertions.assertEquals(4.5, person.getSelectedPlan().getScore(), 0);
+						break ;
+					case 106:
+						Assertions.assertEquals(5.0, person.getSelectedPlan().getScore(), 0);
+						break ;
+					case 107:
+						Assertions.assertEquals(5.5, person.getSelectedPlan().getScore(), 0);
+						break ;
+					case 108:
+						Assertions.assertEquals(6.0, person.getSelectedPlan().getScore(), 0);
+						break ;
+					case 109:
+						Assertions.assertEquals(6.5, person.getSelectedPlan().getScore(), 0);
+						break ;
+					case 110:
+						Assertions.assertEquals(7.0, person.getSelectedPlan().getScore(), 0);
+						break ;
+				}
+			}
+		});
+		controler.run();
 	}
 
 	private static class MockScoringFunctionFactory implements ScoringFunctionFactory {


### PR DESCRIPTION
Before the bugfix of this branch, MSA was not active, even if it was switched on via the config. The reason for this is that the NewScoreAssigner was recreated every iteration and therefore could not save any information across iterations. There was a test for MSA, but it did not create a complete controller, but only tested the scoring via EventsToScore individually, where the NewScoreAssigner was bound differently (correctly).

With the changes to this branch there is 1. a test that tests MSA scoring on a standard controller run (this test fails without the changes to this branch) and 2. the NewScoreAssigner is now bound as a singleton in the PlansScoringModule and is no longer recreated in PlansScoringImpl.

This change will probably affect a lot of your runs!