### PR TITLE
Extend trip analysis

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/analysis/population/TripAnalysis.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/population/TripAnalysis.java
@@ -44,7 +44,8 @@ import static tech.tablesaw.aggregate.AggregateFunctions.count;
 	requires = {"trips.csv", "persons.csv"},
 	produces = {
 		"mode_share.csv", "mode_share_per_dist.csv", "mode_users.csv", "trip_stats.csv",
-		"mode_share_per_%s.csv", "population_trip_stats.csv", "trip_purposes_by_hour.csv",
+		"mode_share_per_%s.csv", "mode_share_per_purpose_per_%s.csv",
+		"population_trip_stats.csv", "trip_purposes_by_hour.csv",
 		"mode_share_distance_distribution.csv", "mode_shift.csv", "mode_chains.csv",
 		"mode_choices.csv", "mode_choice_evaluation.csv", "mode_choice_evaluation_per_mode.csv",
 		"mode_confusion_matrix.csv", "mode_prediction_error.csv"
@@ -284,7 +285,8 @@ public class TripAnalysis implements MATSimAppCommand {
 		writeModeShare(joined, labels);
 
 		if (groups != null) {
-			groups.analyzeModeShare(joined, labels, modeOrder, (g) -> output.getPath("mode_share_per_%s.csv", g));
+			groups.writeModeShare(joined, labels, modeOrder, (g) -> output.getPath("mode_share_per_%s.csv", g));
+			groups.writeModeSharePerPurpose(joined,modeOrder, (g) -> output.getPath("mode_share_per_purpose_per_%s.csv", g));
 		}
 
 		if (persons.containsColumn(ATTR_REF_MODES)) {

--- a/contribs/application/src/main/java/org/matsim/application/analysis/population/TripByGroupAnalysis.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/population/TripByGroupAnalysis.java
@@ -100,7 +100,7 @@ final class TripByGroupAnalysis {
 		}
 	}
 
-	void analyzeModeShare(Table trips, List<String> dists, List<String> modeOrder, Function<String, Path> output) {
+	void writeModeShare(Table trips, List<String> dists, List<String> modeOrder, Function<String, Path> output) {
 
 		for (Group group : groups) {
 
@@ -145,6 +145,12 @@ final class TripByGroupAnalysis {
 			String name = String.join("_", group.columns);
 			joined.write().csv(output.apply(name).toFile());
 		}
+	}
+
+	void writeModeSharePerPurpose(Table trips, List<String> modeOrder, Function<String, Path> output) {
+
+		// TODO: implement
+
 	}
 
 	void groupPersons(Table persons) {

--- a/contribs/application/src/main/java/org/matsim/application/analysis/population/TripByGroupAnalysis.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/population/TripByGroupAnalysis.java
@@ -147,12 +147,6 @@ final class TripByGroupAnalysis {
 		}
 	}
 
-	void writeModeSharePerPurpose(Table trips, List<String> modeOrder, Function<String, Path> output) {
-
-		// TODO: implement
-
-	}
-
 	void groupPersons(Table persons) {
 
 		for (Group g : groups) {

--- a/contribs/simwrapper/src/test/java/org/matsim/simwrapper/dashboard/DashboardTests.java
+++ b/contribs/simwrapper/src/test/java/org/matsim/simwrapper/dashboard/DashboardTests.java
@@ -76,6 +76,7 @@ public class DashboardTests {
 		Assertions.assertThat(out)
 			.isDirectoryContaining("glob:**trip_stats.csv")
 			.isDirectoryContaining("glob:**mode_share.csv")
+			.isDirectoryContaining("glob:**mode_share_per_purpose.csv")
 			.isDirectoryContaining("glob:**mode_shift.csv");
 	}
 


### PR DESCRIPTION
Add two additional outputs to the trip analysis:

- Mode chains, which collects all used main modes during the day, eg. walk-pt-bike
- Mode share by purpose (e.g. by work, leisure etc..)