### PR TITLE
Chore: optimizing memory usage of TestRaptorDeterminism IT

### DIFF
--- a/matsim/src/test/java/ch/sbb/matsim/RaptorDeterminismTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/RaptorDeterminismTest.java
@@ -101,106 +101,141 @@ public class RaptorDeterminismTest {
 	}
 
 
+	static private class ComparisonInstance {
+
+		private final List<? extends Person> personList;
+		private final RaptorStopFinder raptorStopFinder;
+		private final ActivityFacilities activityFacilities;
+		private final RaptorParametersForPerson raptorParametersForPerson;
+		private final List<TransitStopFacility> transitStopFacilities;
+		private final SwissRailRaptorData swissRailRaptorData;
+		private final TripRouter tripRouter;
+		private final Logger logger;
+
+		ComparisonInstance(Config config, Logger logger) {
+			Scenario scenario = ScenarioUtils.createScenario(config);
+			ScenarioUtils.loadScenario(scenario);
+			// SwissRailRaptorModule is installed by TransitRouterModule which installed by TripRouterModule
+			AbstractModule mainModule = AbstractModule.override(List.of(new TripRouterModule(), new EventsManagerModule(), new TimeInterpretationModule(), new TravelDisutilityModule(), new TravelTimeCalculatorModule()), new ScenarioByInstanceModule(scenario));
+			Injector injector = org.matsim.core.controler.Injector.createInjector(config, mainModule);
+			raptorStopFinder = injector.getInstance(RaptorStopFinder.class);
+			activityFacilities = injector.getInstance(ActivityFacilities.class);
+			raptorParametersForPerson = injector.getInstance(RaptorParametersForPerson.class);
+			SwissRailRaptor swissRailRaptor = injector.getInstance(SwissRailRaptor.class);
+			transitStopFacilities = new ArrayList<>(scenario.getTransitSchedule().getFacilities().values());
+			swissRailRaptorData = swissRailRaptor.getUnderlyingData();
+			personList = scenario.getPopulation().getPersons().values().stream().toList();
+			tripRouter = injector.getInstance(TripRouter.class);
+			this.logger = logger;
+		}
+
+		@Override
+		public boolean equals(Object other) {
+			if (! (other instanceof ComparisonInstance comparisonInstance)) {
+				return false;
+			}
+
+
+			logger.info("Comparing order of stop facilities");
+			// Comparing stop facilities order
+			if(transitStopFacilities.size() != comparisonInstance.transitStopFacilities.size()) {
+				return false;
+			}
+			for (int i = 0; i < transitStopFacilities.size(); i++) {
+				if(!transitStopFacilities.get(i).getId().equals(comparisonInstance.transitStopFacilities.get(i).getId())) {
+					return false;
+				}
+			}
+
+			logger.info("Comparing persons and generated PT routes");
+			if(this.personList.size() != comparisonInstance.personList.size()) {
+				return false;
+			}
+			for (int personIndex = 0; personIndex < personList.size(); personIndex++) {
+				if (personIndex % 1000 == 0) {
+					logger.info(String.format("Person %d", personIndex));
+				}
+				Person referencePerson = personList.get(personIndex);
+				Person otherPerson = comparisonInstance.personList.get(personIndex);
+
+				if(!referencePerson.getId().equals(otherPerson.getId())) {
+					return false;
+				}
+
+				RaptorParameters referenceRaptorParameters = raptorParametersForPerson.getRaptorParameters(referencePerson);
+				RaptorParameters otherRaptorParameters = comparisonInstance.raptorParametersForPerson.getRaptorParameters(referencePerson);
+
+				for (TripStructureUtils.Trip referenceTrip : TripStructureUtils.getTrips(referencePerson.getSelectedPlan())) {
+					Facility fromFacility = FacilitiesUtils.toFacility(referenceTrip.getOriginActivity(), activityFacilities);
+					Facility toFacility = FacilitiesUtils.toFacility(referenceTrip.getDestinationActivity(), activityFacilities);
+
+					Facility otherFromFacility = FacilitiesUtils.toFacility(referenceTrip.getOriginActivity(), comparisonInstance.activityFacilities);
+					Facility otherToFacility = FacilitiesUtils.toFacility(referenceTrip.getDestinationActivity(), comparisonInstance.activityFacilities);
+
+					if(!otherFromFacility.getCoord().equals(fromFacility.getCoord()) || !otherToFacility.getCoord().equals(toFacility.getCoord())) {
+						return false;
+					}
+
+
+					// We specifically test the RaptorStopFinder
+					for (RaptorStopFinder.Direction direction : RaptorStopFinder.Direction.values()) {
+						List<InitialStop> referenceInitialStops = raptorStopFinder.findStops(fromFacility, toFacility, referencePerson, referenceTrip.getOriginActivity().getEndTime().seconds(), referenceTrip.getTripAttributes(), referenceRaptorParameters, swissRailRaptorData, direction);
+						List<InitialStop> sortedReferenceInitialStops = new ArrayList<>(referenceInitialStops);
+						sortedReferenceInitialStops.sort(Comparator.comparing(InitialStop::toString));
+
+						List<InitialStop> comparedInitialStops = comparisonInstance.raptorStopFinder.findStops(otherFromFacility, otherToFacility, referencePerson, referenceTrip.getOriginActivity().getEndTime().seconds(), referenceTrip.getTripAttributes(), otherRaptorParameters, comparisonInstance.swissRailRaptorData, direction);
+
+						if(referenceInitialStops.size() != comparedInitialStops.size()) {
+							return false;
+						}
+
+						List<InitialStop> sortedComparedInitialStops = new ArrayList<>(comparedInitialStops);
+						sortedComparedInitialStops.sort(Comparator.comparing(InitialStop::toString));
+						for (int j = 0; j < referenceInitialStops.size(); j++) {
+							if(!sortedReferenceInitialStops.get(j).toString().equals(sortedComparedInitialStops.get(j).toString())) {
+								return false;
+							}
+						}
+						for (int j = 0; j < referenceInitialStops.size(); j++) {
+							if(!referenceInitialStops.get(j).toString().equals(comparedInitialStops.get(j).toString())) {
+								return false;
+							}
+						}
+					}
+
+
+					// Then we test the elements return by raptor
+					List<? extends PlanElement> referenceElements = tripRouter.calcRoute("pt", fromFacility, toFacility, referenceTrip.getOriginActivity().getEndTime().seconds(), referencePerson, referenceTrip.getTripAttributes());
+
+
+					List<? extends PlanElement> comparedElements = comparisonInstance.tripRouter.calcRoute("pt", otherFromFacility, otherToFacility, referenceTrip.getOriginActivity().getEndTime().seconds(), otherPerson, referenceTrip.getTripAttributes());
+					if(!comparePlan(referenceElements, comparedElements)) {
+						return false;
+					}
+
+				}
+			}
+			return true;
+		}
+	}
+
 	@Test
 	public void testRaptorDeterminism() {
 		Logger logger = LogManager.getLogger(RaptorDeterminismTest.class);
 		logger.info("Testing raptor determinism");
 		URL configUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("siouxfalls-2014"), "config_default.xml");
 		Config config = ConfigUtils.loadConfig(configUrl);
-		int scenarioSamples = 5;
-		Scenario[] scenarios = new Scenario[scenarioSamples];
-		RaptorStopFinder[] raptorStopFinders = new RaptorStopFinder[scenarioSamples];
-		ActivityFacilities[] activityFacilities = new ActivityFacilities[scenarioSamples];
-		RaptorParametersForPerson[] raptorParametersForPerson = new RaptorParametersForPerson[scenarioSamples];
-		SwissRailRaptor[] swissRailRaptors = new SwissRailRaptor[scenarioSamples];
-		SwissRailRaptorData[] swissRailRaptorData = new SwissRailRaptorData[scenarioSamples];
-		List<TransitStopFacility>[] transitStopFacilitiesByScenario = new List[scenarioSamples];
-		List<? extends Person>[] personLists = new List[scenarioSamples];
-		TripRouter[] tripRouters = new TripRouter[scenarioSamples];
+		int scenarioSamples = 10;
 
-		logger.info(String.format("Loading scenario %d times", scenarioSamples));
-		for (int scenarioIndex = 0; scenarioIndex < scenarioSamples; scenarioIndex++) {
-			Scenario scenario = ScenarioUtils.createScenario(config);
-			ScenarioUtils.loadScenario(scenario);
 
-			// SwissRailRaptorModule is installed by TransitRouterModule which installed by TripRouterModule
-			AbstractModule mainModule = AbstractModule.override(List.of(new TripRouterModule(), new EventsManagerModule(), new TimeInterpretationModule(), new TravelDisutilityModule(), new TravelTimeCalculatorModule()), new ScenarioByInstanceModule(scenario));
+		logger.info(String.format("Loading sample 1/%d", scenarioSamples));
+		ComparisonInstance referenceSample = new ComparisonInstance(config, logger);
 
-			Injector injector = org.matsim.core.controler.Injector.createInjector(config, mainModule);
-
-			raptorStopFinders[scenarioIndex] = injector.getInstance(RaptorStopFinder.class);
-			activityFacilities[scenarioIndex] = injector.getInstance(ActivityFacilities.class);
-			raptorParametersForPerson[scenarioIndex] = injector.getInstance(RaptorParametersForPerson.class);
-			swissRailRaptors[scenarioIndex] = injector.getInstance(SwissRailRaptor.class);
-			scenarios[scenarioIndex] = scenario;
-			transitStopFacilitiesByScenario[scenarioIndex] = new ArrayList<>(scenario.getTransitSchedule().getFacilities().values());
-			swissRailRaptorData[scenarioIndex] = swissRailRaptors[scenarioIndex].getUnderlyingData();
-			personLists[scenarioIndex] = scenario.getPopulation().getPersons().values().stream().toList();
-
-			tripRouters[scenarioIndex] = injector.getInstance(TripRouter.class);
-		}
-
-		logger.info(String.format("Comparing stop facilities order %d", scenarioSamples));
-
-		for (int scenarioIndex = 1; scenarioIndex < scenarioSamples; scenarioIndex++) {
-			for (int i = 0; i < transitStopFacilitiesByScenario[0].size(); i++) {
-				assert transitStopFacilitiesByScenario[0].get(i).getId().equals(transitStopFacilitiesByScenario[scenarioIndex].get(i).getId());
-			}
-		}
-
-		logger.info("Comparing stop RaptorStopFinder.findStops alongSide ptRouter.calcRoute(pt, ...)");
-
-		for (int personIndex = 0; personIndex < Math.min(10000, personLists[0].size()); personIndex++) {
-			if (personIndex % 1000 == 0) {
-				logger.info(String.format("Person %d", personIndex));
-			}
-			Person referencePerson = personLists[0].get(personIndex);
-			RaptorParameters referenceRaptorParameters = raptorParametersForPerson[0].getRaptorParameters(referencePerson);
-
-			for (TripStructureUtils.Trip referenceTrip : TripStructureUtils.getTrips(referencePerson.getSelectedPlan())) {
-				Facility fromFacility = FacilitiesUtils.toFacility(referenceTrip.getOriginActivity(), activityFacilities[0]);
-				Facility toFacility = FacilitiesUtils.toFacility(referenceTrip.getDestinationActivity(), activityFacilities[0]);
-
-				List<? extends PlanElement> referenceElements = tripRouters[0].calcRoute("pt", fromFacility, toFacility, referenceTrip.getOriginActivity().getEndTime().seconds(), referencePerson, referenceTrip.getTripAttributes());
-
-				for (int scenarioIndex = 1; scenarioIndex < scenarioSamples; scenarioIndex++) {
-
-					assert personLists[scenarioIndex].get(personIndex).getId().equals(referencePerson.getId());
-					Person otherPerson = scenarios[scenarioIndex].getPopulation().getPersons().get(referencePerson.getId());
-
-					RaptorParameters otherRaptorParameters = raptorParametersForPerson[scenarioIndex].getRaptorParameters(referencePerson);
-					Facility otherFromFacility = FacilitiesUtils.toFacility(referenceTrip.getOriginActivity(), activityFacilities[scenarioIndex]);
-					Facility otherToFacility = FacilitiesUtils.toFacility(referenceTrip.getDestinationActivity(), activityFacilities[scenarioIndex]);
-
-					assert otherFromFacility.getCoord().equals(fromFacility.getCoord());
-					assert otherToFacility.getCoord().equals(toFacility.getCoord());
-
-					// We specifically test the RaptorStopFinder
-					for (RaptorStopFinder.Direction direction : RaptorStopFinder.Direction.values()) {
-						List<InitialStop> referenceInitialStops = raptorStopFinders[0].findStops(fromFacility, toFacility, referencePerson, referenceTrip.getOriginActivity().getEndTime().seconds(), referenceTrip.getTripAttributes(), referenceRaptorParameters, swissRailRaptorData[0], direction);
-						List<InitialStop> sortedReferenceInitialStops = new ArrayList<>(referenceInitialStops);
-						sortedReferenceInitialStops.sort(Comparator.comparing(InitialStop::toString));
-
-						List<InitialStop> comparedInitialStops = raptorStopFinders[scenarioIndex].findStops(otherFromFacility, otherToFacility, referencePerson, referenceTrip.getOriginActivity().getEndTime().seconds(), referenceTrip.getTripAttributes(), otherRaptorParameters, swissRailRaptorData[scenarioIndex], direction);
-
-						assert referenceInitialStops.size() == comparedInitialStops.size();
-
-						List<InitialStop> sortedComparedInitialStops = new ArrayList<>(comparedInitialStops);
-						sortedComparedInitialStops.sort(Comparator.comparing(InitialStop::toString));
-						for (int j = 0; j < referenceInitialStops.size(); j++) {
-							assert sortedReferenceInitialStops.get(j).toString().equals(sortedComparedInitialStops.get(j).toString());
-						}
-						for (int j = 0; j < referenceInitialStops.size(); j++) {
-							assert referenceInitialStops.get(j).toString().equals(comparedInitialStops.get(j).toString());
-						}
-					}
-
-					// Then we test the elements return by raptor
-
-					List<? extends PlanElement> comparedElements = tripRouters[scenarioIndex].calcRoute("pt", otherFromFacility, otherToFacility, referenceTrip.getOriginActivity().getEndTime().seconds(), otherPerson, referenceTrip.getTripAttributes());
-					assert comparePlan(referenceElements, comparedElements);
-				}
-			}
+		for(int i=1; i<scenarioSamples; i++) {
+			logger.info(String.format("Loading sample %d/%d", i+1, scenarioSamples));
+			ComparisonInstance otherSample = new ComparisonInstance(config, logger);
+			logger.info(String.format("Comparing sample 1 with sample %d/%d", i+1, scenarioSamples));
+			assert referenceSample.equals(otherSample);
 		}
 	}
 


### PR DESCRIPTION
Following #3687 and #3688, I have reworked the code of the integration test to avoid loading more than 2 samples/scenarios at the same time in memory. This makes the memory usage independent of the number of samples that are compared.

Previously with 5 samples with the limit of 10000 agents being compared, the heap size peaked at 800Mb, now it peaks at 400Mb with any number of samples and without the limit of 10000 agents. 

Depending on the amount of memory available for the IT, the garbage collector might not even kick in now and that could reduce the run time. With this in mind, I reset the number of samples to 10 as 5 samples were not always enough to identify some of the non-deterministic behaviour I encountered in the past.  

I propose to test and adjust the number of samples if necessary.