### PR TITLE
reduce to 10000 persons

### DIFF
--- a/matsim/src/test/java/ch/sbb/matsim/RaptorDeterminismTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/RaptorDeterminismTest.java
@@ -150,7 +150,7 @@ public class RaptorDeterminismTest {
 
 		logger.info("Comparing stop RaptorStopFinder.findStops alongSide ptRouter.calcRoute(pt, ...)");
 
-		for(int personIndex=0; personIndex<personLists[0].size(); personIndex++) {
+		for(int personIndex=0; personIndex<Math.min( 10000, personLists[0].size()); personIndex++) {
 			if(personIndex % 1000 == 0) {
 				logger.info(String.format("Person %d", personIndex));
 			}


### PR DESCRIPTION
We had a couple of regression test failures, presumably because of time limits, see #3687 .  On my local machine, `RaptorDeterminismTest#testRaptorDeterminism` took so long that I interrupted it.  I counted 20sec per 10000 agents, and it goes  to 100'000 agents (i.e. 200sec ≈ 3min 30sec).   I don't know how computing times on my laptop compare to github actions, but this seems more than we can afford.  **As a quick fix, I reduced the test to 10'000 agents.**  

However, I am sceptical in general if we can have such "shotgun tests" as part of the normal regression suite.  We used to have the *IT tests, which were run separately and only about once a week.  I do not know if that functionality still works.