### PR TITLE
Flush FacilitiesWriter only at the end to reduce Filesize

### DIFF
--- a/matsim/src/main/java/org/matsim/facilities/FacilitiesWriterV1.java
+++ b/matsim/src/main/java/org/matsim/facilities/FacilitiesWriterV1.java
@@ -99,7 +99,6 @@ class FacilitiesWriterV1 extends MatsimXmlWriter implements MatsimWriter {
             }
             this.attributesWriter.writeAttributes("\t\t", this.writer, f.getAttributes(), false);
             this.endFacility();
-            this.writer.flush();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/matsim/src/main/java/org/matsim/facilities/FacilitiesWriterV2.java
+++ b/matsim/src/main/java/org/matsim/facilities/FacilitiesWriterV2.java
@@ -99,7 +99,6 @@ class FacilitiesWriterV2 extends MatsimXmlWriter implements MatsimWriter {
             }
             this.attributesWriter.writeAttributes("\t\t", this.writer, f.getAttributes(), false);
             this.endFacility();
-            this.writer.flush();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
The FacilitiesWriter creates surprisingly large files when using ZST compression, because flush is called too early. This PR fixes the problem, analog to https://github.com/matsim-org/matsim-libs/issues/2764.