### PR TITLE
Update deploy-dtds.yaml

### DIFF
--- a/.github/workflows/deploy-dtds.yaml
+++ b/.github/workflows/deploy-dtds.yaml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
       - name: rsync dtds
         uses: burnett01/rsync-deployments@7.0.1
         with:


### PR DESCRIPTION
Add checkout command before copying the files, because the path uses a location relative to GITHUB-WORKSPACE. The later one is defined by the checkout location.

See also https://github.com/Burnett01/rsync-deployments where the checkout is also performed before accessing the files.

Let's see, if this helps...