### PR TITLE
feat: make chargers attributable

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/infrastructure/Charger.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/infrastructure/Charger.java
@@ -24,8 +24,9 @@ import org.matsim.api.core.v01.BasicLocation;
 import org.matsim.api.core.v01.Identifiable;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.ev.charging.ChargingLogic;
+import org.matsim.utils.objectattributes.attributable.Attributable;
 
-public interface Charger extends BasicLocation, Identifiable<Charger> {
+public interface Charger extends BasicLocation, Identifiable<Charger>, Attributable {
 	ChargerSpecification getSpecification();
 
 	ChargingLogic getLogic();

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/infrastructure/ChargerDefaultImpl.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/infrastructure/ChargerDefaultImpl.java
@@ -26,6 +26,7 @@ import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.ev.charging.ChargingLogic;
+import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import com.google.common.base.Preconditions;
 
@@ -75,6 +76,11 @@ class ChargerDefaultImpl implements Charger {
 	@Override
 	public int getPlugCount() {
 		return specification.getPlugCount();
+	}
+
+	@Override
+	public Attributes getAttributes() {
+		return specification.getAttributes();
 	}
 
 	//TODO in order to add a separate coord: adapt DTD, ChargerSpecification and ChargerReader/Writer

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/infrastructure/ChargerSpecification.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/infrastructure/ChargerSpecification.java
@@ -23,6 +23,7 @@ package org.matsim.contrib.ev.infrastructure;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Identifiable;
 import org.matsim.api.core.v01.network.Link;
+import org.matsim.utils.objectattributes.attributable.Attributable;
 
 /**
  * ChargerSpecification is assumed to be immutable.
@@ -34,7 +35,7 @@ import org.matsim.api.core.v01.network.Link;
  *
  * @author Michal Maciejewski (michalm)
  */
-public interface ChargerSpecification extends Identifiable<Charger> {
+public interface ChargerSpecification extends Identifiable<Charger>, Attributable {
 	String DEFAULT_CHARGER_TYPE = "default";
 	int DEFAULT_PLUG_COUNT = 1;
 

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/infrastructure/ImmutableChargerSpecification.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/infrastructure/ImmutableChargerSpecification.java
@@ -24,6 +24,8 @@ import java.util.Objects;
 
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
+import org.matsim.utils.objectattributes.attributable.Attributes;
+import org.matsim.utils.objectattributes.attributable.AttributesImpl;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
@@ -39,6 +41,7 @@ public class ImmutableChargerSpecification implements ChargerSpecification {
 	private final String chargerType;
 	private final double plugPower;
 	private final int plugCount;
+	private final Attributes attributes;
 
 	private ImmutableChargerSpecification( ChargerSpecificationBuilder builder ) {
 		id = Objects.requireNonNull(builder.id);
@@ -46,6 +49,7 @@ public class ImmutableChargerSpecification implements ChargerSpecification {
 		chargerType = Objects.requireNonNull(builder.chargerType);
 		plugPower = Objects.requireNonNull(builder.plugPower);
 		plugCount = Objects.requireNonNull(builder.plugCount);
+		attributes = builder.attributes != null ? builder.attributes : new AttributesImpl();
 
 		Preconditions.checkArgument(plugPower >= 0, "Negative plugPower of charger: %s", id);
 		Preconditions.checkArgument(plugCount >= 0, "Negative plugCount of charger: %s", id);
@@ -91,6 +95,11 @@ public class ImmutableChargerSpecification implements ChargerSpecification {
 	}
 
 	@Override
+	public Attributes getAttributes() {
+		return attributes;
+	}
+
+	@Override
 	public String toString() {
 		return MoreObjects.toStringHelper(this)
 				.add("id", id)
@@ -107,6 +116,7 @@ public class ImmutableChargerSpecification implements ChargerSpecification {
 		private String chargerType;
 		private Double plugPower;
 		private Integer plugCount;
+		private Attributes attributes;
 
 		private ChargerSpecificationBuilder() {
 		}
@@ -133,6 +143,11 @@ public class ImmutableChargerSpecification implements ChargerSpecification {
 
 		public ChargerSpecificationBuilder plugCount( int val ) {
 			plugCount = val;
+			return this;
+		}
+
+		public ChargerSpecificationBuilder attributes( Attributes val ) {
+			attributes = val;
 			return this;
 		}
 

--- a/contribs/ev/src/test/java/org/matsim/contrib/ev/infrastructure/ChargerReaderWriterTest.java
+++ b/contribs/ev/src/test/java/org/matsim/contrib/ev/infrastructure/ChargerReaderWriterTest.java
@@ -1,0 +1,108 @@
+package org.matsim.contrib.ev.infrastructure;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.matsim.api.core.v01.Id;
+import org.matsim.testcases.MatsimTestUtils;
+import org.matsim.utils.objectattributes.attributable.AttributesImpl;
+
+public class ChargerReaderWriterTest {
+    @RegisterExtension
+    MatsimTestUtils utils = new MatsimTestUtils();
+
+    @Test
+    public void testReadWriteChargers() {
+        ChargingInfrastructureSpecificationDefaultImpl infrastructure = new ChargingInfrastructureSpecificationDefaultImpl();
+
+        infrastructure.addChargerSpecification(ImmutableChargerSpecification.newBuilder()
+                .id(Id.create("charger1", Charger.class)) //
+                .chargerType("type1") //
+                .linkId(Id.createLinkId("link1")) //
+                .plugCount(1) //
+                .plugPower(1000.0) //
+                .build());
+
+        infrastructure.addChargerSpecification(ImmutableChargerSpecification.newBuilder()
+                .id(Id.create("charger2", Charger.class)) //
+                .chargerType("type2") //
+                .linkId(Id.createLinkId("link2")) //
+                .plugCount(2) //
+                .plugPower(2000.0) //
+                .build());
+
+        String path = utils.getOutputDirectory() + "/chargers.xml";
+        new ChargerWriter(infrastructure.getChargerSpecifications().values().stream()).write(path);
+
+        ChargingInfrastructureSpecificationDefaultImpl readInfrastructure = new ChargingInfrastructureSpecificationDefaultImpl();
+        new ChargerReader(readInfrastructure).readFile(path);
+
+        ChargerSpecification spec1 = readInfrastructure.getChargerSpecifications()
+                .get(Id.create("charger1", Charger.class));
+        assertEquals("type1", spec1.getChargerType());
+        assertEquals(Id.createLinkId("link1"), spec1.getLinkId());
+        assertEquals(1, spec1.getPlugCount());
+        assertEquals(1000.0, spec1.getPlugPower());
+
+        ChargerSpecification spec2 = readInfrastructure.getChargerSpecifications()
+                .get(Id.create("charger2", Charger.class));
+        assertEquals("type2", spec2.getChargerType());
+        assertEquals(Id.createLinkId("link2"), spec2.getLinkId());
+        assertEquals(2, spec2.getPlugCount());
+        assertEquals(2000.0, spec2.getPlugPower());
+    }
+
+    @Test
+    public void testReadWriteChargersWithAttributes() {
+        ChargingInfrastructureSpecificationDefaultImpl infrastructure = new ChargingInfrastructureSpecificationDefaultImpl();
+
+        AttributesImpl attributes1 = new AttributesImpl();
+        attributes1.putAttribute("attribute1", "value1");
+
+        infrastructure.addChargerSpecification(ImmutableChargerSpecification.newBuilder()
+                .id(Id.create("charger1", Charger.class)) //
+                .chargerType("type1") //
+                .linkId(Id.createLinkId("link1")) //
+                .plugCount(1) //
+                .plugPower(1000.0) //
+                .attributes(attributes1) //
+                .build());
+
+        AttributesImpl attributes2 = new AttributesImpl();
+        attributes2.putAttribute("attribute2", "value2");
+
+        infrastructure.addChargerSpecification(ImmutableChargerSpecification.newBuilder()
+                .id(Id.create("charger2", Charger.class)) //
+                .chargerType("type2") //
+                .linkId(Id.createLinkId("link2")) //
+                .plugCount(2) //
+                .plugPower(2000.0) //
+                .attributes(attributes2) //
+                .build());
+
+        String path = utils.getOutputDirectory() + "/chargers_with_attributes.xml";
+        new ChargerWriter(infrastructure.getChargerSpecifications().values().stream()).write(path);
+
+        ChargingInfrastructureSpecificationDefaultImpl readInfrastructure = new ChargingInfrastructureSpecificationDefaultImpl();
+        new ChargerReader(readInfrastructure).readFile(path);
+
+        ChargerSpecification spec1 = readInfrastructure.getChargerSpecifications()
+                .get(Id.create("charger1", Charger.class));
+        assertEquals("type1", spec1.getChargerType());
+        assertEquals(Id.createLinkId("link1"), spec1.getLinkId());
+        assertEquals(1, spec1.getPlugCount());
+        assertEquals(1000.0, spec1.getPlugPower());
+
+        assertEquals("value1", (String) spec1.getAttributes().getAttribute("attribute1"));
+
+        ChargerSpecification spec2 = readInfrastructure.getChargerSpecifications()
+                .get(Id.create("charger2", Charger.class));
+        assertEquals("type2", spec2.getChargerType());
+        assertEquals(Id.createLinkId("link2"), spec2.getLinkId());
+        assertEquals(2, spec2.getPlugCount());
+        assertEquals(2000.0, spec2.getPlugPower());
+
+        assertEquals("value2", (String) spec2.getAttributes().getAttribute("attribute2"));
+    }
+}

--- a/matsim/src/main/resources/dtd/chargers_v1.dtd
+++ b/matsim/src/main/resources/dtd/chargers_v1.dtd
@@ -9,7 +9,7 @@
 
 <!ELEMENT chargers (charger)*>
 
-<!ELEMENT charger EMPTY>
+<!ELEMENT charger (attributes?)>
 
 <!-- link - id of the link where the charger is located -->
 <!-- plug_power - in kWh -->
@@ -21,3 +21,10 @@
 	plug_power CDATA #REQUIRED
 	plug_count CDATA #IMPLIED
 	type CDATA #IMPLIED >
+
+<!ELEMENT attributes (attribute*)>
+
+<!ELEMENT attribute ANY>
+<!ATTLIST attribute
+	name CDATA #REQUIRED
+	class CDATA #REQUIRED >


### PR DESCRIPTION
This PR makes `ChargerSpecification` and indirectly `Charger` attributable. The functionality is provided to read and write chargers with attributes just like it works for persons, facilities, etc. 

While doing this, the PR also adds a general unit test for reading/writing chargers, plus another one where attributes are used.

The DTD for the chargers is changed in this PR. I don't think we need to introduce a v2, because the basic structure is not changed, only the attributes are added as an optional feature. But may somebody who is more familiar with how DTDs are handled can comment on this?