### PR TITLE
Additional transit schedule validations

### DIFF
--- a/contribs/application/pom.xml
+++ b/contribs/application/pom.xml
@@ -87,7 +87,7 @@
 		<dependency>
 			<groupId>com.github.matsim-org</groupId>
 			<artifactId>gtfs2matsim</artifactId>
-			<version>fdab11f1af</version>
+			<version>0bd5850fd6</version>
 			<exclusions>
 				<!-- Exclude unneeded dependencies and these with known CVE -->
 				<exclusion>

--- a/contribs/application/pom.xml
+++ b/contribs/application/pom.xml
@@ -87,7 +87,7 @@
 		<dependency>
 			<groupId>com.github.matsim-org</groupId>
 			<artifactId>gtfs2matsim</artifactId>
-			<version>02aed74eb3</version>
+			<version>fdab11f1af</version>
 			<exclusions>
 				<!-- Exclude unneeded dependencies and these with known CVE -->
 				<exclusion>

--- a/contribs/application/pom.xml
+++ b/contribs/application/pom.xml
@@ -87,7 +87,7 @@
 		<dependency>
 			<groupId>com.github.matsim-org</groupId>
 			<artifactId>gtfs2matsim</artifactId>
-			<version>fc8b13954d</version>
+			<version>02aed74eb3</version>
 			<exclusions>
 				<!-- Exclude unneeded dependencies and these with known CVE -->
 				<exclusion>

--- a/contribs/application/src/main/java/org/matsim/application/prepare/pt/AdjustSameDepartureTimes.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/pt/AdjustSameDepartureTimes.java
@@ -47,10 +47,11 @@ public class AdjustSameDepartureTimes implements Consumer<TransitSchedule> {
 
 				TransitRoute newRoute = schedule.getFactory().createTransitRoute(route.getId(), route.getRoute(), newStops, route.getTransportMode());
 				newRoute.setDescription(route.getDescription());
-
 				for (Map.Entry<String, Object> e : route.getAttributes().getAsMap().entrySet()) {
 					newRoute.getAttributes().putAttribute(e.getKey(), e.getValue());
 				}
+				route.getDepartures().values().forEach(newRoute::addDeparture);
+
 				line.addRoute(newRoute);
 			}
 		}

--- a/contribs/application/src/main/java/org/matsim/application/prepare/pt/AdjustSameDepartureTimes.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/pt/AdjustSameDepartureTimes.java
@@ -1,0 +1,121 @@
+package org.matsim.application.prepare.pt;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.matsim.core.utils.misc.OptionalTime;
+import org.matsim.pt.transitSchedule.api.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * Some providers set the same departure and arrival times for multiple stops.
+ * This usually happens with on-demand buses, but can also happen on night buses where multiple stops can have a departure at the same minute.
+ * These departure times will lead to artifacts when using a pseudo network.
+ * The purpose of this class is to spread these departures more evently.
+ * However, in the case of on demand buses, the travel times will likely still be too optimistic.
+ */
+public class AdjustSameDepartureTimes implements Consumer<TransitSchedule> {
+
+	private static Logger log = LogManager.getLogger(AdjustSameDepartureTimes.class);
+
+	private static OptionalTime add(OptionalTime x, double t) {
+		if (!x.isDefined()) {
+			return x;
+		}
+		return OptionalTime.defined(x.seconds() + t);
+	}
+
+	@Override
+	public void accept(TransitSchedule schedule) {
+		for (TransitLine line : schedule.getTransitLines().values()) {
+
+			List<TransitRoute> routes = new ArrayList<>(line.getRoutes().values());
+			for (TransitRoute route : routes) {
+				List<TransitRouteStop> newStops = adjustDepartures(schedule.getFactory(), route);
+
+				if (newStops == null) {
+					continue;
+				}
+
+				log.info("Adjusted departures for route {} in line {}", route.getId(), line.getId());
+
+				line.removeRoute(route);
+
+				TransitRoute newRoute = schedule.getFactory().createTransitRoute(route.getId(), route.getRoute(), newStops, route.getTransportMode());
+				newRoute.setDescription(route.getDescription());
+
+				for (Map.Entry<String, Object> e : route.getAttributes().getAsMap().entrySet()) {
+					newRoute.getAttributes().putAttribute(e.getKey(), e.getValue());
+				}
+				line.addRoute(newRoute);
+			}
+		}
+
+	}
+
+	private List<TransitRouteStop> adjustDepartures(TransitScheduleFactory f, TransitRoute route) {
+
+		List<TransitRouteStop> stops = new ArrayList<>(route.getStops());
+
+		boolean adjusted = false;
+		for (int i = 0; i < stops.size() - 1; ) {
+
+			TransitRouteStop stop = stops.get(i);
+
+			OptionalTime dep = stop.getDepartureOffset().or(stop.getArrivalOffset());
+
+			if (!dep.isDefined()) {
+				i++;
+				continue;
+			}
+
+			OptionalTime arr = null;
+			int j = i + 1;
+			for (; j < stops.size(); j++) {
+				TransitRouteStop nextStop = stops.get(j);
+				arr = nextStop.getArrivalOffset().or(nextStop.getDepartureOffset());
+				if (!dep.equals(arr)) {
+					break;
+				}
+			}
+
+			if (arr == null) {
+				i++;
+				continue;
+			}
+
+			if (j > i + 1) {
+				double time = dep.seconds();
+				double diff = (arr.seconds() - time) / (j - i);
+
+				for (int k = i + 1; k < j; k++) {
+					TransitRouteStop stopToAdjust = stops.get(k);
+					int add = (int) (diff * (k - i));
+
+					TransitRouteStop newStop = f.createTransitRouteStop(
+						stopToAdjust.getStopFacility(),
+						add(stopToAdjust.getArrivalOffset(), add),
+						add(stopToAdjust.getDepartureOffset(), add)
+					);
+
+					newStop.setAwaitDepartureTime(stopToAdjust.isAwaitDepartureTime());
+					newStop.setAllowAlighting(stopToAdjust.isAllowAlighting());
+					newStop.setAllowBoarding(stopToAdjust.isAllowBoarding());
+
+					stops.set(k, newStop);
+					adjusted = true;
+				}
+			}
+
+			i = j;
+		}
+
+		if (adjusted)
+			return stops;
+
+		return null;
+	}
+}

--- a/contribs/application/src/main/java/org/matsim/application/prepare/pt/CreateTransitScheduleFromGtfs.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/pt/CreateTransitScheduleFromGtfs.java
@@ -1,5 +1,6 @@
 package org.matsim.application.prepare.pt;
 
+import com.conveyal.gtfs.model.Route;
 import com.conveyal.gtfs.model.Stop;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.logging.log4j.LogManager;
@@ -35,6 +36,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 
@@ -76,6 +78,15 @@ public class CreateTransitScheduleFromGtfs implements MATSimAppCommand {
 
 	@CommandLine.Option(names = "--include-stops", description = "Fully qualified class name to a Predicate<Stop> for filtering certain stops")
 	private Class<?> includeStops;
+
+	@CommandLine.Option(names = "--transform-stops", description = "Fully qualified class name to a Consumer<Stop> for transforming stops before usage")
+	private Class<?> transformStops;
+
+	@CommandLine.Option(names = "--transform-routes", description = "Fully qualified class name to a Consumer<Route> for transforming routes before usage")
+	private Class<?> transformRoutes;
+
+	@CommandLine.Option(names = "--transform-routes", description = "Fully qualified class name to a Consumer<TransitSchedule> to be executed after the schedule was created", arity = "0..*", split = ",")
+	private List<Class<?>> transformSchedule;
 
 	@CommandLine.Option(names = "--merge-stops", description = "Whether stops should be merged by coordinate")
 	private boolean mergeStops;
@@ -134,6 +145,15 @@ public class CreateTransitScheduleFromGtfs implements MATSimAppCommand {
 				log.info("Using prefix: {}", prefix);
 			}
 
+			if (transformStops != null) {
+				converter.setTransformStop(createConsumer(transformStops, Stop.class));
+			}
+
+			if (transformRoutes != null) {
+				converter.setTransformRoute(createConsumer(transformRoutes, Route.class));
+			}
+
+
 			converter.build().convert();
 			i++;
 		}
@@ -144,6 +164,14 @@ public class CreateTransitScheduleFromGtfs implements MATSimAppCommand {
 			TransitSchedulePostProcessTools.copyEarlyDeparturesToFollowingNight(scenario.getTransitSchedule(), 6 * 3600, "copied");
 		}
 
+		if (transformSchedule != null && !transformSchedule.isEmpty()) {
+			for (Class<?> c : transformSchedule) {
+				Consumer<TransitSchedule> f = createConsumer(c, TransitSchedule.class);
+				log.info("Applying {} to created schedule", c.getName());
+				f.accept(scenario.getTransitSchedule());
+			}
+		}
+
 		Network network = NetworkUtils.readNetwork(networkFile);
 
 		Scenario ptScenario = getScenarioWithPseudoPtNetworkAndTransitVehicles(network, scenario.getTransitSchedule(), "pt_");
@@ -151,11 +179,14 @@ public class CreateTransitScheduleFromGtfs implements MATSimAppCommand {
 		if (validate) {
 			//Check schedule and network
 			TransitScheduleValidator.ValidationResult checkResult = TransitScheduleValidator.validateAll(ptScenario.getTransitSchedule(), ptScenario.getNetwork());
+			List<String> warnings = checkResult.getWarnings();
+			if (!warnings.isEmpty())
+				log.warn("TransitScheduleValidator warnings: {}", String.join("\n", warnings));
+
 			if (checkResult.isValid()) {
 				log.info("TransitSchedule and Network valid according to TransitScheduleValidator");
-				log.warn("TransitScheduleValidator warnings: {}", checkResult.getWarnings());
 			} else {
-				log.error(checkResult.getErrors());
+				log.error("TransitScheduleValidator errors: {}", String.join("\n", checkResult.getErrors()));
 				throw new RuntimeException("TransitSchedule and/or Network invalid");
 			}
 		}
@@ -170,6 +201,12 @@ public class CreateTransitScheduleFromGtfs implements MATSimAppCommand {
 		return 0;
 	}
 
+	@SuppressWarnings({"unchecked", "unused"})
+	private <T> Consumer<T> createConsumer(Class<?> consumer, Class<T> type) throws ReflectiveOperationException {
+		return (Consumer<T>) consumer.getDeclaredConstructor().newInstance();
+	}
+
+	@SuppressWarnings("unchecked")
 	private Predicate<Stop> createFilter(int i) throws Exception {
 
 		Predicate<Stop> filter = (stop) -> true;

--- a/contribs/application/src/main/java/org/matsim/application/prepare/pt/CreateTransitScheduleFromGtfs.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/pt/CreateTransitScheduleFromGtfs.java
@@ -85,7 +85,7 @@ public class CreateTransitScheduleFromGtfs implements MATSimAppCommand {
 	@CommandLine.Option(names = "--transform-routes", description = "Fully qualified class name to a Consumer<Route> for transforming routes before usage")
 	private Class<?> transformRoutes;
 
-	@CommandLine.Option(names = "--transform-routes", description = "Fully qualified class name to a Consumer<TransitSchedule> to be executed after the schedule was created", arity = "0..*", split = ",")
+	@CommandLine.Option(names = "--transform-schedule", description = "Fully qualified class name to a Consumer<TransitSchedule> to be executed after the schedule was created", arity = "0..*", split = ",")
 	private List<Class<?>> transformSchedule;
 
 	@CommandLine.Option(names = "--merge-stops", description = "Whether stops should be merged by coordinate")

--- a/contribs/application/src/main/java/org/matsim/application/prepare/pt/CreateTransitScheduleFromGtfs.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/pt/CreateTransitScheduleFromGtfs.java
@@ -32,10 +32,7 @@ import picocli.CommandLine;
 import java.io.File;
 import java.nio.file.Path;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -169,6 +166,16 @@ public class CreateTransitScheduleFromGtfs implements MATSimAppCommand {
 				Consumer<TransitSchedule> f = createConsumer(c, TransitSchedule.class);
 				log.info("Applying {} to created schedule", c.getName());
 				f.accept(scenario.getTransitSchedule());
+			}
+		}
+
+		for (TransitLine line : scenario.getTransitSchedule().getTransitLines().values()) {
+			List<TransitRoute> routes = new ArrayList<>(line.getRoutes().values());
+			for (TransitRoute route : routes) {
+				if (route.getDepartures().isEmpty()) {
+					log.warn("Route {} in line {} with no departures removed.", route.getId(), line.getId());
+					line.removeRoute(route);
+				}
 			}
 		}
 

--- a/matsim/src/main/java/org/matsim/pt/utils/TransitScheduleValidator.java
+++ b/matsim/src/main/java/org/matsim/pt/utils/TransitScheduleValidator.java
@@ -325,7 +325,7 @@ public abstract class TransitScheduleValidator {
 						}
 
 						// Some hard coded rules to detect suspicious stops, these are speed m/s, so quite high values
-						if (((toStop > 3 * mean && both > 30) || toStop > 120) && (((fromStop > 3 * mean && both > 30) || fromStop > 120))) {
+						if (((toStop > 3 * mean && both > 50) || toStop > 120) && (((fromStop > 3 * mean && both > 50) || fromStop > 120))) {
 							DoubleList suspiciousSpeeds = suspiciousStops.computeIfAbsent(stop.getStopFacility(), (k) -> new DoubleArrayList());
 							suspiciousSpeeds.add(toStop);
 							suspiciousSpeeds.add(fromStop);

--- a/matsim/src/main/java/org/matsim/pt/utils/TransitScheduleValidator.java
+++ b/matsim/src/main/java/org/matsim/pt/utils/TransitScheduleValidator.java
@@ -239,6 +239,19 @@ public abstract class TransitScheduleValidator {
 		return result;
 	}
 
+	public static ValidationResult validateDepartures(TransitSchedule schedule) {
+		ValidationResult result = new ValidationResult();
+		for (TransitLine line : schedule.getTransitLines().values()) {
+			for (TransitRoute route : line.getRoutes().values()) {
+				if (route.getDepartures().isEmpty())
+					result.addError("No departures defined for line %s, route %s".formatted(line.getId(), route.getId()));
+
+			}
+		}
+
+		return result;
+	}
+
 	/**
 	 * Validate if coordinates of stops and given travel times are plausible.
 	 */
@@ -367,6 +380,7 @@ public abstract class TransitScheduleValidator {
 		v.add(validateOffsets(schedule));
 		v.add(validateTransfers(schedule));
 		v.add(validateStopCoordinates(schedule));
+		v.add(validateDepartures(schedule));
 		return v;
 	}
 


### PR DESCRIPTION
This PR extends the existing `TransitScheduleValidator` with a few more plausibility checks:
- Every route should have a departure (will result in exception when running the simulation, otherwise)
- Validate travel times between stops. If there are unrealistic high speeds, stops are probably mapped to the wrong location.

Also, the `CreateTransitScheduleFromGtfs` cli was extended to allow incorporating external classes to fix such issues in the input data.
 
Added utility class that can fix issues in the schedule where multiple stops have the same arrival and departure times