### PR TITLE
chore: default zoning params in DvrpTravelTimeMatrixParams

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrixParams.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrixParams.java
@@ -20,6 +20,7 @@
 
 package org.matsim.contrib.zone.skims;
 
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import org.matsim.contrib.common.util.ReflectiveConfigGroupWithConfigurableParameterSets;
 import org.matsim.contrib.common.zones.ZoneSystemParams;
@@ -55,6 +56,7 @@ public class DvrpTravelTimeMatrixParams extends ReflectiveConfigGroupWithConfigu
 			+ " The unit is seconds. Default value is 0 s (for backward compatibility).")
 	@PositiveOrZero
 	public double maxNeighborTravelTime = 0; //[s]
+	@NotNull
 	private ZoneSystemParams zoneSystemParams;
 
 
@@ -101,6 +103,11 @@ public class DvrpTravelTimeMatrixParams extends ReflectiveConfigGroupWithConfigu
 	}
 
 	public ZoneSystemParams getZoneSystemParams() {
+		if(this.zoneSystemParams == null) {
+			SquareGridZoneSystemParams squareGridZoneSystemParams = new SquareGridZoneSystemParams();
+			squareGridZoneSystemParams.cellSize = 200;
+			this.zoneSystemParams = squareGridZoneSystemParams;
+		}
 		return zoneSystemParams;
 	}
 }


### PR DESCRIPTION
@nkuehnel 

In the DvrpConfigGroup class, the getTravelTimeMatrixParams() method creates a DvrpTravelTimeMatrixParams on the fly if it doesn't already exist (meaning it wasn't in the XML input or it wasn't added by the script that created the DvrpConfigGroup). 

However, when a DvrpTravelTimeMatrixParams is created in the above mentioned method, no ZoneSystemParams is created inside it. Which then causes a NullPointerException whenever the ZoneSystemParams  is requested and used. 

To address this, this PR continues the same approach of creating the params on the fly by creating a SquareGridZoneSystemParams with a cellSize of 200m, as was the default in the old implementation. 