### PR TITLE
feat(dvrp): cached free-speed matrices

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpModeRoutingNetworkModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpModeRoutingNetworkModule.java
@@ -20,6 +20,7 @@
 
 package org.matsim.contrib.dvrp.router;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.Set;
 
@@ -32,6 +33,7 @@ import org.matsim.contrib.zone.skims.DvrpTravelTimeMatrixParams;
 import org.matsim.contrib.zone.skims.FreeSpeedTravelTimeMatrix;
 import org.matsim.contrib.zone.skims.TravelTimeMatrix;
 import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.groups.GlobalConfigGroup;
 import org.matsim.core.config.groups.QSimConfigGroup;
 import org.matsim.core.network.NetworkUtils;
@@ -86,9 +88,16 @@ public class DvrpModeRoutingNetworkModule extends AbstractDvrpModeModule {
 						DvrpTravelTimeMatrixParams matrixParams = dvrpConfigGroup.getTravelTimeMatrixParams();
 						ZoneSystem zoneSystem = ZoneSystemUtils.createZoneSystem(getConfig().getContext(), network,
 							matrixParams.getZoneSystemParams(), getConfig().global().getCoordinateSystem(), zone -> true);
-						return FreeSpeedTravelTimeMatrix.createFreeSpeedMatrix(network, zoneSystem,
-							matrixParams, globalConfigGroup.getNumberOfThreads(),
-                                qSimConfigGroup.getTimeStepSize());
+						
+						
+						if (matrixParams.cachePath == null) {
+							return FreeSpeedTravelTimeMatrix.createFreeSpeedMatrix(network, zoneSystem, matrixParams, globalConfigGroup.getNumberOfThreads(),
+								qSimConfigGroup.getTimeStepSize());
+						} else {
+							File cachePath = new File(ConfigGroup.getInputFileURL(getConfig().getContext(), matrixParams.cachePath).getPath());
+							return FreeSpeedTravelTimeMatrix.createFreeSpeedMatrixFromCache(network, zoneSystem, matrixParams, globalConfigGroup.getNumberOfThreads(),
+								qSimConfigGroup.getTimeStepSize(), cachePath);
+						}
                     })).in(Singleton.class);
 		} else {
 			//use DVRP-routing (dvrp-global) network

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpModule.java
@@ -19,7 +19,7 @@
 
 package org.matsim.contrib.dvrp.run;
 
-import jakarta.inject.Provider;
+import java.io.File;
 
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.common.zones.ZoneSystem;
@@ -33,6 +33,7 @@ import org.matsim.contrib.dynagent.run.DynActivityEngine;
 import org.matsim.contrib.zone.skims.DvrpTravelTimeMatrixParams;
 import org.matsim.contrib.zone.skims.FreeSpeedTravelTimeMatrix;
 import org.matsim.contrib.zone.skims.TravelTimeMatrix;
+import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.groups.QSimConfigGroup;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.mobsim.framework.MobsimTimer;
@@ -43,6 +44,8 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
+
+import jakarta.inject.Provider;
 
 /**
  * This module initialises generic (i.e. not taxi or drt-specific) AND global (not mode-specific) dvrp objects.
@@ -90,8 +93,15 @@ public final class DvrpModule extends AbstractModule {
 				DvrpTravelTimeMatrixParams matrixParams = dvrpConfigGroup.getTravelTimeMatrixParams();
 				ZoneSystem zoneSystem = ZoneSystemUtils.createZoneSystem(getConfig().getContext(), network,
 					matrixParams.getZoneSystemParams(), getConfig().global().getCoordinateSystem(), zone -> true);
-				return FreeSpeedTravelTimeMatrix.createFreeSpeedMatrix(network, zoneSystem, params, numberOfThreads,
+				
+				if (params.cachePath == null) {
+					return FreeSpeedTravelTimeMatrix.createFreeSpeedMatrix(network, zoneSystem, params, numberOfThreads,
 						qSimConfigGroup.getTimeStepSize());
+				} else {
+					File cachePath = new File(ConfigGroup.getInputFileURL(getConfig().getContext(), params.cachePath).getPath());
+					return FreeSpeedTravelTimeMatrix.createFreeSpeedMatrixFromCache(network, zoneSystem, params, numberOfThreads,
+						qSimConfigGroup.getTimeStepSize(), cachePath);
+				}
 			}
 		}).in(Singleton.class);
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrixParams.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/DvrpTravelTimeMatrixParams.java
@@ -28,6 +28,7 @@ import org.matsim.contrib.common.zones.systems.geom_free_zones.GeometryFreeZoneS
 import org.matsim.contrib.common.zones.systems.grid.GISFileZoneSystemParams;
 import org.matsim.contrib.common.zones.systems.grid.h3.H3GridZoneSystemParams;
 import org.matsim.contrib.common.zones.systems.grid.square.SquareGridZoneSystemParams;
+import org.matsim.core.config.ReflectiveConfigGroup.Parameter;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -59,6 +60,9 @@ public class DvrpTravelTimeMatrixParams extends ReflectiveConfigGroupWithConfigu
 	@NotNull
 	private ZoneSystemParams zoneSystemParams;
 
+	@Parameter
+	@Comment("Caches the travel time matrix data into a binary file. If the file exists, the matrix will be read from the file, if not, the file will be created.")
+	public String cachePath = null;
 
 	public DvrpTravelTimeMatrixParams() {
 		super(SET_NAME);

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/SparseMatrix.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/SparseMatrix.java
@@ -129,4 +129,8 @@ public final class SparseMatrix {
 	void setRow(Node fromNode, SparseRow row) {
 		rows[fromNode.getId().index()] = row;
 	}
+
+	SparseRow[] getRows() {
+		return rows;
+	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/SparseMatrix.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/SparseMatrix.java
@@ -129,8 +129,4 @@ public final class SparseMatrix {
 	void setRow(Node fromNode, SparseRow row) {
 		rows[fromNode.getId().index()] = row;
 	}
-
-	SparseRow[] getRows() {
-		return rows;
-	}
 }

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/zone/skims/FreeSpeedTravelTimeMatrixTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/zone/skims/FreeSpeedTravelTimeMatrixTest.java
@@ -22,7 +22,10 @@ package org.matsim.contrib.zone.skims;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Network;
@@ -30,11 +33,15 @@ import org.matsim.api.core.v01.network.Node;
 import org.matsim.contrib.common.zones.ZoneSystem;
 import org.matsim.contrib.common.zones.systems.grid.square.SquareGridZoneSystem;
 import org.matsim.core.network.NetworkUtils;
+import org.matsim.testcases.MatsimTestUtils;
 
 /**
  * @author Michal Maciejewski (michalm)
  */
 public class FreeSpeedTravelTimeMatrixTest {
+
+	@RegisterExtension
+	MatsimTestUtils utils = new MatsimTestUtils();
 
 	private final Network network = NetworkUtils.createNetwork();
 	private final Node nodeA = NetworkUtils.createAndAddNode(network, Id.createNodeId("A"), new Coord(0, 0));
@@ -66,6 +73,23 @@ public class FreeSpeedTravelTimeMatrixTest {
 		assertThat(matrix.getTravelTime(nodeC, nodeA, 0)).isEqualTo(0);
 		assertThat(matrix.getTravelTime(nodeB, nodeC, 0)).isEqualTo(20 + 1); // 1 s for moving over nodes
 		assertThat(matrix.getTravelTime(nodeC, nodeB, 0)).isEqualTo(10 + 1); // 1 s for moving over nodes
+	
+		// write and read cache
+		File cachePath = new File(utils.getOutputDirectory(), "cache.bin");
+		matrix.write(cachePath, network);
+		matrix = FreeSpeedTravelTimeMatrix.createFreeSpeedMatrixFromCache(network, zoneSystem, null, 1, 1, cachePath);
+
+		// distances between central nodes: A and B
+		assertThat(matrix.getTravelTime(nodeA, nodeA, 0)).isEqualTo(0);
+		assertThat(matrix.getTravelTime(nodeA, nodeB, 0)).isEqualTo(10 + 1); // 1 s for moving over nodes
+		assertThat(matrix.getTravelTime(nodeB, nodeA, 0)).isEqualTo(20 + 1); // 1 s for moving over nodes
+		assertThat(matrix.getTravelTime(nodeB, nodeB, 0)).isEqualTo(0);
+
+		// non-central node: C and A are in the same zone; A is the central node
+		assertThat(matrix.getTravelTime(nodeA, nodeC, 0)).isEqualTo(0);
+		assertThat(matrix.getTravelTime(nodeC, nodeA, 0)).isEqualTo(0);
+		assertThat(matrix.getTravelTime(nodeB, nodeC, 0)).isEqualTo(20 + 1); // 1 s for moving over nodes
+		assertThat(matrix.getTravelTime(nodeC, nodeB, 0)).isEqualTo(10 + 1); // 1 s for moving over nodes
 	}
 
 	@Test
@@ -75,6 +99,23 @@ public class FreeSpeedTravelTimeMatrixTest {
 
 		ZoneSystem zoneSystem = new SquareGridZoneSystem(network, 100.);
 		var matrix = FreeSpeedTravelTimeMatrix.createFreeSpeedMatrix(network, zoneSystem, params, 1, 1);
+
+		// distances between central nodes: A and B
+		assertThat(matrix.getTravelTime(nodeA, nodeA, 0)).isEqualTo(0);
+		assertThat(matrix.getTravelTime(nodeA, nodeB, 0)).isEqualTo(10 + 1); // 1 s for moving over nodes
+		assertThat(matrix.getTravelTime(nodeB, nodeA, 0)).isEqualTo(20 + 1); // 1 s for moving over nodes
+		assertThat(matrix.getTravelTime(nodeB, nodeB, 0)).isEqualTo(0);
+
+		// non-central node: C and A are in the same zone; A is the central node
+		assertThat(matrix.getTravelTime(nodeA, nodeC, 0)).isEqualTo(11 + 1); // 1 s for moving over nodes
+		assertThat(matrix.getTravelTime(nodeC, nodeA, 0)).isEqualTo(9 + 1); // 1 s for moving over nodes
+		assertThat(matrix.getTravelTime(nodeB, nodeC, 0)).isEqualTo(20 + 11 + 2); // 2 s for moving over nodes
+		assertThat(matrix.getTravelTime(nodeC, nodeB, 0)).isEqualTo(10 + 9 + 2); // 2 s for moving over nodes
+
+		// write and read cache
+		File cachePath = new File(utils.getOutputDirectory(), "cache.bin");
+		matrix.write(cachePath, network);
+		matrix = FreeSpeedTravelTimeMatrix.createFreeSpeedMatrixFromCache(network, zoneSystem, null, 1, 1, cachePath);
 
 		// distances between central nodes: A and B
 		assertThat(matrix.getTravelTime(nodeA, nodeA, 0)).isEqualTo(0);


### PR DESCRIPTION
When working with large scenarios, calculating the dvrp global and mode-specific free-speed matrices takes a lot of time, especially when parametric studies are run in which this has to happen at every simulation start-up. 

This PR introduces the possibility to cache the calculated free-speed matrices using the `cachePath` parameter in the respective `DvrpTravelTimeMatrixParams`. If the file does not exist, the matrix calculation is performed as usual and saved. If the file exists already, the matrix is read from the file. This way, when setting a global path, the calculation will be performed once in the parametric simulation series and then only read for all subsequent runs. There are various verifications included in the reading code to make sure that the travel times contained in the source file correspond to the present network and zoning system. The matrices are saved in a condensed custom binary format. Unit tests are provided.