### PR TITLE
Freight (carrier): Rename internal variables and getter/setter to make them more consitent

### DIFF
--- a/contribs/application/src/main/java/org/matsim/freightDemandGeneration/DemandReaderFromCSV.java
+++ b/contribs/application/src/main/java/org/matsim/freightDemandGeneration/DemandReaderFromCSV.java
@@ -1200,7 +1200,7 @@ public final class DemandReaderFromCSV {
 						double serviceTimePickup = 0;
 						double serviceTimeDelivery = 0;
 						for (CarrierShipment carrierShipment : shipmentsToConnect.values()) {
-							demandForThisLink = demandForThisLink + carrierShipment.getSize();
+                            demandForThisLink = demandForThisLink + carrierShipment.getDemand();
 							serviceTimePickup = serviceTimePickup + carrierShipment.getPickupServiceTime();
 							serviceTimeDelivery = serviceTimeDelivery + carrierShipment.getDeliveryServiceTime();
 							shipmentsToRemove.put(carrierShipment.getId(), carrierShipment);
@@ -1245,7 +1245,7 @@ public final class DemandReaderFromCSV {
 						int demandForThisLink = 0;
 						double serviceTimeService = 0;
 						for (CarrierService carrierService : servicesToConnect.values()) {
-							demandForThisLink = demandForThisLink + carrierService.getCapacityDemand();
+							demandForThisLink = demandForThisLink + carrierService.getDemand();
 							serviceTimeService = serviceTimeService + carrierService.getServiceDuration();
 							servicesToRemove.put(carrierService.getId(), carrierService);
 						}

--- a/contribs/application/src/main/java/org/matsim/freightDemandGeneration/DemandReaderFromCSV.java
+++ b/contribs/application/src/main/java/org/matsim/freightDemandGeneration/DemandReaderFromCSV.java
@@ -655,7 +655,7 @@ public final class DemandReaderFromCSV {
 							createJobId(scenario, newDemandInformationElement, link.getId(), null),
 							CarrierService.class);
 					CarrierService thisService = CarrierService.Builder.newInstance(idNewService, link.getId())
-							.setCapacityDemand(demandForThisLink).setServiceDuration(serviceTime)
+							.setDemand(demandForThisLink).setServiceDuration(serviceTime)
 							.setServiceStartTimeWindow(newDemandInformationElement.getFirstJobElementTimeWindow())
 							.build();
 					CarriersUtils.getCarriers(scenario).getCarriers()
@@ -696,7 +696,7 @@ public final class DemandReaderFromCSV {
 							CarrierService.class);
 						if (demandToDistribute > 0 && singleDemandForThisLink > 0) {
 							CarrierService thisService = CarrierService.Builder.newInstance(idNewService, link.getId())
-								.setCapacityDemand(singleDemandForThisLink).setServiceDuration(serviceTime)
+								.setDemand(singleDemandForThisLink).setServiceDuration(serviceTime)
 								.setServiceStartTimeWindow(newDemandInformationElement.getFirstJobElementTimeWindow())
 								.build();
 							thisCarrier.getServices().put(thisService.getId(), thisService);
@@ -747,7 +747,7 @@ public final class DemandReaderFromCSV {
 						createJobId(scenario, newDemandInformationElement, link.getId(), null), CarrierService.class);
 					if ((demandToDistribute > 0 && singleDemandForThisLink > 0) || demandToDistribute == 0) {
 						CarrierService thisService = CarrierService.Builder.newInstance(idNewService, link.getId())
-							.setCapacityDemand(singleDemandForThisLink).setServiceDuration(serviceTime)
+							.setDemand(singleDemandForThisLink).setServiceDuration(serviceTime)
 							.setServiceStartTimeWindow(newDemandInformationElement.getFirstJobElementTimeWindow())
 							.build();
 						CarriersUtils.getCarriers(scenario).getCarriers()
@@ -1051,8 +1051,8 @@ public final class DemandReaderFromCSV {
 
 			CarrierShipment thisShipment = CarrierShipment.Builder
 				.newInstance(idNewShipment, linkPickup.getId(), linkDelivery.getId(), singleDemandForThisLink)
-				.setPickupServiceTime(serviceTimePickup).setPickupTimeWindow(timeWindowPickup)
-				.setDeliveryServiceTime(serviceTimeDelivery).setDeliveryTimeWindow(timeWindowDelivery)
+				.setPickupDuration(serviceTimePickup).setPickupStartsTimeWindow(timeWindowPickup)
+				.setDeliveryDuration(serviceTimeDelivery).setDeliveryStartsTimeWindow(timeWindowDelivery)
 				.build();
 			thisCarrier.getShipments().put(thisShipment.getId(), thisShipment);
 			if (demandForThisLink == 0)
@@ -1207,10 +1207,10 @@ public final class DemandReaderFromCSV {
 						}
 						CarrierShipment newShipment = CarrierShipment.Builder
 							.newInstance(idNewShipment, baseShipment.getFrom(), baseShipment.getTo(), demandForThisLink)
-							.setPickupServiceTime(serviceTimePickup)
-							.setPickupTimeWindow(baseShipment.getPickupTimeWindow())
-							.setDeliveryServiceTime(serviceTimeDelivery)
-							.setDeliveryTimeWindow(baseShipment.getDeliveryTimeWindow()).build();
+							.setPickupDuration(serviceTimePickup)
+							.setPickupStartsTimeWindow(baseShipment.getPickupTimeWindow())
+							.setDeliveryDuration(serviceTimeDelivery)
+							.setDeliveryStartsTimeWindow(baseShipment.getDeliveryTimeWindow()).build();
 						shipmentsToAdd.add(newShipment);
 					}
 				}
@@ -1253,7 +1253,7 @@ public final class DemandReaderFromCSV {
 							.newInstance(idNewService, baseService.getLocationLinkId())
 							.setServiceDuration(serviceTimeService)
 							.setServiceStartTimeWindow(baseService.getServiceStartTimeWindow())
-							.setCapacityDemand(demandForThisLink).build();
+							.setDemand(demandForThisLink).build();
 						servicesToAdd.add(newService);
 					}
 				}

--- a/contribs/application/src/main/java/org/matsim/freightDemandGeneration/DemandReaderFromCSV.java
+++ b/contribs/application/src/main/java/org/matsim/freightDemandGeneration/DemandReaderFromCSV.java
@@ -1188,8 +1188,8 @@ public final class DemandReaderFromCSV {
 							if (!shipmentsToRemove.containsKey(thisShipmentId)) {
 								CarrierShipment thisShipment = thisCarrier.getShipments().get(thisShipmentId);
 								if (baseShipment.getId() != thisShipment.getId()
-									&& baseShipment.getFrom() == thisShipment.getFrom()
-									&& baseShipment.getTo() == thisShipment.getTo()) {
+									&& baseShipment.getPickupLinkId() == thisShipment.getPickupLinkId()
+									&& baseShipment.getDeliveryLinkId() == thisShipment.getDeliveryLinkId()) {
 									if (baseShipment.getPickupStartsTimeWindow() == thisShipment.getPickupStartsTimeWindow()) {
 									if (baseShipment.getDeliveryStartsTimeWindow() == thisShipment.getDeliveryStartsTimeWindow()) shipmentsToConnect.put(thisShipmentId, thisShipment);
 								}
@@ -1207,7 +1207,7 @@ public final class DemandReaderFromCSV {
 							shipmentsToRemove.put(carrierShipment.getId(), carrierShipment);
 						}
 						CarrierShipment newShipment = CarrierShipment.Builder
-							.newInstance(idNewShipment, baseShipment.getFrom(), baseShipment.getTo(), demandForThisLink)
+							.newInstance(idNewShipment, baseShipment.getPickupLinkId(), baseShipment.getDeliveryLinkId(), demandForThisLink)
 							.setPickupDuration(serviceTimePickup)
 							.setPickupStartsTimeWindow(baseShipment.getPickupStartsTimeWindow())
 							.setDeliveryDuration(serviceTimeDelivery)
@@ -1237,7 +1237,7 @@ public final class DemandReaderFromCSV {
 							if (!servicesToRemove.containsKey(thisServiceId)) {
 								CarrierService thisService = thisCarrier.getServices().get(thisServiceId);
 								if (baseService.getId() != thisService.getId()
-									&& baseService.getLocationLinkId() == thisService.getLocationLinkId() && baseService
+									&& baseService.getServiceLinkId() == thisService.getServiceLinkId() && baseService
 									.getServiceStartTimeWindow() == thisService.getServiceStartTimeWindow())
 									servicesToConnect.put(thisServiceId, thisService);
 							}
@@ -1251,7 +1251,7 @@ public final class DemandReaderFromCSV {
 							servicesToRemove.put(carrierService.getId(), carrierService);
 						}
 						CarrierService newService = CarrierService.Builder
-							.newInstance(idNewService, baseService.getLocationLinkId())
+							.newInstance(idNewService, baseService.getServiceLinkId())
 							.setServiceDuration(serviceTimeService)
 							.setServiceStartTimeWindow(baseService.getServiceStartTimeWindow())
 							.setDemand(demandForThisLink).build();

--- a/contribs/application/src/main/java/org/matsim/freightDemandGeneration/DemandReaderFromCSV.java
+++ b/contribs/application/src/main/java/org/matsim/freightDemandGeneration/DemandReaderFromCSV.java
@@ -1189,10 +1189,11 @@ public final class DemandReaderFromCSV {
 								CarrierShipment thisShipment = thisCarrier.getShipments().get(thisShipmentId);
 								if (baseShipment.getId() != thisShipment.getId()
 									&& baseShipment.getFrom() == thisShipment.getFrom()
-									&& baseShipment.getTo() == thisShipment.getTo()
-									&& baseShipment.getPickupTimeWindow() == thisShipment.getPickupTimeWindow()
-									&& baseShipment.getDeliveryTimeWindow() == thisShipment.getDeliveryTimeWindow())
-									shipmentsToConnect.put(thisShipmentId, thisShipment);
+									&& baseShipment.getTo() == thisShipment.getTo()) {
+									if (baseShipment.getPickupStartsTimeWindow() == thisShipment.getPickupStartsTimeWindow()) {
+									if (baseShipment.getDeliveryStartsTimeWindow() == thisShipment.getDeliveryStartsTimeWindow()) shipmentsToConnect.put(thisShipmentId, thisShipment);
+								}
+								}
 							}
 						}
 						Id<CarrierShipment> idNewShipment = baseShipment.getId();
@@ -1201,16 +1202,16 @@ public final class DemandReaderFromCSV {
 						double serviceTimeDelivery = 0;
 						for (CarrierShipment carrierShipment : shipmentsToConnect.values()) {
                             demandForThisLink = demandForThisLink + carrierShipment.getDemand();
-							serviceTimePickup = serviceTimePickup + carrierShipment.getPickupServiceTime();
-							serviceTimeDelivery = serviceTimeDelivery + carrierShipment.getDeliveryServiceTime();
+							serviceTimePickup = serviceTimePickup + carrierShipment.getPickupDuration();
+							serviceTimeDelivery = serviceTimeDelivery + carrierShipment.getDeliveryDuration();
 							shipmentsToRemove.put(carrierShipment.getId(), carrierShipment);
 						}
 						CarrierShipment newShipment = CarrierShipment.Builder
 							.newInstance(idNewShipment, baseShipment.getFrom(), baseShipment.getTo(), demandForThisLink)
 							.setPickupDuration(serviceTimePickup)
-							.setPickupStartsTimeWindow(baseShipment.getPickupTimeWindow())
+							.setPickupStartsTimeWindow(baseShipment.getPickupStartsTimeWindow())
 							.setDeliveryDuration(serviceTimeDelivery)
-							.setDeliveryStartsTimeWindow(baseShipment.getDeliveryTimeWindow()).build();
+							.setDeliveryStartsTimeWindow(baseShipment.getDeliveryStartsTimeWindow()).build();
 						shipmentsToAdd.add(newShipment);
 					}
 				}

--- a/contribs/application/src/main/java/org/matsim/freightDemandGeneration/FreightDemandGenerationUtils.java
+++ b/contribs/application/src/main/java/org/matsim/freightDemandGeneration/FreightDemandGenerationUtils.java
@@ -130,23 +130,23 @@ public class FreightDemandGenerationUtils {
 			for (Carrier thisCarrier : CarriersUtils.getCarriers(controler.getScenario()).getCarriers().values()) {
 				for (CarrierService thisService : thisCarrier.getServices().values()) {
 					Coord coord = FreightDemandGenerationUtils
-							.getCoordOfMiddlePointOfLink(network.getLinks().get(thisService.getLocationLinkId()));
+							.getCoordOfMiddlePointOfLink(network.getLinks().get(thisService.getServiceLinkId()));
 					writer.write(thisCarrier.getId().toString() + thisService.getId().toString() + "	" + coord.getX()
 							+ "	" + coord.getY() + "	" + "Service" + "	"
-							+ thisService.getLocationLinkId().toString() + "		" + "\n");
+							+ thisService.getServiceLinkId().toString() + "		" + "\n");
 				}
 				for (CarrierShipment thisShipment : thisCarrier.getShipments().values()) {
 					Coord coordFrom = FreightDemandGenerationUtils
-							.getCoordOfMiddlePointOfLink(network.getLinks().get(thisShipment.getFrom()));
+							.getCoordOfMiddlePointOfLink(network.getLinks().get(thisShipment.getPickupLinkId()));
 					Coord coordTo = FreightDemandGenerationUtils
-							.getCoordOfMiddlePointOfLink(network.getLinks().get(thisShipment.getTo()));
+							.getCoordOfMiddlePointOfLink(network.getLinks().get(thisShipment.getDeliveryLinkId()));
 
 					writer.write(thisCarrier.getId().toString() + thisShipment.getId().toString() + "	"
 							+ coordFrom.getX() + "	" + coordFrom.getY() + "	" + "Pickup" + "		"
-							+ thisShipment.getFrom().toString() + "	" + thisShipment.getTo().toString() + "\n");
+							+ thisShipment.getPickupLinkId().toString() + "	" + thisShipment.getDeliveryLinkId().toString() + "\n");
 					writer.write(thisCarrier.getId().toString() + thisShipment.getId() + "	"
 							+ coordTo.getX() + "	" + coordTo.getY() + "	" + "Delivery" + "		"
-							+ thisShipment.getFrom() + "	" + thisShipment.getTo() + "\n");
+							+ thisShipment.getPickupLinkId() + "	" + thisShipment.getDeliveryLinkId() + "\n");
 				}
 			}
 			writer.flush();

--- a/contribs/application/src/test/java/org/matsim/freightDemandGeneration/DemandReaderFromCSVTest.java
+++ b/contribs/application/src/test/java/org/matsim/freightDemandGeneration/DemandReaderFromCSVTest.java
@@ -101,9 +101,9 @@ public class DemandReaderFromCSVTest {
 		locationsPerShipmentElement = new HashMap<>();
 		countDemand = 0;
 		for (CarrierShipment shipment : testCarrier3.getShipments().values()) {
-			countShipmentsWithCertainDemand.merge((Integer) shipment.getSize(), 1, Integer::sum);
-			countDemand = countDemand + shipment.getSize();
-			Assertions.assertEquals(5, shipment.getSize());
+            countShipmentsWithCertainDemand.merge((Integer) shipment.getDemand(), 1, Integer::sum);
+            countDemand = countDemand + shipment.getDemand();
+            Assertions.assertEquals(5, shipment.getDemand());
 			Assertions.assertEquals(2000, shipment.getPickupServiceTime(), MatsimTestUtils.EPSILON);
 			Assertions.assertEquals(1250, shipment.getDeliveryServiceTime(), MatsimTestUtils.EPSILON);
 			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupTimeWindow());
@@ -168,9 +168,9 @@ public class DemandReaderFromCSVTest {
 		locationsPerShipmentElement = new HashMap<>();
 		countDemand = 0;
 		for (CarrierShipment shipment : testCarrier3.getShipments().values()) {
-			countShipmentsWithCertainDemand.merge((Integer) shipment.getSize(), 1, Integer::sum);
-			countDemand = countDemand + shipment.getSize();
-			Assertions.assertEquals(10, shipment.getSize());
+            countShipmentsWithCertainDemand.merge((Integer) shipment.getDemand(), 1, Integer::sum);
+            countDemand = countDemand + shipment.getDemand();
+            Assertions.assertEquals(10, shipment.getDemand());
 			Assertions.assertEquals(4000, shipment.getPickupServiceTime(), MatsimTestUtils.EPSILON);
 			Assertions.assertEquals(2500, shipment.getDeliveryServiceTime(), MatsimTestUtils.EPSILON);
 			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupTimeWindow());
@@ -235,9 +235,9 @@ public class DemandReaderFromCSVTest {
 		locationsPerShipmentElement = new HashMap<>();
 		countDemand = 0;
 		for (CarrierShipment shipment : testCarrier3.getShipments().values()) {
-			countShipmentsWithCertainDemand.merge((Integer) shipment.getSize(), 1, Integer::sum);
-			countDemand = countDemand + shipment.getSize();
-			Assertions.assertEquals(10, shipment.getSize());
+            countShipmentsWithCertainDemand.merge((Integer) shipment.getDemand(), 1, Integer::sum);
+            countDemand = countDemand + shipment.getDemand();
+            Assertions.assertEquals(10, shipment.getDemand());
 			Assertions.assertEquals(4000, shipment.getPickupServiceTime(), MatsimTestUtils.EPSILON);
 			Assertions.assertEquals(2500, shipment.getDeliveryServiceTime(), MatsimTestUtils.EPSILON);
 			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupTimeWindow());
@@ -305,9 +305,9 @@ public class DemandReaderFromCSVTest {
 		locationsPerShipmentElement = new HashMap<>();
 		countDemand = 0;
 		for (CarrierShipment shipment : testCarrier3.getShipments().values()) {
-			countShipmentsWithCertainDemand.merge((Integer) shipment.getSize(), 1, Integer::sum);
-			countDemand = countDemand + shipment.getSize();
-			Assertions.assertEquals(10, shipment.getSize());
+            countShipmentsWithCertainDemand.merge((Integer) shipment.getDemand(), 1, Integer::sum);
+            countDemand = countDemand + shipment.getDemand();
+            Assertions.assertEquals(10, shipment.getDemand());
 			Assertions.assertEquals(4000, shipment.getPickupServiceTime(), MatsimTestUtils.EPSILON);
 			Assertions.assertEquals(2500, shipment.getDeliveryServiceTime(), MatsimTestUtils.EPSILON);
 			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupTimeWindow());
@@ -474,25 +474,27 @@ public class DemandReaderFromCSVTest {
 		Map<String, Set<String>> locationsPerServiceElement = new HashMap<>();
 		int countDemand = 0;
 		for (CarrierService service : testCarrier1.getServices().values()) {
-			countServicesWithCertainDemand.merge((Integer) service.getCapacityDemand(), 1, Integer::sum);
-			countDemand = countDemand + service.getCapacityDemand();
-			if (service.getCapacityDemand() == 0) {
+			countServicesWithCertainDemand.merge((Integer) service.getDemand(), 1, Integer::sum);
+			countDemand = countDemand + service.getDemand();
+			if (service.getDemand() == 0) {
 				Assertions.assertEquals(180, service.getServiceDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(TimeWindow.newInstance(3000, 13000), service.getServiceStartTimeWindow());
 				locationsPerServiceElement.computeIfAbsent("serviceElement1", (k) -> new HashSet<>())
 					.add(service.getLocationLinkId().toString());
-			} else if (service.getCapacityDemand() == 1) {
+			} else if (service.getDemand() == 1) {
 				Assertions.assertEquals(100, service.getServiceDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(TimeWindow.newInstance(5000, 20000), service.getServiceStartTimeWindow());
 				locationsPerServiceElement.computeIfAbsent("serviceElement2", (k) -> new HashSet<>())
 					.add(service.getLocationLinkId().toString());
-			} else if (service.getCapacityDemand() == 2) {
-				Assertions.assertEquals(200, service.getServiceDuration(), MatsimTestUtils.EPSILON);
-				Assertions.assertEquals(TimeWindow.newInstance(5000, 20000), service.getServiceStartTimeWindow());
-				locationsPerServiceElement.computeIfAbsent("serviceElement2", (k) -> new HashSet<>())
-					.add(service.getLocationLinkId().toString());
-			} else
-				Assertions.fail("Service has a wrong demand.");
+			} else {
+				if (service.getDemand() == 2) {
+					Assertions.assertEquals(200, service.getServiceDuration(), MatsimTestUtils.EPSILON);
+					Assertions.assertEquals(TimeWindow.newInstance(5000, 20000), service.getServiceStartTimeWindow());
+					locationsPerServiceElement.computeIfAbsent("serviceElement2", (k) -> new HashSet<>())
+						.add(service.getLocationLinkId().toString());
+				} else
+					Assertions.fail("Service has a wrong demand.");
+			}
 		}
 		Assertions.assertEquals(12, countDemand);
 		Assertions.assertEquals(4, countServicesWithCertainDemand.getInt(0));
@@ -520,9 +522,9 @@ public class DemandReaderFromCSVTest {
 		Map<String, Set<String>> locationsPerShipmentElement = new HashMap<>();
 		countDemand = 0;
 		for (CarrierShipment shipment : testCarrier2.getShipments().values()) {
-			countShipmentsWithCertainDemand.merge((Integer) shipment.getSize(), 1, Integer::sum);
-			countDemand = countDemand + shipment.getSize();
-			if (shipment.getSize() == 0) {
+            countShipmentsWithCertainDemand.merge((Integer) shipment.getDemand(), 1, Integer::sum);
+            countDemand = countDemand + shipment.getDemand();
+            if (shipment.getDemand() == 0) {
 				Assertions.assertEquals(300, shipment.getPickupServiceTime(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(350, shipment.getDeliveryServiceTime(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(TimeWindow.newInstance(10000, 45000), shipment.getPickupTimeWindow());
@@ -531,7 +533,7 @@ public class DemandReaderFromCSVTest {
 					.add(shipment.getFrom().toString());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_delivery", (k) -> new HashSet<>())
 					.add(shipment.getTo().toString());
-			} else if (shipment.getSize() == 2) {
+			} else if (shipment.getDemand() == 2) {
 				Assertions.assertEquals(400, shipment.getPickupServiceTime(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(400, shipment.getDeliveryServiceTime(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getPickupTimeWindow());
@@ -540,17 +542,19 @@ public class DemandReaderFromCSVTest {
 					.add(shipment.getFrom().toString());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_delivery", (k) -> new HashSet<>())
 					.add(shipment.getTo().toString());
-			} else if (shipment.getSize() == 3) {
-				Assertions.assertEquals(600, shipment.getPickupServiceTime(), MatsimTestUtils.EPSILON);
-				Assertions.assertEquals(600, shipment.getDeliveryServiceTime(), MatsimTestUtils.EPSILON);
-				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getPickupTimeWindow());
-				Assertions.assertEquals(TimeWindow.newInstance(20000, 40000), shipment.getDeliveryTimeWindow());
-				locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_pickup", (k) -> new HashSet<>())
-					.add(shipment.getFrom().toString());
-				locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_delivery", (k) -> new HashSet<>())
-					.add(shipment.getTo().toString());
-			} else
-				Assertions.fail("Shipment has an unexpected demand.");
+			} else {
+                if (shipment.getDemand() == 3) {
+                    Assertions.assertEquals(600, shipment.getPickupServiceTime(), MatsimTestUtils.EPSILON);
+                    Assertions.assertEquals(600, shipment.getDeliveryServiceTime(), MatsimTestUtils.EPSILON);
+                    Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getPickupTimeWindow());
+                    Assertions.assertEquals(TimeWindow.newInstance(20000, 40000), shipment.getDeliveryTimeWindow());
+                    locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_pickup", (k) -> new HashSet<>())
+                            .add(shipment.getFrom().toString());
+                    locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_delivery", (k) -> new HashSet<>())
+                            .add(shipment.getTo().toString());
+                } else
+                    Assertions.fail("Shipment has an unexpected demand.");
+            }
 		}
 		Assertions.assertEquals(15, countDemand);
 		Assertions.assertEquals(4, countShipmentsWithCertainDemand.getInt(0));
@@ -579,15 +583,15 @@ public class DemandReaderFromCSVTest {
 		Map<String, Set<String>> locationsPerServiceElement = new HashMap<>();
 		int countDemand = 0;
 		for (CarrierService service : testCarrier1.getServices().values()) {
-			countServicesWithCertainDemand.merge((Integer) service.getCapacityDemand(), 1, Integer::sum);
-			countDemand = countDemand + service.getCapacityDemand();
-			if (service.getCapacityDemand() == 0) {
+			countServicesWithCertainDemand.merge((Integer) service.getDemand(), 1, Integer::sum);
+			countDemand = countDemand + service.getDemand();
+			if (service.getDemand() == 0) {
 				Assertions.assertEquals(180, service.getServiceDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(TimeWindow.newInstance(3000, 13000), service.getServiceStartTimeWindow());
 				locationsPerServiceElement.computeIfAbsent("serviceElement1", (k) -> new HashSet<>())
 					.add(service.getLocationLinkId().toString());
 			} else {
-				Assertions.assertEquals(service.getCapacityDemand() * 100, service.getServiceDuration(), MatsimTestUtils.EPSILON);
+				Assertions.assertEquals(service.getDemand() * 100, service.getServiceDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(TimeWindow.newInstance(5000, 20000), service.getServiceStartTimeWindow());
 				locationsPerServiceElement.computeIfAbsent("serviceElement2", (k) -> new HashSet<>())
 					.add(service.getLocationLinkId().toString());
@@ -617,9 +621,9 @@ public class DemandReaderFromCSVTest {
 		Map<String, Set<String>> locationsPerShipmentElement = new HashMap<>();
 		countDemand = 0;
 		for (CarrierShipment shipment : testCarrier2.getShipments().values()) {
-			countShipmentsWithCertainDemand.merge((Integer) shipment.getSize(), 1, Integer::sum);
-			countDemand = countDemand + shipment.getSize();
-			if (shipment.getSize() == 0) {
+            countShipmentsWithCertainDemand.merge((Integer) shipment.getDemand(), 1, Integer::sum);
+            countDemand = countDemand + shipment.getDemand();
+            if (shipment.getDemand() == 0) {
 				Assertions.assertEquals(300, shipment.getPickupServiceTime(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(350, shipment.getDeliveryServiceTime(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(TimeWindow.newInstance(10000, 45000), shipment.getPickupTimeWindow());
@@ -629,8 +633,8 @@ public class DemandReaderFromCSVTest {
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_delivery", (k) -> new HashSet<>())
 					.add(shipment.getTo().toString());
 			} else {
-				Assertions.assertEquals(shipment.getSize() * 200, shipment.getPickupServiceTime(), MatsimTestUtils.EPSILON);
-				Assertions.assertEquals(shipment.getSize() * 200, shipment.getDeliveryServiceTime(), MatsimTestUtils.EPSILON);
+                Assertions.assertEquals(shipment.getDemand() * 200, shipment.getPickupServiceTime(), MatsimTestUtils.EPSILON);
+                Assertions.assertEquals(shipment.getDemand() * 200, shipment.getDeliveryServiceTime(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getPickupTimeWindow());
 				Assertions.assertEquals(TimeWindow.newInstance(20000, 40000), shipment.getDeliveryTimeWindow());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_pickup", (k) -> new HashSet<>())

--- a/contribs/application/src/test/java/org/matsim/freightDemandGeneration/DemandReaderFromCSVTest.java
+++ b/contribs/application/src/test/java/org/matsim/freightDemandGeneration/DemandReaderFromCSVTest.java
@@ -104,10 +104,10 @@ public class DemandReaderFromCSVTest {
             countShipmentsWithCertainDemand.merge((Integer) shipment.getDemand(), 1, Integer::sum);
             countDemand = countDemand + shipment.getDemand();
             Assertions.assertEquals(5, shipment.getDemand());
-			Assertions.assertEquals(2000, shipment.getPickupServiceTime(), MatsimTestUtils.EPSILON);
-			Assertions.assertEquals(1250, shipment.getDeliveryServiceTime(), MatsimTestUtils.EPSILON);
-			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupTimeWindow());
-			Assertions.assertEquals(TimeWindow.newInstance(10000, 60000), shipment.getDeliveryTimeWindow());
+			Assertions.assertEquals(2000, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
+			Assertions.assertEquals(1250, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
+			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupStartsTimeWindow());
+			Assertions.assertEquals(TimeWindow.newInstance(10000, 60000), shipment.getDeliveryStartsTimeWindow());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_pickup", (k) -> new HashSet<>())
 					.add(shipment.getFrom().toString());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_delivery", (k) -> new HashSet<>())
@@ -171,10 +171,10 @@ public class DemandReaderFromCSVTest {
             countShipmentsWithCertainDemand.merge((Integer) shipment.getDemand(), 1, Integer::sum);
             countDemand = countDemand + shipment.getDemand();
             Assertions.assertEquals(10, shipment.getDemand());
-			Assertions.assertEquals(4000, shipment.getPickupServiceTime(), MatsimTestUtils.EPSILON);
-			Assertions.assertEquals(2500, shipment.getDeliveryServiceTime(), MatsimTestUtils.EPSILON);
-			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupTimeWindow());
-			Assertions.assertEquals(TimeWindow.newInstance(10000, 60000), shipment.getDeliveryTimeWindow());
+			Assertions.assertEquals(4000, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
+			Assertions.assertEquals(2500, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
+			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupStartsTimeWindow());
+			Assertions.assertEquals(TimeWindow.newInstance(10000, 60000), shipment.getDeliveryStartsTimeWindow());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_pickup", (k) -> new HashSet<>())
 				.add(shipment.getFrom().toString());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_delivery", (k) -> new HashSet<>())
@@ -238,10 +238,10 @@ public class DemandReaderFromCSVTest {
             countShipmentsWithCertainDemand.merge((Integer) shipment.getDemand(), 1, Integer::sum);
             countDemand = countDemand + shipment.getDemand();
             Assertions.assertEquals(10, shipment.getDemand());
-			Assertions.assertEquals(4000, shipment.getPickupServiceTime(), MatsimTestUtils.EPSILON);
-			Assertions.assertEquals(2500, shipment.getDeliveryServiceTime(), MatsimTestUtils.EPSILON);
-			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupTimeWindow());
-			Assertions.assertEquals(TimeWindow.newInstance(10000, 60000), shipment.getDeliveryTimeWindow());
+			Assertions.assertEquals(4000, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
+			Assertions.assertEquals(2500, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
+			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupStartsTimeWindow());
+			Assertions.assertEquals(TimeWindow.newInstance(10000, 60000), shipment.getDeliveryStartsTimeWindow());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_pickup", (k) -> new HashSet<>())
 				.add(shipment.getFrom().toString());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_delivery", (k) -> new HashSet<>())
@@ -308,10 +308,10 @@ public class DemandReaderFromCSVTest {
             countShipmentsWithCertainDemand.merge((Integer) shipment.getDemand(), 1, Integer::sum);
             countDemand = countDemand + shipment.getDemand();
             Assertions.assertEquals(10, shipment.getDemand());
-			Assertions.assertEquals(4000, shipment.getPickupServiceTime(), MatsimTestUtils.EPSILON);
-			Assertions.assertEquals(2500, shipment.getDeliveryServiceTime(), MatsimTestUtils.EPSILON);
-			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupTimeWindow());
-			Assertions.assertEquals(TimeWindow.newInstance(10000, 60000), shipment.getDeliveryTimeWindow());
+			Assertions.assertEquals(4000, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
+			Assertions.assertEquals(2500, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
+			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupStartsTimeWindow());
+			Assertions.assertEquals(TimeWindow.newInstance(10000, 60000), shipment.getDeliveryStartsTimeWindow());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_pickup", (k) -> new HashSet<>())
 				.add(shipment.getFrom().toString());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_delivery", (k) -> new HashSet<>())
@@ -525,29 +525,29 @@ public class DemandReaderFromCSVTest {
             countShipmentsWithCertainDemand.merge((Integer) shipment.getDemand(), 1, Integer::sum);
             countDemand = countDemand + shipment.getDemand();
             if (shipment.getDemand() == 0) {
-				Assertions.assertEquals(300, shipment.getPickupServiceTime(), MatsimTestUtils.EPSILON);
-				Assertions.assertEquals(350, shipment.getDeliveryServiceTime(), MatsimTestUtils.EPSILON);
-				Assertions.assertEquals(TimeWindow.newInstance(10000, 45000), shipment.getPickupTimeWindow());
-				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getDeliveryTimeWindow());
+				Assertions.assertEquals(300, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
+				Assertions.assertEquals(350, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
+				Assertions.assertEquals(TimeWindow.newInstance(10000, 45000), shipment.getPickupStartsTimeWindow());
+				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getDeliveryStartsTimeWindow());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_pickup", (k) -> new HashSet<>())
 					.add(shipment.getFrom().toString());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_delivery", (k) -> new HashSet<>())
 					.add(shipment.getTo().toString());
 			} else if (shipment.getDemand() == 2) {
-				Assertions.assertEquals(400, shipment.getPickupServiceTime(), MatsimTestUtils.EPSILON);
-				Assertions.assertEquals(400, shipment.getDeliveryServiceTime(), MatsimTestUtils.EPSILON);
-				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getPickupTimeWindow());
-				Assertions.assertEquals(TimeWindow.newInstance(20000, 40000), shipment.getDeliveryTimeWindow());
+				Assertions.assertEquals(400, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
+				Assertions.assertEquals(400, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
+				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getPickupStartsTimeWindow());
+				Assertions.assertEquals(TimeWindow.newInstance(20000, 40000), shipment.getDeliveryStartsTimeWindow());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_pickup", (k) -> new HashSet<>())
 					.add(shipment.getFrom().toString());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_delivery", (k) -> new HashSet<>())
 					.add(shipment.getTo().toString());
 			} else {
                 if (shipment.getDemand() == 3) {
-                    Assertions.assertEquals(600, shipment.getPickupServiceTime(), MatsimTestUtils.EPSILON);
-                    Assertions.assertEquals(600, shipment.getDeliveryServiceTime(), MatsimTestUtils.EPSILON);
-                    Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getPickupTimeWindow());
-                    Assertions.assertEquals(TimeWindow.newInstance(20000, 40000), shipment.getDeliveryTimeWindow());
+                    Assertions.assertEquals(600, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
+                    Assertions.assertEquals(600, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
+					Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getPickupStartsTimeWindow());
+					Assertions.assertEquals(TimeWindow.newInstance(20000, 40000), shipment.getDeliveryStartsTimeWindow());
                     locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_pickup", (k) -> new HashSet<>())
                             .add(shipment.getFrom().toString());
                     locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_delivery", (k) -> new HashSet<>())
@@ -624,19 +624,19 @@ public class DemandReaderFromCSVTest {
             countShipmentsWithCertainDemand.merge((Integer) shipment.getDemand(), 1, Integer::sum);
             countDemand = countDemand + shipment.getDemand();
             if (shipment.getDemand() == 0) {
-				Assertions.assertEquals(300, shipment.getPickupServiceTime(), MatsimTestUtils.EPSILON);
-				Assertions.assertEquals(350, shipment.getDeliveryServiceTime(), MatsimTestUtils.EPSILON);
-				Assertions.assertEquals(TimeWindow.newInstance(10000, 45000), shipment.getPickupTimeWindow());
-				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getDeliveryTimeWindow());
+				Assertions.assertEquals(300, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
+				Assertions.assertEquals(350, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
+				Assertions.assertEquals(TimeWindow.newInstance(10000, 45000), shipment.getPickupStartsTimeWindow());
+				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getDeliveryStartsTimeWindow());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_pickup", (k) -> new HashSet<>())
 					.add(shipment.getFrom().toString());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_delivery", (k) -> new HashSet<>())
 					.add(shipment.getTo().toString());
 			} else {
-                Assertions.assertEquals(shipment.getDemand() * 200, shipment.getPickupServiceTime(), MatsimTestUtils.EPSILON);
-                Assertions.assertEquals(shipment.getDemand() * 200, shipment.getDeliveryServiceTime(), MatsimTestUtils.EPSILON);
-				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getPickupTimeWindow());
-				Assertions.assertEquals(TimeWindow.newInstance(20000, 40000), shipment.getDeliveryTimeWindow());
+                Assertions.assertEquals(shipment.getDemand() * 200, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
+                Assertions.assertEquals(shipment.getDemand() * 200, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
+				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getPickupStartsTimeWindow());
+				Assertions.assertEquals(TimeWindow.newInstance(20000, 40000), shipment.getDeliveryStartsTimeWindow());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_pickup", (k) -> new HashSet<>())
 					.add(shipment.getFrom().toString());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_delivery", (k) -> new HashSet<>())

--- a/contribs/application/src/test/java/org/matsim/freightDemandGeneration/DemandReaderFromCSVTest.java
+++ b/contribs/application/src/test/java/org/matsim/freightDemandGeneration/DemandReaderFromCSVTest.java
@@ -109,9 +109,9 @@ public class DemandReaderFromCSVTest {
 			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupStartsTimeWindow());
 			Assertions.assertEquals(TimeWindow.newInstance(10000, 60000), shipment.getDeliveryStartsTimeWindow());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_pickup", (k) -> new HashSet<>())
-					.add(shipment.getFrom().toString());
+					.add(shipment.getPickupLinkId().toString());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_delivery", (k) -> new HashSet<>())
-					.add(shipment.getTo().toString());
+					.add(shipment.getDeliveryLinkId().toString());
 		}
 		Assertions.assertEquals(20, countDemand);
 		Assertions.assertEquals(4, countShipmentsWithCertainDemand.getInt(5));
@@ -176,9 +176,9 @@ public class DemandReaderFromCSVTest {
 			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupStartsTimeWindow());
 			Assertions.assertEquals(TimeWindow.newInstance(10000, 60000), shipment.getDeliveryStartsTimeWindow());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_pickup", (k) -> new HashSet<>())
-				.add(shipment.getFrom().toString());
+				.add(shipment.getPickupLinkId().toString());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_delivery", (k) -> new HashSet<>())
-				.add(shipment.getTo().toString());
+				.add(shipment.getDeliveryLinkId().toString());
 		}
 		Assertions.assertEquals(20, countDemand);
 		Assertions.assertEquals(2, countShipmentsWithCertainDemand.getInt(10));
@@ -243,9 +243,9 @@ public class DemandReaderFromCSVTest {
 			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupStartsTimeWindow());
 			Assertions.assertEquals(TimeWindow.newInstance(10000, 60000), shipment.getDeliveryStartsTimeWindow());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_pickup", (k) -> new HashSet<>())
-				.add(shipment.getFrom().toString());
+				.add(shipment.getPickupLinkId().toString());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_delivery", (k) -> new HashSet<>())
-				.add(shipment.getTo().toString());
+				.add(shipment.getDeliveryLinkId().toString());
 		}
 		Assertions.assertEquals(20, countDemand);
 		Assertions.assertEquals(2, countShipmentsWithCertainDemand.getInt(10));
@@ -313,9 +313,9 @@ public class DemandReaderFromCSVTest {
 			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupStartsTimeWindow());
 			Assertions.assertEquals(TimeWindow.newInstance(10000, 60000), shipment.getDeliveryStartsTimeWindow());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_pickup", (k) -> new HashSet<>())
-				.add(shipment.getFrom().toString());
+				.add(shipment.getPickupLinkId().toString());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_delivery", (k) -> new HashSet<>())
-				.add(shipment.getTo().toString());
+				.add(shipment.getDeliveryLinkId().toString());
 		}
 		Assertions.assertEquals(20, countDemand);
 		Assertions.assertEquals(2, countShipmentsWithCertainDemand.getInt(10));
@@ -480,18 +480,18 @@ public class DemandReaderFromCSVTest {
 				Assertions.assertEquals(180, service.getServiceDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(TimeWindow.newInstance(3000, 13000), service.getServiceStartTimeWindow());
 				locationsPerServiceElement.computeIfAbsent("serviceElement1", (k) -> new HashSet<>())
-					.add(service.getLocationLinkId().toString());
+					.add(service.getServiceLinkId().toString());
 			} else if (service.getDemand() == 1) {
 				Assertions.assertEquals(100, service.getServiceDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(TimeWindow.newInstance(5000, 20000), service.getServiceStartTimeWindow());
 				locationsPerServiceElement.computeIfAbsent("serviceElement2", (k) -> new HashSet<>())
-					.add(service.getLocationLinkId().toString());
+					.add(service.getServiceLinkId().toString());
 			} else {
 				if (service.getDemand() == 2) {
 					Assertions.assertEquals(200, service.getServiceDuration(), MatsimTestUtils.EPSILON);
 					Assertions.assertEquals(TimeWindow.newInstance(5000, 20000), service.getServiceStartTimeWindow());
 					locationsPerServiceElement.computeIfAbsent("serviceElement2", (k) -> new HashSet<>())
-						.add(service.getLocationLinkId().toString());
+						.add(service.getServiceLinkId().toString());
 				} else
 					Assertions.fail("Service has a wrong demand.");
 			}
@@ -530,18 +530,18 @@ public class DemandReaderFromCSVTest {
 				Assertions.assertEquals(TimeWindow.newInstance(10000, 45000), shipment.getPickupStartsTimeWindow());
 				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getDeliveryStartsTimeWindow());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_pickup", (k) -> new HashSet<>())
-					.add(shipment.getFrom().toString());
+					.add(shipment.getPickupLinkId().toString());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_delivery", (k) -> new HashSet<>())
-					.add(shipment.getTo().toString());
+					.add(shipment.getDeliveryLinkId().toString());
 			} else if (shipment.getDemand() == 2) {
 				Assertions.assertEquals(400, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(400, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getPickupStartsTimeWindow());
 				Assertions.assertEquals(TimeWindow.newInstance(20000, 40000), shipment.getDeliveryStartsTimeWindow());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_pickup", (k) -> new HashSet<>())
-					.add(shipment.getFrom().toString());
+					.add(shipment.getPickupLinkId().toString());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_delivery", (k) -> new HashSet<>())
-					.add(shipment.getTo().toString());
+					.add(shipment.getDeliveryLinkId().toString());
 			} else {
                 if (shipment.getDemand() == 3) {
                     Assertions.assertEquals(600, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
@@ -549,9 +549,9 @@ public class DemandReaderFromCSVTest {
 					Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getPickupStartsTimeWindow());
 					Assertions.assertEquals(TimeWindow.newInstance(20000, 40000), shipment.getDeliveryStartsTimeWindow());
                     locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_pickup", (k) -> new HashSet<>())
-                            .add(shipment.getFrom().toString());
+                            .add(shipment.getPickupLinkId().toString());
                     locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_delivery", (k) -> new HashSet<>())
-                            .add(shipment.getTo().toString());
+                            .add(shipment.getDeliveryLinkId().toString());
                 } else
                     Assertions.fail("Shipment has an unexpected demand.");
             }
@@ -589,12 +589,12 @@ public class DemandReaderFromCSVTest {
 				Assertions.assertEquals(180, service.getServiceDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(TimeWindow.newInstance(3000, 13000), service.getServiceStartTimeWindow());
 				locationsPerServiceElement.computeIfAbsent("serviceElement1", (k) -> new HashSet<>())
-					.add(service.getLocationLinkId().toString());
+					.add(service.getServiceLinkId().toString());
 			} else {
 				Assertions.assertEquals(service.getDemand() * 100, service.getServiceDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(TimeWindow.newInstance(5000, 20000), service.getServiceStartTimeWindow());
 				locationsPerServiceElement.computeIfAbsent("serviceElement2", (k) -> new HashSet<>())
-					.add(service.getLocationLinkId().toString());
+					.add(service.getServiceLinkId().toString());
 			}
 		}
 		Assertions.assertEquals(12, countDemand);
@@ -629,18 +629,18 @@ public class DemandReaderFromCSVTest {
 				Assertions.assertEquals(TimeWindow.newInstance(10000, 45000), shipment.getPickupStartsTimeWindow());
 				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getDeliveryStartsTimeWindow());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_pickup", (k) -> new HashSet<>())
-					.add(shipment.getFrom().toString());
+					.add(shipment.getPickupLinkId().toString());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_delivery", (k) -> new HashSet<>())
-					.add(shipment.getTo().toString());
+					.add(shipment.getDeliveryLinkId().toString());
 			} else {
                 Assertions.assertEquals(shipment.getDemand() * 200, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
                 Assertions.assertEquals(shipment.getDemand() * 200, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getPickupStartsTimeWindow());
 				Assertions.assertEquals(TimeWindow.newInstance(20000, 40000), shipment.getDeliveryStartsTimeWindow());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_pickup", (k) -> new HashSet<>())
-					.add(shipment.getFrom().toString());
+					.add(shipment.getPickupLinkId().toString());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_delivery", (k) -> new HashSet<>())
-					.add(shipment.getTo().toString());
+					.add(shipment.getDeliveryLinkId().toString());
 			}
 		}
 		Assertions.assertEquals(15, countDemand);

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/DefaultCommercialJobGenerator.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/DefaultCommercialJobGenerator.java
@@ -329,7 +329,7 @@ class DefaultCommercialJobGenerator implements CommercialJobGenerator {
                     double latestStart = Double.parseDouble(commercialJobProperties.get(COMMERCIALJOB_ATTRIBUTE_END_IDX));
 
                     CarrierService.Builder serviceBuilder = CarrierService.Builder.newInstance(serviceId, PopulationUtils.decideOnLinkIdForActivity(activity,scenario));
-                    serviceBuilder.setCapacityDemand(Integer.parseInt(commercialJobProperties.get(COMMERCIALJOB_ATTRIBUTE_AMOUNT_IDX)));
+                    serviceBuilder.setDemand(Integer.parseInt(commercialJobProperties.get(COMMERCIALJOB_ATTRIBUTE_AMOUNT_IDX)));
                     serviceBuilder.setServiceDuration(Double.parseDouble(commercialJobProperties.get(COMMERCIALJOB_ATTRIBUTE_DURATION_IDX)));
                     serviceBuilder.setServiceStartTimeWindow(TimeWindow.newInstance(earliestStart,latestStart));
 

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierJob.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierJob.java
@@ -1,5 +1,6 @@
 package org.matsim.freight.carriers;
 
+import org.matsim.api.core.v01.Id;
 import org.matsim.utils.objectattributes.attributable.Attributable;
 
 /**
@@ -16,4 +17,7 @@ import org.matsim.utils.objectattributes.attributable.Attributable;
  * future) It maybe gets generalized in way, that we only have one job definition with 1 or 2
  * location(s). This then defines, if jsprit takes the job as a service or as a shipment.
  */
-public interface CarrierJob extends Attributable {}
+public interface CarrierJob extends Attributable {
+	Id<? extends CarrierJob> getId();
+	int getDemand();
+}

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanReaderV1.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanReaderV1.java
@@ -116,19 +116,19 @@ class CarrierPlanReaderV1 extends MatsimXmlParser {
 				CarrierShipment.Builder shipmentBuilder = CarrierShipment.Builder.newInstance( Id.create( id, CarrierShipment.class ),
 					  Id.create( from, Link.class ), Id.create( to, Link.class ), size );
 				if( startPickup == null ){
-					shipmentBuilder.setPickupTimeWindow( TimeWindow.newInstance( 0.0, Integer.MAX_VALUE ) ).setDeliveryTimeWindow(
+					shipmentBuilder.setPickupStartsTimeWindow( TimeWindow.newInstance( 0.0, Integer.MAX_VALUE ) ).setDeliveryStartsTimeWindow(
 						  TimeWindow.newInstance( 0.0, Integer.MAX_VALUE ) );
 				} else{
-					shipmentBuilder.setPickupTimeWindow( TimeWindow.newInstance( getDouble( startPickup ), getDouble( endPickup ) ) ).
-																									 setDeliveryTimeWindow(
+					shipmentBuilder.setPickupStartsTimeWindow( TimeWindow.newInstance( getDouble( startPickup ), getDouble( endPickup ) ) ).
+						setDeliveryStartsTimeWindow(
 																										   TimeWindow.newInstance(
 																											     getDouble(
 																													 startDelivery ),
 																											     getDouble(
 																													 endDelivery ) ) );
 				}
-				if( pickupServiceTime != null ) shipmentBuilder.setPickupServiceTime( getDouble( pickupServiceTime ) );
-				if( deliveryServiceTime != null ) shipmentBuilder.setDeliveryServiceTime( getDouble( deliveryServiceTime ) );
+				if( pickupServiceTime != null ) shipmentBuilder.setPickupDuration( getDouble( pickupServiceTime ) );
+				if( deliveryServiceTime != null ) shipmentBuilder.setDeliveryDuration( getDouble( deliveryServiceTime ) );
 				CarrierShipment shipment = shipmentBuilder.build();
 				currentShipments.put( attributes.getValue( ID ), shipment );
 				CarriersUtils.addShipment(currentCarrier, shipment);

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanReaderV1.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanReaderV1.java
@@ -208,16 +208,16 @@ class CarrierPlanReaderV1 extends MatsimXmlParser {
 					case "pickup" -> {
 						String id = attributes.getValue(SHIPMENT_ID);
 						CarrierShipment s = currentShipments.get(id);
-						finishLeg(s.getFrom());
+						finishLeg(s.getPickupLinkId());
 						currentTourBuilder.schedulePickup(s);
-						previousActLoc = s.getFrom();
+						previousActLoc = s.getPickupLinkId();
 					}
 					case "delivery" -> {
 						String id = attributes.getValue(SHIPMENT_ID);
 						CarrierShipment s = currentShipments.get(id);
-						finishLeg(s.getTo());
+						finishLeg(s.getDeliveryLinkId());
 						currentTourBuilder.scheduleDelivery(s);
-						previousActLoc = s.getTo();
+						previousActLoc = s.getDeliveryLinkId();
 					}
 					case "end" -> {
 						finishLeg(currentVehicle.getLinkId());

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2.java
@@ -117,7 +117,7 @@ class CarrierPlanXmlParserV2 extends MatsimXmlParser {
 				Id<Link> to = Id.create(toLocation, Link.class);
 				CarrierService.Builder serviceBuilder = CarrierService.Builder.newInstance(id, to);
 				String capDemandString = atts.getValue("capacityDemand");
-				if (capDemandString != null) serviceBuilder.setCapacityDemand(getInt(capDemandString));
+				if (capDemandString != null) serviceBuilder.setDemand(getInt(capDemandString));
 				String startString = atts.getValue("earliestStart");
 				double start = parseTimeToDouble(startString);
 				double end;
@@ -157,13 +157,13 @@ class CarrierPlanXmlParserV2 extends MatsimXmlParser {
 				String deliveryServiceTime = atts.getValue("deliveryServiceTime");
 
 				if (startPickup != null && endPickup != null)
-					shipmentBuilder.setPickupTimeWindow(TimeWindow.newInstance(parseTimeToDouble(startPickup), parseTimeToDouble(endPickup)));
+					shipmentBuilder.setPickupStartsTimeWindow(TimeWindow.newInstance(parseTimeToDouble(startPickup), parseTimeToDouble(endPickup)));
 				if (startDelivery != null && endDelivery != null)
-					shipmentBuilder.setDeliveryTimeWindow(TimeWindow.newInstance(parseTimeToDouble(startDelivery), parseTimeToDouble(endDelivery)));
+					shipmentBuilder.setDeliveryStartsTimeWindow(TimeWindow.newInstance(parseTimeToDouble(startDelivery), parseTimeToDouble(endDelivery)));
 				if (pickupServiceTime != null)
-					shipmentBuilder.setPickupServiceTime(parseTimeToDouble(pickupServiceTime));
+					shipmentBuilder.setPickupDuration(parseTimeToDouble(pickupServiceTime));
 				if (deliveryServiceTime != null)
-					shipmentBuilder.setDeliveryServiceTime(parseTimeToDouble(deliveryServiceTime));
+					shipmentBuilder.setDeliveryDuration(parseTimeToDouble(deliveryServiceTime));
 
 				currentShipment = shipmentBuilder.build();
 				currentShipments.put(atts.getValue(ID), currentShipment);

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2.java
@@ -261,26 +261,26 @@ class CarrierPlanXmlParserV2 extends MatsimXmlParser {
 						String id = atts.getValue(SHIPMENT_ID);
 						if (id == null) throw new IllegalStateException("pickup.shipmentId is missing.");
 						CarrierShipment s = currentShipments.get(id);
-						finishLeg(s.getFrom());
+						finishLeg(s.getPickupLinkId());
 						currentTourBuilder.schedulePickup(s);
-						previousActLoc = s.getFrom();
+						previousActLoc = s.getPickupLinkId();
 					}
 					case "delivery" -> {
 						String id = atts.getValue(SHIPMENT_ID);
 						if (id == null) throw new IllegalStateException("delivery.shipmentId is missing.");
 						CarrierShipment s = currentShipments.get(id);
-						finishLeg(s.getTo());
+						finishLeg(s.getDeliveryLinkId());
 						currentTourBuilder.scheduleDelivery(s);
-						previousActLoc = s.getTo();
+						previousActLoc = s.getDeliveryLinkId();
 					}
 					case "service" -> {
 						String id = atts.getValue("serviceId");
 						if (id == null) throw new IllegalStateException("act.serviceId is missing.");
 						CarrierService s = serviceMap.get(Id.create(id, CarrierService.class));
 						if (s == null) throw new IllegalStateException("serviceId is not known.");
-						finishLeg(s.getLocationLinkId());
+						finishLeg(s.getServiceLinkId());
 						currentTourBuilder.scheduleService(s);
-						previousActLoc = s.getLocationLinkId();
+						previousActLoc = s.getServiceLinkId();
 					}
 					case "end" -> {
 						finishLeg(currentVehicle.getLinkId());

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2_1.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2_1.java
@@ -263,26 +263,26 @@ class CarrierPlanXmlParserV2_1 extends MatsimXmlParser {
 						String id = atts.getValue(SHIPMENT_ID);
 						if (id == null) throw new IllegalStateException("pickup.shipmentId is missing.");
 						CarrierShipment s = currentShipments.get(id);
-						finishLeg(s.getFrom());
+						finishLeg(s.getPickupLinkId());
 						currentTourBuilder.schedulePickup(s);
-						previousActLoc = s.getFrom();
+						previousActLoc = s.getPickupLinkId();
 					}
 					case "delivery" -> {
 						String id = atts.getValue(SHIPMENT_ID);
 						if (id == null) throw new IllegalStateException("delivery.shipmentId is missing.");
 						CarrierShipment s = currentShipments.get(id);
-						finishLeg(s.getTo());
+						finishLeg(s.getDeliveryLinkId());
 						currentTourBuilder.scheduleDelivery(s);
-						previousActLoc = s.getTo();
+						previousActLoc = s.getDeliveryLinkId();
 					}
 					case "service" -> {
 						String id = atts.getValue("serviceId");
 						if (id == null) throw new IllegalStateException("act.serviceId is missing.");
 						CarrierService s = serviceMap.get(Id.create(id, CarrierService.class));
 						if (s == null) throw new IllegalStateException("serviceId is not known.");
-						finishLeg(s.getLocationLinkId());
+						finishLeg(s.getServiceLinkId());
 						currentTourBuilder.scheduleService(s);
-						previousActLoc = s.getLocationLinkId();
+						previousActLoc = s.getServiceLinkId();
 					}
 					case "end" -> {
 						finishLeg(currentVehicle.getLinkId());

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2_1.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2_1.java
@@ -115,7 +115,7 @@ class CarrierPlanXmlParserV2_1 extends MatsimXmlParser {
 				Id<Link> to = Id.create(toLocation, Link.class);
 				CarrierService.Builder serviceBuilder = CarrierService.Builder.newInstance(id, to);
 				String capDemandString = atts.getValue("capacityDemand");
-				if (capDemandString != null) serviceBuilder.setCapacityDemand(getInt(capDemandString));
+				if (capDemandString != null) serviceBuilder.setDemand(getInt(capDemandString));
 				String startString = atts.getValue("earliestStart");
 				double start = parseTimeToDouble(startString);
 				double end;
@@ -155,13 +155,13 @@ class CarrierPlanXmlParserV2_1 extends MatsimXmlParser {
 				String deliveryServiceTime = atts.getValue("deliveryServiceTime");
 
 				if (startPickup != null && endPickup != null)
-					shipmentBuilder.setPickupTimeWindow(TimeWindow.newInstance(parseTimeToDouble(startPickup), parseTimeToDouble(endPickup)));
+					shipmentBuilder.setPickupStartsTimeWindow(TimeWindow.newInstance(parseTimeToDouble(startPickup), parseTimeToDouble(endPickup)));
 				if (startDelivery != null && endDelivery != null)
-					shipmentBuilder.setDeliveryTimeWindow(TimeWindow.newInstance(parseTimeToDouble(startDelivery), parseTimeToDouble(endDelivery)));
+					shipmentBuilder.setDeliveryStartsTimeWindow(TimeWindow.newInstance(parseTimeToDouble(startDelivery), parseTimeToDouble(endDelivery)));
 				if (pickupServiceTime != null)
-					shipmentBuilder.setPickupServiceTime(parseTimeToDouble(pickupServiceTime));
+					shipmentBuilder.setPickupDuration(parseTimeToDouble(pickupServiceTime));
 				if (deliveryServiceTime != null)
-					shipmentBuilder.setDeliveryServiceTime(parseTimeToDouble(deliveryServiceTime));
+					shipmentBuilder.setDeliveryDuration(parseTimeToDouble(deliveryServiceTime));
 
 				currentShipment = shipmentBuilder.build();
 				currentShipments.put(atts.getValue(ID), currentShipment);

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlWriterV2_1.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlWriterV2_1.java
@@ -157,11 +157,11 @@ import org.matsim.vehicles.VehicleType;
 	}
 
 	private void writeShipment(CarrierShipment s, Id<CarrierShipment> shipmentId, boolean closeElement, boolean lineBreak) {
-		this.writeStartTag(SHIPMENT, List.of(
+        this.writeStartTag(SHIPMENT, List.of(
 				createTuple(ID, shipmentId.toString()),
 				createTuple(FROM, s.getFrom().toString()),
 				createTuple(TO, s.getTo().toString()),
-				createTuple(SIZE, s.getSize()),
+				createTuple(SIZE, s.getDemand()),
 				createTuple(START_PICKUP, getTime(s.getPickupTimeWindow().getStart())),
 				createTuple(END_PICKUP, getTime(s.getPickupTimeWindow().getEnd())),
 				createTuple(START_DELIVERY, getTime(s.getDeliveryTimeWindow().getStart())),
@@ -191,7 +191,7 @@ import org.matsim.vehicles.VehicleType;
 		this.writeStartTag(SERVICE, List.of(
 				createTuple(ID, s.getId().toString()),
 				createTuple(TO, s.getLocationLinkId().toString()),
-				createTuple(CAPACITY_DEMAND, s.getCapacityDemand()),
+				createTuple(CAPACITY_DEMAND, s.getDemand()),
 				createTuple(EARLIEST_START, getTime(s.getServiceStartTimeWindow().getStart())),
 				createTuple(LATEST_END, getTime(s.getServiceStartTimeWindow().getEnd())),
 				createTuple(SERVICE_DURATION, getTime(s.getServiceDuration()))), closeElement, lineBreak

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlWriterV2_1.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlWriterV2_1.java
@@ -157,17 +157,17 @@ import org.matsim.vehicles.VehicleType;
 	}
 
 	private void writeShipment(CarrierShipment s, Id<CarrierShipment> shipmentId, boolean closeElement, boolean lineBreak) {
-        this.writeStartTag(SHIPMENT, List.of(
+		this.writeStartTag(SHIPMENT, List.of(
 				createTuple(ID, shipmentId.toString()),
 				createTuple(FROM, s.getFrom().toString()),
 				createTuple(TO, s.getTo().toString()),
 				createTuple(SIZE, s.getDemand()),
-				createTuple(START_PICKUP, getTime(s.getPickupTimeWindow().getStart())),
-				createTuple(END_PICKUP, getTime(s.getPickupTimeWindow().getEnd())),
-				createTuple(START_DELIVERY, getTime(s.getDeliveryTimeWindow().getStart())),
-				createTuple(END_DELIVERY, getTime(s.getDeliveryTimeWindow().getEnd())),
-				createTuple(PICKUP_SERVICE_TIME, getTime(s.getPickupServiceTime())),
-				createTuple(DELIVERY_SERVICE_TIME, getTime(s.getDeliveryServiceTime()))), closeElement, lineBreak
+				createTuple(START_PICKUP, getTime(s.getPickupStartsTimeWindow().getStart())),
+				createTuple(END_PICKUP, getTime(s.getPickupStartsTimeWindow().getEnd())),
+				createTuple(START_DELIVERY, getTime(s.getDeliveryStartsTimeWindow().getStart())),
+				createTuple(END_DELIVERY, getTime(s.getDeliveryStartsTimeWindow().getEnd())),
+				createTuple(PICKUP_SERVICE_TIME, getTime(s.getPickupDuration())),
+				createTuple(DELIVERY_SERVICE_TIME, getTime(s.getDeliveryDuration()))), closeElement, lineBreak
 		);
 	}
 

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlWriterV2_1.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlWriterV2_1.java
@@ -159,8 +159,8 @@ import org.matsim.vehicles.VehicleType;
 	private void writeShipment(CarrierShipment s, Id<CarrierShipment> shipmentId, boolean closeElement, boolean lineBreak) {
 		this.writeStartTag(SHIPMENT, List.of(
 				createTuple(ID, shipmentId.toString()),
-				createTuple(FROM, s.getFrom().toString()),
-				createTuple(TO, s.getTo().toString()),
+				createTuple(FROM, s.getPickupLinkId().toString()),
+				createTuple(TO, s.getDeliveryLinkId().toString()),
 				createTuple(SIZE, s.getDemand()),
 				createTuple(START_PICKUP, getTime(s.getPickupStartsTimeWindow().getStart())),
 				createTuple(END_PICKUP, getTime(s.getPickupStartsTimeWindow().getEnd())),
@@ -190,7 +190,7 @@ import org.matsim.vehicles.VehicleType;
 	private void writeService(CarrierService s, boolean closeElement, boolean lineBreak) {
 		this.writeStartTag(SERVICE, List.of(
 				createTuple(ID, s.getId().toString()),
-				createTuple(TO, s.getLocationLinkId().toString()),
+				createTuple(TO, s.getServiceLinkId().toString()),
 				createTuple(CAPACITY_DEMAND, s.getDemand()),
 				createTuple(EARLIEST_START, getTime(s.getServiceStartTimeWindow().getStart())),
 				createTuple(LATEST_END, getTime(s.getServiceStartTimeWindow().getEnd())),

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
@@ -141,8 +141,16 @@ public final class CarrierService implements CarrierJob {
 		return id;
 	}
 
-	public Id<Link> getLocationLinkId() {
+	public Id<Link> getServiceLinkId() {
 		return serviceLinkId;
+	}
+
+	/**
+	 * @deprecated please inline and use {@link #getServiceLinkId()} instead
+	 */
+	@Deprecated(since = "dec'24")
+	public Id<Link> getLocationLinkId() {
+		return getServiceLinkId();
 	}
 
 	public double getServiceDuration() {

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
@@ -47,9 +47,29 @@ public final class CarrierService implements CarrierJob {
 			this.serviceLinkId = serviceLinkId;
 		}
 
+		public CarrierService build(){
+			return new CarrierService(this);
+		}
+
 
 		/**
-		 * By default, it is [0.0,Integer.MaxValue].
+		 * Sets a time-window for the beginning of  the service
+		 * When not set, it is by default [0.0., Integer.MAX_VALUE].
+		 * <p>
+		 * Note that the time-window restricts the start-time of the service (i.e. serviceActivity). If one works with hard time-windows (which means that
+		 * time-windows must be met) than the service is allowed to start between startTimeWindow.getStart() and startTimeWindow.getEnd().
+		 *
+		 * @param startTimeWindow 	time-window for the beginning of the service acti
+		 * @return 					the builder
+		 */
+		public Builder setServiceStartTimeWindow(TimeWindow startTimeWindow){
+			this.serviceStartsTimeWindow = startTimeWindow;
+			return this;
+		}
+
+		/**
+		 *  Sets the duration for the pickup activity.
+		 *  When not set, it is by default 0.0.
 		 *
 		 * @param serviceDuration 	duration of the service
 		 * @return 					the builder
@@ -59,23 +79,8 @@ public final class CarrierService implements CarrierJob {
 			return this;
 		}
 
-		/**
-		 * Sets a time-window for the service.
-		 *
-		 * <p>Note that the time-window restricts the start-time of the service (i.e. serviceActivity). If one works with hard time-windows (which means that
-		 * time-windows must be met) than the service is allowed to start between startTimeWindow.getStart() and startTimeWindow.getEnd().
-		 *
-		 * @param startTimeWindow 	time-window for the service
-		 * @return 					the builder
-		 */
-		public Builder setServiceStartTimeWindow(TimeWindow startTimeWindow){
-			this.serviceStartsTimeWindow = startTimeWindow;
-			return this;
-		}
 
-		public CarrierService build(){
-			return new CarrierService(this);
-		}
+
 
 		public Builder setCapacityDemand(int value) {
 			this.demand = value;

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
@@ -33,6 +33,9 @@ public final class CarrierService implements CarrierJob {
 		private final Id<CarrierService> id;
 		private int demand = 0;
 
+		//IMO we could build a general class (CarrierActivity ???), containing the location, StartTimeWindow and Duration.
+		//This could be used for both, CarrierService and CarrierShipment (Pickup and Delivery).
+		//kturner dec'24
 		private final Id<Link> serviceLinkId;
 		private TimeWindow serviceStartsTimeWindow = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
 		private double serviceDuration = 0.0;
@@ -59,7 +62,7 @@ public final class CarrierService implements CarrierJob {
 		 * Note that the time-window restricts the start-time of the service (i.e. serviceActivity). If one works with hard time-windows (which means that
 		 * time-windows must be met) than the service is allowed to start between startTimeWindow.getStart() and startTimeWindow.getEnd().
 		 *
-		 * @param startTimeWindow 	time-window for the beginning of the service acti
+		 * @param startTimeWindow 	time-window for the beginning of the service activity
 		 * @return 					the builder
 		 */
 		public Builder setServiceStartTimeWindow(TimeWindow startTimeWindow){
@@ -79,9 +82,15 @@ public final class CarrierService implements CarrierJob {
 			return this;
 		}
 
-
-
-
+		/**
+		* Sets the demand (size; capacity needed) of the service.
+		 * When not set, it is by default 0.
+		 * <p>
+		 * IMO we can put this into the Builder directly instead of a separate method? kturner dec'24
+		 *
+		 * @param value the demand (size; capacity needed) of the service
+		 * @return the builder
+		*/
 		public Builder setCapacityDemand(int value) {
 			this.demand = value;
 			return this;
@@ -93,6 +102,9 @@ public final class CarrierService implements CarrierJob {
 	private final Id<CarrierService> id;
 	private final int demand;
 
+	//IMO we could build a general class (CarrierActivity ???), containing the location, StartTimeWindow and Duration.
+	//This could be used for both, CarrierService and CarrierShipment (Pickup and Delivery).
+	//kturner dec'24
 	private final Id<Link> serviceLinkId;
 	private final TimeWindow serviceStartsTimeWindow;
 	private final double serviceDuration;
@@ -127,7 +139,7 @@ public final class CarrierService implements CarrierJob {
 	/**
 	 * @deprecated please inline and use {@link #getDemand()} instead
 	 */
-	@Deprecated(since = "dez 2024")
+	@Deprecated(since = "dec'24")
 	public int getCapacityDemand() {
 		return getDemand();
 	}

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
@@ -36,7 +36,6 @@ public final class CarrierService implements CarrierJob {
 
 		private final Id<CarrierService> id;
 		private final Id<Link> locationLinkId;
-		private String name = "service";
 
 		private double serviceTime = 0.0;
 		private TimeWindow timeWindow = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
@@ -48,10 +47,6 @@ public final class CarrierService implements CarrierJob {
 			this.locationLinkId = locationLinkId;
 		}
 
-		public Builder setName(String name){
-			this.name = name;
-			return this;
-		}
 
 		/**
 		 * By default, it is [0.0,Integer.MaxValue].
@@ -92,7 +87,6 @@ public final class CarrierService implements CarrierJob {
 
 	private final Id<CarrierService> id;
 	private final Id<Link> locationId;
-	private final String name;
 	private final double serviceDuration;
 	private final TimeWindow timeWindow;
 	private final int demand;
@@ -104,7 +98,6 @@ public final class CarrierService implements CarrierJob {
 		serviceDuration = builder.serviceTime;
 		timeWindow = builder.timeWindow;
 		demand = builder.demand;
-		name = builder.name;
 	}
 
 	@Override
@@ -148,12 +141,6 @@ public final class CarrierService implements CarrierJob {
 		return attributes;
 	}
 
-	/**
-	 * @return the name
-	 */
-	public String getType() {
-		return name;
-	}
 
 	@Override
 	public String toString() {

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
@@ -83,17 +83,34 @@ public final class CarrierService implements CarrierJob {
 		}
 
 		/**
+		 * Sets the demand (size; capacity needed) of the service.
+		 * When not set, it is by default 0.
+		 * <p>
+		 * IMO we can put this into the Builder directly instead of a separate method? kturner dec'24
+		 *
+		 * @param demand the demand (size; capacity needed) of the service
+		 * @return the builder
+		 */
+		public Builder setDemand(int demand) {
+			this.demand = demand;
+			return this;
+		}
+
+
+		/**
 		* Sets the demand (size; capacity needed) of the service.
 		 * When not set, it is by default 0.
 		 * <p>
 		 * IMO we can put this into the Builder directly instead of a separate method? kturner dec'24
 		 *
+		 * @deprecated please use {@link #setDemand(int)} instead
+		 *
 		 * @param value the demand (size; capacity needed) of the service
 		 * @return the builder
 		*/
+		@Deprecated(since = "dec'24")
 		public Builder setCapacityDemand(int value) {
-			this.demand = value;
-			return this;
+			return setDemand(value);
 		}
 
 	}

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
@@ -35,11 +35,11 @@ public final class CarrierService implements CarrierJob {
 		}
 
 		private final Id<CarrierService> id;
-		private final Id<Link> locationLinkId;
-
-		private double serviceTime = 0.0;
-		private TimeWindow timeWindow = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
 		private int demand = 0;
+
+		private final Id<Link> locationLinkId;
+		private TimeWindow timeWindow = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
+		private double serviceTime = 0.0;
 
 		private Builder(Id<CarrierService> id, Id<Link> locationLinkId) {
 			super();
@@ -86,10 +86,12 @@ public final class CarrierService implements CarrierJob {
 
 
 	private final Id<CarrierService> id;
-	private final Id<Link> locationId;
-	private final double serviceDuration;
-	private final TimeWindow timeWindow;
 	private final int demand;
+
+	private final Id<Link> locationId;
+	private final TimeWindow timeWindow;
+	private final double serviceDuration;
+
 	private final Attributes attributes = new AttributesImpl();
 
 	private CarrierService(Builder builder){

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
@@ -23,7 +23,6 @@ package org.matsim.freight.carriers;
 
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.utils.objectattributes.attributable.Attributable;
 import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.utils.objectattributes.attributable.AttributesImpl;
 
@@ -41,7 +40,7 @@ public final class CarrierService implements CarrierJob {
 
 		private double serviceTime = 0.0;
 		private TimeWindow timeWindow = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
-		private int capacityDemand = 0;
+		private int demand = 0;
 
 		private Builder(Id<CarrierService> id, Id<Link> locationLinkId) {
 			super();
@@ -84,7 +83,7 @@ public final class CarrierService implements CarrierJob {
 		}
 
 		public Builder setCapacityDemand(int value) {
-			this.capacityDemand = value;
+			this.demand = value;
 			return this;
 		}
 
@@ -92,17 +91,11 @@ public final class CarrierService implements CarrierJob {
 
 
 	private final Id<CarrierService> id;
-
 	private final Id<Link> locationId;
-
 	private final String name;
-
 	private final double serviceDuration;
-
 	private final TimeWindow timeWindow;
-
 	private final int demand;
-
 	private final Attributes attributes = new AttributesImpl();
 
 	private CarrierService(Builder builder){
@@ -110,13 +103,16 @@ public final class CarrierService implements CarrierJob {
 		locationId = builder.locationLinkId;
 		serviceDuration = builder.serviceTime;
 		timeWindow = builder.timeWindow;
-		demand = builder.capacityDemand;
+		demand = builder.demand;
 		name = builder.name;
 	}
 
+	@Override
 	public Id<CarrierService> getId() {
 		return id;
 	}
+
+
 
 	public Id<Link> getLocationLinkId() {
 		return locationId;
@@ -130,9 +126,22 @@ public final class CarrierService implements CarrierJob {
 		return timeWindow;
 	}
 
+	/**
+	 * @deprecated please inline and use {@link #getDemand()} instead
+	 */
+	@Deprecated(since = "dez 2024")
 	public int getCapacityDemand() {
+		return getDemand();
+	}
+
+	/**
+	 * @return the demand (size; capacity needed) of the service.
+	 */
+	@Override
+	public int getDemand() {
 		return demand;
 	}
+
 
 	@Override
 	public Attributes getAttributes() {

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
@@ -30,21 +30,21 @@ public final class CarrierService implements CarrierJob {
 
 	public static class Builder {
 
+		private final Id<CarrierService> id;
+		private int demand = 0;
+
+		private final Id<Link> serviceLinkId;
+		private TimeWindow serviceStartsTimeWindow = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
+		private double serviceDuration = 0.0;
+
 		public static Builder newInstance(Id<CarrierService> id, Id<Link> locationLinkId){
 			return new Builder(id,locationLinkId);
 		}
 
-		private final Id<CarrierService> id;
-		private int demand = 0;
-
-		private final Id<Link> locationLinkId;
-		private TimeWindow timeWindow = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
-		private double serviceTime = 0.0;
-
-		private Builder(Id<CarrierService> id, Id<Link> locationLinkId) {
+		private Builder(Id<CarrierService> id, Id<Link> serviceLinkId) {
 			super();
 			this.id = id;
-			this.locationLinkId = locationLinkId;
+			this.serviceLinkId = serviceLinkId;
 		}
 
 
@@ -55,7 +55,7 @@ public final class CarrierService implements CarrierJob {
 		 * @return 					the builder
 		 */
 		public Builder setServiceDuration(double serviceDuration){
-			this.serviceTime = serviceDuration;
+			this.serviceDuration = serviceDuration;
 			return this;
 		}
 
@@ -69,7 +69,7 @@ public final class CarrierService implements CarrierJob {
 		 * @return 					the builder
 		 */
 		public Builder setServiceStartTimeWindow(TimeWindow startTimeWindow){
-			this.timeWindow = startTimeWindow;
+			this.serviceStartsTimeWindow = startTimeWindow;
 			return this;
 		}
 
@@ -88,17 +88,17 @@ public final class CarrierService implements CarrierJob {
 	private final Id<CarrierService> id;
 	private final int demand;
 
-	private final Id<Link> locationId;
-	private final TimeWindow timeWindow;
+	private final Id<Link> serviceLinkId;
+	private final TimeWindow serviceStartsTimeWindow;
 	private final double serviceDuration;
 
 	private final Attributes attributes = new AttributesImpl();
 
 	private CarrierService(Builder builder){
 		id = builder.id;
-		locationId = builder.locationLinkId;
-		serviceDuration = builder.serviceTime;
-		timeWindow = builder.timeWindow;
+		serviceLinkId = builder.serviceLinkId;
+		serviceDuration = builder.serviceDuration;
+		serviceStartsTimeWindow = builder.serviceStartsTimeWindow;
 		demand = builder.demand;
 	}
 
@@ -107,10 +107,8 @@ public final class CarrierService implements CarrierJob {
 		return id;
 	}
 
-
-
 	public Id<Link> getLocationLinkId() {
-		return locationId;
+		return serviceLinkId;
 	}
 
 	public double getServiceDuration() {
@@ -118,7 +116,7 @@ public final class CarrierService implements CarrierJob {
 	}
 
 	public TimeWindow getServiceStartTimeWindow(){
-		return timeWindow;
+		return serviceStartsTimeWindow;
 	}
 
 	/**
@@ -146,7 +144,7 @@ public final class CarrierService implements CarrierJob {
 
 	@Override
 	public String toString() {
-		return "[id=" + id + "][locationId=" + locationId + "][capacityDemand=" + demand + "][serviceDuration=" + serviceDuration + "][startTimeWindow=" + timeWindow + "]";
+		return "[id=" + id + "][locationId=" + serviceLinkId + "][capacityDemand=" + demand + "][serviceDuration=" + serviceDuration + "][startTimeWindow=" + serviceStartsTimeWindow + "]";
 	}
 
 	/* (non-Javadoc)

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
@@ -48,10 +48,16 @@ public final class CarrierShipment implements CarrierJob {
 		private final Id<CarrierShipment> id;
 		private final int demand;
 
+		//IMO we could build a general class (CarrierActivity ???), containing the location, StartTimeWindow and Duration.
+		//This could be used for both, CarrierService and CarrierShipment (Pickup and Delivery).
+		//kturner dec'24
 		private final Id<Link> pickupLinkId;
 		private TimeWindow pickupStartsTimeWindow = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
 		private double pickupDuration = 0.0;
 
+		//IMO we could build a general class (CarrierActivity ???), containing the location, StartTimeWindow and Duration.
+		//This could be used for both, CarrierService and CarrierShipment (Pickup and Delivery).
+		//kturner dec'24
 		private final Id<Link> deliveryLinkId;
 		private TimeWindow deliveryStartsTimeWindow = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
 		private double deliveryDuration = 0.0;
@@ -174,7 +180,7 @@ public final class CarrierShipment implements CarrierJob {
 		/**
 		 * @deprecated please inline and use {@link #setPickupStartsTimeWindow(TimeWindow)} instead
 		 */
-		@Deprecated(since = "dez 2024")
+		@Deprecated(since = "dec'24")
 		public Builder setPickupTimeWindow(TimeWindow pickupTW){
 			return setPickupStartsTimeWindow(pickupTW);
 		}
@@ -182,7 +188,7 @@ public final class CarrierShipment implements CarrierJob {
 		/**
 		 * @deprecated please inline and use {@link #setPickupDuration(double)} instead
 		 */
-		@Deprecated(since = "dez 2024")
+		@Deprecated(since = "dec'24")
 		public Builder setPickupServiceTime(double pickupServiceTime){
 			return setPickupDuration(pickupServiceTime);
 		}
@@ -190,7 +196,7 @@ public final class CarrierShipment implements CarrierJob {
 		/**
 		 * @deprecated please inline and use {@link #setDeliveryStartsTimeWindow(TimeWindow)} instead
 		 */
-		@Deprecated(since = "dez 2024")
+		@Deprecated(since = "dec'24")
 		public Builder setDeliveryTimeWindow(TimeWindow deliveryTW){
 			return setDeliveryStartsTimeWindow(deliveryTW);
 		}
@@ -198,22 +204,25 @@ public final class CarrierShipment implements CarrierJob {
 		/**
 		 * @deprecated please inline and use {@link #setDeliveryDuration(double)} instead
 		 */
-		@Deprecated(since = "dez 2024")
+		@Deprecated(since = "dec'24")
 		public Builder setDeliveryServiceTime(double deliveryServiceTime){
 			return setDeliveryDuration(deliveryServiceTime);
 		}
-
-
-
 	}
 
 	private final Id<CarrierShipment> id;
 	private final int demand;
 
+	//IMO we could build a general class (CarrierActivity ???), containing the location, StartTimeWindow and Duration.
+	//This could be used for both, CarrierService and CarrierShipment (Pickup and Delivery).
+	//kturner dec'24
 	private final Id<Link> pickupLinkId;
 	private final TimeWindow pickupStartsTimeWindow;
 	private double pickupDuration;
 
+	//IMO we could build a general class (CarrierActivity ???), containing the location, StartTimeWindow and Duration.
+	//This could be used for both, CarrierService and CarrierShipment (Pickup and Delivery).
+	//kturner dec'24
 	private final Id<Link> deliveryLinkId;
 	private final TimeWindow deliveryStartsTimeWindow;
 	private double deliveryDuration;
@@ -264,7 +273,7 @@ public final class CarrierShipment implements CarrierJob {
 	/**
 	 * @deprecated please inline and use {@link #getDemand()} instead
 	 */
-	@Deprecated(since = "dez 2024")
+	@Deprecated(since = "dec'24")
 	public int getSize() {
 		return getDemand();
 	}

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
@@ -49,7 +49,6 @@ public final class CarrierShipment implements CarrierJob {
 		 * @deprecated Please use Builder newInstance(Id<CarrierShipment> id, Id<Link> from, Id<Link> to, int size) instead.
 		 * <p>
 		 * Returns a new shipment builder.
-		 *
 		 * <p> The builder is init with the shipment's origin (from), destination (to) and with the shipment's size.
 		 * The default-value for serviceTime is 0.0. The default-value for a timeWindow is [start=0.0, end=Double.maxValue()].
 		 *
@@ -65,7 +64,6 @@ public final class CarrierShipment implements CarrierJob {
 
 		/**
 		 * Returns a new shipment builder.
-		 *
 		 * <p> The builder is init with the shipment's origin (from), destination (to) and with the shipment's size.
 		 * The default-value for serviceTime is 0.0. The default-value for a timeWindow is [start=0.0, end=Double.maxValue()].
 		 *
@@ -80,12 +78,14 @@ public final class CarrierShipment implements CarrierJob {
 		}
 
 		Id<CarrierShipment> id;
-		final Id<Link> from;
-		final Id<Link> to;
 		final int size;
+
+		final Id<Link> from;
 		TimeWindow pickTW = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
-		TimeWindow delTW = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
 		double pickServiceTime = 0.0;
+
+		final Id<Link> to;
+		TimeWindow delTW = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
 		double delServiceTime = 0.0;
 
 		/**
@@ -133,13 +133,16 @@ public final class CarrierShipment implements CarrierJob {
 	}
 
 	private final Id<CarrierShipment> id;
-	private final Id<Link> from;
-	private final Id<Link> to;
 	private final int demand;
+
+	private final Id<Link> from;
 	private final TimeWindow pickupTimeWindow;
-	private final TimeWindow deliveryTimeWindow;
 	private double pickupServiceTime;
+
+	private final Id<Link> to;
+	private final TimeWindow deliveryTimeWindow;
 	private double deliveryServiceTime;
+
 	private final Attributes attributes = new AttributesImpl();
 
 

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
@@ -254,7 +254,7 @@ public final class CarrierShipment implements CarrierJob {
 	/**
 	 * Do we really need the setter? We do have it in the builder.
 	 * I do not see, why we should be able to update it, since most of the values are immutable.
-	 * @deprecated Consider setting it using the Builder. This will maybe be removed and the field gets immutable..
+	 * @deprecated Consider setting it using the Builder. This will maybe be removed and the field gets immutable.
 	 * kturner, dec'24
 	 */
 	@Deprecated(since = "dec'24")
@@ -265,7 +265,7 @@ public final class CarrierShipment implements CarrierJob {
 	/**
 	* Do we really need the setter? We do have it in the builder.
 	* I do not see, why we should be able to update it, since most of the values are immutable.
-	* @deprecated Consider setting it using the Builder. This will maybe be removed and the field gets immutable..
+	* @deprecated Consider setting it using the Builder. This will maybe be removed and the field gets immutable.
 	* kturner, dec'24
 	*/
 	@Deprecated(since = "dec'24")
@@ -317,20 +317,13 @@ public final class CarrierShipment implements CarrierJob {
 		return getDemand();
 	}
 
+
 	/**
 	 * @deprecated please inline and use {@link #getPickupLinkId()} instead
 	 */
 	@Deprecated(since = "dec'24")
 	public Id<Link> getFrom() {
 		return getPickupLinkId();
-	}
-
-	/**
-	 * @deprecated please inline and use {@link #getDeliveryLinkId()} instead
-	 */
-	@Deprecated(since = "dec'24")
-	public Id<Link> getTo() {
-		return getDeliveryLinkId();
 	}
 
 	/**
@@ -341,13 +334,12 @@ public final class CarrierShipment implements CarrierJob {
 		return getPickupStartsTimeWindow();
 	}
 
-
 	/**
-	 * @deprecated please inline and use {@link #getDeliveryStartsTimeWindow()} instead
+	 * @deprecated please inline and use {@link #setPickupDuration(double)} instead
 	 */
 	@Deprecated(since = "dec'24")
-	public TimeWindow getDeliveryTimeWindow() {
-		return getDeliveryStartsTimeWindow();
+	public void setPickupServiceTime(double pickupDuration) {
+		setPickupDuration(pickupDuration);
 	}
 
 	/**
@@ -358,12 +350,21 @@ public final class CarrierShipment implements CarrierJob {
 		return getPickupDuration();
 	}
 
+
 	/**
-	 * @deprecated please inline and use {@link #setPickupDuration(double)} instead
+	 * @deprecated please inline and use {@link #getDeliveryLinkId()} instead
 	 */
 	@Deprecated(since = "dec'24")
-	public void setPickupServiceTime(double pickupDuration) {
-		setPickupDuration(pickupDuration);
+	public Id<Link> getTo() {
+		return getDeliveryLinkId();
+	}
+
+	/**
+	 * @deprecated please inline and use {@link #getDeliveryStartsTimeWindow()} instead
+	 */
+	@Deprecated(since = "dec'24")
+	public TimeWindow getDeliveryTimeWindow() {
+		return getDeliveryStartsTimeWindow();
 	}
 
 	/**

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
@@ -102,7 +102,7 @@ public final class CarrierShipment implements CarrierJob {
 			this.demand = demand;
 		}
 
-		public Builder(Id<CarrierShipment> id, Id<Link> pickupLinkId, Id<Link> deliveryLinkId, int demand) {
+		private Builder(Id<CarrierShipment> id, Id<Link> pickupLinkId, Id<Link> deliveryLinkId, int demand) {
 			super();
 			this.id = id;
 			this.pickupLinkId = pickupLinkId;

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
@@ -45,7 +45,7 @@ public final class CarrierShipment implements CarrierJob {
 	 */
 	public static class Builder {
 
-		private Id<CarrierShipment> id;
+		private final Id<CarrierShipment> id;
 		private final int demand;
 
 		private final Id<Link> pickupLinkId;
@@ -71,7 +71,8 @@ public final class CarrierShipment implements CarrierJob {
 		 */
 		@Deprecated
 		public static Builder newInstance(Id<Link> from, Id<Link> to, int size){
-			return new Builder(from,to,size);
+			var id = Id.create(CarrierConstants.SHIPMENT +"_" + from.toString() + "_" + to.toString(), CarrierShipment.class);
+			return new Builder(id, from,to,size);
 		}
 
 		/**
@@ -95,6 +96,7 @@ public final class CarrierShipment implements CarrierJob {
 		@Deprecated
 		public Builder(Id<Link> pickupLinkId, Id<Link> deliveryLinkId, int demand) {
 			super();
+			this.id = Id.create(CarrierConstants.SHIPMENT +"_" + pickupLinkId.toString() + "_" + deliveryLinkId.toString(), CarrierShipment.class);
 			this.pickupLinkId = pickupLinkId;
 			this.deliveryLinkId = deliveryLinkId;
 			this.demand = demand;

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
@@ -241,19 +241,35 @@ public final class CarrierShipment implements CarrierJob {
 		deliveryStartsTimeWindow = builder.deliveryStartsTimeWindow;
 	}
 
-	public double getPickupServiceTime() {
+	//* getters and setters
+
+	public double getPickupDuration() {
 		return pickupDuration;
 	}
 
-	public void setPickupServiceTime(double pickupDuration) {
-		this.pickupDuration = pickupDuration;
-	}
-
-	public double getDeliveryServiceTime() {
+	public double getDeliveryDuration() {
 		return deliveryDuration;
 	}
 
-	public void setDeliveryServiceTime(double deliveryDuration) {
+	/**
+	 * Do we really need the setter? We do have it in the builder.
+	 * I do not see, why we should be able to update it, since most of the values are immutable.
+	 * @deprecated Consider setting it using the Builder. This will maybe be removed and the field gets immutable..
+	 * kturner, dec'24
+	 */
+	@Deprecated(since = "dec'24")
+	public void setPickupDuration(double pickupDuration) {
+		this.pickupDuration = pickupDuration;
+	}
+
+	/**
+	* Do we really need the setter? We do have it in the builder.
+	* I do not see, why we should be able to update it, since most of the values are immutable.
+	* @deprecated Consider setting it using the Builder. This will maybe be removed and the field gets immutable..
+	* kturner, dec'24
+	*/
+	@Deprecated(since = "dec'24")
+	public void setDeliveryDuration(double deliveryDuration) {
 		this.deliveryDuration = deliveryDuration;
 	}
 
@@ -271,6 +287,29 @@ public final class CarrierShipment implements CarrierJob {
 	}
 
 	/**
+	 * @return the demand (size; capacity needed) of the shipment.
+	 */
+	@Override
+	public int getDemand() {
+		return demand;
+	}
+
+	public TimeWindow getPickupStartsTimeWindow() {
+		return pickupStartsTimeWindow;
+	}
+
+	public TimeWindow getDeliveryStartsTimeWindow() {
+		return deliveryStartsTimeWindow;
+	}
+
+	@Override
+	public Attributes getAttributes() {
+		return attributes;
+	}
+
+	//*** deprecated methods ***
+
+	/**
 	 * @deprecated please inline and use {@link #getDemand()} instead
 	 */
 	@Deprecated(since = "dec'24")
@@ -279,25 +318,55 @@ public final class CarrierShipment implements CarrierJob {
 	}
 
 	/**
-	 * @return the demand (size; capacity needed) of the shipment.
+	 * @deprecated please inline and use {@link #getPickupStartsTimeWindow()} instead
 	 */
-	@Override
-	public int getDemand() {
-		return demand;
-	}
-
+	@Deprecated(since = "dec'24")
 	public TimeWindow getPickupTimeWindow() {
-		return pickupStartsTimeWindow;
+		return getPickupStartsTimeWindow();
 	}
 
+
+	/**
+	 * @deprecated please inline and use {@link #getDeliveryStartsTimeWindow()} instead
+	 */
+	@Deprecated(since = "dec'24")
 	public TimeWindow getDeliveryTimeWindow() {
-		return deliveryStartsTimeWindow;
+		return getDeliveryStartsTimeWindow();
 	}
 
-	@Override
-	public Attributes getAttributes() {
-		return attributes;
+	/**
+	 * @deprecated please inline and use {@link #getPickupDuration()} instead
+	 */
+	@Deprecated(since = "dec'24")
+	public double getPickupServiceTime() {
+		return getPickupDuration();
 	}
+
+	/**
+	 * @deprecated please inline and use {@link #setPickupDuration(double)} instead
+	 */
+	@Deprecated(since = "dec'24")
+	public void setPickupServiceTime(double pickupDuration) {
+		setPickupDuration(pickupDuration);
+	}
+
+	/**
+	 * @deprecated please inline and use {@link #getDeliveryDuration()} instead
+	 */
+	@Deprecated(since = "dec'24")
+	public double getDeliveryServiceTime() {
+		return getDeliveryDuration();
+	}
+
+	/**
+	 * @deprecated please inline and use {@link #setDeliveryDuration(double)} instead
+	 */
+	@Deprecated(since = "dec'24")
+	public void setDeliveryServiceTime(double deliveryDuration) {
+		setDeliveryDuration(deliveryDuration);
+	}
+
+	// *** general methods ***
 
 	@Override
 	public String toString() {

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
@@ -23,7 +23,6 @@ package org.matsim.freight.carriers;
 
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.utils.objectattributes.attributable.Attributable;
 import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.utils.objectattributes.attributable.AttributesImpl;
 
@@ -136,7 +135,7 @@ public final class CarrierShipment implements CarrierJob {
 	private final Id<CarrierShipment> id;
 	private final Id<Link> from;
 	private final Id<Link> to;
-	private final int size;
+	private final int demand;
 	private final TimeWindow pickupTimeWindow;
 	private final TimeWindow deliveryTimeWindow;
 	private double pickupServiceTime;
@@ -148,7 +147,7 @@ public final class CarrierShipment implements CarrierJob {
 		id = builder.id;
 		from = builder.from;
 		to = builder.to;
-		size = builder.size;
+		demand = builder.size;
 		pickupServiceTime = builder.pickServiceTime;
 		deliveryServiceTime = builder.delServiceTime;
 		pickupTimeWindow = builder.pickTW;
@@ -171,9 +170,11 @@ public final class CarrierShipment implements CarrierJob {
 		this.deliveryServiceTime = deliveryServiceTime;
 	}
 
+	@Override
 	public Id<CarrierShipment> getId() {
 		return id;
 	}
+
 	public Id<Link> getFrom() {
 		return from;
 	}
@@ -182,8 +183,20 @@ public final class CarrierShipment implements CarrierJob {
 		return to;
 	}
 
+	/**
+	 * @deprecated please inline and use {@link #getDemand()} instead
+	 */
+	@Deprecated(since = "dez 2024")
 	public int getSize() {
-		return size;
+		return getDemand();
+	}
+
+	/**
+	 * @return the demand (size; capacity needed) of the shipment.
+	 */
+	@Override
+	public int getDemand() {
+		return demand;
 	}
 
 	public TimeWindow getPickupTimeWindow() {
@@ -201,7 +214,7 @@ public final class CarrierShipment implements CarrierJob {
 
 	@Override
 	public String toString() {
-		return "[id= "+ id.toString() + "][hash=" + this.hashCode() + "][from=" + from.toString() + "][to=" + to.toString() + "][size=" + size + "][pickupServiceTime=" + pickupServiceTime + "]" +
+		return "[id= "+ id.toString() + "][hash=" + this.hashCode() + "][from=" + from.toString() + "][to=" + to.toString() + "][size=" + demand + "][pickupServiceTime=" + pickupServiceTime + "]" +
 				"[deliveryServiceTime="+deliveryServiceTime+"][pickupTimeWindow="+pickupTimeWindow+"][deliveryTimeWindow="+deliveryTimeWindow+"]";
 	}
 

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
@@ -77,17 +77,17 @@ public final class CarrierShipment implements CarrierJob {
 
 		/**
 		 * Returns a new shipment builder.
-		 * <p> The builder is init with the shipment's origin (from), destination (to) and with the shipment's size.
+		 * <p> The builder is init with the shipment's origin (from), destination (to) and with the shipment's demand.
 		 * The default-value for serviceTime is 0.0. The default-value for a timeWindow is [start=0.0, end=Double.maxValue()].
 		 *
 		 * @param id 	the id of the shipment
 		 * @param from 	the origin
 		 * @param to 	the destination
-		 * @param size 	size of the shipment
+		 * @param demand 	demand of the shipment
 		 * @return 		the builder
 		 */
-		public static Builder newInstance(Id<CarrierShipment> id, Id<Link> from, Id<Link> to, int size){
-			return new Builder(id, from,to,size);
+		public static Builder newInstance(Id<CarrierShipment> id, Id<Link> from, Id<Link> to, int demand){
+			return new Builder(id, from, to, demand);
 		}
 
 		/**
@@ -110,29 +110,101 @@ public final class CarrierShipment implements CarrierJob {
 			this.demand = demand;
 		}
 
-		public Builder setPickupTimeWindow(TimeWindow pickupTW){
-			this.pickupStartsTimeWindow = pickupTW;
+		/**
+		 * Sets a time-window for the beginning of the pickup
+		 * When not set, it is by default [0.0., Integer.MAX_VALUE].
+		 * <p>
+		 * Note that the time-window restricts the start-time of the shipment's pickup . If one works with hard time-windows (which means that
+		 * time-windows must be met) than the pickup is allowed to start between startTimeWindow.getStart() and startTimeWindow.getEnd().
+		 *
+		 * @param pickupStartsTimeWindow 	time-window for the beginning of the pickup activity
+		 * @return 							the builder
+		 */
+		public Builder setPickupStartsTimeWindow(TimeWindow pickupStartsTimeWindow){
+			this.pickupStartsTimeWindow = pickupStartsTimeWindow;
 			return this;
 		}
 
-		public Builder setDeliveryTimeWindow(TimeWindow deliveryTW){
-			this.deliveryStartsTimeWindow = deliveryTW;
+		/**
+		 *  Sets the duration for the pickup activity.
+		 *  When not set, it is by default 0.0.
+		 *
+		 * @param pickupDuration Duration of the pickup activity (in seconds).
+		 * @return the Builder
+		*/
+		public Builder setPickupDuration(double pickupDuration){
+			this.pickupDuration = pickupDuration;
 			return this;
 		}
 
-		public Builder setPickupServiceTime(double pickupServiceTime){
-			this.pickupDuration = pickupServiceTime;
+		/**
+		 * Sets a time-window for the beginning of the delivery
+		 * When not set, it is by default [0.0., Integer.MAX_VALUE].
+		 * <p>
+		 * Note that the time-window restricts the start-time of the shipment's delivery . If one works with hard time-windows (which means that
+		 * time-windows must be met) than the delivery is allowed to start between startTimeWindow.getStart() and startTimeWindow.getEnd().
+		 *
+		 * @param deliveryStartsTimeWindow 	time-window for the beginning of the delivery activity
+		 * @return 							the builder
+		 */
+		public Builder setDeliveryStartsTimeWindow(TimeWindow deliveryStartsTimeWindow){
+			this.deliveryStartsTimeWindow = deliveryStartsTimeWindow;
 			return this;
 		}
 
-		public Builder setDeliveryServiceTime(double deliveryServiceTime){
-			this.deliveryDuration = deliveryServiceTime;
+		/**
+		 *  Sets the duration for the delivery activity.
+		 *  When not set, it is by default 0.0.
+		 *
+		 * @param deliveryDuration Duration of the delivery activity (in seconds).
+		 * @return the Builder
+		 */
+		public Builder setDeliveryDuration(double deliveryDuration){
+			this.deliveryDuration = deliveryDuration;
 			return this;
 		}
 
 		public CarrierShipment build(){
 			return new CarrierShipment(this);
 		}
+
+		//*** deprecated methods ***
+
+
+		/**
+		 * @deprecated please inline and use {@link #setPickupStartsTimeWindow(TimeWindow)} instead
+		 */
+		@Deprecated(since = "dez 2024")
+		public Builder setPickupTimeWindow(TimeWindow pickupTW){
+			return setPickupStartsTimeWindow(pickupTW);
+		}
+
+		/**
+		 * @deprecated please inline and use {@link #setPickupDuration(double)} instead
+		 */
+		@Deprecated(since = "dez 2024")
+		public Builder setPickupServiceTime(double pickupServiceTime){
+			return setPickupDuration(pickupServiceTime);
+		}
+
+		/**
+		 * @deprecated please inline and use {@link #setDeliveryStartsTimeWindow(TimeWindow)} instead
+		 */
+		@Deprecated(since = "dez 2024")
+		public Builder setDeliveryTimeWindow(TimeWindow deliveryTW){
+			return setDeliveryStartsTimeWindow(deliveryTW);
+		}
+
+		/**
+		 * @deprecated please inline and use {@link #setDeliveryDuration(double)} instead
+		 */
+		@Deprecated(since = "dez 2024")
+		public Builder setDeliveryServiceTime(double deliveryServiceTime){
+			return setDeliveryDuration(deliveryServiceTime);
+		}
+
+
+
 	}
 
 	private final Id<CarrierShipment> id;

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
@@ -278,11 +278,11 @@ public final class CarrierShipment implements CarrierJob {
 		return id;
 	}
 
-	public Id<Link> getFrom() {
+	public Id<Link> getPickupLinkId() {
 		return pickupLinkId;
 	}
 
-	public Id<Link> getTo() {
+	public Id<Link> getDeliveryLinkId() {
 		return deliveryLinkId;
 	}
 
@@ -315,6 +315,22 @@ public final class CarrierShipment implements CarrierJob {
 	@Deprecated(since = "dec'24")
 	public int getSize() {
 		return getDemand();
+	}
+
+	/**
+	 * @deprecated please inline and use {@link #getPickupLinkId()} instead
+	 */
+	@Deprecated(since = "dec'24")
+	public Id<Link> getFrom() {
+		return getPickupLinkId();
+	}
+
+	/**
+	 * @deprecated please inline and use {@link #getDeliveryLinkId()} instead
+	 */
+	@Deprecated(since = "dec'24")
+	public Id<Link> getTo() {
+		return getDeliveryLinkId();
 	}
 
 	/**

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
@@ -45,6 +45,18 @@ public final class CarrierShipment implements CarrierJob {
 	 */
 	public static class Builder {
 
+		Id<CarrierShipment> id;
+		final int demand;
+
+		final Id<Link> pickupLinkId;
+		TimeWindow pickupStartsTimeWindow = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
+		double pickupDuration = 0.0;
+
+		final Id<Link> deliveryLinkId;
+		TimeWindow deliveryStartsTimeWindow = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
+		double deliveryDuration = 0.0;
+
+
 		/**
 		 * @deprecated Please use Builder newInstance(Id<CarrierShipment> id, Id<Link> from, Id<Link> to, int size) instead.
 		 * <p>
@@ -77,53 +89,42 @@ public final class CarrierShipment implements CarrierJob {
 			return new Builder(id, from,to,size);
 		}
 
-		Id<CarrierShipment> id;
-		final int size;
-
-		final Id<Link> from;
-		TimeWindow pickTW = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
-		double pickServiceTime = 0.0;
-
-		final Id<Link> to;
-		TimeWindow delTW = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
-		double delServiceTime = 0.0;
-
 		/**
 		 * @deprecated Please use Builder (Id<CarrierShipment> id, Id<Link> from, Id<Link> to, int size) instead.
 		 */
 		@Deprecated
-		public Builder(Id<Link> from, Id<Link> to, int size) {
+		public Builder(Id<Link> pickupLinkId, Id<Link> deliveryLinkId, int demand) {
 			super();
-			this.from = from;
-			this.to = to;
-			this.size = size;
+			this.pickupLinkId = pickupLinkId;
+			this.deliveryLinkId = deliveryLinkId;
+			this.demand = demand;
 		}
 
-		public Builder(Id<CarrierShipment> id, Id<Link> from, Id<Link> to, int size) {
+		public Builder(Id<CarrierShipment> id, Id<Link> pickupLinkId, Id<Link> deliveryLinkId, int demand) {
 			super();
 			this.id = id;
-			this.from = from;
-			this.to = to;
-			this.size = size;
+			this.pickupLinkId = pickupLinkId;
+			this.deliveryLinkId = deliveryLinkId;
+			this.demand = demand;
 		}
 
 		public Builder setPickupTimeWindow(TimeWindow pickupTW){
-			this.pickTW = pickupTW;
+			this.pickupStartsTimeWindow = pickupTW;
 			return this;
 		}
 
 		public Builder setDeliveryTimeWindow(TimeWindow deliveryTW){
-			this.delTW = deliveryTW;
+			this.deliveryStartsTimeWindow = deliveryTW;
 			return this;
 		}
 
 		public Builder setPickupServiceTime(double pickupServiceTime){
-			this.pickServiceTime = pickupServiceTime;
+			this.pickupDuration = pickupServiceTime;
 			return this;
 		}
 
 		public Builder setDeliveryServiceTime(double deliveryServiceTime){
-			this.delServiceTime = deliveryServiceTime;
+			this.deliveryDuration = deliveryServiceTime;
 			return this;
 		}
 
@@ -135,42 +136,42 @@ public final class CarrierShipment implements CarrierJob {
 	private final Id<CarrierShipment> id;
 	private final int demand;
 
-	private final Id<Link> from;
-	private final TimeWindow pickupTimeWindow;
-	private double pickupServiceTime;
+	private final Id<Link> pickupLinkId;
+	private final TimeWindow pickupStartsTimeWindow;
+	private double pickupDuration;
 
-	private final Id<Link> to;
-	private final TimeWindow deliveryTimeWindow;
-	private double deliveryServiceTime;
+	private final Id<Link> deliveryLinkId;
+	private final TimeWindow deliveryStartsTimeWindow;
+	private double deliveryDuration;
 
 	private final Attributes attributes = new AttributesImpl();
 
 
 	private CarrierShipment(Builder builder) {
 		id = builder.id;
-		from = builder.from;
-		to = builder.to;
-		demand = builder.size;
-		pickupServiceTime = builder.pickServiceTime;
-		deliveryServiceTime = builder.delServiceTime;
-		pickupTimeWindow = builder.pickTW;
-		deliveryTimeWindow = builder.delTW;
+		pickupLinkId = builder.pickupLinkId;
+		deliveryLinkId = builder.deliveryLinkId;
+		demand = builder.demand;
+		pickupDuration = builder.pickupDuration;
+		deliveryDuration = builder.deliveryDuration;
+		pickupStartsTimeWindow = builder.pickupStartsTimeWindow;
+		deliveryStartsTimeWindow = builder.deliveryStartsTimeWindow;
 	}
 
 	public double getPickupServiceTime() {
-		return pickupServiceTime;
+		return pickupDuration;
 	}
 
-	public void setPickupServiceTime(double pickupServiceTime) {
-		this.pickupServiceTime = pickupServiceTime;
+	public void setPickupServiceTime(double pickupDuration) {
+		this.pickupDuration = pickupDuration;
 	}
 
 	public double getDeliveryServiceTime() {
-		return deliveryServiceTime;
+		return deliveryDuration;
 	}
 
-	public void setDeliveryServiceTime(double deliveryServiceTime) {
-		this.deliveryServiceTime = deliveryServiceTime;
+	public void setDeliveryServiceTime(double deliveryDuration) {
+		this.deliveryDuration = deliveryDuration;
 	}
 
 	@Override
@@ -179,11 +180,11 @@ public final class CarrierShipment implements CarrierJob {
 	}
 
 	public Id<Link> getFrom() {
-		return from;
+		return pickupLinkId;
 	}
 
 	public Id<Link> getTo() {
-		return to;
+		return deliveryLinkId;
 	}
 
 	/**
@@ -203,11 +204,11 @@ public final class CarrierShipment implements CarrierJob {
 	}
 
 	public TimeWindow getPickupTimeWindow() {
-		return pickupTimeWindow;
+		return pickupStartsTimeWindow;
 	}
 
 	public TimeWindow getDeliveryTimeWindow() {
-		return deliveryTimeWindow;
+		return deliveryStartsTimeWindow;
 	}
 
 	@Override
@@ -217,8 +218,8 @@ public final class CarrierShipment implements CarrierJob {
 
 	@Override
 	public String toString() {
-		return "[id= "+ id.toString() + "][hash=" + this.hashCode() + "][from=" + from.toString() + "][to=" + to.toString() + "][size=" + demand + "][pickupServiceTime=" + pickupServiceTime + "]" +
-				"[deliveryServiceTime="+deliveryServiceTime+"][pickupTimeWindow="+pickupTimeWindow+"][deliveryTimeWindow="+deliveryTimeWindow+"]";
+		return "[id= "+ id.toString() + "][hash=" + this.hashCode() + "][from=" + pickupLinkId.toString() + "][to=" + deliveryLinkId.toString() + "][size=" + demand + "][pickupServiceTime=" + pickupDuration + "]" +
+				"[deliveryServiceTime="+ deliveryDuration +"][pickupTimeWindow="+ pickupStartsTimeWindow +"][deliveryTimeWindow="+ deliveryStartsTimeWindow +"]";
 	}
 
 	/* (non-Javadoc)

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
@@ -45,16 +45,16 @@ public final class CarrierShipment implements CarrierJob {
 	 */
 	public static class Builder {
 
-		Id<CarrierShipment> id;
-		final int demand;
+		private Id<CarrierShipment> id;
+		private final int demand;
 
-		final Id<Link> pickupLinkId;
-		TimeWindow pickupStartsTimeWindow = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
-		double pickupDuration = 0.0;
+		private final Id<Link> pickupLinkId;
+		private TimeWindow pickupStartsTimeWindow = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
+		private double pickupDuration = 0.0;
 
-		final Id<Link> deliveryLinkId;
-		TimeWindow deliveryStartsTimeWindow = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
-		double deliveryDuration = 0.0;
+		private final Id<Link> deliveryLinkId;
+		private TimeWindow deliveryStartsTimeWindow = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
+		private double deliveryDuration = 0.0;
 
 
 		/**

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
@@ -431,7 +431,7 @@ public class CarriersUtils {
 			CarrierShipment carrierShipment = CarrierShipment.Builder
 				.newInstance(Id.create(carrierService.getId().toString(), CarrierShipment.class),
 					depotServiceIsDeliveredFrom.get(carrierService.getId()), carrierService.getLocationLinkId(),
-					carrierService.getCapacityDemand())
+					carrierService.getDemand())
 				.setDeliveryServiceTime(carrierService.getServiceDuration())
 				// .setPickupServiceTime(pickupServiceTime) //Not set yet, because in service we
 				// have now time for that. Maybe change it later, kmt sep18

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
@@ -432,12 +432,12 @@ public class CarriersUtils {
 				.newInstance(Id.create(carrierService.getId().toString(), CarrierShipment.class),
 					depotServiceIsDeliveredFrom.get(carrierService.getId()), carrierService.getLocationLinkId(),
 					carrierService.getDemand())
-				.setDeliveryServiceTime(carrierService.getServiceDuration())
+				.setDeliveryDuration(carrierService.getServiceDuration())
 				// .setPickupServiceTime(pickupServiceTime) //Not set yet, because in service we
 				// have now time for that. Maybe change it later, kmt sep18
-				.setDeliveryTimeWindow(carrierService.getServiceStartTimeWindow())
+				.setDeliveryStartsTimeWindow(carrierService.getServiceStartTimeWindow())
 				// Limited to end of delivery timeWindow (pickup later than the latest delivery is not useful).
-				.setPickupTimeWindow(TimeWindow.newInstance(0.0, carrierService.getServiceStartTimeWindow().getEnd()))
+				.setPickupStartsTimeWindow(TimeWindow.newInstance(0.0, carrierService.getServiceStartTimeWindow().getEnd()))
 				.build();
 			addShipment(carrierWS, carrierShipment);
 		}

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
@@ -430,7 +430,7 @@ public class CarriersUtils {
 			log.debug("Converting CarrierService to CarrierShipment: {}", carrierService.getId());
 			CarrierShipment carrierShipment = CarrierShipment.Builder
 				.newInstance(Id.create(carrierService.getId().toString(), CarrierShipment.class),
-					depotServiceIsDeliveredFrom.get(carrierService.getId()), carrierService.getLocationLinkId(),
+					depotServiceIsDeliveredFrom.get(carrierService.getId()), carrierService.getServiceLinkId(),
 					carrierService.getDemand())
 				.setDeliveryDuration(carrierService.getServiceDuration())
 				// .setPickupServiceTime(pickupServiceTime) //Not set yet, because in service we

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/Tour.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/Tour.java
@@ -379,7 +379,7 @@ public class Tour {
 
 		@Override
 		public Id<Link> getLocation() {
-			return service.getLocationLinkId();
+			return service.getServiceLinkId();
 		}
 
 		@Override
@@ -544,7 +544,7 @@ public class Tour {
 
 		@Override
 		public Id<Link> getLocation() {
-			return shipment.getFrom();
+			return shipment.getPickupLinkId();
 		}
 
 		@Override
@@ -602,7 +602,7 @@ public class Tour {
 
 		@Override
 		public Id<Link> getLocation() {
-			return shipment.getTo();
+			return shipment.getDeliveryLinkId();
 		}
 
 		@Override

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/Tour.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/Tour.java
@@ -539,7 +539,7 @@ public class Tour {
 
 		@Override
 		public TimeWindow getTimeWindow() {
-			return shipment.getPickupTimeWindow();
+			return shipment.getPickupStartsTimeWindow();
 		}
 
 		@Override
@@ -549,7 +549,7 @@ public class Tour {
 
 		@Override
 		public double getDuration() {
-			return shipment.getPickupServiceTime();
+			return shipment.getPickupDuration();
 		}
 
 		@Override
@@ -592,7 +592,7 @@ public class Tour {
 
 		@Override
 		public TimeWindow getTimeWindow() {
-			return shipment.getDeliveryTimeWindow();
+			return shipment.getDeliveryStartsTimeWindow();
 		}
 
 		@Override
@@ -607,7 +607,7 @@ public class Tour {
 
 		@Override
 		public double getDuration() {
-			return shipment.getDeliveryServiceTime();
+			return shipment.getDeliveryDuration();
 		}
 
 		@Override

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/Tour.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/Tour.java
@@ -374,7 +374,7 @@ public class Tour {
 
 		@Override
 		public String getActivityType() {
-			return service.getType();
+			return CarrierConstants.SERVICE;
 		}
 
 		@Override

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/analysis/CarrierPlanAnalysis.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/analysis/CarrierPlanAnalysis.java
@@ -101,16 +101,16 @@ public class CarrierPlanAnalysis {
 				int numberOfHandledDemandSize;
 				int notHandledJobs;
 				if (numberOfPlanedShipments > 0) {
-					numberOfPlanedDemandSize = carrier.getShipments().values().stream().mapToInt(CarrierShipment::getSize).sum();
+					numberOfPlanedDemandSize = carrier.getShipments().values().stream().mapToInt(carrierShipment -> carrierShipment.getDemand()).sum();
 					numberOfHandledDemandSize = carrier.getSelectedPlan().getScheduledTours().stream().mapToInt(
 						t -> t.getTour().getTourElements().stream().filter(te -> te instanceof Tour.Pickup).mapToInt(
-							te -> (((Tour.Pickup) te).getShipment().getSize())).sum()).sum();
+							te -> ((Tour.Pickup) te).getShipment().getDemand()).sum()).sum();
 					notHandledJobs = numberOfPlanedShipments - numberOfHandledPickups;
 				} else {
-					numberOfPlanedDemandSize = carrier.getServices().values().stream().mapToInt(CarrierService::getCapacityDemand).sum();
+					numberOfPlanedDemandSize = carrier.getServices().values().stream().mapToInt(carrierService -> carrierService.getDemand()).sum();
 					numberOfHandledDemandSize = carrier.getSelectedPlan().getScheduledTours().stream().mapToInt(
 						t -> t.getTour().getTourElements().stream().filter(te -> te instanceof Tour.ServiceActivity).mapToInt(
-							te -> ((Tour.ServiceActivity) te).getService().getCapacityDemand()).sum()).sum();
+							te -> ((Tour.ServiceActivity) te).getService().getDemand()).sum()).sum();
 					notHandledJobs = numberOfPlanedServices - nuOfServiceHandled;
 				}
 

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierServiceEndEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierServiceEndEvent.java
@@ -42,7 +42,7 @@ public final class CarrierServiceEndEvent extends AbstractCarrierEvent {
 	private final double serviceDuration;
 
 	public CarrierServiceEndEvent(double time, Id<Carrier> carrierId, CarrierService service, Id<Vehicle> vehicleId) {
-		super(time, carrierId, service.getLocationLinkId(), vehicleId);
+		super(time, carrierId, service.getServiceLinkId(), vehicleId);
 		this.serviceId = service.getId();
 		this.serviceDuration = service.getServiceDuration();
 	}

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierServiceStartEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierServiceStartEvent.java
@@ -47,7 +47,7 @@ public final class CarrierServiceStartEvent extends AbstractCarrierEvent {
 		super(time, carrierId, service.getLocationLinkId(), vehicleId);
 		this.serviceId = service.getId();
 		this.serviceDuration = service.getServiceDuration();
-		this.capacityDemand = service.getCapacityDemand();
+        this.capacityDemand = service.getDemand();
 	}
 
 	@Override

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierServiceStartEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierServiceStartEvent.java
@@ -44,7 +44,7 @@ public final class CarrierServiceStartEvent extends AbstractCarrierEvent {
 	private final int capacityDemand;
 
 	public CarrierServiceStartEvent(double time, Id<Carrier> carrierId, CarrierService service, Id<Vehicle> vehicleId) {
-		super(time, carrierId, service.getLocationLinkId(), vehicleId);
+		super(time, carrierId, service.getServiceLinkId(), vehicleId);
 		this.serviceId = service.getId();
 		this.serviceDuration = service.getServiceDuration();
         this.capacityDemand = service.getDemand();

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierServiceStartEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierServiceStartEvent.java
@@ -85,7 +85,7 @@ public final class CarrierServiceStartEvent extends AbstractCarrierEvent {
 		Id<Link> locationLinkId = Id.createLinkId(attributes.get(ATTRIBUTE_LINK));
 		CarrierService service = CarrierService.Builder.newInstance(carrierServiceId, locationLinkId)
 				.setServiceDuration(Double.parseDouble(attributes.get(CarrierEventAttributes.ATTRIBUTE_SERVICE_DURATION)))
-				.setCapacityDemand(Integer.parseInt(attributes.get(CarrierEventAttributes.ATTRIBUTE_CAPACITYDEMAND)))
+				.setDemand(Integer.parseInt(attributes.get(CarrierEventAttributes.ATTRIBUTE_CAPACITYDEMAND)))
 				.build();
 		Id<Vehicle> vehicleId = Id.create(attributes.get(ATTRIBUTE_VEHICLE), Vehicle.class);
 		return new CarrierServiceStartEvent(time, carrierId, service, vehicleId);

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentDeliveryEndEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentDeliveryEndEvent.java
@@ -46,7 +46,7 @@ public class CarrierShipmentDeliveryEndEvent extends AbstractCarrierEvent {
 	public CarrierShipmentDeliveryEndEvent(double time, Id<Carrier> carrierId, CarrierShipment shipment, Id<Vehicle> vehicleId) {
 		super(time, carrierId, shipment.getTo(), vehicleId);
 		this.shipmentId = shipment.getId();
-		this.deliveryDuration = shipment.getDeliveryServiceTime();
+		this.deliveryDuration = shipment.getDeliveryDuration();
         this.capacityDemand = shipment.getDemand();
 	}
 

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentDeliveryEndEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentDeliveryEndEvent.java
@@ -83,7 +83,7 @@ public class CarrierShipmentDeliveryEndEvent extends AbstractCarrierEvent {
 		Id<Link> shipmentTo = Id.createLinkId(attributes.get(ATTRIBUTE_LINK));
 		int size = Integer.parseInt(attributes.get(CarrierEventAttributes.ATTRIBUTE_CAPACITYDEMAND));
 		CarrierShipment shipment = CarrierShipment.Builder.newInstance(shipmentId, null, shipmentTo, size)
-				.setDeliveryServiceTime(Double.parseDouble(attributes.get(CarrierEventAttributes.ATTRIBUTE_DROPOFF_DURATION)))
+				.setDeliveryDuration(Double.parseDouble(attributes.get(CarrierEventAttributes.ATTRIBUTE_DROPOFF_DURATION)))
 				.build();
 		Id<Vehicle> vehicleId = Id.createVehicleId(attributes.get(ATTRIBUTE_VEHICLE));
 		return new CarrierShipmentDeliveryEndEvent(time, carrierId, shipment, vehicleId);

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentDeliveryEndEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentDeliveryEndEvent.java
@@ -44,7 +44,7 @@ public class CarrierShipmentDeliveryEndEvent extends AbstractCarrierEvent {
 	private final double deliveryDuration;
 	private final int capacityDemand;
 	public CarrierShipmentDeliveryEndEvent(double time, Id<Carrier> carrierId, CarrierShipment shipment, Id<Vehicle> vehicleId) {
-		super(time, carrierId, shipment.getTo(), vehicleId);
+		super(time, carrierId, shipment.getDeliveryLinkId(), vehicleId);
 		this.shipmentId = shipment.getId();
 		this.deliveryDuration = shipment.getDeliveryDuration();
         this.capacityDemand = shipment.getDemand();

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentDeliveryEndEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentDeliveryEndEvent.java
@@ -47,7 +47,7 @@ public class CarrierShipmentDeliveryEndEvent extends AbstractCarrierEvent {
 		super(time, carrierId, shipment.getTo(), vehicleId);
 		this.shipmentId = shipment.getId();
 		this.deliveryDuration = shipment.getDeliveryServiceTime();
-		this.capacityDemand = shipment.getSize();
+        this.capacityDemand = shipment.getDemand();
 	}
 
 	@Override

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentDeliveryStartEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentDeliveryStartEvent.java
@@ -84,7 +84,7 @@ public class CarrierShipmentDeliveryStartEvent extends AbstractCarrierEvent {
 		Id<Link> shipmentTo = Id.createLinkId(attributes.get(ATTRIBUTE_LINK));
 		int size = Integer.parseInt(attributes.get(ATTRIBUTE_CAPACITYDEMAND));
 		CarrierShipment shipment = CarrierShipment.Builder.newInstance(shipmentId, null, shipmentTo, size)
-				.setDeliveryServiceTime(Double.parseDouble(attributes.get(ATTRIBUTE_DROPOFF_DURATION)))
+				.setDeliveryDuration(Double.parseDouble(attributes.get(ATTRIBUTE_DROPOFF_DURATION)))
 				.build();
 		Id<Vehicle> vehicleId = Id.createVehicleId(attributes.get(ATTRIBUTE_VEHICLE));
 		return new CarrierShipmentDeliveryStartEvent(time, carrierId, shipment, vehicleId);

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentDeliveryStartEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentDeliveryStartEvent.java
@@ -48,7 +48,7 @@ public class CarrierShipmentDeliveryStartEvent extends AbstractCarrierEvent {
 		super(time, carrierId, shipment.getTo(), vehicleId);
 		this.shipmentId = shipment.getId();
 		this.deliveryDuration = shipment.getDeliveryServiceTime();
-		this.capacityDemand = shipment.getSize();
+        this.capacityDemand = shipment.getDemand();
 	}
 
 	@Override

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentDeliveryStartEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentDeliveryStartEvent.java
@@ -45,7 +45,7 @@ public class CarrierShipmentDeliveryStartEvent extends AbstractCarrierEvent {
 	private final double deliveryDuration;
 	private final int capacityDemand;
 	public CarrierShipmentDeliveryStartEvent(double time, Id<Carrier> carrierId, CarrierShipment shipment, Id<Vehicle> vehicleId) {
-		super(time, carrierId, shipment.getTo(), vehicleId);
+		super(time, carrierId, shipment.getDeliveryLinkId(), vehicleId);
 		this.shipmentId = shipment.getId();
 		this.deliveryDuration = shipment.getDeliveryDuration();
         this.capacityDemand = shipment.getDemand();

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentDeliveryStartEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentDeliveryStartEvent.java
@@ -47,7 +47,7 @@ public class CarrierShipmentDeliveryStartEvent extends AbstractCarrierEvent {
 	public CarrierShipmentDeliveryStartEvent(double time, Id<Carrier> carrierId, CarrierShipment shipment, Id<Vehicle> vehicleId) {
 		super(time, carrierId, shipment.getTo(), vehicleId);
 		this.shipmentId = shipment.getId();
-		this.deliveryDuration = shipment.getDeliveryServiceTime();
+		this.deliveryDuration = shipment.getDeliveryDuration();
         this.capacityDemand = shipment.getDemand();
 	}
 

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentPickupEndEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentPickupEndEvent.java
@@ -46,7 +46,7 @@ public class CarrierShipmentPickupEndEvent extends AbstractCarrierEvent {
 
 
 	public CarrierShipmentPickupEndEvent(double time, Id<Carrier> carrierId, CarrierShipment shipment, Id<Vehicle> vehicleId) {
-		super(time, carrierId, shipment.getFrom(), vehicleId);
+		super(time, carrierId, shipment.getPickupLinkId(), vehicleId);
 		this.shipmentId = shipment.getId();
 		this.pickupDuration = shipment.getPickupDuration();
         this.capacityDemand = shipment.getDemand();

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentPickupEndEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentPickupEndEvent.java
@@ -79,7 +79,7 @@ public class CarrierShipmentPickupEndEvent extends AbstractCarrierEvent {
 		Id<Link> shipmentFrom = Id.createLinkId(attributes.get(ATTRIBUTE_LINK));
 		int shipmentSize = Integer.parseInt(attributes.get(ATTRIBUTE_CAPACITYDEMAND));
 		CarrierShipment shipment = CarrierShipment.Builder.newInstance(shipmentId, shipmentFrom, null, shipmentSize)
-				.setPickupServiceTime(Double.parseDouble(attributes.get(ATTRIBUTE_PICKUP_DURATION)))
+				.setPickupDuration(Double.parseDouble(attributes.get(ATTRIBUTE_PICKUP_DURATION)))
 				.build();
 		Id<Vehicle> vehicleId = Id.createVehicleId(attributes.get(ATTRIBUTE_VEHICLE));
 		return new CarrierShipmentPickupEndEvent(time, carrierId, shipment, vehicleId);

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentPickupEndEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentPickupEndEvent.java
@@ -48,7 +48,7 @@ public class CarrierShipmentPickupEndEvent extends AbstractCarrierEvent {
 	public CarrierShipmentPickupEndEvent(double time, Id<Carrier> carrierId, CarrierShipment shipment, Id<Vehicle> vehicleId) {
 		super(time, carrierId, shipment.getFrom(), vehicleId);
 		this.shipmentId = shipment.getId();
-		this.pickupDuration = shipment.getPickupServiceTime();
+		this.pickupDuration = shipment.getPickupDuration();
         this.capacityDemand = shipment.getDemand();
 	}
 

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentPickupEndEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentPickupEndEvent.java
@@ -49,7 +49,7 @@ public class CarrierShipmentPickupEndEvent extends AbstractCarrierEvent {
 		super(time, carrierId, shipment.getFrom(), vehicleId);
 		this.shipmentId = shipment.getId();
 		this.pickupDuration = shipment.getPickupServiceTime();
-		this.capacityDemand = shipment.getSize();
+        this.capacityDemand = shipment.getDemand();
 	}
 
 

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentPickupStartEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentPickupStartEvent.java
@@ -47,7 +47,7 @@ public class CarrierShipmentPickupStartEvent extends AbstractCarrierEvent {
 		super(time, carrierId, shipment.getFrom(), vehicleId);
 		this.shipmentId = shipment.getId();
 		this.pickupDuration = shipment.getPickupServiceTime();
-		this.capacityDemand = shipment.getSize();
+        this.capacityDemand = shipment.getDemand();
 	}
 
 

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentPickupStartEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentPickupStartEvent.java
@@ -44,7 +44,7 @@ public class CarrierShipmentPickupStartEvent extends AbstractCarrierEvent {
 
 
 	public CarrierShipmentPickupStartEvent(double time, Id<Carrier> carrierId, CarrierShipment shipment, Id<Vehicle> vehicleId) {
-		super(time, carrierId, shipment.getFrom(), vehicleId);
+		super(time, carrierId, shipment.getPickupLinkId(), vehicleId);
 		this.shipmentId = shipment.getId();
 		this.pickupDuration = shipment.getPickupDuration();
         this.capacityDemand = shipment.getDemand();

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentPickupStartEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentPickupStartEvent.java
@@ -77,7 +77,7 @@ public class CarrierShipmentPickupStartEvent extends AbstractCarrierEvent {
 		Id<Link> shipmentFrom = Id.createLinkId(attributes.get(ATTRIBUTE_LINK));
 		int shipmentSize = Integer.parseInt(attributes.get(CarrierEventAttributes.ATTRIBUTE_CAPACITYDEMAND));
 		CarrierShipment shipment = CarrierShipment.Builder.newInstance(shipmentId, shipmentFrom, null, shipmentSize)
-				.setPickupServiceTime(Double.parseDouble(attributes.get(CarrierEventAttributes.ATTRIBUTE_PICKUP_DURATION)))
+				.setPickupDuration(Double.parseDouble(attributes.get(CarrierEventAttributes.ATTRIBUTE_PICKUP_DURATION)))
 				.build();
 		Id<Vehicle> vehicleId = Id.createVehicleId(attributes.get(ATTRIBUTE_VEHICLE));
 		return new CarrierShipmentPickupStartEvent(time, carrierId, shipment, vehicleId);

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentPickupStartEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentPickupStartEvent.java
@@ -46,7 +46,7 @@ public class CarrierShipmentPickupStartEvent extends AbstractCarrierEvent {
 	public CarrierShipmentPickupStartEvent(double time, Id<Carrier> carrierId, CarrierShipment shipment, Id<Vehicle> vehicleId) {
 		super(time, carrierId, shipment.getFrom(), vehicleId);
 		this.shipmentId = shipment.getId();
-		this.pickupDuration = shipment.getPickupServiceTime();
+		this.pickupDuration = shipment.getPickupDuration();
         this.capacityDemand = shipment.getDemand();
 	}
 

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/MatsimJspritFactory.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/MatsimJspritFactory.java
@@ -88,11 +88,11 @@ public final class MatsimJspritFactory {
 				.newInstance(Id.create(jspritShipment.getId(), CarrierShipment.class),
 						Id.createLinkId(jspritShipment.getPickupLocation().getId()),
 						Id.createLinkId(jspritShipment.getDeliveryLocation().getId()), jspritShipment.getSize().get(0))
-				.setDeliveryServiceTime(jspritShipment.getDeliveryServiceTime())
-				.setDeliveryTimeWindow(org.matsim.freight.carriers.TimeWindow.newInstance(jspritShipment.getDeliveryTimeWindow().getStart(),
+				.setDeliveryDuration(jspritShipment.getDeliveryServiceTime())
+				.setDeliveryStartsTimeWindow(org.matsim.freight.carriers.TimeWindow.newInstance(jspritShipment.getDeliveryTimeWindow().getStart(),
 						jspritShipment.getDeliveryTimeWindow().getEnd()))
-				.setPickupServiceTime(jspritShipment.getPickupServiceTime())
-				.setPickupTimeWindow(org.matsim.freight.carriers.TimeWindow.newInstance(jspritShipment.getPickupTimeWindow().getStart(),
+				.setPickupDuration(jspritShipment.getPickupServiceTime())
+				.setPickupStartsTimeWindow(org.matsim.freight.carriers.TimeWindow.newInstance(jspritShipment.getPickupTimeWindow().getStart(),
 						jspritShipment.getPickupTimeWindow().getEnd()))
 				.build();
 		CarriersUtils.setSkills(carrierShipment, jspritShipment.getRequiredSkills().values());
@@ -184,7 +184,7 @@ public final class MatsimJspritFactory {
 	static CarrierService createCarrierService(Service jspritService) {
 		CarrierService.Builder serviceBuilder = CarrierService.Builder.newInstance(
 				Id.create(jspritService.getId(), CarrierService.class), Id.create(jspritService.getLocation().getId(), Link.class));
-		serviceBuilder.setCapacityDemand(jspritService.getSize().get(0));
+		serviceBuilder.setDemand(jspritService.getSize().get(0));
 		serviceBuilder.setServiceDuration(jspritService.getServiceDuration());
 		serviceBuilder.setServiceStartTimeWindow(
 				org.matsim.freight.carriers.TimeWindow.newInstance(jspritService.getTimeWindow().getStart(), jspritService.getTimeWindow().getEnd()));

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/MatsimJspritFactory.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/MatsimJspritFactory.java
@@ -118,7 +118,7 @@ public final class MatsimJspritFactory {
 				.setPickupTimeWindow(com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow.newInstance(
 						carrierShipment.getPickupTimeWindow().getStart(),
 						carrierShipment.getPickupTimeWindow().getEnd()))
-				.addSizeDimension(0, carrierShipment.getSize());
+				.addSizeDimension(0, carrierShipment.getDemand());
 		for (String skill : CarriersUtils.getSkills(carrierShipment)) {
 			shipmentBuilder.addRequiredSkill(skill);
 		}
@@ -149,7 +149,7 @@ public final class MatsimJspritFactory {
 				.setPickupTimeWindow(com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow.newInstance(
 						carrierShipment.getPickupTimeWindow().getStart(),
 						carrierShipment.getPickupTimeWindow().getEnd()))
-				.addSizeDimension(0, carrierShipment.getSize());
+				.addSizeDimension(0, carrierShipment.getDemand());
 		for (String skill : CarriersUtils.getSkills(carrierShipment)) {
 			shipmentBuilder.addRequiredSkill(skill);
 		}
@@ -165,7 +165,7 @@ public final class MatsimJspritFactory {
 		Location location = locationBuilder.build();
 
 		Builder serviceBuilder = Builder.newInstance(carrierService.getId().toString());
-		serviceBuilder.addSizeDimension(0, carrierService.getCapacityDemand());
+		serviceBuilder.addSizeDimension(0, carrierService.getDemand());
 		serviceBuilder.setLocation(location).setServiceTime(carrierService.getServiceDuration())
 				.setTimeWindow(com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow.newInstance(
 						carrierService.getServiceStartTimeWindow().getStart(),

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/MatsimJspritFactory.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/MatsimJspritFactory.java
@@ -109,15 +109,15 @@ public final class MatsimJspritFactory {
 	static Shipment createJspritShipment(CarrierShipment carrierShipment) {
 		Shipment.Builder shipmentBuilder = Shipment.Builder.newInstance(carrierShipment.getId().toString())
 				.setDeliveryLocation(Location.newInstance(carrierShipment.getTo().toString()))
-				.setDeliveryServiceTime(carrierShipment.getDeliveryServiceTime())
+				.setDeliveryServiceTime(carrierShipment.getDeliveryDuration())
 				.setDeliveryTimeWindow(com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow
-						.newInstance(carrierShipment.getDeliveryTimeWindow().getStart(),
-								carrierShipment.getDeliveryTimeWindow().getEnd()))
-				.setPickupServiceTime(carrierShipment.getPickupServiceTime())
+						.newInstance(carrierShipment.getDeliveryStartsTimeWindow().getStart(),
+								carrierShipment.getDeliveryStartsTimeWindow().getEnd()))
+				.setPickupServiceTime(carrierShipment.getPickupDuration())
 				.setPickupLocation(Location.newInstance(carrierShipment.getFrom().toString()))
 				.setPickupTimeWindow(com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow.newInstance(
-						carrierShipment.getPickupTimeWindow().getStart(),
-						carrierShipment.getPickupTimeWindow().getEnd()))
+						carrierShipment.getPickupStartsTimeWindow().getStart(),
+						carrierShipment.getPickupStartsTimeWindow().getEnd()))
 				.addSizeDimension(0, carrierShipment.getDemand());
 		for (String skill : CarriersUtils.getSkills(carrierShipment)) {
 			shipmentBuilder.addRequiredSkill(skill);
@@ -141,14 +141,14 @@ public final class MatsimJspritFactory {
 		Location toLocation = toLocationBuilder.build();
 
 		Shipment.Builder shipmentBuilder = Shipment.Builder.newInstance(carrierShipment.getId().toString())
-				.setDeliveryLocation(toLocation).setDeliveryServiceTime(carrierShipment.getDeliveryServiceTime())
+				.setDeliveryLocation(toLocation).setDeliveryServiceTime(carrierShipment.getDeliveryDuration())
 				.setDeliveryTimeWindow(com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow
-						.newInstance(carrierShipment.getDeliveryTimeWindow().getStart(),
-								carrierShipment.getDeliveryTimeWindow().getEnd()))
-				.setPickupServiceTime(carrierShipment.getPickupServiceTime()).setPickupLocation(fromLocation)
+						.newInstance(carrierShipment.getDeliveryStartsTimeWindow().getStart(),
+								carrierShipment.getDeliveryStartsTimeWindow().getEnd()))
+				.setPickupServiceTime(carrierShipment.getPickupDuration()).setPickupLocation(fromLocation)
 				.setPickupTimeWindow(com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow.newInstance(
-						carrierShipment.getPickupTimeWindow().getStart(),
-						carrierShipment.getPickupTimeWindow().getEnd()))
+						carrierShipment.getPickupStartsTimeWindow().getStart(),
+						carrierShipment.getPickupStartsTimeWindow().getEnd()))
 				.addSizeDimension(0, carrierShipment.getDemand());
 		for (String skill : CarriersUtils.getSkills(carrierShipment)) {
 			shipmentBuilder.addRequiredSkill(skill);

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/MatsimJspritFactory.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/MatsimJspritFactory.java
@@ -108,13 +108,13 @@ public final class MatsimJspritFactory {
 	 */
 	static Shipment createJspritShipment(CarrierShipment carrierShipment) {
 		Shipment.Builder shipmentBuilder = Shipment.Builder.newInstance(carrierShipment.getId().toString())
-				.setDeliveryLocation(Location.newInstance(carrierShipment.getTo().toString()))
+				.setDeliveryLocation(Location.newInstance(carrierShipment.getDeliveryLinkId().toString()))
 				.setDeliveryServiceTime(carrierShipment.getDeliveryDuration())
 				.setDeliveryTimeWindow(com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow
 						.newInstance(carrierShipment.getDeliveryStartsTimeWindow().getStart(),
 								carrierShipment.getDeliveryStartsTimeWindow().getEnd()))
 				.setPickupServiceTime(carrierShipment.getPickupDuration())
-				.setPickupLocation(Location.newInstance(carrierShipment.getFrom().toString()))
+				.setPickupLocation(Location.newInstance(carrierShipment.getPickupLinkId().toString()))
 				.setPickupTimeWindow(com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow.newInstance(
 						carrierShipment.getPickupStartsTimeWindow().getStart(),
 						carrierShipment.getPickupStartsTimeWindow().getEnd()))
@@ -127,14 +127,14 @@ public final class MatsimJspritFactory {
 
 	static Shipment createJspritShipment(CarrierShipment carrierShipment, Coord fromCoord, Coord toCoord) {
 		Location.Builder fromLocationBuilder = Location.Builder.newInstance();
-		fromLocationBuilder.setId(carrierShipment.getFrom().toString());
+		fromLocationBuilder.setId(carrierShipment.getPickupLinkId().toString());
 		if (fromCoord != null) {
 			fromLocationBuilder.setCoordinate(Coordinate.newInstance(fromCoord.getX(), fromCoord.getY()));
 		}
 		Location fromLocation = fromLocationBuilder.build();
 
 		Location.Builder toLocationBuilder = Location.Builder.newInstance();
-		toLocationBuilder.setId(carrierShipment.getTo().toString());
+		toLocationBuilder.setId(carrierShipment.getDeliveryLinkId().toString());
 		if (toCoord != null) {
 			toLocationBuilder.setCoordinate(Coordinate.newInstance(toCoord.getX(), toCoord.getY()));
 		}
@@ -158,7 +158,7 @@ public final class MatsimJspritFactory {
 
 	static Service createJspritService(CarrierService carrierService, Coord locationCoord) {
 		Location.Builder locationBuilder = Location.Builder.newInstance();
-		locationBuilder.setId(carrierService.getLocationLinkId().toString());
+		locationBuilder.setId(carrierService.getServiceLinkId().toString());
 		if (locationCoord != null) {
 			locationBuilder.setCoordinate(Coordinate.newInstance(locationCoord.getX(), locationCoord.getY()));
 		}
@@ -515,11 +515,11 @@ public final class MatsimJspritFactory {
 
 				Coord coordinate = null;
 				if (network != null) {
-					Link link = network.getLinks().get(service.getLocationLinkId());
+					Link link = network.getLinks().get(service.getServiceLinkId());
 					if (link != null) {
 						coordinate = link.getCoord();
 					} else
-						log.warn("cannot find linkId {}", service.getLocationLinkId());
+						log.warn("cannot find linkId {}", service.getServiceLinkId());
 				}
 				vrpBuilder.addJob(createJspritService(service, coordinate));
 			}
@@ -530,8 +530,8 @@ public final class MatsimJspritFactory {
 				Coord fromCoordinate = null;
 				Coord toCoordinate = null;
 				if (network != null) {
-					Link fromLink = network.getLinks().get(carrierShipment.getFrom());
-					Link toLink = network.getLinks().get(carrierShipment.getTo());
+					Link fromLink = network.getLinks().get(carrierShipment.getPickupLinkId());
+					Link toLink = network.getLinks().get(carrierShipment.getDeliveryLinkId());
 
 					if (fromLink != null && toLink != null) { // Shipment to be delivered from specified location to
 						// specified location
@@ -540,8 +540,8 @@ public final class MatsimJspritFactory {
 						vrpBuilder.addJob(createJspritShipment(carrierShipment, fromCoordinate, toCoordinate));
 					} else
 						throw new IllegalStateException(
-								"cannot create shipment since neither fromLinkId " + carrierShipment.getTo()
-										+ " nor toLinkId " + carrierShipment.getTo() + " exists in network.");
+								"cannot create shipment since neither fromLinkId " + carrierShipment.getDeliveryLinkId()
+										+ " nor toLinkId " + carrierShipment.getDeliveryLinkId() + " exists in network.");
 
 				}
 				vrpBuilder.addJob(createJspritShipment(carrierShipment, fromCoordinate, toCoordinate));
@@ -611,9 +611,9 @@ public final class MatsimJspritFactory {
 				log.debug("Handle CarrierService: {}", service.toString());
 				Coord coordinate = null;
 				if (network != null) {
-					Link link = network.getLinks().get(service.getLocationLinkId());
+					Link link = network.getLinks().get(service.getServiceLinkId());
 					if (link == null) {
-						throw new IllegalStateException("cannot create service since linkId " + service.getLocationLinkId()
+						throw new IllegalStateException("cannot create service since linkId " + service.getServiceLinkId()
 								+ " does not exists in network.");
 					} else
 						coordinate = link.getCoord();
@@ -628,8 +628,8 @@ public final class MatsimJspritFactory {
 				Coord fromCoordinate = null;
 				Coord toCoordinate = null;
 				if (network != null) {
-					Link fromLink = network.getLinks().get(carrierShipment.getFrom());
-					Link toLink = network.getLinks().get(carrierShipment.getTo());
+					Link fromLink = network.getLinks().get(carrierShipment.getPickupLinkId());
+					Link toLink = network.getLinks().get(carrierShipment.getDeliveryLinkId());
 
 					if (fromLink != null && toLink != null) { // Shipment to be delivered from specified location to
 						// specified location
@@ -638,8 +638,8 @@ public final class MatsimJspritFactory {
 						toCoordinate = toLink.getCoord();
 					} else
 						throw new IllegalStateException("cannot create shipment " + carrierShipment.getId().toString()
-								+ " since either fromLinkId " + carrierShipment.getFrom() + " or toLinkId "
-								+ carrierShipment.getTo() + " exists in network.");
+								+ " since either fromLinkId " + carrierShipment.getPickupLinkId() + " or toLinkId "
+								+ carrierShipment.getDeliveryLinkId() + " exists in network.");
 
 				}
 				vrpBuilder.addJob(createJspritShipment(carrierShipment, fromCoordinate, toCoordinate));

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/usecases/chessboard/FreightScenarioCreator.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/usecases/chessboard/FreightScenarioCreator.java
@@ -101,7 +101,7 @@ final class FreightScenarioCreator {
 
         for(int i=0;i<20;i++){
             CarrierService.Builder serviceBuilder = CarrierService.Builder.newInstance(Id.create((i + 1),CarrierService.class), drawLocationLinkId(innerCityLinks, outerCityLinks));
-            serviceBuilder.setCapacityDemand(1);
+            serviceBuilder.setDemand(1);
             serviceBuilder.setServiceDuration(5*60);
             serviceBuilder.setServiceStartTimeWindow(TimeWindow.newInstance(6*60*60, 15*60*60));
             CarrierService carrierService = serviceBuilder.build();

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsUtils.java
@@ -62,10 +62,10 @@ class MultipleChainsUtils {
         builder.setCapacityDemand(shipment.getDemand());
       builder.setFromLinkId(shipment.getFrom());
       builder.setToLinkId(shipment.getTo());
-      builder.setStartTimeWindow(shipment.getPickupTimeWindow());
-      builder.setEndTimeWindow(shipment.getDeliveryTimeWindow());
-      builder.setPickupServiceTime(shipment.getPickupServiceTime());
-      builder.setDeliveryServiceTime(shipment.getDeliveryServiceTime());
+		builder.setStartTimeWindow(shipment.getPickupStartsTimeWindow());
+		builder.setEndTimeWindow(shipment.getDeliveryStartsTimeWindow());
+      builder.setPickupServiceTime(shipment.getPickupDuration());
+      builder.setDeliveryServiceTime(shipment.getDeliveryDuration());
       shipmentList.add(builder.build());
     }
     return shipmentList;

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsUtils.java
@@ -60,8 +60,8 @@ class MultipleChainsUtils {
           LspShipmentUtils.LspShipmentBuilder.newInstance(
               Id.create(shipment.getId().toString(), LspShipment.class));
         builder.setCapacityDemand(shipment.getDemand());
-      builder.setFromLinkId(shipment.getFrom());
-      builder.setToLinkId(shipment.getTo());
+      builder.setFromLinkId(shipment.getPickupLinkId());
+      builder.setToLinkId(shipment.getDeliveryLinkId());
 		builder.setStartTimeWindow(shipment.getPickupStartsTimeWindow());
 		builder.setEndTimeWindow(shipment.getDeliveryStartsTimeWindow());
       builder.setPickupServiceTime(shipment.getPickupDuration());

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsUtils.java
@@ -59,7 +59,7 @@ class MultipleChainsUtils {
       LspShipmentUtils.LspShipmentBuilder builder =
           LspShipmentUtils.LspShipmentBuilder.newInstance(
               Id.create(shipment.getId().toString(), LspShipment.class));
-      builder.setCapacityDemand(shipment.getSize());
+        builder.setCapacityDemand(shipment.getDemand());
       builder.setFromLinkId(shipment.getFrom());
       builder.setToLinkId(shipment.getTo());
       builder.setStartTimeWindow(shipment.getPickupTimeWindow());

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
@@ -84,7 +84,7 @@ import org.matsim.freight.logistics.shipment.LspShipmentUtils;
     Id<CarrierService> serviceId = Id.create(lspShipment.getId().toString(), CarrierService.class);
     CarrierService carrierService = CarrierService.Builder.newInstance(serviceId, lspShipment.getFrom())
             .setServiceStartTimeWindow(TimeWindow.newInstance(lspShipment.getPickupTimeWindow().getStart(), lspShipment.getPickupTimeWindow().getEnd()))
-            .setCapacityDemand(lspShipment.getSize())
+            .setDemand(lspShipment.getSize())
             .setServiceDuration(lspShipment.getDeliveryServiceTime())
             .build();
     //ensure that the ids of the lspShipment and the carrierService are the same. This is needed for updating the LSPShipmentPlan

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
@@ -184,7 +184,7 @@ import org.matsim.vehicles.VehicleType;
     CarrierService carrierService = CarrierService.Builder.newInstance(serviceId, lspShipment.getTo())
             //TODO TimeWindows are not set. This seems to be a problem. KMT'Aug'24
             //If added here, we also need to decide what happens, if the vehicles StartTime (plus TT) is > TimeWindowEnd ....
-            .setCapacityDemand(lspShipment.getSize())
+            .setDemand(lspShipment.getSize())
             .setServiceDuration(lspShipment.getDeliveryServiceTime())
             .build();
     //ensure that the ids of the lspShipment and the carrierService are the same. This is needed for updating the LSPShipmentPlan
@@ -207,7 +207,7 @@ import org.matsim.vehicles.VehicleType;
     CarrierShipment carrierShipment = CarrierShipment.Builder.newInstance(serviceId, lspShipment.getFrom(), lspShipment.getTo(), lspShipment.getSize())
             //TODO TimeWindows are not set. This seems to be a problem. KMT'Aug'24
             //If added here, we also need to decide what happens, if the vehicles StartTime (plus TT) is > TimeWindowEnd ....
-            .setDeliveryServiceTime(lspShipment.getDeliveryServiceTime())
+            .setDeliveryDuration(lspShipment.getDeliveryServiceTime())
             .build();
     //ensure that the ids of the lspShipment and the carrierShipment are the same. This is needed for updating the LSPShipmentPlan
     if (! Objects.equals(lspShipment.getId().toString(), carrierShipment.getId().toString())) {

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/resourceImplementations/MainRunCarrierScheduler.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/resourceImplementations/MainRunCarrierScheduler.java
@@ -229,7 +229,7 @@ import org.matsim.vehicles.VehicleType;
         Id.create(lspShipment.getId().toString(), CarrierService.class);
     CarrierService.Builder builder =
         CarrierService.Builder.newInstance(serviceId, resource.getEndLinkId());
-    builder.setCapacityDemand(lspShipment.getSize());
+    builder.setDemand(lspShipment.getSize());
     builder.setServiceDuration(lspShipment.getDeliveryServiceTime());
     return builder.build();
   }

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/CarriersUtilsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/CarriersUtilsTest.java
@@ -105,7 +105,7 @@ public class CarriersUtilsTest {
 		Assertions.assertEquals(shipmentId, carrierShipment1b.getId());
 		Assertions.assertEquals(service1.getId(), carrierShipment1b.getId());
 		Assertions.assertEquals(Id.createLinkId("link0"), carrierShipment1b.getFrom());
-		Assertions.assertEquals(20, carrierShipment1b.getSize(), EPSILON);
+		Assertions.assertEquals(20, carrierShipment1b.getDemand(), EPSILON);
 	}
 
 	@Test

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/CarriersUtilsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/CarriersUtilsTest.java
@@ -68,7 +68,7 @@ public class CarriersUtilsTest {
 		Carrier carrier = new CarrierImpl(Id.create("carrier", Carrier.class));
 		Id<CarrierService> serviceId = Id.create("testVehicle", CarrierService.class);
 		CarrierService service1 = CarrierService.Builder.newInstance(serviceId,Id.createLinkId("link0") )
-				.setCapacityDemand(15).setServiceDuration(30).build();
+				.setDemand(15).setServiceDuration(30).build();
 
 		//add Service
 		CarriersUtils.addService(carrier, service1);

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/CarriersUtilsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/CarriersUtilsTest.java
@@ -75,14 +75,14 @@ public class CarriersUtilsTest {
 		Assertions.assertEquals(1, carrier.getServices().size());
 		CarrierService cs1a  = (CarrierService) carrier.getServices().values().toArray()[0];
 		Assertions.assertEquals(service1, cs1a);
-		Assertions.assertEquals(Id.createLinkId("link0"), cs1a.getLocationLinkId());
+		Assertions.assertEquals(Id.createLinkId("link0"), cs1a.getServiceLinkId());
 
 		//get Service
 		CarrierService cs1b  = CarriersUtils.getService(carrier, serviceId );
 		assert cs1b != null;
 		Assertions.assertEquals(serviceId, cs1b.getId());
 		Assertions.assertEquals(service1.getId(), cs1b.getId());
-		Assertions.assertEquals(Id.createLinkId("link0"), cs1b.getLocationLinkId());
+		Assertions.assertEquals(Id.createLinkId("link0"), cs1b.getServiceLinkId());
 		Assertions.assertEquals(30, cs1b.getServiceDuration(), EPSILON);
 	}
 
@@ -97,14 +97,14 @@ public class CarriersUtilsTest {
 		Assertions.assertEquals(1, carrier.getShipments().size());
 		CarrierShipment carrierShipment1a  = (CarrierShipment) carrier.getShipments().values().toArray()[0];
 		Assertions.assertEquals(service1, carrierShipment1a);
-		Assertions.assertEquals(Id.createLinkId("link0"), carrierShipment1a.getFrom());
+		Assertions.assertEquals(Id.createLinkId("link0"), carrierShipment1a.getPickupLinkId());
 
 		//get Shipment
 		CarrierShipment carrierShipment1b  = CarriersUtils.getShipment(carrier, shipmentId );
 		assert carrierShipment1b != null;
 		Assertions.assertEquals(shipmentId, carrierShipment1b.getId());
 		Assertions.assertEquals(service1.getId(), carrierShipment1b.getId());
-		Assertions.assertEquals(Id.createLinkId("link0"), carrierShipment1b.getFrom());
+		Assertions.assertEquals(Id.createLinkId("link0"), carrierShipment1b.getPickupLinkId());
 		Assertions.assertEquals(20, carrierShipment1b.getDemand(), EPSILON);
 	}
 

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/CarriersUtilsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/CarriersUtilsTest.java
@@ -68,7 +68,7 @@ public class CarriersUtilsTest {
 		Carrier carrier = new CarrierImpl(Id.create("carrier", Carrier.class));
 		Id<CarrierService> serviceId = Id.create("testVehicle", CarrierService.class);
 		CarrierService service1 = CarrierService.Builder.newInstance(serviceId,Id.createLinkId("link0") )
-				.setName("service1").setCapacityDemand(15).setServiceDuration(30).build();
+				.setCapacityDemand(15).setServiceDuration(30).build();
 
 		//add Service
 		CarriersUtils.addService(carrier, service1);

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/DistanceConstraintFromVehiclesFileTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/DistanceConstraintFromVehiclesFileTest.java
@@ -421,14 +421,14 @@ public class DistanceConstraintFromVehiclesFileTest {
 		CarrierService service1 = CarrierService.Builder
 				.newInstance(Id.create("Service1", CarrierService.class), Id.createLinkId("j(3,8)"))
 				.setServiceDuration(20).setServiceStartTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
-				.setCapacityDemand(40).build();
+				.setDemand(40).build();
 		CarriersUtils.addService(carrier, service1);
 
 		// Service 2
 		CarrierService service2 = CarrierService.Builder
 				.newInstance(Id.create("Service2", CarrierService.class), Id.createLinkId("j(0,3)R"))
 				.setServiceDuration(20).setServiceStartTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
-				.setCapacityDemand(40).build();
+				.setDemand(40).build();
 		CarriersUtils.addService(carrier, service2);
 
 		return carrier;
@@ -442,7 +442,7 @@ public class DistanceConstraintFromVehiclesFileTest {
 		CarrierService service3 = CarrierService.Builder
 				.newInstance(Id.create("Service3", CarrierService.class), Id.createLinkId("j(9,2)"))
 				.setServiceDuration(20).setServiceStartTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
-				.setCapacityDemand(40).build();
+				.setDemand(40).build();
 		CarriersUtils.addService(carrier, service3);
 
 		return carrier;

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/DistanceConstraintTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/DistanceConstraintTest.java
@@ -614,14 +614,14 @@ public class DistanceConstraintTest {
 		CarrierService service1 = CarrierService.Builder
 				.newInstance(Id.create("Service1", CarrierService.class), Id.createLinkId("j(3,8)"))
 				.setServiceDuration(20).setServiceStartTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
-				.setCapacityDemand(40).build();
+				.setDemand(40).build();
 		CarriersUtils.addService(carrier, service1);
 
 		// Service 2
 		CarrierService service2 = CarrierService.Builder
 				.newInstance(Id.create("Service2", CarrierService.class), Id.createLinkId("j(0,3)R"))
 				.setServiceDuration(20).setServiceStartTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
-				.setCapacityDemand(40).build();
+				.setDemand(40).build();
 		CarriersUtils.addService(carrier, service2);
 
 		return carrier;
@@ -631,14 +631,14 @@ public class DistanceConstraintTest {
 		// Shipment 1
 		CarrierShipment shipment1 = CarrierShipment.Builder
 				.newInstance(Id.create("Shipment1", CarrierShipment.class), Id.createLinkId("i(1,8)"), Id.createLinkId("j(3,8)"), 40)
-				.setDeliveryServiceTime(20).setDeliveryTimeWindow(TimeWindow.newInstance(8 * 3600, 12 * 3600))
+				.setDeliveryDuration(20).setDeliveryStartsTimeWindow(TimeWindow.newInstance(8 * 3600, 12 * 3600))
 				.build();
 		CarriersUtils.addShipment(carrier, shipment1);
 
 		// Shipment 2
 		CarrierShipment shipment2 = CarrierShipment.Builder
 				.newInstance(Id.create("Shipment2", CarrierShipment.class),Id.createLinkId("i(1,8)"), Id.createLinkId("j(0,3)R"), 40)
-				.setDeliveryServiceTime(20).setDeliveryTimeWindow(TimeWindow.newInstance(8 * 3600, 12 * 3600))
+				.setDeliveryDuration(20).setDeliveryStartsTimeWindow(TimeWindow.newInstance(8 * 3600, 12 * 3600))
 				.build();
 		CarriersUtils.addShipment(carrier, shipment2);
 
@@ -653,7 +653,7 @@ public class DistanceConstraintTest {
 		CarrierService service3 = CarrierService.Builder
 				.newInstance(Id.create("Service3", CarrierService.class), Id.createLinkId("j(9,2)"))
 				.setServiceDuration(20).setServiceStartTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
-				.setCapacityDemand(40).build();
+				.setDemand(40).build();
 		CarriersUtils.addService(carrier, service3);
 
 		return carrier;

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/FixedCostsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/FixedCostsTest.java
@@ -200,7 +200,7 @@ public class FixedCostsTest  {
 
 	private static CarrierService createMatsimService(String id, String to, int size) {
 		return CarrierService.Builder.newInstance(Id.create(id, CarrierService.class), Id.create(to, Link.class))
-						     .setCapacityDemand(size)
+						     .setDemand(size)
 						     .setServiceDuration(31.0)
 						     .setServiceStartTimeWindow(TimeWindow.newInstance(3601.0, 36001.0))
 						     .build();

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/MatsimTransformerTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/MatsimTransformerTest.java
@@ -122,7 +122,7 @@ public class MatsimTransformerTest {
 	void whenTransforming_matsimService2jspritService_isMadeCorrectly() {
 		CarrierService carrierService = CarrierService.Builder
 				.newInstance(Id.create("serviceId", CarrierService.class), Id.create("locationId", Link.class))
-				.setCapacityDemand(50).setServiceDuration(30.0)
+				.setDemand(50).setServiceDuration(30.0)
 				.setServiceStartTimeWindow(TimeWindow.newInstance(10.0, 20.0)).build();
 		Service service = MatsimJspritFactory.createJspritService(carrierService, null);
 		assertNotNull(service);
@@ -161,8 +161,8 @@ public class MatsimTransformerTest {
 		CarrierShipment carrierShipment = CarrierShipment.Builder
 				.newInstance(Id.create("ShipmentId", CarrierShipment.class), Id.createLinkId("PickupLocationId"),
 						Id.createLinkId("DeliveryLocationId"), 50)
-				.setPickupServiceTime(30.0).setPickupTimeWindow(TimeWindow.newInstance(10.0, 20.0))
-				.setDeliveryServiceTime(40.0).setDeliveryTimeWindow(TimeWindow.newInstance(50.0, 60.0)).build();
+				.setPickupDuration(30.0).setPickupStartsTimeWindow(TimeWindow.newInstance(10.0, 20.0))
+				.setDeliveryDuration(40.0).setDeliveryStartsTimeWindow(TimeWindow.newInstance(50.0, 60.0)).build();
 		Shipment shipment = MatsimJspritFactory.createJspritShipment(carrierShipment);
 		assertNotNull(shipment);
 		assertEquals("PickupLocationId", shipment.getPickupLocation().getId());
@@ -333,10 +333,10 @@ public class MatsimTransformerTest {
 	private ScheduledTour getMatsimServiceTour() {
 		CarrierService s1 = CarrierService.Builder
 				.newInstance(Id.create("serviceId", CarrierService.class), Id.create("to1", Link.class))
-				.setCapacityDemand(20).build();
+				.setDemand(20).build();
 		CarrierService s2 = CarrierService.Builder
 				.newInstance(Id.create("serviceId2", CarrierService.class), Id.create("to2", Link.class))
-				.setCapacityDemand(10).build();
+				.setDemand(10).build();
 		CarrierVehicle matsimVehicle = getMatsimVehicle("matsimVehicle", "loc", getMatsimVehicleType());
 		double startTime = 15.0;
 		Tour.Builder sTourBuilder = Tour.Builder.newInstance(Id.create("testTour", Tour.class));
@@ -391,8 +391,8 @@ public class MatsimTransformerTest {
 		return CarrierShipment.Builder
 				.newInstance(Id.create(id, CarrierShipment.class), Id.create(from, Link.class),
 						Id.create(to, Link.class), size)
-				.setDeliveryServiceTime(30.0).setDeliveryTimeWindow(TimeWindow.newInstance(10.0, 20.0))
-				.setPickupServiceTime(15.0).setPickupTimeWindow(TimeWindow.newInstance(1.0, 5.0)).build();
+				.setDeliveryDuration(30.0).setDeliveryStartsTimeWindow(TimeWindow.newInstance(10.0, 20.0))
+				.setPickupDuration(15.0).setPickupStartsTimeWindow(TimeWindow.newInstance(1.0, 5.0)).build();
 	}
 
 	@Test
@@ -503,11 +503,11 @@ public class MatsimTransformerTest {
 		carrier.setCarrierCapabilities(ccBuilder.build());
 		CarrierService carrierService1 = CarrierService.Builder
 				.newInstance(Id.create("serviceId", CarrierService.class), Id.create("i(7,4)R", Link.class))
-				.setCapacityDemand(20).setServiceDuration(10.0).build();
+				.setDemand(20).setServiceDuration(10.0).build();
 		CarriersUtils.addService(carrier, carrierService1);
 		CarrierService carrierService2 = CarrierService.Builder
 				.newInstance(Id.create("serviceId2", CarrierService.class), Id.create("i(3,9)", Link.class))
-				.setCapacityDemand(10).setServiceDuration(20.0).build();
+				.setDemand(10).setServiceDuration(20.0).build();
 		CarriersUtils.addService(carrier, carrierService2);
 		return carrier;
 	}

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/MatsimTransformerTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/MatsimTransformerTest.java
@@ -194,13 +194,13 @@ public class MatsimTransformerTest {
 		CarrierShipment carrierShipment = MatsimJspritFactory.createCarrierShipment(shipment);
 		assertNotNull(carrierShipment);
 		assertEquals("PickupLocationId", carrierShipment.getFrom().toString());
-		assertEquals(30.0, carrierShipment.getPickupServiceTime(), 0.01);
-		assertEquals(10.0, carrierShipment.getPickupTimeWindow().getStart(), 0.01);
-		assertEquals(20.0, carrierShipment.getPickupTimeWindow().getEnd(), 0.01);
+		assertEquals(30.0, carrierShipment.getPickupDuration(), 0.01);
+		assertEquals(10.0, carrierShipment.getPickupStartsTimeWindow().getStart(), 0.01);
+		assertEquals(20.0, carrierShipment.getPickupStartsTimeWindow().getEnd(), 0.01);
 		assertEquals("DeliveryLocationId", carrierShipment.getTo().toString());
-		assertEquals(40.0, carrierShipment.getDeliveryServiceTime(), 0.01);
-		assertEquals(50.0, carrierShipment.getDeliveryTimeWindow().getStart(), 0.01);
-		assertEquals(60.0, carrierShipment.getDeliveryTimeWindow().getEnd(), 0.01);
+		assertEquals(40.0, carrierShipment.getDeliveryDuration(), 0.01);
+		assertEquals(50.0, carrierShipment.getDeliveryStartsTimeWindow().getStart(), 0.01);
+		assertEquals(60.0, carrierShipment.getDeliveryStartsTimeWindow().getEnd(), 0.01);
         assertEquals(50, carrierShipment.getDemand());
 
 		CarrierShipment carrierShipment2 = MatsimJspritFactory.createCarrierShipment(shipment);

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/MatsimTransformerTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/MatsimTransformerTest.java
@@ -146,7 +146,7 @@ public class MatsimTransformerTest {
 
 		CarrierService service = MatsimJspritFactory.createCarrierService(carrierService);
 		assertNotNull(service);
-		assertEquals("locationId", service.getLocationLinkId().toString());
+		assertEquals("locationId", service.getServiceLinkId().toString());
 		assertEquals(30.0, service.getServiceDuration(), 0.01);
 		assertEquals(50, service.getDemand());
 		assertEquals(10.0, service.getServiceStartTimeWindow().getStart(), 0.01);
@@ -193,11 +193,11 @@ public class MatsimTransformerTest {
 
 		CarrierShipment carrierShipment = MatsimJspritFactory.createCarrierShipment(shipment);
 		assertNotNull(carrierShipment);
-		assertEquals("PickupLocationId", carrierShipment.getFrom().toString());
+		assertEquals("PickupLocationId", carrierShipment.getPickupLinkId().toString());
 		assertEquals(30.0, carrierShipment.getPickupDuration(), 0.01);
 		assertEquals(10.0, carrierShipment.getPickupStartsTimeWindow().getStart(), 0.01);
 		assertEquals(20.0, carrierShipment.getPickupStartsTimeWindow().getEnd(), 0.01);
-		assertEquals("DeliveryLocationId", carrierShipment.getTo().toString());
+		assertEquals("DeliveryLocationId", carrierShipment.getDeliveryLinkId().toString());
 		assertEquals(40.0, carrierShipment.getDeliveryDuration(), 0.01);
 		assertEquals(50.0, carrierShipment.getDeliveryStartsTimeWindow().getStart(), 0.01);
 		assertEquals(60.0, carrierShipment.getDeliveryStartsTimeWindow().getEnd(), 0.01);
@@ -234,7 +234,7 @@ public class MatsimTransformerTest {
 					CarrierService carrierService = ((Tour.ServiceActivity) e)
 							.getService();
 					Service service = Service.Builder.newInstance(carrierService.getId().toString())
-							.setLocation(Location.newInstance(carrierService.getLocationLinkId().toString())).build();
+							.setLocation(Location.newInstance(carrierService.getServiceLinkId().toString())).build();
 					services.add(service);
 				}
 			}

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/MatsimTransformerTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/MatsimTransformerTest.java
@@ -148,7 +148,7 @@ public class MatsimTransformerTest {
 		assertNotNull(service);
 		assertEquals("locationId", service.getLocationLinkId().toString());
 		assertEquals(30.0, service.getServiceDuration(), 0.01);
-		assertEquals(50, service.getCapacityDemand());
+		assertEquals(50, service.getDemand());
 		assertEquals(10.0, service.getServiceStartTimeWindow().getStart(), 0.01);
 
 		CarrierService service2 = MatsimJspritFactory.createCarrierService(carrierService);
@@ -201,7 +201,7 @@ public class MatsimTransformerTest {
 		assertEquals(40.0, carrierShipment.getDeliveryServiceTime(), 0.01);
 		assertEquals(50.0, carrierShipment.getDeliveryTimeWindow().getStart(), 0.01);
 		assertEquals(60.0, carrierShipment.getDeliveryTimeWindow().getEnd(), 0.01);
-		assertEquals(50, carrierShipment.getSize());
+        assertEquals(50, carrierShipment.getDemand());
 
 		CarrierShipment carrierShipment2 = MatsimJspritFactory.createCarrierShipment(shipment);
 		assertNotSame(carrierShipment, carrierShipment2);

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/SkillsIT.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/SkillsIT.java
@@ -161,10 +161,10 @@ public class SkillsIT {
 				carrierLocation,
 				Id.createLinkId("i(10,10)R"),
 				1)
-				.setPickupTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
-				.setPickupServiceTime(Time.parseTime("00:05:00"))
-				.setDeliveryTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
-				.setDeliveryServiceTime(Time.parseTime("00:05:00"))
+				.setPickupStartsTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
+				.setPickupDuration(Time.parseTime("00:05:00"))
+				.setDeliveryStartsTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
+				.setDeliveryDuration(Time.parseTime("00:05:00"))
 				.build();
 		CarriersUtils.addSkill(shipmentOne, "skill 1");
 		CarriersUtils.addShipment(carrier, shipmentOne);
@@ -174,10 +174,10 @@ public class SkillsIT {
 				carrierLocation,
 				Id.createLinkId("i(10,10)R"),
 				1)
-				.setPickupTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
-				.setPickupServiceTime(Time.parseTime("00:05:00"))
-				.setDeliveryTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
-				.setDeliveryServiceTime(Time.parseTime("00:05:00"))
+				.setPickupStartsTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
+				.setPickupDuration(Time.parseTime("00:05:00"))
+				.setDeliveryStartsTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
+				.setDeliveryDuration(Time.parseTime("00:05:00"))
 				.build();
 		CarriersUtils.addSkill(shipmentTwo, "skill 2");
 		CarriersUtils.addShipment(carrier, shipmentTwo);
@@ -190,10 +190,10 @@ public class SkillsIT {
 				carrierLocation,
 				Id.createLinkId("i(10,10)R"),
 				1)
-				.setPickupTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
-				.setPickupServiceTime(Time.parseTime("00:05:00"))
-				.setDeliveryTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
-				.setDeliveryServiceTime(Time.parseTime("00:05:00"))
+				.setPickupStartsTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
+				.setPickupDuration(Time.parseTime("00:05:00"))
+				.setDeliveryStartsTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
+				.setDeliveryDuration(Time.parseTime("00:05:00"))
 				.build();
 		CarriersUtils.addSkill(shipmentOne, "skill 1");
 		CarriersUtils.addShipment(carrier, shipmentOne);
@@ -203,10 +203,10 @@ public class SkillsIT {
 				carrierLocation,
 				Id.createLinkId("i(10,10)R"),
 				1)
-				.setPickupTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
-				.setPickupServiceTime(Time.parseTime("00:05:00"))
-				.setDeliveryTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
-				.setDeliveryServiceTime(Time.parseTime("00:05:00"))
+				.setPickupStartsTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
+				.setPickupDuration(Time.parseTime("00:05:00"))
+				.setDeliveryStartsTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
+				.setDeliveryDuration(Time.parseTime("00:05:00"))
 				.build();
 		CarriersUtils.addSkill(shipmentTwo, "skill 1");
 		CarriersUtils.addShipment(carrier, shipmentTwo);

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsIT.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsIT.java
@@ -44,7 +44,6 @@ import org.matsim.freight.carriers.jsprit.NetworkBasedTransportCosts.Builder;
 import org.matsim.freight.carriers.jsprit.NetworkRouter;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.vehicles.*;
-import org.matsim.vehicles.EngineInformation.FuelType;
 
 //TODO: length of routes (legs) AND end time of route are missing.
 /**
@@ -286,16 +285,16 @@ public class CarrierControllerUtilsIT{
 		}
 
 		return CarrierShipment.Builder.newInstance(shipmentId, fromLinkId, toLinkId, size)
-				.setDeliveryServiceTime(30.0)
-				.setDeliveryTimeWindow(TimeWindow.newInstance(0.0, 36000.0))
-				.setPickupServiceTime(5.0)
-				.setPickupTimeWindow(TimeWindow.newInstance(0.0, 7200.0))
+				.setDeliveryDuration(30.0)
+				.setDeliveryStartsTimeWindow(TimeWindow.newInstance(0.0, 36000.0))
+				.setPickupDuration(5.0)
+				.setPickupStartsTimeWindow(TimeWindow.newInstance(0.0, 7200.0))
 				.build();
 	}
 
 	private static CarrierService createMatsimService(String id, String to, int size) {
 		return CarrierService.Builder.newInstance(Id.create(id, CarrierService.class), Id.create(to, Link.class))
-				.setCapacityDemand(size)
+				.setDemand(size)
 				.setServiceDuration(31.0)
 				.setServiceStartTimeWindow(TimeWindow.newInstance(0.0, 36001.0))
 				.build();

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsTest.java
@@ -165,7 +165,7 @@ public class CarrierControllerUtilsTest{
 
 		int demandServices = 0;
 		for (CarrierService carrierService : carrierWServices.getServices().values()) {
-			demandServices += carrierService.getCapacityDemand();
+			demandServices += carrierService.getDemand();
 		}
 		Assertions.assertEquals(4, demandServices);
 
@@ -180,7 +180,7 @@ public class CarrierControllerUtilsTest{
 		Assertions.assertEquals(2, carrierWShipments.getShipments().size());
 		int demandShipments = 0;
 		for (CarrierShipment carrierShipment : carrierWShipments.getShipments().values()) {
-			demandShipments += carrierShipment.getSize();
+            demandShipments += carrierShipment.getDemand();
 		}
 		Assertions.assertEquals(3, demandShipments);
 	}
@@ -192,7 +192,7 @@ public class CarrierControllerUtilsTest{
 		Assertions.assertEquals(2, carrierWShipmentsOnlyFromCarrierWShipments.getShipments().size());
 		int demandShipments = 0;
 		for (CarrierShipment carrierShipment : carrierWShipmentsOnlyFromCarrierWServices.getShipments().values()) {
-			demandShipments += carrierShipment.getSize();
+            demandShipments += carrierShipment.getDemand();
 		}
 		Assertions.assertEquals(4, demandShipments);
 	}
@@ -204,7 +204,7 @@ public class CarrierControllerUtilsTest{
 		Assertions.assertEquals(2, carrierWShipmentsOnlyFromCarrierWServices.getShipments().size());
 		int demandShipments = 0;
 		for (CarrierShipment carrierShipment : carrierWShipmentsOnlyFromCarrierWServices.getShipments().values()) {
-			demandShipments += carrierShipment.getSize();
+            demandShipments += carrierShipment.getDemand();
 		}
 		Assertions.assertEquals(4, demandShipments);
 	}
@@ -246,7 +246,7 @@ public class CarrierControllerUtilsTest{
 				foundShipment1 = true;
 				Assertions.assertEquals(Id.createLinkId("i(1,0)"), carrierShipment1.getFrom());
 				Assertions.assertEquals(Id.createLinkId("i(7,6)R"), carrierShipment1.getTo());
-				Assertions.assertEquals(1, carrierShipment1.getSize());
+            Assertions.assertEquals(1, carrierShipment1.getDemand());
 				Assertions.assertEquals(30.0, carrierShipment1.getDeliveryServiceTime(), 0);
 				Assertions.assertEquals(3600.0, carrierShipment1.getDeliveryTimeWindow().getStart(), 0);
 				Assertions.assertEquals(36000.0, carrierShipment1.getDeliveryTimeWindow().getEnd(), 0);
@@ -261,7 +261,7 @@ public class CarrierControllerUtilsTest{
 				foundShipment2 = true;
 				Assertions.assertEquals(Id.createLinkId("i(3,0)"), carrierShipment2.getFrom());
 				Assertions.assertEquals(Id.createLinkId("i(3,7)"), carrierShipment2.getTo());
-				Assertions.assertEquals(2, carrierShipment2.getSize());
+            Assertions.assertEquals(2, carrierShipment2.getDemand());
 				Assertions.assertEquals(30.0, carrierShipment2.getDeliveryServiceTime(), 0);
 				Assertions.assertEquals(3600.0, carrierShipment2.getDeliveryTimeWindow().getStart(), 0);
 				Assertions.assertEquals(36000.0, carrierShipment2.getDeliveryTimeWindow().getEnd(), 0);
@@ -284,7 +284,7 @@ public class CarrierControllerUtilsTest{
 				foundService1 = true;
 				Assertions.assertEquals(Id.createLinkId("i(6,0)"), carrierShipment1.getFrom());
 				Assertions.assertEquals(Id.createLinkId("i(3,9)"), carrierShipment1.getTo());
-				Assertions.assertEquals(2, carrierShipment1.getSize());
+            Assertions.assertEquals(2, carrierShipment1.getDemand());
 				Assertions.assertEquals(31.0, carrierShipment1.getDeliveryServiceTime(), 0);
 				Assertions.assertEquals(3601.0, carrierShipment1.getDeliveryTimeWindow().getStart(), 0);
 				Assertions.assertEquals(36001.0, carrierShipment1.getDeliveryTimeWindow().getEnd(), 0);
@@ -298,7 +298,7 @@ public class CarrierControllerUtilsTest{
 				foundService2 = true;
 				Assertions.assertEquals(Id.createLinkId("i(6,0)"), carrierShipment2.getFrom());
 				Assertions.assertEquals(Id.createLinkId("i(4,9)"), carrierShipment2.getTo());
-				Assertions.assertEquals(2, carrierShipment2.getSize());
+            Assertions.assertEquals(2, carrierShipment2.getDemand());
 				Assertions.assertEquals(31.0, carrierShipment2.getDeliveryServiceTime(), 0);
 				Assertions.assertEquals(3601.0, carrierShipment2.getDeliveryTimeWindow().getStart(), 0);
 				Assertions.assertEquals(36001.0, carrierShipment2.getDeliveryTimeWindow().getEnd(), 0);

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsTest.java
@@ -244,8 +244,8 @@ public class CarrierControllerUtilsTest{
 		if (carrierShipment1.getId() == Id.create("shipment1", CarrierShipment.class)) {
 				System.out.println("Found Shipment1");
 				foundShipment1 = true;
-				Assertions.assertEquals(Id.createLinkId("i(1,0)"), carrierShipment1.getFrom());
-				Assertions.assertEquals(Id.createLinkId("i(7,6)R"), carrierShipment1.getTo());
+				Assertions.assertEquals(Id.createLinkId("i(1,0)"), carrierShipment1.getPickupLinkId());
+				Assertions.assertEquals(Id.createLinkId("i(7,6)R"), carrierShipment1.getDeliveryLinkId());
             Assertions.assertEquals(1, carrierShipment1.getDemand());
 				Assertions.assertEquals(30.0, carrierShipment1.getDeliveryDuration(), 0);
 			Assertions.assertEquals(3600.0, carrierShipment1.getDeliveryStartsTimeWindow().getStart(), 0);
@@ -259,8 +259,8 @@ public class CarrierControllerUtilsTest{
 		if (carrierShipment2.getId() == Id.create("shipment2", CarrierShipment.class)) {
 				System.out.println("Found Shipment2");
 				foundShipment2 = true;
-				Assertions.assertEquals(Id.createLinkId("i(3,0)"), carrierShipment2.getFrom());
-				Assertions.assertEquals(Id.createLinkId("i(3,7)"), carrierShipment2.getTo());
+				Assertions.assertEquals(Id.createLinkId("i(3,0)"), carrierShipment2.getPickupLinkId());
+				Assertions.assertEquals(Id.createLinkId("i(3,7)"), carrierShipment2.getDeliveryLinkId());
             Assertions.assertEquals(2, carrierShipment2.getDemand());
 				Assertions.assertEquals(30.0, carrierShipment2.getDeliveryDuration(), 0);
 			Assertions.assertEquals(3600.0, carrierShipment2.getDeliveryStartsTimeWindow().getStart(), 0);
@@ -282,8 +282,8 @@ public class CarrierControllerUtilsTest{
 		assert carrierShipment1 != null;
 		if (carrierShipment1.getId() == Id.create("Service1", CarrierShipment.class)) {
 				foundService1 = true;
-				Assertions.assertEquals(Id.createLinkId("i(6,0)"), carrierShipment1.getFrom());
-				Assertions.assertEquals(Id.createLinkId("i(3,9)"), carrierShipment1.getTo());
+				Assertions.assertEquals(Id.createLinkId("i(6,0)"), carrierShipment1.getPickupLinkId());
+				Assertions.assertEquals(Id.createLinkId("i(3,9)"), carrierShipment1.getDeliveryLinkId());
             Assertions.assertEquals(2, carrierShipment1.getDemand());
 				Assertions.assertEquals(31.0, carrierShipment1.getDeliveryDuration(), 0);
 			Assertions.assertEquals(3601.0, carrierShipment1.getDeliveryStartsTimeWindow().getStart(), 0);
@@ -296,8 +296,8 @@ public class CarrierControllerUtilsTest{
 		assert carrierShipment2 != null;
 		if (carrierShipment2.getId() == Id.create("Service2", CarrierShipment.class)) {
 				foundService2 = true;
-				Assertions.assertEquals(Id.createLinkId("i(6,0)"), carrierShipment2.getFrom());
-				Assertions.assertEquals(Id.createLinkId("i(4,9)"), carrierShipment2.getTo());
+				Assertions.assertEquals(Id.createLinkId("i(6,0)"), carrierShipment2.getPickupLinkId());
+				Assertions.assertEquals(Id.createLinkId("i(4,9)"), carrierShipment2.getDeliveryLinkId());
             Assertions.assertEquals(2, carrierShipment2.getDemand());
 				Assertions.assertEquals(31.0, carrierShipment2.getDeliveryDuration(), 0);
 			Assertions.assertEquals(3601.0, carrierShipment2.getDeliveryStartsTimeWindow().getStart(), 0);

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsTest.java
@@ -343,16 +343,16 @@ public class CarrierControllerUtilsTest{
 		}
 
 		return CarrierShipment.Builder.newInstance(shipmentId, fromLinkId, toLinkId, size)
-				.setDeliveryServiceTime(30.0)
-				.setDeliveryTimeWindow(TimeWindow.newInstance(3600.0, 36000.0))
-				.setPickupServiceTime(5.0)
-				.setPickupTimeWindow(TimeWindow.newInstance(0.0, 7200.0))
+				.setDeliveryDuration(30.0)
+				.setDeliveryStartsTimeWindow(TimeWindow.newInstance(3600.0, 36000.0))
+				.setPickupDuration(5.0)
+				.setPickupStartsTimeWindow(TimeWindow.newInstance(0.0, 7200.0))
 				.build();
 	}
 
 	private static CarrierService createMatsimService(String id, String to, int size) {
 		return CarrierService.Builder.newInstance(Id.create(id, CarrierService.class), Id.create(to, Link.class))
-				.setCapacityDemand(size)
+				.setDemand(size)
 				.setServiceDuration(31.0)
 				.setServiceStartTimeWindow(TimeWindow.newInstance(3601.0, 36001.0))
 				.build();

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsTest.java
@@ -247,12 +247,12 @@ public class CarrierControllerUtilsTest{
 				Assertions.assertEquals(Id.createLinkId("i(1,0)"), carrierShipment1.getFrom());
 				Assertions.assertEquals(Id.createLinkId("i(7,6)R"), carrierShipment1.getTo());
             Assertions.assertEquals(1, carrierShipment1.getDemand());
-				Assertions.assertEquals(30.0, carrierShipment1.getDeliveryServiceTime(), 0);
-				Assertions.assertEquals(3600.0, carrierShipment1.getDeliveryTimeWindow().getStart(), 0);
-				Assertions.assertEquals(36000.0, carrierShipment1.getDeliveryTimeWindow().getEnd(), 0);
-				Assertions.assertEquals(5.0, carrierShipment1.getPickupServiceTime(), 0);
-				Assertions.assertEquals(0.0, carrierShipment1.getPickupTimeWindow().getStart(), 0);
-				Assertions.assertEquals(7200.0, carrierShipment1.getPickupTimeWindow().getEnd(), 0);
+				Assertions.assertEquals(30.0, carrierShipment1.getDeliveryDuration(), 0);
+			Assertions.assertEquals(3600.0, carrierShipment1.getDeliveryStartsTimeWindow().getStart(), 0);
+			Assertions.assertEquals(36000.0, carrierShipment1.getDeliveryStartsTimeWindow().getEnd(), 0);
+				Assertions.assertEquals(5.0, carrierShipment1.getPickupDuration(), 0);
+			Assertions.assertEquals(0.0, carrierShipment1.getPickupStartsTimeWindow().getStart(), 0);
+			Assertions.assertEquals(7200.0, carrierShipment1.getPickupStartsTimeWindow().getEnd(), 0);
 			}
 		CarrierShipment carrierShipment2 = CarriersUtils.getShipment(carrierWShipmentsOnlyFromCarrierWShipments, Id.create("shipment2", CarrierShipment.class));
 		assert carrierShipment2 != null;
@@ -262,12 +262,12 @@ public class CarrierControllerUtilsTest{
 				Assertions.assertEquals(Id.createLinkId("i(3,0)"), carrierShipment2.getFrom());
 				Assertions.assertEquals(Id.createLinkId("i(3,7)"), carrierShipment2.getTo());
             Assertions.assertEquals(2, carrierShipment2.getDemand());
-				Assertions.assertEquals(30.0, carrierShipment2.getDeliveryServiceTime(), 0);
-				Assertions.assertEquals(3600.0, carrierShipment2.getDeliveryTimeWindow().getStart(), 0);
-				Assertions.assertEquals(36000.0, carrierShipment2.getDeliveryTimeWindow().getEnd(), 0);
-				Assertions.assertEquals(5.0, carrierShipment2.getPickupServiceTime(), 0);
-				Assertions.assertEquals(0.0, carrierShipment2.getPickupTimeWindow().getStart(), 0);
-				Assertions.assertEquals(7200.0, carrierShipment2.getPickupTimeWindow().getEnd(), 0);
+				Assertions.assertEquals(30.0, carrierShipment2.getDeliveryDuration(), 0);
+			Assertions.assertEquals(3600.0, carrierShipment2.getDeliveryStartsTimeWindow().getStart(), 0);
+			Assertions.assertEquals(36000.0, carrierShipment2.getDeliveryStartsTimeWindow().getEnd(), 0);
+				Assertions.assertEquals(5.0, carrierShipment2.getPickupDuration(), 0);
+			Assertions.assertEquals(0.0, carrierShipment2.getPickupStartsTimeWindow().getStart(), 0);
+			Assertions.assertEquals(7200.0, carrierShipment2.getPickupStartsTimeWindow().getEnd(), 0);
 			}
 		Assertions.assertTrue(foundShipment1, "Not found Shipment1 after copying");
 		Assertions.assertTrue(foundShipment2, "Not found Shipment2 after copying");
@@ -285,12 +285,12 @@ public class CarrierControllerUtilsTest{
 				Assertions.assertEquals(Id.createLinkId("i(6,0)"), carrierShipment1.getFrom());
 				Assertions.assertEquals(Id.createLinkId("i(3,9)"), carrierShipment1.getTo());
             Assertions.assertEquals(2, carrierShipment1.getDemand());
-				Assertions.assertEquals(31.0, carrierShipment1.getDeliveryServiceTime(), 0);
-				Assertions.assertEquals(3601.0, carrierShipment1.getDeliveryTimeWindow().getStart(), 0);
-				Assertions.assertEquals(36001.0, carrierShipment1.getDeliveryTimeWindow().getEnd(), 0);
-				Assertions.assertEquals(0.0, carrierShipment1.getPickupServiceTime(), 0);
-				Assertions.assertEquals(0.0, carrierShipment1.getPickupTimeWindow().getStart(), 0);
-				Assertions.assertEquals(36001.0, carrierShipment1.getPickupTimeWindow().getEnd(), 0);
+				Assertions.assertEquals(31.0, carrierShipment1.getDeliveryDuration(), 0);
+			Assertions.assertEquals(3601.0, carrierShipment1.getDeliveryStartsTimeWindow().getStart(), 0);
+			Assertions.assertEquals(36001.0, carrierShipment1.getDeliveryStartsTimeWindow().getEnd(), 0);
+				Assertions.assertEquals(0.0, carrierShipment1.getPickupDuration(), 0);
+			Assertions.assertEquals(0.0, carrierShipment1.getPickupStartsTimeWindow().getStart(), 0);
+			Assertions.assertEquals(36001.0, carrierShipment1.getPickupStartsTimeWindow().getEnd(), 0);
 			}
 		CarrierShipment carrierShipment2 = CarriersUtils.getShipment(carrierWShipmentsOnlyFromCarrierWServices, Id.create("Service2", CarrierShipment.class));
 		assert carrierShipment2 != null;
@@ -299,12 +299,12 @@ public class CarrierControllerUtilsTest{
 				Assertions.assertEquals(Id.createLinkId("i(6,0)"), carrierShipment2.getFrom());
 				Assertions.assertEquals(Id.createLinkId("i(4,9)"), carrierShipment2.getTo());
             Assertions.assertEquals(2, carrierShipment2.getDemand());
-				Assertions.assertEquals(31.0, carrierShipment2.getDeliveryServiceTime(), 0);
-				Assertions.assertEquals(3601.0, carrierShipment2.getDeliveryTimeWindow().getStart(), 0);
-				Assertions.assertEquals(36001.0, carrierShipment2.getDeliveryTimeWindow().getEnd(), 0);
-				Assertions.assertEquals(0.0, carrierShipment2.getPickupServiceTime(), 0);
-				Assertions.assertEquals(0.0, carrierShipment2.getPickupTimeWindow().getStart(), 0);
-				Assertions.assertEquals(36001.0, carrierShipment2.getPickupTimeWindow().getEnd(), 0);
+				Assertions.assertEquals(31.0, carrierShipment2.getDeliveryDuration(), 0);
+			Assertions.assertEquals(3601.0, carrierShipment2.getDeliveryStartsTimeWindow().getStart(), 0);
+			Assertions.assertEquals(36001.0, carrierShipment2.getDeliveryStartsTimeWindow().getEnd(), 0);
+				Assertions.assertEquals(0.0, carrierShipment2.getPickupDuration(), 0);
+			Assertions.assertEquals(0.0, carrierShipment2.getPickupStartsTimeWindow().getStart(), 0);
+			Assertions.assertEquals(36001.0, carrierShipment2.getPickupStartsTimeWindow().getEnd(), 0);
 			}
 		Assertions.assertTrue(foundService1, "Not found converted Service1 after converting");
 		Assertions.assertTrue(foundService2, "Not found converted Service2 after converting");

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/simulationTrackers/CollectionTrackerTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/simulationTrackers/CollectionTrackerTest.java
@@ -56,7 +56,6 @@ import org.matsim.freight.logistics.resourceImplementations.ResourceImplementati
 import org.matsim.freight.logistics.shipment.LspShipment;
 import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 import org.matsim.testcases.MatsimTestUtils;
-import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehicleUtils;
 
@@ -238,7 +237,7 @@ public class CollectionTrackerTest {
 						if (element instanceof ServiceActivity activity) {
 							scheduledCosts += activity.getService().getServiceDuration() * scheduledTour.getVehicle().getType().getCostInformation().getCostsPerSecond();
 							totalScheduledCosts += scheduledCosts;
-							totalScheduledWeight += activity.getService().getCapacityDemand();
+                            totalScheduledWeight += activity.getService().getDemand();
 							totalNumberOfScheduledShipments++;
 						}
 					}

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/CollectionLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/CollectionLSPSchedulingTest.java
@@ -197,7 +197,7 @@ public class CollectionLSPSchedulingTest {
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
 			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
-			assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+                assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -212,7 +212,7 @@ public class CollectionLSPSchedulingTest {
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
 			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
-			assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+                assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/CollectionLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/CollectionLSPSchedulingTest.java
@@ -196,7 +196,7 @@ public class CollectionLSPSchedulingTest {
 			{
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
-			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
+			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
                 assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
@@ -211,7 +211,7 @@ public class CollectionLSPSchedulingTest {
 			{
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
-			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
+			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
                 assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
@@ -434,7 +434,7 @@ public class CompleteLSPSchedulingTest {
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
 			assertSame(service.getLocationLinkId(), shipment.getFrom());
-			assertEquals(service.getCapacityDemand(), shipment.getSize());
+            assertEquals(service.getDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
 			for (LogisticChainElement clientElement : reloadEventHandler.getTranshipmentHub().getClientElements()) {
@@ -461,7 +461,7 @@ public class CompleteLSPSchedulingTest {
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
 			assertSame(service.getLocationLinkId(), toLinkId);
-			assertEquals(service.getCapacityDemand(), shipment.getSize());
+            assertEquals(service.getDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
 			for (LogisticChainElement clientElement : reloadEventHandler.getTranshipmentHub().getClientElements()) {
@@ -485,7 +485,7 @@ public class CompleteLSPSchedulingTest {
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
 			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
-			assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -503,7 +503,7 @@ public class CompleteLSPSchedulingTest {
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
 			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
-			assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -522,7 +522,7 @@ public class CompleteLSPSchedulingTest {
 			LSPTourStartEventHandler mainRunStartHandler = (LSPTourStartEventHandler) eventHandlers.get(2);
 			assertSame(mainRunStartHandler.getCarrierService().getLocationLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(mainRunStartHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(mainRunStartHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
@@ -540,7 +540,7 @@ public class CompleteLSPSchedulingTest {
 			LSPTourEndEventHandler mainRunEndHandler = (LSPTourEndEventHandler) eventHandlers.get(3);
 			assertSame(mainRunEndHandler.getCarrierService().getLocationLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(mainRunEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(mainRunEndHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
@@ -558,7 +558,7 @@ public class CompleteLSPSchedulingTest {
 			LSPTourStartEventHandler lspTourStartEventHandler = (LSPTourStartEventHandler) eventHandlers.get(4);
 			assertSame(lspTourStartEventHandler.getCarrierService().getLocationLinkId(), shipment.getTo());
 			assertEquals(lspTourStartEventHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(lspTourStartEventHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(lspTourStartEventHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, lspTourStartEventHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, lspTourStartEventHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(lspTourStartEventHandler.getLogisticChainElement(), planElements.get(8).getLogisticChainElement());
@@ -576,7 +576,7 @@ public class CompleteLSPSchedulingTest {
 			DistributionServiceStartEventHandler distributionServiceHandler = (DistributionServiceStartEventHandler) eventHandlers.get(5);
 			assertSame(distributionServiceHandler.getCarrierService().getLocationLinkId(), shipment.getTo());
 			assertEquals(distributionServiceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(distributionServiceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(distributionServiceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, distributionServiceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, distributionServiceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(distributionServiceHandler.getLogisticChainElement(), planElements.get(8).getLogisticChainElement());

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
@@ -433,7 +433,7 @@ public class CompleteLSPSchedulingTest {
 			CarrierService service = entry.getKey();
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
-			assertSame(service.getLocationLinkId(), shipment.getFrom());
+			assertSame(service.getServiceLinkId(), shipment.getFrom());
             assertEquals(service.getDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
@@ -460,7 +460,7 @@ public class CompleteLSPSchedulingTest {
 			CarrierService service = entry.getKey();
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
-			assertSame(service.getLocationLinkId(), toLinkId);
+			assertSame(service.getServiceLinkId(), toLinkId);
             assertEquals(service.getDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
@@ -484,7 +484,7 @@ public class CompleteLSPSchedulingTest {
 
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
-			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
+			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
@@ -502,7 +502,7 @@ public class CompleteLSPSchedulingTest {
 			//CollectionServiceEnd
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
-			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
+			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
@@ -520,7 +520,7 @@ public class CompleteLSPSchedulingTest {
 			//MainRunStart
 			assertInstanceOf(LSPTourStartEventHandler.class, eventHandlers.get(2));
 			LSPTourStartEventHandler mainRunStartHandler = (LSPTourStartEventHandler) eventHandlers.get(2);
-			assertSame(mainRunStartHandler.getCarrierService().getLocationLinkId(), toLinkId);
+			assertSame(mainRunStartHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(mainRunStartHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
@@ -538,7 +538,7 @@ public class CompleteLSPSchedulingTest {
 			//MainRunEnd
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.get(3));
 			LSPTourEndEventHandler mainRunEndHandler = (LSPTourEndEventHandler) eventHandlers.get(3);
-			assertSame(mainRunEndHandler.getCarrierService().getLocationLinkId(), toLinkId);
+			assertSame(mainRunEndHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(mainRunEndHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
@@ -556,7 +556,7 @@ public class CompleteLSPSchedulingTest {
 			//DistributionRunStart
 			assertInstanceOf(LSPTourStartEventHandler.class, eventHandlers.get(4));
 			LSPTourStartEventHandler lspTourStartEventHandler = (LSPTourStartEventHandler) eventHandlers.get(4);
-			assertSame(lspTourStartEventHandler.getCarrierService().getLocationLinkId(), shipment.getTo());
+			assertSame(lspTourStartEventHandler.getCarrierService().getServiceLinkId(), shipment.getTo());
 			assertEquals(lspTourStartEventHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(lspTourStartEventHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, lspTourStartEventHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
@@ -574,7 +574,7 @@ public class CompleteLSPSchedulingTest {
 			//DistributionServiceStart
 			assertInstanceOf(DistributionServiceStartEventHandler.class, eventHandlers.get(5));
 			DistributionServiceStartEventHandler distributionServiceHandler = (DistributionServiceStartEventHandler) eventHandlers.get(5);
-			assertSame(distributionServiceHandler.getCarrierService().getLocationLinkId(), shipment.getTo());
+			assertSame(distributionServiceHandler.getCarrierService().getServiceLinkId(), shipment.getTo());
 			assertEquals(distributionServiceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(distributionServiceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, distributionServiceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/FirstReloadLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/FirstReloadLSPSchedulingTest.java
@@ -260,7 +260,7 @@ public class FirstReloadLSPSchedulingTest {
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
 			assertSame(service.getLocationLinkId(), shipment.getFrom());
-			assertEquals(service.getCapacityDemand(), shipment.getSize());
+            assertEquals(service.getDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
 			for (LogisticChainElement clientElement : reloadEventHandler.getTranshipmentHub().getClientElements()) {
@@ -284,7 +284,7 @@ public class FirstReloadLSPSchedulingTest {
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
 			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
-			assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -297,7 +297,7 @@ public class FirstReloadLSPSchedulingTest {
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
 			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
-			assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/FirstReloadLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/FirstReloadLSPSchedulingTest.java
@@ -259,7 +259,7 @@ public class FirstReloadLSPSchedulingTest {
 			CarrierService service = entry.getKey();
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
-			assertSame(service.getLocationLinkId(), shipment.getFrom());
+			assertSame(service.getServiceLinkId(), shipment.getFrom());
             assertEquals(service.getDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
@@ -283,7 +283,7 @@ public class FirstReloadLSPSchedulingTest {
 
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
-			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
+			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
@@ -296,7 +296,7 @@ public class FirstReloadLSPSchedulingTest {
 
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
-			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
+			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MainRunLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MainRunLSPSchedulingTest.java
@@ -325,7 +325,7 @@ public class MainRunLSPSchedulingTest {
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
 			assertSame(service.getLocationLinkId(), shipment.getFrom());
-			assertEquals(service.getCapacityDemand(), shipment.getSize());
+            assertEquals(service.getDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
 			for (LogisticChainElement clientElement : reloadEventHandler.getTranshipmentHub().getClientElements()) {
@@ -351,7 +351,7 @@ public class MainRunLSPSchedulingTest {
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
 			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
-			assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -369,7 +369,7 @@ public class MainRunLSPSchedulingTest {
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
 			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
-			assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -388,7 +388,7 @@ public class MainRunLSPSchedulingTest {
 			LSPTourStartEventHandler mainRunStartHandler = (LSPTourStartEventHandler) eventHandlers.get(2);
 			assertSame(mainRunStartHandler.getCarrierService().getLocationLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(mainRunStartHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(mainRunStartHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
@@ -406,7 +406,7 @@ public class MainRunLSPSchedulingTest {
 			LSPTourEndEventHandler mainRunEndHandler = (LSPTourEndEventHandler) eventHandlers.get(3);
 			assertSame(mainRunEndHandler.getCarrierService().getLocationLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(mainRunEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(mainRunEndHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MainRunLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MainRunLSPSchedulingTest.java
@@ -324,7 +324,7 @@ public class MainRunLSPSchedulingTest {
 			CarrierService service = entry.getKey();
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
-			assertSame(service.getLocationLinkId(), shipment.getFrom());
+			assertSame(service.getServiceLinkId(), shipment.getFrom());
             assertEquals(service.getDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
@@ -350,7 +350,7 @@ public class MainRunLSPSchedulingTest {
 
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
-			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
+			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
@@ -368,7 +368,7 @@ public class MainRunLSPSchedulingTest {
 			//CollectionServiceEnd
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
-			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
+			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
@@ -386,7 +386,7 @@ public class MainRunLSPSchedulingTest {
 			//MainRunTourStart
 			assertInstanceOf(LSPTourStartEventHandler.class, eventHandlers.get(2));
 			LSPTourStartEventHandler mainRunStartHandler = (LSPTourStartEventHandler) eventHandlers.get(2);
-			assertSame(mainRunStartHandler.getCarrierService().getLocationLinkId(), toLinkId);
+			assertSame(mainRunStartHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(mainRunStartHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
@@ -404,7 +404,7 @@ public class MainRunLSPSchedulingTest {
 			//MainRunTourEnd
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.get(3));
 			LSPTourEndEventHandler mainRunEndHandler = (LSPTourEndEventHandler) eventHandlers.get(3);
-			assertSame(mainRunEndHandler.getCarrierService().getLocationLinkId(), toLinkId);
+			assertSame(mainRunEndHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(mainRunEndHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCollectionLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCollectionLSPSchedulingTest.java
@@ -198,7 +198,7 @@ public class MultipleShipmentsCollectionLSPSchedulingTest {
 
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
-			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
+			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
@@ -211,7 +211,7 @@ public class MultipleShipmentsCollectionLSPSchedulingTest {
 
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
-			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
+			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCollectionLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCollectionLSPSchedulingTest.java
@@ -199,7 +199,7 @@ public class MultipleShipmentsCollectionLSPSchedulingTest {
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
 			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
-			assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -212,7 +212,7 @@ public class MultipleShipmentsCollectionLSPSchedulingTest {
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
 			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
-			assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
@@ -437,7 +437,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
 			assertSame(service.getLocationLinkId(), shipment.getFrom());
-			assertEquals(service.getCapacityDemand(), shipment.getSize());
+            assertEquals(service.getDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
 			for (LogisticChainElement clientElement : reloadEventHandler.getTranshipmentHub().getClientElements()) {
@@ -464,7 +464,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
 			assertSame(service.getLocationLinkId(), toLinkId);
-			assertEquals(service.getCapacityDemand(), shipment.getSize());
+            assertEquals(service.getDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
 			for (LogisticChainElement clientElement : reloadEventHandler.getTranshipmentHub().getClientElements()) {
@@ -488,7 +488,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
 			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
-			assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -506,7 +506,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
 			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
-			assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -525,7 +525,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			LSPTourStartEventHandler mainRunStartHandler = (LSPTourStartEventHandler) eventHandlers.get(2);
 			assertSame(mainRunStartHandler.getCarrierService().getLocationLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(mainRunStartHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(mainRunStartHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
@@ -543,7 +543,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			LSPTourEndEventHandler mainRunEndHandler = (LSPTourEndEventHandler) eventHandlers.get(3);
 			assertSame(mainRunEndHandler.getCarrierService().getLocationLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(mainRunEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(mainRunEndHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
@@ -561,7 +561,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			LSPTourStartEventHandler lspTourStartEventHandler = (LSPTourStartEventHandler) eventHandlers.get(4);
 			assertSame(lspTourStartEventHandler.getCarrierService().getLocationLinkId(), shipment.getTo());
 			assertEquals(lspTourStartEventHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(lspTourStartEventHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(lspTourStartEventHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, lspTourStartEventHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, lspTourStartEventHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(lspTourStartEventHandler.getLogisticChainElement(), planElements.get(8).getLogisticChainElement());
@@ -579,7 +579,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			DistributionServiceStartEventHandler distributionServiceHandler = (DistributionServiceStartEventHandler) eventHandlers.get(5);
 			assertSame(distributionServiceHandler.getCarrierService().getLocationLinkId(), shipment.getTo());
 			assertEquals(distributionServiceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(distributionServiceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(distributionServiceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, distributionServiceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, distributionServiceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(distributionServiceHandler.getLogisticChainElement(), planElements.get(8).getLogisticChainElement());

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
@@ -436,7 +436,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			CarrierService service = entry.getKey();
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
-			assertSame(service.getLocationLinkId(), shipment.getFrom());
+			assertSame(service.getServiceLinkId(), shipment.getFrom());
             assertEquals(service.getDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
@@ -463,7 +463,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			CarrierService service = entry.getKey();
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
-			assertSame(service.getLocationLinkId(), toLinkId);
+			assertSame(service.getServiceLinkId(), toLinkId);
             assertEquals(service.getDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
@@ -487,7 +487,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
-			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
+			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
@@ -505,7 +505,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			//CollectionServiceEnd
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
-			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
+			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
@@ -523,7 +523,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			//MainRunTourStart
 			assertInstanceOf(LSPTourStartEventHandler.class, eventHandlers.get(2));
 			LSPTourStartEventHandler mainRunStartHandler = (LSPTourStartEventHandler) eventHandlers.get(2);
-			assertSame(mainRunStartHandler.getCarrierService().getLocationLinkId(), toLinkId);
+			assertSame(mainRunStartHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(mainRunStartHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
@@ -541,7 +541,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			//MainRunTourEnd
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.get(3));
 			LSPTourEndEventHandler mainRunEndHandler = (LSPTourEndEventHandler) eventHandlers.get(3);
-			assertSame(mainRunEndHandler.getCarrierService().getLocationLinkId(), toLinkId);
+			assertSame(mainRunEndHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(mainRunEndHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
@@ -559,7 +559,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			//DistributionTourStart
 			assertInstanceOf(LSPTourStartEventHandler.class, eventHandlers.get(4));
 			LSPTourStartEventHandler lspTourStartEventHandler = (LSPTourStartEventHandler) eventHandlers.get(4);
-			assertSame(lspTourStartEventHandler.getCarrierService().getLocationLinkId(), shipment.getTo());
+			assertSame(lspTourStartEventHandler.getCarrierService().getServiceLinkId(), shipment.getTo());
 			assertEquals(lspTourStartEventHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(lspTourStartEventHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, lspTourStartEventHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
@@ -577,7 +577,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			//DistributionServiceStart
 			assertInstanceOf(DistributionServiceStartEventHandler.class, eventHandlers.get(5));
 			DistributionServiceStartEventHandler distributionServiceHandler = (DistributionServiceStartEventHandler) eventHandlers.get(5);
-			assertSame(distributionServiceHandler.getCarrierService().getLocationLinkId(), shipment.getTo());
+			assertSame(distributionServiceHandler.getCarrierService().getServiceLinkId(), shipment.getTo());
 			assertEquals(distributionServiceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(distributionServiceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, distributionServiceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsFirstReloadLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsFirstReloadLSPSchedulingTest.java
@@ -258,7 +258,7 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 			CarrierService service = entry.getKey();
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
-			assertSame(service.getLocationLinkId(), shipment.getFrom());
+			assertSame(service.getServiceLinkId(), shipment.getFrom());
             assertEquals(service.getDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
@@ -282,7 +282,7 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
-			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
+			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
@@ -295,7 +295,7 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
-			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
+			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsFirstReloadLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsFirstReloadLSPSchedulingTest.java
@@ -259,7 +259,7 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
 			assertSame(service.getLocationLinkId(), shipment.getFrom());
-			assertEquals(service.getCapacityDemand(), shipment.getSize());
+            assertEquals(service.getDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
 			for (LogisticChainElement clientElement : reloadEventHandler.getTranshipmentHub().getClientElements()) {
@@ -283,7 +283,7 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
 			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
-			assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -296,7 +296,7 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
 			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
-			assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsMainRunLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsMainRunLSPSchedulingTest.java
@@ -324,7 +324,7 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 			CarrierService service = entry.getKey();
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
-			assertSame(service.getLocationLinkId(), shipment.getFrom());
+			assertSame(service.getServiceLinkId(), shipment.getFrom());
             assertEquals(service.getDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
@@ -350,7 +350,7 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
-			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
+			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
@@ -368,7 +368,7 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 			//CollectionServiceEnd
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
-			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
+			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
@@ -386,7 +386,7 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 			//MainRunTourStart
 			assertInstanceOf(LSPTourStartEventHandler.class, eventHandlers.get(2));
 			LSPTourStartEventHandler mainRunStartHandler = (LSPTourStartEventHandler) eventHandlers.get(2);
-			assertSame(mainRunStartHandler.getCarrierService().getLocationLinkId(), toLinkId);
+			assertSame(mainRunStartHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(mainRunStartHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
@@ -404,7 +404,7 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 			//MainRunEnd
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.get(3));
 			LSPTourEndEventHandler mainRunEndHandler = (LSPTourEndEventHandler) eventHandlers.get(3);
-			assertSame(mainRunEndHandler.getCarrierService().getLocationLinkId(), toLinkId);
+			assertSame(mainRunEndHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(mainRunEndHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsMainRunLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsMainRunLSPSchedulingTest.java
@@ -222,16 +222,16 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 
 	@Test
 	public void testMainRunLSPScheduling() {
-		
+
 		/*for(LSPShipment shipment : lsp.getShipments()) {
 			ArrayList<AbstractShipmentPlanElement> scheduleElements = new ArrayList<AbstractShipmentPlanElement>(shipment.getSchedule().getPlanElements().values());
 			Collections.sort(scheduleElements, new AbstractShipmentPlanElementComparator());
-			
+
 			System.out.println();
 			for(int i = 0; i < shipment.getSchedule().getPlanElements().size(); i++) {
 				System.out.println("Scheduled: " + scheduleElements.get(i).getSolutionElement().getId() + "  " + scheduleElements.get(i).getResourceId() +"  "+ scheduleElements.get(i).getElementType() + " Start: " + scheduleElements.get(i).getStartTime() + " End: " + scheduleElements.get(i).getEndTime());
 			}
-			System.out.println();	
+			System.out.println();
 		}*/
 
 
@@ -325,7 +325,7 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
 			assertSame(service.getLocationLinkId(), shipment.getFrom());
-			assertEquals(service.getCapacityDemand(), shipment.getSize());
+            assertEquals(service.getDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
 			for (LogisticChainElement clientElement : reloadEventHandler.getTranshipmentHub().getClientElements()) {
@@ -351,7 +351,7 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
 			assertSame(endHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
-			assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -369,7 +369,7 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
 			assertSame(serviceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
-			assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -388,7 +388,7 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 			LSPTourStartEventHandler mainRunStartHandler = (LSPTourStartEventHandler) eventHandlers.get(2);
 			assertSame(mainRunStartHandler.getCarrierService().getLocationLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(mainRunStartHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(mainRunStartHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
@@ -406,7 +406,7 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 			LSPTourEndEventHandler mainRunEndHandler = (LSPTourEndEventHandler) eventHandlers.get(3);
 			assertSame(mainRunEndHandler.getCarrierService().getLocationLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(mainRunEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+            assertEquals(mainRunEndHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsSecondReloadLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsSecondReloadLSPSchedulingTest.java
@@ -368,7 +368,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 				CarrierService service = entry.getKey();
 				LspShipment shipment = entry.getValue().lspShipment;
 				LogisticChainElement element = entry.getValue().logisticChainElement;
-				assertSame(service.getLocationLinkId(), shipment.getFrom());
+				assertSame(service.getServiceLinkId(), shipment.getFrom());
                 assertEquals(service.getDemand(), shipment.getSize());
 				assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 				boolean handledByTranshipmentHub = false;
@@ -400,7 +400,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 				CarrierService service = entry.getKey();
 				LspShipment shipment = entry.getValue().lspShipment;
 				LogisticChainElement element = entry.getValue().logisticChainElement;
-				assertSame(service.getLocationLinkId(), toLinkId);
+				assertSame(service.getServiceLinkId(), toLinkId);
                 assertEquals(service.getDemand(), shipment.getSize());
 				assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 				boolean handledByTranshipmentHub = false;
@@ -430,7 +430,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			{
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler collectionEndHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
-			assertSame(collectionEndHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
+			assertSame(collectionEndHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
                 assertEquals(collectionEndHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(collectionEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(collectionEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
@@ -449,7 +449,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			{//CollectionServiceEnd
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler collectionServiceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
-			assertSame(collectionServiceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
+			assertSame(collectionServiceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
                 assertEquals(collectionServiceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(collectionServiceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(collectionServiceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
@@ -468,7 +468,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			{//MainRunStart
 			assertInstanceOf(LSPTourStartEventHandler.class, eventHandlers.get(2));
 			LSPTourStartEventHandler mainRunStartHandler = (LSPTourStartEventHandler) eventHandlers.get(2);
-			assertSame(mainRunStartHandler.getCarrierService().getLocationLinkId(), toLinkId);
+			assertSame(mainRunStartHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
                 assertEquals(mainRunStartHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
@@ -487,7 +487,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			{//MainRunEnd
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.get(3));
 			LSPTourEndEventHandler mainRunEndHandler = (LSPTourEndEventHandler) eventHandlers.get(3);
-			assertSame(mainRunEndHandler.getCarrierService().getLocationLinkId(), toLinkId);
+			assertSame(mainRunEndHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
                 assertEquals(mainRunEndHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsSecondReloadLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsSecondReloadLSPSchedulingTest.java
@@ -251,14 +251,14 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 
 	@Test
 	public void testSecondReloadLSPScheduling() {
-		
+
 		/*for(LSPShipment shipment : lsp.getShipments()) {
 			ArrayList<AbstractShipmentPlanElement> elementList = new ArrayList<AbstractShipmentPlanElement>(shipment.getSchedule().getPlanElements().values());
 			Collections.sort(elementList, new AbstractShipmentPlanElementComparator());
 			System.out.println();
 			for(AbstractShipmentPlanElement element : elementList) {
-				System.out.println(element.getSolutionElement().getId() + " " + element.getResourceId() + " " + element.getElementType() + " " + element.getStartTime() + " " + element.getEndTime());	
-			}			
+				System.out.println(element.getSolutionElement().getId() + " " + element.getResourceId() + " " + element.getElementType() + " " + element.getStartTime() + " " + element.getEndTime());
+			}
 			System.out.println();
 		}*/
 
@@ -369,7 +369,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 				LspShipment shipment = entry.getValue().lspShipment;
 				LogisticChainElement element = entry.getValue().logisticChainElement;
 				assertSame(service.getLocationLinkId(), shipment.getFrom());
-				assertEquals(service.getCapacityDemand(), shipment.getSize());
+                assertEquals(service.getDemand(), shipment.getSize());
 				assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 				boolean handledByTranshipmentHub = false;
 				for (LogisticChainElement clientElement :
@@ -401,7 +401,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 				LspShipment shipment = entry.getValue().lspShipment;
 				LogisticChainElement element = entry.getValue().logisticChainElement;
 				assertSame(service.getLocationLinkId(), toLinkId);
-				assertEquals(service.getCapacityDemand(), shipment.getSize());
+                assertEquals(service.getDemand(), shipment.getSize());
 				assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 				boolean handledByTranshipmentHub = false;
 				for (LogisticChainElement clientElement : reloadEventHandler.getTranshipmentHub().getClientElements()) {
@@ -431,7 +431,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler collectionEndHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
 			assertSame(collectionEndHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
-			assertEquals(collectionEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+                assertEquals(collectionEndHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(collectionEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(collectionEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(collectionEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -450,7 +450,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler collectionServiceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
 			assertSame(collectionServiceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
-			assertEquals(collectionServiceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+                assertEquals(collectionServiceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(collectionServiceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(collectionServiceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(collectionServiceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -470,7 +470,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			LSPTourStartEventHandler mainRunStartHandler = (LSPTourStartEventHandler) eventHandlers.get(2);
 			assertSame(mainRunStartHandler.getCarrierService().getLocationLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(mainRunStartHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+                assertEquals(mainRunStartHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
@@ -489,7 +489,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			LSPTourEndEventHandler mainRunEndHandler = (LSPTourEndEventHandler) eventHandlers.get(3);
 			assertSame(mainRunEndHandler.getCarrierService().getLocationLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(mainRunEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+                assertEquals(mainRunEndHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/SecondReloadLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/SecondReloadLSPSchedulingTest.java
@@ -368,7 +368,7 @@ public class SecondReloadLSPSchedulingTest {
 				CarrierService service = entry.getKey();
 				LspShipment shipment = entry.getValue().lspShipment;
 				LogisticChainElement element = entry.getValue().logisticChainElement;
-				assertSame(service.getLocationLinkId(), shipment.getFrom());
+				assertSame(service.getServiceLinkId(), shipment.getFrom());
                 assertEquals(service.getDemand(), shipment.getSize());
 				assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 				boolean handledByTranshipmentHub = false;
@@ -406,7 +406,7 @@ public class SecondReloadLSPSchedulingTest {
 				CarrierService service = entry.getKey();
 				LspShipment shipment = entry.getValue().lspShipment;
 				LogisticChainElement element = entry.getValue().logisticChainElement;
-				assertSame(service.getLocationLinkId(), toLinkId);
+				assertSame(service.getServiceLinkId(), toLinkId);
                 assertEquals(service.getDemand(), shipment.getSize());
 				assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 				boolean handledByTranshipmentHub = false;
@@ -437,7 +437,7 @@ public class SecondReloadLSPSchedulingTest {
 			{//CollectionTourEnd
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler collectionEndHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
-			assertSame(collectionEndHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
+			assertSame(collectionEndHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
                 assertEquals(collectionEndHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(collectionEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(collectionEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
@@ -456,7 +456,7 @@ public class SecondReloadLSPSchedulingTest {
 			{//CollectionServiceEnd
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler collectionServiceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
-			assertSame(collectionServiceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
+			assertSame(collectionServiceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
                 assertEquals(collectionServiceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(collectionServiceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(collectionServiceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
@@ -475,7 +475,7 @@ public class SecondReloadLSPSchedulingTest {
 			{//MainRunStart
 			assertInstanceOf(LSPTourStartEventHandler.class, eventHandlers.get(2));
 			LSPTourStartEventHandler mainRunStartHandler = (LSPTourStartEventHandler) eventHandlers.get(2);
-			assertSame(mainRunStartHandler.getCarrierService().getLocationLinkId(), toLinkId);
+			assertSame(mainRunStartHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
                 assertEquals(mainRunStartHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
@@ -494,7 +494,7 @@ public class SecondReloadLSPSchedulingTest {
 			{//MainRunEnd
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.get(3));
 			LSPTourEndEventHandler mainRunEndHandler = (LSPTourEndEventHandler) eventHandlers.get(3);
-			assertSame(mainRunEndHandler.getCarrierService().getLocationLinkId(), toLinkId);
+			assertSame(mainRunEndHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
                 assertEquals(mainRunEndHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/SecondReloadLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/SecondReloadLSPSchedulingTest.java
@@ -369,7 +369,7 @@ public class SecondReloadLSPSchedulingTest {
 				LspShipment shipment = entry.getValue().lspShipment;
 				LogisticChainElement element = entry.getValue().logisticChainElement;
 				assertSame(service.getLocationLinkId(), shipment.getFrom());
-				assertEquals(service.getCapacityDemand(), shipment.getSize());
+                assertEquals(service.getDemand(), shipment.getSize());
 				assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 				boolean handledByTranshipmentHub = false;
 				for (LogisticChainElement clientElement :
@@ -407,7 +407,7 @@ public class SecondReloadLSPSchedulingTest {
 				LspShipment shipment = entry.getValue().lspShipment;
 				LogisticChainElement element = entry.getValue().logisticChainElement;
 				assertSame(service.getLocationLinkId(), toLinkId);
-				assertEquals(service.getCapacityDemand(), shipment.getSize());
+                assertEquals(service.getDemand(), shipment.getSize());
 				assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 				boolean handledByTranshipmentHub = false;
 				for (LogisticChainElement clientElement :
@@ -438,7 +438,7 @@ public class SecondReloadLSPSchedulingTest {
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler collectionEndHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
 			assertSame(collectionEndHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
-			assertEquals(collectionEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+                assertEquals(collectionEndHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(collectionEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(collectionEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(collectionEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -457,7 +457,7 @@ public class SecondReloadLSPSchedulingTest {
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler collectionServiceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
 			assertSame(collectionServiceHandler.getCarrierService().getLocationLinkId(), shipment.getFrom());
-			assertEquals(collectionServiceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+                assertEquals(collectionServiceHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(collectionServiceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(collectionServiceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(collectionServiceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -477,7 +477,7 @@ public class SecondReloadLSPSchedulingTest {
 			LSPTourStartEventHandler mainRunStartHandler = (LSPTourStartEventHandler) eventHandlers.get(2);
 			assertSame(mainRunStartHandler.getCarrierService().getLocationLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(mainRunStartHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+                assertEquals(mainRunStartHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
@@ -496,7 +496,7 @@ public class SecondReloadLSPSchedulingTest {
 			LSPTourEndEventHandler mainRunEndHandler = (LSPTourEndEventHandler) eventHandlers.get(3);
 			assertSame(mainRunEndHandler.getCarrierService().getLocationLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(mainRunEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
+                assertEquals(mainRunEndHandler.getCarrierService().getDemand(), shipment.getSize());
 			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());

--- a/contribs/freightreceiver/src/main/java/org/matsim/freight/receiver/ReceiverControlerListener.java
+++ b/contribs/freightreceiver/src/main/java/org/matsim/freight/receiver/ReceiverControlerListener.java
@@ -178,7 +178,7 @@ class ReceiverControlerListener implements ScoringListener, IterationEndsListene
 
 							String shipmentId = act.getShipment().getId().toString();
 							if (act.getActivityType().equalsIgnoreCase("delivery")) {
-								Id<Link> linkId = act.getShipment().getTo();
+								Id<Link> linkId = act.getShipment().getDeliveryLinkId();
 								if (!receiverLinkMap.containsKey(linkId)) {
 									LOG.error("Woops, the carrier is delivering a shipment to an unknown receiver!");
 									throw new RuntimeException("Don't know to whom delivery is.");

--- a/contribs/freightreceiver/src/main/java/org/matsim/freight/receiver/ReceiverTriggersCarrierReplanningListener.java
+++ b/contribs/freightreceiver/src/main/java/org/matsim/freight/receiver/ReceiverTriggersCarrierReplanningListener.java
@@ -86,7 +86,7 @@ class ReceiverTriggersCarrierReplanningListener implements IterationStartsListen
                                                                   // TODO This only looks at the FIRST time window. This may need revision once we handle multiple
                                                                   // time windows.
                                                                   .build();
-                    if (newShipment.getSize() != 0) {
+                    if (newShipment.getDemand() != 0) {
                         receiverOrder.getCarrier().getShipments().put(newShipment.getId(), newShipment );
                     }
                 }

--- a/contribs/freightreceiver/src/main/java/org/matsim/freight/receiver/ReceiverTriggersCarrierReplanningListener.java
+++ b/contribs/freightreceiver/src/main/java/org/matsim/freight/receiver/ReceiverTriggersCarrierReplanningListener.java
@@ -81,8 +81,8 @@ class ReceiverTriggersCarrierReplanningListener implements IterationStartsListen
                                     order.getReceiver().getLinkId(),
                                     (int) (Math.round(order.getDailyOrderQuantity()*order.getProduct().getProductType().getRequiredCapacity())) );
                     CarrierShipment newShipment = builder
-                                                                  .setDeliveryServiceTime( order.getServiceDuration() )
-                                                                  .setDeliveryTimeWindow( receiverPlan.getTimeWindows().get( 0 ) )
+                                                                  .setDeliveryDuration( order.getServiceDuration() )
+                                                                  .setDeliveryStartsTimeWindow( receiverPlan.getTimeWindows().get( 0 ) )
                                                                   // TODO This only looks at the FIRST time window. This may need revision once we handle multiple
                                                                   // time windows.
                                                                   .build();

--- a/contribs/freightreceiver/src/main/java/org/matsim/freight/receiver/run/chessboard/ReceiverChessboardScenario.java
+++ b/contribs/freightreceiver/src/main/java/org/matsim/freight/receiver/run/chessboard/ReceiverChessboardScenario.java
@@ -228,8 +228,8 @@ public class ReceiverChessboardScenario {
                 LOG.warn("Multiple time windows set. Only the first is used");
             }
 
-            CarrierShipment shipment = shpBuilder.setDeliveryServiceTime(order.getServiceDuration())
-                    .setDeliveryTimeWindow(receiverPlan.getTimeWindows().get(0))
+            CarrierShipment shipment = shpBuilder.setDeliveryDuration(order.getServiceDuration())
+                    .setDeliveryStartsTimeWindow(receiverPlan.getTimeWindows().get(0))
                     .build();
             carriers.getCarriers().get(receiverOrder.getCarrierId()).getShipments().put(shipment.getId(), shipment);
         }

--- a/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/DefaultIntegrateExistingTrafficToSmallScaleCommercialImpl.java
+++ b/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/DefaultIntegrateExistingTrafficToSmallScaleCommercialImpl.java
@@ -372,8 +372,8 @@ public class DefaultIntegrateExistingTrafficToSmallScaleCommercialImpl implement
 							}
 						}
 						if (tourElement instanceof Tour.Pickup pickup) {
-							startZone = findZoneOfLink(linksPerZone, pickup.getShipment().getFrom());
-							String stopZone = findZoneOfLink(linksPerZone, pickup.getShipment().getTo());
+							startZone = findZoneOfLink(linksPerZone, pickup.getShipment().getPickupLinkId());
+							String stopZone = findZoneOfLink(linksPerZone, pickup.getShipment().getDeliveryLinkId());
 							try {
 								reduceVolumeForThisExistingJobElement(trafficVolumePerTypeAndZone_start,
 									trafficVolumePerTypeAndZone_stop, modeORvehType, purpose, startZone, stopZone);
@@ -395,7 +395,7 @@ public class DefaultIntegrateExistingTrafficToSmallScaleCommercialImpl implement
 					for (CarrierService service : carrier.getServices().values()) {
 						String startZone = (String) possibleStartAreas.toArray()[MatsimRandom.getRandom()
 							.nextInt(possibleStartAreas.size())];
-						String stopZone = findZoneOfLink(linksPerZone, service.getLocationLinkId());
+						String stopZone = findZoneOfLink(linksPerZone, service.getServiceLinkId());
 						try {
 							reduceVolumeForThisExistingJobElement(trafficVolumePerTypeAndZone_start,
 								trafficVolumePerTypeAndZone_stop, modeORvehType, purpose, startZone, stopZone);
@@ -407,8 +407,8 @@ public class DefaultIntegrateExistingTrafficToSmallScaleCommercialImpl implement
 					}
 				} else if (!carrier.getShipments().isEmpty()) {
 					for (CarrierShipment shipment : carrier.getShipments().values()) {
-						String startZone = findZoneOfLink(linksPerZone, shipment.getFrom());
-						String stopZone = findZoneOfLink(linksPerZone, shipment.getTo());
+						String startZone = findZoneOfLink(linksPerZone, shipment.getPickupLinkId());
+						String stopZone = findZoneOfLink(linksPerZone, shipment.getDeliveryLinkId());
 						try {
 							reduceVolumeForThisExistingJobElement(trafficVolumePerTypeAndZone_start,
 								trafficVolumePerTypeAndZone_stop, modeORvehType, purpose, startZone, stopZone);

--- a/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/DefaultUnhandledServicesSolution.java
+++ b/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/DefaultUnhandledServicesSolution.java
@@ -40,7 +40,7 @@ public class DefaultUnhandledServicesSolution implements UnhandledServicesSoluti
 	private void redrawAllServiceDurations(Carrier carrier, GenerateSmallScaleCommercialTrafficDemand.CarrierAttributes carrierAttributes, int additionalTravelBufferPerIterationInMinutes) {
 		for (CarrierService service : carrier.getServices().values()) {
 			double newServiceDuration = generator.getServiceTimePerStop(carrier, carrierAttributes, additionalTravelBufferPerIterationInMinutes);
-			CarrierService redrawnService = CarrierService.Builder.newInstance(service.getId(), service.getLocationLinkId())
+			CarrierService redrawnService = CarrierService.Builder.newInstance(service.getId(), service.getServiceLinkId())
 				.setServiceDuration(newServiceDuration).setServiceStartTimeWindow(service.getServiceStartTimeWindow()).build();
 			carrier.getServices().put(redrawnService.getId(), redrawnService);
 		}

--- a/contribs/vsp/src/main/java/org/matsim/freight/carriers/analysis/FreightAnalysisEventHandler.java
+++ b/contribs/vsp/src/main/java/org/matsim/freight/carriers/analysis/FreightAnalysisEventHandler.java
@@ -391,8 +391,8 @@ class FreightAnalysisEventHandler implements  ActivityStartEventHandler, LinkEnt
 					if (shipmentTracker == null) {
 						continue;
 					}
-					Id<Link> from = shipment.getFrom();
-					Id<Link> toLink = shipment.getTo();
+					Id<Link> from = shipment.getPickupLinkId();
+					Id<Link> toLink = shipment.getDeliveryLinkId();
 					// if info is not certain, export the guess if that is wanted.
 					String carrierIdString = id2String(carrier.getId());
 					String shipmentIdString = id2String(shipment.getId());

--- a/contribs/vsp/src/main/java/org/matsim/freight/carriers/analysis/FreightAnalysisServiceTracking.java
+++ b/contribs/vsp/src/main/java/org/matsim/freight/carriers/analysis/FreightAnalysisServiceTracking.java
@@ -57,7 +57,7 @@ class FreightAnalysisServiceTracking {
 	public void trackServiceActivityStart(ActivityStartEvent activityStartEvent) {
 		for (ServiceTracker.CarrierServiceTracker cst: carrierServiceTrackers.values()) {
 			for (ServiceTracker service : cst.serviceTrackers.values()) {
-				if (service.service.getLocationLinkId().equals(activityStartEvent.getLinkId())) {
+				if (service.service.getServiceLinkId().equals(activityStartEvent.getLinkId())) {
 					if (service.driverId == null) {
 						// if there is no driver, but there is a service which is to be performed at the moment at this place, we guess this could be the event for it.
 						// (Does not work well obviously as soon as there are multiple services at a location that have generous time windows, like e.g. at stores).

--- a/contribs/vsp/src/main/java/org/matsim/freight/carriers/analysis/FreightAnalysisShipmentTracking.java
+++ b/contribs/vsp/src/main/java/org/matsim/freight/carriers/analysis/FreightAnalysisShipmentTracking.java
@@ -128,8 +128,8 @@ class ShipmentTracker {
 
 	public ShipmentTracker(CarrierShipment shipment) {
 		this.id = shipment.getId();
-		this.from = shipment.getFrom();
-		this.to=shipment.getTo();
+		this.from = shipment.getPickupLinkId();
+		this.to=shipment.getDeliveryLinkId();
 		this.shipment=shipment;
 	}
 

--- a/contribs/vsp/src/main/java/org/matsim/freight/carriers/analysis/FreightAnalysisShipmentTracking.java
+++ b/contribs/vsp/src/main/java/org/matsim/freight/carriers/analysis/FreightAnalysisShipmentTracking.java
@@ -57,12 +57,14 @@ class FreightAnalysisShipmentTracking {
     	for (ShipmentTracker shipment: shipments.values()){
     		if (shipment.to==activityStartEvent.getLinkId() ){
 				if(shipment.driverId == null){
-					if(shipment.shipment.getDeliveryTimeWindow().getStart()<=activityStartEvent.getTime() && activityStartEvent.getTime()<=shipment.shipment.getDeliveryTimeWindow().getEnd()){
-						if (shipment.possibleDrivers.contains(activityStartEvent.getPersonId().toString())) {
-							shipment.driverIdGuess = activityStartEvent.getPersonId();
-							shipment.deliveryTimeGuess=activityStartEvent.getTime();
-						}
-					}
+					if(shipment.shipment.getDeliveryStartsTimeWindow().getStart() <= activityStartEvent.getTime()) {
+                        if (activityStartEvent.getTime()<= shipment.shipment.getDeliveryStartsTimeWindow().getEnd()) {
+                            if (shipment.possibleDrivers.contains(activityStartEvent.getPersonId().toString())) {
+                                shipment.driverIdGuess = activityStartEvent.getPersonId();
+                                shipment.deliveryTimeGuess=activityStartEvent.getTime();
+                            }
+                        }
+                    }
 				} else if (shipment.driverId.toString().equals(activityStartEvent.getPersonId().toString())){
 					shipment.deliveryTime=activityStartEvent.getTime();
 				}
@@ -75,8 +77,10 @@ class FreightAnalysisShipmentTracking {
     	for (ShipmentTracker shipmentTracker: shipments.values()){
     		if (shipmentTracker.from==activityStartEvent.getLinkId()){
     			if (shipmentTracker.driverId==null){
-    				if(shipmentTracker.shipment.getPickupTimeWindow().getStart()<=activityStartEvent.getTime() && activityStartEvent.getTime()<=shipmentTracker.shipment.getPickupTimeWindow().getEnd()){
-    					shipmentTracker.possibleDrivers.add(activityStartEvent.getPersonId().toString());
+					if(shipmentTracker.shipment.getPickupStartsTimeWindow().getStart() <= activityStartEvent.getTime()) {
+						if (activityStartEvent.getTime()<= shipmentTracker.shipment.getPickupStartsTimeWindow().getEnd()) {
+							shipmentTracker.possibleDrivers.add(activityStartEvent.getPersonId().toString());
+						}
 					}
 				}
 			}


### PR DESCRIPTION
In this PR I changed the names of some variables and the corresponding getter and setter to make them more consistent between `CarrierService` and `CarrierShipment`.

I kept the old methods as deprecated for not breaking outside code.

Moreover, the XML-schemes were kept unchanged, until we decide, for a more general approach in defining the CarrierActivities (service, pickup, delivery).
See also #3601 