### PR TITLE
Config: setInsistingOnDeprecatedConfigVersion to "false"

### DIFF
--- a/matsim/src/main/java/org/matsim/core/config/ConfigReader.java
+++ b/matsim/src/main/java/org/matsim/core/config/ConfigReader.java
@@ -102,6 +102,9 @@ public final class ConfigReader extends MatsimXmlParser {
 		}
 		else if ( CONFIG_V2.equals( doctype ) ) {
 			this.delegate = new ConfigReaderMatsimV2( this.config );
+			config.global().setInsistingOnDeprecatedConfigVersion(false);
+			// Currently, V2 is the current version.
+			// IMO: The default should be "false". -> Change in {@link GlobalConfigGroup}.  kmt, Aug'24
 			log.info( "using config_v2-reader" );
 		}
 		else {

--- a/matsim/src/main/java/org/matsim/core/config/ConfigUtils.java
+++ b/matsim/src/main/java/org/matsim/core/config/ConfigUtils.java
@@ -55,6 +55,7 @@ public class ConfigUtils implements MatsimExtensionPoint {
 	public static Config createConfig() {
 		Config config = new Config();
 		config.addCoreModules();
+		config.global().setInsistingOnDeprecatedConfigVersion(false); // IMO: The default should be "false". -> Change in {@link GlobalConfigGroup}.  kmt, Aug'24
 		return config;
 	}
 

--- a/matsim/src/main/java/org/matsim/core/config/groups/GlobalConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/GlobalConfigGroup.java
@@ -108,6 +108,9 @@ public final class GlobalConfigGroup extends ReflectiveConfigGroup {
 	// ---
 	private boolean insistingOnDeprecatedConfigVersion = true ;
 	// yyyy this should be set to false eventually.  kai, aug'18
+	// IMO: Yes, false would be the default and if read in an older version, set it to true.
+	// That would also avoid the setting to "false" in ConfigUtils. This should not be needed, because creating
+	// a new Config should always result in the newest version. 	// kmt, Aug'24
 	private static final String INSITING_ON_DEPRECATED_CONFIG_VERSION = "insistingOnDeprecatedConfigVersion" ;
 	@StringGetter( INSITING_ON_DEPRECATED_CONFIG_VERSION )
 	public final boolean isInsistingOnDeprecatedConfigVersion() { return this.insistingOnDeprecatedConfigVersion ; }


### PR DESCRIPTION
, when creating a new Config or reading in a Config in the current version (v2).

This avoids the misleading error in VSPConsitencyCheck, where it suggests, that we have an old version, but it is only created in Code.

On the midterm, the default in `GlobalConfigGroup` should be changed, and the "true" should be assigned when reading in an old version. 
