### PR TITLE
fix(dvrp): edge case for cached TT matrices

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -86,7 +86,7 @@ public class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableParamet
 
 	@Parameter
 	@Comment("Caches the travel time matrix data into a binary file. If the file exists, the matrix will be read from the file, if not, the file will be created.")
-	public String travelTimeCachePath = null;
+	public String travelTimeMatrixCachePath = null;
 
 	@Parameter
 	@Comment("Minimum vehicle stop duration. Must be positive.")

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -85,6 +85,10 @@ public class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableParamet
 	public boolean useModeFilteredSubnetwork = false;
 
 	@Parameter
+	@Comment("Caches the travel time matrix data into a binary file. If the file exists, the matrix will be read from the file, if not, the file will be created.")
+	public String travelTimeCachePath = null;
+
+	@Parameter
 	@Comment("Minimum vehicle stop duration. Must be positive.")
 	@Positive
 	public double stopDuration = Double.NaN;// seconds

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -59,7 +59,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 	@Override
 	public void install() {
 		DvrpModes.registerDvrpMode(binder(), getMode());
-		install(new DvrpModeRoutingNetworkModule(getMode(), drtCfg.useModeFilteredSubnetwork, drtCfg.travelTimeCachePath));
+		install(new DvrpModeRoutingNetworkModule(getMode(), drtCfg.useModeFilteredSubnetwork, drtCfg.travelTimeMatrixCachePath));
 		bindModal(TravelTime.class).to(Key.get(TravelTime.class, Names.named(DvrpTravelTimeModule.DVRP_ESTIMATED)));
 		bindModal(TravelDisutilityFactory.class).toInstance(TimeAsTravelDisutility::new);
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -59,7 +59,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 	@Override
 	public void install() {
 		DvrpModes.registerDvrpMode(binder(), getMode());
-		install(new DvrpModeRoutingNetworkModule(getMode(), drtCfg.useModeFilteredSubnetwork));
+		install(new DvrpModeRoutingNetworkModule(getMode(), drtCfg.useModeFilteredSubnetwork, drtCfg.travelTimeCachePath));
 		bindModal(TravelTime.class).to(Key.get(TravelTime.class, Names.named(DvrpTravelTimeModule.DVRP_ESTIMATED)));
 		bindModal(TravelDisutilityFactory.class).toInstance(TimeAsTravelDisutility::new);
 

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpModeRoutingNetworkModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpModeRoutingNetworkModule.java
@@ -52,6 +52,7 @@ import com.google.inject.name.Names;
  */
 public class DvrpModeRoutingNetworkModule extends AbstractDvrpModeModule {
 	private final boolean useModeFilteredSubnetwork;
+	private final String modalCachePath;
 
 	@Inject
 	private DvrpConfigGroup dvrpConfigGroup;
@@ -62,9 +63,14 @@ public class DvrpModeRoutingNetworkModule extends AbstractDvrpModeModule {
 	@Inject
 	private QSimConfigGroup qSimConfigGroup;
 
-	public DvrpModeRoutingNetworkModule(String mode, boolean useModeFilteredSubnetwork) {
+	public DvrpModeRoutingNetworkModule(String mode, boolean useModeFilteredSubnetwork, String modalCachePath) {
 		super(mode);
 		this.useModeFilteredSubnetwork = useModeFilteredSubnetwork;
+		this.modalCachePath = modalCachePath;
+	}
+
+	public DvrpModeRoutingNetworkModule(String mode, boolean useModeFilteredSubnetwork) {
+		this(mode, useModeFilteredSubnetwork, null);
 	}
 
 	@Override
@@ -91,11 +97,11 @@ public class DvrpModeRoutingNetworkModule extends AbstractDvrpModeModule {
 							matrixParams.getZoneSystemParams(), getConfig().global().getCoordinateSystem(), zone -> true);
 						
 						
-						if (matrixParams.cachePath == null) {
+						if (modalCachePath == null) {
 							return FreeSpeedTravelTimeMatrix.createFreeSpeedMatrix(network, zoneSystem, matrixParams, globalConfigGroup.getNumberOfThreads(),
 								qSimConfigGroup.getTimeStepSize());
 						} else {
-							URL cachePath = ConfigGroup.getInputFileURL(getConfig().getContext(), matrixParams.cachePath);
+							URL cachePath = ConfigGroup.getInputFileURL(getConfig().getContext(), modalCachePath);
 							return FreeSpeedTravelTimeMatrix.createFreeSpeedMatrixFromCache(network, zoneSystem, matrixParams, globalConfigGroup.getNumberOfThreads(),
 								qSimConfigGroup.getTimeStepSize(), cachePath);
 						}


### PR DESCRIPTION
Following #3716, this PR fixes another edge case regarding DVRP travel times matrices: By default, the path configured in the `DvrpTravelTimeMatrixParams` is used when the travel time matrix is generated for DVRP. However, DRT may allow the user to `useModeFilteredSubnetwork` to filter the network by the DRT mode. In that case, still the same path was used, although a different matrix (the one only for DRT) should be written at that point. This PR introduces a new config option `travelTimeMatrixCachePath` in the `DrtConfigGroup` which now lets the user define specifically where the mode-specific matrix is saved if `useModeFilteredSubnetwork` is active.