### PR TITLE
feat: DiscreteModeChoiceModule writes utilities as an output

### DIFF
--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/DiscreteModeChoiceModule.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/DiscreteModeChoiceModule.java
@@ -23,6 +23,7 @@ public class DiscreteModeChoiceModule extends AbstractModule {
 	@Override
 	public void install() {
 		addPlanStrategyBinding(STRATEGY_NAME).toProvider(DiscreteModeChoiceStrategyProvider.class);
+		addControlerListenerBinding().to(UtilitiesWriterHandler.class);
 
 		if (getConfig().replanning().getPlanSelectorForRemoval().equals(NonSelectedPlanSelector.NAME)) {
 			bindPlanSelectorForRemoval().to(NonSelectedPlanSelector.class);

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/UtilitiesWriterHandler.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/UtilitiesWriterHandler.java
@@ -1,0 +1,52 @@
+package org.matsim.contribs.discrete_mode_choice.modules;
+
+import com.google.inject.Inject;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.contribs.discrete_mode_choice.modules.config.DiscreteModeChoiceConfigGroup;
+import org.matsim.contribs.discrete_mode_choice.modules.utils.ExtractPlanUtilities;
+import org.matsim.core.config.groups.ControllerConfigGroup;
+import org.matsim.core.controler.OutputDirectoryHierarchy;
+import org.matsim.core.controler.events.IterationStartsEvent;
+import org.matsim.core.controler.events.ShutdownEvent;
+import org.matsim.core.controler.listener.IterationStartsListener;
+import org.matsim.core.controler.listener.ShutdownListener;
+
+import java.io.IOException;
+
+public class UtilitiesWriterHandler implements ShutdownListener, IterationStartsListener {
+	private final OutputDirectoryHierarchy outputDirectoryHierarchy;
+	private final ControllerConfigGroup controllerConfigGroup;
+	private final Population population;
+	private final DiscreteModeChoiceConfigGroup discreteModeChoiceConfigGroup;
+
+	@Inject
+	public UtilitiesWriterHandler(ControllerConfigGroup controllerConfigGroup, DiscreteModeChoiceConfigGroup discreteModeChoiceConfigGroup, Population population, OutputDirectoryHierarchy outputDirectoryHierarchy) {
+		this.controllerConfigGroup = controllerConfigGroup;
+		this.discreteModeChoiceConfigGroup = discreteModeChoiceConfigGroup;
+		this.population = population;
+		this.outputDirectoryHierarchy = outputDirectoryHierarchy;
+	}
+
+	@Override
+	public void notifyShutdown(ShutdownEvent event) {
+		String filePath = this.outputDirectoryHierarchy.getOutputFilename("dmc_utilities.csv");
+		try {
+			ExtractPlanUtilities.writePlanUtilities(population, filePath);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public void notifyIterationStarts(IterationStartsEvent event) {
+		if(event.getIteration() == controllerConfigGroup.getFirstIteration() ||  this.discreteModeChoiceConfigGroup.getWriteUtilitiesInterval() % event.getIteration() != 0) {
+			return;
+		}
+		String filePath = this.outputDirectoryHierarchy.getIterationFilename(event.getIteration(), "dmc_utilities.csv");
+		try {
+			ExtractPlanUtilities.writePlanUtilities(population, filePath);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/config/DiscreteModeChoiceConfigGroup.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/config/DiscreteModeChoiceConfigGroup.java
@@ -55,7 +55,7 @@ public class DiscreteModeChoiceConfigGroup extends ReflectiveConfigGroup {
 
 	private Collection<String> cachedModes = new HashSet<>();
 	@Positive
-	private int writeUtilitiesInterval = 0;
+	private int writeUtilitiesInterval = 1;
 	public static final String GROUP_NAME = "DiscreteModeChoice";
 
 	public static final String PERFORM_REROUTE = "performReroute";

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/config/DiscreteModeChoiceConfigGroup.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/config/DiscreteModeChoiceConfigGroup.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import jakarta.validation.constraints.Positive;
 import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceModel;
 import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceModel.FallbackBehaviour;
 import org.matsim.contribs.discrete_mode_choice.modules.ConstraintModule;
@@ -27,7 +28,7 @@ import org.matsim.core.utils.collections.Tuple;
 
 /**
  * Main config group for the DiscreteModeChoice extension.
- * 
+ *
  * @author sebhoerl
  */
 public class DiscreteModeChoiceConfigGroup extends ReflectiveConfigGroup {
@@ -53,7 +54,8 @@ public class DiscreteModeChoiceConfigGroup extends ReflectiveConfigGroup {
 	private Collection<String> tripFilters = new HashSet<>();
 
 	private Collection<String> cachedModes = new HashSet<>();
-
+	@Positive
+	private int writeUtilitiesInterval = 0;
 	public static final String GROUP_NAME = "DiscreteModeChoice";
 
 	public static final String PERFORM_REROUTE = "performReroute";
@@ -109,6 +111,9 @@ public class DiscreteModeChoiceConfigGroup extends ReflectiveConfigGroup {
 
 	public static final String CACHED_MODES = "cachedModes";
 	public static final String CACHED_MODES_CMT = "Trips tested with the modes listed here will be cached for each combination of trip and agent during one replanning pass.";
+
+	public static final String WRITE_UTILITIES_INTERVAL = "writeUtilitiesInterval";
+	public static final String WRITE_UTILITIES_INTERVAL_CMT = "Specifies the interval, in iterations, at which the dmc_utilities.csv file is written. If set to 0, the file is written only at the end of the simulation";
 
 	public DiscreteModeChoiceConfigGroup() {
 		super(GROUP_NAME);
@@ -434,6 +439,22 @@ public class DiscreteModeChoiceConfigGroup extends ReflectiveConfigGroup {
 	@StringGetter(CACHED_MODES)
 	public String getCachedModesAsString() {
 		return String.join(", ", cachedModes);
+	}
+
+	/**
+	 * @param writeUtilitiesInterval -- {@value #WRITE_UTILITIES_INTERVAL_CMT}
+	 */
+	@StringSetter(WRITE_UTILITIES_INTERVAL)
+	public void setWriteUtilitiesInterval(int writeUtilitiesInterval) {
+		this.writeUtilitiesInterval = writeUtilitiesInterval;
+	}
+
+	/**
+	 * @return -- {@value #WRITE_UTILITIES_INTERVAL_CMT}
+	 */
+	@StringGetter(WRITE_UTILITIES_INTERVAL)
+	public int getWriteUtilitiesInterval() {
+		return this.writeUtilitiesInterval;
 	}
 
 	// --- Component configuration ---

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/utils/ExtractPlanUtilities.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/utils/ExtractPlanUtilities.java
@@ -1,0 +1,51 @@
+package org.matsim.contribs.discrete_mode_choice.modules.utils;
+
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Plan;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.core.config.CommandLine;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.population.io.PopulationReader;
+import org.matsim.core.scenario.ScenarioUtils;
+
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class ExtractPlanUtilities {
+	public static void writePlanUtilities(Population population, String filePath) throws IOException {
+		FileWriter writer = new FileWriter(filePath);
+		writer.write(String.join(CSV_SEPARATOR, CSV_HEADER));
+		writer.write("\n");
+
+		for(Person person: population.getPersons().values()) {
+			double utility = Double.NaN;
+			Plan plan = person.getSelectedPlan();
+			if(plan != null && plan.getAttributes().getAttribute("utility") != null) {
+				utility = (double) plan.getAttributes().getAttribute("utility");
+			}
+			writer.write(String.join(CSV_SEPARATOR, new String[]{
+				person.getId().toString(),
+				String.valueOf(utility)
+			}));
+			writer.write("\n");
+		}
+		writer.close();
+	}
+
+	public static final String CMD_PLANS_PATH = "plans-path";
+	public static final String CMD_OUTPUT_PATH = "output-path";
+	public static final String CSV_SEPARATOR = ";";
+	public static final String[] CSV_HEADER = new String[]{"person_id", "utility"};
+
+	public static void main(String[] args) throws CommandLine.ConfigurationException, IOException {
+		CommandLine commandLine = new CommandLine.Builder(args).requireOptions(CMD_PLANS_PATH, CMD_OUTPUT_PATH).build();
+
+		Config config = ConfigUtils.createConfig();
+		Scenario scenario = ScenarioUtils.createScenario(config);
+		new PopulationReader(scenario).readFile(commandLine.getOptionStrict(CMD_PLANS_PATH));
+
+		writePlanUtilities(scenario.getPopulation(), commandLine.getOptionStrict(CMD_OUTPUT_PATH));
+	}
+}

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/replanning/DiscreteModeChoiceAlgorithm.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/replanning/DiscreteModeChoiceAlgorithm.java
@@ -13,13 +13,14 @@ import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceTrip;
 import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceModel.NoFeasibleChoiceException;
 import org.matsim.contribs.discrete_mode_choice.model.trip_based.candidates.RoutedTripCandidate;
 import org.matsim.contribs.discrete_mode_choice.model.trip_based.candidates.TripCandidate;
+import org.matsim.contribs.discrete_mode_choice.model.utilities.UtilityCandidate;
 import org.matsim.core.population.algorithms.PlanAlgorithm;
 import org.matsim.core.router.TripRouter;
 
 /**
  * This replanning algorithm uses a predefined discrete mode choice model to
  * perform mode decisions for a given plan.
- * 
+ *
  * @author sebhoerl
  */
 public class DiscreteModeChoiceAlgorithm implements PlanAlgorithm {
@@ -68,6 +69,7 @@ public class DiscreteModeChoiceAlgorithm implements PlanAlgorithm {
 
 				TripRouter.insertTrip(plan, trip.getOriginActivity(), insertElements, trip.getDestinationActivity());
 			}
+			plan.getAttributes().putAttribute("utility", chosenCandidates.stream().mapToDouble(UtilityCandidate::getUtility).sum());
 		} catch (NoFeasibleChoiceException e) {
 			throw new IllegalStateException(e);
 		}


### PR DESCRIPTION
This PR allows a the DiscreteModeChoice Module, part of the discrete_mode_choice contrib, to output a file `dmc_utilities.csv` during iterations and at the end of the simulations. This file contains the utilities computed by the DMC models for each person, it has a header `person_id;utility`. 

The generation interval of this file during the iterations can be specified through the `writeUtilitiesInterval` parameter in the DiscreteModeChoice config group. 

This functionality is achieved by storing the utility as a plan attribute. This means that output population files also contain the utility. To generate the CSV file containing the utitlies from a population file, the `modules.utils.ExtractPlanUtilities` can be used. 