### PR TITLE
fix: properly initializing DvrpLoadParams and DrtEstimatorParams in DrtConfigGroup

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preplanned/run/PreplannedDrtModeModule.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preplanned/run/PreplannedDrtModeModule.java
@@ -64,13 +64,13 @@ public final class PreplannedDrtModeModule extends AbstractDvrpModeModule {
 
 		bindModal(DvrpLoadFromTrip.class).toProvider(modalProvider(getter -> {
 			DvrpLoadType loadType = getter.getModal(DvrpLoadType.class);
-			return new DefaultDvrpLoadFromTrip(loadType, drtCfg.loadParams.defaultRequestDimension);
+			return new DefaultDvrpLoadFromTrip(loadType, drtCfg.getLoadParams().defaultRequestDimension);
 		})).asEagerSingleton();
 
 		install(new FleetModule(getMode(), drtCfg.vehiclesFile == null ?
 				null :
 				ConfigGroup.getInputFileURL(getConfig().getContext(), drtCfg.vehiclesFile),
-				drtCfg.changeStartLinkToLastLinkInSchedule, drtCfg.loadParams));
+				drtCfg.changeStartLinkToLastLinkInSchedule, drtCfg.getLoadParams()));
 
 		Preconditions.checkArgument(drtCfg.getRebalancingParams().isEmpty(), "Rebalancing must not be enabled."
 				+ " It would interfere with simulation of pre-calculated vehicle schedules."

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preplanned/run/PreplannedDrtModeModule.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preplanned/run/PreplannedDrtModeModule.java
@@ -64,13 +64,13 @@ public final class PreplannedDrtModeModule extends AbstractDvrpModeModule {
 
 		bindModal(DvrpLoadFromTrip.class).toProvider(modalProvider(getter -> {
 			DvrpLoadType loadType = getter.getModal(DvrpLoadType.class);
-			return new DefaultDvrpLoadFromTrip(loadType, drtCfg.getLoadParams().defaultRequestDimension);
+			return new DefaultDvrpLoadFromTrip(loadType, drtCfg.addOrGetLoadParams().defaultRequestDimension);
 		})).asEagerSingleton();
 
 		install(new FleetModule(getMode(), drtCfg.vehiclesFile == null ?
 				null :
 				ConfigGroup.getInputFileURL(getConfig().getContext(), drtCfg.vehiclesFile),
-				drtCfg.changeStartLinkToLastLinkInSchedule, drtCfg.getLoadParams()));
+				drtCfg.changeStartLinkToLastLinkInSchedule, drtCfg.addOrGetLoadParams()));
 
 		Preconditions.checkArgument(drtCfg.getRebalancingParams().isEmpty(), "Rebalancing must not be enabled."
 				+ " It would interfere with simulation of pre-calculated vehicle schedules."

--- a/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/estimator/MultiModalDrtLegEstimatorTest.java
+++ b/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/estimator/MultiModalDrtLegEstimatorTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.matsim.application.MATSimApplication;
 import org.matsim.contrib.drt.estimator.DrtEstimatorModule;
+import org.matsim.contrib.drt.estimator.DrtEstimatorParams;
 import org.matsim.contrib.drt.estimator.impl.ExampleDrtEstimator;
 import org.matsim.contrib.drt.extension.DrtTestScenario;
 import org.matsim.contrib.drt.extension.modechoice.MultiModalDrtLegEstimator;
@@ -71,6 +72,9 @@ public class MultiModalDrtLegEstimatorTest {
 
 		config.replanning().clearStrategySettings();
 		strategies.forEach(s -> config.replanning().addStrategySettings(s));
+
+		MultiModeDrtConfigGroup multiModeDrtConfigGroup = (MultiModeDrtConfigGroup) config.getModules().get(MultiModeDrtConfigGroup.GROUP_NAME);
+		multiModeDrtConfigGroup.getModalElements().forEach(drtConfigGroup -> drtConfigGroup.addParameterSet(new DrtEstimatorParams()));
 	}
 
 	@BeforeEach

--- a/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/reconfiguration/CapacityReconfigurationTest.java
+++ b/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/reconfiguration/CapacityReconfigurationTest.java
@@ -62,7 +62,7 @@ public class CapacityReconfigurationTest {
 		assertEquals(198, tracker.pickedUpPassengers);
 		assertEquals(0, tracker.pickedUpGoods);
 	}
-	
+
 	@Test
 	void testSimpleReconfiguration() {
 		Id.resetCaches();
@@ -173,10 +173,10 @@ public class CapacityReconfigurationTest {
 				.addOrGetDefaultDrtOptimizationConstraintsSet().rejectRequestIfMaxWaitOrTravelTimeViolated = useRejections;
 
 		// produce analysis output on capacities and loads
-		drtConfig.loadParams.analysisInterval = 1;
+		drtConfig.getLoadParams().analysisInterval = 1;
 
 		// set up two dimensions
-		drtConfig.loadParams.dimensions = List.of("passengers", "goods");
+		drtConfig.getLoadParams().dimensions = List.of("passengers", "goods");
 
 		return drtConfig;
 	}

--- a/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/reconfiguration/CapacityReconfigurationTest.java
+++ b/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/reconfiguration/CapacityReconfigurationTest.java
@@ -16,6 +16,7 @@ import org.matsim.contrib.drt.extension.reconfiguration.run.CapacityReconfigurat
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.run.DrtControlerCreator;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
+import org.matsim.contrib.dvrp.load.DvrpLoadParams;
 import org.matsim.contrib.dvrp.load.DvrpLoadType;
 import org.matsim.contrib.dvrp.passenger.DefaultDvrpLoadFromTrip;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
@@ -172,11 +173,13 @@ public class CapacityReconfigurationTest {
 		drtConfig.addOrGetDrtOptimizationConstraintsParams()
 				.addOrGetDefaultDrtOptimizationConstraintsSet().rejectRequestIfMaxWaitOrTravelTimeViolated = useRejections;
 
+		DvrpLoadParams loadParams = drtConfig.addOrGetLoadParams();
+
 		// produce analysis output on capacities and loads
-		drtConfig.getLoadParams().analysisInterval = 1;
+		loadParams.analysisInterval = 1;
 
 		// set up two dimensions
-		drtConfig.getLoadParams().dimensions = List.of("passengers", "goods");
+		loadParams.dimensions = List.of("passengers", "goods");
 
 		return drtConfig;
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtModeAnalysisModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtModeAnalysisModule.java
@@ -35,7 +35,6 @@ import org.matsim.contrib.drt.sharingmetrics.SharingMetricsModule;
 import org.matsim.contrib.dvrp.analysis.CapacityLoadAnalysisHandler;
 import org.matsim.contrib.dvrp.analysis.ExecutedScheduleCollector;
 import org.matsim.contrib.dvrp.fleet.FleetSpecification;
-import org.matsim.contrib.dvrp.load.DvrpLoad;
 import org.matsim.contrib.dvrp.load.DvrpLoadType;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
 import org.matsim.contrib.dvrp.schedule.Task;
@@ -147,7 +146,7 @@ public class DrtModeAnalysisModule extends AbstractDvrpModeModule {
 			getter.getModal(FleetSpecification.class), //
 			getter.get(OutputDirectoryHierarchy.class), //
 			getter.get(EventsManager.class), //
-			drtCfg.loadParams.analysisInterval, //
+			drtCfg.getLoadParams().analysisInterval, //
 			getter.getModal(DvrpLoadType.class))));
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtModeAnalysisModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtModeAnalysisModule.java
@@ -146,7 +146,7 @@ public class DrtModeAnalysisModule extends AbstractDvrpModeModule {
 			getter.getModal(FleetSpecification.class), //
 			getter.get(OutputDirectoryHierarchy.class), //
 			getter.get(EventsManager.class), //
-			drtCfg.getLoadParams().analysisInterval, //
+			drtCfg.addOrGetLoadParams().analysisInterval, //
 			getter.getModal(DvrpLoadType.class))));
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -190,7 +190,7 @@ public class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableParamet
 	private PrebookingParams prebookingParams;
 
 	@Nullable
-	private DrtEstimatorParams drtEstimatorParams = new DrtEstimatorParams();
+	private DrtEstimatorParams drtEstimatorParams;
 
 	@Nullable
 	private DvrpLoadParams loadParams;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -383,7 +383,7 @@ public class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableParamet
 		return Optional.ofNullable(drtEstimatorParams);
 	}
 
-	public DvrpLoadParams getLoadParams() {
+	public DvrpLoadParams addOrGetLoadParams() {
 		if(this.loadParams == null) {
 			this.addParameterSet(new DvrpLoadParams());
 		}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -190,10 +190,10 @@ public class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableParamet
 	private PrebookingParams prebookingParams;
 
 	@Nullable
-	private DrtEstimatorParams drtEstimatorParams;
+	private DrtEstimatorParams drtEstimatorParams = new DrtEstimatorParams();
 
-	@NotNull
-	public DvrpLoadParams loadParams;
+	@Nullable
+	private DvrpLoadParams loadParams;
 
 	@Nullable
 	private DrtRequestInsertionRetryParams drtRequestInsertionRetryParams;
@@ -205,8 +205,6 @@ public class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableParamet
 	public DrtConfigGroup(Supplier<DrtOptimizationConstraintsSet> constraintsSetSupplier) {
 		super(GROUP_NAME);
 		initSingletonParameterSets(constraintsSetSupplier);
-		this.addParameterSet(new DvrpLoadParams());
-		this.addParameterSet(new DrtEstimatorParams());
 	}
 
 	private void initSingletonParameterSets(Supplier<DrtOptimizationConstraintsSet> constraintsSetSupplier) {
@@ -383,6 +381,13 @@ public class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableParamet
 
 	public Optional<DrtEstimatorParams> getDrtEstimatorParams() {
 		return Optional.ofNullable(drtEstimatorParams);
+	}
+
+	public DvrpLoadParams getLoadParams() {
+		if(this.loadParams == null) {
+			this.addParameterSet(new DvrpLoadParams());
+		}
+		return this.loadParams;
 	}
 
 	/**

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigGroup.java
@@ -49,7 +49,6 @@ import org.matsim.contrib.dvrp.load.DvrpLoadParams;
 import org.matsim.contrib.dvrp.router.DvrpModeRoutingNetworkModule;
 import org.matsim.contrib.dvrp.run.Modal;
 import org.matsim.core.config.Config;
-import org.matsim.core.config.ReflectiveConfigGroup.Parameter;
 import org.matsim.core.config.groups.QSimConfigGroup.EndtimeInterpretation;
 import org.matsim.core.config.groups.RoutingConfigGroup;
 import org.matsim.core.config.groups.ScoringConfigGroup;
@@ -60,7 +59,6 @@ import com.google.common.base.Verify;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.PositiveOrZero;
 
 public class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableParameterSets implements Modal {
 	private static final Logger log = LogManager.getLogger(DrtConfigGroup.class);
@@ -192,9 +190,10 @@ public class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableParamet
 	private PrebookingParams prebookingParams;
 
 	@Nullable
-	private DrtEstimatorParams drtEstimatorParams = new DrtEstimatorParams();
+	private DrtEstimatorParams drtEstimatorParams;
 
-	public DvrpLoadParams loadParams = new DvrpLoadParams();
+	@NotNull
+	public DvrpLoadParams loadParams;
 
 	@Nullable
 	private DrtRequestInsertionRetryParams drtRequestInsertionRetryParams;
@@ -206,6 +205,8 @@ public class DrtConfigGroup extends ReflectiveConfigGroupWithConfigurableParamet
 	public DrtConfigGroup(Supplier<DrtOptimizationConstraintsSet> constraintsSetSupplier) {
 		super(GROUP_NAME);
 		initSingletonParameterSets(constraintsSetSupplier);
+		this.addParameterSet(new DvrpLoadParams());
+		this.addParameterSet(new DrtEstimatorParams());
 	}
 
 	private void initSingletonParameterSets(Supplier<DrtOptimizationConstraintsSet> constraintsSetSupplier) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -75,7 +75,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 		install(new FleetModule(getMode(), drtCfg.vehiclesFile == null ?
 				null :
 				ConfigGroup.getInputFileURL(getConfig().getContext(), drtCfg.vehiclesFile),
-				drtCfg.changeStartLinkToLastLinkInSchedule, drtCfg.loadParams));
+				drtCfg.changeStartLinkToLastLinkInSchedule, drtCfg.getLoadParams()));
 		install(new DrtModeZonalSystemModule(drtCfg));
 		install(new RebalancingModule(drtCfg));
 		install(new DrtModeRoutingModule(drtCfg));
@@ -123,7 +123,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 
 		bindModal(DvrpLoadFromTrip.class).toProvider(modalProvider(getter -> {
 			DvrpLoadType loadType = getter.getModal(DvrpLoadType.class);
-			return new DefaultDvrpLoadFromTrip(loadType, drtCfg.loadParams.defaultRequestDimension);
+			return new DefaultDvrpLoadFromTrip(loadType, drtCfg.getLoadParams().defaultRequestDimension);
 		})).asEagerSingleton();
 
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -24,6 +24,7 @@ import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.analysis.DrtEventSequenceCollector;
 import org.matsim.contrib.drt.analysis.zonal.DrtModeZonalSystemModule;
 import org.matsim.contrib.drt.estimator.DrtEstimatorModule;
+import org.matsim.contrib.drt.estimator.DrtEstimatorParams;
 import org.matsim.contrib.drt.fare.DrtFareHandler;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingModule;
 import org.matsim.contrib.drt.prebooking.analysis.PrebookingModeAnalysisModule;
@@ -52,6 +53,8 @@ import org.matsim.core.router.util.TravelTime;
 import com.google.inject.Key;
 import com.google.inject.Singleton;
 import com.google.inject.name.Names;
+
+import java.util.Optional;
 
 /**
  * @author michalm (Michal Maciejewski)
@@ -118,7 +121,11 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 		install(new AdaptiveTravelTimeMatrixModule(drtCfg.mode));
 
 		if (drtCfg.simulationType == DrtConfigGroup.SimulationType.estimateAndTeleport ) {
-			install(new DrtEstimatorModule(getMode(), drtCfg, drtCfg.getDrtEstimatorParams().get()));
+			Optional<DrtEstimatorParams> drtEstimatorParams = drtCfg.getDrtEstimatorParams();
+			if(drtEstimatorParams.isEmpty()) {
+				throw new IllegalStateException("parameter set 'estimator' is required when 'simulationType' is set to 'estimateAndTeleport'");
+			}
+			install(new DrtEstimatorModule(getMode(), drtCfg, drtEstimatorParams.get()));
 		}
 
 		bindModal(DvrpLoadFromTrip.class).toProvider(modalProvider(getter -> {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeModule.java
@@ -75,7 +75,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 		install(new FleetModule(getMode(), drtCfg.vehiclesFile == null ?
 				null :
 				ConfigGroup.getInputFileURL(getConfig().getContext(), drtCfg.vehiclesFile),
-				drtCfg.changeStartLinkToLastLinkInSchedule, drtCfg.getLoadParams()));
+				drtCfg.changeStartLinkToLastLinkInSchedule, drtCfg.addOrGetLoadParams()));
 		install(new DrtModeZonalSystemModule(drtCfg));
 		install(new RebalancingModule(drtCfg));
 		install(new DrtModeRoutingModule(drtCfg));
@@ -123,7 +123,7 @@ public final class DrtModeModule extends AbstractDvrpModeModule {
 
 		bindModal(DvrpLoadFromTrip.class).toProvider(modalProvider(getter -> {
 			DvrpLoadType loadType = getter.getModal(DvrpLoadType.class);
-			return new DefaultDvrpLoadFromTrip(loadType, drtCfg.getLoadParams().defaultRequestDimension);
+			return new DefaultDvrpLoadFromTrip(loadType, drtCfg.addOrGetLoadParams().defaultRequestDimension);
 		})).asEagerSingleton();
 
 	}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/estimator/DrtEstimateAndTeleportTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/estimator/DrtEstimateAndTeleportTest.java
@@ -39,6 +39,7 @@ public class DrtEstimateAndTeleportTest {
 			new OTFVisConfigGroup());
 		DrtConfigGroup drtConfigGroup = DrtConfigGroup.getSingleModeDrtConfig(config);
 		drtConfigGroup.simulationType = DrtConfigGroup.SimulationType.estimateAndTeleport;
+		drtConfigGroup.addParameterSet(new DrtEstimatorParams());
 
 		Controler controler = DrtControlerCreator.createControler(config, false);
 		controler.addOverridingModule(new AbstractModule() {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/teleportation/DrtTeleportationTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/teleportation/DrtTeleportationTest.java
@@ -8,6 +8,7 @@ import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.matsim.contrib.drt.estimator.DrtEstimatorModule;
+import org.matsim.contrib.drt.estimator.DrtEstimatorParams;
 import org.matsim.contrib.drt.estimator.impl.PessimisticDrtEstimator;
 import org.matsim.contrib.drt.fare.DrtFareParams;
 import org.matsim.contrib.drt.optimizer.constraints.DefaultDrtOptimizationConstraintsSet;
@@ -58,6 +59,7 @@ class DrtTeleportationTest {
 
 		// Setup to enable estimator and teleportation
 		drtConfigGroup.simulationType = DrtConfigGroup.SimulationType.estimateAndTeleport;
+		drtConfigGroup.addParameterSet(new DrtEstimatorParams());
 
 		// This uses the helper method to bind an estimator. Alternatively a separate modal module could also be created.
 		controler.addOverridingModule(new AbstractModule() {


### PR DESCRIPTION
The `DvrpLoadParams` and `DrtEstimatorParams` parameter sets in the `DrtConfigGroup` are initialized directly with the attributes declaration. This causes an inconsistency with the base `ConfigGroup` class as these two parameter sets are not recorded in the `ConfigGroup.parameterSetsPerType` attribute. Which can cause a crash if the method `removeParameterSet` is called with one of the two sets mentioned above.

This PR fixes this by initializing the parameter sets in the constructor by calling the `addParameterSet` method.