### PR TITLE
Drt: streamline constraints and separate soft vs hard constraint handling

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/edrt/run/EDrtModeOptimizerQSimModule.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/edrt/run/EDrtModeOptimizerQSimModule.java
@@ -181,8 +181,7 @@ public class EDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 								getter.getModal(StopTimeCalculator.class), scheduleWaitBeforeDrive)))
 				.asEagerSingleton();
 
-		bindModal(DefaultOfferAcceptor.class).toProvider(modalProvider(getter -> new DefaultOfferAcceptor(
-				defaultConstraintsSet.maxAllowedPickupDelay)));
+		bindModal(DefaultOfferAcceptor.class).toProvider(modalProvider(getter -> new DefaultOfferAcceptor()));
 		bindModal(DrtOfferAcceptor.class).to(modalKey(DefaultOfferAcceptor.class));
 
 		bindModal(ScheduleTimingUpdater.class).toProvider(modalProvider(

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtModeOptimizerQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtModeOptimizerQSimModule.java
@@ -147,8 +147,7 @@ public class DrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 								getter.getModal(StopTimeCalculator.class), scheduleWaitBeforeDrive)))
 				.asEagerSingleton();
 
-		bindModal(DefaultOfferAcceptor.class).toProvider(modalProvider(getter -> new DefaultOfferAcceptor(
-				defaultOptimizationConstraintsSet.maxAllowedPickupDelay)));
+		bindModal(DefaultOfferAcceptor.class).toProvider(modalProvider(getter -> new DefaultOfferAcceptor()));
 		bindModal(DrtOfferAcceptor.class).to(modalKey(DefaultOfferAcceptor.class));
 
 		bindModal(ScheduleTimingUpdater.class).toProvider(modalProvider(

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/constraints/DrtRouteConstraints.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/constraints/DrtRouteConstraints.java
@@ -1,3 +1,22 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2024 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
 package org.matsim.contrib.drt.optimizer.constraints;
 
 /**
@@ -6,7 +25,17 @@ package org.matsim.contrib.drt.optimizer.constraints;
 public record DrtRouteConstraints( //
 		double maxTravelTime, //
 		double maxRideTime, //
-		double maxWaitTime//
+		double maxWaitTime, //
+		double maxPickupDelay, //
+        double lateDiversionThreshold
 ) {
 
+	public final static DrtRouteConstraints UNDEFINED =
+			new DrtRouteConstraints(
+					Double.POSITIVE_INFINITY,
+					Double.POSITIVE_INFINITY,
+					Double.POSITIVE_INFINITY,
+					Double.POSITIVE_INFINITY,
+					0
+			);
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategy.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategy.java
@@ -20,6 +20,8 @@
 
 package org.matsim.contrib.drt.optimizer.insertion;
 
+import org.matsim.contrib.drt.optimizer.VehicleEntry;
+import org.matsim.contrib.drt.optimizer.Waypoint;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionDetourTimeCalculator.DetourTimeInfo;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 
@@ -46,6 +48,31 @@ public interface CostCalculationStrategy {
 				return InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
 			}
 
+			// check if the max riding time constraints is violated (with default config, the max ride duration
+			// is infinity)
+			double rideDuration = detourTimeInfo.dropoffDetourInfo.arrivalTime - detourTimeInfo.pickupDetourInfo.departureTime;
+			if (rideDuration > request.getMaxRideDuration()) {
+				return InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
+			}
+
+			if(insertion != null) {
+
+				// in case of prebooking, we may have intermediate stay times after pickup
+				// insertion that may reduce the effective pickup delay that remains that the
+				// dropoff insertion point
+				double effectiveDropoffTimeLoss = InsertionDetourTimeCalculator.calculateRemainingPickupTimeLossAtDropoff(
+						insertion, detourTimeInfo.pickupDetourInfo) + detourTimeInfo.dropoffDetourInfo.dropoffTimeLoss;
+
+				double lateDiversionThreshold = request.getLateDiversionThreshold();
+				if (lateDiversionThreshold > 0) {
+					if (insertion.vehicleEntry.stops != null && !insertion.vehicleEntry.stops.isEmpty()) {
+						if (lateDiversionViolation(insertion, detourTimeInfo, insertion.vehicleEntry, effectiveDropoffTimeLoss, lateDiversionThreshold) > 0) {
+							return InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
+						}
+					}
+				}
+			}
+
 			return totalTimeLoss;
 		}
 	}
@@ -55,6 +82,8 @@ public interface CostCalculationStrategy {
 		//XXX however, at the same time prefer max-wait-time to max-travel-time violations
 		static final double MAX_WAIT_TIME_VIOLATION_PENALTY = 1;// 1 second of penalty per 1 second of late departure
 		static final double MAX_TRAVEL_TIME_VIOLATION_PENALTY = 10;// 10 seconds of penalty per 1 second of late arrival
+		static final double MAX_RIDE_TIME_VIOLATION_PENALTY = 10;// 10 seconds of penalty per 1 second of exceeded detour
+		static final double LATE_DIVERSION_VIOLATION_PENALTY = 10;// 1 second of penalty per 1 second of late diversion of onboard requests
 
 		@Override
 		public double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion,
@@ -69,9 +98,50 @@ public interface CostCalculationStrategy {
 			double travelTimeViolation = Math.max(0, detourTimeInfo.dropoffDetourInfo.arrivalTime - request.getLatestArrivalTime());
 			// (if drt vehicle drops off too late) (submission time + alpha * directTravelTime + beta)
 
-			return MAX_WAIT_TIME_VIOLATION_PENALTY * waitTimeViolation
+			double detourViolation = Math.max(0, (detourTimeInfo.dropoffDetourInfo.arrivalTime - detourTimeInfo.pickupDetourInfo.departureTime) - request.getMaxRideDuration());
+
+			double lateDiversionViolation = 0;
+			if(insertion != null) {
+				// in case of prebooking, we may have intermediate stay times after pickup
+				// insertion that may reduce the effective pickup delay that remains that the
+				// dropoff insertion point
+				double effectiveDropoffTimeLoss = InsertionDetourTimeCalculator.calculateRemainingPickupTimeLossAtDropoff(
+						insertion, detourTimeInfo.pickupDetourInfo) + detourTimeInfo.dropoffDetourInfo.dropoffTimeLoss;
+
+                lateDiversionViolation = lateDiversionViolation(insertion, detourTimeInfo, insertion.vehicleEntry, effectiveDropoffTimeLoss, request.getLateDiversionThreshold());
+            }
+
+            return MAX_WAIT_TIME_VIOLATION_PENALTY * waitTimeViolation
 					+ MAX_TRAVEL_TIME_VIOLATION_PENALTY * travelTimeViolation
+					+ MAX_RIDE_TIME_VIOLATION_PENALTY * detourViolation
+					+ MAX_RIDE_TIME_VIOLATION_PENALTY * lateDiversionViolation
 					+ totalTimeLoss;
 		}
+	}
+
+    private static double lateDiversionViolation(InsertionGenerator.Insertion insertion, DetourTimeInfo detourTimeInfo,
+                                                 VehicleEntry vEntry, double effectiveDropoffTimeLoss, double lateDiversionThreshold) {
+        double violation = 0;
+        if (detourTimeInfo.pickupDetourInfo.pickupTimeLoss > 0) {
+            violation += lateDiversionViolationBetweenStopIndices(vEntry, insertion.pickup.index, insertion.dropoff.index, lateDiversionThreshold);
+        }
+        if (effectiveDropoffTimeLoss > 0) {
+            violation += lateDiversionViolationBetweenStopIndices(vEntry, insertion.dropoff.index, vEntry.stops.size(), lateDiversionThreshold);
+        }
+        return violation;
+    }
+
+	private static double lateDiversionViolationBetweenStopIndices(VehicleEntry vehicleEntry, int start, int end, double lateDiversionThreshold) {
+		double violation = 0;
+		for (int s = start; s < end; s++) {
+			Waypoint.Stop stop = vehicleEntry.stops.get(s);
+			if (!stop.task.getDropoffRequests().isEmpty()) {
+				double remainingRideDuration = stop.getArrivalTime() - vehicleEntry.start.getDepartureTime();
+				if (remainingRideDuration < lateDiversionThreshold) {
+					violation += lateDiversionThreshold - remainingRideDuration;
+				}
+			}
+		}
+		return violation;
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DefaultOfferAcceptor.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DefaultOfferAcceptor.java
@@ -1,29 +1,32 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2021 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
 package org.matsim.contrib.drt.passenger;
 
 import java.util.Optional;
 
 public class DefaultOfferAcceptor implements DrtOfferAcceptor{
-	private final double maxAllowedPickupDelay;
-
-	/**
-	 * Generate Default offer acceptor with max allowed pickup delay.
-	 * @param maxAllowedPickupDelay: maximum allowed delay since the initially assigned pickup time.
-	 */
-	public DefaultOfferAcceptor(double maxAllowedPickupDelay) {
-		this.maxAllowedPickupDelay = maxAllowedPickupDelay;
-	}
-
-	/**
-	 * Generate Default offer acceptor. 
-	 */
-	public DefaultOfferAcceptor() {
-		this.maxAllowedPickupDelay = Double.POSITIVE_INFINITY;
-	}
 
 	@Override
 	public Optional<AcceptedDrtRequest> acceptDrtOffer(DrtRequest request, double departureTime, double arrivalTime) {
 		double updatedLatestStartTime = Math.min(departureTime
-			+ maxAllowedPickupDelay, request.getLatestStartTime());
+			+ request.getMaxPickupDelay(), request.getLatestStartTime());
 		return Optional.of(AcceptedDrtRequest
 			.newBuilder()
 			.request(request)

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DrtRequest.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DrtRequest.java
@@ -40,6 +40,8 @@ public class DrtRequest implements PassengerRequest {
 	private final double latestStartTime;
 	private final double latestArrivalTime;
 	private final double maxRideDuration;
+	private final double maxPickupDelay;
+	private final double lateDiversionThreshold;
 
 	private final List<Id<Person>> passengerIds = new ArrayList<>();
 	private final String mode;
@@ -58,6 +60,8 @@ public class DrtRequest implements PassengerRequest {
 		mode = builder.mode;
 		fromLink = builder.fromLink;
 		toLink = builder.toLink;
+		maxPickupDelay = builder.maxPickupDelay;
+		lateDiversionThreshold = builder.lateDiversionThreshold;
 	}
 
 	public static Builder newBuilder() {
@@ -76,6 +80,8 @@ public class DrtRequest implements PassengerRequest {
 		builder.mode = copy.getMode();
 		builder.fromLink = copy.getFromLink();
 		builder.toLink = copy.getToLink();
+		builder.maxPickupDelay = copy.getMaxPickupDelay();
+		builder.lateDiversionThreshold = copy.getLateDiversionThreshold();
 		return builder;
 	}
 
@@ -106,6 +112,10 @@ public class DrtRequest implements PassengerRequest {
 	public double getMaxRideDuration() {
 		return maxRideDuration;
 	}
+
+	public double getMaxPickupDelay() {return maxPickupDelay;}
+
+	public double getLateDiversionThreshold() {return lateDiversionThreshold;}
 
 	@Override
 	public Link getFromLink() {
@@ -155,6 +165,8 @@ public class DrtRequest implements PassengerRequest {
 		private double latestStartTime;
 		private double latestArrivalTime;
 		private double maxRideDuration;
+		private double maxPickupDelay;
+		private double lateDiversionThreshold;
 		private List<Id<Person>> passengerIds = new ArrayList<>();
 		private String mode;
 		private Link fromLink;
@@ -190,6 +202,16 @@ public class DrtRequest implements PassengerRequest {
 
 		public Builder maxRideDuration(double maxRideDuration) {
 			this.maxRideDuration = maxRideDuration;
+			return this;
+		}
+
+		public Builder maxPickupDelay(double maxPickupDelay) {
+			this.maxPickupDelay = maxPickupDelay;
+			return this;
+		}
+
+		public Builder lateDiversionThreshold(double lateDiversionThreshold) {
+			this.lateDiversionThreshold = lateDiversionThreshold;
 			return this;
 		}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DefaultDrtRouteConstraintsCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DefaultDrtRouteConstraintsCalculator.java
@@ -46,8 +46,7 @@ public class DefaultDrtRouteConstraintsCalculator implements DrtRouteConstraints
 			double maxDetour = Math.max(defaultSet.minimumAllowedDetour, unsharedRideTime * (defaultSet.maxDetourAlpha -1) + defaultSet.maxDetourBeta);
 			double maxRideTime = unsharedRideTime + Math.min(defaultSet.maxAbsoluteDetour, maxDetour);
 			double maxWaitTime = constraintsSet.maxWaitTime;
-
-			return new DrtRouteConstraints(maxTravelTime, maxRideTime, maxWaitTime);
+			return new DrtRouteConstraints(maxTravelTime, maxRideTime, maxWaitTime, constraintsSet.maxAllowedPickupDelay, constraintsSet.lateDiversionthreshold);
 		} else {
 			throw new IllegalArgumentException("Constraint set is not a default set");
 		}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRoute.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRoute.java
@@ -17,10 +17,14 @@
  * *********************************************************************** */
 package org.matsim.contrib.drt.routing;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.MoreObjects;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Link;
+import org.matsim.contrib.drt.optimizer.constraints.DrtRouteConstraints;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.core.population.routes.AbstractRoute;
 import org.matsim.core.utils.misc.OptionalTime;
@@ -29,10 +33,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -60,10 +60,6 @@ public class DrtRoute extends AbstractRoute {
 		return routeDescription.getDirectRideTime();
 	}
 
-	public double getMaxWaitTime() {
-		return routeDescription.getMaxWaitTime();
-	}
-
 	public List<String> getUnsharedPath() {
 		return routeDescription.getUnsharedPath();
 	}
@@ -72,16 +68,12 @@ public class DrtRoute extends AbstractRoute {
 		return getTravelTime().seconds(); // currently DrtRoute.travelTime is set to the max allowed travel time
 	}
 
-	public double getMaxRideTime() {
-		return routeDescription.getMaxRideTime();
+	public DrtRouteConstraints getConstraints() {
+		return routeDescription.getConstraints();
 	}
 
 	public void setDirectRideTime(double directRideTime) {
 		this.routeDescription.setDirectRideTime(directRideTime);
-	}
-
-	public void setMaxWaitTime(double maxWaitTime) {
-		this.routeDescription.setMaxWaitTime(maxWaitTime);
 	}
 
 	public void setUnsharedPath(VrpPathWithTravelData unsharedPath) {
@@ -90,10 +82,11 @@ public class DrtRoute extends AbstractRoute {
 		this.routeDescription.setUnsharedPath(links);
 	}
 
-	public void setMaxRideTime(double maxRideTime) {
-		this.routeDescription.setMaxRideTime(maxRideTime);
+	public void setConstraints(DrtRouteConstraints constraints) {
+		//TODO: consolidate constraints / route description
+		this.routeDescription.setConstraints(constraints);
+		super.setTravelTime(constraints.maxTravelTime());
 	}
-
 
 	@Override
 	public String getRouteDescription() {
@@ -112,9 +105,10 @@ public class DrtRoute extends AbstractRoute {
 		// Handle old routeDescription (non-json)
 		if (pat.matcher(routeDescription).find()) {
 			String[] values = routeDescription.split(" ");
-			this.routeDescription.setMaxWaitTime(requiresZeroOrPositive(Double.parseDouble(values[0])));
+			double maxWaitTime = requiresZeroOrPositive(Double.parseDouble(values[0]));
 			this.routeDescription.setDirectRideTime(requiresZeroOrPositive(Double.parseDouble(values[1])));
-
+			DrtRouteConstraints constraints = new DrtRouteConstraints(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, maxWaitTime, Double.POSITIVE_INFINITY, 0);
+			this.routeDescription.setConstraints(constraints);
 			// Handle new routeDescription (json)
 		} else if (routeDescription.startsWith("{")) {
 			try {
@@ -146,7 +140,7 @@ public class DrtRoute extends AbstractRoute {
 	@Override
 	public String toString() {
 		return MoreObjects.toStringHelper(this)
-				.add("maxWaitTime", routeDescription.getMaxWaitTime())
+				.add("maxWaitTime", routeDescription.constraints.maxWaitTime())
 				.add("directRideTime", routeDescription.getDirectRideTime())
 				.add("super", super.toString())
 				.toString();
@@ -154,24 +148,19 @@ public class DrtRoute extends AbstractRoute {
 
 
 	public static class RouteDescription {
-		private OptionalTime maxWaitTime = OptionalTime.undefined();
 		private OptionalTime directRideTime = OptionalTime.undefined();
 		private List<String> unsharedPath = new ArrayList<String>();
-		private OptionalTime maxRideTime = OptionalTime.undefined();
+
+		private DrtRouteConstraints constraints = DrtRouteConstraints.UNDEFINED;
 
 		@JsonProperty("directRideTime")
 		public double getDirectRideTime() {
 			return directRideTime.isUndefined() ? OptionalTime.undefined().seconds() : directRideTime.seconds();
 		}
 
-		@JsonProperty("maxRideTime")
-		public double getMaxRideTime() {
-			return maxRideTime.seconds();
-		}
-
-		@JsonProperty("maxWaitTime")
-		public double getMaxWaitTime() {
-			return maxWaitTime.isUndefined() ? OptionalTime.undefined().seconds() : maxWaitTime.seconds();
+		@JsonProperty("constraints")
+		public DrtRouteConstraints getConstraints() {
+			return constraints;
 		}
 
 		@JsonProperty("unsharedPath")
@@ -183,12 +172,8 @@ public class DrtRoute extends AbstractRoute {
 			this.directRideTime = OptionalTime.defined(directRideTime);
 		}
 
-		public void setMaxRideTime(double maxRideTime) {
-			this.maxRideTime = OptionalTime.defined(maxRideTime);
-		}
-
-		public void setMaxWaitTime(double maxWaitTime) {
-			this.maxWaitTime = OptionalTime.defined(maxWaitTime);
+		public void setConstraints(DrtRouteConstraints constraints) {
+			this.constraints = constraints;
 		}
 
 		public void setUnsharedPath(List<String> unsharedPath) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRouteCreator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRouteCreator.java
@@ -3,7 +3,7 @@
  *                                                                         *
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2016 by the members listed in the COPYING,        *
+ * copyright       : (C) 2024 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -61,8 +61,6 @@ public class DrtRouteCreator implements DefaultMainLegRouter.RouteCreator {
 				travelDisutilityFactory.createTravelDisutility(travelTime), travelTime);
 	}
 
-
-
 	public Route createRoute(double departureTime, Link accessActLink, Link egressActLink, Person person,
 			Attributes tripAttributes, RouteFactories routeFactories) {
 		VrpPathWithTravelData unsharedPath = VrpPaths.calcAndCreatePath(accessActLink, egressActLink, departureTime,
@@ -75,10 +73,8 @@ public class DrtRouteCreator implements DefaultMainLegRouter.RouteCreator {
 
 		DrtRoute route = routeFactories.createRoute(DrtRoute.class, accessActLink.getId(), egressActLink.getId());
 		route.setDistance(unsharedDistance);
-		route.setTravelTime(constraints.maxTravelTime());
-		route.setMaxRideTime(constraints.maxRideTime());
 		route.setDirectRideTime(unsharedRideTime);
-		route.setMaxWaitTime(constraints.maxWaitTime());
+		route.setConstraints(constraints);
 
 		if (this.drtCfg.storeUnsharedPath) {
 			route.setUnsharedPath(unsharedPath);

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategyTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategyTest.java
@@ -59,6 +59,7 @@ public class CostCalculationStrategyTest {
 		var drtRequest = DrtRequest.newBuilder()
 				.latestStartTime(latestStartTime)
 				.latestArrivalTime(latestArrivalTime)
+				.maxRideDuration(Double.POSITIVE_INFINITY)
 				.build();
 		assertThat(new CostCalculationStrategy.RejectSoftConstraintViolations().calcCost(drtRequest, null,
 				detourTimeInfo)).isEqualTo(expectedCost);
@@ -89,6 +90,7 @@ public class CostCalculationStrategyTest {
 		var drtRequest = DrtRequest.newBuilder()
 				.latestStartTime(latestStartTime)
 				.latestArrivalTime(latestArrivalTime)
+				.maxRideDuration(Double.POSITIVE_INFINITY)
 				.build();
 		assertThat(new CostCalculationStrategy.DiscourageSoftConstraintViolations().calcCost(drtRequest, null,
 				detourTimeInfo)).isEqualTo(expectedCost);

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
@@ -94,19 +94,21 @@ public class InsertionCostCalculatorTest {
 		VehicleEntry entry = entry(new double[] {60, 60, 300}, ImmutableList.copyOf(stops), start);
 		var insertion = insertion(entry, 0, 1);
 
-		DrtRequest drtRequest = DrtRequest.newBuilder()
+		DrtRequest.Builder builder = DrtRequest.newBuilder();
+
+		DrtRequest drtRequest = builder
 				.fromLink(fromLink)
 				.toLink(toLink)
 				.latestStartTime(120)
 				.latestArrivalTime(300)
 				.maxRideDuration(Double.MAX_VALUE)
+				.lateDiversionThreshold(180)
 				.build();
 
 		DrtConfigGroup drtConfigGroup = new DrtConfigGroup();
 		DrtOptimizationConstraintsSet drtOptimizationConstraintsSet = drtConfigGroup.addOrGetDrtOptimizationConstraintsParams().addOrGetDefaultDrtOptimizationConstraintsSet();
 
 		// new insertion before dropoff of boarded passenger within threshold - infeasible solution
-		drtOptimizationConstraintsSet.lateDiversionthreshold = 180;
 		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 30), new DropoffDetourInfo(300, 30)),
 				INFEASIBLE_SOLUTION_COST, drtRequest, drtOptimizationConstraintsSet);
 
@@ -114,10 +116,18 @@ public class InsertionCostCalculatorTest {
 		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(120, 0), new DropoffDetourInfo(300, 30)),
 				30, drtRequest, drtOptimizationConstraintsSet);
 
+		DrtRequest drtRequest2 = builder
+				.fromLink(fromLink)
+				.toLink(toLink)
+				.latestStartTime(120)
+				.latestArrivalTime(300)
+				.maxRideDuration(Double.MAX_VALUE)
+				.lateDiversionThreshold(120)
+				.build();
+
 		// new insertion before dropoff of boarded passenger, but outside of threshold - feasible solution
-		drtOptimizationConstraintsSet.lateDiversionthreshold = 120;
 		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 30), new DropoffDetourInfo(300, 30)),
-				60, drtRequest, drtOptimizationConstraintsSet);
+				60, drtRequest2, drtOptimizationConstraintsSet);
 
 
 		// new insertion after dropoff of boarded passenger - feasible solution
@@ -152,26 +162,35 @@ public class InsertionCostCalculatorTest {
 
 		var insertion = insertion(entry, 0, 2);
 
-		DrtRequest drtRequest = DrtRequest.newBuilder()
+		DrtRequest.Builder builder = DrtRequest.newBuilder();
+		DrtRequest drtRequest = builder
 				.fromLink(fromLink)
 				.toLink(toLink)
 				.latestStartTime(120)
 				.latestArrivalTime(300)
 				.maxRideDuration(Double.MAX_VALUE)
+				.lateDiversionThreshold(300)
 				.build();
 
 		DrtConfigGroup drtConfigGroup = new DrtConfigGroup();
 
 		// new insertion before dropoff of boarded passenger within threshold - infeasible solution
 		DrtOptimizationConstraintsSet constraintsSet = drtConfigGroup.addOrGetDrtOptimizationConstraintsParams().addOrGetDefaultDrtOptimizationConstraintsSet();
-		constraintsSet.lateDiversionthreshold = 300;
 		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 60), new DropoffDetourInfo(300, 60)),
 				INFEASIBLE_SOLUTION_COST, drtRequest, constraintsSet);
 
+		DrtRequest drtRequest2 = builder
+				.fromLink(fromLink)
+				.toLink(toLink)
+				.latestStartTime(120)
+				.latestArrivalTime(300)
+				.maxRideDuration(Double.MAX_VALUE)
+				.lateDiversionThreshold(200)
+				.build();
+
 		// new insertion before dropoff of boarded passenger outside of threshold - feasible solution
-		constraintsSet.lateDiversionthreshold = 200;
 		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 60), new DropoffDetourInfo(300, 60)),
-				120, drtRequest, constraintsSet);
+				120, drtRequest2, constraintsSet);
 	}
 
 	private void assertCalculate(Insertion insertion, DetourTimeInfo detourTimeInfo, double expectedCost, DrtRequest drtRequest, DrtOptimizationConstraintsSet constraintsSet) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/DrtRoutingModuleTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/DrtRoutingModuleTest.java
@@ -230,7 +230,14 @@ public class DrtRoutingModuleTest {
 	@Test
 	void testRouteDescriptionHandling() {
 		String oldRouteFormat = "600 400";
-		String newRouteFormat = "{\"maxWaitTime\":600.0,\"directRideTime\":400.0,\"unsharedPath\":[\"a\",\"b\",\"c\"]}";
+		String newRouteFormat = "{\"directRideTime\":400.0,\"unsharedPath\":[\"a\",\"b\",\"c\"]," +
+				"\"constraints\":{" +
+				"\"maxTravelTime\":\"Infinity\"," +
+				"\"maxRideTime\":\"Infinity\"," +
+				"\"maxWaitTime\":600.0," +
+				"\"maxPickupDelay\":\"Infinity\"," +
+				"\"lateDiversionThreshold\":0.0" +
+				"}}";
 
 		Scenario scenario = createTestScenario();
 		ActivityFacilities facilities = scenario.getActivityFacilities();
@@ -245,11 +252,11 @@ public class DrtRoutingModuleTest {
 		DrtRoute drtRoute = new DrtRoute(h.getLinkId(), w.getLinkId());
 
 		drtRoute.setRouteDescription(oldRouteFormat);
-		Assertions.assertTrue(drtRoute.getMaxWaitTime() == 600.);
+		Assertions.assertTrue(drtRoute.getConstraints().maxWaitTime() == 600.);
 		Assertions.assertTrue(drtRoute.getDirectRideTime() == 400);
 
 		drtRoute.setRouteDescription(newRouteFormat);
-		Assertions.assertTrue(drtRoute.getMaxWaitTime() == 600.);
+		Assertions.assertTrue(drtRoute.getConstraints().maxWaitTime() == 600.);
 		Assertions.assertTrue(drtRoute.getDirectRideTime() == 400);
 		Assertions.assertTrue(drtRoute.getUnsharedPath().equals(Arrays.asList("a", "b", "c")));
 


### PR DESCRIPTION
- streamlined constraints
-- extended DrtRouteConstraints to include the late diversion and pickup delay constraints, which can now be set per request
-- re-use the immutable constraints object in the DrtRoute class to avoid unneccessary duplication
-- updated the handling of route description json-ification (@steffenaxer ?) to have a nested constraints representation. not sure how stable that is for future udpates
-- we could think about further re-using the constraints object in the drt request object itself
- separated the max ride duration, late pickup and diversion threshold constraints in the handling of the cost calculation. until now these three constraints will always lead to rejection even if rejection for soft constraints is turned off

