### PR TITLE
Avoid creating unnecessary travel time calculators

### DIFF
--- a/matsim/src/test/java/org/matsim/core/router/NetworkRoutingInclAccessEgressModuleTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/NetworkRoutingInclAccessEgressModuleTest.java
@@ -189,6 +189,7 @@ public class NetworkRoutingInclAccessEgressModuleTest {
         config.qsim().setVehiclesSource(QSimConfigGroup.VehiclesSource.modeVehicleTypesFromVehiclesData);
         config.qsim().setMainModes(modes);
         config.routing().setNetworkModes(modes);
+		config.travelTimeCalculator().setAnalyzedModes(new HashSet<>(modes));
         ScoringConfigGroup scoring = config.scoring();
 
         ScoringConfigGroup.ModeParams slowParams = new ScoringConfigGroup.ModeParams(SLOW_MODE);

--- a/matsim/src/test/java/org/matsim/core/trafficmonitoring/TravelTimeCalculatorModuleTest.java
+++ b/matsim/src/test/java/org/matsim/core/trafficmonitoring/TravelTimeCalculatorModuleTest.java
@@ -97,9 +97,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 	 void testOneTravelTimeCalculatorPerMode() {
 		Config config = ConfigUtils.createConfig();
 
-//		config.travelTimeCalculator().setAnalyzedModesAsString("car,bike" );
+		config.travelTimeCalculator().setAnalyzedModesAsString("car,bike");
 		config.routing().setNetworkModes( new LinkedHashSet<>( Arrays.asList( TransportMode.car, TransportMode.bike ) ) );
 		// (this is now newly taken from the router network modes. kai, feb'19)
+		 // analyzed modes still need to be set correctly now, because these two settings can differ  rakow, oct'24
 
 		config.travelTimeCalculator().setSeparateModes(true);
 		Scenario scenario = ScenarioUtils.createScenario(config);


### PR DESCRIPTION
During initialization, a `TravelTimeCalculator` is created for every network mode defined in the routing. However, not every of these modes are necessarily run on the network as well.  E.g. there could be routed only modes like, walk, bike, or ride that have a fixed travel time.
These will have a calculator installed that never does anything, but still takes up computing resources because it will process a lot of events.

In this PR the behavior is changed, so that a travel time calculator is only installed for analyzed modes, which can already be defined in the travel time config.


