### PR TITLE
Add matsim.tempDir property for specifying ImageIO cache directory

### DIFF
--- a/matsim/src/main/java/org/matsim/core/controler/ControlerDefaultsModule.java
+++ b/matsim/src/main/java/org/matsim/core/controler/ControlerDefaultsModule.java
@@ -51,6 +51,9 @@ import javax.imageio.ImageIO;
 import java.io.File;
 
 public final class ControlerDefaultsModule extends AbstractModule {
+
+	public static final String MATSIM_TEMP_DIR_PROPERTY = "matsim.tempDir";
+
     @Override
     public void install() {
         install(new EventsManagerModule());
@@ -86,8 +89,16 @@ public final class ControlerDefaultsModule extends AbstractModule {
 		//  the cache needs to be always set correctly.
 		addControlerListenerBinding().toInstance(new StartupListener() {
 			@Inject private OutputDirectoryHierarchy outputDirectoryHierarchy;
-			@Override   public void notifyStartup(StartupEvent event) {
-				ImageIO.setCacheDirectory(new File(outputDirectoryHierarchy.getTempPath()));
+
+			String matsimTempDir = System.getProperty(MATSIM_TEMP_DIR_PROPERTY);
+
+			if (matsimTempDir == null) {
+				matsimTempDir = outputDirectoryHierarchy.getTempPath();
+			}
+			
+			@Override
+			public void notifyStartup(StartupEvent event) {
+				ImageIO.setCacheDirectory(new File(matsimTempDir));
 			}
 		});
 


### PR DESCRIPTION
Currently, the ImageIO cache directory is hard coded to a `tmp` folder inside the output folder. We learned, that ImageIO is using some random access methods to write its temporary files which causes issue when using [mountpoint-s3](https://github.com/awslabs/mountpoint-s3/blob/main/doc/TROUBLESHOOTING.md#random-writes) for the output folder.

This change makes this specific ImageIO directory configurable via a system property `matsim.tempDir`. The default behavior remains unchanged.