### PR TITLE
Fix in IMC when no plan candidate is feasible

### DIFF
--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/search/TopKChoicesGenerator.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/search/TopKChoicesGenerator.java
@@ -170,8 +170,8 @@ public class TopKChoicesGenerator extends AbstractCandidateGenerator {
 		List<PlanCandidate> result = candidates.keySet().stream().sorted().limit(topK).collect(Collectors.toList());
 
 		// threshold need to be rechecked again on the global best
-		if (!Double.isNaN(diffThreshold) && diffThreshold >= 0) {
-			double best = result.get(0).getUtility();
+		if (!Double.isNaN(diffThreshold) && diffThreshold >= 0 && !result.isEmpty()) {
+			double best = result.getFirst().getUtility();
 
 			// absolute threshold
 			result.removeIf(c -> c.getUtility() < best - diffThreshold);


### PR DESCRIPTION
Fix a null pointer exception in case no plan candidates have been generated.