### PR TITLE
Write additional attributes when using SUMO network converter

### DIFF
--- a/contribs/sumo/src/main/java/org/matsim/contrib/sumo/SumoNetworkConverter.java
+++ b/contribs/sumo/src/main/java/org/matsim/contrib/sumo/SumoNetworkConverter.java
@@ -165,7 +165,10 @@ public class SumoNetworkConverter implements Callable<Integer> {
 		SumoNetworkFeatureExtractor props = new SumoNetworkFeatureExtractor(handler);
 
 		try (CSVPrinter out = new CSVPrinter(IOUtils.getBufferedWriter(output), CSVFormat.DEFAULT)) {
-			out.printRecord(props.getHeader());
+			List<String> header = new ArrayList<>(props.getHeader());
+			header.addAll(handler.attributes);
+
+			out.printRecord(header);
 			props.print(out);
 
 		} catch (IOException e) {

--- a/contribs/sumo/src/main/java/org/matsim/contrib/sumo/SumoNetworkFeatureExtractor.java
+++ b/contribs/sumo/src/main/java/org/matsim/contrib/sumo/SumoNetworkFeatureExtractor.java
@@ -274,6 +274,10 @@ class SumoNetworkFeatureExtractor {
 		out.print(numConnections.getInt('r'));
 		out.print(numConnections.getInt('s'));
 
+		for (String attribute : handler.attributes) {
+			out.print(edge.attributes.getOrDefault(attribute, ""));
+		}
+
 		out.println();
 	}
 

--- a/contribs/sumo/src/main/java/org/matsim/contrib/sumo/SumoNetworkHandler.java
+++ b/contribs/sumo/src/main/java/org/matsim/contrib/sumo/SumoNetworkHandler.java
@@ -48,6 +48,11 @@ public class SumoNetworkHandler extends DefaultHandler {
 	final Map<String, Type> types = new HashMap<>();
 
 	/**
+	 * Attribute names that have been observed during parsing.
+	 */
+	Set<String> attributes = new LinkedHashSet<>();
+
+	/**
 	 * Stores current parsed edge.
 	 */
 	private Edge tmpEdge = null;
@@ -257,6 +262,14 @@ public class SumoNetworkHandler extends DefaultHandler {
 					case "origTo":
 						tmpEdge.origTo = value;
 						break;
+					// Redundant attribute, that does not need to be stored
+					case "highway":
+						break;
+					default:
+						String attribute = attributes.getValue("key").intern();
+						this.attributes.add(attribute);
+						tmpEdge.attributes.put(attribute, value);
+						break;
 				}
 
 				break;
@@ -344,6 +357,8 @@ public class SumoNetworkHandler extends DefaultHandler {
 
 		@Nullable
 		String origTo;
+
+		final Map<String, String> attributes = new HashMap<>();
 
 		public Edge(String id, String from, String to, String type, int priority, String name, String[] shape) {
 			this.id = id;

--- a/contribs/sumo/src/test/java/org/matsim/contrib/sumo/SumoNetworkConverterTest.java
+++ b/contribs/sumo/src/test/java/org/matsim/contrib/sumo/SumoNetworkConverterTest.java
@@ -1,6 +1,9 @@
 package org.matsim.contrib.sumo;
 
 import com.google.common.io.Resources;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.TransportMode;
@@ -8,6 +11,8 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.core.network.NetworkUtils;
 
+import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -42,9 +47,16 @@ public class SumoNetworkConverterTest {
 
 		assert Files.exists(geometry) : "Geometries must exist";
 
-		Path fts = Path.of(output.toString().replace(".xml", "-ft.csv"));
+		String csv = output.toString().replace(".xml", "-ft.csv");
+		Path fts = Path.of(csv);
 
 		assert Files.exists(fts) : "Features must exists";
+
+		CSVParser parser = CSVParser.parse(new File(csv), StandardCharsets.UTF_8, CSVFormat.DEFAULT.builder().setHeader().setHeader().build());
+
+		List<String> header = parser.getHeaderNames();
+		Assertions.assertEquals("linkId", header.get(0));
+		Assertions.assertEquals("highway_type", header.get(1));
 
 	}
 }


### PR DESCRIPTION
The SUMO Network converter now allows writing additional attributes found in the network. This is especially useful when osm attributes such as smoothness, surface, cycleway etc. should be kept