### PR TITLE
feat: flexibilize DrtRouteConstraintsCalculator

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DefaultDrtRouteConstraintsCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DefaultDrtRouteConstraintsCalculator.java
@@ -1,7 +1,9 @@
 package org.matsim.contrib.drt.routing;
 
+import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.drt.optimizer.constraints.DefaultDrtOptimizationConstraintsSet;
 import org.matsim.contrib.drt.optimizer.constraints.DrtOptimizationConstraintsSet;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * @author nkuehnel / MOIA
@@ -16,7 +18,7 @@ public class DefaultDrtRouteConstraintsCalculator implements DrtRouteConstraints
      * @return maximum travel time
      */
     @Override
-    public double getMaxTravelTime(DrtOptimizationConstraintsSet constraintsSet, double unsharedRideTime) {
+    public double getMaxTravelTime(DrtOptimizationConstraintsSet constraintsSet, double unsharedRideTime, Person person, Attributes attributes) {
         if(constraintsSet instanceof DefaultDrtOptimizationConstraintsSet defaultSet) {
             return defaultSet.maxTravelTimeAlpha * unsharedRideTime
                 + defaultSet.maxTravelTimeBeta;
@@ -33,7 +35,7 @@ public class DefaultDrtRouteConstraintsCalculator implements DrtRouteConstraints
      * @return maximum ride time
      */
     @Override
-    public double getMaxRideTime(DrtOptimizationConstraintsSet constraintsSet, double unsharedRideTime) {
+    public double getMaxRideTime(DrtOptimizationConstraintsSet constraintsSet, double unsharedRideTime, Person person, Attributes attributes) {
         if(constraintsSet instanceof DefaultDrtOptimizationConstraintsSet defaultSet) {
             return Math.min(unsharedRideTime + defaultSet.maxAbsoluteDetour,
                     defaultSet.maxDetourAlpha * unsharedRideTime
@@ -42,4 +44,14 @@ public class DefaultDrtRouteConstraintsCalculator implements DrtRouteConstraints
             throw new IllegalArgumentException("Constraint set is not a default set");
         }
     }
+
+	@Override
+	public double getMaxWaitTime(DrtOptimizationConstraintsSet constraintsSet, double unsharedRideTime, Person person,
+			Attributes tripAttributes) {
+        if(constraintsSet instanceof DefaultDrtOptimizationConstraintsSet defaultSet) {
+            return constraintsSet.maxWaitTime;
+        } else {
+            throw new IllegalArgumentException("Constraint set is not a default set");
+        }
+	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRouteConstraintsCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRouteConstraintsCalculator.java
@@ -1,13 +1,17 @@
 package org.matsim.contrib.drt.routing;
 
+import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.drt.optimizer.constraints.DrtOptimizationConstraintsSet;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * @author nkuehnel / MOIA
  */
 public interface DrtRouteConstraintsCalculator {
 
-    double getMaxTravelTime(DrtOptimizationConstraintsSet constraintsSet, double unsharedRideTime);
+    double getMaxTravelTime(DrtOptimizationConstraintsSet constraintsSet, double unsharedRideTime, Person person, Attributes tripAttributes);
 
-    double getMaxRideTime(DrtOptimizationConstraintsSet constraintsSet, double unsharedRideTime);
+    double getMaxRideTime(DrtOptimizationConstraintsSet constraintsSet, double unsharedRideTime, Person person, Attributes tripAttributes);
+    
+    double getMaxWaitTime(DrtOptimizationConstraintsSet constraintsSet, double unsharedRideTime, Person person, Attributes tripAttributes);
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRouteCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRouteCreator.java
@@ -74,15 +74,16 @@ public class DrtRouteCreator implements DefaultMainLegRouter.RouteCreator {
 		DrtOptimizationConstraintsSet constraintsSet =
 				constraintSetChooser.chooseConstraintSet(departureTime, accessActLink, egressActLink, person, tripAttributes)
 						.orElse(drtCfg.addOrGetDrtOptimizationConstraintsParams().addOrGetDefaultDrtOptimizationConstraintsSet());
-		double maxTravelTime = routeConstraintsCalculator.getMaxTravelTime(constraintsSet, unsharedRideTime);
-		double maxRideDuration = routeConstraintsCalculator.getMaxRideTime(constraintsSet, unsharedRideTime);
+		double maxTravelTime = routeConstraintsCalculator.getMaxTravelTime(constraintsSet, unsharedRideTime, person, tripAttributes);
+		double maxRideDuration = routeConstraintsCalculator.getMaxRideTime(constraintsSet, unsharedRideTime, person, tripAttributes);
+		double maxWaitTime = routeConstraintsCalculator.getMaxWaitTime(constraintsSet, unsharedRideTime, person, tripAttributes);
 
 		DrtRoute route = routeFactories.createRoute(DrtRoute.class, accessActLink.getId(), egressActLink.getId());
 		route.setDistance(unsharedDistance);
 		route.setTravelTime(maxTravelTime);
 		route.setMaxRideTime(maxRideDuration);
 		route.setDirectRideTime(unsharedRideTime);
-		route.setMaxWaitTime(constraintsSet.maxWaitTime);
+		route.setMaxWaitTime(maxWaitTime);
 
 		if (this.drtCfg.storeUnsharedPath) {
 			route.setUnsharedPath(unsharedPath);


### PR DESCRIPTION
Our use case is that we want to have individual wait time, travel time, etc. constraints per request. So far, we were implementing a custom `DrtRouteCreator` for that, but now there is `DrtRouteConstraintsCalculator`. However, the interface right now doesn't seem to be very useful, because almost no information is passed on. This PR flexibilizes the interface by passing the person and the trip attributes.

As a sidenote, I'm a bit sceptical about how the `DrtOptimizationConstraintsSet` is passed on to this interface. My feeling is that this is actually something that should be negotiated behind that interface. Using the `DrtOptimizationConstraintsSet` sounds like the "default implementation", while any other implementation will specifically be more complicated than using this data structure. I think the main reason is that the `DrtOptimizationConstraintsSet` combines certain things that seem to be handled by the interface (travel time, ride time) while other parameters in `DrtOptimizationConstraintsSet` concern more specifically the `DrtRouteCreator`. In my mind, some kind of internal version of `DrtOptimizationConstraintsSet` (with various properties) should be the output of `DrtRouteConstraintsCalculator` instead of having multiple methods, and then one specific implementation would obtain the information from the configuration with the `ConstraintSetChooser` and so on. What do you think @nkuehnel?