### PR TITLE
noise: handle activities without coord

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/analysis/noise/NoiseAnalysis.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/noise/NoiseAnalysis.java
@@ -181,7 +181,7 @@ public class NoiseAnalysis implements MATSimAppCommand {
 		config.transit().setTransitScheduleFile(null);
 		config.transit().setVehiclesFile(null);
 		config.plans().setInputFile(ApplicationUtils.matchInput("plans", input.getRunDirectory()).toAbsolutePath().toString());
-		config.facilities().setInputFile(null);
+		config.facilities().setInputFile(ApplicationUtils.matchInput("facilities", input.getRunDirectory()).toAbsolutePath().toString());
 		config.eventsManager().setNumberOfThreads(null);
 		config.eventsManager().setEstimatedNumberOfEvents(null);
 		//ts, aug '24: not sure if and why we need to set 1 thread

--- a/contribs/noise/src/main/java/org/matsim/contrib/noise/Grid.java
+++ b/contribs/noise/src/main/java/org/matsim/contrib/noise/Grid.java
@@ -18,7 +18,7 @@
  * *********************************************************************** */
 
 /**
- * 
+ *
  */
 package org.matsim.contrib.noise;
 
@@ -34,6 +34,7 @@ import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.population.Activity;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.noise.NoiseConfigGroup;
+import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.router.TripStructureUtils;
 import org.matsim.core.router.TripStructureUtils.StageActivityHandling;
 import org.matsim.core.utils.collections.QuadTree;
@@ -46,50 +47,50 @@ import org.matsim.core.utils.misc.Counter;
 
 /**
  * Computes a grid of receiver points and provides some basic spatial functionality,
- * e.g. the nearest receiver point for the coordinates of each 'considered' activity type. 
- * 
+ * e.g. the nearest receiver point for the coordinates of each 'considered' activity type.
+ *
  * @author lkroeger, ikaddoura
  *
  */
 final class Grid {
-	
+
 	private static final Logger log = LogManager.getLogger(Grid.class);
 
 	private final Scenario scenario;
 	private final NoiseConfigGroup noiseParams;
-		
+
 	private final Map<Id<Person>, List<Coord>> personId2consideredActivityCoords = new HashMap<Id<Person>, List<Coord>>();
-	
+
 	private final Set<Coord> consideredActivityCoordsForSpatialFunctionality = new HashSet <Coord>();
 	private final Set<Coord> consideredActivityCoordsForReceiverPointGrid = new HashSet <Coord>();
-	
+
 	private final Set<String> consideredActivitiesForSpatialFunctionality = new HashSet<String>();
 	private final Set<String> consideredActivitiesForReceiverPointGrid = new HashSet<String>();
-	
+
 	private double xCoordMin = Double.MAX_VALUE;
 	private double xCoordMax = Double.MIN_VALUE;
 	private double yCoordMin = Double.MAX_VALUE;
 	private double yCoordMax = Double.MIN_VALUE;
-	
+
 	private final Map<Coord,Id<ReceiverPoint>> activityCoord2receiverPointId = new HashMap<Coord, Id<ReceiverPoint>>();
 	private Map<Id<ReceiverPoint>, NoiseReceiverPoint> receiverPoints;
-	
+
 	public Grid(Scenario scenario) {
-		this.scenario = scenario;	
+		this.scenario = scenario;
 
 		if (this.scenario.getConfig().getModule("noise") == null) {
 			throw new RuntimeException("Could not find a noise config group. "
 					+ "Check if the custom module is loaded, e.g. 'ConfigUtils.loadConfig(configFile, new NoiseConfigGroup())'"
 					+ " Aborting...");
 		}
-		
+
 		this.noiseParams = (NoiseConfigGroup) this.scenario.getConfig().getModule("noise");
-		
+
 		this.receiverPoints = new HashMap<>();
-		
+
 		String[] consideredActTypesForDamagesArray = noiseParams.getConsideredActivitiesForDamageCalculationArray();
 		Collections.addAll(this.consideredActivitiesForSpatialFunctionality, consideredActTypesForDamagesArray);
-		
+
 		String[] consideredActTypesForReceiverPointGridArray = noiseParams.getConsideredActivitiesForReceiverPointGridArray();
 		Collections.addAll(this.consideredActivitiesForReceiverPointGrid, consideredActTypesForReceiverPointGridArray);
 
@@ -110,7 +111,7 @@ final class Grid {
 			log.info("Loading receiver points based on provided point coordinates in " + this.noiseParams.getReceiverPointsCSVFile());
 			loadGrid();
 		}
-		
+
 		setActivityCoord2NearestReceiverPointId();
 
 		// delete unnecessary information
@@ -127,17 +128,19 @@ final class Grid {
 					List<Coord> activityCoordinates = personId2consideredActivityCoords.computeIfAbsent(person.getId(), value -> new ArrayList<>());
 
 					activityCoordinates.add(activity.getCoord());
-					
-					consideredActivityCoordsForSpatialFunctionality.add(activity.getCoord());
+
+					//activity.getCoord() might be null, so we need to handle that (by outsourcing that to PopulationUtils)
+					consideredActivityCoordsForSpatialFunctionality.add(PopulationUtils.decideOnCoordForActivity(activity, scenario));
 				}
-				
+
 				if (this.consideredActivitiesForReceiverPointGrid.contains(activity.getType()) || consideredActivityPrefix(activity.getType(), consideredActivitiesForReceiverPointGrid)) {
-					consideredActivityCoordsForReceiverPointGrid.add(activity.getCoord());
+					//activity.getCoord() might be null, so we need to handle that (by outsourcing that to PopulationUtils)
+					consideredActivityCoordsForReceiverPointGrid.add(PopulationUtils.decideOnCoordForActivity(activity, scenario));
 				}
 			}
 		}
 	}
-	
+
 	private boolean consideredActivityPrefix(String type, Set<String> list) {
 		for (String consideredActivity : list) {
 			if (consideredActivity.endsWith("*")) {
@@ -150,9 +153,9 @@ final class Grid {
 	}
 
 	private void loadGrid() {
-				
+
 		String gridCSVFile = this.noiseParams.getReceiverPointsCSVFile();
-		
+
 		CoordinateTransformation ct = TransformationFactory.getCoordinateTransformation(this.noiseParams.getReceiverPointsCSVFileCoordinateSystem(), this.scenario.getConfig().global().getCoordinateSystem());
 		try {
 			readReceiverPoints(gridCSVFile, ct);
@@ -175,7 +178,7 @@ final class Grid {
 				yCoordMax = coord.getY();
 			}
 		}
-		
+
 		log.info("Total number of receiver points: " + receiverPoints.size());
 	}
 
@@ -202,11 +205,11 @@ final class Grid {
 
 
 	private void createGrid() {
-		
+
 		if (this.noiseParams.getReceiverPointsGridMinX() == 0. && this.noiseParams.getReceiverPointsGridMinY() == 0. && this.noiseParams.getReceiverPointsGridMaxX() == 0. && this.noiseParams.getReceiverPointsGridMaxY() == 0.) {
-			
+
 			log.info("Creating receiver points for the entire area between the minimum and maximium x and y activity coordinates of all activity locations.");
-						
+
 			for (Coord coord : consideredActivityCoordsForReceiverPointGrid) {
 				if (coord.getX() < xCoordMin) {
 					xCoordMin = coord.getX();
@@ -221,28 +224,28 @@ final class Grid {
 					yCoordMax = coord.getY();
 				}
 			}
-			
+
 		} else {
-			
+
 			xCoordMin = this.noiseParams.getReceiverPointsGridMinX();
 			xCoordMax = this.noiseParams.getReceiverPointsGridMaxX();
 			yCoordMin = this.noiseParams.getReceiverPointsGridMinY();
 			yCoordMax = this.noiseParams.getReceiverPointsGridMaxY();
-			
-			log.info("Creating receiver points for the area between the coordinates (" + xCoordMin + "/" + yCoordMin + ") and (" + xCoordMax + "/" + yCoordMax + ").");			
+
+			log.info("Creating receiver points for the area between the coordinates (" + xCoordMin + "/" + yCoordMin + ") and (" + xCoordMax + "/" + yCoordMax + ").");
 		}
-		
-		createReceiverPoints();		
+
+		createReceiverPoints();
 	}
-	
+
 	private void createReceiverPoints() {
 
 		Counter counter = new Counter("create receiver point #");
-		
+
 		for (double y = yCoordMax + 100. ; y > yCoordMin - 100. - noiseParams.getReceiverPointGap() ; y = y - noiseParams.getReceiverPointGap()) {
-		
+
 			for (double x = xCoordMin - 100. ; x < xCoordMax + 100. + noiseParams.getReceiverPointGap() ; x = x + noiseParams.getReceiverPointGap()) {
-				
+
 				Id<ReceiverPoint> id = Id.create(counter.getCounter(), ReceiverPoint.class);
 				Coord coord = new Coord(x, y);
 				NoiseReceiverPoint rp = new NoiseReceiverPoint(id, coord);
@@ -253,7 +256,7 @@ final class Grid {
 		counter.printCounter();
 		log.info("Total number of receiver points: " + receiverPoints.size());
 	}
-	
+
 	private void setActivityCoord2NearestReceiverPointId () {
 		double gap = noiseParams.getReceiverPointGap();
 		Counter counter = new Counter("fill quadtree #") ;
@@ -263,10 +266,10 @@ final class Grid {
 			counter.incCounter();
 		}
 		counter.printCounter();
-		
+
 		counter = new Counter("compute nearest receiver-points #");
 		for (Coord coord : consideredActivityCoordsForSpatialFunctionality) {
-			
+
 			// TODO maybe add a check here so we consider only the rp in the 9 surrounding cells?
 			ReceiverPoint rp = qTree.getClosest(coord.getX(), coord.getY());
 			if(rp != null) {
@@ -274,16 +277,16 @@ final class Grid {
 					log.warn("this must not happen");
 				}
 			}
-			
+
 			counter.incCounter();
 		}
 		counter.printCounter();
 	}
 
 	private void readReceiverPoints(String file, CoordinateTransformation ct) throws IOException {
-		
+
 		Map<Id<ReceiverPoint>, Coord> id2Coord = new HashMap<>();
-		
+
 		BufferedReader br = IOUtils.getBufferedReader(file);
 		String line = null;
 		try {
@@ -291,12 +294,12 @@ final class Grid {
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
-		
+
 		String[] headers = line.split(",");
 		log.info("id: " + headers[0]);
 		log.info("xCoord: " + headers[1]);
 		log.info("yCoord: " + headers[2]);
-		
+
 		int lineCounter = 0;
 
 		while( (line = br.readLine()) != null) {
@@ -308,13 +311,13 @@ final class Grid {
 			String[] columns = line.split(",");
 			if (line.isEmpty() || line.equals("") || columns.length != headers.length) {
 				log.warn("Skipping line " + lineCounter + ". Line is empty or the columns are inconsistent with the headers: [" + line.toString() + "]");
-			
+
 			} else {
 				String id = null;
 				double x = 0;
 				double y = 0;
 
-				for (int column = 0; column < columns.length; column++){					
+				for (int column = 0; column < columns.length; column++){
 					if (column == 0) {
 						id = columns[column];
 					} else if (column == 1) {
@@ -329,11 +332,11 @@ final class Grid {
                 NoiseReceiverPoint rp = new NoiseReceiverPoint(Id.create(id, ReceiverPoint.class), transformedCoord);
                 receiverPoints.put(rp.getId(), rp);
 				lineCounter++;
-			}			
+			}
 		}
 		log.info("Done. Number of read lines: " + lineCounter);
 	}
-	
+
 	public Map<Id<Person>, List<Coord>> getPersonId2listOfConsideredActivityCoords() {
 		return personId2consideredActivityCoords;
 	}


### PR DESCRIPTION
Some scenarios (like matsim-berlin) have some activities which do not have a coord. `NoiseOfflineCalculation` needs to account for that, otherwise we get an `NPE`.

Before this PR, activity coordinates were just dumped into a `Set` and then retrieved, without any check. Now we use `PopulationUtils.decideOnCoordForActivity(activity, scenario)` for the determination of activity coordinates...