### PR TITLE
Improve write speed in FreeSpeedTravelTimeMatrix

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/FreeSpeedTravelTimeMatrix.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/FreeSpeedTravelTimeMatrix.java
@@ -20,13 +20,9 @@
 
 package org.matsim.contrib.zone.skims;
 
-import java.io.*;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-
+import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
+import com.google.common.collect.Sets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
@@ -40,14 +36,13 @@ import org.matsim.contrib.dvrp.router.TimeAsTravelDisutility;
 import org.matsim.contrib.dvrp.trafficmonitoring.QSimFreeSpeedTravelTime;
 import org.matsim.contrib.zone.skims.SparseMatrix.NodeAndTime;
 import org.matsim.contrib.zone.skims.SparseMatrix.SparseRow;
-import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.router.util.TravelTime;
-
-import com.google.common.base.Preconditions;
-import com.google.common.base.Verify;
-import com.google.common.collect.Sets;
 import org.matsim.core.utils.io.IOUtils;
 import org.matsim.core.utils.misc.Counter;
+
+import java.io.*;
+import java.net.URL;
+import java.util.*;
 
 /**
  * @author Michal Maciejewski (michalm)


### PR DESCRIPTION
# Background
During simulations at MOIA we noticed that for some scenarios, when there is no pre-calculated freespeed cache, it can be costly to create on the fly. For a filtered service area depicting Hamburg it took 122s just to write the freespeed TT cache file (excluding calculation time). 

With this implementation that falls to 18 seconds, albeit still using only a single core so there is still room for improvement. 
 I *could* also provide a strawman parallelised implementation brings the time down to ~2s (on an 8 core Macbook M2), but it adds significant complexity to the code.