### PR TITLE
chore: move config option for load analysis

### DIFF
--- a/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/reconfiguration/CapacityReconfigurationTest.java
+++ b/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/reconfiguration/CapacityReconfigurationTest.java
@@ -173,7 +173,7 @@ public class CapacityReconfigurationTest {
 				.addOrGetDefaultDrtOptimizationConstraintsSet().rejectRequestIfMaxWaitOrTravelTimeViolated = useRejections;
 
 		// produce analysis output on capacities and loads
-		drtConfig.loadCapacityAnalysisInterval = 1;
+		drtConfig.loadParams.analysisInterval = 1;
 
 		// set up two dimensions
 		drtConfig.loadParams.dimensions = List.of("passengers", "goods");

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtModeAnalysisModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtModeAnalysisModule.java
@@ -142,6 +142,12 @@ public class DrtModeAnalysisModule extends AbstractDvrpModeModule {
 
 		install(new SharingMetricsModule(drtCfg));
 
-		addControlerListenerBinding().toProvider(modalProvider(getter -> new CapacityLoadAnalysisHandler(getMode(), getter.getModal(FleetSpecification.class), getter.get(OutputDirectoryHierarchy.class), getter.get(EventsManager.class), drtCfg.loadCapacityAnalysisInterval, getter.getModal(DvrpLoadType.class))));
+		addControlerListenerBinding().toProvider(modalProvider( //
+			getter -> new CapacityLoadAnalysisHandler(getMode(), //
+			getter.getModal(FleetSpecification.class), //
+			getter.get(OutputDirectoryHierarchy.class), //
+			getter.get(EventsManager.class), //
+			drtCfg.loadParams.analysisInterval, //
+			getter.getModal(DvrpLoadType.class))));
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -158,11 +158,6 @@ public class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableParamet
 	@Comment("Store planned unshared drt route as a link sequence")
 	public boolean storeUnsharedPath = false; // If true, the planned unshared path is stored and exported in plans
 
-	@Parameter
-	@Comment("Defines how often to write analysis on capacities and loads of the mode")
-	@PositiveOrZero
-	public int loadCapacityAnalysisInterval = 0;
-
 	public enum SimulationType {
 		fullSimulation, estimateAndTeleport
 	}

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/load/DvrpLoadParams.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/load/DvrpLoadParams.java
@@ -10,6 +10,7 @@ import org.matsim.core.config.ReflectiveConfigGroup;
 import com.google.common.base.Preconditions;
 
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.PositiveOrZero;
 
 /**
  * @author Sebastian Hörl (sebhoerl), IRT SystemX
@@ -57,6 +58,11 @@ public class DvrpLoadParams extends ReflectiveConfigGroup {
     @Parameter
     @Comment("if no other load information is given, each request obtains a unit load for the given dimension")
     public String defaultRequestDimension = "passengers";
+
+    @Parameter
+    @Comment("Defines how often to write analysis on capacities and loads of the mode")
+    @PositiveOrZero
+    public int analysisInterval = 0;
 
     @Override
     public void checkConsistency(Config config) {


### PR DESCRIPTION
It makes more sense to control the analysis interval for multidimensional loads / capacities inside the DvrpLoadParams instead of the main DRT config group.