### PR TITLE
Update VSP Consistency checker

### DIFF
--- a/matsim/src/main/java/org/matsim/core/config/consistency/VspConfigConsistencyCheckerImpl.java
+++ b/matsim/src/main/java/org/matsim/core/config/consistency/VspConfigConsistencyCheckerImpl.java
@@ -46,13 +46,7 @@ import java.util.Set;
  *
  */
 public final class VspConfigConsistencyCheckerImpl implements ConfigConsistencyChecker {
-	// yyyy TODOS:
 
-	// VSP now regularly uses marg utls of travelling != null to fit distance distributions.  There should be a switch to switch off the warnings.
-
-	// VSP says that people < 18J should not use car, and implements that via car availability.  How to handle that?
-
-	//
 	private static final  Logger log = LogManager.getLogger(VspConfigConsistencyCheckerImpl.class);
 
 	public VspConfigConsistencyCheckerImpl() {
@@ -96,10 +90,6 @@ public final class VspConfigConsistencyCheckerImpl implements ConfigConsistencyC
 
 		problem = checkLocationChoiceConfigGroup( config, problem );
 
-		// === mode choice:
-
-		problem = checkModeChoiceConfigGroup( config, lvl, problem );
-
 		// === planCalcScore:
 
 		problem = checkPlanCalcScoreConfigGroup( config, lvl, problem );
@@ -115,10 +105,6 @@ public final class VspConfigConsistencyCheckerImpl implements ConfigConsistencyC
 		// === qsim:
 
 		problem = checkQsimConfigGroup( config, lvl, problem );
-
-		// === subtour mode choice:
-
-		problem = checkSubtourModeChoiceConfigGroup( config, lvl, problem );
 
 		// === strategy:
 
@@ -157,20 +143,20 @@ public final class VspConfigConsistencyCheckerImpl implements ConfigConsistencyC
 		}
 
 	}
-	private boolean checkSubtourModeChoiceConfigGroup( Config config, Level lvl, boolean problem ){
-		if ( config.subtourModeChoice().considerCarAvailability() ) {
-//			problem = true;
-			log.log( lvl, "you are considering car abailability; vsp config is not doing that.   Instead, we are using a daily monetary constant for car.");
-		}
-		return problem;
-	}
-	private boolean checkModeChoiceConfigGroup( Config config, Level lvl, boolean problem ){
-		if ( !config.changeMode().getIgnoreCarAvailability() ) {
-//			problem = true;
-			log.log( lvl, "you are considering car abailability; vsp config is not doing that.   Instead, we are using a daily monetary constant for car.");
-		}
-		return problem;
-	}
+//	private boolean checkSubtourModeChoiceConfigGroup( Config config, Level lvl, boolean problem ){
+//		if ( config.subtourModeChoice().considerCarAvailability() ) {
+////			problem = true;
+//			log.log( lvl, "you are considering car abailability; vsp config is not doing that.   Instead, we are using a daily monetary constant for car.");
+//		}
+//		return problem;
+//	}
+//	private boolean checkModeChoiceConfigGroup( Config config, Level lvl, boolean problem ){
+//		if ( !config.changeMode().getIgnoreCarAvailability() ) {
+////			problem = true;
+//			log.log( lvl, "you are considering car abailability; vsp config is not doing that.   Instead, we are using a daily monetary constant for car.");
+//		}
+//		return problem;
+//	}
 	private static boolean checkGlobalConfigGroup( Config config, Level lvl, boolean problem ){
 		if ( config.global().isInsistingOnDeprecatedConfigVersion() ) {
 			problem = true ;
@@ -263,7 +249,7 @@ public final class VspConfigConsistencyCheckerImpl implements ConfigConsistencyC
 		if ( config.qsim().getVehiclesSource()==VehiclesSource.defaultVehicle ) {
 			log.log( lvl, "found qsim.vehiclesSource=defaultVehicle; vsp should use one of the other settings or talk to kai");
 		}
-		if ( config.qsim().getLinkDynamics() != QSimConfigGroup.LinkDynamics.PassingQ ) {
+		if ( config.qsim().getLinkDynamics() != QSimConfigGroup.LinkDynamics.PassingQ && config.qsim().getMainModes().contains(TransportMode.bike) ) {
 			log.log( lvl, "found qsim.linkDynamics=" + config.qsim().getLinkDynamics() + "; vsp should use PassingQ or talk to kai");
 		}
 
@@ -428,7 +414,7 @@ public final class VspConfigConsistencyCheckerImpl implements ConfigConsistencyC
 		// added may'23
 		for ( ModeParams params : config.scoring().getModes().values() ){
 			if ( config.vspExperimental().getCheckingOfMarginalUtilityOfTravellng()== CheckingOfMarginalUtilityOfTravellng.allZero ){
-				if( params.getMarginalUtilityOfTraveling() != 0. ){
+				if( params.getMarginalUtilityOfTraveling() != 0. && !params.getMode().equals( TransportMode.ride ) && !params.getMode().equals( TransportMode.bike ) ){
 					log.log( lvl, "You are setting the marginal utility of traveling with mode " + params.getMode() + " to " + params.getMarginalUtilityOfTraveling()
 								      + ". VSP standard is to set this to zero.  Please document carefully why you are using a value different from zero, e.g. by showing distance distributions." );
 				}


### PR DESCRIPTION
Some VSP consistency checks have been updated:
- Considering car availability does not produce a warning anymore
- Setting marginal utilities for bike and ride is now allowed 