### PR TITLE
Update deprecated expression in pom of decongestion contrib

### DIFF
--- a/contribs/decongestion/pom.xml
+++ b/contribs/decongestion/pom.xml
@@ -8,7 +8,7 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>otfvis</artifactId>
-			<version>${parent.version}</version>
+			<version>${project.parent.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
Use §{project.parent.version}, because the expression ${parent.version} is deprecated.
(This warning came from the log of the weekly builds: 
![grafik](https://github.com/user-attachments/assets/4707e525-3280-4c41-ae1c-bae6758adb83)
)