### PR TITLE
Use correct transit modes in pt pseudo network

### DIFF
--- a/matsim/src/main/java/org/matsim/pt/utils/CreatePseudoNetwork.java
+++ b/matsim/src/main/java/org/matsim/pt/utils/CreatePseudoNetwork.java
@@ -120,6 +120,7 @@ public class CreatePseudoNetwork {
 			this.nodes.put(stop, node);
 
 			Link loopLink = this.network.getFactory().createLink(Id.createLinkId (this.prefix + stop.getId()), node, node);
+			loopLink.setAllowedModes(this.transitModes);
 			stop.setLinkId(loopLink.getId());
 			this.network.addLink(loopLink);
 			Tuple<Node, Node> connection = new Tuple<>(node, node);


### PR DESCRIPTION
In PR #3357 loop-links have been added to PT pseudo networks. These loop links had not the correct mode, which is fixed in this PR.

