### PR TITLE
Support GeoPackage via URL

### DIFF
--- a/matsim/src/main/java/org/matsim/core/utils/gis/GeoFileReader.java
+++ b/matsim/src/main/java/org/matsim/core/utils/gis/GeoFileReader.java
@@ -20,6 +20,7 @@
 
 package org.matsim.core.utils.gis;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.geotools.api.data.*;
@@ -38,7 +39,11 @@ import org.matsim.core.utils.misc.Counter;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.*;
 
 /**
@@ -98,10 +103,46 @@ public class GeoFileReader implements MatsimSomeReader {
 	public static Collection<SimpleFeature> getAllFeatures(final URL url) {
 		try {
 			log.info( "will try to read from " + url.getPath() ) ;
+			if (url.getFile().endsWith(".gpkg")) {
+				return getAllFeaturesGPKG(url);
+			}
 			return getSimpleFeatures(FileDataStoreFinder.getDataStore(url));
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);
+		} catch (URISyntaxException e) {
+			throw new IllegalArgumentException(e);
 		}
+	}
+
+	/**
+	 * Loads geo package like normal shape files using the first layer found in the file.
+	 */
+	private static Collection<SimpleFeature> getAllFeaturesGPKG(final URL url) throws URISyntaxException, IOException {
+
+		File file;
+		// Remote files have to be downloaded
+		if (url.getProtocol().startsWith("http")) {
+
+			String name = FilenameUtils.getBaseName(url.getFile());
+
+			Path tmp = Files.createTempFile(name, ".gpkg");
+			Files.copy(url.openStream(), tmp, StandardCopyOption.REPLACE_EXISTING);
+
+			file = tmp.toFile();
+			file.deleteOnExit();
+		} else
+		 	file = new File(url.toURI());
+
+		Map<String, Object> params = new HashMap<>();
+		params.put(GeoPkgDataStoreFactory.DBTYPE.key, "geopkg");
+		params.put(GeoPkgDataStoreFactory.DATABASE.key, file.toString());
+		params.put(GeoPkgDataStoreFactory.READ_ONLY.key, true);
+		DataStore dataStore = DataStoreFinder.getDataStore(params);
+
+		String[] typeNames = dataStore.getTypeNames();
+
+		// Use first layer
+		return getSimpleFeatures(dataStore, typeNames[0]);
 	}
 
 	/**
@@ -194,7 +235,7 @@ public class GeoFileReader implements MatsimSomeReader {
 		 * <p></p>
 		 * Then, get the features by
 		 * <p></p>
-		 * <pre> Set<{@link Feature}> features = geoFileReader.getFeatureSet(); </pre>
+		 * <pre> Set<{@link org.geotools.api.feature.Feature}> features = geoFileReader.getFeatureSet(); </pre>
 		 * <p></p>
 		 * If you need metadata you can use
 		 * <p></p>

--- a/matsim/src/main/java/org/matsim/core/utils/gis/GeoFileReader.java
+++ b/matsim/src/main/java/org/matsim/core/utils/gis/GeoFileReader.java
@@ -31,7 +31,6 @@ import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.geopkg.GeoPkgDataStoreFactory;
-import org.geotools.jdbc.JDBCDataStore;
 import org.matsim.core.api.internal.MatsimSomeReader;
 import org.matsim.core.gbl.Gbl;
 import org.matsim.core.utils.misc.Counter;
@@ -83,7 +82,7 @@ public class GeoFileReader implements MatsimSomeReader {
 				Map<String, Object> params = new HashMap<>();
 				params.put(GeoPkgDataStoreFactory.DBTYPE.key, "geopkg");
 				params.put(GeoPkgDataStoreFactory.DATABASE.key, filename);
-				params.put("read-only", true);
+				params.put(GeoPkgDataStoreFactory.READ_ONLY.key, true);
 				DataStore dataStore = DataStoreFinder.getDataStore(params);
 				return getSimpleFeatures(dataStore, layerName);
 			} else {
@@ -235,7 +234,7 @@ public class GeoFileReader implements MatsimSomeReader {
 				Map<String, Object> params = new HashMap<>();
 				params.put(GeoPkgDataStoreFactory.DBTYPE.key, "geopkg");
 				params.put(GeoPkgDataStoreFactory.DATABASE.key, filename);
-				params.put("read-only", true);
+				params.put(GeoPkgDataStoreFactory.READ_ONLY.key, true);
 
 				DataStore datastore = DataStoreFinder.getDataStore(params);
 				featureSource = datastore.getFeatureSource(layerName);


### PR DESCRIPTION
Adds support for using GeoPackage via URLs in `ShpOption` as well as `GeoFileReader`. 

URLs are not natively supported, and the content will be saved to a temporary file instead.