### PR TITLE
Add matsim.tempDir property for specifying ImageIO cache directory

### DIFF
--- a/matsim/src/main/java/org/matsim/core/controler/ControlerDefaultsModule.java
+++ b/matsim/src/main/java/org/matsim/core/controler/ControlerDefaultsModule.java
@@ -51,6 +51,9 @@ import javax.imageio.ImageIO;
 import java.io.File;
 
 public final class ControlerDefaultsModule extends AbstractModule {
+
+	public static final String MATSIM_TEMP_DIR_PROPERTY = "matsim.tempDir";
+
     @Override
     public void install() {
         install(new EventsManagerModule());
@@ -85,9 +88,16 @@ public final class ControlerDefaultsModule extends AbstractModule {
 		// Maybe not the best place to but this but since ChartUtils is used by many modules, including default ones,
 		//  the cache needs to be always set correctly.
 		addControlerListenerBinding().toInstance(new StartupListener() {
-			@Inject private OutputDirectoryHierarchy outputDirectoryHierarchy;
-			@Override   public void notifyStartup(StartupEvent event) {
-				ImageIO.setCacheDirectory(new File(outputDirectoryHierarchy.getTempPath()));
+			@Inject
+			private OutputDirectoryHierarchy outputDirectoryHierarchy;
+
+			@Override
+			public void notifyStartup(StartupEvent event) {
+				String matsimTempDir = System.getProperty(MATSIM_TEMP_DIR_PROPERTY);
+				if (matsimTempDir == null) {
+					matsimTempDir = outputDirectoryHierarchy.getTempPath();
+				}
+				ImageIO.setCacheDirectory(new File(matsimTempDir));
 			}
 		});
 

--- a/matsim/src/main/java/org/matsim/core/controler/ControlerDefaultsModule.java
+++ b/matsim/src/main/java/org/matsim/core/controler/ControlerDefaultsModule.java
@@ -52,8 +52,6 @@ import java.io.File;
 
 public final class ControlerDefaultsModule extends AbstractModule {
 
-	public static final String MATSIM_TEMP_DIR_PROPERTY = "matsim.tempDir";
-
     @Override
     public void install() {
         install(new EventsManagerModule());
@@ -88,16 +86,10 @@ public final class ControlerDefaultsModule extends AbstractModule {
 		// Maybe not the best place to but this but since ChartUtils is used by many modules, including default ones,
 		//  the cache needs to be always set correctly.
 		addControlerListenerBinding().toInstance(new StartupListener() {
-			@Inject
-			private OutputDirectoryHierarchy outputDirectoryHierarchy;
 
 			@Override
 			public void notifyStartup(StartupEvent event) {
-				String matsimTempDir = System.getProperty(MATSIM_TEMP_DIR_PROPERTY);
-				if (matsimTempDir == null) {
-					matsimTempDir = outputDirectoryHierarchy.getTempPath();
-				}
-				ImageIO.setCacheDirectory(new File(matsimTempDir));
+				ImageIO.setCacheDirectory(new File(event.getServices().getControlerIO().getTempPath()));
 			}
 		});
 

--- a/matsim/src/main/java/org/matsim/core/controler/OutputDirectoryHierarchy.java
+++ b/matsim/src/main/java/org/matsim/core/controler/OutputDirectoryHierarchy.java
@@ -47,6 +47,8 @@ public final class OutputDirectoryHierarchy {
 
 	private static final String DIRECTORY_ITERS = "ITERS";
 
+	public static final String MATSIM_TEMP_DIR_PROPERTY = "matsim.tempDir";
+
 	private static final  Logger log = LogManager.getLogger(OutputDirectoryHierarchy.class);
 
 	private String runId = null;
@@ -108,7 +110,11 @@ public final class OutputDirectoryHierarchy {
 	 * @return path to a temp-directory.
 	 */
 	public final String getTempPath() {
-		return outputPath + "/tmp";
+		String matsimTempDir = System.getProperty(MATSIM_TEMP_DIR_PROPERTY);
+		if (matsimTempDir == null) {
+			matsimTempDir = outputPath + "/tmp";
+		}
+		return matsimTempDir;
 	}
 
 	/**

--- a/matsim/src/test/java/org/matsim/core/controler/OutputDirectoryHierarchyTest.java
+++ b/matsim/src/test/java/org/matsim/core/controler/OutputDirectoryHierarchyTest.java
@@ -164,6 +164,8 @@ public class OutputDirectoryHierarchyTest {
 
 		String javaTempDir = System.getProperty("java.io.tmpdir");
 		System.setProperty(OutputDirectoryHierarchy.MATSIM_TEMP_DIR_PROPERTY, javaTempDir);
+		Assertions.assertNotNull(javaTempDir);
+
 		System.setProperty("matsim.preferLocalDtds", "true");
 
 		URL scenarioURL = ExamplesUtils.getTestScenarioURL("siouxfalls-2014");

--- a/matsim/src/test/java/org/matsim/core/controler/OutputDirectoryHierarchyTest.java
+++ b/matsim/src/test/java/org/matsim/core/controler/OutputDirectoryHierarchyTest.java
@@ -21,14 +21,26 @@ package org.matsim.core.controler;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.population.Activity;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.groups.ControllerConfigGroup;
+import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
+import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.utils.io.IOUtils;
+import org.matsim.examples.ExamplesUtils;
 import org.matsim.testcases.MatsimTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URL;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author thibautd
@@ -146,4 +158,27 @@ public class OutputDirectoryHierarchyTest {
 				"Directory was not cleared" );
 
 	}
+
+	@Test
+	void testTmpDir() {
+
+		String javaTempDir = System.getProperty("java.io.tmpdir");
+		System.setProperty(OutputDirectoryHierarchy.MATSIM_TEMP_DIR_PROPERTY, javaTempDir);
+		System.setProperty("matsim.preferLocalDtds", "true");
+
+		URL scenarioURL = ExamplesUtils.getTestScenarioURL("siouxfalls-2014");
+
+		Config config = ConfigUtils.loadConfig(IOUtils.extendUrl(scenarioURL, "config_default.xml"));
+		config.controller().setOverwriteFileSetting(OverwriteFileSetting.deleteDirectoryIfExists);
+		config.controller().setLastIteration(1);
+
+		Scenario scenario = ScenarioUtils.loadScenario(config);
+
+		Controler controller = new Controler(scenario);
+		controller.run();
+
+		String matsimTempDir = controller.getControlerIO().getTempPath();
+		Assertions.assertEquals(javaTempDir, matsimTempDir);
+	}
+
 }


### PR DESCRIPTION
This change makes the temp dir from the `OutputDirectoryHierarchy` configurable via a system property `matsim.tempDir`. The default behavior remains unchanged if this property is not set.

Currently, the ImageIO cache directory is hard coded to a tmp folder inside the output folder via `OutputDirectoryHierarchy`. We learned, that ImageIO is using some random access methods to write its temporary files which causes issues when using [mountpoint-s3](https://github.com/awslabs/mountpoint-s3/blob/main/doc/TROUBLESHOOTING.md#random-writes) for the output folder.