### PR TITLE
fix(drt): names in attribute-based prebooking

### DIFF
--- a/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/operations/shifts/run/RunPrebookingShiftDrtScenarioIT.java
+++ b/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/operations/shifts/run/RunPrebookingShiftDrtScenarioIT.java
@@ -280,8 +280,8 @@ public class RunPrebookingShiftDrtScenarioIT {
             Plan plan = factory.createPlan();
             Activity start = factory.createActivityFromLinkId("start", Id.createLinkId(1));
             start.setEndTime(5000);
-            start.getAttributes().putAttribute("prebooking:submissionTime" + "drt", 1800.);
-            start.getAttributes().putAttribute("prebooking:plannedDepartureTime" + "drt", 5000.);
+            AttributeBasedPrebookingLogic.setSubmissionTime("drt", start, 1800.0);
+            AttributeBasedPrebookingLogic.setPlannedDepartureTime("drt", start, 5000.0);
             plan.addActivity(start);
             plan.addLeg(factory.createLeg("drt"));
             plan.addActivity(factory.createActivityFromLinkId("end", Id.createLinkId(2)));
@@ -295,8 +295,8 @@ public class RunPrebookingShiftDrtScenarioIT {
             Plan plan = factory.createPlan();
             Activity start = factory.createActivityFromLinkId("start", Id.createLinkId(1));
             start.setEndTime(5000);
-            start.getAttributes().putAttribute("prebooking:submissionTime" + "drt", 900.);
-            start.getAttributes().putAttribute("prebooking:plannedDepartureTime" + "drt", 5005.);
+            AttributeBasedPrebookingLogic.setSubmissionTime("drt", start, 900.0);
+            AttributeBasedPrebookingLogic.setPlannedDepartureTime("drt", start, 5005.0);
             plan.addActivity(start);
             plan.addLeg(factory.createLeg("drt"));
             plan.addActivity(factory.createActivityFromLinkId("end", Id.createLinkId(2)));
@@ -310,8 +310,8 @@ public class RunPrebookingShiftDrtScenarioIT {
             Plan plan = factory.createPlan();
             Activity start = factory.createActivityFromLinkId("start", Id.createLinkId(1));
             start.setEndTime(5000);
-            start.getAttributes().putAttribute("prebooking:submissionTime" + "drt", 4000.);
-            start.getAttributes().putAttribute("prebooking:plannedDepartureTime" + "drt", 5000.);
+            AttributeBasedPrebookingLogic.setSubmissionTime("drt", start, 4000.0);
+            AttributeBasedPrebookingLogic.setPlannedDepartureTime("drt", start, 5000.0);
             plan.addActivity(start);
             plan.addLeg(factory.createLeg("drt"));
             plan.addActivity(factory.createActivityFromLinkId("end", Id.createLinkId(2)));
@@ -325,8 +325,8 @@ public class RunPrebookingShiftDrtScenarioIT {
             Plan plan = factory.createPlan();
             Activity start = factory.createActivityFromLinkId("start", Id.createLinkId(1));
             start.setEndTime(8000);
-            start.getAttributes().putAttribute("prebooking:submissionTime" + "drt", 4000.);
-            start.getAttributes().putAttribute("prebooking:plannedDepartureTime" + "drt", 11000.);
+            AttributeBasedPrebookingLogic.setSubmissionTime("drt", start, 4000.0);
+            AttributeBasedPrebookingLogic.setPlannedDepartureTime("drt", start, 11000.0);
             plan.addActivity(start);
             plan.addLeg(factory.createLeg("drt"));
             plan.addActivity(factory.createActivityFromLinkId("end", Id.createLinkId(2)));
@@ -340,8 +340,8 @@ public class RunPrebookingShiftDrtScenarioIT {
             Plan plan = factory.createPlan();
             Activity start = factory.createActivityFromLinkId("start", Id.createLinkId(1));
             start.setEndTime(6000.);
-            start.getAttributes().putAttribute("prebooking:submissionTime" + "drt", 4000.);
-            start.getAttributes().putAttribute("prebooking:plannedDepartureTime" + "drt", 6000.);
+            AttributeBasedPrebookingLogic.setSubmissionTime("drt", start, 4000.0);
+            AttributeBasedPrebookingLogic.setPlannedDepartureTime("drt", start, 6000.0);
             plan.addActivity(start);
             plan.addLeg(factory.createLeg("drt"));
             plan.addActivity(factory.createActivityFromLinkId("end", Id.createLinkId(2)));
@@ -355,8 +355,8 @@ public class RunPrebookingShiftDrtScenarioIT {
             Plan plan = factory.createPlan();
             Activity start = factory.createActivityFromLinkId("start", Id.createLinkId(1));
             start.setEndTime(6500.);
-            start.getAttributes().putAttribute("prebooking:submissionTime" + "drt", 4000.);
-            start.getAttributes().putAttribute("prebooking:plannedDepartureTime" + "drt", 6500.);
+            AttributeBasedPrebookingLogic.setSubmissionTime("drt", start, 4000.0);
+            AttributeBasedPrebookingLogic.setPlannedDepartureTime("drt", start, 6500.0);
             plan.addActivity(start);
             plan.addLeg(factory.createLeg("drt"));
             plan.addActivity(factory.createActivityFromLinkId("end", Id.createLinkId(2)));

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/prebooking/logic/AttributeBasedPrebookingLogic.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/prebooking/logic/AttributeBasedPrebookingLogic.java
@@ -35,23 +35,32 @@ import com.google.common.base.Preconditions;
  * @author Sebastian Hörl (sebhoerl), IRT SystemX
  */
 public class AttributeBasedPrebookingLogic implements PrebookingLogic, MobsimInitializedListener {
-	static private final String SUBMISSION_TIME_ATTRIBUTE_PREFIX = "prebooking:submissionTime";
-	static private final String PLANNED_DEPARTURE_ATTRIBUTE_PREFIX = "prebooking:plannedDepartureTime";
+	static private final String SUBMISSION_TIME_ATTRIBUTE_PREFIX = "prebooking:submissionTime:";
+	static private final String PLANNED_DEPARTURE_ATTRIBUTE_PREFIX = "prebooking:plannedDepartureTime:";
 
-	static public String getSubmissionAttribute(String mode) {
+	static public String getSubmissionTimeAttribute(String mode) {
 		return SUBMISSION_TIME_ATTRIBUTE_PREFIX + mode;
 	}
 
-	static public String getPlannedDepartureAttribute(String mode) {
+	static public String getPlannedDepartureTimeAttribute(String mode) {
 		return PLANNED_DEPARTURE_ATTRIBUTE_PREFIX + mode;
 	}
 
 	static public Optional<Double> getSubmissionTime(String mode, Trip trip) {
-		return Optional.ofNullable((Double) trip.getTripAttributes().getAttribute(getSubmissionAttribute(mode)));
+		return Optional.ofNullable((Double) trip.getTripAttributes().getAttribute(getSubmissionTimeAttribute(mode)));
 	}
 
 	static public Optional<Double> getPlannedDepartureTime(String mode, Trip trip) {
-		return Optional.ofNullable((Double) trip.getTripAttributes().getAttribute(getPlannedDepartureAttribute(mode)));
+		return Optional
+				.ofNullable((Double) trip.getTripAttributes().getAttribute(getPlannedDepartureTimeAttribute(mode)));
+	}
+
+	static public void setSubmissionTime(String mode, Trip trip, double submissionTime) {
+		trip.getTripAttributes().putAttribute(getSubmissionTimeAttribute(mode), submissionTime);
+	}
+
+	static public void setPlannedDepartureTime(String mode, Trip trip, double plannedDepartureTime) {
+		trip.getTripAttributes().putAttribute(getPlannedDepartureTimeAttribute(mode), plannedDepartureTime);
 	}
 
 	private final PrebookingQueue prebookingQueue;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/prebooking/logic/AttributeBasedPrebookingLogic.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/prebooking/logic/AttributeBasedPrebookingLogic.java
@@ -2,6 +2,7 @@ package org.matsim.contrib.drt.prebooking.logic;
 
 import java.util.Optional;
 
+import org.matsim.api.core.v01.population.Activity;
 import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.contrib.drt.prebooking.logic.helpers.PopulationIterator;
@@ -61,6 +62,14 @@ public class AttributeBasedPrebookingLogic implements PrebookingLogic, MobsimIni
 
 	static public void setPlannedDepartureTime(String mode, Trip trip, double plannedDepartureTime) {
 		trip.getTripAttributes().putAttribute(getPlannedDepartureTimeAttribute(mode), plannedDepartureTime);
+	}
+
+	static public void setSubmissionTime(String mode, Activity originActivity, double submissionTime) {
+		originActivity.getAttributes().putAttribute(getSubmissionTimeAttribute(mode), submissionTime);
+	}
+
+	static public void setPlannedDepartureTime(String mode, Activity originActivity, double plannedDepartureTime) {
+		originActivity.getAttributes().putAttribute(getPlannedDepartureTimeAttribute(mode), plannedDepartureTime);
 	}
 
 	private final PrebookingQueue prebookingQueue;

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/prebooking/PrebookingTestEnvironment.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/prebooking/PrebookingTestEnvironment.java
@@ -283,13 +283,13 @@ public class PrebookingTestEnvironment {
 			plan.addLeg(firstLeg);
 
 			if (!Double.isNaN(request.submissionTime)) {
-				firstActivity.getAttributes().putAttribute(AttributeBasedPrebookingLogic.getSubmissionAttribute("drt"),
+				firstActivity.getAttributes().putAttribute(AttributeBasedPrebookingLogic.getSubmissionTimeAttribute("drt"),
 						request.submissionTime);
 			}
 
 			if (!Double.isNaN(request.plannedDepartureTime)) {
 				firstActivity.getAttributes().putAttribute(
-						AttributeBasedPrebookingLogic.getPlannedDepartureAttribute("drt"),
+						AttributeBasedPrebookingLogic.getPlannedDepartureTimeAttribute("drt"),
 						request.plannedDepartureTime);
 			}
 


### PR DESCRIPTION
A colon was missing in the attribute-based prebooking logic. And a convenience setter has been added.