### PR TITLE
Inline xml writing into Event class

### DIFF
--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/events/EmissionEvent.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/events/EmissionEvent.java
@@ -25,6 +25,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.events.Event;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.emissions.Pollutant;
+import org.matsim.core.utils.io.XmlUtils;
 import org.matsim.vehicles.Vehicle;
 
 import java.util.Map;
@@ -67,4 +68,20 @@ public abstract class EmissionEvent extends Event {
         }
         return attributes;
     }
+
+	@Override
+	public void writeAsXML(StringBuilder out) {
+		// Writes common attributes
+		writeXMLStart(out);
+
+		XmlUtils.writeEncodedAttributeKeyValue(out, ATTRIBUTE_LINK_ID, this.linkId.toString());
+		XmlUtils.writeEncodedAttributeKeyValue(out, ATTRIBUTE_VEHICLE_ID, this.vehicleId.toString());
+
+		for (Map.Entry<Pollutant, Double> entry : emissions.entrySet()) {
+			out.append(entry.getKey().name()).append("=\"");
+			out.append((double) entry.getValue()).append("\" ");
+		}
+
+		writeXMLEnd(out);
+	}
 }

--- a/matsim/src/main/java/org/matsim/api/core/v01/events/ActivityEndEvent.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/ActivityEndEvent.java
@@ -102,7 +102,6 @@ public final class ActivityEndEvent extends Event implements HasPersonId, HasLin
 	public void writeAsXML(StringBuilder out) {
 		// Writes common attributes
 		writeXMLStart(out);
-		out.append(ATTRIBUTE_ACTTYPE).append("=\"");
 		writeEncodedAttributeKeyValue(out, ATTRIBUTE_ACTTYPE, this.acttype);
 		writeXMLEnd(out);
 	}

--- a/matsim/src/main/java/org/matsim/api/core/v01/events/ActivityEndEvent.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/ActivityEndEvent.java
@@ -29,6 +29,8 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.facilities.ActivityFacility;
 
+import static org.matsim.core.utils.io.XmlUtils.writeEncodedAttributeKeyValue;
+
 public final class ActivityEndEvent extends Event implements HasPersonId, HasLinkId, HasFacilityId, BasicLocation {
 
 	public static final String EVENT_TYPE = "actend";
@@ -49,7 +51,7 @@ public final class ActivityEndEvent extends Event implements HasPersonId, HasLin
 		this( time, agentId, linkId, facilityId, acttype, null);
 	}
 	// this is the new constructor:
-	public ActivityEndEvent(final double time, final Id<Person> agentId, final Id<Link> linkId, 
+	public ActivityEndEvent(final double time, final Id<Person> agentId, final Id<Link> linkId,
 			final Id<ActivityFacility> facilityId, final String acttype, final Coord coord) {
 		super(time);
 		this.linkId = linkId;
@@ -79,7 +81,7 @@ public final class ActivityEndEvent extends Event implements HasPersonId, HasLin
 	@Override public Id<Person> getPersonId() {
 		return this.personId;
 	}
-	
+
 	@Override
 	public Map<String, String> getAttributes() {
 		Map<String, String> attr = super.getAttributes();
@@ -94,5 +96,14 @@ public final class ActivityEndEvent extends Event implements HasPersonId, HasLin
 	public void setCoord( Coord coord ) {
 		// yy  this is to retrofit the coordinate into existing events that don't have it.
 		this.coord = coord;
+	}
+
+	@Override
+	public void writeAsXML(StringBuilder out) {
+		// Writes common attributes
+		writeXMLStart(out);
+		out.append(ATTRIBUTE_ACTTYPE).append("=\"");
+		writeEncodedAttributeKeyValue(out, ATTRIBUTE_ACTTYPE, this.acttype);
+		writeXMLEnd(out);
 	}
 }

--- a/matsim/src/main/java/org/matsim/api/core/v01/events/ActivityStartEvent.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/ActivityStartEvent.java
@@ -20,14 +20,16 @@
 
 package org.matsim.api.core.v01.events;
 
-import java.util.Map;
-
 import org.matsim.api.core.v01.BasicLocation;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.facilities.ActivityFacility;
+
+import java.util.Map;
+
+import static org.matsim.core.utils.io.XmlUtils.writeEncodedAttributeKeyValue;
 
 public class ActivityStartEvent extends Event implements HasFacilityId, HasPersonId, HasLinkId, BasicLocation{
 
@@ -91,7 +93,7 @@ public class ActivityStartEvent extends Event implements HasFacilityId, HasPerso
 	@Override public Id<Person> getPersonId() {
 		return this.personId;
 	}
-	
+
 	@Override
 	public Map<String, String> getAttributes() {
 		Map<String, String> attr = super.getAttributes();
@@ -108,5 +110,13 @@ public class ActivityStartEvent extends Event implements HasFacilityId, HasPerso
 	public void setCoord( Coord coord ) {
 		// yy  this is to retrofit the coordinate into existing events that don't have it.  :-(  kai, mar'20
 		this.coord = coord;
+	}
+
+	@Override
+	public void writeAsXML(StringBuilder out) {
+		// Writes common attributes
+		writeXMLStart(out);
+		writeEncodedAttributeKeyValue(out, ATTRIBUTE_ACTTYPE, this.acttype);
+		writeXMLEnd(out);
 	}
 }

--- a/matsim/src/main/java/org/matsim/api/core/v01/events/Event.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/Event.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.matsim.api.core.v01.BasicLocation;
+import org.matsim.core.utils.io.XmlUtils;
 
 public abstract class Event {
 
@@ -105,6 +106,26 @@ public abstract class Event {
 	public int hashCode() {
 		return getAttributes().hashCode(); // Two equal events must at least have the same attributes, so they will get the same hashCode like this.
 	}
+
+	/**
+	 * Write a xml representation of this event to the given writer.
+	 * The implementation must write the whole xml element <event ... />. Starting with \t and adding a newline at the end.
+	 *
+	 * The provided default implementation writes the whole element based on {@link #getAttributes()}. This is slow and should be overridden.
+	 * The overriding implementation must *not* call the super method.
+	 */
+	public void writeAsXML(StringBuilder out) {
+		out.append("\t<event ");
+		Map<String, String> attr = getAttributes();
+		for (Map.Entry<String, String> entry : attr.entrySet()) {
+			out.append(entry.getKey());
+			out.append("=\"");
+			out.append(XmlUtils.encodeAttributeValue(entry.getValue()));
+			out.append("\" ");
+		}
+		out.append(" />\n");
+	}
+
 }
 
 

--- a/matsim/src/main/java/org/matsim/api/core/v01/events/Event.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/Event.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import org.matsim.api.core.v01.BasicLocation;
 import org.matsim.core.utils.io.XmlUtils;
 
+import static org.matsim.core.utils.io.XmlUtils.writeEncodedAttributeValue;
+
 public abstract class Event {
 
 	public final static String ATTRIBUTE_TIME = "time";
@@ -105,6 +107,49 @@ public abstract class Event {
 	@Override
 	public int hashCode() {
 		return getAttributes().hashCode(); // Two equal events must at least have the same attributes, so they will get the same hashCode like this.
+	}
+
+
+	/**
+	 * Write the start of the xml representation and some common attributes. This method should be called first by {@link #writeAsXML(StringBuilder)}.
+	 */
+	protected final void writeXMLStart(StringBuilder out) {
+		out.append("\t<event time=\"").append(time).append("\" type=\"");
+		writeEncodedAttributeValue(out, getEventType()).append("\" ");
+
+		if (this instanceof HasPersonId hasPersonId && hasPersonId.getPersonId() != null) {
+			out.append("person=\"");
+			writeEncodedAttributeValue(out, hasPersonId.getPersonId().toString()).append("\" ");
+		}
+
+		if (this instanceof HasFacilityId hasFacilityId && hasFacilityId.getFacilityId() != null) {
+			out.append("facility=\"");
+			writeEncodedAttributeValue(out, hasFacilityId.getFacilityId().toString()).append("\" ");
+		}
+
+		if (this instanceof HasLinkId hasLinkId && hasLinkId.getLinkId() != null) {
+			out.append("link=\"");
+			writeEncodedAttributeValue(out, hasLinkId.getLinkId().toString()).append("\" ");
+		}
+
+		if (this instanceof BasicLocation basicLocation && basicLocation.getCoord() != null) {
+			if (basicLocation.getCoord() != null) {
+				out.append("x=\"").append(basicLocation.getCoord().getX()).append("\" ");
+				out.append("y=\"").append(basicLocation.getCoord().getY()).append("\" ");
+			}
+		}
+
+		if (this instanceof HasVehicleId hasVehicleId && hasVehicleId.getVehicleId() != null) {
+			out.append("vehicle=\"");
+			writeEncodedAttributeValue(out, hasVehicleId.getVehicleId().toString()).append("\" ");
+		}
+	}
+
+	/**
+	 * Write the closing part of the xml tag.
+	 */
+	protected final void writeXMLEnd(StringBuilder out) {
+		out.append(" />\n");
 	}
 
 	/**

--- a/matsim/src/main/java/org/matsim/api/core/v01/events/LinkEnterEvent.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/LinkEnterEvent.java
@@ -76,7 +76,7 @@ public class LinkEnterEvent extends Event implements HasLinkId, HasVehicleId {
 
 	@Override
 	public void writeAsXML(StringBuilder out) {
-		// All common attributes
+		// Writes all common attributes
 		writeXMLStart(out);
 		writeXMLEnd(out);
 	}

--- a/matsim/src/main/java/org/matsim/api/core/v01/events/LinkEnterEvent.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/LinkEnterEvent.java
@@ -73,4 +73,11 @@ public class LinkEnterEvent extends Event implements HasLinkId, HasVehicleId {
 		// linkId, vehicleId handled by superclass
 		return atts;
 	}
+
+	@Override
+	public void writeAsXML(StringBuilder out) {
+		// All common attributes
+		writeXMLStart(out);
+		writeXMLEnd(out);
+	}
 }

--- a/matsim/src/main/java/org/matsim/api/core/v01/events/LinkLeaveEvent.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/LinkLeaveEvent.java
@@ -79,7 +79,7 @@ public class LinkLeaveEvent extends Event implements HasLinkId, HasVehicleId {
 
 	@Override
 	public void writeAsXML(StringBuilder out) {
-		// All common attributes
+		// Writes all common attributes
 		writeXMLStart(out);
 		writeXMLEnd(out);
 	}

--- a/matsim/src/main/java/org/matsim/api/core/v01/events/LinkLeaveEvent.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/LinkLeaveEvent.java
@@ -76,4 +76,11 @@ public class LinkLeaveEvent extends Event implements HasLinkId, HasVehicleId {
 		// linkId, vehicleId handled by superclass
 		return atts;
 	}
+
+	@Override
+	public void writeAsXML(StringBuilder out) {
+		// All common attributes
+		writeXMLStart(out);
+		writeXMLEnd(out);
+	}
 }

--- a/matsim/src/main/java/org/matsim/api/core/v01/events/PersonArrivalEvent.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/PersonArrivalEvent.java
@@ -76,7 +76,7 @@ public class PersonArrivalEvent extends Event implements HasPersonId, HasLinkId 
 
 	@Override
 	public void writeAsXML(StringBuilder out) {
-		// All common attributes
+		// Writes all common attributes
 		writeXMLStart(out);
 		if (this.legMode != null) {
 			writeEncodedAttributeKeyValue(out, ATTRIBUTE_LEGMODE, this.legMode);

--- a/matsim/src/main/java/org/matsim/api/core/v01/events/PersonArrivalEvent.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/PersonArrivalEvent.java
@@ -26,6 +26,8 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
 
+import static org.matsim.core.utils.io.XmlUtils.writeEncodedAttributeKeyValue;
+
 public class PersonArrivalEvent extends Event implements HasPersonId, HasLinkId {
 
 	public static final String EVENT_TYPE = "arrival";
@@ -70,5 +72,15 @@ public class PersonArrivalEvent extends Event implements HasPersonId, HasLinkId 
 			attr.put(ATTRIBUTE_LEGMODE, this.legMode);
 		}
 		return attr;
+	}
+
+	@Override
+	public void writeAsXML(StringBuilder out) {
+		// All common attributes
+		writeXMLStart(out);
+		if (this.legMode != null) {
+			writeEncodedAttributeKeyValue(out, ATTRIBUTE_LEGMODE, this.legMode);
+		}
+		writeXMLEnd(out);
 	}
 }

--- a/matsim/src/main/java/org/matsim/api/core/v01/events/PersonDepartureEvent.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/PersonDepartureEvent.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
+import org.matsim.core.utils.io.XmlUtils;
 
 public class PersonDepartureEvent extends Event implements HasPersonId, HasLinkId {
 
@@ -81,5 +82,17 @@ public class PersonDepartureEvent extends Event implements HasPersonId, HasLinkI
 			attr.put(ATTRIBUTE_ROUTING_MODE, this.routingMode);
 		}
 		return attr;
+	}
+
+	@Override
+	public void writeAsXML(StringBuilder out) {
+		writeXMLStart(out);
+		if (this.legMode != null) {
+			XmlUtils.writeEncodedAttributeKeyValue(out, ATTRIBUTE_LEGMODE, this.legMode);
+		}
+		if (this.routingMode != null) {
+			XmlUtils.writeEncodedAttributeKeyValue(out, ATTRIBUTE_ROUTING_MODE, this.routingMode);
+		}
+		writeXMLEnd(out);
 	}
 }

--- a/matsim/src/main/java/org/matsim/api/core/v01/events/PersonEntersVehicleEvent.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/PersonEntersVehicleEvent.java
@@ -68,4 +68,11 @@ public class PersonEntersVehicleEvent extends Event implements HasPersonId, HasV
 		// personId, vehicleId handled by superclass
 		return atts;
 	}
+
+	@Override
+	public void writeAsXML(StringBuilder out) {
+		// Writes all common attributes
+		writeXMLStart(out);
+		writeXMLEnd(out);
+	}
 }

--- a/matsim/src/main/java/org/matsim/api/core/v01/events/PersonLeavesVehicleEvent.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/PersonLeavesVehicleEvent.java
@@ -69,4 +69,11 @@ public class PersonLeavesVehicleEvent extends Event implements HasPersonId, HasV
 		// personId, vehicleId handled by superclass
 		return attrs;
 	}
+
+	@Override
+	public void writeAsXML(StringBuilder out) {
+		// Writes all common attributes
+		writeXMLStart(out);
+		writeXMLEnd(out);
+	}
 }

--- a/matsim/src/main/java/org/matsim/api/core/v01/events/PersonMoneyEvent.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/PersonMoneyEvent.java
@@ -25,6 +25,8 @@ import org.matsim.api.core.v01.population.Person;
 
 import java.util.Map;
 
+import static org.matsim.core.utils.io.XmlUtils.writeEncodedAttributeKeyValue;
+
 /**
  * This event specifies that an agent has gained (or paid) some money.
  * Scoring functions should handle these Events by adding the amount somehow
@@ -133,5 +135,24 @@ public final class PersonMoneyEvent extends Event implements HasPersonId {
 			attr.put(ATTRIBUTE_REFERENCE, this.reference);
 		}
 		return attr;
+	}
+
+	@Override
+	public void writeAsXML(StringBuilder out) {
+		// Writes all common attributes
+		writeXMLStart(out);
+
+		out.append("amount=\"").append(this.amount).append("\" ");
+		if (this.purpose != null) {
+			writeEncodedAttributeKeyValue(out, ATTRIBUTE_PURPOSE, this.purpose);
+		}
+		if (this.transactionPartner != null) {
+			writeEncodedAttributeKeyValue(out, ATTRIBUTE_TRANSACTION_PARTNER, this.transactionPartner);
+		}
+		if (this.reference != null) {
+			writeEncodedAttributeKeyValue(out, ATTRIBUTE_REFERENCE, this.reference);
+		}
+
+		writeXMLEnd(out);
 	}
 }

--- a/matsim/src/main/java/org/matsim/api/core/v01/events/PersonScoreEvent.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/PersonScoreEvent.java
@@ -20,6 +20,7 @@ package org.matsim.api.core.v01.events;
 
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.population.Person;
+import org.matsim.core.utils.io.XmlUtils;
 
 import java.util.Map;
 
@@ -74,5 +75,15 @@ public class PersonScoreEvent extends Event implements HasPersonId {
 			attr.put(ATTRIBUTE_KIND, this.kind);
 		}
 		return attr;
+	}
+
+	@Override
+	public void writeAsXML(StringBuilder out) {
+		writeXMLStart(out);
+		out.append("amount=\"").append(this.amount).append("\" ");
+		if (this.kind != null) {
+			XmlUtils.writeEncodedAttributeKeyValue(out, ATTRIBUTE_KIND, this.kind);
+		}
+		writeXMLEnd(out);
 	}
 }

--- a/matsim/src/main/java/org/matsim/api/core/v01/events/PersonStuckEvent.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/PersonStuckEvent.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
+import org.matsim.core.utils.io.XmlUtils;
 
 public class PersonStuckEvent extends Event implements HasPersonId, HasLinkId {
 
@@ -70,5 +71,17 @@ public class PersonStuckEvent extends Event implements HasPersonId, HasLinkId {
 			attr.put(ATTRIBUTE_LEGMODE, this.legMode);
 		}
 		return attr;
+	}
+
+	@Override
+	public void writeAsXML(StringBuilder out) {
+		// Writes all common attributes
+		writeXMLStart(out);
+
+		if (this.legMode != null) {
+			XmlUtils.writeEncodedAttributeKeyValue(out, ATTRIBUTE_LEGMODE, this.legMode);
+		}
+
+		writeXMLEnd(out);
 	}
 }

--- a/matsim/src/main/java/org/matsim/api/core/v01/events/TransitDriverStartsEvent.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/TransitDriverStartsEvent.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.population.Person;
+import org.matsim.core.utils.io.XmlUtils;
 import org.matsim.pt.transitSchedule.api.Departure;
 import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
@@ -45,7 +46,7 @@ public class TransitDriverStartsEvent extends Event {
 	private final Id<TransitLine> transitLineId;
 	private final Id<Departure> departureId;
 
-	public TransitDriverStartsEvent(final double time, final Id<Person> driverId, final Id<Vehicle> vehicleId, 
+	public TransitDriverStartsEvent(final double time, final Id<Person> driverId, final Id<Vehicle> vehicleId,
 			final Id<TransitLine> transitLineId, final Id<TransitRoute> transitRouteId, final Id<Departure> departureId) {
 		super(time);
 		this.driverId = driverId;
@@ -54,23 +55,23 @@ public class TransitDriverStartsEvent extends Event {
 		this.transitLineId = transitLineId;
 		this.departureId = departureId;
 	}
-	
+
 	public Id<Person> getDriverId() {
 		return driverId;
 	}
-	
+
 	public Id<Vehicle> getVehicleId() {
 		return vehicleId;
 	}
-	
+
 	public Id<TransitRoute> getTransitRouteId() {
 		return transitRouteId;
 	}
-	
+
 	public Id<TransitLine> getTransitLineId() {
 		return transitLineId;
 	}
-	
+
 	public Id<Departure> getDepartureId() {
 		return departureId;
 	}
@@ -79,7 +80,7 @@ public class TransitDriverStartsEvent extends Event {
 	public String getEventType() {
 		return EVENT_TYPE;
 	}
-	
+
 	@Override
 	public Map<String, String> getAttributes() {
 		Map<String, String> atts = super.getAttributes();
@@ -89,5 +90,18 @@ public class TransitDriverStartsEvent extends Event {
 		atts.put(ATTRIBUTE_TRANSIT_ROUTE_ID, this.getTransitRouteId().toString());
 		atts.put(ATTRIBUTE_DEPARTURE_ID, this.getDepartureId().toString());
 		return atts;
+	}
+
+	@Override
+	public void writeAsXML(StringBuilder out) {
+		writeXMLStart(out);
+
+		XmlUtils.writeEncodedAttributeKeyValue(out, ATTRIBUTE_DRIVER_ID, this.getDriverId().toString());
+		XmlUtils.writeEncodedAttributeKeyValue(out, ATTRIBUTE_VEHICLE_ID, this.getVehicleId().toString());
+		XmlUtils.writeEncodedAttributeKeyValue(out, ATTRIBUTE_TRANSIT_LINE_ID, this.getTransitLineId().toString());
+		XmlUtils.writeEncodedAttributeKeyValue(out, ATTRIBUTE_TRANSIT_ROUTE_ID, this.getTransitRouteId().toString());
+		XmlUtils.writeEncodedAttributeKeyValue(out, ATTRIBUTE_DEPARTURE_ID, this.getDepartureId().toString());
+
+		writeXMLEnd(out);
 	}
 }

--- a/matsim/src/main/java/org/matsim/api/core/v01/events/VehicleAbortsEvent.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/VehicleAbortsEvent.java
@@ -61,4 +61,10 @@ public class VehicleAbortsEvent extends Event implements  HasLinkId, HasVehicleI
 		// linkId, vehicleId handled by superclass
 		return atts;
 	}
+
+	@Override
+	public void writeAsXML(StringBuilder out) {
+		writeXMLStart(out);
+		writeXMLEnd(out);
+	}
 }

--- a/matsim/src/main/java/org/matsim/core/utils/io/XmlUtils.java
+++ b/matsim/src/main/java/org/matsim/core/utils/io/XmlUtils.java
@@ -82,6 +82,45 @@ public final class XmlUtils {
 		return attributeValue;
 	}
 
+	/**
+	 * Write encoded attribute value to the given StringBuilder.
+	 * This is an optimized version of {@link #encodeAttributeValue(String)}, which does not create any intermediate objects.
+	 */
+	public static StringBuilder writeEncodedAttributeValue(StringBuilder out, String attributeValue) {
+
+		if (attributeValue == null) {
+			// By convention, null values are written as "null" in the xml output.
+			out.append("null");
+			return out;
+		}
+
+		int len = attributeValue.length();
+
+		for (int pos = 0; pos < len; pos++) {
+			char ch = attributeValue.charAt(pos);
+			switch (ch) {
+				case '<' -> out.append("&lt;");
+				case '>' -> out.append("&gt;");
+				case '\"' -> out.append("&quot;");
+				case '&' -> out.append("&amp;");
+				default -> out.append(ch);
+			};
+		}
+
+		return out;
+	}
+
+	/**
+	 * Helper function to write an attribute key-value pair to the given StringBuilder.
+	 * Note, do not use this for primitive types as these don't need to be encoded and the {@link StringBuilder} has specialized methods fot these.
+	 */
+	public static StringBuilder writeEncodedAttributeKeyValue(StringBuilder out, String key, String value) {
+		out.append(key).append("=\"");
+		writeEncodedAttributeValue(out, value);
+		out.append("\" ");
+		return out;
+	}
+
 	public static String encodeContent(final String content) {
 		if (content.contains("&") || content.contains("<") || content.contains(">")) {
 			return content.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");

--- a/matsim/src/main/java/org/matsim/core/utils/io/XmlUtils.java
+++ b/matsim/src/main/java/org/matsim/core/utils/io/XmlUtils.java
@@ -39,8 +39,45 @@ public final class XmlUtils {
 	 * @return String with some characters replaced by their xml-encoding.
 	 */
 	public static String encodeAttributeValue(final String attributeValue) {
-		if (attributeValue.contains("&") || attributeValue.contains("\"") || attributeValue.contains("<") || attributeValue.contains(">")) {
-			return attributeValue.replace("&", "&amp;").replace("\"", "&quot;").replace("<", "&lt;").replace(">", "&gt;");
+		if (attributeValue == null) {
+			return null;
+		}
+		int len = attributeValue.length();
+		boolean encode = false;
+		for (int pos = 0; pos < len; pos++) {
+			char ch = attributeValue.charAt(pos);
+			if (ch == '<') {
+				encode = true;
+				break;
+			} else if (ch == '>') {
+				encode = true;
+				break;
+			} else if (ch == '\"') {
+				encode = true;
+				break;
+			} else if (ch == '&') {
+				encode = true;
+				break;
+			}
+		}
+		if (encode) {
+			StringBuilder bf = new StringBuilder(attributeValue.length() + 30);
+			for (int pos = 0; pos < len; pos++) {
+				char ch = attributeValue.charAt(pos);
+				if (ch == '<') {
+					bf.append("&lt;");
+				} else if (ch == '>') {
+					bf.append("&gt;");
+				} else if (ch == '\"') {
+					bf.append("&quot;");
+				} else if (ch == '&') {
+					bf.append("&amp;");
+				} else {
+					bf.append(ch);
+				}
+			}
+
+			return bf.toString();
 		}
 		return attributeValue;
 	}


### PR DESCRIPTION
The current XML event writer is **very** inefficient.  For every event that needs to be written:
- A map is created
- Attributes put into the map and often converted to a new string object
- Every attribute will be XML encoded
  -  Which is not needed for primitives
  -  Creates a new string in case the attribute needs to be encoded
- Multiple calls to a BufferedWriter are made
  - Which is a synchronized data structure and not very efficient with a lot of invocations

This PR moves the serialization code to the events itself and makes use of a StringBuilder. 
Event classes are responsible to write their xml representation via `writeAsXML(StringBuilder out)` directly to the builder. Using this approach, not a single new object needs to be allocated for writing an event.

Events who don't overwrite this method will use the old behavior. The resulting output should be 100% identical. 
For now `writeAsXML` was implemented for the most often used events and more may be added in further PRs.

In a quick test on a realistic but not terrible large scenario, the mobsim was roughly speed up by 10%.
