### PR TITLE
Minor improvments within scoring 

### DIFF
--- a/matsim/src/main/java/org/matsim/core/scoring/EventsToActivities.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/EventsToActivities.java
@@ -81,8 +81,9 @@ public final class EventsToActivities implements ActivityStartEventHandler, Acti
             activity = firstActivity;
         }
         activity.setEndTime(event.getTime());
+		PersonExperiencedActivity personExperiencedActivity = new PersonExperiencedActivity(event.getPersonId(), activity);
         for (ActivityHandler activityHandler : this.activityHandlers) {
-            activityHandler.handleActivity(new PersonExperiencedActivity(event.getPersonId(), activity));
+            activityHandler.handleActivity(personExperiencedActivity);
         }
     }
 
@@ -107,8 +108,9 @@ public final class EventsToActivities implements ActivityStartEventHandler, Acti
 
     public void finish() {
         this.activities.forEach((id, activity) -> {
+			PersonExperiencedActivity personExperiencedActivity = new PersonExperiencedActivity(id, activity);
             for (ActivityHandler activityHandler : this.activityHandlers) {
-                activityHandler.handleActivity(new PersonExperiencedActivity(id, activity));
+                activityHandler.handleActivity(personExperiencedActivity);
             }
         });
     }


### PR DESCRIPTION
This PR makes use of IdMaps and the code avoids now the creation of multiple exp. act or leg while looping over handlers. Each handler should get the same instance of an object. One could even think to make the act or leg immutable, as the scoring should just read something and not modify information.