### PR TITLE
Freight (carrier): renamings in CarrierService/CarrierShipment

### DIFF
--- a/contribs/application/src/main/java/org/matsim/freightDemandGeneration/DemandReaderFromCSV.java
+++ b/contribs/application/src/main/java/org/matsim/freightDemandGeneration/DemandReaderFromCSV.java
@@ -1238,7 +1238,7 @@ public final class DemandReaderFromCSV {
 								CarrierService thisService = thisCarrier.getServices().get(thisServiceId);
 								if (baseService.getId() != thisService.getId()
 									&& baseService.getServiceLinkId() == thisService.getServiceLinkId() && baseService
-									.getServiceStartTimeWindow() == thisService.getServiceStartTimeWindow())
+									.getServiceStaringTimeWindow() == thisService.getServiceStaringTimeWindow())
 									servicesToConnect.put(thisServiceId, thisService);
 							}
 						}
@@ -1253,7 +1253,7 @@ public final class DemandReaderFromCSV {
 						CarrierService.Builder builder = CarrierService.Builder
 							.newInstance(idNewService, baseService.getServiceLinkId())
 							.setServiceDuration(serviceTimeService);
-						CarrierService newService = builder.setServiceStartingTimeWindow(baseService.getServiceStartTimeWindow())
+						CarrierService newService = builder.setServiceStartingTimeWindow(baseService.getServiceStaringTimeWindow())
 							.setCapacityDemand(demandForThisLink).build();
 						servicesToAdd.add(newService);
 					}

--- a/contribs/application/src/main/java/org/matsim/freightDemandGeneration/DemandReaderFromCSV.java
+++ b/contribs/application/src/main/java/org/matsim/freightDemandGeneration/DemandReaderFromCSV.java
@@ -1051,8 +1051,8 @@ public final class DemandReaderFromCSV {
 
 			CarrierShipment thisShipment = CarrierShipment.Builder
 				.newInstance(idNewShipment, linkPickup.getId(), linkDelivery.getId(), singleDemandForThisLink)
-				.setPickupDuration(serviceTimePickup).setPickupStartsTimeWindow(timeWindowPickup)
-				.setDeliveryDuration(serviceTimeDelivery).setDeliveryStartsTimeWindow(timeWindowDelivery)
+				.setPickupDuration(serviceTimePickup).setPickupStartingTimeWindow(timeWindowPickup)
+				.setDeliveryDuration(serviceTimeDelivery).setDeliveryStartingTimeWindow(timeWindowDelivery)
 				.build();
 			thisCarrier.getShipments().put(thisShipment.getId(), thisShipment);
 			if (demandForThisLink == 0)
@@ -1190,8 +1190,8 @@ public final class DemandReaderFromCSV {
 								if (baseShipment.getId() != thisShipment.getId()
 									&& baseShipment.getPickupLinkId() == thisShipment.getPickupLinkId()
 									&& baseShipment.getDeliveryLinkId() == thisShipment.getDeliveryLinkId()) {
-									if (baseShipment.getPickupStartsTimeWindow() == thisShipment.getPickupStartsTimeWindow()) {
-									if (baseShipment.getDeliveryStartsTimeWindow() == thisShipment.getDeliveryStartsTimeWindow()) shipmentsToConnect.put(thisShipmentId, thisShipment);
+									if (baseShipment.getPickupStartingTimeWindow() == thisShipment.getPickupStartingTimeWindow()) {
+									if (baseShipment.getDeliveryStartingTimeWindow() == thisShipment.getDeliveryStartingTimeWindow()) shipmentsToConnect.put(thisShipmentId, thisShipment);
 								}
 								}
 							}
@@ -1209,9 +1209,9 @@ public final class DemandReaderFromCSV {
 						CarrierShipment newShipment = CarrierShipment.Builder
 							.newInstance(idNewShipment, baseShipment.getPickupLinkId(), baseShipment.getDeliveryLinkId(), demandForThisLink)
 							.setPickupDuration(serviceTimePickup)
-							.setPickupStartsTimeWindow(baseShipment.getPickupStartsTimeWindow())
+							.setPickupStartingTimeWindow(baseShipment.getPickupStartingTimeWindow())
 							.setDeliveryDuration(serviceTimeDelivery)
-							.setDeliveryStartsTimeWindow(baseShipment.getDeliveryStartsTimeWindow()).build();
+							.setDeliveryStartingTimeWindow(baseShipment.getDeliveryStartingTimeWindow()).build();
 						shipmentsToAdd.add(newShipment);
 					}
 				}

--- a/contribs/application/src/main/java/org/matsim/freightDemandGeneration/DemandReaderFromCSV.java
+++ b/contribs/application/src/main/java/org/matsim/freightDemandGeneration/DemandReaderFromCSV.java
@@ -654,9 +654,9 @@ public final class DemandReaderFromCSV {
 					Id<CarrierService> idNewService = Id.create(
 							createJobId(scenario, newDemandInformationElement, link.getId(), null),
 							CarrierService.class);
-					CarrierService thisService = CarrierService.Builder.newInstance(idNewService, link.getId())
-							.setCapacityDemand(demandForThisLink).setServiceDuration(serviceTime)
-							.setServiceStartTimeWindow(newDemandInformationElement.getFirstJobElementTimeWindow())
+					CarrierService.Builder builder = CarrierService.Builder.newInstance(idNewService, link.getId())
+							.setCapacityDemand(demandForThisLink).setServiceDuration(serviceTime);
+					CarrierService thisService = builder.setServiceStartingTimeWindow(newDemandInformationElement.getFirstJobElementTimeWindow())
 							.build();
 					CarriersUtils.getCarriers(scenario).getCarriers()
 							.get(Id.create(newDemandInformationElement.getCarrierName(), Carrier.class)).getServices()
@@ -695,9 +695,9 @@ public final class DemandReaderFromCSV {
 							createJobId(scenario, newDemandInformationElement, link.getId(), null),
 							CarrierService.class);
 						if (demandToDistribute > 0 && singleDemandForThisLink > 0) {
-							CarrierService thisService = CarrierService.Builder.newInstance(idNewService, link.getId())
-								.setCapacityDemand(singleDemandForThisLink).setServiceDuration(serviceTime)
-								.setServiceStartTimeWindow(newDemandInformationElement.getFirstJobElementTimeWindow())
+							CarrierService.Builder builder = CarrierService.Builder.newInstance(idNewService, link.getId())
+								.setCapacityDemand(singleDemandForThisLink).setServiceDuration(serviceTime);
+							CarrierService thisService = builder.setServiceStartingTimeWindow(newDemandInformationElement.getFirstJobElementTimeWindow())
 								.build();
 							thisCarrier.getServices().put(thisService.getId(), thisService);
 						}
@@ -746,9 +746,9 @@ public final class DemandReaderFromCSV {
 					Id<CarrierService> idNewService = Id.create(
 						createJobId(scenario, newDemandInformationElement, link.getId(), null), CarrierService.class);
 					if ((demandToDistribute > 0 && singleDemandForThisLink > 0) || demandToDistribute == 0) {
-						CarrierService thisService = CarrierService.Builder.newInstance(idNewService, link.getId())
-							.setCapacityDemand(singleDemandForThisLink).setServiceDuration(serviceTime)
-							.setServiceStartTimeWindow(newDemandInformationElement.getFirstJobElementTimeWindow())
+						CarrierService.Builder builder = CarrierService.Builder.newInstance(idNewService, link.getId())
+							.setCapacityDemand(singleDemandForThisLink).setServiceDuration(serviceTime);
+						CarrierService thisService = builder.setServiceStartingTimeWindow(newDemandInformationElement.getFirstJobElementTimeWindow())
 							.build();
 						CarriersUtils.getCarriers(scenario).getCarriers()
 							.get(Id.create(newDemandInformationElement.getCarrierName(), Carrier.class)).getServices()
@@ -1250,10 +1250,10 @@ public final class DemandReaderFromCSV {
 							serviceTimeService = serviceTimeService + carrierService.getServiceDuration();
 							servicesToRemove.put(carrierService.getId(), carrierService);
 						}
-						CarrierService newService = CarrierService.Builder
+						CarrierService.Builder builder = CarrierService.Builder
 							.newInstance(idNewService, baseService.getServiceLinkId())
-							.setServiceDuration(serviceTimeService)
-							.setServiceStartTimeWindow(baseService.getServiceStartTimeWindow())
+							.setServiceDuration(serviceTimeService);
+						CarrierService newService = builder.setServiceStartingTimeWindow(baseService.getServiceStartTimeWindow())
 							.setCapacityDemand(demandForThisLink).build();
 						servicesToAdd.add(newService);
 					}

--- a/contribs/application/src/main/java/org/matsim/freightDemandGeneration/DemandReaderFromCSV.java
+++ b/contribs/application/src/main/java/org/matsim/freightDemandGeneration/DemandReaderFromCSV.java
@@ -655,7 +655,7 @@ public final class DemandReaderFromCSV {
 							createJobId(scenario, newDemandInformationElement, link.getId(), null),
 							CarrierService.class);
 					CarrierService thisService = CarrierService.Builder.newInstance(idNewService, link.getId())
-							.setDemand(demandForThisLink).setServiceDuration(serviceTime)
+							.setCapacityDemand(demandForThisLink).setServiceDuration(serviceTime)
 							.setServiceStartTimeWindow(newDemandInformationElement.getFirstJobElementTimeWindow())
 							.build();
 					CarriersUtils.getCarriers(scenario).getCarriers()
@@ -696,7 +696,7 @@ public final class DemandReaderFromCSV {
 							CarrierService.class);
 						if (demandToDistribute > 0 && singleDemandForThisLink > 0) {
 							CarrierService thisService = CarrierService.Builder.newInstance(idNewService, link.getId())
-								.setDemand(singleDemandForThisLink).setServiceDuration(serviceTime)
+								.setCapacityDemand(singleDemandForThisLink).setServiceDuration(serviceTime)
 								.setServiceStartTimeWindow(newDemandInformationElement.getFirstJobElementTimeWindow())
 								.build();
 							thisCarrier.getServices().put(thisService.getId(), thisService);
@@ -747,7 +747,7 @@ public final class DemandReaderFromCSV {
 						createJobId(scenario, newDemandInformationElement, link.getId(), null), CarrierService.class);
 					if ((demandToDistribute > 0 && singleDemandForThisLink > 0) || demandToDistribute == 0) {
 						CarrierService thisService = CarrierService.Builder.newInstance(idNewService, link.getId())
-							.setDemand(singleDemandForThisLink).setServiceDuration(serviceTime)
+							.setCapacityDemand(singleDemandForThisLink).setServiceDuration(serviceTime)
 							.setServiceStartTimeWindow(newDemandInformationElement.getFirstJobElementTimeWindow())
 							.build();
 						CarriersUtils.getCarriers(scenario).getCarriers()
@@ -1201,7 +1201,7 @@ public final class DemandReaderFromCSV {
 						double serviceTimePickup = 0;
 						double serviceTimeDelivery = 0;
 						for (CarrierShipment carrierShipment : shipmentsToConnect.values()) {
-                            demandForThisLink = demandForThisLink + carrierShipment.getDemand();
+                            demandForThisLink = demandForThisLink + carrierShipment.getCapacityDemand();
 							serviceTimePickup = serviceTimePickup + carrierShipment.getPickupDuration();
 							serviceTimeDelivery = serviceTimeDelivery + carrierShipment.getDeliveryDuration();
 							shipmentsToRemove.put(carrierShipment.getId(), carrierShipment);
@@ -1246,7 +1246,7 @@ public final class DemandReaderFromCSV {
 						int demandForThisLink = 0;
 						double serviceTimeService = 0;
 						for (CarrierService carrierService : servicesToConnect.values()) {
-							demandForThisLink = demandForThisLink + carrierService.getDemand();
+							demandForThisLink = demandForThisLink + carrierService.getCapacityDemand();
 							serviceTimeService = serviceTimeService + carrierService.getServiceDuration();
 							servicesToRemove.put(carrierService.getId(), carrierService);
 						}
@@ -1254,7 +1254,7 @@ public final class DemandReaderFromCSV {
 							.newInstance(idNewService, baseService.getServiceLinkId())
 							.setServiceDuration(serviceTimeService)
 							.setServiceStartTimeWindow(baseService.getServiceStartTimeWindow())
-							.setDemand(demandForThisLink).build();
+							.setCapacityDemand(demandForThisLink).build();
 						servicesToAdd.add(newService);
 					}
 				}

--- a/contribs/application/src/test/java/org/matsim/freightDemandGeneration/DemandReaderFromCSVTest.java
+++ b/contribs/application/src/test/java/org/matsim/freightDemandGeneration/DemandReaderFromCSVTest.java
@@ -106,8 +106,8 @@ public class DemandReaderFromCSVTest {
             Assertions.assertEquals(5, shipment.getCapacityDemand());
 			Assertions.assertEquals(2000, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
 			Assertions.assertEquals(1250, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
-			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupStartsTimeWindow());
-			Assertions.assertEquals(TimeWindow.newInstance(10000, 60000), shipment.getDeliveryStartsTimeWindow());
+			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupStartingTimeWindow());
+			Assertions.assertEquals(TimeWindow.newInstance(10000, 60000), shipment.getDeliveryStartingTimeWindow());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_pickup", (k) -> new HashSet<>())
 					.add(shipment.getPickupLinkId().toString());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_delivery", (k) -> new HashSet<>())
@@ -173,8 +173,8 @@ public class DemandReaderFromCSVTest {
             Assertions.assertEquals(10, shipment.getCapacityDemand());
 			Assertions.assertEquals(4000, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
 			Assertions.assertEquals(2500, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
-			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupStartsTimeWindow());
-			Assertions.assertEquals(TimeWindow.newInstance(10000, 60000), shipment.getDeliveryStartsTimeWindow());
+			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupStartingTimeWindow());
+			Assertions.assertEquals(TimeWindow.newInstance(10000, 60000), shipment.getDeliveryStartingTimeWindow());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_pickup", (k) -> new HashSet<>())
 				.add(shipment.getPickupLinkId().toString());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_delivery", (k) -> new HashSet<>())
@@ -240,8 +240,8 @@ public class DemandReaderFromCSVTest {
             Assertions.assertEquals(10, shipment.getCapacityDemand());
 			Assertions.assertEquals(4000, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
 			Assertions.assertEquals(2500, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
-			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupStartsTimeWindow());
-			Assertions.assertEquals(TimeWindow.newInstance(10000, 60000), shipment.getDeliveryStartsTimeWindow());
+			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupStartingTimeWindow());
+			Assertions.assertEquals(TimeWindow.newInstance(10000, 60000), shipment.getDeliveryStartingTimeWindow());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_pickup", (k) -> new HashSet<>())
 				.add(shipment.getPickupLinkId().toString());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_delivery", (k) -> new HashSet<>())
@@ -310,8 +310,8 @@ public class DemandReaderFromCSVTest {
             Assertions.assertEquals(10, shipment.getCapacityDemand());
 			Assertions.assertEquals(4000, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
 			Assertions.assertEquals(2500, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
-			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupStartsTimeWindow());
-			Assertions.assertEquals(TimeWindow.newInstance(10000, 60000), shipment.getDeliveryStartsTimeWindow());
+			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupStartingTimeWindow());
+			Assertions.assertEquals(TimeWindow.newInstance(10000, 60000), shipment.getDeliveryStartingTimeWindow());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_pickup", (k) -> new HashSet<>())
 				.add(shipment.getPickupLinkId().toString());
 			locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_delivery", (k) -> new HashSet<>())
@@ -527,8 +527,8 @@ public class DemandReaderFromCSVTest {
             if (shipment.getCapacityDemand() == 0) {
 				Assertions.assertEquals(300, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(350, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
-				Assertions.assertEquals(TimeWindow.newInstance(10000, 45000), shipment.getPickupStartsTimeWindow());
-				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getDeliveryStartsTimeWindow());
+				Assertions.assertEquals(TimeWindow.newInstance(10000, 45000), shipment.getPickupStartingTimeWindow());
+				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getDeliveryStartingTimeWindow());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_pickup", (k) -> new HashSet<>())
 					.add(shipment.getPickupLinkId().toString());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_delivery", (k) -> new HashSet<>())
@@ -536,8 +536,8 @@ public class DemandReaderFromCSVTest {
 			} else if (shipment.getCapacityDemand() == 2) {
 				Assertions.assertEquals(400, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(400, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
-				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getPickupStartsTimeWindow());
-				Assertions.assertEquals(TimeWindow.newInstance(20000, 40000), shipment.getDeliveryStartsTimeWindow());
+				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getPickupStartingTimeWindow());
+				Assertions.assertEquals(TimeWindow.newInstance(20000, 40000), shipment.getDeliveryStartingTimeWindow());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_pickup", (k) -> new HashSet<>())
 					.add(shipment.getPickupLinkId().toString());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_delivery", (k) -> new HashSet<>())
@@ -546,8 +546,8 @@ public class DemandReaderFromCSVTest {
                 if (shipment.getCapacityDemand() == 3) {
                     Assertions.assertEquals(600, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
                     Assertions.assertEquals(600, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
-					Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getPickupStartsTimeWindow());
-					Assertions.assertEquals(TimeWindow.newInstance(20000, 40000), shipment.getDeliveryStartsTimeWindow());
+					Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getPickupStartingTimeWindow());
+					Assertions.assertEquals(TimeWindow.newInstance(20000, 40000), shipment.getDeliveryStartingTimeWindow());
                     locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_pickup", (k) -> new HashSet<>())
                             .add(shipment.getPickupLinkId().toString());
                     locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_delivery", (k) -> new HashSet<>())
@@ -626,8 +626,8 @@ public class DemandReaderFromCSVTest {
             if (shipment.getCapacityDemand() == 0) {
 				Assertions.assertEquals(300, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(350, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
-				Assertions.assertEquals(TimeWindow.newInstance(10000, 45000), shipment.getPickupStartsTimeWindow());
-				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getDeliveryStartsTimeWindow());
+				Assertions.assertEquals(TimeWindow.newInstance(10000, 45000), shipment.getPickupStartingTimeWindow());
+				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getDeliveryStartingTimeWindow());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_pickup", (k) -> new HashSet<>())
 					.add(shipment.getPickupLinkId().toString());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_delivery", (k) -> new HashSet<>())
@@ -635,8 +635,8 @@ public class DemandReaderFromCSVTest {
 			} else {
                 Assertions.assertEquals(shipment.getCapacityDemand() * 200, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
                 Assertions.assertEquals(shipment.getCapacityDemand() * 200, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
-				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getPickupStartsTimeWindow());
-				Assertions.assertEquals(TimeWindow.newInstance(20000, 40000), shipment.getDeliveryStartsTimeWindow());
+				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getPickupStartingTimeWindow());
+				Assertions.assertEquals(TimeWindow.newInstance(20000, 40000), shipment.getDeliveryStartingTimeWindow());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_pickup", (k) -> new HashSet<>())
 					.add(shipment.getPickupLinkId().toString());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_delivery", (k) -> new HashSet<>())

--- a/contribs/application/src/test/java/org/matsim/freightDemandGeneration/DemandReaderFromCSVTest.java
+++ b/contribs/application/src/test/java/org/matsim/freightDemandGeneration/DemandReaderFromCSVTest.java
@@ -101,9 +101,9 @@ public class DemandReaderFromCSVTest {
 		locationsPerShipmentElement = new HashMap<>();
 		countDemand = 0;
 		for (CarrierShipment shipment : testCarrier3.getShipments().values()) {
-            countShipmentsWithCertainDemand.merge((Integer) shipment.getDemand(), 1, Integer::sum);
-            countDemand = countDemand + shipment.getDemand();
-            Assertions.assertEquals(5, shipment.getDemand());
+            countShipmentsWithCertainDemand.merge((Integer) shipment.getCapacityDemand(), 1, Integer::sum);
+            countDemand = countDemand + shipment.getCapacityDemand();
+            Assertions.assertEquals(5, shipment.getCapacityDemand());
 			Assertions.assertEquals(2000, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
 			Assertions.assertEquals(1250, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
 			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupStartsTimeWindow());
@@ -168,9 +168,9 @@ public class DemandReaderFromCSVTest {
 		locationsPerShipmentElement = new HashMap<>();
 		countDemand = 0;
 		for (CarrierShipment shipment : testCarrier3.getShipments().values()) {
-            countShipmentsWithCertainDemand.merge((Integer) shipment.getDemand(), 1, Integer::sum);
-            countDemand = countDemand + shipment.getDemand();
-            Assertions.assertEquals(10, shipment.getDemand());
+            countShipmentsWithCertainDemand.merge((Integer) shipment.getCapacityDemand(), 1, Integer::sum);
+            countDemand = countDemand + shipment.getCapacityDemand();
+            Assertions.assertEquals(10, shipment.getCapacityDemand());
 			Assertions.assertEquals(4000, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
 			Assertions.assertEquals(2500, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
 			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupStartsTimeWindow());
@@ -235,9 +235,9 @@ public class DemandReaderFromCSVTest {
 		locationsPerShipmentElement = new HashMap<>();
 		countDemand = 0;
 		for (CarrierShipment shipment : testCarrier3.getShipments().values()) {
-            countShipmentsWithCertainDemand.merge((Integer) shipment.getDemand(), 1, Integer::sum);
-            countDemand = countDemand + shipment.getDemand();
-            Assertions.assertEquals(10, shipment.getDemand());
+            countShipmentsWithCertainDemand.merge((Integer) shipment.getCapacityDemand(), 1, Integer::sum);
+            countDemand = countDemand + shipment.getCapacityDemand();
+            Assertions.assertEquals(10, shipment.getCapacityDemand());
 			Assertions.assertEquals(4000, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
 			Assertions.assertEquals(2500, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
 			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupStartsTimeWindow());
@@ -305,9 +305,9 @@ public class DemandReaderFromCSVTest {
 		locationsPerShipmentElement = new HashMap<>();
 		countDemand = 0;
 		for (CarrierShipment shipment : testCarrier3.getShipments().values()) {
-            countShipmentsWithCertainDemand.merge((Integer) shipment.getDemand(), 1, Integer::sum);
-            countDemand = countDemand + shipment.getDemand();
-            Assertions.assertEquals(10, shipment.getDemand());
+            countShipmentsWithCertainDemand.merge((Integer) shipment.getCapacityDemand(), 1, Integer::sum);
+            countDemand = countDemand + shipment.getCapacityDemand();
+            Assertions.assertEquals(10, shipment.getCapacityDemand());
 			Assertions.assertEquals(4000, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
 			Assertions.assertEquals(2500, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
 			Assertions.assertEquals(TimeWindow.newInstance(8000, 50000), shipment.getPickupStartsTimeWindow());
@@ -474,20 +474,20 @@ public class DemandReaderFromCSVTest {
 		Map<String, Set<String>> locationsPerServiceElement = new HashMap<>();
 		int countDemand = 0;
 		for (CarrierService service : testCarrier1.getServices().values()) {
-			countServicesWithCertainDemand.merge((Integer) service.getDemand(), 1, Integer::sum);
-			countDemand = countDemand + service.getDemand();
-			if (service.getDemand() == 0) {
+			countServicesWithCertainDemand.merge((Integer) service.getCapacityDemand(), 1, Integer::sum);
+			countDemand = countDemand + service.getCapacityDemand();
+			if (service.getCapacityDemand() == 0) {
 				Assertions.assertEquals(180, service.getServiceDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(TimeWindow.newInstance(3000, 13000), service.getServiceStartTimeWindow());
 				locationsPerServiceElement.computeIfAbsent("serviceElement1", (k) -> new HashSet<>())
 					.add(service.getServiceLinkId().toString());
-			} else if (service.getDemand() == 1) {
+			} else if (service.getCapacityDemand() == 1) {
 				Assertions.assertEquals(100, service.getServiceDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(TimeWindow.newInstance(5000, 20000), service.getServiceStartTimeWindow());
 				locationsPerServiceElement.computeIfAbsent("serviceElement2", (k) -> new HashSet<>())
 					.add(service.getServiceLinkId().toString());
 			} else {
-				if (service.getDemand() == 2) {
+				if (service.getCapacityDemand() == 2) {
 					Assertions.assertEquals(200, service.getServiceDuration(), MatsimTestUtils.EPSILON);
 					Assertions.assertEquals(TimeWindow.newInstance(5000, 20000), service.getServiceStartTimeWindow());
 					locationsPerServiceElement.computeIfAbsent("serviceElement2", (k) -> new HashSet<>())
@@ -522,9 +522,9 @@ public class DemandReaderFromCSVTest {
 		Map<String, Set<String>> locationsPerShipmentElement = new HashMap<>();
 		countDemand = 0;
 		for (CarrierShipment shipment : testCarrier2.getShipments().values()) {
-            countShipmentsWithCertainDemand.merge((Integer) shipment.getDemand(), 1, Integer::sum);
-            countDemand = countDemand + shipment.getDemand();
-            if (shipment.getDemand() == 0) {
+            countShipmentsWithCertainDemand.merge((Integer) shipment.getCapacityDemand(), 1, Integer::sum);
+            countDemand = countDemand + shipment.getCapacityDemand();
+            if (shipment.getCapacityDemand() == 0) {
 				Assertions.assertEquals(300, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(350, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(TimeWindow.newInstance(10000, 45000), shipment.getPickupStartsTimeWindow());
@@ -533,7 +533,7 @@ public class DemandReaderFromCSVTest {
 					.add(shipment.getPickupLinkId().toString());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_delivery", (k) -> new HashSet<>())
 					.add(shipment.getDeliveryLinkId().toString());
-			} else if (shipment.getDemand() == 2) {
+			} else if (shipment.getCapacityDemand() == 2) {
 				Assertions.assertEquals(400, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(400, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getPickupStartsTimeWindow());
@@ -543,7 +543,7 @@ public class DemandReaderFromCSVTest {
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_delivery", (k) -> new HashSet<>())
 					.add(shipment.getDeliveryLinkId().toString());
 			} else {
-                if (shipment.getDemand() == 3) {
+                if (shipment.getCapacityDemand() == 3) {
                     Assertions.assertEquals(600, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
                     Assertions.assertEquals(600, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
 					Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getPickupStartsTimeWindow());
@@ -583,15 +583,15 @@ public class DemandReaderFromCSVTest {
 		Map<String, Set<String>> locationsPerServiceElement = new HashMap<>();
 		int countDemand = 0;
 		for (CarrierService service : testCarrier1.getServices().values()) {
-			countServicesWithCertainDemand.merge((Integer) service.getDemand(), 1, Integer::sum);
-			countDemand = countDemand + service.getDemand();
-			if (service.getDemand() == 0) {
+			countServicesWithCertainDemand.merge((Integer) service.getCapacityDemand(), 1, Integer::sum);
+			countDemand = countDemand + service.getCapacityDemand();
+			if (service.getCapacityDemand() == 0) {
 				Assertions.assertEquals(180, service.getServiceDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(TimeWindow.newInstance(3000, 13000), service.getServiceStartTimeWindow());
 				locationsPerServiceElement.computeIfAbsent("serviceElement1", (k) -> new HashSet<>())
 					.add(service.getServiceLinkId().toString());
 			} else {
-				Assertions.assertEquals(service.getDemand() * 100, service.getServiceDuration(), MatsimTestUtils.EPSILON);
+				Assertions.assertEquals(service.getCapacityDemand() * 100, service.getServiceDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(TimeWindow.newInstance(5000, 20000), service.getServiceStartTimeWindow());
 				locationsPerServiceElement.computeIfAbsent("serviceElement2", (k) -> new HashSet<>())
 					.add(service.getServiceLinkId().toString());
@@ -621,9 +621,9 @@ public class DemandReaderFromCSVTest {
 		Map<String, Set<String>> locationsPerShipmentElement = new HashMap<>();
 		countDemand = 0;
 		for (CarrierShipment shipment : testCarrier2.getShipments().values()) {
-            countShipmentsWithCertainDemand.merge((Integer) shipment.getDemand(), 1, Integer::sum);
-            countDemand = countDemand + shipment.getDemand();
-            if (shipment.getDemand() == 0) {
+            countShipmentsWithCertainDemand.merge((Integer) shipment.getCapacityDemand(), 1, Integer::sum);
+            countDemand = countDemand + shipment.getCapacityDemand();
+            if (shipment.getCapacityDemand() == 0) {
 				Assertions.assertEquals(300, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(350, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(TimeWindow.newInstance(10000, 45000), shipment.getPickupStartsTimeWindow());
@@ -633,8 +633,8 @@ public class DemandReaderFromCSVTest {
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement1_delivery", (k) -> new HashSet<>())
 					.add(shipment.getDeliveryLinkId().toString());
 			} else {
-                Assertions.assertEquals(shipment.getDemand() * 200, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
-                Assertions.assertEquals(shipment.getDemand() * 200, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
+                Assertions.assertEquals(shipment.getCapacityDemand() * 200, shipment.getPickupDuration(), MatsimTestUtils.EPSILON);
+                Assertions.assertEquals(shipment.getCapacityDemand() * 200, shipment.getDeliveryDuration(), MatsimTestUtils.EPSILON);
 				Assertions.assertEquals(TimeWindow.newInstance(11000, 44000), shipment.getPickupStartsTimeWindow());
 				Assertions.assertEquals(TimeWindow.newInstance(20000, 40000), shipment.getDeliveryStartsTimeWindow());
 				locationsPerShipmentElement.computeIfAbsent("ShipmentElement2_pickup", (k) -> new HashSet<>())

--- a/contribs/application/src/test/java/org/matsim/freightDemandGeneration/DemandReaderFromCSVTest.java
+++ b/contribs/application/src/test/java/org/matsim/freightDemandGeneration/DemandReaderFromCSVTest.java
@@ -478,18 +478,18 @@ public class DemandReaderFromCSVTest {
 			countDemand = countDemand + service.getCapacityDemand();
 			if (service.getCapacityDemand() == 0) {
 				Assertions.assertEquals(180, service.getServiceDuration(), MatsimTestUtils.EPSILON);
-				Assertions.assertEquals(TimeWindow.newInstance(3000, 13000), service.getServiceStartTimeWindow());
+				Assertions.assertEquals(TimeWindow.newInstance(3000, 13000), service.getServiceStaringTimeWindow());
 				locationsPerServiceElement.computeIfAbsent("serviceElement1", (k) -> new HashSet<>())
 					.add(service.getServiceLinkId().toString());
 			} else if (service.getCapacityDemand() == 1) {
 				Assertions.assertEquals(100, service.getServiceDuration(), MatsimTestUtils.EPSILON);
-				Assertions.assertEquals(TimeWindow.newInstance(5000, 20000), service.getServiceStartTimeWindow());
+				Assertions.assertEquals(TimeWindow.newInstance(5000, 20000), service.getServiceStaringTimeWindow());
 				locationsPerServiceElement.computeIfAbsent("serviceElement2", (k) -> new HashSet<>())
 					.add(service.getServiceLinkId().toString());
 			} else {
 				if (service.getCapacityDemand() == 2) {
 					Assertions.assertEquals(200, service.getServiceDuration(), MatsimTestUtils.EPSILON);
-					Assertions.assertEquals(TimeWindow.newInstance(5000, 20000), service.getServiceStartTimeWindow());
+					Assertions.assertEquals(TimeWindow.newInstance(5000, 20000), service.getServiceStaringTimeWindow());
 					locationsPerServiceElement.computeIfAbsent("serviceElement2", (k) -> new HashSet<>())
 						.add(service.getServiceLinkId().toString());
 				} else
@@ -587,12 +587,12 @@ public class DemandReaderFromCSVTest {
 			countDemand = countDemand + service.getCapacityDemand();
 			if (service.getCapacityDemand() == 0) {
 				Assertions.assertEquals(180, service.getServiceDuration(), MatsimTestUtils.EPSILON);
-				Assertions.assertEquals(TimeWindow.newInstance(3000, 13000), service.getServiceStartTimeWindow());
+				Assertions.assertEquals(TimeWindow.newInstance(3000, 13000), service.getServiceStaringTimeWindow());
 				locationsPerServiceElement.computeIfAbsent("serviceElement1", (k) -> new HashSet<>())
 					.add(service.getServiceLinkId().toString());
 			} else {
 				Assertions.assertEquals(service.getCapacityDemand() * 100, service.getServiceDuration(), MatsimTestUtils.EPSILON);
-				Assertions.assertEquals(TimeWindow.newInstance(5000, 20000), service.getServiceStartTimeWindow());
+				Assertions.assertEquals(TimeWindow.newInstance(5000, 20000), service.getServiceStaringTimeWindow());
 				locationsPerServiceElement.computeIfAbsent("serviceElement2", (k) -> new HashSet<>())
 					.add(service.getServiceLinkId().toString());
 			}

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/DefaultCommercialJobGenerator.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/DefaultCommercialJobGenerator.java
@@ -331,9 +331,9 @@ class DefaultCommercialJobGenerator implements CommercialJobGenerator {
                     CarrierService.Builder serviceBuilder = CarrierService.Builder.newInstance(serviceId, PopulationUtils.decideOnLinkIdForActivity(activity,scenario));
                     serviceBuilder.setCapacityDemand(Integer.parseInt(commercialJobProperties.get(COMMERCIALJOB_ATTRIBUTE_AMOUNT_IDX)));
                     serviceBuilder.setServiceDuration(Double.parseDouble(commercialJobProperties.get(COMMERCIALJOB_ATTRIBUTE_DURATION_IDX)));
-                    serviceBuilder.setServiceStartTimeWindow(TimeWindow.newInstance(earliestStart,latestStart));
+					serviceBuilder.setServiceStartingTimeWindow(TimeWindow.newInstance(earliestStart,latestStart));
 
-                    Id<Carrier> carrierId = JointDemandUtils.getCurrentlySelectedCarrierForJob(activity, jobIdx);
+					Id<Carrier> carrierId = JointDemandUtils.getCurrentlySelectedCarrierForJob(activity, jobIdx);
                     if (carriers.getCarriers().containsKey(carrierId)) {
                         Carrier carrier = carriers.getCarriers().get(carrierId);
                         CarrierService service = serviceBuilder.build();

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/DefaultCommercialJobGenerator.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/DefaultCommercialJobGenerator.java
@@ -329,7 +329,7 @@ class DefaultCommercialJobGenerator implements CommercialJobGenerator {
                     double latestStart = Double.parseDouble(commercialJobProperties.get(COMMERCIALJOB_ATTRIBUTE_END_IDX));
 
                     CarrierService.Builder serviceBuilder = CarrierService.Builder.newInstance(serviceId, PopulationUtils.decideOnLinkIdForActivity(activity,scenario));
-                    serviceBuilder.setDemand(Integer.parseInt(commercialJobProperties.get(COMMERCIALJOB_ATTRIBUTE_AMOUNT_IDX)));
+                    serviceBuilder.setCapacityDemand(Integer.parseInt(commercialJobProperties.get(COMMERCIALJOB_ATTRIBUTE_AMOUNT_IDX)));
                     serviceBuilder.setServiceDuration(Double.parseDouble(commercialJobProperties.get(COMMERCIALJOB_ATTRIBUTE_DURATION_IDX)));
                     serviceBuilder.setServiceStartTimeWindow(TimeWindow.newInstance(earliestStart,latestStart));
 

--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/ScoreCommercialJobs.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/ScoreCommercialJobs.java
@@ -112,9 +112,9 @@ class ScoreCommercialJobs implements ActivityStartEventHandler, ActivityEndEvent
     }
 
     private double calcDifference(CarrierService service, double time) {
-        if (time < service.getServiceStartTimeWindow().getStart()) return (service.getServiceStartTimeWindow().getStart() - time);
-        else if (time >= service.getServiceStartTimeWindow().getStart() && time <= service.getServiceStartTimeWindow().getEnd()) return 0;
-        else return (time - service.getServiceStartTimeWindow().getEnd());
+        if (time < service.getServiceStaringTimeWindow().getStart()) return (service.getServiceStaringTimeWindow().getStart() - time);
+        else if (time >= service.getServiceStaringTimeWindow().getStart() && time <= service.getServiceStaringTimeWindow().getEnd()) return 0;
+        else return (time - service.getServiceStaringTimeWindow().getEnd());
     }
 
     @Override

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierJob.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierJob.java
@@ -19,5 +19,5 @@ import org.matsim.utils.objectattributes.attributable.Attributable;
  */
 public interface CarrierJob extends Attributable {
 	Id<? extends CarrierJob> getId();
-	int getDemand();
+	int getCapacityDemand();
 }

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanReaderV1.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanReaderV1.java
@@ -116,11 +116,11 @@ class CarrierPlanReaderV1 extends MatsimXmlParser {
 				CarrierShipment.Builder shipmentBuilder = CarrierShipment.Builder.newInstance( Id.create( id, CarrierShipment.class ),
 					  Id.create( from, Link.class ), Id.create( to, Link.class ), size );
 				if( startPickup == null ){
-					shipmentBuilder.setPickupStartsTimeWindow( TimeWindow.newInstance( 0.0, Integer.MAX_VALUE ) ).setDeliveryStartsTimeWindow(
+					shipmentBuilder.setPickupStartingTimeWindow( TimeWindow.newInstance( 0.0, Integer.MAX_VALUE ) ).setDeliveryStartingTimeWindow(
 						  TimeWindow.newInstance( 0.0, Integer.MAX_VALUE ) );
 				} else{
-					shipmentBuilder.setPickupStartsTimeWindow( TimeWindow.newInstance( getDouble( startPickup ), getDouble( endPickup ) ) ).
-						setDeliveryStartsTimeWindow(
+					shipmentBuilder.setPickupStartingTimeWindow( TimeWindow.newInstance( getDouble( startPickup ), getDouble( endPickup ) ) ).
+						setDeliveryStartingTimeWindow(
 																										   TimeWindow.newInstance(
 																											     getDouble(
 																													 startDelivery ),

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2.java
@@ -123,7 +123,7 @@ class CarrierPlanXmlParserV2 extends MatsimXmlParser {
 				double end;
 				String endString = atts.getValue("latestEnd");
 				end = parseTimeToDouble(endString);
-				serviceBuilder.setServiceStartTimeWindow(TimeWindow.newInstance(start, end));
+				serviceBuilder.setServiceStartingTimeWindow(TimeWindow.newInstance(start, end));
 				String serviceTimeString = atts.getValue("serviceDuration");
 				if (serviceTimeString != null) serviceBuilder.setServiceDuration(parseTimeToDouble(serviceTimeString));
 				currentService = serviceBuilder.build();

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2.java
@@ -157,9 +157,9 @@ class CarrierPlanXmlParserV2 extends MatsimXmlParser {
 				String deliveryServiceTime = atts.getValue("deliveryServiceTime");
 
 				if (startPickup != null && endPickup != null)
-					shipmentBuilder.setPickupStartsTimeWindow(TimeWindow.newInstance(parseTimeToDouble(startPickup), parseTimeToDouble(endPickup)));
+					shipmentBuilder.setPickupStartingTimeWindow(TimeWindow.newInstance(parseTimeToDouble(startPickup), parseTimeToDouble(endPickup)));
 				if (startDelivery != null && endDelivery != null)
-					shipmentBuilder.setDeliveryStartsTimeWindow(TimeWindow.newInstance(parseTimeToDouble(startDelivery), parseTimeToDouble(endDelivery)));
+					shipmentBuilder.setDeliveryStartingTimeWindow(TimeWindow.newInstance(parseTimeToDouble(startDelivery), parseTimeToDouble(endDelivery)));
 				if (pickupServiceTime != null)
 					shipmentBuilder.setPickupDuration(parseTimeToDouble(pickupServiceTime));
 				if (deliveryServiceTime != null)

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2.java
@@ -117,7 +117,7 @@ class CarrierPlanXmlParserV2 extends MatsimXmlParser {
 				Id<Link> to = Id.create(toLocation, Link.class);
 				CarrierService.Builder serviceBuilder = CarrierService.Builder.newInstance(id, to);
 				String capDemandString = atts.getValue("capacityDemand");
-				if (capDemandString != null) serviceBuilder.setDemand(getInt(capDemandString));
+				if (capDemandString != null) serviceBuilder.setCapacityDemand(getInt(capDemandString));
 				String startString = atts.getValue("earliestStart");
 				double start = parseTimeToDouble(startString);
 				double end;

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2_1.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2_1.java
@@ -121,7 +121,7 @@ class CarrierPlanXmlParserV2_1 extends MatsimXmlParser {
 				double end;
 				String endString = atts.getValue("latestEnd");
 				end = parseTimeToDouble(endString);
-				serviceBuilder.setServiceStartTimeWindow(TimeWindow.newInstance(start, end));
+				serviceBuilder.setServiceStartingTimeWindow(TimeWindow.newInstance(start, end));
 				String serviceTimeString = atts.getValue("serviceDuration");
 				if (serviceTimeString != null) serviceBuilder.setServiceDuration(parseTimeToDouble(serviceTimeString));
 				currentService = serviceBuilder.build();

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2_1.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2_1.java
@@ -115,7 +115,7 @@ class CarrierPlanXmlParserV2_1 extends MatsimXmlParser {
 				Id<Link> to = Id.create(toLocation, Link.class);
 				CarrierService.Builder serviceBuilder = CarrierService.Builder.newInstance(id, to);
 				String capDemandString = atts.getValue("capacityDemand");
-				if (capDemandString != null) serviceBuilder.setDemand(getInt(capDemandString));
+				if (capDemandString != null) serviceBuilder.setCapacityDemand(getInt(capDemandString));
 				String startString = atts.getValue("earliestStart");
 				double start = parseTimeToDouble(startString);
 				double end;

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2_1.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2_1.java
@@ -155,9 +155,9 @@ class CarrierPlanXmlParserV2_1 extends MatsimXmlParser {
 				String deliveryServiceTime = atts.getValue("deliveryServiceTime");
 
 				if (startPickup != null && endPickup != null)
-					shipmentBuilder.setPickupStartsTimeWindow(TimeWindow.newInstance(parseTimeToDouble(startPickup), parseTimeToDouble(endPickup)));
+					shipmentBuilder.setPickupStartingTimeWindow(TimeWindow.newInstance(parseTimeToDouble(startPickup), parseTimeToDouble(endPickup)));
 				if (startDelivery != null && endDelivery != null)
-					shipmentBuilder.setDeliveryStartsTimeWindow(TimeWindow.newInstance(parseTimeToDouble(startDelivery), parseTimeToDouble(endDelivery)));
+					shipmentBuilder.setDeliveryStartingTimeWindow(TimeWindow.newInstance(parseTimeToDouble(startDelivery), parseTimeToDouble(endDelivery)));
 				if (pickupServiceTime != null)
 					shipmentBuilder.setPickupDuration(parseTimeToDouble(pickupServiceTime));
 				if (deliveryServiceTime != null)

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlWriterV2_1.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlWriterV2_1.java
@@ -192,8 +192,8 @@ import org.matsim.vehicles.VehicleType;
 				createTuple(ID, s.getId().toString()),
 				createTuple(TO, s.getServiceLinkId().toString()),
 				createTuple(CAPACITY_DEMAND, s.getCapacityDemand()),
-				createTuple(EARLIEST_START, getTime(s.getServiceStartTimeWindow().getStart())),
-				createTuple(LATEST_END, getTime(s.getServiceStartTimeWindow().getEnd())),
+				createTuple(EARLIEST_START, getTime(s.getServiceStaringTimeWindow().getStart())),
+				createTuple(LATEST_END, getTime(s.getServiceStaringTimeWindow().getEnd())),
 				createTuple(SERVICE_DURATION, getTime(s.getServiceDuration()))), closeElement, lineBreak
 		);
 	}

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlWriterV2_1.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlWriterV2_1.java
@@ -162,10 +162,10 @@ import org.matsim.vehicles.VehicleType;
 				createTuple(FROM, s.getPickupLinkId().toString()),
 				createTuple(TO, s.getDeliveryLinkId().toString()),
 				createTuple(SIZE, s.getCapacityDemand()),
-				createTuple(START_PICKUP, getTime(s.getPickupStartsTimeWindow().getStart())),
-				createTuple(END_PICKUP, getTime(s.getPickupStartsTimeWindow().getEnd())),
-				createTuple(START_DELIVERY, getTime(s.getDeliveryStartsTimeWindow().getStart())),
-				createTuple(END_DELIVERY, getTime(s.getDeliveryStartsTimeWindow().getEnd())),
+				createTuple(START_PICKUP, getTime(s.getPickupStartingTimeWindow().getStart())),
+				createTuple(END_PICKUP, getTime(s.getPickupStartingTimeWindow().getEnd())),
+				createTuple(START_DELIVERY, getTime(s.getDeliveryStartingTimeWindow().getStart())),
+				createTuple(END_DELIVERY, getTime(s.getDeliveryStartingTimeWindow().getEnd())),
 				createTuple(PICKUP_SERVICE_TIME, getTime(s.getPickupDuration())),
 				createTuple(DELIVERY_SERVICE_TIME, getTime(s.getDeliveryDuration()))), closeElement, lineBreak
 		);

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlWriterV2_1.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlWriterV2_1.java
@@ -161,7 +161,7 @@ import org.matsim.vehicles.VehicleType;
 				createTuple(ID, shipmentId.toString()),
 				createTuple(FROM, s.getPickupLinkId().toString()),
 				createTuple(TO, s.getDeliveryLinkId().toString()),
-				createTuple(SIZE, s.getDemand()),
+				createTuple(SIZE, s.getCapacityDemand()),
 				createTuple(START_PICKUP, getTime(s.getPickupStartsTimeWindow().getStart())),
 				createTuple(END_PICKUP, getTime(s.getPickupStartsTimeWindow().getEnd())),
 				createTuple(START_DELIVERY, getTime(s.getDeliveryStartsTimeWindow().getStart())),
@@ -191,7 +191,7 @@ import org.matsim.vehicles.VehicleType;
 		this.writeStartTag(SERVICE, List.of(
 				createTuple(ID, s.getId().toString()),
 				createTuple(TO, s.getServiceLinkId().toString()),
-				createTuple(CAPACITY_DEMAND, s.getDemand()),
+				createTuple(CAPACITY_DEMAND, s.getCapacityDemand()),
 				createTuple(EARLIEST_START, getTime(s.getServiceStartTimeWindow().getStart())),
 				createTuple(LATEST_END, getTime(s.getServiceStartTimeWindow().getEnd())),
 				createTuple(SERVICE_DURATION, getTime(s.getServiceDuration()))), closeElement, lineBreak

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
@@ -88,7 +88,7 @@ public final class CarrierService implements CarrierJob {
 
 
 		/**
-		 * Sets a time-window for the beginning of  the service
+		 * Sets a time-window for the beginning of the service
 		 * When not set, it is by default [0.0., Integer.MAX_VALUE].
 		 * <p>
 		 * Note that the time-window restricts the start-time of the service (i.e. serviceActivity). If one works with hard time-windows (which means that
@@ -97,9 +97,26 @@ public final class CarrierService implements CarrierJob {
 		 * @param startTimeWindow 	time-window for the beginning of the service activity
 		 * @return 					the builder
 		 */
-		public Builder setServiceStartTimeWindow(TimeWindow startTimeWindow){
+		public Builder setServiceStartingTimeWindow(TimeWindow startTimeWindow){
 			this.serviceStartsTimeWindow = startTimeWindow;
 			return this;
+		}
+
+		/**
+		 * Sets a time-window for the beginning of  the service
+		 * When not set, it is by default [0.0., Integer.MAX_VALUE].
+		 * <p>
+		 * Note that the time-window restricts the start-time of the service (i.e. serviceActivity). If one works with hard time-windows (which means that
+		 * time-windows must be met) than the service is allowed to start between startTimeWindow.getStart() and startTimeWindow.getEnd().
+		 *
+		 * @deprecated since jan'25, use {@link #setServiceStartingTimeWindow(TimeWindow)} instead
+		 *
+		 * @param startTimeWindow 	time-window for the beginning of the service activity
+		 * @return 					the builder
+		 */
+		@Deprecated(since = "jan'25")
+		public Builder setServiceStartTimeWindow(TimeWindow startTimeWindow){
+			return setServiceStartingTimeWindow(startTimeWindow);
 		}
 
 		/**

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
@@ -220,7 +220,7 @@ public final class CarrierService implements CarrierJob {
 
 	@Override
 	public String toString() {
-		return "[id=" + id + "][locationId=" + serviceLinkId + "][capacityDemand=" + capacityDemand + "][serviceDuration=" + serviceDuration + "][startTimeWindow=" + serviceStartingTimeWindow + "]";
+		return "[id=" + id + "][serviceLinkId=" + serviceLinkId + "][capacityDemand=" + capacityDemand + "][serviceDuration=" + serviceDuration + "][serviceStartingTimeWindow=" + serviceStartingTimeWindow + "]";
 	}
 
 	/* (non-Javadoc)

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
@@ -31,7 +31,7 @@ public final class CarrierService implements CarrierJob {
 	public static class Builder {
 
 		private final Id<CarrierService> id;
-		private int demand = 0;
+		private int capacityDemand = 0;
 
 		//IMO we could build a general class (CarrierActivity ???), containing the location, StartTimeWindow and Duration.
 		//This could be used for both, CarrierService and CarrierShipment (Pickup and Delivery).
@@ -82,20 +82,6 @@ public final class CarrierService implements CarrierJob {
 			return this;
 		}
 
-		/**
-		 * Sets the demand (size; capacity needed) of the service.
-		 * When not set, it is by default 0.
-		 * <p>
-		 * IMO we can put this into the Builder directly instead of a separate method? kturner dec'24
-		 *
-		 * @param demand the demand (size; capacity needed) of the service
-		 * @return the builder
-		 */
-		public Builder setDemand(int demand) {
-			this.demand = demand;
-			return this;
-		}
-
 
 		/**
 		* Sets the demand (size; capacity needed) of the service.
@@ -103,21 +89,19 @@ public final class CarrierService implements CarrierJob {
 		 * <p>
 		 * IMO we can put this into the Builder directly instead of a separate method? kturner dec'24
 		 *
-		 * @deprecated please use {@link #setDemand(int)} instead
-		 *
-		 * @param value the demand (size; capacity needed) of the service
+		 * @param capacityDemand the demand (size; capacity needed) of the service
 		 * @return the builder
 		*/
-		@Deprecated(since = "dec'24")
-		public Builder setCapacityDemand(int value) {
-			return setDemand(value);
+		public Builder setCapacityDemand(int capacityDemand) {
+			this.capacityDemand = capacityDemand;
+			return this;
 		}
 
 	}
 
 
 	private final Id<CarrierService> id;
-	private final int demand;
+	private final int capacityDemand;
 
 	//IMO we could build a general class (CarrierActivity ???), containing the location, StartTimeWindow and Duration.
 	//This could be used for both, CarrierService and CarrierShipment (Pickup and Delivery).
@@ -133,7 +117,7 @@ public final class CarrierService implements CarrierJob {
 		serviceLinkId = builder.serviceLinkId;
 		serviceDuration = builder.serviceDuration;
 		serviceStartsTimeWindow = builder.serviceStartsTimeWindow;
-		demand = builder.demand;
+		capacityDemand = builder.capacityDemand;
 	}
 
 	@Override
@@ -162,19 +146,11 @@ public final class CarrierService implements CarrierJob {
 	}
 
 	/**
-	 * @deprecated please inline and use {@link #getDemand()} instead
-	 */
-	@Deprecated(since = "dec'24")
-	public int getCapacityDemand() {
-		return getDemand();
-	}
-
-	/**
 	 * @return the demand (size; capacity needed) of the service.
 	 */
 	@Override
-	public int getDemand() {
-		return demand;
+	public int getCapacityDemand() {
+		return capacityDemand;
 	}
 
 
@@ -186,7 +162,7 @@ public final class CarrierService implements CarrierJob {
 
 	@Override
 	public String toString() {
-		return "[id=" + id + "][locationId=" + serviceLinkId + "][capacityDemand=" + demand + "][serviceDuration=" + serviceDuration + "][startTimeWindow=" + serviceStartsTimeWindow + "]";
+		return "[id=" + id + "][locationId=" + serviceLinkId + "][capacityDemand=" + capacityDemand + "][serviceDuration=" + serviceDuration + "][startTimeWindow=" + serviceStartsTimeWindow + "]";
 	}
 
 	/* (non-Javadoc)

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
@@ -37,7 +37,7 @@ public final class CarrierService implements CarrierJob {
 		//This could be used for both, CarrierService and CarrierShipment (Pickup and Delivery).
 		//kturner dec'24
 		private final Id<Link> serviceLinkId;
-		private TimeWindow serviceStartsTimeWindow = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
+		private TimeWindow serviceStartingTimeWindow = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
 		private double serviceDuration = 0.0;
 
 
@@ -92,13 +92,13 @@ public final class CarrierService implements CarrierJob {
 		 * When not set, it is by default [0.0., Integer.MAX_VALUE].
 		 * <p>
 		 * Note that the time-window restricts the start-time of the service (i.e. serviceActivity). If one works with hard time-windows (which means that
-		 * time-windows must be met) than the service is allowed to start between startTimeWindow.getStart() and startTimeWindow.getEnd().
+		 * time-windows must be met) than the service is allowed to start between startingTimeWindow.getStart() and startingTimeWindow.getEnd().
 		 *
-		 * @param startTimeWindow 	time-window for the beginning of the service activity
+		 * @param startingTimeWindow 	time-window for the beginning of the service activity
 		 * @return 					the builder
 		 */
-		public Builder setServiceStartingTimeWindow(TimeWindow startTimeWindow){
-			this.serviceStartsTimeWindow = startTimeWindow;
+		public Builder setServiceStartingTimeWindow(TimeWindow startingTimeWindow){
+			this.serviceStartingTimeWindow = startingTimeWindow;
 			return this;
 		}
 
@@ -157,7 +157,7 @@ public final class CarrierService implements CarrierJob {
 	//This could be used for both, CarrierService and CarrierShipment (Pickup and Delivery).
 	//kturner dec'24
 	private final Id<Link> serviceLinkId;
-	private final TimeWindow serviceStartsTimeWindow;
+	private final TimeWindow serviceStartingTimeWindow;
 	private final double serviceDuration;
 
 	private final Attributes attributes = new AttributesImpl();
@@ -166,7 +166,7 @@ public final class CarrierService implements CarrierJob {
 		id = builder.id;
 		serviceLinkId = builder.serviceLinkId;
 		serviceDuration = builder.serviceDuration;
-		serviceStartsTimeWindow = builder.serviceStartsTimeWindow;
+		serviceStartingTimeWindow = builder.serviceStartingTimeWindow;
 		capacityDemand = builder.capacityDemand;
 	}
 
@@ -191,8 +191,16 @@ public final class CarrierService implements CarrierJob {
 		return serviceDuration;
 	}
 
+	public TimeWindow getServiceStaringTimeWindow(){
+		return serviceStartingTimeWindow;
+	}
+
+	/**
+	 * @deprecated please use {@link #getServiceStaringTimeWindow()} instead
+	 */
+	@Deprecated(since = "jan'25")
 	public TimeWindow getServiceStartTimeWindow(){
-		return serviceStartsTimeWindow;
+		return getServiceStaringTimeWindow();
 	}
 
 	/**
@@ -212,7 +220,7 @@ public final class CarrierService implements CarrierJob {
 
 	@Override
 	public String toString() {
-		return "[id=" + id + "][locationId=" + serviceLinkId + "][capacityDemand=" + capacityDemand + "][serviceDuration=" + serviceDuration + "][startTimeWindow=" + serviceStartsTimeWindow + "]";
+		return "[id=" + id + "][locationId=" + serviceLinkId + "][capacityDemand=" + capacityDemand + "][serviceDuration=" + serviceDuration + "][startTimeWindow=" + serviceStartingTimeWindow + "]";
 	}
 
 	/* (non-Javadoc)

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierService.java
@@ -31,7 +31,7 @@ public final class CarrierService implements CarrierJob {
 	public static class Builder {
 
 		private final Id<CarrierService> id;
-		private int capacityDemand = 0;
+		private int capacityDemand;
 
 		//IMO we could build a general class (CarrierActivity ???), containing the location, StartTimeWindow and Duration.
 		//This could be used for both, CarrierService and CarrierShipment (Pickup and Delivery).
@@ -40,14 +40,46 @@ public final class CarrierService implements CarrierJob {
 		private TimeWindow serviceStartsTimeWindow = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
 		private double serviceDuration = 0.0;
 
-		public static Builder newInstance(Id<CarrierService> id, Id<Link> locationLinkId){
-			return new Builder(id,locationLinkId);
+
+		/**
+		 * Returns a new service builder.
+		 * <p>
+		 * The builder is init with the service's location, and with the service's demand.
+		 * The default-value for serviceTime is 0.0. The default-value for a timeWindow is [start=0.0, end=Double.maxValue()].
+		 *<p>
+		 * The capacity demand is set by default to 0 and needs to be changed later by calling {@link #setCapacityDemand(int)}.
+		 *
+		 * @deprecated since jan'25, use {@link #newInstance(Id, Id, int)} instead
+		 *
+		 * @param id 	the id of the shipment
+		 * @param locationLinkId 	the location (link Id) where the service is performed
+		 * @return 		the builder
+		 */
+		@Deprecated(since = "jan'25")
+		public static Builder newInstance(Id<CarrierService> id, Id<Link> locationLinkId) {
+			return newInstance(id, locationLinkId, 0);
 		}
 
-		private Builder(Id<CarrierService> id, Id<Link> serviceLinkId) {
+		/**
+		 * Returns a new service builder.
+		 * <p>
+		 * The builder is init with the service's location, and with the service's demand.
+		 * The default-value for serviceTime is 0.0. The default-value for a timeWindow is [start=0.0, end=Double.maxValue()].
+		 *
+		 * @param id 	the id of the shipment
+		 * @param locationLinkId 	the location (link Id) where the service is performed
+		 * @param capacityDemand 	the demand (size; capacity needed) of the service
+		 * @return 		the builder
+		 */
+		public static Builder newInstance(Id<CarrierService> id, Id<Link> locationLinkId, int capacityDemand){
+			return new Builder(id,locationLinkId, capacityDemand );
+		}
+
+		private Builder(Id<CarrierService> id, Id<Link> serviceLinkId, int capacityDemand) {
 			super();
 			this.id = id;
 			this.serviceLinkId = serviceLinkId;
+			this.capacityDemand = capacityDemand;
 		}
 
 		public CarrierService build(){
@@ -82,16 +114,17 @@ public final class CarrierService implements CarrierJob {
 			return this;
 		}
 
-
 		/**
 		* Sets the demand (size; capacity needed) of the service.
 		 * When not set, it is by default 0.
 		 * <p>
 		 * IMO we can put this into the Builder directly instead of a separate method? kturner dec'24
+		 * @deprecated please use the constructor including the capacity demand {@link #newInstance(Id, Id, int)} instead
 		 *
 		 * @param capacityDemand the demand (size; capacity needed) of the service
 		 * @return the builder
 		*/
+		@Deprecated(since = "jan'25")
 		public Builder setCapacityDemand(int capacityDemand) {
 			this.capacityDemand = capacityDemand;
 			return this;

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
@@ -260,7 +260,7 @@ public final class CarrierShipment implements CarrierJob {
 	 * @return the demand (size; capacity needed) of the shipment.
 	 */
 	@Override
-	public int getDemand() {
+	public int getCapacityDemand() {
 		return demand;
 	}
 
@@ -280,11 +280,11 @@ public final class CarrierShipment implements CarrierJob {
 	//*** deprecated methods ***
 
 	/**
-	 * @deprecated please inline and use {@link #getDemand()} instead
+	 * @deprecated please inline and use {@link #getCapacityDemand()} instead
 	 */
 	@Deprecated(since = "dec'24")
 	public int getSize() {
-		return getDemand();
+		return getCapacityDemand();
 	}
 
 

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
@@ -46,7 +46,7 @@ public final class CarrierShipment implements CarrierJob {
 	public static class Builder {
 
 		private final Id<CarrierShipment> id;
-		private final int demand;
+		private final int capacityDemand;
 
 		//IMO we could build a general class (CarrierActivity ???), containing the location, StartTimeWindow and Duration.
 		//This could be used for both, CarrierService and CarrierShipment (Pickup and Delivery).
@@ -71,19 +71,19 @@ public final class CarrierShipment implements CarrierJob {
 		 * @param id 	the id of the shipment
 		 * @param from 	the origin
 		 * @param to 	the destination
-		 * @param demand 	demand of the shipment
+		 * @param capacityDemand 	the demand (size; capacity needed) of the shipment
 		 * @return 		the builder
 		 */
-		public static Builder newInstance(Id<CarrierShipment> id, Id<Link> from, Id<Link> to, int demand){
-			return new Builder(id, from, to, demand);
+		public static Builder newInstance(Id<CarrierShipment> id, Id<Link> from, Id<Link> to, int capacityDemand){
+			return new Builder(id, from, to, capacityDemand);
 		}
 
-		private Builder(Id<CarrierShipment> id, Id<Link> pickupLinkId, Id<Link> deliveryLinkId, int demand) {
+		private Builder(Id<CarrierShipment> id, Id<Link> pickupLinkId, Id<Link> deliveryLinkId, int capacityDemand) {
 			super();
 			this.id = id;
 			this.pickupLinkId = pickupLinkId;
 			this.deliveryLinkId = deliveryLinkId;
-			this.demand = demand;
+			this.capacityDemand = capacityDemand;
 		}
 
 		/**
@@ -181,7 +181,7 @@ public final class CarrierShipment implements CarrierJob {
 	}
 
 	private final Id<CarrierShipment> id;
-	private final int demand;
+	private final int capacityDemand;
 
 	//IMO we could build a general class (CarrierActivity ???), containing the location, StartTimeWindow and Duration.
 	//This could be used for both, CarrierService and CarrierShipment (Pickup and Delivery).
@@ -204,7 +204,7 @@ public final class CarrierShipment implements CarrierJob {
 		id = builder.id;
 		pickupLinkId = builder.pickupLinkId;
 		deliveryLinkId = builder.deliveryLinkId;
-		demand = builder.demand;
+		capacityDemand = builder.capacityDemand;
 		pickupDuration = builder.pickupDuration;
 		deliveryDuration = builder.deliveryDuration;
 		pickupStartsTimeWindow = builder.pickupStartsTimeWindow;
@@ -261,7 +261,7 @@ public final class CarrierShipment implements CarrierJob {
 	 */
 	@Override
 	public int getCapacityDemand() {
-		return demand;
+		return capacityDemand;
 	}
 
 	public TimeWindow getPickupStartsTimeWindow() {
@@ -357,7 +357,7 @@ public final class CarrierShipment implements CarrierJob {
 
 	@Override
 	public String toString() {
-		return "[id= "+ id.toString() + "][hash=" + this.hashCode() + "][from=" + pickupLinkId.toString() + "][to=" + deliveryLinkId.toString() + "][size=" + demand + "][pickupServiceTime=" + pickupDuration + "]" +
+		return "[id= "+ id.toString() + "][hash=" + this.hashCode() + "][from=" + pickupLinkId.toString() + "][to=" + deliveryLinkId.toString() + "][size=" + capacityDemand + "][pickupServiceTime=" + pickupDuration + "]" +
 				"[deliveryServiceTime="+ deliveryDuration +"][pickupTimeWindow="+ pickupStartsTimeWindow +"][deliveryTimeWindow="+ deliveryStartsTimeWindow +"]";
 	}
 

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
@@ -407,8 +407,8 @@ public final class CarrierShipment implements CarrierJob {
 
 	@Override
 	public String toString() {
-		return "[id= "+ id.toString() + "][hash=" + this.hashCode() + "][from=" + pickupLinkId.toString() + "][to=" + deliveryLinkId.toString() + "][size=" + capacityDemand + "][pickupServiceTime=" + pickupDuration + "]" +
-				"[deliveryServiceTime="+ deliveryDuration +"][pickupTimeWindow="+ pickupStartingTimeWindow +"][deliveryTimeWindow="+ deliveryStartingTimeWindow +"]";
+		return "[id= "+ id.toString() + "][hash=" + this.hashCode() + "][pickupLinkId=" + pickupLinkId.toString() + "][deliveryLinkId=" + deliveryLinkId.toString() + "][capacityDemand=" + capacityDemand + "][pickupDuration=" + pickupDuration + "]" +
+				"[deliveryDuration="+ deliveryDuration +"][pickupStartingTimeWindow="+ pickupStartingTimeWindow +"][deliveryStartingTimeWindow="+ deliveryStartingTimeWindow +"]";
 	}
 
 	/* (non-Javadoc)

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierShipment.java
@@ -52,14 +52,14 @@ public final class CarrierShipment implements CarrierJob {
 		//This could be used for both, CarrierService and CarrierShipment (Pickup and Delivery).
 		//kturner dec'24
 		private final Id<Link> pickupLinkId;
-		private TimeWindow pickupStartsTimeWindow = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
+		private TimeWindow pickupStartingTimeWindow = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
 		private double pickupDuration = 0.0;
 
 		//IMO we could build a general class (CarrierActivity ???), containing the location, StartTimeWindow and Duration.
 		//This could be used for both, CarrierService and CarrierShipment (Pickup and Delivery).
 		//kturner dec'24
 		private final Id<Link> deliveryLinkId;
-		private TimeWindow deliveryStartsTimeWindow = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
+		private TimeWindow deliveryStartingTimeWindow = TimeWindow.newInstance(0.0, Integer.MAX_VALUE);
 		private double deliveryDuration = 0.0;
 
 		/**
@@ -93,12 +93,29 @@ public final class CarrierShipment implements CarrierJob {
 		 * Note that the time-window restricts the start-time of the shipment's pickup . If one works with hard time-windows (which means that
 		 * time-windows must be met) than the pickup is allowed to start between startTimeWindow.getStart() and startTimeWindow.getEnd().
 		 *
-		 * @param pickupStartsTimeWindow 	time-window for the beginning of the pickup activity
+		 * @param pickupStartingTimeWindow 	time-window for the beginning of the pickup activity
 		 * @return 							the builder
 		 */
-		public Builder setPickupStartsTimeWindow(TimeWindow pickupStartsTimeWindow){
-			this.pickupStartsTimeWindow = pickupStartsTimeWindow;
+		public Builder setPickupStartingTimeWindow(TimeWindow pickupStartingTimeWindow){
+			this.pickupStartingTimeWindow = pickupStartingTimeWindow;
 			return this;
+		}
+
+		/**
+		 * Sets a time-window for the beginning of the pickup
+		 * When not set, it is by default [0.0., Integer.MAX_VALUE].
+		 * <p>
+		 * Note that the time-window restricts the start-time of the shipment's pickup . If one works with hard time-windows (which means that
+		 * time-windows must be met) than the pickup is allowed to start between startTimeWindow.getStart() and startTimeWindow.getEnd().
+		 *
+		 * @deprecated since jan'25, use {@link #setPickupStartingTimeWindow(TimeWindow)} instead
+		 *
+		 * @param pickupStartingTimeWindow 	time-window for the beginning of the pickup activity
+		 * @return 							the builder
+		 */
+		@Deprecated(since = "jan'25")
+		public Builder setPickupStartsTimeWindow(TimeWindow pickupStartingTimeWindow){
+			return setPickupStartingTimeWindow(pickupStartingTimeWindow);
 		}
 
 		/**
@@ -120,12 +137,29 @@ public final class CarrierShipment implements CarrierJob {
 		 * Note that the time-window restricts the start-time of the shipment's delivery . If one works with hard time-windows (which means that
 		 * time-windows must be met) than the delivery is allowed to start between startTimeWindow.getStart() and startTimeWindow.getEnd().
 		 *
-		 * @param deliveryStartsTimeWindow 	time-window for the beginning of the delivery activity
+		 * @param deliveryStartingTimeWindow 	time-window for the beginning of the delivery activity
 		 * @return 							the builder
 		 */
-		public Builder setDeliveryStartsTimeWindow(TimeWindow deliveryStartsTimeWindow){
-			this.deliveryStartsTimeWindow = deliveryStartsTimeWindow;
+		public Builder setDeliveryStartingTimeWindow(TimeWindow deliveryStartingTimeWindow){
+			this.deliveryStartingTimeWindow = deliveryStartingTimeWindow;
 			return this;
+		}
+
+		/**
+		 * Sets a time-window for the beginning of the delivery
+		 * When not set, it is by default [0.0., Integer.MAX_VALUE].
+		 * <p>
+		 * Note that the time-window restricts the start-time of the shipment's delivery . If one works with hard time-windows (which means that
+		 * time-windows must be met) than the delivery is allowed to start between startTimeWindow.getStart() and startTimeWindow.getEnd().
+		 *
+		 * @deprecated since jan'25, use {@link #setDeliveryStartingTimeWindow(TimeWindow)} instead
+		 *
+		 * @param deliveryStartingTimeWindow 	time-window for the beginning of the delivery activity
+		 * @return 							the builder
+		 */
+		@Deprecated(since = "jan'25")
+		public Builder setDeliveryStartsTimeWindow(TimeWindow deliveryStartingTimeWindow){
+			return setDeliveryStartingTimeWindow(deliveryStartingTimeWindow);
 		}
 
 		/**
@@ -148,11 +182,11 @@ public final class CarrierShipment implements CarrierJob {
 
 
 		/**
-		 * @deprecated please inline and use {@link #setPickupStartsTimeWindow(TimeWindow)} instead
+		 * @deprecated please inline and use {@link #setPickupStartingTimeWindow(TimeWindow)} instead
 		 */
 		@Deprecated(since = "dec'24")
 		public Builder setPickupTimeWindow(TimeWindow pickupTW){
-			return setPickupStartsTimeWindow(pickupTW);
+			return setPickupStartingTimeWindow(pickupTW);
 		}
 
 		/**
@@ -164,11 +198,11 @@ public final class CarrierShipment implements CarrierJob {
 		}
 
 		/**
-		 * @deprecated please inline and use {@link #setDeliveryStartsTimeWindow(TimeWindow)} instead
+		 * @deprecated please inline and use {@link #setDeliveryStartingTimeWindow(TimeWindow)} instead
 		 */
 		@Deprecated(since = "dec'24")
 		public Builder setDeliveryTimeWindow(TimeWindow deliveryTW){
-			return setDeliveryStartsTimeWindow(deliveryTW);
+			return setDeliveryStartingTimeWindow(deliveryTW);
 		}
 
 		/**
@@ -187,14 +221,14 @@ public final class CarrierShipment implements CarrierJob {
 	//This could be used for both, CarrierService and CarrierShipment (Pickup and Delivery).
 	//kturner dec'24
 	private final Id<Link> pickupLinkId;
-	private final TimeWindow pickupStartsTimeWindow;
+	private final TimeWindow pickupStartingTimeWindow;
 	private double pickupDuration;
 
 	//IMO we could build a general class (CarrierActivity ???), containing the location, StartTimeWindow and Duration.
 	//This could be used for both, CarrierService and CarrierShipment (Pickup and Delivery).
 	//kturner dec'24
 	private final Id<Link> deliveryLinkId;
-	private final TimeWindow deliveryStartsTimeWindow;
+	private final TimeWindow deliveryStartingTimeWindow;
 	private double deliveryDuration;
 
 	private final Attributes attributes = new AttributesImpl();
@@ -207,8 +241,8 @@ public final class CarrierShipment implements CarrierJob {
 		capacityDemand = builder.capacityDemand;
 		pickupDuration = builder.pickupDuration;
 		deliveryDuration = builder.deliveryDuration;
-		pickupStartsTimeWindow = builder.pickupStartsTimeWindow;
-		deliveryStartsTimeWindow = builder.deliveryStartsTimeWindow;
+		pickupStartingTimeWindow = builder.pickupStartingTimeWindow;
+		deliveryStartingTimeWindow = builder.deliveryStartingTimeWindow;
 	}
 
 	//* getters and setters
@@ -264,12 +298,28 @@ public final class CarrierShipment implements CarrierJob {
 		return capacityDemand;
 	}
 
-	public TimeWindow getPickupStartsTimeWindow() {
-		return pickupStartsTimeWindow;
+	public TimeWindow getPickupStartingTimeWindow() {
+		return pickupStartingTimeWindow;
 	}
 
+	/**
+	 * @deprecated since jan'25, use {@link #getPickupStartingTimeWindow()} instead
+	 */
+	@Deprecated(since = "jan'25")
+	public TimeWindow getPickupStartsTimeWindow() {
+		return getPickupStartingTimeWindow();
+	}
+
+	public TimeWindow getDeliveryStartingTimeWindow() {
+		return deliveryStartingTimeWindow;
+	}
+
+	/**
+	 * @deprecated since jan'25, use {@link #getDeliveryStartingTimeWindow()} instead
+	 */
+	@Deprecated(since = "jan'25")
 	public TimeWindow getDeliveryStartsTimeWindow() {
-		return deliveryStartsTimeWindow;
+		return getDeliveryStartingTimeWindow();
 	}
 
 	@Override
@@ -297,11 +347,11 @@ public final class CarrierShipment implements CarrierJob {
 	}
 
 	/**
-	 * @deprecated please inline and use {@link #getPickupStartsTimeWindow()} instead
+	 * @deprecated please inline and use {@link #getPickupStartingTimeWindow()} instead
 	 */
 	@Deprecated(since = "dec'24")
 	public TimeWindow getPickupTimeWindow() {
-		return getPickupStartsTimeWindow();
+		return getPickupStartingTimeWindow();
 	}
 
 	/**
@@ -330,11 +380,11 @@ public final class CarrierShipment implements CarrierJob {
 	}
 
 	/**
-	 * @deprecated please inline and use {@link #getDeliveryStartsTimeWindow()} instead
+	 * @deprecated please inline and use {@link #getDeliveryStartingTimeWindow()} instead
 	 */
 	@Deprecated(since = "dec'24")
 	public TimeWindow getDeliveryTimeWindow() {
-		return getDeliveryStartsTimeWindow();
+		return getDeliveryStartingTimeWindow();
 	}
 
 	/**
@@ -358,7 +408,7 @@ public final class CarrierShipment implements CarrierJob {
 	@Override
 	public String toString() {
 		return "[id= "+ id.toString() + "][hash=" + this.hashCode() + "][from=" + pickupLinkId.toString() + "][to=" + deliveryLinkId.toString() + "][size=" + capacityDemand + "][pickupServiceTime=" + pickupDuration + "]" +
-				"[deliveryServiceTime="+ deliveryDuration +"][pickupTimeWindow="+ pickupStartsTimeWindow +"][deliveryTimeWindow="+ deliveryStartsTimeWindow +"]";
+				"[deliveryServiceTime="+ deliveryDuration +"][pickupTimeWindow="+ pickupStartingTimeWindow +"][deliveryTimeWindow="+ deliveryStartingTimeWindow +"]";
 	}
 
 	/* (non-Javadoc)

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
@@ -435,9 +435,9 @@ public class CarriersUtils {
 				.setDeliveryDuration(carrierService.getServiceDuration())
 				// .setPickupServiceTime(pickupServiceTime) //Not set yet, because in service we
 				// have now time for that. Maybe change it later, kmt sep18
-				.setDeliveryStartsTimeWindow(carrierService.getServiceStaringTimeWindow())
+				.setDeliveryStartingTimeWindow(carrierService.getServiceStaringTimeWindow())
 				// Limited to end of delivery timeWindow (pickup later than the latest delivery is not useful).
-				.setPickupStartsTimeWindow(TimeWindow.newInstance(0.0, carrierService.getServiceStaringTimeWindow().getEnd()))
+				.setPickupStartingTimeWindow(TimeWindow.newInstance(0.0, carrierService.getServiceStaringTimeWindow().getEnd()))
 				.build();
 			addShipment(carrierWS, carrierShipment);
 		}

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
@@ -435,9 +435,9 @@ public class CarriersUtils {
 				.setDeliveryDuration(carrierService.getServiceDuration())
 				// .setPickupServiceTime(pickupServiceTime) //Not set yet, because in service we
 				// have now time for that. Maybe change it later, kmt sep18
-				.setDeliveryStartsTimeWindow(carrierService.getServiceStartTimeWindow())
+				.setDeliveryStartsTimeWindow(carrierService.getServiceStaringTimeWindow())
 				// Limited to end of delivery timeWindow (pickup later than the latest delivery is not useful).
-				.setPickupStartsTimeWindow(TimeWindow.newInstance(0.0, carrierService.getServiceStartTimeWindow().getEnd()))
+				.setPickupStartsTimeWindow(TimeWindow.newInstance(0.0, carrierService.getServiceStaringTimeWindow().getEnd()))
 				.build();
 			addShipment(carrierWS, carrierShipment);
 		}

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
@@ -431,7 +431,7 @@ public class CarriersUtils {
 			CarrierShipment carrierShipment = CarrierShipment.Builder
 				.newInstance(Id.create(carrierService.getId().toString(), CarrierShipment.class),
 					depotServiceIsDeliveredFrom.get(carrierService.getId()), carrierService.getServiceLinkId(),
-					carrierService.getDemand())
+					carrierService.getCapacityDemand())
 				.setDeliveryDuration(carrierService.getServiceDuration())
 				// .setPickupServiceTime(pickupServiceTime) //Not set yet, because in service we
 				// have now time for that. Maybe change it later, kmt sep18

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/Tour.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/Tour.java
@@ -539,7 +539,7 @@ public class Tour {
 
 		@Override
 		public TimeWindow getTimeWindow() {
-			return shipment.getPickupStartsTimeWindow();
+			return shipment.getPickupStartingTimeWindow();
 		}
 
 		@Override
@@ -592,7 +592,7 @@ public class Tour {
 
 		@Override
 		public TimeWindow getTimeWindow() {
-			return shipment.getDeliveryStartsTimeWindow();
+			return shipment.getDeliveryStartingTimeWindow();
 		}
 
 		@Override

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/Tour.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/Tour.java
@@ -389,7 +389,7 @@ public class Tour {
 
 		@Override
 		public TimeWindow getTimeWindow() {
-			return service.getServiceStartTimeWindow();
+			return service.getServiceStaringTimeWindow();
 		}
 
 		@Override

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/analysis/CarrierPlanAnalysis.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/analysis/CarrierPlanAnalysis.java
@@ -101,16 +101,16 @@ public class CarrierPlanAnalysis {
 				int numberOfHandledDemandSize;
 				int notHandledJobs;
 				if (numberOfPlanedShipments > 0) {
-					numberOfPlanedDemandSize = carrier.getShipments().values().stream().mapToInt(carrierShipment -> carrierShipment.getDemand()).sum();
+					numberOfPlanedDemandSize = carrier.getShipments().values().stream().mapToInt(carrierShipment -> carrierShipment.getCapacityDemand()).sum();
 					numberOfHandledDemandSize = carrier.getSelectedPlan().getScheduledTours().stream().mapToInt(
 						t -> t.getTour().getTourElements().stream().filter(te -> te instanceof Tour.Pickup).mapToInt(
-							te -> ((Tour.Pickup) te).getShipment().getDemand()).sum()).sum();
+							te -> ((Tour.Pickup) te).getShipment().getCapacityDemand()).sum()).sum();
 					notHandledJobs = numberOfPlanedShipments - numberOfHandledPickups;
 				} else {
-					numberOfPlanedDemandSize = carrier.getServices().values().stream().mapToInt(carrierService -> carrierService.getDemand()).sum();
+					numberOfPlanedDemandSize = carrier.getServices().values().stream().mapToInt(carrierService -> carrierService.getCapacityDemand()).sum();
 					numberOfHandledDemandSize = carrier.getSelectedPlan().getScheduledTours().stream().mapToInt(
 						t -> t.getTour().getTourElements().stream().filter(te -> te instanceof Tour.ServiceActivity).mapToInt(
-							te -> ((Tour.ServiceActivity) te).getService().getDemand()).sum()).sum();
+							te -> ((Tour.ServiceActivity) te).getService().getCapacityDemand()).sum()).sum();
 					notHandledJobs = numberOfPlanedServices - nuOfServiceHandled;
 				}
 

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierServiceStartEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierServiceStartEvent.java
@@ -47,7 +47,7 @@ public final class CarrierServiceStartEvent extends AbstractCarrierEvent {
 		super(time, carrierId, service.getServiceLinkId(), vehicleId);
 		this.serviceId = service.getId();
 		this.serviceDuration = service.getServiceDuration();
-        this.capacityDemand = service.getDemand();
+        this.capacityDemand = service.getCapacityDemand();
 	}
 
 	@Override
@@ -85,7 +85,7 @@ public final class CarrierServiceStartEvent extends AbstractCarrierEvent {
 		Id<Link> locationLinkId = Id.createLinkId(attributes.get(ATTRIBUTE_LINK));
 		CarrierService service = CarrierService.Builder.newInstance(carrierServiceId, locationLinkId)
 				.setServiceDuration(Double.parseDouble(attributes.get(CarrierEventAttributes.ATTRIBUTE_SERVICE_DURATION)))
-				.setDemand(Integer.parseInt(attributes.get(CarrierEventAttributes.ATTRIBUTE_CAPACITYDEMAND)))
+				.setCapacityDemand(Integer.parseInt(attributes.get(CarrierEventAttributes.ATTRIBUTE_CAPACITYDEMAND)))
 				.build();
 		Id<Vehicle> vehicleId = Id.create(attributes.get(ATTRIBUTE_VEHICLE), Vehicle.class);
 		return new CarrierServiceStartEvent(time, carrierId, service, vehicleId);

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentDeliveryEndEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentDeliveryEndEvent.java
@@ -47,7 +47,7 @@ public class CarrierShipmentDeliveryEndEvent extends AbstractCarrierEvent {
 		super(time, carrierId, shipment.getDeliveryLinkId(), vehicleId);
 		this.shipmentId = shipment.getId();
 		this.deliveryDuration = shipment.getDeliveryDuration();
-        this.capacityDemand = shipment.getDemand();
+        this.capacityDemand = shipment.getCapacityDemand();
 	}
 
 	@Override

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentDeliveryStartEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentDeliveryStartEvent.java
@@ -48,7 +48,7 @@ public class CarrierShipmentDeliveryStartEvent extends AbstractCarrierEvent {
 		super(time, carrierId, shipment.getDeliveryLinkId(), vehicleId);
 		this.shipmentId = shipment.getId();
 		this.deliveryDuration = shipment.getDeliveryDuration();
-        this.capacityDemand = shipment.getDemand();
+        this.capacityDemand = shipment.getCapacityDemand();
 	}
 
 	@Override

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentPickupEndEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentPickupEndEvent.java
@@ -49,7 +49,7 @@ public class CarrierShipmentPickupEndEvent extends AbstractCarrierEvent {
 		super(time, carrierId, shipment.getPickupLinkId(), vehicleId);
 		this.shipmentId = shipment.getId();
 		this.pickupDuration = shipment.getPickupDuration();
-        this.capacityDemand = shipment.getDemand();
+        this.capacityDemand = shipment.getCapacityDemand();
 	}
 
 

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentPickupStartEvent.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierShipmentPickupStartEvent.java
@@ -47,7 +47,7 @@ public class CarrierShipmentPickupStartEvent extends AbstractCarrierEvent {
 		super(time, carrierId, shipment.getPickupLinkId(), vehicleId);
 		this.shipmentId = shipment.getId();
 		this.pickupDuration = shipment.getPickupDuration();
-        this.capacityDemand = shipment.getDemand();
+        this.capacityDemand = shipment.getCapacityDemand();
 	}
 
 

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/MatsimJspritFactory.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/MatsimJspritFactory.java
@@ -90,10 +90,10 @@ public final class MatsimJspritFactory {
 						Id.createLinkId(jspritShipment.getPickupLocation().getId()),
 						Id.createLinkId(jspritShipment.getDeliveryLocation().getId()), jspritShipment.getSize().get(0))
 				.setDeliveryDuration(jspritShipment.getDeliveryServiceTime())
-				.setDeliveryStartsTimeWindow(org.matsim.freight.carriers.TimeWindow.newInstance(jspritShipment.getDeliveryTimeWindow().getStart(),
+				.setDeliveryStartingTimeWindow(org.matsim.freight.carriers.TimeWindow.newInstance(jspritShipment.getDeliveryTimeWindow().getStart(),
 						jspritShipment.getDeliveryTimeWindow().getEnd()))
 				.setPickupDuration(jspritShipment.getPickupServiceTime())
-				.setPickupStartsTimeWindow(org.matsim.freight.carriers.TimeWindow.newInstance(jspritShipment.getPickupTimeWindow().getStart(),
+				.setPickupStartingTimeWindow(org.matsim.freight.carriers.TimeWindow.newInstance(jspritShipment.getPickupTimeWindow().getStart(),
 						jspritShipment.getPickupTimeWindow().getEnd()))
 				.build();
 		CarriersUtils.setSkills(carrierShipment, jspritShipment.getRequiredSkills().values());
@@ -112,13 +112,13 @@ public final class MatsimJspritFactory {
 				.setDeliveryLocation(Location.newInstance(carrierShipment.getDeliveryLinkId().toString()))
 				.setDeliveryServiceTime(carrierShipment.getDeliveryDuration())
 				.setDeliveryTimeWindow(com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow
-						.newInstance(carrierShipment.getDeliveryStartsTimeWindow().getStart(),
-								carrierShipment.getDeliveryStartsTimeWindow().getEnd()))
+						.newInstance(carrierShipment.getDeliveryStartingTimeWindow().getStart(),
+								carrierShipment.getDeliveryStartingTimeWindow().getEnd()))
 				.setPickupServiceTime(carrierShipment.getPickupDuration())
 				.setPickupLocation(Location.newInstance(carrierShipment.getPickupLinkId().toString()))
 				.setPickupTimeWindow(com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow.newInstance(
-						carrierShipment.getPickupStartsTimeWindow().getStart(),
-						carrierShipment.getPickupStartsTimeWindow().getEnd()))
+						carrierShipment.getPickupStartingTimeWindow().getStart(),
+						carrierShipment.getPickupStartingTimeWindow().getEnd()))
 				.addSizeDimension(0, carrierShipment.getCapacityDemand());
 		for (String skill : CarriersUtils.getSkills(carrierShipment)) {
 			shipmentBuilder.addRequiredSkill(skill);
@@ -144,12 +144,12 @@ public final class MatsimJspritFactory {
 		Shipment.Builder shipmentBuilder = Shipment.Builder.newInstance(carrierShipment.getId().toString())
 				.setDeliveryLocation(toLocation).setDeliveryServiceTime(carrierShipment.getDeliveryDuration())
 				.setDeliveryTimeWindow(com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow
-						.newInstance(carrierShipment.getDeliveryStartsTimeWindow().getStart(),
-								carrierShipment.getDeliveryStartsTimeWindow().getEnd()))
+						.newInstance(carrierShipment.getDeliveryStartingTimeWindow().getStart(),
+								carrierShipment.getDeliveryStartingTimeWindow().getEnd()))
 				.setPickupServiceTime(carrierShipment.getPickupDuration()).setPickupLocation(fromLocation)
 				.setPickupTimeWindow(com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow.newInstance(
-						carrierShipment.getPickupStartsTimeWindow().getStart(),
-						carrierShipment.getPickupStartsTimeWindow().getEnd()))
+						carrierShipment.getPickupStartingTimeWindow().getStart(),
+						carrierShipment.getPickupStartingTimeWindow().getEnd()))
 				.addSizeDimension(0, carrierShipment.getCapacityDemand());
 		for (String skill : CarriersUtils.getSkills(carrierShipment)) {
 			shipmentBuilder.addRequiredSkill(skill);

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/MatsimJspritFactory.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/MatsimJspritFactory.java
@@ -58,6 +58,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.core.utils.io.IOUtils;
 import org.matsim.freight.carriers.*;
+import org.matsim.freight.carriers.TimeWindow;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehicleUtils;
 
@@ -186,8 +187,7 @@ public final class MatsimJspritFactory {
 				Id.create(jspritService.getId(), CarrierService.class), Id.create(jspritService.getLocation().getId(), Link.class));
 		serviceBuilder.setCapacityDemand(jspritService.getSize().get(0));
 		serviceBuilder.setServiceDuration(jspritService.getServiceDuration());
-		serviceBuilder.setServiceStartTimeWindow(
-				org.matsim.freight.carriers.TimeWindow.newInstance(jspritService.getTimeWindow().getStart(), jspritService.getTimeWindow().getEnd()));
+		serviceBuilder.setServiceStartingTimeWindow(TimeWindow.newInstance(jspritService.getTimeWindow().getStart(), jspritService.getTimeWindow().getEnd()));
 		CarrierService carrierService = serviceBuilder.build();
 		CarriersUtils.setSkills(carrierService, jspritService.getRequiredSkills().values());
 		return carrierService;

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/MatsimJspritFactory.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/MatsimJspritFactory.java
@@ -118,7 +118,7 @@ public final class MatsimJspritFactory {
 				.setPickupTimeWindow(com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow.newInstance(
 						carrierShipment.getPickupStartsTimeWindow().getStart(),
 						carrierShipment.getPickupStartsTimeWindow().getEnd()))
-				.addSizeDimension(0, carrierShipment.getDemand());
+				.addSizeDimension(0, carrierShipment.getCapacityDemand());
 		for (String skill : CarriersUtils.getSkills(carrierShipment)) {
 			shipmentBuilder.addRequiredSkill(skill);
 		}
@@ -149,7 +149,7 @@ public final class MatsimJspritFactory {
 				.setPickupTimeWindow(com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow.newInstance(
 						carrierShipment.getPickupStartsTimeWindow().getStart(),
 						carrierShipment.getPickupStartsTimeWindow().getEnd()))
-				.addSizeDimension(0, carrierShipment.getDemand());
+				.addSizeDimension(0, carrierShipment.getCapacityDemand());
 		for (String skill : CarriersUtils.getSkills(carrierShipment)) {
 			shipmentBuilder.addRequiredSkill(skill);
 		}
@@ -165,7 +165,7 @@ public final class MatsimJspritFactory {
 		Location location = locationBuilder.build();
 
 		Builder serviceBuilder = Builder.newInstance(carrierService.getId().toString());
-		serviceBuilder.addSizeDimension(0, carrierService.getDemand());
+		serviceBuilder.addSizeDimension(0, carrierService.getCapacityDemand());
 		serviceBuilder.setLocation(location).setServiceTime(carrierService.getServiceDuration())
 				.setTimeWindow(com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow.newInstance(
 						carrierService.getServiceStartTimeWindow().getStart(),
@@ -184,7 +184,7 @@ public final class MatsimJspritFactory {
 	static CarrierService createCarrierService(Service jspritService) {
 		CarrierService.Builder serviceBuilder = CarrierService.Builder.newInstance(
 				Id.create(jspritService.getId(), CarrierService.class), Id.create(jspritService.getLocation().getId(), Link.class));
-		serviceBuilder.setDemand(jspritService.getSize().get(0));
+		serviceBuilder.setCapacityDemand(jspritService.getSize().get(0));
 		serviceBuilder.setServiceDuration(jspritService.getServiceDuration());
 		serviceBuilder.setServiceStartTimeWindow(
 				org.matsim.freight.carriers.TimeWindow.newInstance(jspritService.getTimeWindow().getStart(), jspritService.getTimeWindow().getEnd()));

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/MatsimJspritFactory.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/MatsimJspritFactory.java
@@ -169,8 +169,8 @@ public final class MatsimJspritFactory {
 		serviceBuilder.addSizeDimension(0, carrierService.getCapacityDemand());
 		serviceBuilder.setLocation(location).setServiceTime(carrierService.getServiceDuration())
 				.setTimeWindow(com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow.newInstance(
-						carrierService.getServiceStartTimeWindow().getStart(),
-						carrierService.getServiceStartTimeWindow().getEnd()));
+						carrierService.getServiceStaringTimeWindow().getStart(),
+						carrierService.getServiceStaringTimeWindow().getEnd()));
 		for (String skill : CarriersUtils.getSkills(carrierService)) {
 			serviceBuilder.addRequiredSkill(skill);
 		}

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/usecases/chessboard/FreightScenarioCreator.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/usecases/chessboard/FreightScenarioCreator.java
@@ -101,7 +101,7 @@ final class FreightScenarioCreator {
 
         for(int i=0;i<20;i++){
             CarrierService.Builder serviceBuilder = CarrierService.Builder.newInstance(Id.create((i + 1),CarrierService.class), drawLocationLinkId(innerCityLinks, outerCityLinks));
-            serviceBuilder.setDemand(1);
+            serviceBuilder.setCapacityDemand(1);
             serviceBuilder.setServiceDuration(5*60);
             serviceBuilder.setServiceStartTimeWindow(TimeWindow.newInstance(6*60*60, 15*60*60));
             CarrierService carrierService = serviceBuilder.build();

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/usecases/chessboard/FreightScenarioCreator.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/usecases/chessboard/FreightScenarioCreator.java
@@ -103,8 +103,8 @@ final class FreightScenarioCreator {
             CarrierService.Builder serviceBuilder = CarrierService.Builder.newInstance(Id.create((i + 1),CarrierService.class), drawLocationLinkId(innerCityLinks, outerCityLinks));
             serviceBuilder.setCapacityDemand(1);
             serviceBuilder.setServiceDuration(5*60);
-            serviceBuilder.setServiceStartTimeWindow(TimeWindow.newInstance(6*60*60, 15*60*60));
-            CarrierService carrierService = serviceBuilder.build();
+			serviceBuilder.setServiceStartingTimeWindow(TimeWindow.newInstance(6*60*60, 15*60*60));
+			CarrierService carrierService = serviceBuilder.build();
             CarriersUtils.addService(carrier, carrierService);
         }
     }

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsUtils.java
@@ -59,7 +59,7 @@ class MultipleChainsUtils {
       LspShipmentUtils.LspShipmentBuilder builder =
           LspShipmentUtils.LspShipmentBuilder.newInstance(
               Id.create(shipment.getId().toString(), LspShipment.class));
-        builder.setCapacityDemand(shipment.getDemand());
+        builder.setCapacityDemand(shipment.getCapacityDemand());
       builder.setFromLinkId(shipment.getPickupLinkId());
       builder.setToLinkId(shipment.getDeliveryLinkId());
 		builder.setStartTimeWindow(shipment.getPickupStartsTimeWindow());

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsUtils.java
@@ -62,8 +62,8 @@ class MultipleChainsUtils {
         builder.setCapacityDemand(shipment.getCapacityDemand());
       builder.setFromLinkId(shipment.getPickupLinkId());
       builder.setToLinkId(shipment.getDeliveryLinkId());
-		builder.setStartTimeWindow(shipment.getPickupStartsTimeWindow());
-		builder.setEndTimeWindow(shipment.getDeliveryStartsTimeWindow());
+		builder.setStartTimeWindow(shipment.getPickupStartingTimeWindow());
+		builder.setEndTimeWindow(shipment.getDeliveryStartingTimeWindow());
       builder.setPickupServiceTime(shipment.getPickupDuration());
       builder.setDeliveryServiceTime(shipment.getDeliveryDuration());
       shipmentList.add(builder.build());

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
@@ -84,7 +84,7 @@ import org.matsim.freight.logistics.shipment.LspShipmentUtils;
     Id<CarrierService> serviceId = Id.create(lspShipment.getId().toString(), CarrierService.class);
     CarrierService carrierService = CarrierService.Builder.newInstance(serviceId, lspShipment.getFrom())
             .setServiceStartTimeWindow(TimeWindow.newInstance(lspShipment.getPickupTimeWindow().getStart(), lspShipment.getPickupTimeWindow().getEnd()))
-            .setDemand(lspShipment.getSize())
+            .setCapacityDemand(lspShipment.getSize())
             .setServiceDuration(lspShipment.getDeliveryServiceTime())
             .build();
     //ensure that the ids of the lspShipment and the carrierService are the same. This is needed for updating the LSPShipmentPlan

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/resourceImplementations/CollectionCarrierScheduler.java
@@ -82,8 +82,8 @@ import org.matsim.freight.logistics.shipment.LspShipmentUtils;
 
   private CarrierService convertToCarrierService(LspShipment lspShipment) {
     Id<CarrierService> serviceId = Id.create(lspShipment.getId().toString(), CarrierService.class);
-    CarrierService carrierService = CarrierService.Builder.newInstance(serviceId, lspShipment.getFrom())
-            .setServiceStartTimeWindow(TimeWindow.newInstance(lspShipment.getPickupTimeWindow().getStart(), lspShipment.getPickupTimeWindow().getEnd()))
+	  CarrierService.Builder builder = CarrierService.Builder.newInstance(serviceId, lspShipment.getFrom());
+	  CarrierService carrierService = builder.setServiceStartingTimeWindow(TimeWindow.newInstance(lspShipment.getPickupTimeWindow().getStart(), lspShipment.getPickupTimeWindow().getEnd()))
             .setCapacityDemand(lspShipment.getSize())
             .setServiceDuration(lspShipment.getDeliveryServiceTime())
             .build();

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
@@ -184,7 +184,7 @@ import org.matsim.vehicles.VehicleType;
     CarrierService carrierService = CarrierService.Builder.newInstance(serviceId, lspShipment.getTo())
             //TODO TimeWindows are not set. This seems to be a problem. KMT'Aug'24
             //If added here, we also need to decide what happens, if the vehicles StartTime (plus TT) is > TimeWindowEnd ....
-            .setDemand(lspShipment.getSize())
+            .setCapacityDemand(lspShipment.getSize())
             .setServiceDuration(lspShipment.getDeliveryServiceTime())
             .build();
     //ensure that the ids of the lspShipment and the carrierService are the same. This is needed for updating the LSPShipmentPlan

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/resourceImplementations/MainRunCarrierScheduler.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/resourceImplementations/MainRunCarrierScheduler.java
@@ -229,7 +229,7 @@ import org.matsim.vehicles.VehicleType;
         Id.create(lspShipment.getId().toString(), CarrierService.class);
     CarrierService.Builder builder =
         CarrierService.Builder.newInstance(serviceId, resource.getEndLinkId());
-    builder.setDemand(lspShipment.getSize());
+    builder.setCapacityDemand(lspShipment.getSize());
     builder.setServiceDuration(lspShipment.getDeliveryServiceTime());
     return builder.build();
   }

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/CarriersUtilsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/CarriersUtilsTest.java
@@ -68,7 +68,7 @@ public class CarriersUtilsTest {
 		Carrier carrier = new CarrierImpl(Id.create("carrier", Carrier.class));
 		Id<CarrierService> serviceId = Id.create("testVehicle", CarrierService.class);
 		CarrierService service1 = CarrierService.Builder.newInstance(serviceId,Id.createLinkId("link0") )
-				.setDemand(15).setServiceDuration(30).build();
+				.setCapacityDemand(15).setServiceDuration(30).build();
 
 		//add Service
 		CarriersUtils.addService(carrier, service1);
@@ -105,7 +105,7 @@ public class CarriersUtilsTest {
 		Assertions.assertEquals(shipmentId, carrierShipment1b.getId());
 		Assertions.assertEquals(service1.getId(), carrierShipment1b.getId());
 		Assertions.assertEquals(Id.createLinkId("link0"), carrierShipment1b.getPickupLinkId());
-		Assertions.assertEquals(20, carrierShipment1b.getDemand(), EPSILON);
+		Assertions.assertEquals(20, carrierShipment1b.getCapacityDemand(), EPSILON);
 	}
 
 	@Test

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/DistanceConstraintFromVehiclesFileTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/DistanceConstraintFromVehiclesFileTest.java
@@ -421,14 +421,14 @@ public class DistanceConstraintFromVehiclesFileTest {
 		CarrierService service1 = CarrierService.Builder
 				.newInstance(Id.create("Service1", CarrierService.class), Id.createLinkId("j(3,8)"))
 				.setServiceDuration(20).setServiceStartTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
-				.setDemand(40).build();
+				.setCapacityDemand(40).build();
 		CarriersUtils.addService(carrier, service1);
 
 		// Service 2
 		CarrierService service2 = CarrierService.Builder
 				.newInstance(Id.create("Service2", CarrierService.class), Id.createLinkId("j(0,3)R"))
 				.setServiceDuration(20).setServiceStartTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
-				.setDemand(40).build();
+				.setCapacityDemand(40).build();
 		CarriersUtils.addService(carrier, service2);
 
 		return carrier;
@@ -442,7 +442,7 @@ public class DistanceConstraintFromVehiclesFileTest {
 		CarrierService service3 = CarrierService.Builder
 				.newInstance(Id.create("Service3", CarrierService.class), Id.createLinkId("j(9,2)"))
 				.setServiceDuration(20).setServiceStartTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
-				.setDemand(40).build();
+				.setCapacityDemand(40).build();
 		CarriersUtils.addService(carrier, service3);
 
 		return carrier;

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/DistanceConstraintFromVehiclesFileTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/DistanceConstraintFromVehiclesFileTest.java
@@ -418,16 +418,18 @@ public class DistanceConstraintFromVehiclesFileTest {
 
 	private static Carrier addTwoServicesToCarrier(Carrier carrier) {
 		// Service 1
-		CarrierService service1 = CarrierService.Builder
+		CarrierService.Builder builder1 = CarrierService.Builder
 				.newInstance(Id.create("Service1", CarrierService.class), Id.createLinkId("j(3,8)"))
-				.setServiceDuration(20).setServiceStartTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
+				.setServiceDuration(20);
+		CarrierService service1 = builder1.setServiceStartingTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
 				.setCapacityDemand(40).build();
 		CarriersUtils.addService(carrier, service1);
 
 		// Service 2
-		CarrierService service2 = CarrierService.Builder
+		CarrierService.Builder builder = CarrierService.Builder
 				.newInstance(Id.create("Service2", CarrierService.class), Id.createLinkId("j(0,3)R"))
-				.setServiceDuration(20).setServiceStartTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
+				.setServiceDuration(20);
+		CarrierService service2 = builder.setServiceStartingTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
 				.setCapacityDemand(40).build();
 		CarriersUtils.addService(carrier, service2);
 
@@ -439,9 +441,10 @@ public class DistanceConstraintFromVehiclesFileTest {
 		addTwoServicesToCarrier(carrier);
 
 		// Service 3
-		CarrierService service3 = CarrierService.Builder
+		CarrierService.Builder builder = CarrierService.Builder
 				.newInstance(Id.create("Service3", CarrierService.class), Id.createLinkId("j(9,2)"))
-				.setServiceDuration(20).setServiceStartTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
+				.setServiceDuration(20);
+		CarrierService service3 = builder.setServiceStartingTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
 				.setCapacityDemand(40).build();
 		CarriersUtils.addService(carrier, service3);
 

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/DistanceConstraintTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/DistanceConstraintTest.java
@@ -633,14 +633,14 @@ public class DistanceConstraintTest {
 		// Shipment 1
 		CarrierShipment shipment1 = CarrierShipment.Builder
 				.newInstance(Id.create("Shipment1", CarrierShipment.class), Id.createLinkId("i(1,8)"), Id.createLinkId("j(3,8)"), 40)
-				.setDeliveryDuration(20).setDeliveryStartsTimeWindow(TimeWindow.newInstance(8 * 3600, 12 * 3600))
+				.setDeliveryDuration(20).setDeliveryStartingTimeWindow(TimeWindow.newInstance(8 * 3600, 12 * 3600))
 				.build();
 		CarriersUtils.addShipment(carrier, shipment1);
 
 		// Shipment 2
 		CarrierShipment shipment2 = CarrierShipment.Builder
 				.newInstance(Id.create("Shipment2", CarrierShipment.class),Id.createLinkId("i(1,8)"), Id.createLinkId("j(0,3)R"), 40)
-				.setDeliveryDuration(20).setDeliveryStartsTimeWindow(TimeWindow.newInstance(8 * 3600, 12 * 3600))
+				.setDeliveryDuration(20).setDeliveryStartingTimeWindow(TimeWindow.newInstance(8 * 3600, 12 * 3600))
 				.build();
 		CarriersUtils.addShipment(carrier, shipment2);
 

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/DistanceConstraintTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/DistanceConstraintTest.java
@@ -614,14 +614,14 @@ public class DistanceConstraintTest {
 		CarrierService service1 = CarrierService.Builder
 				.newInstance(Id.create("Service1", CarrierService.class), Id.createLinkId("j(3,8)"))
 				.setServiceDuration(20).setServiceStartTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
-				.setDemand(40).build();
+				.setCapacityDemand(40).build();
 		CarriersUtils.addService(carrier, service1);
 
 		// Service 2
 		CarrierService service2 = CarrierService.Builder
 				.newInstance(Id.create("Service2", CarrierService.class), Id.createLinkId("j(0,3)R"))
 				.setServiceDuration(20).setServiceStartTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
-				.setDemand(40).build();
+				.setCapacityDemand(40).build();
 		CarriersUtils.addService(carrier, service2);
 
 		return carrier;
@@ -653,7 +653,7 @@ public class DistanceConstraintTest {
 		CarrierService service3 = CarrierService.Builder
 				.newInstance(Id.create("Service3", CarrierService.class), Id.createLinkId("j(9,2)"))
 				.setServiceDuration(20).setServiceStartTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
-				.setDemand(40).build();
+				.setCapacityDemand(40).build();
 		CarriersUtils.addService(carrier, service3);
 
 		return carrier;

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/DistanceConstraintTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/DistanceConstraintTest.java
@@ -611,16 +611,18 @@ public class DistanceConstraintTest {
 
 	private static Carrier addTwoServicesToCarrier(Carrier carrier) {
 		// Service 1
-		CarrierService service1 = CarrierService.Builder
+		CarrierService.Builder builder1 = CarrierService.Builder
 				.newInstance(Id.create("Service1", CarrierService.class), Id.createLinkId("j(3,8)"))
-				.setServiceDuration(20).setServiceStartTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
+				.setServiceDuration(20);
+		CarrierService service1 = builder1.setServiceStartingTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
 				.setCapacityDemand(40).build();
 		CarriersUtils.addService(carrier, service1);
 
 		// Service 2
-		CarrierService service2 = CarrierService.Builder
+		CarrierService.Builder builder = CarrierService.Builder
 				.newInstance(Id.create("Service2", CarrierService.class), Id.createLinkId("j(0,3)R"))
-				.setServiceDuration(20).setServiceStartTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
+				.setServiceDuration(20);
+		CarrierService service2 = builder.setServiceStartingTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
 				.setCapacityDemand(40).build();
 		CarriersUtils.addService(carrier, service2);
 
@@ -650,9 +652,10 @@ public class DistanceConstraintTest {
 		addTwoServicesToCarrier(carrier);
 
 		// Service 3
-		CarrierService service3 = CarrierService.Builder
+		CarrierService.Builder builder = CarrierService.Builder
 				.newInstance(Id.create("Service3", CarrierService.class), Id.createLinkId("j(9,2)"))
-				.setServiceDuration(20).setServiceStartTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
+				.setServiceDuration(20);
+		CarrierService service3 = builder.setServiceStartingTimeWindow(TimeWindow.newInstance(8 * 3600, 10 * 3600))
 				.setCapacityDemand(40).build();
 		CarriersUtils.addService(carrier, service3);
 

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/FixedCostsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/FixedCostsTest.java
@@ -200,7 +200,7 @@ public class FixedCostsTest  {
 
 	private static CarrierService createMatsimService(String id, String to, int size) {
 		return CarrierService.Builder.newInstance(Id.create(id, CarrierService.class), Id.create(to, Link.class))
-						     .setDemand(size)
+						     .setCapacityDemand(size)
 						     .setServiceDuration(31.0)
 						     .setServiceStartTimeWindow(TimeWindow.newInstance(3601.0, 36001.0))
 						     .build();

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/FixedCostsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/FixedCostsTest.java
@@ -199,10 +199,10 @@ public class FixedCostsTest  {
 	}
 
 	private static CarrierService createMatsimService(String id, String to, int size) {
-		return CarrierService.Builder.newInstance(Id.create(id, CarrierService.class), Id.create(to, Link.class))
+		CarrierService.Builder builder = CarrierService.Builder.newInstance(Id.create(id, CarrierService.class), Id.create(to, Link.class))
 						     .setCapacityDemand(size)
-						     .setServiceDuration(31.0)
-						     .setServiceStartTimeWindow(TimeWindow.newInstance(3601.0, 36001.0))
+						     .setServiceDuration(31.0);
+		return builder.setServiceStartingTimeWindow(TimeWindow.newInstance(3601.0, 36001.0))
 						     .build();
 	}
 

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/IntegrationIT.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/IntegrationIT.java
@@ -88,9 +88,10 @@ public class IntegrationIT {
 			Assertions.assertEquals(2, carrier.getPlans().size(), "The number of plans is not as expected");
 			// Test method if all jobs are handled
 			Assertions.assertTrue(CarriersUtils.allJobsHandledBySelectedPlan(carrier), "Not all jobs are handled");
-			CarrierService newService = CarrierService.Builder.newInstance(Id.create(
+			CarrierService.Builder builder = CarrierService.Builder.newInstance(Id.create(
 				"service" + carrier.getServices().size(), CarrierService.class), Id.createLinkId("100603"))
-				.setServiceDuration(10.).setServiceStartTimeWindow(TimeWindow.newInstance(0,86000)).build();
+				.setServiceDuration(10.);
+			CarrierService newService = builder.setServiceStartingTimeWindow(TimeWindow.newInstance(0, 86000)).build();
 			carrier.getServices().put(newService.getId(), newService);
 			Assertions.assertFalse(CarriersUtils.allJobsHandledBySelectedPlan(carrier), "All jobs are handled although a new service was added");
 		}

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/MatsimTransformerTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/MatsimTransformerTest.java
@@ -161,8 +161,8 @@ public class MatsimTransformerTest {
 		CarrierShipment carrierShipment = CarrierShipment.Builder
 				.newInstance(Id.create("ShipmentId", CarrierShipment.class), Id.createLinkId("PickupLocationId"),
 						Id.createLinkId("DeliveryLocationId"), 50)
-				.setPickupDuration(30.0).setPickupStartsTimeWindow(TimeWindow.newInstance(10.0, 20.0))
-				.setDeliveryDuration(40.0).setDeliveryStartsTimeWindow(TimeWindow.newInstance(50.0, 60.0)).build();
+				.setPickupDuration(30.0).setPickupStartingTimeWindow(TimeWindow.newInstance(10.0, 20.0))
+				.setDeliveryDuration(40.0).setDeliveryStartingTimeWindow(TimeWindow.newInstance(50.0, 60.0)).build();
 		Shipment shipment = MatsimJspritFactory.createJspritShipment(carrierShipment);
 		assertNotNull(shipment);
 		assertEquals("PickupLocationId", shipment.getPickupLocation().getId());
@@ -195,12 +195,12 @@ public class MatsimTransformerTest {
 		assertNotNull(carrierShipment);
 		assertEquals("PickupLocationId", carrierShipment.getPickupLinkId().toString());
 		assertEquals(30.0, carrierShipment.getPickupDuration(), 0.01);
-		assertEquals(10.0, carrierShipment.getPickupStartsTimeWindow().getStart(), 0.01);
-		assertEquals(20.0, carrierShipment.getPickupStartsTimeWindow().getEnd(), 0.01);
+		assertEquals(10.0, carrierShipment.getPickupStartingTimeWindow().getStart(), 0.01);
+		assertEquals(20.0, carrierShipment.getPickupStartingTimeWindow().getEnd(), 0.01);
 		assertEquals("DeliveryLocationId", carrierShipment.getDeliveryLinkId().toString());
 		assertEquals(40.0, carrierShipment.getDeliveryDuration(), 0.01);
-		assertEquals(50.0, carrierShipment.getDeliveryStartsTimeWindow().getStart(), 0.01);
-		assertEquals(60.0, carrierShipment.getDeliveryStartsTimeWindow().getEnd(), 0.01);
+		assertEquals(50.0, carrierShipment.getDeliveryStartingTimeWindow().getStart(), 0.01);
+		assertEquals(60.0, carrierShipment.getDeliveryStartingTimeWindow().getEnd(), 0.01);
         assertEquals(50, carrierShipment.getCapacityDemand());
 
 		CarrierShipment carrierShipment2 = MatsimJspritFactory.createCarrierShipment(shipment);
@@ -391,8 +391,8 @@ public class MatsimTransformerTest {
 		return CarrierShipment.Builder
 				.newInstance(Id.create(id, CarrierShipment.class), Id.create(from, Link.class),
 						Id.create(to, Link.class), size)
-				.setDeliveryDuration(30.0).setDeliveryStartsTimeWindow(TimeWindow.newInstance(10.0, 20.0))
-				.setPickupDuration(15.0).setPickupStartsTimeWindow(TimeWindow.newInstance(1.0, 5.0)).build();
+				.setDeliveryDuration(30.0).setDeliveryStartingTimeWindow(TimeWindow.newInstance(10.0, 20.0))
+				.setPickupDuration(15.0).setPickupStartingTimeWindow(TimeWindow.newInstance(1.0, 5.0)).build();
 	}
 
 	@Test

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/MatsimTransformerTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/MatsimTransformerTest.java
@@ -120,10 +120,10 @@ public class MatsimTransformerTest {
 
 	@Test
 	void whenTransforming_matsimService2jspritService_isMadeCorrectly() {
-		CarrierService carrierService = CarrierService.Builder
+		CarrierService.Builder builder = CarrierService.Builder
 				.newInstance(Id.create("serviceId", CarrierService.class), Id.create("locationId", Link.class))
-				.setCapacityDemand(50).setServiceDuration(30.0)
-				.setServiceStartTimeWindow(TimeWindow.newInstance(10.0, 20.0)).build();
+				.setCapacityDemand(50).setServiceDuration(30.0);
+		CarrierService carrierService = builder.setServiceStartingTimeWindow(TimeWindow.newInstance(10.0, 20.0)).build();
 		Service service = MatsimJspritFactory.createJspritService(carrierService, null);
 		assertNotNull(service);
 		assertEquals("locationId", service.getLocation().getId());

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/MatsimTransformerTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/MatsimTransformerTest.java
@@ -149,7 +149,7 @@ public class MatsimTransformerTest {
 		assertEquals("locationId", service.getServiceLinkId().toString());
 		assertEquals(30.0, service.getServiceDuration(), 0.01);
 		assertEquals(50, service.getCapacityDemand());
-		assertEquals(10.0, service.getServiceStartTimeWindow().getStart(), 0.01);
+		assertEquals(10.0, service.getServiceStaringTimeWindow().getStart(), 0.01);
 
 		CarrierService service2 = MatsimJspritFactory.createCarrierService(carrierService);
 		assertNotSame(service, service2);

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/MatsimTransformerTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/MatsimTransformerTest.java
@@ -122,7 +122,7 @@ public class MatsimTransformerTest {
 	void whenTransforming_matsimService2jspritService_isMadeCorrectly() {
 		CarrierService carrierService = CarrierService.Builder
 				.newInstance(Id.create("serviceId", CarrierService.class), Id.create("locationId", Link.class))
-				.setDemand(50).setServiceDuration(30.0)
+				.setCapacityDemand(50).setServiceDuration(30.0)
 				.setServiceStartTimeWindow(TimeWindow.newInstance(10.0, 20.0)).build();
 		Service service = MatsimJspritFactory.createJspritService(carrierService, null);
 		assertNotNull(service);
@@ -148,7 +148,7 @@ public class MatsimTransformerTest {
 		assertNotNull(service);
 		assertEquals("locationId", service.getServiceLinkId().toString());
 		assertEquals(30.0, service.getServiceDuration(), 0.01);
-		assertEquals(50, service.getDemand());
+		assertEquals(50, service.getCapacityDemand());
 		assertEquals(10.0, service.getServiceStartTimeWindow().getStart(), 0.01);
 
 		CarrierService service2 = MatsimJspritFactory.createCarrierService(carrierService);
@@ -201,7 +201,7 @@ public class MatsimTransformerTest {
 		assertEquals(40.0, carrierShipment.getDeliveryDuration(), 0.01);
 		assertEquals(50.0, carrierShipment.getDeliveryStartsTimeWindow().getStart(), 0.01);
 		assertEquals(60.0, carrierShipment.getDeliveryStartsTimeWindow().getEnd(), 0.01);
-        assertEquals(50, carrierShipment.getDemand());
+        assertEquals(50, carrierShipment.getCapacityDemand());
 
 		CarrierShipment carrierShipment2 = MatsimJspritFactory.createCarrierShipment(shipment);
 		assertNotSame(carrierShipment, carrierShipment2);
@@ -333,10 +333,10 @@ public class MatsimTransformerTest {
 	private ScheduledTour getMatsimServiceTour() {
 		CarrierService s1 = CarrierService.Builder
 				.newInstance(Id.create("serviceId", CarrierService.class), Id.create("to1", Link.class))
-				.setDemand(20).build();
+				.setCapacityDemand(20).build();
 		CarrierService s2 = CarrierService.Builder
 				.newInstance(Id.create("serviceId2", CarrierService.class), Id.create("to2", Link.class))
-				.setDemand(10).build();
+				.setCapacityDemand(10).build();
 		CarrierVehicle matsimVehicle = getMatsimVehicle("matsimVehicle", "loc", getMatsimVehicleType());
 		double startTime = 15.0;
 		Tour.Builder sTourBuilder = Tour.Builder.newInstance(Id.create("testTour", Tour.class));
@@ -503,11 +503,11 @@ public class MatsimTransformerTest {
 		carrier.setCarrierCapabilities(ccBuilder.build());
 		CarrierService carrierService1 = CarrierService.Builder
 				.newInstance(Id.create("serviceId", CarrierService.class), Id.create("i(7,4)R", Link.class))
-				.setDemand(20).setServiceDuration(10.0).build();
+				.setCapacityDemand(20).setServiceDuration(10.0).build();
 		CarriersUtils.addService(carrier, carrierService1);
 		CarrierService carrierService2 = CarrierService.Builder
 				.newInstance(Id.create("serviceId2", CarrierService.class), Id.create("i(3,9)", Link.class))
-				.setDemand(10).setServiceDuration(20.0).build();
+				.setCapacityDemand(10).setServiceDuration(20.0).build();
 		CarriersUtils.addService(carrier, carrierService2);
 		return carrier;
 	}

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/SkillsIT.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/SkillsIT.java
@@ -161,9 +161,9 @@ public class SkillsIT {
 				carrierLocation,
 				Id.createLinkId("i(10,10)R"),
 				1)
-				.setPickupStartsTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
+				.setPickupStartingTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
 				.setPickupDuration(Time.parseTime("00:05:00"))
-				.setDeliveryStartsTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
+				.setDeliveryStartingTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
 				.setDeliveryDuration(Time.parseTime("00:05:00"))
 				.build();
 		CarriersUtils.addSkill(shipmentOne, "skill 1");
@@ -174,9 +174,9 @@ public class SkillsIT {
 				carrierLocation,
 				Id.createLinkId("i(10,10)R"),
 				1)
-				.setPickupStartsTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
+				.setPickupStartingTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
 				.setPickupDuration(Time.parseTime("00:05:00"))
-				.setDeliveryStartsTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
+				.setDeliveryStartingTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
 				.setDeliveryDuration(Time.parseTime("00:05:00"))
 				.build();
 		CarriersUtils.addSkill(shipmentTwo, "skill 2");
@@ -190,9 +190,9 @@ public class SkillsIT {
 				carrierLocation,
 				Id.createLinkId("i(10,10)R"),
 				1)
-				.setPickupStartsTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
+				.setPickupStartingTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
 				.setPickupDuration(Time.parseTime("00:05:00"))
-				.setDeliveryStartsTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
+				.setDeliveryStartingTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
 				.setDeliveryDuration(Time.parseTime("00:05:00"))
 				.build();
 		CarriersUtils.addSkill(shipmentOne, "skill 1");
@@ -203,9 +203,9 @@ public class SkillsIT {
 				carrierLocation,
 				Id.createLinkId("i(10,10)R"),
 				1)
-				.setPickupStartsTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
+				.setPickupStartingTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
 				.setPickupDuration(Time.parseTime("00:05:00"))
-				.setDeliveryStartsTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
+				.setDeliveryStartingTimeWindow(TimeWindow.newInstance(0.0, Time.parseTime("24:00:00")))
 				.setDeliveryDuration(Time.parseTime("00:05:00"))
 				.build();
 		CarriersUtils.addSkill(shipmentTwo, "skill 1");

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsIT.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsIT.java
@@ -293,10 +293,10 @@ public class CarrierControllerUtilsIT{
 	}
 
 	private static CarrierService createMatsimService(String id, String to, int size) {
-		return CarrierService.Builder.newInstance(Id.create(id, CarrierService.class), Id.create(to, Link.class))
+		CarrierService.Builder builder = CarrierService.Builder.newInstance(Id.create(id, CarrierService.class), Id.create(to, Link.class))
 				.setCapacityDemand(size)
-				.setServiceDuration(31.0)
-				.setServiceStartTimeWindow(TimeWindow.newInstance(0.0, 36001.0))
+				.setServiceDuration(31.0);
+		return builder.setServiceStartingTimeWindow(TimeWindow.newInstance(0.0, 36001.0))
 				.build();
 	}
 }

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsIT.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsIT.java
@@ -294,7 +294,7 @@ public class CarrierControllerUtilsIT{
 
 	private static CarrierService createMatsimService(String id, String to, int size) {
 		return CarrierService.Builder.newInstance(Id.create(id, CarrierService.class), Id.create(to, Link.class))
-				.setDemand(size)
+				.setCapacityDemand(size)
 				.setServiceDuration(31.0)
 				.setServiceStartTimeWindow(TimeWindow.newInstance(0.0, 36001.0))
 				.build();

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsIT.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsIT.java
@@ -286,9 +286,9 @@ public class CarrierControllerUtilsIT{
 
 		return CarrierShipment.Builder.newInstance(shipmentId, fromLinkId, toLinkId, size)
 				.setDeliveryDuration(30.0)
-				.setDeliveryStartsTimeWindow(TimeWindow.newInstance(0.0, 36000.0))
+				.setDeliveryStartingTimeWindow(TimeWindow.newInstance(0.0, 36000.0))
 				.setPickupDuration(5.0)
-				.setPickupStartsTimeWindow(TimeWindow.newInstance(0.0, 7200.0))
+				.setPickupStartingTimeWindow(TimeWindow.newInstance(0.0, 7200.0))
 				.build();
 	}
 

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsTest.java
@@ -165,7 +165,7 @@ public class CarrierControllerUtilsTest{
 
 		int demandServices = 0;
 		for (CarrierService carrierService : carrierWServices.getServices().values()) {
-			demandServices += carrierService.getDemand();
+			demandServices += carrierService.getCapacityDemand();
 		}
 		Assertions.assertEquals(4, demandServices);
 
@@ -180,7 +180,7 @@ public class CarrierControllerUtilsTest{
 		Assertions.assertEquals(2, carrierWShipments.getShipments().size());
 		int demandShipments = 0;
 		for (CarrierShipment carrierShipment : carrierWShipments.getShipments().values()) {
-            demandShipments += carrierShipment.getDemand();
+            demandShipments += carrierShipment.getCapacityDemand();
 		}
 		Assertions.assertEquals(3, demandShipments);
 	}
@@ -192,7 +192,7 @@ public class CarrierControllerUtilsTest{
 		Assertions.assertEquals(2, carrierWShipmentsOnlyFromCarrierWShipments.getShipments().size());
 		int demandShipments = 0;
 		for (CarrierShipment carrierShipment : carrierWShipmentsOnlyFromCarrierWServices.getShipments().values()) {
-            demandShipments += carrierShipment.getDemand();
+            demandShipments += carrierShipment.getCapacityDemand();
 		}
 		Assertions.assertEquals(4, demandShipments);
 	}
@@ -204,7 +204,7 @@ public class CarrierControllerUtilsTest{
 		Assertions.assertEquals(2, carrierWShipmentsOnlyFromCarrierWServices.getShipments().size());
 		int demandShipments = 0;
 		for (CarrierShipment carrierShipment : carrierWShipmentsOnlyFromCarrierWServices.getShipments().values()) {
-            demandShipments += carrierShipment.getDemand();
+            demandShipments += carrierShipment.getCapacityDemand();
 		}
 		Assertions.assertEquals(4, demandShipments);
 	}
@@ -246,7 +246,7 @@ public class CarrierControllerUtilsTest{
 				foundShipment1 = true;
 				Assertions.assertEquals(Id.createLinkId("i(1,0)"), carrierShipment1.getPickupLinkId());
 				Assertions.assertEquals(Id.createLinkId("i(7,6)R"), carrierShipment1.getDeliveryLinkId());
-            Assertions.assertEquals(1, carrierShipment1.getDemand());
+            Assertions.assertEquals(1, carrierShipment1.getCapacityDemand());
 				Assertions.assertEquals(30.0, carrierShipment1.getDeliveryDuration(), 0);
 			Assertions.assertEquals(3600.0, carrierShipment1.getDeliveryStartsTimeWindow().getStart(), 0);
 			Assertions.assertEquals(36000.0, carrierShipment1.getDeliveryStartsTimeWindow().getEnd(), 0);
@@ -261,7 +261,7 @@ public class CarrierControllerUtilsTest{
 				foundShipment2 = true;
 				Assertions.assertEquals(Id.createLinkId("i(3,0)"), carrierShipment2.getPickupLinkId());
 				Assertions.assertEquals(Id.createLinkId("i(3,7)"), carrierShipment2.getDeliveryLinkId());
-            Assertions.assertEquals(2, carrierShipment2.getDemand());
+            Assertions.assertEquals(2, carrierShipment2.getCapacityDemand());
 				Assertions.assertEquals(30.0, carrierShipment2.getDeliveryDuration(), 0);
 			Assertions.assertEquals(3600.0, carrierShipment2.getDeliveryStartsTimeWindow().getStart(), 0);
 			Assertions.assertEquals(36000.0, carrierShipment2.getDeliveryStartsTimeWindow().getEnd(), 0);
@@ -284,7 +284,7 @@ public class CarrierControllerUtilsTest{
 				foundService1 = true;
 				Assertions.assertEquals(Id.createLinkId("i(6,0)"), carrierShipment1.getPickupLinkId());
 				Assertions.assertEquals(Id.createLinkId("i(3,9)"), carrierShipment1.getDeliveryLinkId());
-            Assertions.assertEquals(2, carrierShipment1.getDemand());
+            Assertions.assertEquals(2, carrierShipment1.getCapacityDemand());
 				Assertions.assertEquals(31.0, carrierShipment1.getDeliveryDuration(), 0);
 			Assertions.assertEquals(3601.0, carrierShipment1.getDeliveryStartsTimeWindow().getStart(), 0);
 			Assertions.assertEquals(36001.0, carrierShipment1.getDeliveryStartsTimeWindow().getEnd(), 0);
@@ -298,7 +298,7 @@ public class CarrierControllerUtilsTest{
 				foundService2 = true;
 				Assertions.assertEquals(Id.createLinkId("i(6,0)"), carrierShipment2.getPickupLinkId());
 				Assertions.assertEquals(Id.createLinkId("i(4,9)"), carrierShipment2.getDeliveryLinkId());
-            Assertions.assertEquals(2, carrierShipment2.getDemand());
+            Assertions.assertEquals(2, carrierShipment2.getCapacityDemand());
 				Assertions.assertEquals(31.0, carrierShipment2.getDeliveryDuration(), 0);
 			Assertions.assertEquals(3601.0, carrierShipment2.getDeliveryStartsTimeWindow().getStart(), 0);
 			Assertions.assertEquals(36001.0, carrierShipment2.getDeliveryStartsTimeWindow().getEnd(), 0);
@@ -352,7 +352,7 @@ public class CarrierControllerUtilsTest{
 
 	private static CarrierService createMatsimService(String id, String to, int size) {
 		return CarrierService.Builder.newInstance(Id.create(id, CarrierService.class), Id.create(to, Link.class))
-				.setDemand(size)
+				.setCapacityDemand(size)
 				.setServiceDuration(31.0)
 				.setServiceStartTimeWindow(TimeWindow.newInstance(3601.0, 36001.0))
 				.build();

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsTest.java
@@ -248,11 +248,11 @@ public class CarrierControllerUtilsTest{
 				Assertions.assertEquals(Id.createLinkId("i(7,6)R"), carrierShipment1.getDeliveryLinkId());
             Assertions.assertEquals(1, carrierShipment1.getCapacityDemand());
 				Assertions.assertEquals(30.0, carrierShipment1.getDeliveryDuration(), 0);
-			Assertions.assertEquals(3600.0, carrierShipment1.getDeliveryStartsTimeWindow().getStart(), 0);
-			Assertions.assertEquals(36000.0, carrierShipment1.getDeliveryStartsTimeWindow().getEnd(), 0);
+			Assertions.assertEquals(3600.0, carrierShipment1.getDeliveryStartingTimeWindow().getStart(), 0);
+			Assertions.assertEquals(36000.0, carrierShipment1.getDeliveryStartingTimeWindow().getEnd(), 0);
 				Assertions.assertEquals(5.0, carrierShipment1.getPickupDuration(), 0);
-			Assertions.assertEquals(0.0, carrierShipment1.getPickupStartsTimeWindow().getStart(), 0);
-			Assertions.assertEquals(7200.0, carrierShipment1.getPickupStartsTimeWindow().getEnd(), 0);
+			Assertions.assertEquals(0.0, carrierShipment1.getPickupStartingTimeWindow().getStart(), 0);
+			Assertions.assertEquals(7200.0, carrierShipment1.getPickupStartingTimeWindow().getEnd(), 0);
 			}
 		CarrierShipment carrierShipment2 = CarriersUtils.getShipment(carrierWShipmentsOnlyFromCarrierWShipments, Id.create("shipment2", CarrierShipment.class));
 		assert carrierShipment2 != null;
@@ -263,11 +263,11 @@ public class CarrierControllerUtilsTest{
 				Assertions.assertEquals(Id.createLinkId("i(3,7)"), carrierShipment2.getDeliveryLinkId());
             Assertions.assertEquals(2, carrierShipment2.getCapacityDemand());
 				Assertions.assertEquals(30.0, carrierShipment2.getDeliveryDuration(), 0);
-			Assertions.assertEquals(3600.0, carrierShipment2.getDeliveryStartsTimeWindow().getStart(), 0);
-			Assertions.assertEquals(36000.0, carrierShipment2.getDeliveryStartsTimeWindow().getEnd(), 0);
+			Assertions.assertEquals(3600.0, carrierShipment2.getDeliveryStartingTimeWindow().getStart(), 0);
+			Assertions.assertEquals(36000.0, carrierShipment2.getDeliveryStartingTimeWindow().getEnd(), 0);
 				Assertions.assertEquals(5.0, carrierShipment2.getPickupDuration(), 0);
-			Assertions.assertEquals(0.0, carrierShipment2.getPickupStartsTimeWindow().getStart(), 0);
-			Assertions.assertEquals(7200.0, carrierShipment2.getPickupStartsTimeWindow().getEnd(), 0);
+			Assertions.assertEquals(0.0, carrierShipment2.getPickupStartingTimeWindow().getStart(), 0);
+			Assertions.assertEquals(7200.0, carrierShipment2.getPickupStartingTimeWindow().getEnd(), 0);
 			}
 		Assertions.assertTrue(foundShipment1, "Not found Shipment1 after copying");
 		Assertions.assertTrue(foundShipment2, "Not found Shipment2 after copying");
@@ -286,11 +286,11 @@ public class CarrierControllerUtilsTest{
 				Assertions.assertEquals(Id.createLinkId("i(3,9)"), carrierShipment1.getDeliveryLinkId());
             Assertions.assertEquals(2, carrierShipment1.getCapacityDemand());
 				Assertions.assertEquals(31.0, carrierShipment1.getDeliveryDuration(), 0);
-			Assertions.assertEquals(3601.0, carrierShipment1.getDeliveryStartsTimeWindow().getStart(), 0);
-			Assertions.assertEquals(36001.0, carrierShipment1.getDeliveryStartsTimeWindow().getEnd(), 0);
+			Assertions.assertEquals(3601.0, carrierShipment1.getDeliveryStartingTimeWindow().getStart(), 0);
+			Assertions.assertEquals(36001.0, carrierShipment1.getDeliveryStartingTimeWindow().getEnd(), 0);
 				Assertions.assertEquals(0.0, carrierShipment1.getPickupDuration(), 0);
-			Assertions.assertEquals(0.0, carrierShipment1.getPickupStartsTimeWindow().getStart(), 0);
-			Assertions.assertEquals(36001.0, carrierShipment1.getPickupStartsTimeWindow().getEnd(), 0);
+			Assertions.assertEquals(0.0, carrierShipment1.getPickupStartingTimeWindow().getStart(), 0);
+			Assertions.assertEquals(36001.0, carrierShipment1.getPickupStartingTimeWindow().getEnd(), 0);
 			}
 		CarrierShipment carrierShipment2 = CarriersUtils.getShipment(carrierWShipmentsOnlyFromCarrierWServices, Id.create("Service2", CarrierShipment.class));
 		assert carrierShipment2 != null;
@@ -300,11 +300,11 @@ public class CarrierControllerUtilsTest{
 				Assertions.assertEquals(Id.createLinkId("i(4,9)"), carrierShipment2.getDeliveryLinkId());
             Assertions.assertEquals(2, carrierShipment2.getCapacityDemand());
 				Assertions.assertEquals(31.0, carrierShipment2.getDeliveryDuration(), 0);
-			Assertions.assertEquals(3601.0, carrierShipment2.getDeliveryStartsTimeWindow().getStart(), 0);
-			Assertions.assertEquals(36001.0, carrierShipment2.getDeliveryStartsTimeWindow().getEnd(), 0);
+			Assertions.assertEquals(3601.0, carrierShipment2.getDeliveryStartingTimeWindow().getStart(), 0);
+			Assertions.assertEquals(36001.0, carrierShipment2.getDeliveryStartingTimeWindow().getEnd(), 0);
 				Assertions.assertEquals(0.0, carrierShipment2.getPickupDuration(), 0);
-			Assertions.assertEquals(0.0, carrierShipment2.getPickupStartsTimeWindow().getStart(), 0);
-			Assertions.assertEquals(36001.0, carrierShipment2.getPickupStartsTimeWindow().getEnd(), 0);
+			Assertions.assertEquals(0.0, carrierShipment2.getPickupStartingTimeWindow().getStart(), 0);
+			Assertions.assertEquals(36001.0, carrierShipment2.getPickupStartingTimeWindow().getEnd(), 0);
 			}
 		Assertions.assertTrue(foundService1, "Not found converted Service1 after converting");
 		Assertions.assertTrue(foundService2, "Not found converted Service2 after converting");
@@ -344,9 +344,9 @@ public class CarrierControllerUtilsTest{
 
 		return CarrierShipment.Builder.newInstance(shipmentId, fromLinkId, toLinkId, size)
 				.setDeliveryDuration(30.0)
-				.setDeliveryStartsTimeWindow(TimeWindow.newInstance(3600.0, 36000.0))
+				.setDeliveryStartingTimeWindow(TimeWindow.newInstance(3600.0, 36000.0))
 				.setPickupDuration(5.0)
-				.setPickupStartsTimeWindow(TimeWindow.newInstance(0.0, 7200.0))
+				.setPickupStartingTimeWindow(TimeWindow.newInstance(0.0, 7200.0))
 				.build();
 	}
 

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsTest.java
@@ -351,10 +351,10 @@ public class CarrierControllerUtilsTest{
 	}
 
 	private static CarrierService createMatsimService(String id, String to, int size) {
-		return CarrierService.Builder.newInstance(Id.create(id, CarrierService.class), Id.create(to, Link.class))
+		CarrierService.Builder builder = CarrierService.Builder.newInstance(Id.create(id, CarrierService.class), Id.create(to, Link.class))
 				.setCapacityDemand(size)
-				.setServiceDuration(31.0)
-				.setServiceStartTimeWindow(TimeWindow.newInstance(3601.0, 36001.0))
+				.setServiceDuration(31.0);
+		return builder.setServiceStartingTimeWindow(TimeWindow.newInstance(3601.0, 36001.0))
 				.build();
 	}
 

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/simulationTrackers/CollectionTrackerTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/simulationTrackers/CollectionTrackerTest.java
@@ -237,7 +237,7 @@ public class CollectionTrackerTest {
 						if (element instanceof ServiceActivity activity) {
 							scheduledCosts += activity.getService().getServiceDuration() * scheduledTour.getVehicle().getType().getCostInformation().getCostsPerSecond();
 							totalScheduledCosts += scheduledCosts;
-                            totalScheduledWeight += activity.getService().getDemand();
+                            totalScheduledWeight += activity.getService().getCapacityDemand();
 							totalNumberOfScheduledShipments++;
 						}
 					}

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/CollectionLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/CollectionLSPSchedulingTest.java
@@ -199,8 +199,8 @@ public class CollectionLSPSchedulingTest {
 			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
                 assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
-			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(2).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), collectionLSP.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements().iterator().next());
 			assertSame(endHandler.getLspShipment(), shipment);
@@ -214,8 +214,8 @@ public class CollectionLSPSchedulingTest {
 			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
                 assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
-			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(serviceHandler.getElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), collectionLSP.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements().iterator().next());
 			assertSame(serviceHandler.getLspShipment(), shipment);

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/CollectionLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/CollectionLSPSchedulingTest.java
@@ -197,7 +197,7 @@ public class CollectionLSPSchedulingTest {
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
 			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
-                assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
+                assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -212,7 +212,7 @@ public class CollectionLSPSchedulingTest {
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
 			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
-                assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
+                assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
@@ -487,8 +487,8 @@ public class CompleteLSPSchedulingTest {
 			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
-			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(2).getLogisticChainElement());
@@ -505,8 +505,8 @@ public class CompleteLSPSchedulingTest {
 			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
-			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(serviceHandler.getElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), planElements.get(2).getLogisticChainElement());
@@ -523,8 +523,8 @@ public class CompleteLSPSchedulingTest {
 			assertSame(mainRunStartHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(mainRunStartHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
-			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
-			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
+			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), 0.0);
+			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(5).getLogisticChainElement());
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(6).getLogisticChainElement());
@@ -541,8 +541,8 @@ public class CompleteLSPSchedulingTest {
 			assertSame(mainRunEndHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(mainRunEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
-			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
-			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
+			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), 0.0);
+			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(5).getLogisticChainElement());
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(6).getLogisticChainElement());
@@ -559,8 +559,8 @@ public class CompleteLSPSchedulingTest {
 			assertSame(lspTourStartEventHandler.getCarrierService().getServiceLinkId(), shipment.getTo());
 			assertEquals(lspTourStartEventHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(lspTourStartEventHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
-			assertEquals(0, lspTourStartEventHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
-			assertEquals(Integer.MAX_VALUE, lspTourStartEventHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
+			assertEquals(0, lspTourStartEventHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), 0.0);
+			assertEquals(Integer.MAX_VALUE, lspTourStartEventHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), 0.0);
 			assertSame(lspTourStartEventHandler.getLogisticChainElement(), planElements.get(8).getLogisticChainElement());
 			assertSame(lspTourStartEventHandler.getLogisticChainElement(), planElements.get(9).getLogisticChainElement());
 			assertSame(lspTourStartEventHandler.getLogisticChainElement(), planElements.get(10).getLogisticChainElement());
@@ -577,8 +577,8 @@ public class CompleteLSPSchedulingTest {
 			assertSame(distributionServiceHandler.getCarrierService().getServiceLinkId(), shipment.getTo());
 			assertEquals(distributionServiceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(distributionServiceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
-			assertEquals(0, distributionServiceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
-			assertEquals(Integer.MAX_VALUE, distributionServiceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
+			assertEquals(0, distributionServiceHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), 0.0);
+			assertEquals(Integer.MAX_VALUE, distributionServiceHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), 0.0);
 			assertSame(distributionServiceHandler.getLogisticChainElement(), planElements.get(8).getLogisticChainElement());
 			assertSame(distributionServiceHandler.getLogisticChainElement(), planElements.get(9).getLogisticChainElement());
 			assertSame(distributionServiceHandler.getLogisticChainElement(), planElements.get(10).getLogisticChainElement());

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/CompleteLSPSchedulingTest.java
@@ -434,7 +434,7 @@ public class CompleteLSPSchedulingTest {
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
 			assertSame(service.getServiceLinkId(), shipment.getFrom());
-            assertEquals(service.getDemand(), shipment.getSize());
+            assertEquals(service.getCapacityDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
 			for (LogisticChainElement clientElement : reloadEventHandler.getTranshipmentHub().getClientElements()) {
@@ -461,7 +461,7 @@ public class CompleteLSPSchedulingTest {
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
 			assertSame(service.getServiceLinkId(), toLinkId);
-            assertEquals(service.getDemand(), shipment.getSize());
+            assertEquals(service.getCapacityDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
 			for (LogisticChainElement clientElement : reloadEventHandler.getTranshipmentHub().getClientElements()) {
@@ -485,7 +485,7 @@ public class CompleteLSPSchedulingTest {
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
 			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
-            assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -503,7 +503,7 @@ public class CompleteLSPSchedulingTest {
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
 			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
-            assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -522,7 +522,7 @@ public class CompleteLSPSchedulingTest {
 			LSPTourStartEventHandler mainRunStartHandler = (LSPTourStartEventHandler) eventHandlers.get(2);
 			assertSame(mainRunStartHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-            assertEquals(mainRunStartHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(mainRunStartHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
@@ -540,7 +540,7 @@ public class CompleteLSPSchedulingTest {
 			LSPTourEndEventHandler mainRunEndHandler = (LSPTourEndEventHandler) eventHandlers.get(3);
 			assertSame(mainRunEndHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-            assertEquals(mainRunEndHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(mainRunEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
@@ -558,7 +558,7 @@ public class CompleteLSPSchedulingTest {
 			LSPTourStartEventHandler lspTourStartEventHandler = (LSPTourStartEventHandler) eventHandlers.get(4);
 			assertSame(lspTourStartEventHandler.getCarrierService().getServiceLinkId(), shipment.getTo());
 			assertEquals(lspTourStartEventHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-            assertEquals(lspTourStartEventHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(lspTourStartEventHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(0, lspTourStartEventHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, lspTourStartEventHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(lspTourStartEventHandler.getLogisticChainElement(), planElements.get(8).getLogisticChainElement());
@@ -576,7 +576,7 @@ public class CompleteLSPSchedulingTest {
 			DistributionServiceStartEventHandler distributionServiceHandler = (DistributionServiceStartEventHandler) eventHandlers.get(5);
 			assertSame(distributionServiceHandler.getCarrierService().getServiceLinkId(), shipment.getTo());
 			assertEquals(distributionServiceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-            assertEquals(distributionServiceHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(distributionServiceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(0, distributionServiceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, distributionServiceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(distributionServiceHandler.getLogisticChainElement(), planElements.get(8).getLogisticChainElement());

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/FirstReloadLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/FirstReloadLSPSchedulingTest.java
@@ -260,7 +260,7 @@ public class FirstReloadLSPSchedulingTest {
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
 			assertSame(service.getServiceLinkId(), shipment.getFrom());
-            assertEquals(service.getDemand(), shipment.getSize());
+            assertEquals(service.getCapacityDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
 			for (LogisticChainElement clientElement : reloadEventHandler.getTranshipmentHub().getClientElements()) {
@@ -284,7 +284,7 @@ public class FirstReloadLSPSchedulingTest {
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
 			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
-            assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -297,7 +297,7 @@ public class FirstReloadLSPSchedulingTest {
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
 			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
-            assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/FirstReloadLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/FirstReloadLSPSchedulingTest.java
@@ -286,8 +286,8 @@ public class FirstReloadLSPSchedulingTest {
 			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
-			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(2).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), lsp.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements().iterator().next());
 			assertSame(endHandler.getLspShipment(), shipment);
@@ -299,8 +299,8 @@ public class FirstReloadLSPSchedulingTest {
 			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
-			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(serviceHandler.getElement(), planElements.getFirst().getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), lsp.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements().iterator().next());
 			assertSame(serviceHandler.getLspShipment(), shipment);

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MainRunLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MainRunLSPSchedulingTest.java
@@ -353,8 +353,8 @@ public class MainRunLSPSchedulingTest {
 			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
-			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(2).getLogisticChainElement());
@@ -371,8 +371,8 @@ public class MainRunLSPSchedulingTest {
 			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
-			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(serviceHandler.getElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), planElements.get(2).getLogisticChainElement());
@@ -389,8 +389,8 @@ public class MainRunLSPSchedulingTest {
 			assertSame(mainRunStartHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(mainRunStartHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
-			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
-			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
+			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), 0.0);
+			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(5).getLogisticChainElement());
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(6).getLogisticChainElement());
@@ -407,8 +407,8 @@ public class MainRunLSPSchedulingTest {
 			assertSame(mainRunEndHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(mainRunEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
-			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
-			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
+			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), 0.0);
+			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(5).getLogisticChainElement());
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(6).getLogisticChainElement());

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MainRunLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MainRunLSPSchedulingTest.java
@@ -325,7 +325,7 @@ public class MainRunLSPSchedulingTest {
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
 			assertSame(service.getServiceLinkId(), shipment.getFrom());
-            assertEquals(service.getDemand(), shipment.getSize());
+            assertEquals(service.getCapacityDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
 			for (LogisticChainElement clientElement : reloadEventHandler.getTranshipmentHub().getClientElements()) {
@@ -351,7 +351,7 @@ public class MainRunLSPSchedulingTest {
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
 			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
-            assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -369,7 +369,7 @@ public class MainRunLSPSchedulingTest {
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
 			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
-            assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -388,7 +388,7 @@ public class MainRunLSPSchedulingTest {
 			LSPTourStartEventHandler mainRunStartHandler = (LSPTourStartEventHandler) eventHandlers.get(2);
 			assertSame(mainRunStartHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-            assertEquals(mainRunStartHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(mainRunStartHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
@@ -406,7 +406,7 @@ public class MainRunLSPSchedulingTest {
 			LSPTourEndEventHandler mainRunEndHandler = (LSPTourEndEventHandler) eventHandlers.get(3);
 			assertSame(mainRunEndHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-            assertEquals(mainRunEndHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(mainRunEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCollectionLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCollectionLSPSchedulingTest.java
@@ -201,8 +201,8 @@ public class MultipleShipmentsCollectionLSPSchedulingTest {
 			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
-			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(2).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), collectionLSP.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements().iterator().next());
 			assertSame(endHandler.getLspShipment(), shipment);
@@ -214,8 +214,8 @@ public class MultipleShipmentsCollectionLSPSchedulingTest {
 			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
-			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(serviceHandler.getElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), collectionLSP.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements().iterator().next());
 			assertSame(serviceHandler.getLspShipment(), shipment);

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCollectionLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCollectionLSPSchedulingTest.java
@@ -199,7 +199,7 @@ public class MultipleShipmentsCollectionLSPSchedulingTest {
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
 			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
-            assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -212,7 +212,7 @@ public class MultipleShipmentsCollectionLSPSchedulingTest {
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
 			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
-            assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
@@ -490,8 +490,8 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
-			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(2).getLogisticChainElement());
@@ -508,8 +508,8 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
-			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(serviceHandler.getElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), planElements.get(2).getLogisticChainElement());
@@ -526,8 +526,8 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			assertSame(mainRunStartHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(mainRunStartHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
-			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
-			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
+			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), 0.0);
+			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(5).getLogisticChainElement());
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(6).getLogisticChainElement());
@@ -544,8 +544,8 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			assertSame(mainRunEndHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(mainRunEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
-			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
-			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
+			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), 0.0);
+			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(5).getLogisticChainElement());
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(6).getLogisticChainElement());
@@ -562,8 +562,8 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			assertSame(lspTourStartEventHandler.getCarrierService().getServiceLinkId(), shipment.getTo());
 			assertEquals(lspTourStartEventHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(lspTourStartEventHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
-			assertEquals(0, lspTourStartEventHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
-			assertEquals(Integer.MAX_VALUE, lspTourStartEventHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
+			assertEquals(0, lspTourStartEventHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), 0.0);
+			assertEquals(Integer.MAX_VALUE, lspTourStartEventHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), 0.0);
 			assertSame(lspTourStartEventHandler.getLogisticChainElement(), planElements.get(8).getLogisticChainElement());
 			assertSame(lspTourStartEventHandler.getLogisticChainElement(), planElements.get(9).getLogisticChainElement());
 			assertSame(lspTourStartEventHandler.getLogisticChainElement(), planElements.get(10).getLogisticChainElement());
@@ -580,8 +580,8 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			assertSame(distributionServiceHandler.getCarrierService().getServiceLinkId(), shipment.getTo());
 			assertEquals(distributionServiceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(distributionServiceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
-			assertEquals(0, distributionServiceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
-			assertEquals(Integer.MAX_VALUE, distributionServiceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
+			assertEquals(0, distributionServiceHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), 0.0);
+			assertEquals(Integer.MAX_VALUE, distributionServiceHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), 0.0);
 			assertSame(distributionServiceHandler.getLogisticChainElement(), planElements.get(8).getLogisticChainElement());
 			assertSame(distributionServiceHandler.getLogisticChainElement(), planElements.get(9).getLogisticChainElement());
 			assertSame(distributionServiceHandler.getLogisticChainElement(), planElements.get(10).getLogisticChainElement());

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsCompleteLSPSchedulingTest.java
@@ -437,7 +437,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
 			assertSame(service.getServiceLinkId(), shipment.getFrom());
-            assertEquals(service.getDemand(), shipment.getSize());
+            assertEquals(service.getCapacityDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
 			for (LogisticChainElement clientElement : reloadEventHandler.getTranshipmentHub().getClientElements()) {
@@ -464,7 +464,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
 			assertSame(service.getServiceLinkId(), toLinkId);
-            assertEquals(service.getDemand(), shipment.getSize());
+            assertEquals(service.getCapacityDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
 			for (LogisticChainElement clientElement : reloadEventHandler.getTranshipmentHub().getClientElements()) {
@@ -488,7 +488,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
 			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
-            assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -506,7 +506,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
 			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
-            assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -525,7 +525,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			LSPTourStartEventHandler mainRunStartHandler = (LSPTourStartEventHandler) eventHandlers.get(2);
 			assertSame(mainRunStartHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-            assertEquals(mainRunStartHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(mainRunStartHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
@@ -543,7 +543,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			LSPTourEndEventHandler mainRunEndHandler = (LSPTourEndEventHandler) eventHandlers.get(3);
 			assertSame(mainRunEndHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-            assertEquals(mainRunEndHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(mainRunEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
@@ -561,7 +561,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			LSPTourStartEventHandler lspTourStartEventHandler = (LSPTourStartEventHandler) eventHandlers.get(4);
 			assertSame(lspTourStartEventHandler.getCarrierService().getServiceLinkId(), shipment.getTo());
 			assertEquals(lspTourStartEventHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-            assertEquals(lspTourStartEventHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(lspTourStartEventHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(0, lspTourStartEventHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, lspTourStartEventHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(lspTourStartEventHandler.getLogisticChainElement(), planElements.get(8).getLogisticChainElement());
@@ -579,7 +579,7 @@ public class MultipleShipmentsCompleteLSPSchedulingTest {
 			DistributionServiceStartEventHandler distributionServiceHandler = (DistributionServiceStartEventHandler) eventHandlers.get(5);
 			assertSame(distributionServiceHandler.getCarrierService().getServiceLinkId(), shipment.getTo());
 			assertEquals(distributionServiceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-            assertEquals(distributionServiceHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(distributionServiceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(0, distributionServiceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, distributionServiceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(distributionServiceHandler.getLogisticChainElement(), planElements.get(8).getLogisticChainElement());

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsFirstReloadLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsFirstReloadLSPSchedulingTest.java
@@ -285,8 +285,8 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
-			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(2).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), lsp.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements().iterator().next());
 			assertSame(endHandler.getLspShipment(), shipment);
@@ -298,8 +298,8 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
-			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(serviceHandler.getElement(), planElements.getFirst().getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), lsp.getSelectedPlan().getLogisticChains().iterator().next().getLogisticChainElements().iterator().next());
 			assertSame(serviceHandler.getLspShipment(), shipment);

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsFirstReloadLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsFirstReloadLSPSchedulingTest.java
@@ -259,7 +259,7 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
 			assertSame(service.getServiceLinkId(), shipment.getFrom());
-            assertEquals(service.getDemand(), shipment.getSize());
+            assertEquals(service.getCapacityDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
 			for (LogisticChainElement clientElement : reloadEventHandler.getTranshipmentHub().getClientElements()) {
@@ -283,7 +283,7 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
 			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
-            assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -296,7 +296,7 @@ public class MultipleShipmentsFirstReloadLSPSchedulingTest {
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
 			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
-            assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsMainRunLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsMainRunLSPSchedulingTest.java
@@ -325,7 +325,7 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 			LspShipment shipment = entry.getValue().lspShipment;
 			LogisticChainElement element = entry.getValue().logisticChainElement;
 			assertSame(service.getServiceLinkId(), shipment.getFrom());
-            assertEquals(service.getDemand(), shipment.getSize());
+            assertEquals(service.getCapacityDemand(), shipment.getSize());
 			assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			boolean handledByTranshipmentHub = false;
 			for (LogisticChainElement clientElement : reloadEventHandler.getTranshipmentHub().getClientElements()) {
@@ -351,7 +351,7 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler endHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
 			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
-            assertEquals(endHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -369,7 +369,7 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler serviceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
 			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
-            assertEquals(serviceHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -388,7 +388,7 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 			LSPTourStartEventHandler mainRunStartHandler = (LSPTourStartEventHandler) eventHandlers.get(2);
 			assertSame(mainRunStartHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-            assertEquals(mainRunStartHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(mainRunStartHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
@@ -406,7 +406,7 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 			LSPTourEndEventHandler mainRunEndHandler = (LSPTourEndEventHandler) eventHandlers.get(3);
 			assertSame(mainRunEndHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-            assertEquals(mainRunEndHandler.getCarrierService().getDemand(), shipment.getSize());
+            assertEquals(mainRunEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsMainRunLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsMainRunLSPSchedulingTest.java
@@ -353,8 +353,8 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 			assertSame(endHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(endHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(endHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
-			assertEquals(endHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(endHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(endHandler.getLogisticChainElement(), planElements.get(2).getLogisticChainElement());
@@ -371,8 +371,8 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 			assertSame(serviceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
             assertEquals(serviceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(serviceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
-			assertEquals(serviceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(serviceHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(serviceHandler.getElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(serviceHandler.getElement(), planElements.get(2).getLogisticChainElement());
@@ -389,8 +389,8 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 			assertSame(mainRunStartHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(mainRunStartHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
-			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
-			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
+			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), 0.0);
+			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(5).getLogisticChainElement());
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(6).getLogisticChainElement());
@@ -407,8 +407,8 @@ public class MultipleShipmentsMainRunLSPSchedulingTest {
 			assertSame(mainRunEndHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
             assertEquals(mainRunEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
-			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
-			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
+			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), 0.0);
+			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(5).getLogisticChainElement());
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(6).getLogisticChainElement());

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsSecondReloadLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsSecondReloadLSPSchedulingTest.java
@@ -369,7 +369,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 				LspShipment shipment = entry.getValue().lspShipment;
 				LogisticChainElement element = entry.getValue().logisticChainElement;
 				assertSame(service.getServiceLinkId(), shipment.getFrom());
-                assertEquals(service.getDemand(), shipment.getSize());
+                assertEquals(service.getCapacityDemand(), shipment.getSize());
 				assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 				boolean handledByTranshipmentHub = false;
 				for (LogisticChainElement clientElement :
@@ -401,7 +401,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 				LspShipment shipment = entry.getValue().lspShipment;
 				LogisticChainElement element = entry.getValue().logisticChainElement;
 				assertSame(service.getServiceLinkId(), toLinkId);
-                assertEquals(service.getDemand(), shipment.getSize());
+                assertEquals(service.getCapacityDemand(), shipment.getSize());
 				assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 				boolean handledByTranshipmentHub = false;
 				for (LogisticChainElement clientElement : reloadEventHandler.getTranshipmentHub().getClientElements()) {
@@ -431,7 +431,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler collectionEndHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
 			assertSame(collectionEndHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
-                assertEquals(collectionEndHandler.getCarrierService().getDemand(), shipment.getSize());
+                assertEquals(collectionEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(collectionEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(collectionEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(collectionEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -450,7 +450,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler collectionServiceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
 			assertSame(collectionServiceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
-                assertEquals(collectionServiceHandler.getCarrierService().getDemand(), shipment.getSize());
+                assertEquals(collectionServiceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(collectionServiceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(collectionServiceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(collectionServiceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -470,7 +470,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			LSPTourStartEventHandler mainRunStartHandler = (LSPTourStartEventHandler) eventHandlers.get(2);
 			assertSame(mainRunStartHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-                assertEquals(mainRunStartHandler.getCarrierService().getDemand(), shipment.getSize());
+                assertEquals(mainRunStartHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
@@ -489,7 +489,7 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			LSPTourEndEventHandler mainRunEndHandler = (LSPTourEndEventHandler) eventHandlers.get(3);
 			assertSame(mainRunEndHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-                assertEquals(mainRunEndHandler.getCarrierService().getDemand(), shipment.getSize());
+                assertEquals(mainRunEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsSecondReloadLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/MultipleShipmentsSecondReloadLSPSchedulingTest.java
@@ -433,8 +433,8 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			assertSame(collectionEndHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
                 assertEquals(collectionEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(collectionEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(collectionEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
-			assertEquals(collectionEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
+			assertEquals(collectionEndHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(collectionEndHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(collectionEndHandler.getLogisticChainElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(collectionEndHandler.getLogisticChainElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(collectionEndHandler.getLogisticChainElement(), planElements.get(2).getLogisticChainElement());
@@ -452,8 +452,8 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			assertSame(collectionServiceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
                 assertEquals(collectionServiceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(collectionServiceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(collectionServiceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
-			assertEquals(collectionServiceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
+			assertEquals(collectionServiceHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(collectionServiceHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(collectionServiceHandler.getElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(collectionServiceHandler.getElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(collectionServiceHandler.getElement(), planElements.get(2).getLogisticChainElement());
@@ -471,8 +471,8 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			assertSame(mainRunStartHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
                 assertEquals(mainRunStartHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
-			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
-			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
+			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), 0.0);
+			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(5).getLogisticChainElement());
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(6).getLogisticChainElement());
@@ -490,8 +490,8 @@ public class MultipleShipmentsSecondReloadLSPSchedulingTest {
 			assertSame(mainRunEndHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
                 assertEquals(mainRunEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
-			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
-			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
+			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), 0.0);
+			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(5).getLogisticChainElement());
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(6).getLogisticChainElement());

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/SecondReloadLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/SecondReloadLSPSchedulingTest.java
@@ -440,8 +440,8 @@ public class SecondReloadLSPSchedulingTest {
 			assertSame(collectionEndHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
                 assertEquals(collectionEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(collectionEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(collectionEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
-			assertEquals(collectionEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
+			assertEquals(collectionEndHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(collectionEndHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(collectionEndHandler.getLogisticChainElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(collectionEndHandler.getLogisticChainElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(collectionEndHandler.getLogisticChainElement(), planElements.get(2).getLogisticChainElement());
@@ -459,8 +459,8 @@ public class SecondReloadLSPSchedulingTest {
 			assertSame(collectionServiceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
                 assertEquals(collectionServiceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(collectionServiceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-			assertEquals(collectionServiceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
-			assertEquals(collectionServiceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
+			assertEquals(collectionServiceHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
+			assertEquals(collectionServiceHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
 			assertSame(collectionServiceHandler.getElement(), planElements.get(0).getLogisticChainElement());
 			assertSame(collectionServiceHandler.getElement(), planElements.get(1).getLogisticChainElement());
 			assertSame(collectionServiceHandler.getElement(), planElements.get(2).getLogisticChainElement());
@@ -478,8 +478,8 @@ public class SecondReloadLSPSchedulingTest {
 			assertSame(mainRunStartHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
                 assertEquals(mainRunStartHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
-			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
-			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
+			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), 0.0);
+			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(5).getLogisticChainElement());
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(6).getLogisticChainElement());
@@ -497,8 +497,8 @@ public class SecondReloadLSPSchedulingTest {
 			assertSame(mainRunEndHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
                 assertEquals(mainRunEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
-			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
-			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
+			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStaringTimeWindow().getStart(), 0.0);
+			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStaringTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(5).getLogisticChainElement());
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(6).getLogisticChainElement());

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/SecondReloadLSPSchedulingTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/resourceImplementations/SecondReloadLSPSchedulingTest.java
@@ -369,7 +369,7 @@ public class SecondReloadLSPSchedulingTest {
 				LspShipment shipment = entry.getValue().lspShipment;
 				LogisticChainElement element = entry.getValue().logisticChainElement;
 				assertSame(service.getServiceLinkId(), shipment.getFrom());
-                assertEquals(service.getDemand(), shipment.getSize());
+                assertEquals(service.getCapacityDemand(), shipment.getSize());
 				assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 				boolean handledByTranshipmentHub = false;
 				for (LogisticChainElement clientElement :
@@ -407,7 +407,7 @@ public class SecondReloadLSPSchedulingTest {
 				LspShipment shipment = entry.getValue().lspShipment;
 				LogisticChainElement element = entry.getValue().logisticChainElement;
 				assertSame(service.getServiceLinkId(), toLinkId);
-                assertEquals(service.getDemand(), shipment.getSize());
+                assertEquals(service.getCapacityDemand(), shipment.getSize());
 				assertEquals(service.getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 				boolean handledByTranshipmentHub = false;
 				for (LogisticChainElement clientElement :
@@ -438,7 +438,7 @@ public class SecondReloadLSPSchedulingTest {
 			assertInstanceOf(LSPTourEndEventHandler.class, eventHandlers.getFirst());
 			LSPTourEndEventHandler collectionEndHandler = (LSPTourEndEventHandler) eventHandlers.getFirst();
 			assertSame(collectionEndHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
-                assertEquals(collectionEndHandler.getCarrierService().getDemand(), shipment.getSize());
+                assertEquals(collectionEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(collectionEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(collectionEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(collectionEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -457,7 +457,7 @@ public class SecondReloadLSPSchedulingTest {
 			assertInstanceOf(CollectionServiceEndEventHandler.class, eventHandlers.get(1));
 			CollectionServiceEndEventHandler collectionServiceHandler = (CollectionServiceEndEventHandler) eventHandlers.get(1);
 			assertSame(collectionServiceHandler.getCarrierService().getServiceLinkId(), shipment.getFrom());
-                assertEquals(collectionServiceHandler.getCarrierService().getDemand(), shipment.getSize());
+                assertEquals(collectionServiceHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(collectionServiceHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
 			assertEquals(collectionServiceHandler.getCarrierService().getServiceStartTimeWindow().getStart(), shipment.getPickupTimeWindow().getStart(), 0.0);
 			assertEquals(collectionServiceHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), shipment.getPickupTimeWindow().getEnd(), 0.0);
@@ -477,7 +477,7 @@ public class SecondReloadLSPSchedulingTest {
 			LSPTourStartEventHandler mainRunStartHandler = (LSPTourStartEventHandler) eventHandlers.get(2);
 			assertSame(mainRunStartHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunStartHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-                assertEquals(mainRunStartHandler.getCarrierService().getDemand(), shipment.getSize());
+                assertEquals(mainRunStartHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(0, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunStartHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunStartHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());
@@ -496,7 +496,7 @@ public class SecondReloadLSPSchedulingTest {
 			LSPTourEndEventHandler mainRunEndHandler = (LSPTourEndEventHandler) eventHandlers.get(3);
 			assertSame(mainRunEndHandler.getCarrierService().getServiceLinkId(), toLinkId);
 			assertEquals(mainRunEndHandler.getCarrierService().getServiceDuration(), shipment.getDeliveryServiceTime(), 0.0);
-                assertEquals(mainRunEndHandler.getCarrierService().getDemand(), shipment.getSize());
+                assertEquals(mainRunEndHandler.getCarrierService().getCapacityDemand(), shipment.getSize());
 			assertEquals(0, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getStart(), 0.0);
 			assertEquals(Integer.MAX_VALUE, mainRunEndHandler.getCarrierService().getServiceStartTimeWindow().getEnd(), 0.0);
 			assertSame(mainRunEndHandler.getLogisticChainElement(), planElements.get(4).getLogisticChainElement());

--- a/contribs/freightreceiver/src/main/java/org/matsim/freight/receiver/ReceiverTriggersCarrierReplanningListener.java
+++ b/contribs/freightreceiver/src/main/java/org/matsim/freight/receiver/ReceiverTriggersCarrierReplanningListener.java
@@ -86,7 +86,7 @@ class ReceiverTriggersCarrierReplanningListener implements IterationStartsListen
                                                                   // TODO This only looks at the FIRST time window. This may need revision once we handle multiple
                                                                   // time windows.
                                                                   .build();
-                    if (newShipment.getDemand() != 0) {
+                    if (newShipment.getCapacityDemand() != 0) {
                         receiverOrder.getCarrier().getShipments().put(newShipment.getId(), newShipment );
                     }
                 }

--- a/contribs/freightreceiver/src/main/java/org/matsim/freight/receiver/ReceiverTriggersCarrierReplanningListener.java
+++ b/contribs/freightreceiver/src/main/java/org/matsim/freight/receiver/ReceiverTriggersCarrierReplanningListener.java
@@ -82,7 +82,7 @@ class ReceiverTriggersCarrierReplanningListener implements IterationStartsListen
                                     (int) (Math.round(order.getDailyOrderQuantity()*order.getProduct().getProductType().getRequiredCapacity())) );
                     CarrierShipment newShipment = builder
                                                                   .setDeliveryDuration( order.getServiceDuration() )
-                                                                  .setDeliveryStartsTimeWindow( receiverPlan.getTimeWindows().get( 0 ) )
+                                                                  .setDeliveryStartingTimeWindow( receiverPlan.getTimeWindows().get( 0 ) )
                                                                   // TODO This only looks at the FIRST time window. This may need revision once we handle multiple
                                                                   // time windows.
                                                                   .build();

--- a/contribs/freightreceiver/src/main/java/org/matsim/freight/receiver/run/chessboard/ReceiverChessboardScenario.java
+++ b/contribs/freightreceiver/src/main/java/org/matsim/freight/receiver/run/chessboard/ReceiverChessboardScenario.java
@@ -229,7 +229,7 @@ public class ReceiverChessboardScenario {
             }
 
             CarrierShipment shipment = shpBuilder.setDeliveryDuration(order.getServiceDuration())
-                    .setDeliveryStartsTimeWindow(receiverPlan.getTimeWindows().get(0))
+                    .setDeliveryStartingTimeWindow(receiverPlan.getTimeWindows().get(0))
                     .build();
             carriers.getCarriers().get(receiverOrder.getCarrierId()).getShipments().put(shipment.getId(), shipment);
         }

--- a/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/DefaultUnhandledServicesSolution.java
+++ b/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/DefaultUnhandledServicesSolution.java
@@ -4,10 +4,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.core.gbl.MatsimRandom;
-import org.matsim.freight.carriers.Carrier;
-import org.matsim.freight.carriers.CarrierService;
-import org.matsim.freight.carriers.CarrierVehicle;
-import org.matsim.freight.carriers.CarriersUtils;
+import org.matsim.freight.carriers.*;
 
 import java.util.*;
 import java.util.concurrent.ExecutionException;
@@ -40,8 +37,9 @@ public class DefaultUnhandledServicesSolution implements UnhandledServicesSoluti
 	private void redrawAllServiceDurations(Carrier carrier, GenerateSmallScaleCommercialTrafficDemand.CarrierAttributes carrierAttributes, int additionalTravelBufferPerIterationInMinutes) {
 		for (CarrierService service : carrier.getServices().values()) {
 			double newServiceDuration = generator.getServiceTimePerStop(carrier, carrierAttributes, additionalTravelBufferPerIterationInMinutes);
-			CarrierService redrawnService = CarrierService.Builder.newInstance(service.getId(), service.getServiceLinkId())
-				.setServiceDuration(newServiceDuration).setServiceStartTimeWindow(service.getServiceStartTimeWindow()).build();
+			CarrierService.Builder builder = CarrierService.Builder.newInstance(service.getId(), service.getServiceLinkId())
+				.setServiceDuration(newServiceDuration);
+			CarrierService redrawnService = builder.setServiceStartingTimeWindow(service.getServiceStartTimeWindow()).build();
 			carrier.getServices().put(redrawnService.getId(), redrawnService);
 		}
 	}

--- a/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/DefaultUnhandledServicesSolution.java
+++ b/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/DefaultUnhandledServicesSolution.java
@@ -39,7 +39,7 @@ public class DefaultUnhandledServicesSolution implements UnhandledServicesSoluti
 			double newServiceDuration = generator.getServiceTimePerStop(carrier, carrierAttributes, additionalTravelBufferPerIterationInMinutes);
 			CarrierService.Builder builder = CarrierService.Builder.newInstance(service.getId(), service.getServiceLinkId())
 				.setServiceDuration(newServiceDuration);
-			CarrierService redrawnService = builder.setServiceStartingTimeWindow(service.getServiceStartTimeWindow()).build();
+			CarrierService redrawnService = builder.setServiceStartingTimeWindow(service.getServiceStaringTimeWindow()).build();
 			carrier.getServices().put(redrawnService.getId(), redrawnService);
 		}
 	}

--- a/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/GenerateSmallScaleCommercialTrafficDemand.java
+++ b/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/GenerateSmallScaleCommercialTrafficDemand.java
@@ -800,8 +800,9 @@ public class GenerateSmallScaleCommercialTrafficDemand implements MATSimAppComma
 		Id<CarrierService> idNewService = Id.create(newCarrier.getId().toString() + "_" + linkId + "_" + rnd.nextInt(10000),
 			CarrierService.class);
 
-		CarrierService thisService = CarrierService.Builder.newInstance(idNewService, linkId)
-			.setServiceDuration(serviceTimePerStop).setServiceStartTimeWindow(serviceTimeWindow).build();
+		CarrierService.Builder builder = CarrierService.Builder.newInstance(idNewService, linkId)
+			.setServiceDuration(serviceTimePerStop);
+		CarrierService thisService = builder.setServiceStartingTimeWindow(serviceTimeWindow).build();
 		newCarrier.getServices().put(thisService.getId(), thisService);
 	}
 

--- a/contribs/vsp/src/main/java/org/matsim/freight/carriers/analysis/FreightAnalysisServiceTracking.java
+++ b/contribs/vsp/src/main/java/org/matsim/freight/carriers/analysis/FreightAnalysisServiceTracking.java
@@ -61,7 +61,7 @@ class FreightAnalysisServiceTracking {
 					if (service.driverId == null) {
 						// if there is no driver, but there is a service which is to be performed at the moment at this place, we guess this could be the event for it.
 						// (Does not work well obviously as soon as there are multiple services at a location that have generous time windows, like e.g. at stores).
-						if (service.service.getServiceStartTimeWindow().getStart() <= activityStartEvent.getTime() && activityStartEvent.getTime() <= service.service.getServiceStartTimeWindow().getEnd()) {
+						if (service.service.getServiceStaringTimeWindow().getStart() <= activityStartEvent.getTime() && activityStartEvent.getTime() <= service.service.getServiceStaringTimeWindow().getEnd()) {
 							service.driverIdGuess = activityStartEvent.getPersonId();
 							service.arrivalTimeGuess = activityStartEvent.getTime();
 						}

--- a/contribs/vsp/src/main/java/org/matsim/freight/carriers/analysis/FreightAnalysisShipmentTracking.java
+++ b/contribs/vsp/src/main/java/org/matsim/freight/carriers/analysis/FreightAnalysisShipmentTracking.java
@@ -57,8 +57,8 @@ class FreightAnalysisShipmentTracking {
     	for (ShipmentTracker shipment: shipments.values()){
     		if (shipment.to==activityStartEvent.getLinkId() ){
 				if(shipment.driverId == null){
-					if(shipment.shipment.getDeliveryStartsTimeWindow().getStart() <= activityStartEvent.getTime()) {
-                        if (activityStartEvent.getTime()<= shipment.shipment.getDeliveryStartsTimeWindow().getEnd()) {
+					if(shipment.shipment.getDeliveryStartingTimeWindow().getStart() <= activityStartEvent.getTime()) {
+                        if (activityStartEvent.getTime()<= shipment.shipment.getDeliveryStartingTimeWindow().getEnd()) {
                             if (shipment.possibleDrivers.contains(activityStartEvent.getPersonId().toString())) {
                                 shipment.driverIdGuess = activityStartEvent.getPersonId();
                                 shipment.deliveryTimeGuess=activityStartEvent.getTime();
@@ -77,8 +77,8 @@ class FreightAnalysisShipmentTracking {
     	for (ShipmentTracker shipmentTracker: shipments.values()){
     		if (shipmentTracker.from==activityStartEvent.getLinkId()){
     			if (shipmentTracker.driverId==null){
-					if(shipmentTracker.shipment.getPickupStartsTimeWindow().getStart() <= activityStartEvent.getTime()) {
-						if (activityStartEvent.getTime()<= shipmentTracker.shipment.getPickupStartsTimeWindow().getEnd()) {
+					if(shipmentTracker.shipment.getPickupStartingTimeWindow().getStart() <= activityStartEvent.getTime()) {
+						if (activityStartEvent.getTime()<= shipmentTracker.shipment.getPickupStartingTimeWindow().getEnd()) {
 							shipmentTracker.possibleDrivers.add(activityStartEvent.getPersonId().toString());
 						}
 					}


### PR DESCRIPTION
As a follow-up and partly revert of #3645, this PR renames some internal variables and the corresponding getter/setters.
The new names introduced now, some from a discussion with @rewertvsp and @kainagel.

The getters/setters (before the changes in #3645) are still there, marked as deprecated, and point to the new methods.

- size / capacityDemand / demand --> `capacityDemand`
- <Service/Pickup/delivery>Start(s)TimeWindow -->`<Service/Pickup/delivery>Start**ing**TimeWindow `

Moreover, I added a new `getInstance` method for the `CarrierService.Builder`, allowing to set the `capacityDemand` already in the Builder. The method with the current signature is marked as deprecated.
This is done to move a step forward, to have the `capacityDemand` of the job immutable .