### PR TITLE
Uniquely responsible activity and departure handlers

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISSConfigGroup.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISSConfigGroup.java
@@ -21,25 +21,25 @@ import java.util.Set;
  */
 public class FISSConfigGroup extends ReflectiveConfigGroup {
 
-    public static final String GROUP_NAME = "fiss";
+	public static final String GROUP_NAME = "fiss";
 
-    @Parameter
-    @Comment("Defines the share of agents that should be explicitly assigned in the QSim. " +
-            "Values between (0,1]")
-    @Positive
-    public double sampleFactor = 1.; // TODO: sample factors by mode?
+	@Parameter
+	@Comment("Defines the share of agents that should be explicitly assigned in the QSim. " +
+				 "Values between (0,1]")
+	@Positive
+	public double sampleFactor = 1.; // TODO: sample factors by mode?
 
-    @Parameter
-    @Comment("Defines the mods that will be considered for the FISS. Defaults to {car}")
-    @NotNull
-    public Set<String> sampledModes = Collections.singleton(TransportMode.car);
+	@Parameter
+	@Comment("Defines the mods that will be considered for the FISS. Defaults to {car}")
+	@NotNull
+	public Set<String> sampledModes = Collections.singleton(TransportMode.car);
 
 	@Parameter
 	@Comment("Disable FISS in the last iteration to get events of all agents. May be required for post-processing")
 	public boolean switchOffFISSLastIteration = true;
 
-    public FISSConfigGroup() {
-        super(GROUP_NAME);
-    }
+	public FISSConfigGroup() {
+		super(GROUP_NAME);
+	}
 
 }

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISSConfigurator.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISSConfigurator.java
@@ -48,7 +48,7 @@ public class FISSConfigurator {
         Config config = controler.getConfig();
 
         if (!config.qsim().getVehiclesSource()
-                .equals(QSimConfigGroup.VehiclesSource.modeVehicleTypesFromVehiclesData)) {
+                   .equals(QSimConfigGroup.VehiclesSource.modeVehicleTypesFromVehiclesData)) {
             throw new IllegalArgumentException("For the time being, FISS works with vehicle types from vehicles data, please check config!");
         }
 
@@ -56,7 +56,7 @@ public class FISSConfigurator {
 
         Vehicles vehiclesContainer = scenario.getVehicles();
 
-		Set<String> finalFissModes = new HashSet<>(fissConfigGroup.sampledModes);
+        Set<String> finalFissModes = new HashSet<>(fissConfigGroup.sampledModes);
 
         for (String sampledMode : fissConfigGroup.sampledModes) {
             if (!config.qsim().getMainModes().contains(sampledMode)) {

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISSQSimModule.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISSQSimModule.java
@@ -27,20 +27,20 @@ import org.matsim.core.router.util.TravelTime;
  */
 public class FISSQSimModule extends AbstractQSimModule {
 
-    static final public String COMPONENT_NAME = "FISS";
+	static final public String COMPONENT_NAME = "FISS";
 
-    @Override
-    protected void configureQSim() {
-	    addQSimComponentBinding( COMPONENT_NAME ).to( FISS.class );
-    }
+	@Override
+	protected void configureQSim() {
+		addQSimComponentBinding( COMPONENT_NAME ).to( FISS.class );
+	}
 
-    @Provides
-    @Singleton
-    FISS provideMultiModalDepartureHandler(MatsimServices matsimServices, QNetsimEngineI qNetsimEngine,
-										   QSimConfigGroup qsimConfig, Scenario scenario, EventsManager eventsManager,
-										   @Named(TransportMode.car) TravelTime travelTime) {
-        Config config = scenario.getConfig();
-        FISSConfigGroup fissConfigGroup = ConfigUtils.addOrGetModule(config, FISSConfigGroup.class);
+	@Provides
+	@Singleton
+	FISS provideMultiModalDepartureHandler(MatsimServices matsimServices, QNetsimEngineI qNetsimEngine,
+					       QSimConfigGroup qsimConfig, Scenario scenario, EventsManager eventsManager,
+					       @Named(TransportMode.car) TravelTime travelTime) {
+		Config config = scenario.getConfig();
+		FISSConfigGroup fissConfigGroup = ConfigUtils.addOrGetModule(config, FISSConfigGroup.class);
 		return new FISS(matsimServices, qNetsimEngine, scenario, eventsManager, fissConfigGroup, travelTime);
-    }
+	}
 }

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/ActivityEngine.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/ActivityEngine.java
@@ -33,4 +33,7 @@ public interface ActivityEngine extends ActivityHandler, MobsimEngine {
 	// Suggested names: NopActivityEngine, SleepActivityEngine, IdleActivityEngine, StaticActivityEngine???
 	// michalm, mar '19
 
+ // "FallbackActivityHandler"?  I think that different from the TeleportationDepartureHandler, this one here can be replaced (with current design).
+ // But maybe that is not a design decision, but just happened.  kai, jan'25
+
 }

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSim.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSim.java
@@ -530,6 +530,16 @@ public final class QSim implements VisMobsim, Netsim, ActivityEndRescheduler {
 
 		events.processEvent(new PersonDepartureEvent(now, agent.getId(), linkId, agent.getMode(), routingMode));
 
+// The following used to be
+//		for (DepartureHandler departureHandler : this.departureHandlers) {
+//			if (departureHandler.handleDeparture(now, agent, linkId)) {
+//				return;
+//			}
+//		}
+// I am now testing if more than one dp handler feels responsible.  Since the teleportation handler feels responsible in any case, it needs to be
+// treated separately.
+
+
 		DepartureHandler responsible = null;
 		for (DepartureHandler departureHandler : this.departureHandlers) {
 			if ( responsible==null ) {

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSim.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSim.java
@@ -532,15 +532,18 @@ public final class QSim implements VisMobsim, Netsim, ActivityEndRescheduler {
 
 		DepartureHandler responsible = null;
 		for (DepartureHandler departureHandler : this.departureHandlers) {
-			if (departureHandler.handleDeparture(now, agent, linkId) ) {
-				if ( responsible==null ){
+			if ( responsible==null ) {
+				if ( departureHandler.handleDeparture( now, agent, linkId ) ){
 					responsible = departureHandler;
-				} else {
-					StringBuilder strb = new StringBuilder();
-					strb.append( "More than one departure handler feels responsible for agent=" ).append( agent ).append( "; dpHandler1=" )
-					    .append( responsible ).append( "; dpHandler2=" ).append( departureHandler );
-					log.fatal( strb.toString() );
-					throw new RuntimeException( strb.toString() );
+				}
+			} else if ( ! ( departureHandler instanceof  DefaultTeleportationEngine) ) {
+				if ( departureHandler.handleDeparture( now, agent, linkId ) ){
+					String str = "More than one departure handler feels responsible for"
+								     + System.lineSeparator() + "agent=" + agent
+								     + System.lineSeparator() + "dpHandler1=" + responsible
+								     + System.lineSeparator() + "dpHandler2=" + departureHandler;
+					log.fatal( str );
+					throw new RuntimeException( str );
 				}
 			}
 		}

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSim.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSim.java
@@ -486,14 +486,17 @@ public final class QSim implements VisMobsim, Netsim, ActivityEndRescheduler {
 //				return;
 //			}
 //		}
-// I am now checking all activity handlers if they feel responsible, and throw an exception if there are two or more. kai, jan'24
+// I am now checking all activity handlers if they feel responsible, and throw an exception if there are two or more. Since the ActivityEngine feels
+// responsible in any case, the code needs to hedge against that.  kai, jan'24
 
 		ActivityHandler responsible = null;
 		for (ActivityHandler activityHandler : this.activityHandlers) {
-			if (activityHandler.handleActivity(agent)) {
-				if ( responsible==null ) {
+			if ( responsible==null ){
+				if( activityHandler.handleActivity( agent ) ){
 					responsible = activityHandler;
-				} else {
+				}
+			} else if ( ! ( activityHandler instanceof ActivityEngine) ) {
+				if ( activityHandler.handleActivity( agent ) ) {
 					String msg = "More than one activity handler feels reponsible for agent=" + agent
 								      + System.lineSeparator() + "activityHandler1=" + responsible
 								      + System.lineSeparator() + "activityHandler2=" + activityHandler ;
@@ -501,6 +504,10 @@ public final class QSim implements VisMobsim, Netsim, ActivityEndRescheduler {
 					throw new RuntimeException( msg );
 				}
 			}
+		}
+		if ( responsible==null ){
+			log.warn( "no departure handler wanted to handle the activity of agent " + agent.getId() );
+			// yy my intuition is that this should be followed by setting the agent state to abort. kai, nov'14
 		}
 
 	}

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSim.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSim.java
@@ -235,7 +235,10 @@ public final class QSim implements VisMobsim, Netsim, ActivityEndRescheduler {
 		boolean tryBlockWithException = false;
 		try {
 			// Teleportation must be last (default) departure handler, so add it only before running:
-			this.departureHandlers.add(this.teleportationEngine);
+			if ( this.teleportationEngine!= null ){
+				this.departureHandlers.add( this.teleportationEngine );
+			}
+			// (this can be "null", in which case it makes more sense to not register the "null" into the registry.  kai, jan'25)
 
 			// ActivityEngine must be last (=default) activity handler, so add it only before running:
 			this.activityHandlers.add(this.activityEngine);

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/interfaces/ActivityHandler.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/interfaces/ActivityHandler.java
@@ -20,8 +20,12 @@
 package org.matsim.core.mobsim.qsim.interfaces;
 
 import org.matsim.core.mobsim.framework.MobsimAgent;
+import org.matsim.core.mobsim.qsim.QSimProvider;
 import org.matsim.core.mobsim.qsim.components.QSimComponent;
 
+/**
+ * {@link QSimComponent}s of type {@link ActivityHandler} are added into a specific registry in {@link QSimProvider#get()}.  This registry is later used in {@link org.matsim.core.mobsim.qsim.QSim#arrangeAgentActivity(MobsimAgent)} (not public, therefore cannot be referenced from javadoc).
+ */
 public interface ActivityHandler extends QSimComponent {
 
 	boolean handleActivity(MobsimAgent agent);


### PR DESCRIPTION
Previously, the code would use the first departure/activity handler that felt responsible.  Now it will check if there are more than one, and if so then abort.

(Since, with current design, the teleportation handler always feels responsible, the code needs to hedge against that.  Might make sense to register teleportation handlers only for those modes mentioned in the config.)