### PR TITLE
fix glob patterns in dashboards for runs without run id

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/ApplicationUtils.java
+++ b/contribs/application/src/main/java/org/matsim/application/ApplicationUtils.java
@@ -450,7 +450,7 @@ public class ApplicationUtils {
 		if (path.isPresent())
 			return path.get();
 
-		throw new IllegalArgumentException("Could not match input file: " + name);
+		throw new IllegalArgumentException("Could not match input file: %s (in %s)".formatted(name, dir));
 	}
 
 	private static Optional<Path> matchSuffix(String suffix, Path dir) {

--- a/contribs/application/src/main/java/org/matsim/application/ApplicationUtils.java
+++ b/contribs/application/src/main/java/org/matsim/application/ApplicationUtils.java
@@ -446,7 +446,7 @@ public class ApplicationUtils {
 			return path.get();
 
 		// Even more permissive pattern
-		path = matchPattern(".+\\.[a-zA-Z0-9_.\\-]*(_|\\.)" + name + "\\..+", dir);
+		path = matchPattern(".+[a-zA-Z0-9_.\\-]*(_|\\.)" + name + ".+", dir);
 		if (path.isPresent())
 			return path.get();
 

--- a/contribs/simwrapper/src/main/java/org/matsim/simwrapper/dashboard/OverviewDashboard.java
+++ b/contribs/simwrapper/src/main/java/org/matsim/simwrapper/dashboard/OverviewDashboard.java
@@ -58,7 +58,7 @@ public class OverviewDashboard implements Dashboard {
 		});
 
 		layout.row("config").el(XML.class, (viz, data) -> {
-			viz.file = data.output("*.output_config.xml");
+			viz.file = data.output("(*.)?output_config.xml");
 			viz.height = 6d;
 			viz.width = 2d;
 			viz.unfoldLevel = 1;
@@ -66,7 +66,7 @@ public class OverviewDashboard implements Dashboard {
 		}).el(PieChart.class, (viz, data) -> {
 			viz.title = "Mode Share";
 			viz.description = "at final Iteration";
-			viz.dataset = data.output("*.modestats.csv");
+			viz.dataset = data.output("(*.)?modestats.csv");
 			viz.ignoreColumns = List.of("iteration");
 			viz.useLastRow = true;
 		});
@@ -75,7 +75,7 @@ public class OverviewDashboard implements Dashboard {
 		layout.row("second").el(Line.class, (viz, data) -> {
 
 			viz.title = "Score";
-			viz.dataset = data.output("*.scorestats.csv");
+			viz.dataset = data.output("(*.)?scorestats.csv");
 			viz.description = "per Iteration";
 			viz.x = "iteration";
 			viz.columns = List.of("avg_executed", "avg_worst", "avg_best");
@@ -88,7 +88,7 @@ public class OverviewDashboard implements Dashboard {
 			.el(Area.class, (viz, data) -> {
 				viz.title = "Mode Share Progression";
 				viz.description = "per Iteration";
-				viz.dataset = data.output("*.modestats.csv");
+				viz.dataset = data.output("(*.)?modestats.csv");
 				viz.x = "iteration";
 				viz.xAxisName = "Iteration";
 				viz.yAxisName = "Share";

--- a/contribs/simwrapper/src/main/java/org/matsim/simwrapper/dashboard/PublicTransitDashboard.java
+++ b/contribs/simwrapper/src/main/java/org/matsim/simwrapper/dashboard/PublicTransitDashboard.java
@@ -28,14 +28,14 @@ public class PublicTransitDashboard implements Dashboard {
 
 		header.title = "Public Transit";
 		header.tab = "PT";
-		header.triggerPattern = "*output_transitSchedule*xml*";
+		header.triggerPattern = "(*.)?output_transitSchedule*xml*";
 
 		layout.row("viewer").el(TransitViewer.class, (viz, data) -> {
 			viz.title = "Transit Viewer";
 			viz.height = 12d;
 			viz.description = "Visualize the transit schedule.";
-			viz.network = "*output_network.xml.gz";
-			viz.transitSchedule = data.output("*output_transitSchedule.xml.gz");
+			viz.network = "(*.)?output_network.xml.gz";
+			viz.transitSchedule = data.output("(*.)?output_transitSchedule.xml.gz");
 
 			if (!customRouteTypes.isEmpty())
 				viz.customRouteTypes = customRouteTypes;


### PR DESCRIPTION
Some dashboards were not working correctly because the file matching patterns were expecting a run id in the filename.