### PR TITLE
fix turn restriction related bug in LeastCostPathTree

### DIFF
--- a/matsim/src/main/java/org/matsim/core/router/speedy/LeastCostPathTree.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/LeastCostPathTree.java
@@ -204,7 +204,6 @@ public class LeastCostPathTree {
         this.data[index + 2] = distance;
     }
 
-
     public int getComingFrom(int nodeIndex) {
         if (graph.hasTurnRestrictions()) {
             // always make sure to only expose uncolored node indices. nkuehnel Feb'25

--- a/matsim/src/main/java/org/matsim/core/router/speedy/LeastCostPathTree.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/LeastCostPathTree.java
@@ -206,7 +206,7 @@ public class LeastCostPathTree {
 
 
     public int getComingFrom(int nodeIndex) {
-        if(graph.hasTurnRestrictions()) {
+        if (graph.hasTurnRestrictions()) {
             // always make sure to only expose uncolored node indices. nkuehnel Feb'25
             return graph.getNode(comingFrom[nodeIndex]).getId().index();
         } else {

--- a/matsim/src/main/java/org/matsim/core/router/speedy/LeastCostPathTree.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/LeastCostPathTree.java
@@ -204,8 +204,14 @@ public class LeastCostPathTree {
         this.data[index + 2] = distance;
     }
 
+
     public int getComingFrom(int nodeIndex) {
-        return this.comingFrom[nodeIndex];
+        if(graph.hasTurnRestrictions()) {
+            // always make sure to only expose uncolored node indices. nkuehnel Feb'25
+            return graph.getNode(comingFrom[nodeIndex]).getId().index();
+        } else {
+            return this.comingFrom[nodeIndex];
+        }
     }
 
     public interface StopCriterion {


### PR DESCRIPTION
the comingFrom[nodeIndex] data structure is exposed and used for path construction in the OneToManyPathCalculator. However, some nodes may internally be reached via colored nodes which are not known outside the speedy graph structure. So make sure to always return the uncolored node id index