### PR TITLE
IMC contrib maintenance

### DIFF
--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/EstimateRouter.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/EstimateRouter.java
@@ -1,9 +1,10 @@
 package org.matsim.modechoice;
 
 import com.google.inject.Inject;
-import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.population.Leg;
 import org.matsim.api.core.v01.population.PlanElement;
+import org.matsim.core.config.groups.PlansConfigGroup;
+import org.matsim.core.router.AnalysisMainModeIdentifier;
 import org.matsim.core.router.TripRouter;
 import org.matsim.core.router.TripStructureUtils;
 import org.matsim.core.utils.timing.TimeInterpretation;
@@ -23,14 +24,18 @@ public final class EstimateRouter {
 
 	private final TripRouter tripRouter;
 	private final ActivityFacilities facilities;
+	private final AnalysisMainModeIdentifier mmi;
 	private final TimeInterpretation timeInterpretation;
 
 	@Inject
 	public EstimateRouter(TripRouter tripRouter, ActivityFacilities facilities,
-	                      TimeInterpretation timeInterpretation) {
+						  AnalysisMainModeIdentifier mmi) {
 		this.tripRouter = tripRouter;
 		this.facilities = facilities;
-		this.timeInterpretation = timeInterpretation;
+		this.mmi = mmi;
+		// ignore the travel times of individual legs
+		this.timeInterpretation = TimeInterpretation.create(PlansConfigGroup.ActivityDurationInterpretation.tryEndTimeThenDuration,
+			PlansConfigGroup.TripDurationHandling.ignoreDelays);
 	}
 
 	/**
@@ -73,7 +78,6 @@ public final class EstimateRouter {
 				}
 				 */
 
-				// Use the end-time of an activity or the time tracker if not available
 				final List<? extends PlanElement> newTrip = tripRouter.calcRoute(
 						mode, from, to,
 						oldTrip.getOriginActivity().getEndTime().orElse(timeTracker.getTime().seconds()),
@@ -81,6 +85,7 @@ public final class EstimateRouter {
 						oldTrip.getTripAttributes()
 				);
 
+				// update time tracker, however it will be updated before each iteration
 				timeTracker.addElements(newTrip);
 
 				// store and increment
@@ -131,12 +136,6 @@ public final class EstimateRouter {
 					.map(el -> (Leg) el)
 					.collect(Collectors.toList());
 
-			// not a real pt trip, see reasoning above
-			if (mode.equals(TransportMode.pt) && ll.stream().noneMatch(l -> l.getMode().equals(TransportMode.pt))) {
-				model.setLegs(mode, new List[model.trips()]);
-				continue;
-			}
-
 			List<Leg>[] legs = new List[model.trips()];
 			legs[idx] = ll;
 
@@ -168,10 +167,13 @@ public final class EstimateRouter {
 		List<Leg> oldLegs = oldTrip.getLegsOnly();
 		boolean undefined = oldLegs.stream().anyMatch(l -> timeInterpretation.decideOnLegTravelTime(l).isUndefined());
 
-		// If no time is known the previous trips need to be routed
+		// If no time is known the previous trips needs to be routed
 		if (undefined) {
-			String routingMode = TripStructureUtils.getRoutingMode(oldLegs.get(0));
-			List<? extends PlanElement> legs = routeTrip(oldTrip, plan, routingMode != null ? routingMode : oldLegs.get(0).getMode(), timeTracker);
+			String routingMode = TripStructureUtils.getRoutingMode(oldLegs.getFirst());
+			if (routingMode == null)
+				routingMode = mmi.identifyMainMode(oldLegs);
+
+			List<? extends PlanElement> legs = routeTrip(oldTrip, plan, routingMode, timeTracker);
 			timeTracker.addElements(legs);
 
 		} else

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/EstimateRouter.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/EstimateRouter.java
@@ -89,21 +89,6 @@ public final class EstimateRouter {
 						.map(el -> (Leg) el)
 						.collect(Collectors.toList());
 
-				// The PT router can return walk only trips that don't actually use pt
-				// this one special case is handled here, it is unclear if similar behaviour might be present in other modes
-				if (mode.equals(TransportMode.pt) && ll.stream().noneMatch(l -> l.getMode().equals(TransportMode.pt))) {
-					legs[i++] = null;
-					continue;
-				}
-
-				// TODO: might consider access agress walk modes
-
-				// Filters all kind of modes that did return only walk legs when they could not be used (e.g. drt)
-				if (!mode.equals(TransportMode.walk) && ll.stream().allMatch(l -> l.getMode().equals(TransportMode.walk))) {
-					legs[i++] = null;
-					continue;
-				}
-
 				legs[i++] = ll;
 
 			}

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/InformedModeChoiceConfigGroup.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/InformedModeChoiceConfigGroup.java
@@ -34,6 +34,10 @@ public class InformedModeChoiceConfigGroup extends ReflectiveConfigGroup {
 	private double invBeta = Double.POSITIVE_INFINITY;
 
 	@Parameter
+	@Comment("Normalize utility values when selecting")
+	private boolean normalizeUtility = false;
+
+	@Parameter
 	@Comment("Name of the candidate pruner to apply, needs to be bound with guice.")
 	private String pruning = null;
 
@@ -140,6 +144,14 @@ public class InformedModeChoiceConfigGroup extends ReflectiveConfigGroup {
 		Map<String, String> comments = super.getComments();
 		comments.put(CONFIG_PARAM_MODES, "Defines all modes that are available and open for mode choice.");
 		return comments;
+	}
+
+	public boolean isNormalizeUtility() {
+		return normalizeUtility;
+	}
+
+	public void setNormalizeUtility(boolean normalizeUtility) {
+		this.normalizeUtility = normalizeUtility;
 	}
 
 	public enum Schedule {

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/InformedModeChoiceModule.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/InformedModeChoiceModule.java
@@ -54,22 +54,29 @@ public final class InformedModeChoiceModule extends AbstractModule {
 		// Copy list because it is unmodifiable
 		List<ReplanningConfigGroup.StrategySettings> strategies = new ArrayList<>(config.replanning().getStrategySettings());
 		List<ReplanningConfigGroup.StrategySettings> found = strategies.stream()
-			.filter(s -> s.getSubpopulation().equals(subpopulation))
+			.filter(s -> subpopulation == null || Objects.equals(s.getSubpopulation(), subpopulation))
 			.filter(s -> s.getStrategyName().equals(existing))
 			.toList();
 
 		if (found.isEmpty())
 			throw new IllegalArgumentException("No strategy %s found for subpopulation %s".formatted(existing, subpopulation));
 
-		if (found.size() > 1)
+		if (subpopulation != null && found.size() > 1)
 			throw new IllegalArgumentException("Multiple strategies %s found for subpopulation %s".formatted(existing, subpopulation));
 
-		ReplanningConfigGroup.StrategySettings old = found.getFirst();
-		old.setStrategyName(replacement);
+		found.forEach(s -> s.setStrategyName(replacement));
 
 		// reset und set new strategies
 		config.replanning().clearStrategySettings();
 		strategies.forEach(s -> config.replanning().addStrategySettings(s));
+	}
+
+	/**
+	 * Replace a strategy in the config for all subpoopulations.
+	 * @see #replaceReplanningStrategy(Config, String, String, String)
+	 */
+	public static void replaceReplanningStrategy(Config config, String existing, String replacement) {
+		replaceReplanningStrategy(config, null, existing, replacement);
 	}
 
 	public static Builder newBuilder() {

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/ModeChoiceWeightScheduler.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/ModeChoiceWeightScheduler.java
@@ -55,7 +55,7 @@ public final class ModeChoiceWeightScheduler implements StartupListener, Iterati
 	@Override
 	public void notifyIterationStarts(IterationStartsEvent event) {
 
-		if (anneal == InformedModeChoiceConfigGroup.Schedule.off || event.getIteration() == 0)
+		if (anneal == InformedModeChoiceConfigGroup.Schedule.off || event.getIteration() == 0 || currentBeta == Double.POSITIVE_INFINITY)
 			return;
 
 		// anneal target is 0, iterations are offset by 1 because first iteration does not do replanning

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/ModeChoiceWeightScheduler.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/ModeChoiceWeightScheduler.java
@@ -1,5 +1,6 @@
 package org.matsim.modechoice;
 
+import com.google.inject.Inject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.core.config.Config;
@@ -30,14 +31,16 @@ public final class ModeChoiceWeightScheduler implements StartupListener, Iterati
 
 	private InformedModeChoiceConfigGroup.Schedule anneal;
 
-	@Override
-	public void notifyStartup(StartupEvent event) {
-
-		Config config = event.getServices().getConfig();
+	@Inject
+	public ModeChoiceWeightScheduler(Config config) {
 		InformedModeChoiceConfigGroup imc = ConfigUtils.addOrGetModule(config, InformedModeChoiceConfigGroup.class);
-
 		startBeta = currentBeta = imc.getInvBeta();
 		anneal = imc.getAnneal();
+	}
+
+	@Override
+	public void notifyStartup(StartupEvent event) {
+		Config config = event.getServices().getConfig();
 
 		// The first iteration does not do any replanning
 		n = config.controller().getLastIteration() - 1;

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/ModeEstimate.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/ModeEstimate.java
@@ -19,6 +19,12 @@ public final class ModeEstimate {
 	private final double[] tripEst;
 
 	/**
+	 * Mark trips with no real usage. E.g pt trips that consist only of walk legs.
+	 * These trips will not be considered during estimation.
+	 */
+	private final boolean[] noRealUsage;
+
+	/**
 	 * Whether this should be for a minimum estimate. Otherwise, maximum is assumed.
 	 */
 	private final boolean min;
@@ -42,6 +48,7 @@ public final class ModeEstimate {
 		this.usable = isUsable;
 		this.est = usable ? new double[n] : null;
 		this.tripEst = storeTripEst ? new double[n] : null;
+		this.noRealUsage = usable ? new boolean[n] : null;
 	}
 
 	public String getMode() {
@@ -66,6 +73,10 @@ public final class ModeEstimate {
 
 	public double[] getTripEstimates() {
 		return tripEst;
+	}
+
+	public boolean[] getNoRealUsage() {
+		return noRealUsage;
 	}
 
 	@Override

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/PlanModel.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/PlanModel.java
@@ -257,6 +257,9 @@ public final class PlanModel implements Iterable<TripStructureUtils.Trip>, HasPe
 		return estimates;
 	}
 
+	/**
+	 * Iterate over estimates and collect modes that match the predicate.
+	 */
 	public Set<String> filterModes(Predicate<? super ModeEstimate> predicate) {
 		Set<String> modes = new HashSet<>();
 		for (Map.Entry<String, List<ModeEstimate>> e : estimates.entrySet()) {

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/PlanModel.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/PlanModel.java
@@ -49,11 +49,6 @@ public final class PlanModel implements Iterable<TripStructureUtils.Trip>, HasPe
 	private boolean fullyRouted;
 
 	/**
-	 * Original plan.
-	 */
-	private Plan plan;
-
-	/**
 	 * Create a new plan model instance from an existing plan.
 	 */
 	public static PlanModel newInstance(Plan plan) {
@@ -66,7 +61,6 @@ public final class PlanModel implements Iterable<TripStructureUtils.Trip>, HasPe
 		List<TripStructureUtils.Trip> tripList = TripStructureUtils.getTrips(plan);
 
 		this.trips = tripList.toArray(new TripStructureUtils.Trip[0]);
-		this.plan = plan;
 		this.legs = new HashMap<>();
 		this.estimates = new HashMap<>();
 		this.currentModes = new String[trips.length];
@@ -78,11 +72,6 @@ public final class PlanModel implements Iterable<TripStructureUtils.Trip>, HasPe
 	@Override
 	public Person getPerson() {
 		return person;
-	}
-
-	public Plan getPlan() {
-		// TODO: This should better be removed, memory usage by keeping these plans is increased
-		return plan;
 	}
 
 	public int trips() {
@@ -123,8 +112,6 @@ public final class PlanModel implements Iterable<TripStructureUtils.Trip>, HasPe
 	 * Update current plan an underlying modes.
 	 */
 	public void setPlan(Plan plan) {
-		this.plan = plan;
-
 		List<TripStructureUtils.Trip> newTrips = TripStructureUtils.getTrips(plan);
 
 		if (newTrips.size() != this.trips.length)
@@ -223,6 +210,13 @@ public final class PlanModel implements Iterable<TripStructureUtils.Trip>, HasPe
 		return trips[i];
 	}
 
+	/**
+	 * Get all trips of the day.
+	 */
+	public List<TripStructureUtils.Trip> getTrips() {
+		return Arrays.asList(trips);
+	}
+
 	void setLegs(String mode, List<Leg>[] legs) {
 		mode = mode.intern();
 
@@ -301,6 +295,20 @@ public final class PlanModel implements Iterable<TripStructureUtils.Trip>, HasPe
 			return null;
 
 		return legs[i];
+	}
+
+	/**
+	 * Check whether a mode is available for a trip.
+	 * If for instance not pt option is found in the legs this will return false.
+	 */
+	public boolean hasModeForTrip(String mode, int i) {
+
+		List<Leg>[] legs = this.legs.get(mode);
+		if (legs == null)
+			return false;
+
+		List<Leg> ll = legs[i];
+		return ll.stream().anyMatch(l -> l.getMode().equals(mode));
 	}
 
 	/**

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/PlanModelService.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/PlanModelService.java
@@ -167,8 +167,10 @@ public final class PlanModelService implements StartupListener {
 				if (!c.isUsable())
 					continue;
 
+				// All estimates are stored within the objects and modified directly here
 				double[] values = c.getEstimates();
 				double[] tValues = c.getTripEstimates();
+				boolean[] noUsage = c.getNoRealUsage();
 
 				// Collect all estimates
 				for (int i = 0; i < planModel.trips(); i++) {
@@ -181,13 +183,15 @@ public final class PlanModelService implements StartupListener {
 						continue;
 					}
 
-					TripEstimator tripEst =  tripEstimator.get(c.getMode());
+					TripEstimator tripEst = tripEstimator.get(c.getMode());
 
 					// some options may produce equivalent results, but are re-estimated
 					// however, the more expensive computation is routing and only done once
+					boolean realUsage = planModel.hasModeForTrip(c.getMode(), i);
+					noUsage[i] = !realUsage;
 
 					double estimate = 0;
-					if (tripEst != null) {
+					if (tripEst != null && realUsage) {
 						MinMaxEstimate minMax = tripEst.estimate(context, c.getMode(), planModel, legs, c.getOption());
 						double tripEstimate = c.isMin() ? minMax.getMin() : minMax.getMax();
 

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/constraints/RelaxedMassConservationConstraint.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/constraints/RelaxedMassConservationConstraint.java
@@ -37,7 +37,7 @@ public final class RelaxedMassConservationConstraint implements TripConstraint<R
 	@Override
 	public Context getContext(EstimatorContext context, PlanModel model) {
 
-		Collection<TripStructureUtils.Subtour> subtours = TripStructureUtils.getSubtours(model.getPlan(), coordDistance);
+		Collection<TripStructureUtils.Subtour> subtours = TripStructureUtils.getSubtoursFromTrips(model.getTrips(), coordDistance);
 
 		Object2IntMap<Object> facilities = new Object2IntArrayMap<>();
 

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/constraints/RelaxedSubtourConstraint.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/constraints/RelaxedSubtourConstraint.java
@@ -33,7 +33,7 @@ public final class RelaxedSubtourConstraint implements TripConstraint<int[]> {
 	@Override
 	public int[] getContext(EstimatorContext context, PlanModel model) {
 
-		Collection<TripStructureUtils.Subtour> subtours = TripStructureUtils.getSubtours(model.getPlan(), coordDistance);
+		Collection<TripStructureUtils.Subtour> subtours = TripStructureUtils.getSubtoursFromTrips(model.getTrips(), coordDistance);
 
 		// ids will contain unique identifier to which subtour a trip belongs.
 		int[] ids = new int[model.trips()];

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/pruning/CandidatePruner.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/pruning/CandidatePruner.java
@@ -41,13 +41,12 @@ public interface CandidatePruner {
 		return -1;
 	}
 
-
 	/**
 	 * Calculate threshold to be applied on a single trip. Modes worse than this threshold on this trip will be discarded.
 	 *
 	 * @return positive threshold, if negative it will not be applied
 	 */
 	default double tripThreshold(PlanModel planModel, int idx) {
-		return -1;
+		return planThreshold(planModel);
 	}
 }

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/replanning/MultinomialLogitSelectorProvider.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/replanning/MultinomialLogitSelectorProvider.java
@@ -1,7 +1,10 @@
 package org.matsim.modechoice.replanning;
 
 import com.google.inject.Provider;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.gbl.MatsimRandom;
+import org.matsim.modechoice.InformedModeChoiceConfigGroup;
 import org.matsim.modechoice.ModeChoiceWeightScheduler;
 
 import jakarta.inject.Inject;
@@ -14,8 +17,17 @@ public class MultinomialLogitSelectorProvider implements Provider<PlanSelector> 
 	@Inject
 	private ModeChoiceWeightScheduler weights;
 
+	@Inject
+	private Config config;
+
 	@Override
 	public PlanSelector get() {
+
+		InformedModeChoiceConfigGroup c = ConfigUtils.addOrGetModule(config, InformedModeChoiceConfigGroup.class);
+		if (c.isNormalizeUtility()) {
+			return new NormalizedMultinomialLogitSelector(weights.getInvBeta(), MatsimRandom.getLocalInstance());
+		}
+
 		return new MultinomialLogitSelector(weights.getInvBeta(), MatsimRandom.getLocalInstance());
 	}
 }

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/replanning/RandomSubtourModeStrategy.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/replanning/RandomSubtourModeStrategy.java
@@ -81,7 +81,8 @@ public class RandomSubtourModeStrategy extends AbstractMultithreadedModule {
 
 				// only select trips that are allowed to change
 				for (int i = 0; i < model.trips(); i++) {
-					if (nonChainBasedModes.contains(model.getTripMode(i))) {
+					String m = model.getTripMode(i);
+					if (nonChainBasedModes.contains(m) && switchModes.contains(m)) {
 						options.add(i);
 					}
 				}

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/replanning/RandomSubtourModeStrategy.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/replanning/RandomSubtourModeStrategy.java
@@ -87,9 +87,9 @@ public class RandomSubtourModeStrategy extends AbstractMultithreadedModule {
 					}
 				}
 
-				if (!options.isEmpty()) {
+				while (!options.isEmpty()) {
 
-					int idx = options.getInt(rnd.nextInt(options.size()));
+					int idx = options.removeInt(rnd.nextInt(options.size()));
 
 					String[] current = model.getCurrentModes();
 
@@ -98,9 +98,14 @@ public class RandomSubtourModeStrategy extends AbstractMultithreadedModule {
 					if (config.isRequireDifferentModes())
 						candidates.remove(current[idx]);
 
-					if (!candidates.isEmpty()) {
+					while (!candidates.isEmpty()) {
 
-						current[idx] = candidates.get(rnd.nextInt(candidates.size()));
+						current[idx] = candidates.remove(rnd.nextInt(candidates.size()));
+
+						// Check further constraints
+						if (!planModelService.isValidOption(model, current))
+							continue;
+
 						new PlanCandidate(current, -1).applyTo(plan);
 						return;
 					}
@@ -141,7 +146,6 @@ public class RandomSubtourModeStrategy extends AbstractMultithreadedModule {
 							candidates.add(new PlanCandidate(option, -1));
 
 				}
-
 
 				if (!candidates.isEmpty()) {
 					PlanCandidate select = candidates.get(rnd.nextInt(candidates.size()));

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/replanning/SelectSingleTripModeStrategy.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/replanning/SelectSingleTripModeStrategy.java
@@ -81,7 +81,7 @@ public class SelectSingleTripModeStrategy extends AbstractMultithreadedModule {
 		public void run(Plan plan) {
 			PlanModel model = PlanModel.newInstance(plan);
 
-			PlanCandidate c = chooseCandidate(model, null);
+			PlanCandidate c = chooseCandidate(model);
 
 			if (c != null) {
 				if (pruner != null) {
@@ -96,11 +96,10 @@ public class SelectSingleTripModeStrategy extends AbstractMultithreadedModule {
 		/**
 		 * Choose one candidate with one single trip changed.
 		 *
-		 * @param avoidList combinations to avoid, can be null
-		 * @return true if a candidate was selected
+		 * @return selected candidate or null if no candidate is found
 		 */
 		@Nullable
-		public PlanCandidate chooseCandidate(PlanModel model, @Nullable Collection<String[]> avoidList) {
+		public PlanCandidate chooseCandidate(PlanModel model) {
 
 			// empty plan
 			if (model.trips() == 0)
@@ -117,33 +116,12 @@ public class SelectSingleTripModeStrategy extends AbstractMultithreadedModule {
 				}
 			}
 
-			if (avoidList != null) {
-				String[] current = model.getCurrentModes();
-
-				IntListIterator it = options.iterator();
-
-				outer:
-				while (it.hasNext()) {
-					int idx = it.nextInt();
-
-					for (String m : modes) {
-						current[idx] = m;
-						if (!avoidList.contains(current)) {
-							continue outer;
-						}
-					}
-
-					// if at least one option is found, idx is not removed
-					it.remove();
-				}
-			}
-
 			if (options.isEmpty())
 				return null;
 
+			// Select one random trip index
 			int idx = options.getInt(rnd.nextInt(options.size()));
-
-			// Set one trip to be modifiable
+			// Set it to be modifiable
 			mask[idx] = true;
 
 			List<PlanCandidate> candidates = generator.generate(model, modes, mask);
@@ -165,16 +143,6 @@ public class SelectSingleTripModeStrategy extends AbstractMultithreadedModule {
 			// Remove options that are the same as the current mode
 			if (requireDifferentModes)
 				candidates.removeIf(c -> Objects.equals(c.getMode(idx), model.getTripMode(idx)));
-
-			// Remove avoided combinations
-			if (avoidList != null) {
-				String[] current = model.getCurrentModes();
-
-				candidates.removeIf(c -> {
-					current[idx] = c.getMode(idx);
-					return avoidList.contains(current);
-				});
-			}
 
 			PlanCandidate selected = selector.select(candidates);
 

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/replanning/SelectSingleTripModeStrategy.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/replanning/SelectSingleTripModeStrategy.java
@@ -31,13 +31,13 @@ public class SelectSingleTripModeStrategy extends AbstractMultithreadedModule {
 	private final Provider<SingleTripChoicesGenerator> generator;
 	private final Provider<PlanSelector> selector;
 
-	private final List<String> modes;
+	private final Set<String> modes;
 	private final Provider<CandidatePruner> pruner;
 
 	private final boolean requireDifferentModes;
 
 	public SelectSingleTripModeStrategy(GlobalConfigGroup globalConfigGroup,
-	                                    List<String> modes,
+	                                    Set<String> modes,
 	                                    Provider<SingleTripChoicesGenerator> generator,
 	                                    Provider<PlanSelector> selector,
 	                                    Provider<CandidatePruner> pruner, boolean requireDifferentModes) {

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/replanning/SelectSingleTripModeStrategyProvider.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/replanning/SelectSingleTripModeStrategyProvider.java
@@ -15,6 +15,8 @@ import org.matsim.modechoice.search.SingleTripChoicesGenerator;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
 
+import java.util.HashSet;
+
 /**
  * Provider for {@link SelectFromGeneratorStrategy}.
  */
@@ -47,7 +49,7 @@ public class SelectSingleTripModeStrategyProvider implements Provider<PlanStrate
 
 		PlanStrategyImpl.Builder builder = new PlanStrategyImpl.Builder(new RandomPlanSelector<>());
 
-		builder.addStrategyModule(new SelectSingleTripModeStrategy(globalConfigGroup,  config.getModes(), generator, selector, pruner, config.isRequireDifferentModes()));
+		builder.addStrategyModule(new SelectSingleTripModeStrategy(globalConfigGroup,  new HashSet<>(config.getModes()), generator, selector, pruner, config.isRequireDifferentModes()));
 
 		builder.addStrategyModule(new ReRoute(facilities, tripRouterProvider, globalConfigGroup, timeInterpretation));
 

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/replanning/SelectSubtourModeStrategy.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/replanning/SelectSubtourModeStrategy.java
@@ -129,9 +129,6 @@ public class SelectSubtourModeStrategy extends AbstractMultithreadedModule {
 
 				List<String[]> options = new ArrayList<>();
 
-				// current mode for comparison
-				options.add(model.getCurrentModes());
-
 				// generate all single mode options
 				for (String m : config.getModes()) {
 					String[] option = model.getCurrentModes();
@@ -140,11 +137,9 @@ public class SelectSubtourModeStrategy extends AbstractMultithreadedModule {
 					for (int i = 0; i < mask.length; i++) {
 						if (mask[i])
 							option[i] = m;
-					}
 
-					// Current option is not added twice
-					if (!Arrays.equals(model.getCurrentModesMutable(), option))
 						options.add(option);
+					}
 				}
 
 				List<PlanCandidate> singleModeCandidates = ctx.generator.generatePredefined(model, options);

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/replanning/SelectSubtourModeStrategy.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/replanning/SelectSubtourModeStrategy.java
@@ -130,7 +130,7 @@ public class SelectSubtourModeStrategy extends AbstractMultithreadedModule {
 				List<String[]> options = new ArrayList<>();
 
 				// current mode for comparison
-				options.add(model.getCurrentModesMutable());
+				options.add(model.getCurrentModes());
 
 				// generate all single mode options
 				for (String m : config.getModes()) {
@@ -156,16 +156,16 @@ public class SelectSubtourModeStrategy extends AbstractMultithreadedModule {
 					continue;
 				}
 
-				Set<PlanCandidate> candidateSet = new LinkedHashSet<>();
-
 				// Single modes are also added
-				candidateSet.addAll(singleModeCandidates);
+				Set<PlanCandidate> candidateSet = new LinkedHashSet<>(singleModeCandidates);
 
 				// one could either allow all modes here or only non chain based
 				// config switch might be useful to investigate which option is better
 
-				// execute best k modes
-				candidateSet.addAll(ctx.generator.generate(model, nonChainBasedModes, mask));
+				// execute best k modes, setting k to 0 disables this, then this strategy is similar to random subtour
+				if (config.getTopK() > 0) {
+					candidateSet.addAll(ctx.generator.generate(model, nonChainBasedModes, mask));
+				}
 
 				// candidates are unique after this
 				List<PlanCandidate> candidates = new ArrayList<>(candidateSet);

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/search/ModeArrayIterator.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/search/ModeArrayIterator.java
@@ -1,0 +1,130 @@
+package org.matsim.modechoice.search;
+
+import it.unimi.dsi.fastutil.objects.ObjectHeapPriorityQueue;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Searches all possible combination by using a heap. Uses arrays to store combinations of unlimited size.
+ */
+final class ModeArrayIterator implements ModeIterator {
+
+	private final String[] result;
+	private final double[] max;
+	private final double best;
+	private final double[][] estimates;
+	private final ModeChoiceSearch search;
+	private final ObjectHeapPriorityQueue<Entry> heap;
+	private final Set<Entry> seen;
+
+
+	public ModeArrayIterator(String[] result, double[] max, Entry shortest, double best, ModeChoiceSearch search) {
+		this.result = result;
+		this.max = max;
+		this.best = best;
+		this.estimates = search.estimates;
+		this.search = search;
+		this.heap = new ObjectHeapPriorityQueue<>();
+		this.seen = new HashSet<>();
+
+		heap.enqueue(shortest);
+		seen.add(shortest);
+	}
+
+	@Override
+	public double nextDouble() {
+
+		Entry entry = heap.dequeue();
+
+		for (int i = 0; i < result.length; i++) {
+
+			byte mode = -1;
+			byte originalMode = entry.modes[i];
+
+			// This mode had no options
+			if (originalMode == -1)
+				continue;
+
+			double min = estimates[i][originalMode];
+			double max = Double.NEGATIVE_INFINITY;
+
+			// search for a deviation that is worse than the current mode
+
+			for (byte j = 0; j < estimates[i].length; j++) {
+				if (estimates[i][j] <= min && j != originalMode && estimates[i][j] > max) {
+					max = estimates[i][j];
+					mode = j;
+				}
+			}
+
+			if (mode != -1) {
+				byte[] path = Arrays.copyOf(entry.modes, entry.modes.length);
+				path[i] = mode;
+
+				// recompute the deviation from the maximum
+				// there might be a way to store and update this, without recomputing
+
+				double dev = 0;
+				for (int j = 0; j < result.length; j++) {
+					byte legMode = path[j];
+					if (legMode == -1)
+						continue;
+
+					dev += this.max[j] - estimates[j][legMode];
+				}
+
+				Entry e = new Entry(path, dev);
+
+				if (!seen.contains(e)) {
+					heap.enqueue(e);
+					seen.add(e);
+				}
+			}
+		}
+
+
+		search.convert(entry.modes, result);
+		return best - entry.deviation;
+	}
+
+	@Override
+	public boolean hasNext() {
+		return !heap.isEmpty();
+	}
+
+	@Override
+	public int maxIters() {
+		return 1_000_000;
+	}
+
+	record Entry(byte[] modes, double deviation) implements Comparable<Entry> {
+
+		@Override
+		public int compareTo(Entry o) {
+			return Double.compare(deviation, o.deviation);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			Entry entry = (Entry) o;
+			return Double.compare(entry.deviation, deviation) == 0 && Arrays.equals(modes, entry.modes);
+		}
+
+		@Override
+		public int hashCode() {
+			int result = Objects.hash(deviation);
+			result = 31 * result + Arrays.hashCode(modes);
+			return result;
+		}
+
+		@Override
+		public String toString() {
+			return Arrays.toString(modes) + " = " + deviation;
+		}
+	}
+}

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/search/ModeChoiceSearch.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/search/ModeChoiceSearch.java
@@ -2,15 +2,10 @@ package org.matsim.modechoice.search;
 
 import it.unimi.dsi.fastutil.bytes.Byte2ObjectMap;
 import it.unimi.dsi.fastutil.bytes.Byte2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.doubles.DoubleIterator;
-import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
-import it.unimi.dsi.fastutil.longs.LongSet;
 import it.unimi.dsi.fastutil.objects.Object2ByteMap;
 import it.unimi.dsi.fastutil.objects.Object2ByteOpenHashMap;
-import it.unimi.dsi.fastutil.objects.ObjectHeapPriorityQueue;
 
 import java.util.Arrays;
-import java.util.Objects;
 
 /**
  * This class finds the best solutions by doing an exhaustive search over the best possible combinations of modes.
@@ -20,15 +15,16 @@ final class ModeChoiceSearch {
 	/**
 	 * Stores the estimates for all modes by trip x mode
 	 */
-	private final double[][] estimates;
+	final double[][] estimates;
 
 	/**
 	 * Mode to index mapping.
 	 */
+	final Byte2ObjectMap<String> inv;
+	final int depth;
+
 	private final Object2ByteMap<String> mapping;
-	private final Byte2ObjectMap<String> inv;
-	private final int depth;
-	private final long base;
+	private final double maxSize;
 
 	/**
 	 * Constructor
@@ -44,14 +40,8 @@ final class ModeChoiceSearch {
 		// Number of options per trip, +1 to encode null value
 		this.depth = modes + 1;
 
-		long b = 1;
-		for (int i = 0; i < trips - 1; i++) {
-			b *= depth;
-		}
-		// Base for the index calculation
-		this.base = b;
-
-		if (Math.pow(depth, trips) > Long.MAX_VALUE)
+		maxSize = Math.pow(depth, trips);
+		if (!Double.isFinite(maxSize))
 			throw new IllegalArgumentException("Too many mode combinations: %s ^ %s".formatted(modes, trips));
 
 		clear();
@@ -64,7 +54,7 @@ final class ModeChoiceSearch {
 	 * @param result mode assignment will be written into this array, no memory is allocated during search.
 	 * @return iterator returning the summed utility.
 	 */
-	public DoubleIterator iter(String[] result) {
+	public ModeIterator iter(String[] result) {
 
 		assert result.length == estimates.length;
 
@@ -94,8 +84,20 @@ final class ModeChoiceSearch {
 				total += max;
 		}
 
+		long b = 1;
+		for (int i = 0; i < this.estimates.length - 1; i++) {
+			b *= depth;
+		}
 
-		return new Iterator(result, maxs, new Entry(path, depth, 0), total);
+		if (maxSize < Integer.MAX_VALUE) {
+			return new ModeIntIterator(result, maxs, new ModeIntIterator.Entry(path, depth, 0), total, (int) b, this);
+		}
+
+		if (maxSize < Long.MAX_VALUE) {
+			return new ModeLongIterator(result, maxs, new ModeLongIterator.Entry(path, depth, 0), total, b, this);
+		}
+
+		return new ModeArrayIterator(result, maxs, new ModeArrayIterator.Entry(path, 0), total, this);
 	}
 
 	/**
@@ -162,190 +164,12 @@ final class ModeChoiceSearch {
 	/**
 	 * Byte representation as string array.
 	 */
-	private void convert(byte[] path, String[] modes) {
+	void convert(byte[] path, String[] modes) {
 		for (int i = 0; i < path.length; i++) {
 			String m = inv.get(path[i]);
 			// Pre-defined entries are not touched
 			if (m != null)
 				modes[i] = m;
-		}
-	}
-
-	static final class Entry implements Comparable<Entry> {
-		private final long index;
-		private final double deviation;
-
-		Entry(byte[] modes, int depth, double deviation) {
-			this.index = toIndex(modes, depth);
-			this.deviation = deviation;
-		}
-
-		Entry(long index, double deviation) {
-			this.index = index;
-			this.deviation = deviation;
-		}
-
-		static long toIndex(byte[] modes, int depth) {
-			long result = modes[0] + 1;
-			long base = depth;
-			for (int i = 1; i < modes.length; i++) {
-				result += (modes[i] + 1) * base;
-				base *= depth;
-			}
-
-			return result;
-		}
-
-		/**
-		 * Convert the mode array to an index, where one mode at index {@code idx} is replaced.
-		 */
-		static long toIndex(byte[] modes, int depth, int idx, byte mode) {
-			long result = (idx == 0 ? mode : modes[0]) + 1;
-			long base = depth;
-			for (int i = 1; i < modes.length; i++) {
-				result += ((idx == i ? mode : modes[i]) + 1) * base;
-				base *= depth;
-			}
-
-			return result;
-		}
-
-		@Override
-		public int compareTo(Entry o) {
-			return Double.compare(deviation, o.deviation);
-		}
-
-		@Override
-		public boolean equals(Object o) {
-			if (this == o) return true;
-			if (o == null || getClass() != o.getClass()) return false;
-			Entry entry = (Entry) o;
-			return Double.compare(entry.deviation, deviation) == 0 && index == entry.index;
-		}
-
-		@Override
-		public int hashCode() {
-			int result = Objects.hash(deviation);
-			result = 31 * result + Long.hashCode(index);
-			return result;
-		}
-
-		@Override
-		public String toString() {
-			return "idx: " + index + " = " + deviation;
-		}
-
-		public long getIndex() {
-			return index;
-		}
-
-		void toArray(byte[] array, long base, int depth) {
-			long idx = index;
-			for (int i = array.length - 1; i > 0; i--) {
-
-				long v = idx / base;
-				array[i] = (byte) (v - 1);
-
-				idx -= v * base;
-				base /= depth;
-			}
-
-			array[0] = (byte) (idx - 1);
-		}
-	}
-
-	/**
-	 * Searches all possible combination by using a heap.
-	 */
-	final class Iterator implements DoubleIterator {
-
-		// This implementation uses a heap and stores all seen combinations
-		// Because the graph structure is fixed, it does not need to be as complicated as other k shortest path algorithms
-		// Two major improvements may be investigated:
-		// Could this be implemented with pre allocated memory and without objects ?
-		// Do all seen combinations need to be stored ?
-		// This is the case in Yens algorithms and other and will consume a lot of memory, when many top k paths are generated and a lot are thrown away.
-
-		private final String[] result;
-		private final byte[] modes;
-		private final double[] max;
-		private final double best;
-		private final ObjectHeapPriorityQueue<Entry> heap;
-		private final LongSet seen;
-
-
-		Iterator(String[] result, double[] max, Entry shortest, double best) {
-			this.result = result;
-			this.modes = new byte[result.length];
-			this.max = max;
-			this.best = best;
-			this.heap = new ObjectHeapPriorityQueue<>();
-			this.seen = new LongOpenHashSet();
-
-			heap.enqueue(shortest);
-			seen.add(shortest.index);
-		}
-
-		@Override
-		public double nextDouble() {
-
-			Entry entry = heap.dequeue();
-			// Create the array of indices from the entry
-			entry.toArray(modes, base, depth);
-
-			for (int i = 0; i < result.length; i++) {
-
-				byte mode = -1;
-				byte originalMode = modes[i];
-
-				// This mode had no options
-				if (originalMode == -1)
-					continue;
-
-				double min = estimates[i][originalMode];
-				double max = Double.NEGATIVE_INFINITY;
-
-				// search for a deviation that is worse than the current mode
-
-				for (byte j = 0; j < estimates[i].length; j++) {
-					if (estimates[i][j] <= min && j != originalMode && estimates[i][j] > max) {
-						max = estimates[i][j];
-						mode = j;
-					}
-				}
-
-				if (mode != -1) {
-					long newIdx = Entry.toIndex(modes, depth, i, mode);
-
-					// recompute the deviation from the maximum
-					// there might be a way to store and update this, without recomputing
-					double dev = 0;
-					for (int j = 0; j < result.length; j++) {
-						// Use either the replaced mode or the original mode
-						byte legMode = j == i ? mode : modes[j];
-
-						if (legMode == -1)
-							continue;
-
-						dev += this.max[j] - estimates[j][legMode];
-					}
-
-					Entry e = new Entry(newIdx, dev);
-
-					if (!seen.contains(e.index)) {
-						heap.enqueue(e);
-						seen.add(e.index);
-					}
-				}
-			}
-
-			convert(modes, result);
-			return best - entry.deviation;
-		}
-
-		@Override
-		public boolean hasNext() {
-			return !heap.isEmpty();
 		}
 	}
 

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/search/ModeChoiceSearch.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/search/ModeChoiceSearch.java
@@ -104,17 +104,24 @@ final class ModeChoiceSearch {
 	 * Copy estimates into the internal map.
 	 */
 	public void addEstimates(String mode, double[] values) {
-		addEstimates(mode, values, null);
+		addEstimates(mode, values, null, null);
 	}
 
-	public void addEstimates(String mode, double[] values, boolean[] mask) {
+	/**
+	 * Copy estimates into the internal map.
+	 * @param mode added mode
+	 * @param values utility estimates
+	 * @param mask only use estimates where the mask is true
+	 * @param filter only use estimates where the filter is false
+	 */
+	public void addEstimates(String mode, double[] values, boolean[] mask, boolean[] filter) {
 
 		byte idx = mapping.computeIfAbsent(mode, k -> (byte) mapping.size());
 		inv.putIfAbsent(idx, mode);
 
 		// estimates needs to be accessed by each trip index first and then by mode
 		for (int i = 0; i < values.length; i++) {
-			if (mask == null || mask[i])
+			if ( (mask == null || mask[i]) && (filter == null || !filter[i]) )
 				estimates[i][idx] = values[i];
 		}
 	}

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/search/ModeIntIterator.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/search/ModeIntIterator.java
@@ -1,0 +1,189 @@
+package org.matsim.modechoice.search;
+
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.objects.ObjectHeapPriorityQueue;
+
+import java.util.Objects;
+
+/**
+ * Copy of the {@link ModeLongIterator} that uses an int instead of a long to store the index.
+ * @see ModeLongIterator
+ */
+final class ModeIntIterator implements ModeIterator {
+
+
+    private final String[] result;
+    private final byte[] modes;
+    private final double[] max;
+    private final double best;
+    private final double[][] estimates;
+    private final int base;
+    private final int depth;
+    private final ModeChoiceSearch search;
+    private final ObjectHeapPriorityQueue<Entry> heap;
+    private final IntSet seen;
+
+
+    ModeIntIterator(String[] result, double[] max, Entry shortest, double best, int base, ModeChoiceSearch search) {
+
+        this.result = result;
+        this.modes = new byte[result.length];
+        this.max = max;
+        this.best = best;
+        this.estimates = search.estimates;
+        this.base = base;
+		this.depth = search.depth;
+        this.search = search;
+        this.heap = new ObjectHeapPriorityQueue<>();
+        this.seen = new IntOpenHashSet();
+
+		heap.enqueue(shortest);
+		seen.add(shortest.index);
+    }
+
+    @Override
+    public double nextDouble() {
+
+        Entry entry = heap.dequeue();
+        // Create the array of indices from the entry
+        entry.toArray(modes, base, depth);
+
+        for (int i = 0; i < result.length; i++) {
+
+            byte mode = -1;
+            byte originalMode = modes[i];
+
+            // This mode had no options
+            if (originalMode == -1)
+                continue;
+
+            double min = estimates[i][originalMode];
+            double max = Double.NEGATIVE_INFINITY;
+
+            // search for a deviation that is worse than the current mode
+
+            for (byte j = 0; j < estimates[i].length; j++) {
+                if (estimates[i][j] <= min && j != originalMode && estimates[i][j] > max) {
+                    max = estimates[i][j];
+                    mode = j;
+                }
+            }
+
+            if (mode != -1) {
+                int newIdx = Entry.toIndex(modes, depth, i, mode);
+
+				// recompute the deviation from the maximum
+                // there might be a way to store and update this, without recomputing
+                double dev = 0;
+                for (int j = 0; j < result.length; j++) {
+                    // Use either the replaced mode or the original mode
+                    byte legMode = j == i ? mode : modes[j];
+
+                    if (legMode == -1)
+                        continue;
+
+                    dev += this.max[j] - estimates[j][legMode];
+                }
+
+                Entry e = new Entry(newIdx, dev);
+
+                if (!seen.contains(e.index)) {
+                    heap.enqueue(e);
+                    seen.add(e.index);
+                }
+            }
+        }
+
+        search.convert(modes, result);
+        return best - entry.deviation;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return !heap.isEmpty();
+    }
+
+	static final class Entry implements Comparable<Entry> {
+		private final int index;
+		private final double deviation;
+
+		Entry(byte[] modes, int depth, double deviation) {
+			this.index = toIndex(modes, depth);
+			this.deviation = deviation;
+		}
+
+		Entry(int index, double deviation) {
+			this.index = index;
+			this.deviation = deviation;
+		}
+
+		static int toIndex(byte[] modes, int depth) {
+			int result = modes[0] + 1;
+			int base = depth;
+			for (int i = 1; i < modes.length; i++) {
+				result += (modes[i] + 1) * base;
+				base *= depth;
+			}
+
+			return result;
+		}
+
+		/**
+		 * Convert the mode array to an index, where one mode at index {@code idx} is replaced.
+		 */
+		static int toIndex(byte[] modes, int depth, int idx, byte mode) {
+			int result = (idx == 0 ? mode : modes[0]) + 1;
+			int base = depth;
+			for (int i = 1; i < modes.length; i++) {
+				result += ((idx == i ? mode : modes[i]) + 1) * base;
+				base *= depth;
+			}
+
+			return result;
+		}
+
+		@Override
+		public int compareTo(Entry o) {
+			return Double.compare(deviation, o.deviation);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			Entry entry = (Entry) o;
+			return Double.compare(entry.deviation, deviation) == 0 && index == entry.index;
+		}
+
+		@Override
+		public int hashCode() {
+			int result = Objects.hash(deviation);
+			result = 31 * result + Long.hashCode(index);
+			return result;
+		}
+
+		@Override
+		public String toString() {
+			return "idx: " + index + " = " + deviation;
+		}
+
+		public long getIndex() {
+			return index;
+		}
+
+		void toArray(byte[] array, int base, int depth) {
+			int idx = index;
+			for (int i = array.length - 1; i > 0; i--) {
+
+				int v = idx / base;
+				array[i] = (byte) (v - 1);
+
+				idx -= v * base;
+				base /= depth;
+			}
+
+			array[0] = (byte) (idx - 1);
+		}
+	}
+}

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/search/ModeIterator.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/search/ModeIterator.java
@@ -1,0 +1,16 @@
+package org.matsim.modechoice.search;
+
+import it.unimi.dsi.fastutil.doubles.DoubleIterator;
+
+sealed interface ModeIterator extends DoubleIterator permits ModeArrayIterator, ModeLongIterator, ModeIntIterator {
+
+	/**
+	 * Maximum number of iterations. Memory usage will increase the more iterations are done.
+	 */
+	int MAX_ITER = 10_000_000;
+
+	default int maxIters() {
+		return MAX_ITER;
+	}
+
+}

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/search/ModeLongIterator.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/search/ModeLongIterator.java
@@ -1,0 +1,194 @@
+package org.matsim.modechoice.search;
+
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
+import it.unimi.dsi.fastutil.objects.ObjectHeapPriorityQueue;
+
+import java.util.Objects;
+
+/**
+ * Searches all possible combination by using a heap.
+ */
+final class ModeLongIterator implements ModeIterator {
+
+	// This implementation uses a heap and stores all seen combinations
+	// Because the graph structure is fixed, it does not need to be as complicated as other k shortest path algorithms
+	// Two major improvements may be investigated:
+	// Could this be implemented with pre allocated memory and without objects ?
+	// Do all seen combinations need to be stored ?
+	// This is the case in Yens algorithms and other and will consume a lot of memory, when many top k paths are generated and a lot are thrown away.
+
+	private final String[] result;
+	private final byte[] modes;
+	private final double[] max;
+	private final double best;
+	private final double[][] estimates;
+	private final long base;
+	private final int depth;
+	private final ModeChoiceSearch search;
+	private final ObjectHeapPriorityQueue<Entry> heap;
+	private final LongSet seen;
+
+
+	ModeLongIterator(String[] result, double[] max, Entry shortest, double best, long base, ModeChoiceSearch search) {
+
+		this.result = result;
+		this.modes = new byte[result.length];
+		this.max = max;
+		this.best = best;
+		this.estimates = search.estimates;
+		this.base = base;
+		this.depth = search.depth;
+		this.search = search;
+		this.heap = new ObjectHeapPriorityQueue<>();
+		this.seen = new LongOpenHashSet();
+
+		heap.enqueue(shortest);
+		seen.add(shortest.index);
+	}
+
+	@Override
+	public double nextDouble() {
+
+		Entry entry = heap.dequeue();
+		// Create the array of indices from the entry
+		entry.toArray(modes, base, depth);
+
+		for (int i = 0; i < result.length; i++) {
+
+			byte mode = -1;
+			byte originalMode = modes[i];
+
+			// This mode had no options
+			if (originalMode == -1)
+				continue;
+
+			double min = estimates[i][originalMode];
+			double max = Double.NEGATIVE_INFINITY;
+
+			// search for a deviation that is worse than the current mode
+
+			for (byte j = 0; j < estimates[i].length; j++) {
+				if (estimates[i][j] <= min && j != originalMode && estimates[i][j] > max) {
+					max = estimates[i][j];
+					mode = j;
+				}
+			}
+
+			if (mode != -1) {
+				long newIdx = Entry.toIndex(modes, depth, i, mode);
+
+				// recompute the deviation from the maximum
+				// there might be a way to store and update this, without recomputing
+				double dev = 0;
+				for (int j = 0; j < result.length; j++) {
+					// Use either the replaced mode or the original mode
+					byte legMode = j == i ? mode : modes[j];
+
+					if (legMode == -1)
+						continue;
+
+					dev += this.max[j] - estimates[j][legMode];
+				}
+
+				Entry e = new Entry(newIdx, dev);
+
+				if (!seen.contains(e.index)) {
+					heap.enqueue(e);
+					seen.add(e.index);
+				}
+			}
+		}
+
+		search.convert(modes, result);
+		return best - entry.deviation;
+	}
+
+	@Override
+	public boolean hasNext() {
+		return !heap.isEmpty();
+	}
+
+	static final class Entry implements Comparable<Entry> {
+		private final long index;
+		private final double deviation;
+
+		Entry(byte[] modes, int depth, double deviation) {
+			this.index = toIndex(modes, depth);
+			this.deviation = deviation;
+		}
+
+		Entry(long index, double deviation) {
+			this.index = index;
+			this.deviation = deviation;
+		}
+
+		static long toIndex(byte[] modes, int depth) {
+			long result = modes[0] + 1;
+			long base = depth;
+			for (int i = 1; i < modes.length; i++) {
+				result += (modes[i] + 1) * base;
+				base *= depth;
+			}
+
+			return result;
+		}
+
+		/**
+		 * Convert the mode array to an index, where one mode at index {@code idx} is replaced.
+		 */
+		static long toIndex(byte[] modes, int depth, int idx, byte mode) {
+			long result = (idx == 0 ? mode : modes[0]) + 1;
+			long base = depth;
+			for (int i = 1; i < modes.length; i++) {
+				result += ((idx == i ? mode : modes[i]) + 1) * base;
+				base *= depth;
+			}
+
+			return result;
+		}
+
+		@Override
+		public int compareTo(Entry o) {
+			return Double.compare(deviation, o.deviation);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			Entry entry = (Entry) o;
+			return Double.compare(entry.deviation, deviation) == 0 && index == entry.index;
+		}
+
+		@Override
+		public int hashCode() {
+			int result = Objects.hash(deviation);
+			result = 31 * result + Long.hashCode(index);
+			return result;
+		}
+
+		@Override
+		public String toString() {
+			return "idx: " + index + " = " + deviation;
+		}
+
+		public long getIndex() {
+			return index;
+		}
+
+		void toArray(byte[] array, long base, int depth) {
+			long idx = index;
+			for (int i = array.length - 1; i > 0; i--) {
+
+				long v = idx / base;
+				array[i] = (byte) (v - 1);
+
+				idx -= v * base;
+				base /= depth;
+			}
+
+			array[0] = (byte) (idx - 1);
+		}
+	}
+}

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/search/SingleTripChoicesGenerator.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/search/SingleTripChoicesGenerator.java
@@ -61,6 +61,10 @@ public class SingleTripChoicesGenerator extends AbstractCandidateGenerator {
 
 			ModeEstimate est = opt.get();
 
+			// Not actual used modes are not generated here
+			if (est.getNoRealUsage()[idx])
+				continue;
+
 			String[] modes = planModel.getCurrentModes();
 			modes[idx] = est.getMode();
 

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/search/TopKChoicesGenerator.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/search/TopKChoicesGenerator.java
@@ -111,7 +111,8 @@ public class TopKChoicesGenerator extends AbstractCandidateGenerator {
 						continue m;
 				}
 
-				search.addEstimates(mode.getMode(), mode.getEstimates(), mask);
+				// Only add estimates for desired modes and those that have actual usage
+				search.addEstimates(mode.getMode(), mode.getEstimates(), mask, mode.getNoRealUsage());
 			}
 
 			if (search.isEmpty())

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/search/TopKChoicesGenerator.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/search/TopKChoicesGenerator.java
@@ -22,11 +22,6 @@ import static org.matsim.modechoice.PlanModelService.ConstraintHolder;
 @SuppressWarnings("unchecked")
 public class TopKChoicesGenerator extends AbstractCandidateGenerator {
 
-	/**
-	 * Maximum number of iterations. Memory usage will increase the more iterations are done.
-	 */
-	private static final int MAX_ITER = 10_000_000;
-
 	private static final Logger log = LogManager.getLogger(TopKChoicesGenerator.class);
 
 
@@ -167,14 +162,14 @@ public class TopKChoicesGenerator extends AbstractCandidateGenerator {
 
 			int k = 0;
 			int n = 0;
-			DoubleIterator it = search.iter(result);
+			ModeIterator it = search.iter(result);
 			double best = Double.NEGATIVE_INFINITY;
 
 			outer:
 			while (it.hasNext() && k < topK) {
 				double estimate = preDeterminedEstimate + it.nextDouble();
 
-				if (n++ > MAX_ITER) {
+				if (n++ > it.maxIters()) {
 					log.warn("Maximum number of iterations reached for person {}", context.person.getId());
 					break;
 				}

--- a/contribs/informed-mode-choice/src/test/java/org/matsim/modechoice/ModeChoiceWeightSchedulerTest.java
+++ b/contribs/informed-mode-choice/src/test/java/org/matsim/modechoice/ModeChoiceWeightSchedulerTest.java
@@ -20,7 +20,7 @@ public class ModeChoiceWeightSchedulerTest extends ScenarioTest {
 		imc.setInvBeta(1);
 		imc.setAnneal(InformedModeChoiceConfigGroup.Schedule.linear);
 
-		ModeChoiceWeightScheduler scheduler = injector.getInstance(ModeChoiceWeightScheduler.class);
+		ModeChoiceWeightScheduler scheduler = new ModeChoiceWeightScheduler(controler.getConfig());
 		MatsimServices services = injector.getInstance(MatsimServices.class);
 		scheduler.notifyStartup(new StartupEvent(services));
 
@@ -46,7 +46,7 @@ public class ModeChoiceWeightSchedulerTest extends ScenarioTest {
 		imc.setInvBeta(1);
 		imc.setAnneal(InformedModeChoiceConfigGroup.Schedule.quadratic);
 
-		ModeChoiceWeightScheduler scheduler = injector.getInstance(ModeChoiceWeightScheduler.class);
+		ModeChoiceWeightScheduler scheduler = new ModeChoiceWeightScheduler(controler.getConfig());
 		MatsimServices services = injector.getInstance(MatsimServices.class);
 		scheduler.notifyStartup(new StartupEvent(services));
 

--- a/contribs/informed-mode-choice/src/test/java/org/matsim/modechoice/replanning/MultinomialLogitSelectorTest.java
+++ b/contribs/informed-mode-choice/src/test/java/org/matsim/modechoice/replanning/MultinomialLogitSelectorTest.java
@@ -5,96 +5,64 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.matsim.modechoice.PlanCandidate;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MultinomialLogitSelectorTest {
-
-	private MultinomialLogitSelector selector;
+class MultinomialLogitSelectorTest {
 
 	private static final int N = 500_000;
+	private final Offset<Double> offset = Offset.offset(0.01);
+	private MultinomialLogitSelector selector;
 
 	@BeforeEach
 	public void setUp() throws Exception {
 		selector = new MultinomialLogitSelector(1, new Random(0));
 	}
 
-	@Test
-	void selection() {
+	private double[] sample(double... utils) {
+		List<PlanCandidate> candidates = new ArrayList<>();
 
-		List<PlanCandidate> candidates = List.of(
-				new PlanCandidate(new String[]{"car"}, -1),
-				new PlanCandidate(new String[]{"pt"}, -1.5),
-				new PlanCandidate(new String[]{"walk"}, -2)
-		);
+		for (int i = 0; i < utils.length; i++) {
+			candidates.add(new PlanCandidate(new String[]{"" + i}, utils[i]));
+		}
 
-
-		double[] sample = selector.sample(1000, candidates);
-
-		assertThat(sample)
-				.containsExactly(0.51, 0.306, 0.184);
-
-		candidates = List.of(
-				new PlanCandidate(new String[]{"car"}, -50),
-				new PlanCandidate(new String[]{"pt"}, -60),
-				new PlanCandidate(new String[]{"walk"}, -70)
-		);
-
-		sample = selector.sample(1000, candidates);
-
-		assertThat(sample)
-				.containsExactly(0.491, 0.323, 0.186);
-
-
-		candidates = List.of(
-				new PlanCandidate(new String[]{"car"}, 7),
-				new PlanCandidate(new String[]{"pt"}, 7),
-				new PlanCandidate(new String[]{"walk"}, 5)
-		);
-
-		sample = selector.sample(N, candidates);
-
-		assertThat(sample)
-				.containsExactly(0.42231, 0.42174, 0.15595);
-
+		return selector.sample(N, candidates);
 	}
 
 	@Test
-	void invariance() {
+	void probabilities() {
 
-		List<PlanCandidate> candidates = List.of(
-				new PlanCandidate(new String[]{"car"}, -1),
-				new PlanCandidate(new String[]{"pt"}, -2),
-				new PlanCandidate(new String[]{"walk"}, -3)
-		);
+		// checked with https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.softmax.html
 
+		assertThat(sample(-1, -2, -3))
+			.containsExactly(new double[]{0.66524096, 0.24472847, 0.09003057}, offset);
 
-		double[] sample1 = selector.sample(N, candidates);
+		assertThat(sample(-3, -1, -2))
+			.containsExactly(new double[]{0.09003057, 0.66524096, 0.24472847}, offset);
 
-		candidates = List.of(
-				new PlanCandidate(new String[]{"car"}, -10),
-				new PlanCandidate(new String[]{"pt"}, -20),
-				new PlanCandidate(new String[]{"walk"}, -30)
-		);
+		assertThat(sample(-2, -4, -6))
+			.containsExactly(new double[]{0.86681333, 0.11731043, 0.01587624}, offset);
 
-		double[] sample2 = selector.sample(N, candidates);
+		assertThat(sample(-0.5, -1, -1.5))
+			.containsExactly(new double[]{0.50648039, 0.30719589, 0.18632372}, offset);
 
-		candidates = List.of(
-				new PlanCandidate(new String[]{"car"}, 10),
-				new PlanCandidate(new String[]{"pt"}, 0),
-				new PlanCandidate(new String[]{"walk"}, -10)
-		);
+		selector = new MultinomialLogitSelector(2, new Random(0));
 
-		double[] sample3 = selector.sample(N, candidates);
+		assertThat(sample(-1, -2, -3))
+			.containsExactly(new double[]{0.50648039, 0.30719589, 0.18632372}, offset);
 
-		assertThat(sample1)
-				.containsExactly(0.50625, 0.306986, 0.186764);
-		assertThat(sample2)
-				.containsExactly(0.506194, 0.307304, 0.186502);
-		assertThat(sample3)
-				.containsExactly(0.506376, 0.30703, 0.186594);
+		selector = new MultinomialLogitSelector(0.5, new Random(0));
+
+		assertThat(sample(-1, -2, -3))
+			.containsExactly(new double[]{0.86681333, 0.11731043, 0.01587624}, offset);
+
+		selector = new MultinomialLogitSelector(10, new Random(0));
+
+		assertThat(sample(-1, -2, -3))
+			.containsExactly(new double[]{0.3671654 , 0.33222499, 0.30060961}, offset);
 
 	}
 
@@ -103,83 +71,8 @@ public class MultinomialLogitSelectorTest {
 
 		selector = new MultinomialLogitSelector(0, new Random(0));
 
-		List<PlanCandidate> candidates = List.of(
-				new PlanCandidate(new String[]{"car"}, 1.04),
-				new PlanCandidate(new String[]{"pt"}, 1.06),
-				new PlanCandidate(new String[]{"walk"}, 1.05)
-		);
-
-		double[] sample = selector.sample(N, candidates);
-
-		assertThat(sample).containsExactly(0, 1, 0);
-
-	}
-
-	@Test
-	void sameScore() {
-
-		selector = new MultinomialLogitSelector(0.01, new Random(0));
-
-		List<PlanCandidate> candidates = List.of(
-				new PlanCandidate(new String[]{"car"}, 1.),
-				new PlanCandidate(new String[]{"walk"}, 1.)
-		);
-
-		double[] sample = selector.sample(N, candidates);
-
-		assertThat(sample[0]).isCloseTo(0.5, Offset.offset(0.01));
-		assertThat(sample[1]).isCloseTo(0.5, Offset.offset(0.01));
-	}
-
-	@Test
-	void single() {
-
-
-		selector = new MultinomialLogitSelector(1, new Random(0));
-
-		List<PlanCandidate> candidates = List.of(
-				new PlanCandidate(new String[]{"car"}, 1.)
-		);
-
-		double[] sample = selector.sample(N, candidates);
-
-		assertThat(sample[0]).isEqualTo(1);
-
-	}
-
-	@Test
-	void precision() {
-
-		selector = new MultinomialLogitSelector(0.01, new Random(0));
-
-		List<PlanCandidate> candidates = List.of(
-				new PlanCandidate(new String[]{"car1"}, 2),
-				new PlanCandidate(new String[]{"car2"}, 10000),
-				new PlanCandidate(new String[]{"car3"}, 1)
-		);
-
-		double[] sample = selector.sample(N, candidates);
-
-		assertThat(sample[1]).isEqualTo(1);
-
-	}
-
-	@Test
-	void inf() {
-
-		selector = new MultinomialLogitSelector(10000, new Random(0));
-
-		List<PlanCandidate> candidates = List.of(
-				new PlanCandidate(new String[]{"car1"}, 2),
-				new PlanCandidate(new String[]{"car2"}, 10000),
-				new PlanCandidate(new String[]{"car3"}, 1)
-		);
-
-		double[] sample = selector.sample(N, candidates);
-
-		assertThat(sample[0]).isEqualTo(0.333, Offset.offset(0.001));
-		assertThat(sample[1]).isEqualTo(0.333, Offset.offset(0.001));
-		assertThat(sample[2]).isEqualTo(0.333, Offset.offset(0.001));
+		assertThat(sample(1.04, 1.06, 1.05))
+			.containsExactly(0, 1, 0);
 
 	}
 
@@ -187,18 +80,38 @@ public class MultinomialLogitSelectorTest {
 	void random() {
 
 		selector = new MultinomialLogitSelector(Double.POSITIVE_INFINITY, new Random(0));
+		assertThat(sample(100, 3, 1))
+			.containsExactly(new double[]{0.333, 0.333, 0.333}, offset);
 
-		List<PlanCandidate> candidates = List.of(
-			new PlanCandidate(new String[]{"car1"}, 100),
-			new PlanCandidate(new String[]{"car2"}, 3),
-			new PlanCandidate(new String[]{"car3"}, 1)
-		);
+	}
 
-		double[] sample = selector.sample(N, candidates);
+	@Test
+	void invariance() {
 
-		assertThat(sample[0]).isEqualTo(0.333, Offset.offset(0.001));
-		assertThat(sample[1]).isEqualTo(0.333, Offset.offset(0.001));
-		assertThat(sample[2]).isEqualTo(0.333, Offset.offset(0.001));
+		// Selector is invariant to shifting, but not to scale of utilities
+		assertThat(sample(-1, -2, -3))
+			.containsExactly(new double[]{0.664678, 0.244972, 0.09035}, offset);
+
+		assertThat(sample(1, 0, -1))
+			.containsExactly(new double[]{0.665126, 0.244834, 0.09004}, offset);
+
+	}
+
+	@Test
+	void smallScale() {
+
+		selector = new MultinomialLogitSelector(1 / 10000d, new Random(0));
+
+		assertThat(sample(-1e-4, -1e-4, -2e-4))
+			.containsExactly(new double[]{0.4223188, 0.4223188, 0.1553624}, offset);
+
+		assertThat(sample(-1, -1, -2))
+			.containsExactly(new double[]{1/2d, 1/2d, 0}, offset);
+
+		selector = new MultinomialLogitSelector(2e-8, new Random(0));
+
+		assertThat(sample(-1, -1.0001, -2))
+			.containsExactly(new double[]{1, 0, 0}, offset);
 
 	}
 }

--- a/contribs/informed-mode-choice/src/test/java/org/matsim/modechoice/replanning/NormalizedMultinomialLogitSelectorTest.java
+++ b/contribs/informed-mode-choice/src/test/java/org/matsim/modechoice/replanning/NormalizedMultinomialLogitSelectorTest.java
@@ -1,0 +1,204 @@
+package org.matsim.modechoice.replanning;
+
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.matsim.modechoice.PlanCandidate;
+
+import java.util.List;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NormalizedMultinomialLogitSelectorTest {
+
+	private NormalizedMultinomialLogitSelector selector;
+
+	private static final int N = 500_000;
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		selector = new NormalizedMultinomialLogitSelector(1, new Random(0));
+	}
+
+	@Test
+	void selection() {
+
+		List<PlanCandidate> candidates = List.of(
+				new PlanCandidate(new String[]{"car"}, -1),
+				new PlanCandidate(new String[]{"pt"}, -1.5),
+				new PlanCandidate(new String[]{"walk"}, -2)
+		);
+
+
+		double[] sample = selector.sample(1000, candidates);
+
+		assertThat(sample)
+				.containsExactly(0.51, 0.306, 0.184);
+
+		candidates = List.of(
+				new PlanCandidate(new String[]{"car"}, -50),
+				new PlanCandidate(new String[]{"pt"}, -60),
+				new PlanCandidate(new String[]{"walk"}, -70)
+		);
+
+		sample = selector.sample(1000, candidates);
+
+		assertThat(sample)
+				.containsExactly(0.491, 0.323, 0.186);
+
+
+		candidates = List.of(
+				new PlanCandidate(new String[]{"car"}, 7),
+				new PlanCandidate(new String[]{"pt"}, 7),
+				new PlanCandidate(new String[]{"walk"}, 5)
+		);
+
+		sample = selector.sample(N, candidates);
+
+		assertThat(sample)
+				.containsExactly(0.42231, 0.42174, 0.15595);
+
+	}
+
+	@Test
+	void invariance() {
+
+		List<PlanCandidate> candidates = List.of(
+				new PlanCandidate(new String[]{"car"}, -1),
+				new PlanCandidate(new String[]{"pt"}, -2),
+				new PlanCandidate(new String[]{"walk"}, -3)
+		);
+
+
+		double[] sample1 = selector.sample(N, candidates);
+
+		candidates = List.of(
+				new PlanCandidate(new String[]{"car"}, -10),
+				new PlanCandidate(new String[]{"pt"}, -20),
+				new PlanCandidate(new String[]{"walk"}, -30)
+		);
+
+		double[] sample2 = selector.sample(N, candidates);
+
+		candidates = List.of(
+				new PlanCandidate(new String[]{"car"}, 10),
+				new PlanCandidate(new String[]{"pt"}, 0),
+				new PlanCandidate(new String[]{"walk"}, -10)
+		);
+
+		double[] sample3 = selector.sample(N, candidates);
+
+		assertThat(sample1)
+				.containsExactly(0.50625, 0.306986, 0.186764);
+		assertThat(sample2)
+				.containsExactly(0.506194, 0.307304, 0.186502);
+		assertThat(sample3)
+				.containsExactly(0.506376, 0.30703, 0.186594);
+
+	}
+
+	@Test
+	void best() {
+
+		selector = new NormalizedMultinomialLogitSelector(0, new Random(0));
+
+		List<PlanCandidate> candidates = List.of(
+				new PlanCandidate(new String[]{"car"}, 1.04),
+				new PlanCandidate(new String[]{"pt"}, 1.06),
+				new PlanCandidate(new String[]{"walk"}, 1.05)
+		);
+
+		double[] sample = selector.sample(N, candidates);
+
+		assertThat(sample).containsExactly(0, 1, 0);
+
+	}
+
+	@Test
+	void sameScore() {
+
+		selector = new NormalizedMultinomialLogitSelector(0.01, new Random(0));
+
+		List<PlanCandidate> candidates = List.of(
+				new PlanCandidate(new String[]{"car"}, 1.),
+				new PlanCandidate(new String[]{"walk"}, 1.)
+		);
+
+		double[] sample = selector.sample(N, candidates);
+
+		assertThat(sample[0]).isCloseTo(0.5, Offset.offset(0.01));
+		assertThat(sample[1]).isCloseTo(0.5, Offset.offset(0.01));
+	}
+
+	@Test
+	void single() {
+
+
+		selector = new NormalizedMultinomialLogitSelector(1, new Random(0));
+
+		List<PlanCandidate> candidates = List.of(
+				new PlanCandidate(new String[]{"car"}, 1.)
+		);
+
+		double[] sample = selector.sample(N, candidates);
+
+		assertThat(sample[0]).isEqualTo(1);
+
+	}
+
+	@Test
+	void precision() {
+
+		selector = new NormalizedMultinomialLogitSelector(0.01, new Random(0));
+
+		List<PlanCandidate> candidates = List.of(
+				new PlanCandidate(new String[]{"car1"}, 2),
+				new PlanCandidate(new String[]{"car2"}, 10000),
+				new PlanCandidate(new String[]{"car3"}, 1)
+		);
+
+		double[] sample = selector.sample(N, candidates);
+
+		assertThat(sample[1]).isEqualTo(1);
+
+	}
+
+	@Test
+	void inf() {
+
+		selector = new NormalizedMultinomialLogitSelector(10000, new Random(0));
+
+		List<PlanCandidate> candidates = List.of(
+				new PlanCandidate(new String[]{"car1"}, 2),
+				new PlanCandidate(new String[]{"car2"}, 10000),
+				new PlanCandidate(new String[]{"car3"}, 1)
+		);
+
+		double[] sample = selector.sample(N, candidates);
+
+		assertThat(sample[0]).isEqualTo(0.333, Offset.offset(0.001));
+		assertThat(sample[1]).isEqualTo(0.333, Offset.offset(0.001));
+		assertThat(sample[2]).isEqualTo(0.333, Offset.offset(0.001));
+
+	}
+
+	@Test
+	void random() {
+
+		selector = new NormalizedMultinomialLogitSelector(Double.POSITIVE_INFINITY, new Random(0));
+
+		List<PlanCandidate> candidates = List.of(
+			new PlanCandidate(new String[]{"car1"}, 100),
+			new PlanCandidate(new String[]{"car2"}, 3),
+			new PlanCandidate(new String[]{"car3"}, 1)
+		);
+
+		double[] sample = selector.sample(N, candidates);
+
+		assertThat(sample[0]).isEqualTo(0.333, Offset.offset(0.001));
+		assertThat(sample[1]).isEqualTo(0.333, Offset.offset(0.001));
+		assertThat(sample[2]).isEqualTo(0.333, Offset.offset(0.001));
+
+	}
+}

--- a/contribs/informed-mode-choice/src/test/java/org/matsim/modechoice/replanning/SelectSubtourModeStrategyTest.java
+++ b/contribs/informed-mode-choice/src/test/java/org/matsim/modechoice/replanning/SelectSubtourModeStrategyTest.java
@@ -30,7 +30,6 @@ public class SelectSubtourModeStrategyTest extends ScenarioTest {
 		PrepareForMobsim prepare = injector.getInstance(PrepareForMobsim.class);
 		prepare.run();
 
-
 		PlanStrategy strategy = injector.getInstance(Key.get(PlanStrategy.class, Names.named(InformedModeChoiceModule.SELECT_SUBTOUR_MODE_STRATEGY)));
 
 		Person person = controler.getScenario().getPopulation().getPersons().get(TestScenario.Agents.get(5));
@@ -69,7 +68,6 @@ public class SelectSubtourModeStrategyTest extends ScenarioTest {
 
 	@Test
 	void allowedModes() {
-
 
 		TopKChoicesGenerator generator = injector.getInstance(TopKChoicesGenerator.class);
 

--- a/contribs/informed-mode-choice/src/test/java/org/matsim/modechoice/replanning/SelectVsRandomSubtourTest.java
+++ b/contribs/informed-mode-choice/src/test/java/org/matsim/modechoice/replanning/SelectVsRandomSubtourTest.java
@@ -1,0 +1,107 @@
+package org.matsim.modechoice.replanning;
+
+import com.google.inject.Key;
+import com.google.inject.name.Names;
+import it.unimi.dsi.fastutil.objects.Object2DoubleAVLTreeMap;
+import it.unimi.dsi.fastutil.objects.Object2DoubleSortedMap;
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.Test;
+import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Plan;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.controler.PrepareForMobsim;
+import org.matsim.core.replanning.PlanStrategy;
+import org.matsim.core.router.TripStructureUtils;
+import org.matsim.modechoice.InformedModeChoiceConfigGroup;
+import org.matsim.modechoice.InformedModeChoiceModule;
+import org.matsim.modechoice.ScenarioTest;
+import org.matsim.modechoice.TestScenario;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Checks if {@link RandomSubtourModeStrategy} and {@link SelectSubtourModeStrategy} are equivalent under specific configuration.
+ */
+public class SelectVsRandomSubtourTest extends ScenarioTest {
+
+	@Override
+	protected String[] getArgs() {
+		return new String[]{"--mc"};
+	}
+
+
+	@Override
+	protected void prepareConfig(Config config) {
+		InformedModeChoiceConfigGroup imc = ConfigUtils.addOrGetModule(config, InformedModeChoiceConfigGroup.class);
+		imc.setTopK(0);
+		imc.setInvBeta(Double.POSITIVE_INFINITY);
+	}
+
+
+	@Test
+	void replanning() {
+
+		PrepareForMobsim prepare = injector.getInstance(PrepareForMobsim.class);
+		prepare.run();
+
+		PlanStrategy select = injector.getInstance(Key.get(PlanStrategy.class, Names.named(InformedModeChoiceModule.SELECT_SUBTOUR_MODE_STRATEGY)));
+		PlanStrategy random = injector.getInstance(Key.get(PlanStrategy.class, Names.named(InformedModeChoiceModule.RANDOM_SUBTOUR_MODE_STRATEGY)));
+
+		List<Plan> plans = TestScenario.Agents.stream()
+			.map(agent -> controler.getScenario().getPopulation().getPersons().get(agent))
+			.map(Person::getSelectedPlan)
+			.toList();
+
+		double[] randomModes = sampleModes(plans, random);
+		double[] selectModes = sampleModes(plans, select);
+
+		assertThat(selectModes)
+			.containsExactly(randomModes, Offset.offset(1200d));
+
+	}
+
+	/**
+	 * Run the strategy and count obtained modes.
+	 */
+	private double[] sampleModes(List<Plan> plans, PlanStrategy strategy) {
+
+		Object2DoubleSortedMap<String> modes = new Object2DoubleAVLTreeMap<>();
+
+		for (Plan plan : plans) {
+
+			Person person = plan.getPerson();
+			person.getPlans().clear();
+
+			person.addPlan(plan);
+
+		}
+
+		for (int i = 0; i < 500; i++) {
+			int finalI = i;
+			strategy.init(() -> finalI);
+
+			for (Plan plan : plans)
+				strategy.run(plan.getPerson());
+
+			strategy.finish();
+
+			for (Plan plan : plans) {
+
+				Plan selected = plan.getPerson().getSelectedPlan();
+				plan.getPerson().getPlans().removeIf(p -> selected != p);
+				for (Leg leg : TripStructureUtils.getLegs(selected)) {
+					modes.mergeDouble(leg.getMode(), 1, Double::sum);
+				}
+
+			}
+		}
+
+		System.out.println("Modes: " + modes.keySet());
+
+		return modes.values().toDoubleArray();
+	}
+}

--- a/contribs/informed-mode-choice/src/test/java/org/matsim/modechoice/search/ModeChoiceSearchTest.java
+++ b/contribs/informed-mode-choice/src/test/java/org/matsim/modechoice/search/ModeChoiceSearchTest.java
@@ -3,6 +3,8 @@ package org.matsim.modechoice.search;
 import it.unimi.dsi.fastutil.doubles.DoubleIterator;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ModeChoiceSearchTest {
@@ -97,4 +99,60 @@ public class ModeChoiceSearchTest {
 
 	}
 
+	@Test
+	void entry() {
+
+		int depth = 6;
+		long base = (long) Math.pow(depth, 9);
+
+		long b = 1;
+		for (int i = 0; i < 9; i++) {
+			b *= depth;
+		}
+
+		assertThat(b)
+			.isEqualTo(base);
+
+		byte[] modes = new byte[10];
+		Arrays.fill(modes, (byte) -1);
+
+		assertThat(ModeChoiceSearch.Entry.toIndex(modes, depth))
+			.isEqualTo(0);
+
+		modes[0] = 0;
+
+		assertThat(ModeChoiceSearch.Entry.toIndex(modes, depth))
+			.isEqualTo(1);
+
+		modes[1] = 1;
+		modes[2] = 2;
+		modes[3] = 3;
+		modes[4] = 4;
+
+		ModeChoiceSearch.Entry e = new ModeChoiceSearch.Entry(modes, depth, 0);
+
+		assertThat(e.getIndex())
+			.isEqualTo(7465);
+
+		byte[] result = new byte[10];
+		Arrays.fill(result, (byte) -1);
+
+		e.toArray(result, base, depth);
+
+		assertThat(result)
+			.isEqualTo(modes);
+
+		Arrays.fill(modes, (byte) 4);
+
+		e = new ModeChoiceSearch.Entry(modes, depth, 0);
+
+		e.toArray(result, base, depth);
+
+		assertThat(result)
+			.isEqualTo(modes);
+
+		assertThat(e.getIndex())
+			.isEqualTo(base * depth - 1);
+
+	}
 }

--- a/contribs/informed-mode-choice/src/test/java/org/matsim/modechoice/search/ModeChoiceSearchTest.java
+++ b/contribs/informed-mode-choice/src/test/java/org/matsim/modechoice/search/ModeChoiceSearchTest.java
@@ -153,10 +153,16 @@ public class ModeChoiceSearchTest {
 		assertThat(ModeLongIterator.Entry.toIndex(modes, depth))
 			.isEqualTo(0);
 
+		assertThat(ModeLongIterator.Entry.toIndex(modes, depth, 0, (byte) 0))
+			.isEqualTo(1);
+
 		modes[0] = 0;
 
 		assertThat(ModeLongIterator.Entry.toIndex(modes, depth))
 			.isEqualTo(1);
+
+		assertThat(ModeLongIterator.Entry.toIndex(modes, depth, 1,  (byte) 0))
+			.isEqualTo(depth + 1);
 
 		modes[1] = 1;
 		modes[2] = 2;
@@ -214,6 +220,12 @@ public class ModeChoiceSearchTest {
 
 		assertThat(ModeIntIterator.Entry.toIndex(modes, depth))
 			.isEqualTo(1);
+
+		assertThat(ModeLongIterator.Entry.toIndex(modes, depth, 0, (byte) 0))
+			.isEqualTo(1);
+
+		assertThat(ModeLongIterator.Entry.toIndex(modes, depth, 1,  (byte) 0))
+			.isEqualTo(depth + 1);
 
 		modes[1] = 1;
 		modes[2] = 2;

--- a/contribs/informed-mode-choice/src/test/java/org/matsim/modechoice/search/ModeChoiceSearchTest.java
+++ b/contribs/informed-mode-choice/src/test/java/org/matsim/modechoice/search/ModeChoiceSearchTest.java
@@ -100,7 +100,41 @@ public class ModeChoiceSearchTest {
 	}
 
 	@Test
-	void entry() {
+	void huge() {
+
+		ModeChoiceSearch search = new ModeChoiceSearch(25, 5);
+
+		for (int i = 0; i < 5; i++) {
+			double[] values = new double[25];
+
+			Arrays.fill(values, i);
+
+			search.addEstimates(String.valueOf(i), values);
+		}
+
+		String[] result = new String[25];
+
+		ModeIterator it = search.iter(result);
+
+		double v = it.nextDouble();
+
+		assertThat(v)
+			.isEqualTo(100);
+
+		assertThat(result)
+			.containsOnly("4");
+
+		// All combinations with 99 util
+		for (int i = 0; i < 25; i++) {
+			assertThat(it.nextDouble()).isEqualTo(99);
+		}
+
+		assertThat(it.nextDouble()).isEqualTo(98);
+
+	}
+
+	@Test
+	void longEntry() {
 
 		int depth = 6;
 		long base = (long) Math.pow(depth, 9);
@@ -116,12 +150,12 @@ public class ModeChoiceSearchTest {
 		byte[] modes = new byte[10];
 		Arrays.fill(modes, (byte) -1);
 
-		assertThat(ModeChoiceSearch.Entry.toIndex(modes, depth))
+		assertThat(ModeLongIterator.Entry.toIndex(modes, depth))
 			.isEqualTo(0);
 
 		modes[0] = 0;
 
-		assertThat(ModeChoiceSearch.Entry.toIndex(modes, depth))
+		assertThat(ModeLongIterator.Entry.toIndex(modes, depth))
 			.isEqualTo(1);
 
 		modes[1] = 1;
@@ -129,7 +163,7 @@ public class ModeChoiceSearchTest {
 		modes[3] = 3;
 		modes[4] = 4;
 
-		ModeChoiceSearch.Entry e = new ModeChoiceSearch.Entry(modes, depth, 0);
+		ModeLongIterator.Entry e = new ModeLongIterator.Entry(modes, depth, 0);
 
 		assertThat(e.getIndex())
 			.isEqualTo(7465);
@@ -144,7 +178,64 @@ public class ModeChoiceSearchTest {
 
 		Arrays.fill(modes, (byte) 4);
 
-		e = new ModeChoiceSearch.Entry(modes, depth, 0);
+		e = new ModeLongIterator.Entry(modes, depth, 0);
+
+		e.toArray(result, base, depth);
+
+		assertThat(result)
+			.isEqualTo(modes);
+
+		assertThat(e.getIndex())
+			.isEqualTo(base * depth - 1);
+
+	}
+
+	@Test
+	void intEntry() {
+
+		int depth = 6;
+		int base = (int) Math.pow(depth, 5);
+
+		int b = 1;
+		for (int i = 0; i < 5; i++) {
+			b *= depth;
+		}
+
+		assertThat(b)
+			.isEqualTo(base);
+
+		byte[] modes = new byte[6];
+		Arrays.fill(modes, (byte) -1);
+
+		assertThat(ModeIntIterator.Entry.toIndex(modes, depth))
+			.isEqualTo(0);
+
+		modes[0] = 0;
+
+		assertThat(ModeIntIterator.Entry.toIndex(modes, depth))
+			.isEqualTo(1);
+
+		modes[1] = 1;
+		modes[2] = 2;
+		modes[3] = 3;
+		modes[4] = 4;
+
+		ModeIntIterator.Entry e = new ModeIntIterator.Entry(modes, depth, 0);
+
+		assertThat(e.getIndex())
+			.isEqualTo(7465);
+
+		byte[] result = new byte[6];
+		Arrays.fill(result, (byte) -1);
+
+		e.toArray(result, base, depth);
+
+		assertThat(result)
+			.isEqualTo(modes);
+
+		Arrays.fill(modes, (byte) 4);
+
+		e = new ModeIntIterator.Entry(modes, depth, 0);
 
 		e.toArray(result, base, depth);
 

--- a/contribs/informed-mode-choice/src/test/java/org/matsim/modechoice/search/TopKMinMaxTest.java
+++ b/contribs/informed-mode-choice/src/test/java/org/matsim/modechoice/search/TopKMinMaxTest.java
@@ -19,6 +19,7 @@ import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.groups.PlansConfigGroup;
 import org.matsim.core.controler.ControlerListenerManager;
 import org.matsim.core.population.PopulationUtils;
+import org.matsim.core.router.DefaultAnalysisMainModeIdentifier;
 import org.matsim.core.router.TripRouter;
 import org.matsim.core.scoring.functions.ScoringParameters;
 import org.matsim.core.scoring.functions.ScoringParametersForPerson;
@@ -207,7 +208,8 @@ public class TopKMinMaxTest {
 
 			bind(EstimateRouter.class).toInstance(new EstimateRouter(router,
 					FacilitiesUtils.createActivityFacilities(),
-					TimeInterpretation.create(PlansConfigGroup.ActivityDurationInterpretation.minOfDurationAndEndTime, PlansConfigGroup.TripDurationHandling.shiftActivityEndTimes)));
+					new DefaultAnalysisMainModeIdentifier()
+			));
 
 			MapBinder<String, ModeOptions> optionBinder = MapBinder.newMapBinder(binder(), new TypeLiteral<>() {}, new TypeLiteral<>(){});
 			optionBinder.addBinding(TransportMode.car).toInstance(new ModeOptions.AlwaysAvailable());

--- a/contribs/vsp/src/test/java/org/matsim/contrib/vsp/pt/fare/PtTripFareEstimatorTest.java
+++ b/contribs/vsp/src/test/java/org/matsim/contrib/vsp/pt/fare/PtTripFareEstimatorTest.java
@@ -103,7 +103,7 @@ public class PtTripFareEstimatorTest {
 
 			List<Leg> trip = model.getLegs(TransportMode.pt, i);
 
-			if (trip == null) {
+			if (trip == null || !model.hasModeForTrip(TransportMode.pt, i)) {
 				continue;
 			}
 

--- a/matsim/src/main/java/org/matsim/core/replanning/GenericStrategyManagerImpl.java
+++ b/matsim/src/main/java/org/matsim/core/replanning/GenericStrategyManagerImpl.java
@@ -51,7 +51,7 @@ import org.matsim.core.replanning.selectors.WorstPlanForRemovalSelector;
  */
 public class GenericStrategyManagerImpl<PL extends BasicPlan, AG extends HasPlansAndId<? extends BasicPlan, AG>> implements GenericStrategyManager<PL, AG>{
 	// the "I extends ... <, I>" is correct, although it feels odd.  kai, nov'15
-	
+
 	private static final Logger log = LogManager.getLogger( GenericStrategyManagerImpl.class );
 
 
@@ -90,7 +90,7 @@ public class GenericStrategyManagerImpl<PL extends BasicPlan, AG extends HasPlan
 
 
 //	private String subpopulationAttributeName = null;
-	
+
 	public GenericStrategyManagerImpl() {
 		this(new WeightedStrategyChooser<>());
 	}
@@ -210,6 +210,8 @@ public class GenericStrategyManagerImpl<PL extends BasicPlan, AG extends HasPlan
 			final Iterable<? extends HasPlansAndId<PL, AG>> persons,
 			final ReplanningContext replanningContext )
 	{
+		this.strategyChooser.beforeReplanning(replanningContext);
+
 		// initialize all strategies
 		for (GenericPlanStrategy<PL, AG> strategy : distinctStrategies()) {
 			strategy.init(replanningContext);
@@ -234,7 +236,7 @@ public class GenericStrategyManagerImpl<PL extends BasicPlan, AG extends HasPlan
 			if (strategy==null) {
 				throw new RuntimeException("No strategy found! Have you defined at least one replanning strategy per subpopulation? Current subpopulation = " + subpopName);
 			}
-			
+
 			// ... and run the strategy:
 			strategy.run(person);
 		}

--- a/matsim/src/main/java/org/matsim/core/replanning/choosers/BalancedInnovationStrategyChooser.java
+++ b/matsim/src/main/java/org/matsim/core/replanning/choosers/BalancedInnovationStrategyChooser.java
@@ -153,7 +153,8 @@ public class BalancedInnovationStrategyChooser<PL extends BasicPlan, AG extends 
 			}
 
 			// If the difference becomes too large, agents are allowed to innovate again
-			if (carryOver.getInt(subpopulation) > 0 && diff > 50 && !twoAhead.contains(id)) {
+			// some carry overs are always reserved for agent that need to innovate one step
+			if (carryOver.getInt(subpopulation) > 20 && diff > 50 && !twoAhead.contains(id)) {
 				carryOver.mergeInt(subpopulation, -1, Integer::sum);
 
 				twoAhead.add(id);

--- a/matsim/src/main/java/org/matsim/core/replanning/choosers/BalancedInnovationStrategyChooser.java
+++ b/matsim/src/main/java/org/matsim/core/replanning/choosers/BalancedInnovationStrategyChooser.java
@@ -20,8 +20,8 @@ import java.util.Map;
 
 /**
  * Strategy chooser which ensures that all agents perform innovative strategies in a balanced manner.
- * That is at any time all agents have either performed n, n+1, n+2 times an innovative strategy. This difference is never larger than 2.
- * Reducing the distance to 1, is possible, but restricts the number of innovations per iteration.
+ * That is at any time all agents have either performed n, n+1 or n+2 times an innovative strategy. This difference is never larger than 2.
+ * The class also tries to balance the number of innovations in a single iteration.
  */
 public class BalancedInnovationStrategyChooser<PL extends BasicPlan, AG extends HasPlansAndId<? extends BasicPlan, AG>> implements StrategyChooser<PL, AG> {
 
@@ -181,7 +181,7 @@ public class BalancedInnovationStrategyChooser<PL extends BasicPlan, AG extends 
 	private GenericPlanStrategy<PL, AG> chooseStrategy(double total, double[] w, StrategyChooser.Weights<PL, AG> weights) {
 		double rnd = MatsimRandom.getRandom().nextDouble() * total;
 		double sum = 0.0;
-		for (int i = 0, max = weights.size(); i < max; i++) {
+		for (int i = 0, max = w.length; i < max; i++) {
 			sum += w[i];
 			if (rnd <= sum) {
 				return weights.getStrategy(i);

--- a/matsim/src/main/java/org/matsim/core/replanning/choosers/BalancedInnovationStrategyChooser.java
+++ b/matsim/src/main/java/org/matsim/core/replanning/choosers/BalancedInnovationStrategyChooser.java
@@ -9,6 +9,8 @@ import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import org.matsim.api.core.v01.population.*;
+import org.matsim.core.controler.AbstractModule;
+import org.matsim.core.controler.Controller;
 import org.matsim.core.gbl.MatsimRandom;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.replanning.GenericPlanStrategy;
@@ -79,6 +81,19 @@ public class BalancedInnovationStrategyChooser<PL extends BasicPlan, AG extends 
 		binder.bind(new TypeLiteral<StrategyChooser<Plan, Person>>() {
 		}).to(new TypeLiteral<BalancedInnovationStrategyChooser<Plan, Person>>() {
 		}).in(Singleton.class);
+	}
+
+
+	/**
+	 * Install this strategy chooser in the given controller.
+	 */
+	public static void install(Controller controller) {
+		controller.addOverridingModule(new AbstractModule() {
+			@Override
+			public void install() {
+				BalancedInnovationStrategyChooser.bind(binder());
+			}
+		});
 	}
 
 	@Override

--- a/matsim/src/main/java/org/matsim/core/replanning/choosers/BalancedInnovationStrategyChooser.java
+++ b/matsim/src/main/java/org/matsim/core/replanning/choosers/BalancedInnovationStrategyChooser.java
@@ -153,7 +153,7 @@ public class BalancedInnovationStrategyChooser<PL extends BasicPlan, AG extends 
 			}
 
 			// If the difference becomes too large, agents are allowed to innovate again
-			if (carryOver.getInt(subpopulation) > 0 && diff > 10 && !twoAhead.contains(id)) {
+			if (carryOver.getInt(subpopulation) > 0 && diff > 50 && !twoAhead.contains(id)) {
 				carryOver.mergeInt(subpopulation, -1, Integer::sum);
 
 				twoAhead.add(id);

--- a/matsim/src/main/java/org/matsim/core/replanning/choosers/ForceInnovationStrategyChooser.java
+++ b/matsim/src/main/java/org/matsim/core/replanning/choosers/ForceInnovationStrategyChooser.java
@@ -9,6 +9,9 @@ import org.matsim.core.replanning.ReplanningUtils;
 
 /**
  * This chooser forces to select an innovative strategy every X iteration for every X person in the population.
+ * This chooser forces innovation regardless of the weights.
+ * <p>
+ * For a more consistent innovation rate use {@link BalancedInnovationStrategyChooser}.
  */
 public class ForceInnovationStrategyChooser<PL extends BasicPlan, AG extends HasPlansAndId<? extends BasicPlan, AG>> implements StrategyChooser<PL, AG> {
 

--- a/matsim/src/main/java/org/matsim/core/replanning/choosers/StrategyChooser.java
+++ b/matsim/src/main/java/org/matsim/core/replanning/choosers/StrategyChooser.java
@@ -9,6 +9,10 @@ import org.matsim.core.replanning.ReplanningContext;
  * Interface for choosing a strategy for each person, each iteration.
  */
 public interface StrategyChooser<T extends BasicPlan, I extends HasPlansAndId<? extends BasicPlan, I>> {
+
+	default void beforeReplanning(ReplanningContext replanningContext) {
+	}
+
 	GenericPlanStrategy<T, I> chooseStrategy(HasPlansAndId<T, I> person, final String subpopulation, ReplanningContext replanningContext, Weights<T,I> weights);
 
 

--- a/matsim/src/main/java/org/matsim/core/router/TripStructureUtils.java
+++ b/matsim/src/main/java/org/matsim/core/router/TripStructureUtils.java
@@ -234,19 +234,19 @@ public final class TripStructureUtils {
 		return getSubtours( plan.getPlanElements(), isStageActivity, 0);
 	}
 
-	// for contrib socnetsim only
-	// I think now that we should actually keep this.  kai, jan'20
-	@Deprecated
 	public static Collection<Subtour> getSubtours(
-			final List<? extends PlanElement> planElements,
-			final Predicate<String> isStageActivity, double coordDistance) {
-		final List<Subtour> subtours = new ArrayList<>();
+		final List<? extends PlanElement> planElements,
+		final Predicate<String> isStageActivity, double coordDistance) {
+		return getSubtoursFromTrips(getTrips(planElements, isStageActivity), coordDistance);
+	}
 
+	public static Collection<Subtour> getSubtoursFromTrips(List<Trip> trips, double coordDistance) {
+
+		final List<Subtour> subtours = new ArrayList<>();
 		Object destinationId = null;
 
 		// can be either id or coordinate
 		final List<Object> originIds = new ArrayList<>();
-		final List<Trip> trips = getTrips( planElements, isStageActivity );
 		final List<Trip> nonAllocatedTrips = new ArrayList<>( trips );
 
 		for (Trip trip : trips) {

--- a/matsim/src/test/java/org/matsim/core/replanning/choosers/BalancedInnovationStrategyChooserTest.java
+++ b/matsim/src/test/java/org/matsim/core/replanning/choosers/BalancedInnovationStrategyChooserTest.java
@@ -78,26 +78,31 @@ class BalancedInnovationStrategyChooserTest {
 		assertThat(count.getSum()).isCloseTo(3000, Offset.offset(30));
 
 		runReplanning();
-		assertThat(count.getSum()).isCloseTo(3000 * 2, Offset.offset(50));
+		assertThat(count.getSum()).isCloseTo(3000 * 2, Offset.offset(65));
 
 		runReplanning();
-		assertThat(count.getSum()).isCloseTo(3000 * 3, Offset.offset(50));
+		assertThat(count.getSum()).isCloseTo(3000 * 3, Offset.offset(65));
 
 		assertThat(count.getDifference()).isLessThanOrEqualTo(2);
 
 
-		for (int i = 0; i < 500 - 3; i++) {
+		for (int i = 0; i < 600 - 3; i++) {
 			int before = count.getSum();
 
 			runReplanning();
 
 			// Check the number of iterations per iteration
-//			assertThat(count.getSum() - before)
+			int diff = count.getSum() - before;
+
+			if (Math.abs(diff - 3000) > 500)
+				System.out.println(i + " " + diff);
+
+//			assertThat(diff)
 //				.isCloseTo(3000, Offset.offset(600));
 
 		}
 
-		assertThat(count.getSum()).isCloseTo(3000 * 500, Offset.offset(100));
+		assertThat(count.getSum()).isCloseTo(3000 * 600, Offset.offset(200));
 		assertThat(count.getDifference()).isLessThanOrEqualTo(2);
 	}
 

--- a/matsim/src/test/java/org/matsim/core/replanning/choosers/BalancedInnovationStrategyChooserTest.java
+++ b/matsim/src/test/java/org/matsim/core/replanning/choosers/BalancedInnovationStrategyChooserTest.java
@@ -75,7 +75,7 @@ class BalancedInnovationStrategyChooserTest {
 		assertThat(count.getSum()).isEqualTo(0);
 
 		runReplanning();
-		assertThat(count.getSum()).isCloseTo(3000, Offset.offset(30));
+		assertThat(count.getSum()).isCloseTo(3000, Offset.offset(65));
 
 		runReplanning();
 		assertThat(count.getSum()).isCloseTo(3000 * 2, Offset.offset(65));
@@ -85,7 +85,6 @@ class BalancedInnovationStrategyChooserTest {
 
 		assertThat(count.getDifference()).isLessThanOrEqualTo(2);
 
-
 		for (int i = 0; i < 600 - 3; i++) {
 			int before = count.getSum();
 
@@ -94,15 +93,12 @@ class BalancedInnovationStrategyChooserTest {
 			// Check the number of iterations per iteration
 			int diff = count.getSum() - before;
 
-			if (Math.abs(diff - 3000) > 500)
-				System.out.println(i + " " + diff);
-
-//			assertThat(diff)
-//				.isCloseTo(3000, Offset.offset(600));
+			assertThat(diff)
+				.isCloseTo(3000, Offset.offset(300));
 
 		}
 
-		assertThat(count.getSum()).isCloseTo(3000 * 600, Offset.offset(200));
+		assertThat(count.getSum()).isCloseTo(3000 * 600, Offset.offset(300));
 		assertThat(count.getDifference()).isLessThanOrEqualTo(2);
 	}
 

--- a/matsim/src/test/java/org/matsim/core/replanning/choosers/BalancedInnovationStrategyChooserTest.java
+++ b/matsim/src/test/java/org/matsim/core/replanning/choosers/BalancedInnovationStrategyChooserTest.java
@@ -50,7 +50,7 @@ class BalancedInnovationStrategyChooserTest {
 
 			@Override
 			public double getWeight(int i) {
-				return 0.15;
+				return i == 0 ? 0.7 : 0.15;
 			}
 
 			@Override
@@ -75,36 +75,36 @@ class BalancedInnovationStrategyChooserTest {
 		assertThat(count.getSum()).isEqualTo(0);
 
 		runReplanning();
-		assertThat(count.getSum()).isCloseTo(6666, Offset.offset(30));
+		assertThat(count.getSum()).isCloseTo(3000, Offset.offset(30));
 
 		runReplanning();
-		assertThat(count.getSum()).isCloseTo(6666 * 2, Offset.offset(1500));
+		assertThat(count.getSum()).isCloseTo(3000 * 2, Offset.offset(50));
 
 		runReplanning();
-		assertThat(count.getSum()).isCloseTo(6666 * 3, Offset.offset(1500));
+		assertThat(count.getSum()).isCloseTo(3000 * 3, Offset.offset(50));
 
 		assertThat(count.getDifference()).isLessThanOrEqualTo(2);
 
 
-		for (int i = 0; i < 500 -3; i++) {
-
+		for (int i = 0; i < 500 - 3; i++) {
 			int before = count.getSum();
 
 			runReplanning();
 
-			// TODO: expected value per iteration is quite far off
-
 			// Check the number of iterations per iteration
-			assertThat(count.getSum() - before)
-				.isCloseTo(6666, Offset.offset(3500));
+//			assertThat(count.getSum() - before)
+//				.isCloseTo(3000, Offset.offset(600));
 
 		}
 
-		assertThat(count.getSum()).isCloseTo(6666 * 500, Offset.offset(2500));
+		assertThat(count.getSum()).isCloseTo(3000 * 500, Offset.offset(100));
 		assertThat(count.getDifference()).isLessThanOrEqualTo(2);
 	}
 
 	private void runReplanning() {
+
+		chooser.beforeReplanning(null);
+
 		for (Person person : population.getPersons().values()) {
 			GenericPlanStrategy strategy = chooser.chooseStrategy(person, PopulationUtils.getSubpopulation(person), null, weights);
 			strategy.run(person);

--- a/matsim/src/test/java/org/matsim/core/replanning/choosers/BalancedInnovationStrategyChooserTest.java
+++ b/matsim/src/test/java/org/matsim/core/replanning/choosers/BalancedInnovationStrategyChooserTest.java
@@ -1,0 +1,147 @@
+package org.matsim.core.replanning.choosers;
+
+import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Plan;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.api.core.v01.replanning.PlanStrategyModule;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.population.PopulationUtils;
+import org.matsim.core.replanning.GenericPlanStrategy;
+import org.matsim.core.replanning.PlanStrategy;
+import org.matsim.core.replanning.PlanStrategyImpl;
+import org.matsim.core.replanning.ReplanningContext;
+import org.matsim.core.replanning.selectors.RandomPlanSelector;
+
+import java.util.IntSummaryStatistics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("rawtypes")
+class BalancedInnovationStrategyChooserTest {
+
+	private Population population;
+	private BalancedInnovationStrategyChooser chooser;
+	private StrategyChooser.Weights<Plan, Person> weights;
+	private InnovationCounting count;
+
+	@BeforeEach
+	void setUp() {
+
+		population = PopulationUtils.createPopulation(ConfigUtils.createConfig());
+		for (int i = 0; i < 10000; i++) {
+			Person person = population.getFactory().createPerson(Id.createPersonId(Integer.toString(i)));
+			person.addPlan(population.getFactory().createPlan());
+			population.addPerson(person);
+		}
+
+		chooser = new BalancedInnovationStrategyChooser(population);
+		count = new InnovationCounting();
+		weights = new StrategyChooser.Weights<>() {
+			@Override
+			public int size() {
+				return 3;
+			}
+
+			@Override
+			public double getWeight(int i) {
+				return 0.15;
+			}
+
+			@Override
+			public double getTotalWeights() {
+				return 3 * 0.15;
+			}
+
+			@Override
+			public PlanStrategy getStrategy(int i) {
+				return switch (i) {
+					case 0 -> new PlanStrategyImpl.Builder(new RandomPlanSelector<>()).build();
+					case 1, 2 -> new PlanStrategyImpl.Builder(new RandomPlanSelector<>()).addStrategyModule(count).build();
+					default -> throw new IllegalStateException("Unexpected value: " + i);
+				};
+			}
+		};
+	}
+
+	@Test
+	void innovationRates() {
+
+		assertThat(count.getSum()).isEqualTo(0);
+
+		runReplanning();
+		assertThat(count.getSum()).isCloseTo(6666, Offset.offset(30));
+
+		runReplanning();
+		assertThat(count.getSum()).isCloseTo(6666 * 2, Offset.offset(1500));
+
+		runReplanning();
+		assertThat(count.getSum()).isCloseTo(6666 * 3, Offset.offset(1500));
+
+		assertThat(count.getDifference()).isLessThanOrEqualTo(2);
+
+
+		for (int i = 0; i < 500 -3; i++) {
+
+			int before = count.getSum();
+
+			runReplanning();
+
+			// TODO: expected value per iteration is quite far off
+
+			// Check the number of iterations per iteration
+			assertThat(count.getSum() - before)
+				.isCloseTo(6666, Offset.offset(3500));
+
+		}
+
+		assertThat(count.getSum()).isCloseTo(6666 * 500, Offset.offset(2500));
+		assertThat(count.getDifference()).isLessThanOrEqualTo(2);
+	}
+
+	private void runReplanning() {
+		for (Person person : population.getPersons().values()) {
+			GenericPlanStrategy strategy = chooser.chooseStrategy(person, PopulationUtils.getSubpopulation(person), null, weights);
+			strategy.run(person);
+		}
+	}
+
+	private final static class InnovationCounting implements PlanStrategyModule {
+
+		private final Int2IntMap count;
+
+		private InnovationCounting() {
+			count = new Int2IntOpenHashMap();
+		}
+
+		@Override
+		public void prepareReplanning(ReplanningContext replanningContext) {
+
+		}
+
+		@Override
+		public void handlePlan(Plan plan) {
+			count.mergeInt(plan.getPerson().getId().index(), 1, Integer::sum);
+		}
+
+		@Override
+		public void finishReplanning() {
+		}
+
+		int getSum() {
+			return count.values().intStream().sum();
+		}
+
+		int getDifference() {
+			IntSummaryStatistics stats = count.values().intStream().summaryStatistics();
+			return stats.getMax() - stats.getMin();
+		}
+
+	}
+
+}

--- a/matsim/src/test/java/org/matsim/core/replanning/choosers/BalancedInnovationStrategyChooserTest.java
+++ b/matsim/src/test/java/org/matsim/core/replanning/choosers/BalancedInnovationStrategyChooserTest.java
@@ -80,13 +80,13 @@ class BalancedInnovationStrategyChooserTest {
 		assertThat(count.getSum()).isEqualTo(0);
 
 		runReplanning();
-		assertThat(count.getSum()).isCloseTo(3000, Offset.offset(65));
+		assertThat(count.getSum()).isCloseTo(3000, Offset.offset(70));
 
 		runReplanning();
-		assertThat(count.getSum()).isCloseTo(3000 * 2, Offset.offset(65));
+		assertThat(count.getSum()).isCloseTo(3000 * 2, Offset.offset(70));
 
 		runReplanning();
-		assertThat(count.getSum()).isCloseTo(3000 * 3, Offset.offset(65));
+		assertThat(count.getSum()).isCloseTo(3000 * 3, Offset.offset(140));
 
 		assertThat(count.getDifference()).isLessThanOrEqualTo(2);
 
@@ -95,7 +95,7 @@ class BalancedInnovationStrategyChooserTest {
 
 			runReplanning();
 
-			// Check the number of iterations per iteration
+			// Check the number of innovations per iteration
 			int diff = count.getSum() - before;
 
 			assertThat(diff)


### PR DESCRIPTION
Several cleanups and improvements in the informed-mode-choice contrib:

- Reduced memory usage, estimation should now also work for plans with 25+ trips
- Add new `BalancedInnovationStrategyChooser`, which ensures no agent executes innovative strategies more than n+2 times than any other agent
- Add config option to disable normalization of utility estimates
- Results of `SelectSubtourModeStrategy` are now consistent with `RandomSubtourModeStrategy` under equivalent configuration.