### PR TITLE
fix: prebooking setting agents stuck

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/prebooking/PrebookingManager.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/prebooking/PrebookingManager.java
@@ -378,6 +378,7 @@ public class PrebookingManager implements MobsimEngine, MobsimAfterSimStepListen
 
 	// Rejections
 
+	private static final String ABORT_STUCK_REASON = " rejected prebooked request";
 	private final IdSet<Person> stuckUponActivity = new IdSet<>(Person.class);
 
 	private void processRejections(double now) {
@@ -456,7 +457,7 @@ public class PrebookingManager implements MobsimEngine, MobsimAfterSimStepListen
 		((HasModifiablePlan) agent).resetCaches();
 		internalInterface.getMobsim().rescheduleActivityEnd(agent);
 		eventsManager.processEvent(new PersonStuckEvent(now, agent.getId(), agent.getCurrentLinkId(),
-				this.mode));
+				null, mode + ABORT_STUCK_REASON));
 
 		internalInterface.getMobsim().getAgentCounter().incLost();
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/prebooking/PrebookingManager.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/prebooking/PrebookingManager.java
@@ -378,6 +378,8 @@ public class PrebookingManager implements MobsimEngine, MobsimAfterSimStepListen
 
 	// Rejections
 
+	private final IdSet<Person> stuckUponActivity = new IdSet<>(Person.class);
+
 	private void processRejections(double now) {
 		for (Id<Request> requestId : rejectedEventIds) {
 			RequestItem item = requests.remove(requestId);
@@ -401,25 +403,20 @@ public class PrebookingManager implements MobsimEngine, MobsimAfterSimStepListen
 						Plan plan = WithinDayAgentUtils.getModifiablePlan(agent);
 						PlanElement planElement = plan.getPlanElements().get(index);
 
-						if (planElement instanceof Activity currentActivity) {
-							Activity activity = currentActivity;
-							activity.setEndTime(Double.POSITIVE_INFINITY);
-							activity.setMaximumDurationUndefined();
-
-							((HasModifiablePlan) agent).resetCaches();
-							internalInterface.getMobsim().rescheduleActivityEnd(agent);
-							eventsManager.processEvent(new PersonStuckEvent(now, agent.getId(), agent.getCurrentLinkId(),
-									this.mode));
-
-							internalInterface.getMobsim().getAgentCounter().incLost();
-							internalInterface.getMobsim().getAgentCounter().decLiving();
+						if (planElement instanceof Activity) {
+							// the agent is on an activity, let it get stuck further below
+							stuckUponActivity.add(passengerId);
 						} else {
-							// If the current element is a leg, the agent is walking towards the pickup location
-							// We make the agent stuck at the interaction activity
+							// the agent is on a leg, so we cannot make it stuck directly. 
+							// instead, we set the next activity to an infinite duration and 
+							// make the agent get stuck right after the activity starts
+							
 							while (index < plan.getPlanElements().size()) {
 								if (plan.getPlanElements().get(index) instanceof Activity activity) {
-									activity.setEndTime(Double.POSITIVE_INFINITY);
+									activity.setEndTime(Double.MAX_VALUE); // very long but not infinite (= regular last activity)
 									activity.setMaximumDurationUndefined();
+									stuckUponActivity.add(agent.getId());
+									break;
 								}
 
 								index++;
@@ -431,6 +428,40 @@ public class PrebookingManager implements MobsimEngine, MobsimAfterSimStepListen
 		}
 
 		rejectedEventIds.clear();
+
+		Iterator<Id<Person>> stuckIterator = stuckUponActivity.iterator();
+		while (stuckIterator.hasNext()) {
+			Id<Person> personId = stuckIterator.next();
+			MobsimAgent agent = internalInterface.getMobsim().getAgents().get(personId);
+
+			PlanElement planElement = WithinDayAgentUtils.getCurrentPlanElement(agent);
+			if (planElement instanceof Activity activity) {
+				abortAgent(agent, activity, now);
+				stuckIterator.remove();
+			}
+		}
+	}
+
+	private void abortAgent(MobsimAgent agent, Activity activity, double now) {
+		// this would be the simple way, but then it looks like the agent is stuck 
+		// because of something related to the activity. however, we want to make 
+		//it clear that drt is the cause here
+		
+		// agent.setStateToAbort(now);
+		// internalInterface.arrangeNextAgentState(agent);
+
+		activity.setEndTime(Double.POSITIVE_INFINITY);
+		activity.setMaximumDurationUndefined();
+
+		((HasModifiablePlan) agent).resetCaches();
+		internalInterface.getMobsim().rescheduleActivityEnd(agent);
+		eventsManager.processEvent(new PersonStuckEvent(now, agent.getId(), agent.getCurrentLinkId(),
+				this.mode));
+
+		internalInterface.getMobsim().getAgentCounter().incLost();
+
+		// will be called by the activity engine
+		// internalInterface.getMobsim().getAgentCounter().decLiving();
 	}
 
 	// Stuck

--- a/matsim/src/main/java/org/matsim/api/core/v01/events/PersonStuckEvent.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/PersonStuckEvent.java
@@ -34,16 +34,23 @@ public class PersonStuckEvent extends Event implements HasPersonId, HasLinkId {
 	public static final String ATTRIBUTE_LINK = "link";
 	public static final String ATTRIBUTE_LEGMODE = "legMode";
 	public static final String ATTRIBUTE_PERSON = "person";
+	public static final String ATTRIBUTE_REASON = "reason";
 
 	private final Id<Person> personId;
 	private final Id<Link> linkId;
 	private final String legMode;
+	private final String reason;
 
-	public PersonStuckEvent(final double time, final Id<Person> agentId, final Id<Link> linkId, final String legMode) {
+	public PersonStuckEvent(final double time, final Id<Person> agentId, final Id<Link> linkId, final String legMode, String reason) {
 		super(time);
 		this.personId = agentId;
 		this.linkId = linkId;
 		this.legMode = legMode;
+		this.reason = reason;
+	}
+
+	public PersonStuckEvent(final double time, final Id<Person> agentId, final Id<Link> linkId, final String legMode) {
+		this(time, agentId, linkId, legMode, null);
 	}
 
 	public Id<Person> getPersonId() {
@@ -58,6 +65,10 @@ public class PersonStuckEvent extends Event implements HasPersonId, HasLinkId {
 		return this.legMode;
 	}
 
+	public String getReason() {
+		return this.reason;
+	}
+
 	@Override
 	public String getEventType() {
 		return EVENT_TYPE;
@@ -70,6 +81,9 @@ public class PersonStuckEvent extends Event implements HasPersonId, HasLinkId {
 		if (this.legMode != null) {
 			attr.put(ATTRIBUTE_LEGMODE, this.legMode);
 		}
+		if (this.reason != null) {
+			attr.put(ATTRIBUTE_REASON, this.legMode);
+		}
 		return attr;
 	}
 
@@ -80,6 +94,10 @@ public class PersonStuckEvent extends Event implements HasPersonId, HasLinkId {
 
 		if (this.legMode != null) {
 			XmlUtils.writeEncodedAttributeKeyValue(out, ATTRIBUTE_LEGMODE, this.legMode);
+		}
+
+		if (this.reason != null) {
+			XmlUtils.writeEncodedAttributeKeyValue(out, ATTRIBUTE_REASON, this.reason);
 		}
 
 		writeXMLEnd(out);


### PR DESCRIPTION
The implementation for making agents stuck if their prebooked request is rejected was still not ideal:
- When an agent is on a leg, the next activity is set to an infinite end time, which makes the ActivityEngine let the agent go to sleep like on a regular end of day (without a specific *stuck* event). In that case, it would be nice to have the source of ending the day being identified as being stuck.
- When an agent is on an activity, we ended the activity in the same way, but additionally created a *stuck* event (nice!). However, we call `AgentCounter.decLiving` which is also called by the `ActivityEngine` which sends the agent to sleep. In consequence, the counter is called twice and in some particular situations (no fixed end time), this makes the simulation stop too early because the counter falls to zero.

The current PR should now fix the issues:
- In both cases, a *stuck* event is generated that clearly names DRT as the source of why the agent is stuck.
- The counting of agents should now be correct.

Internally, the logic is as follows:
- There is now a `stuckUponNextActivity` set in the `PrebookingManager` that manages letting agents get stuck.
- If an agent is on an activity, the agent is added to that set 
- If an agent is on a leg, the next activity in the schedule is searched, the end time is set to "never" (MAX_VALUE, which is different from POSITIVE_INFINITY which would let the agent simply go to sleep), and the agent is added to the set
- After processing all potential stuck agents, we go through the `stuckUponNextActivity` set to check whether the agent is in an activity, and if so, we make the agent stuck by letting the ActivityEngine send them to sleep, but we also create an explicit *stuck* event