### PR TITLE
Add more linktypes to the SUMO converter

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/prepare/network/params/ApplyNetworkParams.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/network/params/ApplyNetworkParams.java
@@ -257,7 +257,10 @@ public class ApplyNetworkParams implements MATSimAppCommand {
 			return false;
 
 		link.setFreespeed(freeSpeed);
-		link.getAttributes().putAttribute("speed_factor", freeSpeed);
+		link.getAttributes().putAttribute(
+			"speed_factor",
+			BigDecimal.valueOf(freeSpeed).setScale(5, RoundingMode.HALF_EVEN).doubleValue()
+		);
 
 		return modified;
 	}

--- a/contribs/emissions/src/main/java/org/matsim/contrib/emissions/OsmHbefaMapping.java
+++ b/contribs/emissions/src/main/java/org/matsim/contrib/emissions/OsmHbefaMapping.java
@@ -85,6 +85,8 @@ public class OsmHbefaMapping extends HbefaRoadTypeMapping {
         mapping.put("residential", new Hbefa("Access",30,50));
         mapping.put("service", new Hbefa("Access",30,50));
         mapping.put("living", new Hbefa("Access",30,50));
+        mapping.put("cycleway", new Hbefa("Access",30,50));
+        mapping.put("path", new Hbefa("Access",30,50));
 
         return mapping;
     }

--- a/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/LinkProperties.java
+++ b/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/LinkProperties.java
@@ -18,6 +18,7 @@ public class LinkProperties {
 	public static final int LEVEL_UNCLASSIFIED = 6;
 	public static final int LEVEL_RESIDENTIAL = 7;
 	public static final int LEVEL_LIVING_STREET = 8;
+	public static final int LEVEL_PATH = 9;
 
 	/**
 	 * Assume for links with max speed lower than 51km/h to be in urban areas.

--- a/contribs/sumo/src/main/java/org/matsim/contrib/sumo/SumoNetworkConverter.java
+++ b/contribs/sumo/src/main/java/org/matsim/contrib/sumo/SumoNetworkConverter.java
@@ -246,7 +246,11 @@ public class SumoNetworkConverter implements Callable<Integer> {
 		Map<String, LinkProperties> linkProperties = LinkProperties.createLinkProperties();
 
 		// add additional service tag
-		linkProperties.put(OsmTags.SERVICE, new LinkProperties(LinkProperties.LEVEL_LIVING_STREET, 1, 15 / 3.6, 450, false));
+		linkProperties.put(OsmTags.SERVICE, new LinkProperties(LinkProperties.LEVEL_PATH, 1, 15 / 3.6, 450, false));
+		linkProperties.put(OsmTags.PATH, new LinkProperties(LinkProperties.LEVEL_PATH, 1, 10 / 3.6, 300, false));
+
+		// This is for bikes
+		linkProperties.put(OsmTags.CYCLEWAY, new LinkProperties(LinkProperties.LEVEL_PATH, 1, 10 / 3.6, 50, false));
 
 		for (SumoNetworkHandler.Edge edge : sumoHandler.edges.values()) {
 

--- a/contribs/sumo/src/main/java/org/matsim/contrib/sumo/SumoNetworkConverter.java
+++ b/contribs/sumo/src/main/java/org/matsim/contrib/sumo/SumoNetworkConverter.java
@@ -247,10 +247,10 @@ public class SumoNetworkConverter implements Callable<Integer> {
 
 		// add additional service tag
 		linkProperties.put(OsmTags.SERVICE, new LinkProperties(LinkProperties.LEVEL_PATH, 1, 15 / 3.6, 450, false));
-		linkProperties.put(OsmTags.PATH, new LinkProperties(LinkProperties.LEVEL_PATH, 1, 10 / 3.6, 300, false));
+		linkProperties.put(OsmTags.PATH, new LinkProperties(LinkProperties.LEVEL_PATH, 1, 15 / 3.6, 300, false));
 
 		// This is for bikes
-		linkProperties.put(OsmTags.CYCLEWAY, new LinkProperties(LinkProperties.LEVEL_PATH, 1, 10 / 3.6, 50, false));
+		linkProperties.put(OsmTags.CYCLEWAY, new LinkProperties(LinkProperties.LEVEL_PATH, 1, 15 / 3.6, 300, false));
 
 		for (SumoNetworkHandler.Edge edge : sumoHandler.edges.values()) {
 


### PR DESCRIPTION
The SUMO network converter now also recognizes service, path and cycleway links, which allows adding bike infrastructure if necessary.