### PR TITLE
integrateUnitsForFuelConsumption

### DIFF
--- a/matsim/src/main/java/org/matsim/vehicles/VehicleUtils.java
+++ b/matsim/src/main/java/org/matsim/vehicles/VehicleUtils.java
@@ -299,16 +299,24 @@ public final class VehicleUtils {
 		vehicleType.getAttributes().putAttribute(ACCESSTIME, accessTime);
 	}
 
+	/**
+	 * @deprecated use getFuelConsumptionPerMeter instead
+	 */
+	@Deprecated
 	public static Double getFuelConsumption(VehicleType vehicleType) {
-		return getFuelConsumption(vehicleType.getEngineInformation());
+		return getFuelConsumptionLitersPerMeter(vehicleType.getEngineInformation());
 	}
 
+	/**
+	 * @deprecated use setFuelConsumptionPerMeter instead
+	 */
+	@Deprecated
 	public static void setFuelConsumption(VehicleType vehicleType, double literPerMeter) {
-		setFuelConsumption(vehicleType.getEngineInformation(), literPerMeter);
+		setFuelConsumptionLitersPerMeter(vehicleType.getEngineInformation(), literPerMeter);
 	}
 
 	//******** EngineInformation attributes ************
-
+	//TODO create enum for fuel type
 	public static String getHbefaTechnology( EngineInformation ei ){
 		return (String) ei.getAttributes().getAttribute( HBEFA_TECHNOLOGY ) ;
 	}
@@ -345,6 +353,14 @@ public final class VehicleUtils {
 		engineInformation.getAttributes().putAttribute(ENERGYCONSUMPTION, energyConsumptionKWhPerMeter);
 	}
 
+	public static Double getFuelConsumptionLitersPerMeter(EngineInformation engineInformation) {
+		return (Double) engineInformation.getAttributes().getAttribute(FUELCONSUMPTION);
+	}
+
+	public static void setFuelConsumptionLitersPerMeter(EngineInformation engineInformation, double fuelConsumptionLitersPerMeter) {
+		engineInformation.getAttributes().putAttribute(FUELCONSUMPTION, fuelConsumptionLitersPerMeter);
+	}
+
 	public static Double getEnergyCapacity(EngineInformation engineInformation) {
 		return (Double) engineInformation.getAttributes().getAttribute(ENERGYCAPACITY);
 	}
@@ -377,21 +393,33 @@ public final class VehicleUtils {
 		return new VehicleImpl( id , type );
 	}
 
+	/**
+	 * @deprecated use getHbefaTechnology instead
+	 */
 	@Deprecated
 	static EngineInformation.FuelType getFuelType(EngineInformation engineInformation ){
 		return (EngineInformation.FuelType) engineInformation.getAttributes().getAttribute( FUEL_TYPE );
 	}
 
+	/**
+	 * @deprecated use setHbefaTechnology instead
+	 */
 	@Deprecated
 	static void setFuelType(EngineInformation engineInformation, EngineInformation.FuelType fuelType ){
 		engineInformation.getAttributes().putAttribute( FUEL_TYPE,  fuelType);
 	}
 
+	/**
+	 * @Deprecated use getFuelConsumptionPerMeter instead
+	 */
 	@Deprecated
 	static Double getFuelConsumption(EngineInformation engineInformation ){
 		return (Double) engineInformation.getAttributes().getAttribute( FUELCONSUMPTION );
 	}
 
+	/**
+	 * @Deprecated use setFuelConsumptionPerMeter instead
+	 */
 	@Deprecated
 	static void setFuelConsumption(EngineInformation engineInformation, double fuelConsumption ){
 		engineInformation.getAttributes().putAttribute( FUELCONSUMPTION,  fuelConsumption);


### PR DESCRIPTION
- "old" methods are still runnable, but now marked as deprecated
- now use method with including the units of the consumption 