### PR TITLE
Improved Scenario Cutout

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/prepare/population/PersonNetworkLinkCheck.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/population/PersonNetworkLinkCheck.java
@@ -57,6 +57,8 @@ public final class PersonNetworkLinkCheck implements MATSimAppCommand, PersonAlg
 		Population population = PopulationUtils.readPopulation(populationPath);
 		ParallelPersonAlgorithmUtils.run(population, Runtime.getRuntime().availableProcessors(), this);
 
+		PopulationUtils.writePopulation(population, output);
+
 		return 0;
 	}
 
@@ -73,7 +75,7 @@ public final class PersonNetworkLinkCheck implements MATSimAppCommand, PersonAlg
 
 					if (leg.getRoute() instanceof NetworkRoute r)
 						checkNetworkRoute(leg, r);
-					else
+					else if (leg.getRoute() != null)
 						checkRoute(leg, leg.getRoute());
 
 				}

--- a/contribs/application/src/main/java/org/matsim/application/prepare/population/PersonNetworkLinkCheck.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/population/PersonNetworkLinkCheck.java
@@ -14,6 +14,7 @@ import org.matsim.core.population.algorithms.PersonAlgorithm;
 import org.matsim.core.population.routes.NetworkRoute;
 import picocli.CommandLine;
 
+import java.util.Objects;
 import java.util.stream.Stream;
 
 /**
@@ -39,11 +40,18 @@ public final class PersonNetworkLinkCheck implements MATSimAppCommand, PersonAlg
 	private Network network;
 
 	@SuppressWarnings("unused")
-	PersonNetworkLinkCheck() {
+	public PersonNetworkLinkCheck() {
 	}
 
-	public PersonNetworkLinkCheck(Network network) {
+	private PersonNetworkLinkCheck(Network network) {
 		this.network = network;
+	}
+
+	/**
+	 * Create an instance of the class used directly as a {@link PersonAlgorithm}.
+	 */
+	public static PersonAlgorithm createPersonAlgorithm(Network network) {
+		return new PersonNetworkLinkCheck(network);
 	}
 
 	public static void main(String[] args) {
@@ -64,6 +72,8 @@ public final class PersonNetworkLinkCheck implements MATSimAppCommand, PersonAlg
 
 	@Override
 	public void run(Person person) {
+
+		Objects.requireNonNull(network, "Network not set. Make sure to use PersonNetworkLinkCheck.createPersonAlgorithm(network).");
 
 		for (Plan plan : person.getPlans()) {
 

--- a/contribs/application/src/main/java/org/matsim/application/prepare/population/PersonNetworkLinkCheck.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/population/PersonNetworkLinkCheck.java
@@ -28,7 +28,7 @@ public final class PersonNetworkLinkCheck implements MATSimAppCommand, PersonAlg
 
 	private static final Logger log = LogManager.getLogger(PersonNetworkLinkCheck.class);
 
-	@CommandLine.Option(names = "--population", description = "Path to population", required = true)
+	@CommandLine.Option(names = {"--input", "--population"}, description = "Path to population", required = true)
 	private String populationPath;
 
 	@CommandLine.Option(names = "--network", description = "Path to network", required = true)

--- a/contribs/application/src/main/java/org/matsim/application/prepare/population/PersonNetworkLinkCheck.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/population/PersonNetworkLinkCheck.java
@@ -1,0 +1,111 @@
+package org.matsim.application.prepare.population;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.population.*;
+import org.matsim.application.MATSimAppCommand;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.population.PopulationUtils;
+import org.matsim.core.population.algorithms.ParallelPersonAlgorithmUtils;
+import org.matsim.core.population.algorithms.PersonAlgorithm;
+import org.matsim.core.population.routes.NetworkRoute;
+import picocli.CommandLine;
+
+import java.util.stream.Stream;
+
+/**
+ * Checks the plan of a person for non-existing link ids.
+ * Invalid occurrences will be removed and routes or activities link ids reset if necesarry.
+ *
+ * This class can be used from CLI or as a {@link PersonAlgorithm}.
+ */
+@CommandLine.Command(name = "person-network-link-check", description = "Check the plan of a person for non-existing link ids.")
+public final class PersonNetworkLinkCheck implements MATSimAppCommand, PersonAlgorithm {
+
+	@CommandLine.Option(names = "--population", description = "Path to population", required = true)
+	private String populationPath;
+
+	@CommandLine.Option(names = "--network", description = "Path to network", required = true)
+	private String networkPath;
+
+	@CommandLine.Option(names = "--output", description = "Path to output population", required = true)
+	private String output;
+
+	private Network network;
+
+	@SuppressWarnings("unused")
+	PersonNetworkLinkCheck() {
+	}
+
+	public PersonNetworkLinkCheck(Network network) {
+		this.network = network;
+	}
+
+	public static void main(String[] args) {
+		new PersonNetworkLinkCheck().execute(args);
+	}
+
+	@Override
+	public Integer call() throws Exception {
+
+		network = NetworkUtils.readNetwork(networkPath);
+		Population population = PopulationUtils.readPopulation(populationPath);
+		ParallelPersonAlgorithmUtils.run(population, Runtime.getRuntime().availableProcessors(), this);
+
+		return 0;
+	}
+
+	@Override
+	public void run(Person person) {
+
+		for (Plan plan : person.getPlans()) {
+
+			for (PlanElement el : plan.getPlanElements()) {
+
+				if (el instanceof Activity act) {
+					checkActivity(act);
+				} else if (el instanceof Leg leg) {
+
+					if (leg.getRoute() instanceof NetworkRoute r)
+						checkNetworkRoute(leg, r);
+					else
+						checkRoute(leg, leg.getRoute());
+
+				}
+			}
+		}
+	}
+
+	private void checkActivity(Activity act) {
+		// activity link ids are reset, if they are not contained in the network
+		if (act.getLinkId() != null && !network.getLinks().containsKey(act.getLinkId()))
+			act.setLinkId(null);
+	}
+
+	private void checkRoute(Leg leg, Route route) {
+		if (!network.getLinks().containsKey(route.getStartLinkId()) || !network.getLinks().containsKey(route.getEndLinkId()))
+			leg.setRoute(null);
+	}
+
+	private void checkNetworkRoute(Leg leg, NetworkRoute r) {
+
+		Stream<Id<Link>> stream = Stream.concat(Stream.of(r.getStartLinkId(), r.getEndLinkId()), r.getLinkIds().stream());
+
+		boolean valid = stream.allMatch(l -> {
+
+			Link link = network.getLinks().get(l);
+
+			// Check if link is present in the network
+			if (link == null)
+				return false;
+
+			// Check if the link has the needed mode
+			return link.getAllowedModes().contains(leg.getMode());
+		});
+
+		if (!valid) {
+			leg.setRoute(null);
+		}
+	}
+}

--- a/contribs/application/src/main/java/org/matsim/application/prepare/scenario/CreateScenarioCutOut.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/scenario/CreateScenarioCutOut.java
@@ -479,16 +479,26 @@ public class CreateScenarioCutOut implements MATSimAppCommand, PersonAlgorithm {
 			// Setting capacity outside shapefile (and buffer) to a very large value, not max value, as this causes problem in the qsim
 			link.setCapacity(1_000_000);
 
+			Double prevSpeed = null;
+
 			// Do this for the whole simulation run
 			for (double time = 0; time < changeEventsMaxTime; time += timeFrameLength) {
 
 				// Setting freespeed to the link average
 				double freespeed = link.getLength() / tt.getLinkTravelTimes().getLinkTravelTime(link, time, null, null);
+
+				// Skip if the speed is the same as the previous speed
+				if (prevSpeed != null && Math.abs(freespeed - prevSpeed) < 1e-6) {
+					continue;
+				}
+
 				NetworkChangeEvent event = new NetworkChangeEvent(time);
 				event.setFreespeedChange(new NetworkChangeEvent.ChangeValue(NetworkChangeEvent.ChangeType.ABSOLUTE_IN_SI_UNITS, freespeed));
 				NetworkUtils.addNetworkChangeEvent(scenario.getNetwork(), event);
 				event.addLink(link);
 				events.add(event);
+
+				prevSpeed = freespeed;
 			}
 		}
 

--- a/contribs/application/src/main/java/org/matsim/application/prepare/scenario/CreateScenarioCutOut.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/scenario/CreateScenarioCutOut.java
@@ -126,7 +126,7 @@ public class CreateScenarioCutOut implements MATSimAppCommand, PersonAlgorithm {
 	@CommandLine.Option(names = "--network-modes", description = "Modes to consider when cutting network", defaultValue = "car,bike", split = ",")
 	private Set<String> modes;
 
-	@CommandLine.Option(names = "--keep-modes", description = "Network modes of links that are always kept", defaultValue = TransportMode.pt, split = ",")
+	@CommandLine.Option(names = "--keep-modes", description = "Network modes of links that are always kept. No change events will be generated for these.", defaultValue = TransportMode.pt, split = ",")
 	private Set<String> keepModes;
 
 	@CommandLine.Option(names = "--check-beeline", description = "Additional check if agents might cross the zone using a direct beeline.")
@@ -475,6 +475,11 @@ public class CreateScenarioCutOut implements MATSimAppCommand, PersonAlgorithm {
 			// Don't generate events for links thar are in the shapefile + buffer
 			if (geomBuffer.contains(MGC.coord2Point(link.getCoord())))
 				continue;
+
+			// Don't generate events for these fixed modes.
+			if (link.getAllowedModes().equals(keepModes))
+				continue;
+
 
 			// Setting capacity outside shapefile (and buffer) to a very large value, not max value, as this causes problem in the qsim
 			link.setCapacity(1_000_000);

--- a/contribs/application/src/main/java/org/matsim/application/prepare/scenario/CreateScenarioCutOut.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/scenario/CreateScenarioCutOut.java
@@ -126,6 +126,9 @@ public class CreateScenarioCutOut implements MATSimAppCommand, PersonAlgorithm {
 	@CommandLine.Option(names = "--network-modes", description = "Modes to consider when cutting network", defaultValue = "car,bike", split = ",")
 	private Set<String> modes;
 
+	@CommandLine.Option(names = "--clean-modes", description = "Additional modes to consider for network cleaning", split = ",")
+	private Set<String> cleanModes;
+
 	@CommandLine.Option(names = "--keep-modes", description = "Network modes of links that are always kept. No change events will be generated for these.", defaultValue = TransportMode.pt, split = ",")
 	private Set<String> keepModes;
 
@@ -305,6 +308,13 @@ public class CreateScenarioCutOut implements MATSimAppCommand, PersonAlgorithm {
 		for (String mode : modes) {
 			log.info("Cleaning mode {}", mode);
 			cleaner.run(Set.of(mode));
+		}
+
+		if (cleanModes != null) {
+			for (String mode : cleanModes) {
+				log.info("Cleaning mode {}", mode);
+				cleaner.run(Set.of(mode));
+			}
 		}
 
 		log.info("number of links after cleaning: {}", scenario.getNetwork().getLinks().size());

--- a/contribs/application/src/main/java/org/matsim/application/prepare/scenario/CreateScenarioCutOut.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/scenario/CreateScenarioCutOut.java
@@ -310,7 +310,7 @@ public class CreateScenarioCutOut implements MATSimAppCommand, PersonAlgorithm {
 		log.info("number of links after cleaning: {}", scenario.getNetwork().getLinks().size());
 		log.info("number of nodes after cleaning: {}", scenario.getNetwork().getNodes().size());
 
-		ParallelPersonAlgorithmUtils.run(scenario.getPopulation(), Runtime.getRuntime().availableProcessors(), new PersonNetworkLinkCheck(scenario.getNetwork()));
+		ParallelPersonAlgorithmUtils.run(scenario.getPopulation(), Runtime.getRuntime().availableProcessors(), PersonNetworkLinkCheck.createPersonAlgorithm(scenario.getNetwork()));
 
 		PopulationUtils.writePopulation(scenario.getPopulation(), outputPopulation);
 

--- a/contribs/application/src/main/java/org/matsim/application/prepare/scenario/CreateScenarioCutOut.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/scenario/CreateScenarioCutOut.java
@@ -129,6 +129,9 @@ public class CreateScenarioCutOut implements MATSimAppCommand, PersonAlgorithm {
 	@CommandLine.Option(names = "--keep-modes", description = "Network modes of links that are always kept", defaultValue = TransportMode.pt, split = ",")
 	private Set<String> keepModes;
 
+	@CommandLine.Option(names = "--check-beeline", description = "Additional check if agents might cross the zone using a direct beeline.")
+	private boolean checkBeeline;
+
 	@CommandLine.Mixin
 	private CrsOptions crs;
 
@@ -530,13 +533,13 @@ public class CreateScenarioCutOut implements MATSimAppCommand, PersonAlgorithm {
 			Coord originCoord = getActivityCoord(trip.getOriginActivity());
 			Coord destinationCoord = getActivityCoord(trip.getDestinationActivity());
 
-			if (originCoord != null && destinationCoord != null) {
+			// also keep persons traveling through or close to area (beeline)
+			if (checkBeeline && originCoord != null && destinationCoord != null) {
 				LineString line = geoFactory.createLineString(new Coordinate[]{
 					MGC.coord2Coordinate(originCoord),
 					MGC.coord2Coordinate(destinationCoord)
 				});
 
-				// also keep persons traveling through or close to area (beeline)
 				if (line.intersects(geom)) {
 					keepPerson = true;
 				}

--- a/contribs/application/src/test/java/org/matsim/application/prepare/scenario/CreateScenarioCutOutTest.java
+++ b/contribs/application/src/test/java/org/matsim/application/prepare/scenario/CreateScenarioCutOutTest.java
@@ -35,7 +35,7 @@ class CreateScenarioCutOutTest {
 	 */
 	@Test
 	void testBasicCutout() {
-		// TODO Rueckfrage: Soll die cap auch auf inf gesetzt werden, wenn es keine Events gibt, die die freespeed anpassen?
+
 		new CreateScenarioCutOut().execute(
 			"--buffer", "100",
 			"--population", utils.getClassInputDirectory() + "plans_without_facilities.xml",

--- a/contribs/application/test/input/org/matsim/application/prepare/scenario/CreateScenarioCutOutTest/withEvents/cut_change_events.xml
+++ b/contribs/application/test/input/org/matsim/application/prepare/scenario/CreateScenarioCutOutTest/withEvents/cut_change_events.xml
@@ -6,41 +6,6 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="2"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="2"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="2"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="2"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="2"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="2"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="2"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="2"/>
 		<freespeed type="absolute" value="0.3125"/>
@@ -51,32 +16,7 @@
 		<freespeed type="absolute" value="0.3472222222222222"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="2"/>
-		<freespeed type="absolute" value="0.3472222222222222"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="2"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="2"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="2"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="2"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="2"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -86,77 +26,12 @@
 		<freespeed type="absolute" value="0.30864197530864196"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="2"/>
-		<freespeed type="absolute" value="0.30864197530864196"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="2"/>
-		<freespeed type="absolute" value="0.30864197530864196"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="19:00:00">
 		<link refId="2"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="2"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="2"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="2"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="2"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="3"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="3"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="3"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="3"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="3"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="3"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="3"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="3"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -191,42 +66,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="3"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="3"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="16:00:00">
 		<link refId="3"/>
 		<freespeed type="absolute" value="0.30864197530864196"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="3"/>
-		<freespeed type="absolute" value="0.30864197530864196"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="3"/>
-		<freespeed type="absolute" value="0.30864197530864196"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="3"/>
-		<freespeed type="absolute" value="0.30864197530864196"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
-		<link refId="3"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
 		<link refId="3"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -242,41 +87,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="4"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="4"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="4"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="4"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="4"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="4"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="4"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="4"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -301,22 +111,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="4"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
-		<link refId="4"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="4"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="4"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -331,72 +126,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="4"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="4"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="4"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="21:00:00">
 		<link refId="4"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="4"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="4"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="5"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="5"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="5"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="5"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="5"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="5"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="5"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="5"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -436,11 +171,6 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="5"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="16:00:00">
 		<link refId="5"/>
 		<freespeed type="absolute" value="0.5167961327111796"/>
@@ -452,11 +182,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="18:00:00">
-		<link refId="5"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="5"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -486,41 +211,6 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="6"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="6"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="6"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="6"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="6"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="6"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="6"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="6"/>
 		<freespeed type="absolute" value="0.3472222222222222"/>
@@ -536,47 +226,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="6"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="6"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="6"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="6"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="15:00:00">
-		<link refId="6"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="6"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="6"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="6"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="6"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -586,57 +236,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="6"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="6"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="6"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="7"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="7"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="7"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="7"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="7"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="7"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="7"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="7"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -691,16 +291,6 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="7"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="7"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
 		<link refId="7"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
@@ -726,41 +316,6 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="8"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="8"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="8"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="8"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="8"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="8"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="8"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="8"/>
 		<freespeed type="absolute" value="0.4166666666666667"/>
@@ -776,62 +331,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="8"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="8"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="8"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="8"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="15:00:00">
 		<link refId="8"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="8"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="8"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="8"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="8"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
-		<link refId="8"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="8"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
 		<link refId="8"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -842,41 +347,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="9"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="9"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="9"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="9"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="9"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="9"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="9"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="9"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -911,11 +381,6 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="9"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="15:00:00">
 		<link refId="9"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
@@ -927,16 +392,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="17:00:00">
-		<link refId="9"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="9"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="9"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -966,77 +421,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="10"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="10"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="10"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="10"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="10"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="10"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="10"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="10"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="10"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="10:00:00">
-		<link refId="10"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="10"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="10"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="10"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="10"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="10"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -1046,37 +436,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="10"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
-		<link refId="10"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="10"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="10"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="10"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="10"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
 		<link refId="10"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -1086,77 +446,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="11"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="11"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="11"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="11"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="11"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="11"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="11"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="11"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="11"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="10:00:00">
-		<link refId="11"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="11"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="11"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="11"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="11"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="11"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -1166,37 +461,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="11"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
-		<link refId="11"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="11"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="11"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="11"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="11"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
 		<link refId="11"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -1206,77 +471,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="12"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="12"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="12"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="12"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="12"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="12"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="12"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="12"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="12"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="10:00:00">
-		<link refId="12"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="12"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="12"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="12"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="12"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="12"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -1286,37 +486,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="12"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
-		<link refId="12"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="12"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="12"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="12"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="12"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
 		<link refId="12"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -1326,77 +496,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="13"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="13"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="13"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="13"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="13"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="13"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="13"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="13"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="13"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="10:00:00">
-		<link refId="13"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="13"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="13"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="13"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="13"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="13"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -1416,26 +521,6 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="13"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="13"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="13"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="13"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="23:00:00">
 		<link refId="13"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
@@ -1446,47 +531,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="14"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="14"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="14"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="14"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="14"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="14"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="14"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
-		<link refId="14"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="09:00:00">
 		<link refId="14"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -1496,42 +541,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="14"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="14"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="14"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="14"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="14"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="16:00:00">
-		<link refId="14"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="14"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
 		<link refId="14"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -1566,47 +576,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="15"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="15"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="15"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="15"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="15"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="15"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="15"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
-		<link refId="15"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="09:00:00">
 		<link refId="15"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -1616,42 +586,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="15"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="15"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="15"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="15"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="15"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="16:00:00">
-		<link refId="15"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="15"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
 		<link refId="15"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -1666,57 +601,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="15"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="15"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="15"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="16"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="16"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="16"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="16"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="16"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="16"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="16"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="16"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -1726,57 +611,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="16"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="10:00:00">
-		<link refId="16"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="16"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="16"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="16"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="16"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="16"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="16"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="16"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="16"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="16"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -1786,57 +621,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="16"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="16"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="16"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="17"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="17"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="17"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="17"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="17"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="17"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="17"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="17"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -1846,17 +631,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="17"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="10:00:00">
-		<link refId="17"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
 		<link refId="17"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -1871,92 +646,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="17"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="17"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="17"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="17"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="17"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="17"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
 		<link refId="17"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="17"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="17"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="17"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="18"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="18"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="18"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="18"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="18"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="18"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="18"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="18"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -1981,57 +676,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="18"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="18"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="14:00:00">
 		<link refId="18"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="18"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="18"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="18"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="18"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="18"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
-		<link refId="18"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="18"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
 		<link refId="18"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -2046,77 +696,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="19"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="19"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="19"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="19"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="19"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="19"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="19"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="19"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="19"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="10:00:00">
-		<link refId="19"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="19"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="19"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="19"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="19"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="19"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -2126,37 +711,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="19"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
-		<link refId="19"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="19"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="19"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="19"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="19"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
 		<link refId="19"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -2166,77 +721,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="20"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="20"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="20"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="20"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="20"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="20"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="20"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="20"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="20"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="10:00:00">
-		<link refId="20"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="20"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="20"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="20"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="20"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="20"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -2246,37 +736,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="20"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
-		<link refId="20"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="20"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="20"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="20"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="20"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
 		<link refId="20"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -2286,77 +746,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="21"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="21"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="21"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="21"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="21"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="21"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="21"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="21"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="21"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="10:00:00">
-		<link refId="21"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="21"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="21"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="21"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="21"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="21"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -2366,37 +761,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="21"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
-		<link refId="21"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="21"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="21"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="21"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="21"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
 		<link refId="21"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -2406,77 +771,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="22"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="22"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="22"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="22"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="22"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="22"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="22"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="22"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="22"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="10:00:00">
-		<link refId="22"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="22"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="22"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="22"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="22"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="22"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -2496,21 +796,6 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="22"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="22"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="22"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="22:00:00">
 		<link refId="22"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
@@ -2526,47 +811,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="23"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="23"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="23"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="23"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="23"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="23"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="23"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
-		<link refId="23"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="09:00:00">
 		<link refId="23"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -2576,42 +821,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="23"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="23"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="23"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="23"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="23"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="16:00:00">
-		<link refId="23"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="23"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
 		<link refId="23"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -2646,77 +856,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="24"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="24"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="24"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="24"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="24"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="24"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="24"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="24"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="24"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="10:00:00">
-		<link refId="24"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="24"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="24"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="24"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="24"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="24"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -2746,57 +891,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="24"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="24"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="24"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="25"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="25"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="25"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="25"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="25"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="25"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="25"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="25"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -2806,57 +901,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="25"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="10:00:00">
-		<link refId="25"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="25"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="25"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="25"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="25"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="25"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="25"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="25"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="25"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="25"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -2866,57 +911,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="25"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="25"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="25"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="26"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="26"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="26"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="26"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="26"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="26"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="26"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="26"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -2926,57 +921,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="26"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="10:00:00">
-		<link refId="26"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="26"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="26"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="26"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="26"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="26"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="26"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="26"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="26"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="26"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -2986,57 +931,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="26"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="26"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="26"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="27"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="27"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="27"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="27"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="27"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="27"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="27"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="27"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -3052,56 +947,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="10:00:00">
-		<link refId="27"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="27"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="27"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="27"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="27"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="27"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="27"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="27"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="27"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="27"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
 		<link refId="27"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -3126,77 +971,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="28"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="28"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="28"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="28"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="28"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="28"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="28"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="28"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="28"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="10:00:00">
-		<link refId="28"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="28"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="28"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="28"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="28"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="28"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -3206,37 +986,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="28"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
-		<link refId="28"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="28"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="28"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="28"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="28"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
 		<link refId="28"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -3246,77 +996,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="29"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="29"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="29"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="29"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="29"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="29"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="29"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="29"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="29"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="10:00:00">
-		<link refId="29"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="29"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="29"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="29"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="29"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="29"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -3326,37 +1011,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="29"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
-		<link refId="29"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="29"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="29"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="29"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="29"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
 		<link refId="29"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -3366,77 +1021,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="30"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="30"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="30"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="30"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="30"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="30"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="30"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="30"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="30"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="10:00:00">
-		<link refId="30"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="30"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="30"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="30"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="30"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="30"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -3446,37 +1036,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="30"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
-		<link refId="30"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="30"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="30"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="30"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="30"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
 		<link refId="30"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -3486,77 +1046,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="31"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="31"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="31"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="31"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="31"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="31"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="31"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="31"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="31"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="31"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="31"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="31"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="31"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="31"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="31"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -3576,21 +1071,6 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="31"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="31"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="31"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="22:00:00">
 		<link refId="31"/>
 		<freespeed type="absolute" value="7.45156482861401"/>
@@ -3606,52 +1086,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="32"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="32"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="32"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="32"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="32"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="32"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="32"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
-		<link refId="32"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="32"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
 		<link refId="32"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -3661,42 +1096,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="32"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="32"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="32"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="32"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="16:00:00">
 		<link refId="32"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="32"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
-		<link refId="32"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="32"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -3726,52 +1131,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="33"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="33"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="33"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="33"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="33"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="33"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="33"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
-		<link refId="33"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="33"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
 		<link refId="33"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -3781,32 +1141,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="33"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="33"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="33"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="33"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="16:00:00">
-		<link refId="33"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
 		<link refId="33"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -3816,67 +1151,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="33"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
 		<link refId="33"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="33"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="33"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="33"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="34"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="34"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="34"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="34"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="34"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="34"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="34"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="34"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -3886,57 +1166,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="34"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="34"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="34"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="34"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="34"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="34"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="34"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="34"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="34"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="34"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="34"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -3946,57 +1176,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="34"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="34"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="34"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="35"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="35"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="35"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="35"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="35"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="35"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="35"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="35"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -4006,57 +1186,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="35"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="35"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="35"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="35"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="35"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="35"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="35"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="35"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="35"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="35"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="35"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -4066,57 +1196,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="35"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="35"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="35"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="36"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="36"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="36"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="36"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="36"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="36"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="36"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="36"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -4126,57 +1206,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="36"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="10:00:00">
-		<link refId="36"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="36"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="36"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="36"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="36"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="36"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="36"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="36"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="36"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="36"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -4186,57 +1216,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="36"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="36"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="36"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="37"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="37"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="37"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="37"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="37"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="37"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="37"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="37"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -4246,37 +1226,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="37"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="37"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="37"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="37"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="37"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="37"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="37"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -4286,77 +1236,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="37"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="37"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="19:00:00">
 		<link refId="37"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="37"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="37"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="37"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="37"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="38"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="38"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="38"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="38"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="38"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="38"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="38"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="38"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -4366,37 +1251,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="38"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="38"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="38"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="38"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="38"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="38"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="38"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -4406,77 +1261,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="38"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="38"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="19:00:00">
 		<link refId="38"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="38"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="38"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="38"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="38"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="39"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="39"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="39"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="39"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="39"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="39"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="39"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="39"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -4497,26 +1287,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="39"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="39"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="39"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="39"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="39"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -4546,57 +1316,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="39"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="39"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="39"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="40"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="40"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="40"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="40"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="40"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="40"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="40"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="40"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -4606,37 +1326,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="40"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="40"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="40"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="40"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="40"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="40"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="40"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -4686,41 +1376,6 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="41"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="41"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="41"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="41"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="41"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="41"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="41"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="41"/>
 		<freespeed type="absolute" value="1.5367474739713396"/>
@@ -4741,26 +1396,6 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="41"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="41"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="41"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="41"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="16:00:00">
 		<link refId="41"/>
 		<freespeed type="absolute" value="4.7233755130766655"/>
@@ -4772,11 +1407,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="18:00:00">
-		<link refId="41"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="41"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -4806,52 +1436,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="42"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="42"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="42"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="42"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="42"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="42"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="42"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
-		<link refId="42"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="42"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
 		<link refId="42"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -4861,102 +1446,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="42"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="42"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="42"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="42"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="16:00:00">
 		<link refId="42"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="42"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="42"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="42"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="42"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="42"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="42"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="42"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="43"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="43"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="43"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="43"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="43"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="43"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="43"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="43"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -4981,102 +1476,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="43"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="43"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="43"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="43"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="43"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="43"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="43"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="43"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
 		<link refId="43"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="43"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="43"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="43"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="44"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="44"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="44"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="44"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="44"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="44"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="44"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="44"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -5086,57 +1491,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="44"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="44"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="44"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="44"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="44"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="44"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="44"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="44"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="44"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="44"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="44"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -5156,47 +1511,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="44"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="45"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="45"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="45"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="45"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="45"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="45"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="45"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="45"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -5211,56 +1526,6 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="45"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="45"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="45"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="45"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="45"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="45"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="45"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="45"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="45"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="45"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
 		<link refId="45"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
@@ -5276,47 +1541,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="45"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="47"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="47"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="47"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="47"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="47"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="47"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="47"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="47"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -5326,57 +1551,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="47"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="47"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="47"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="12:00:00">
-		<link refId="47"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="47"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="47"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="47"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="47"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="47"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="47"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="47"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -5386,57 +1561,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="47"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="47"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="47"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="48"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="48"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="48"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="48"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="48"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="48"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="48"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="48"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -5456,47 +1581,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="48"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="12:00:00">
-		<link refId="48"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="48"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="48"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="48"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="48"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="48"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="48"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="48"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -5506,57 +1591,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="48"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="48"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="48"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="49"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="49"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="49"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="49"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="49"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="49"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="49"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="49"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -5566,37 +1601,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="49"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="49"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="49"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="49"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="49"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="49"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="49"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -5606,77 +1611,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="49"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="49"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="49"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="49"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="49"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="49"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="49"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="50"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="50"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="50"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="50"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="50"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="50"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="50"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="50"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -5701,42 +1636,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="50"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="50"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="50"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="50"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="16:00:00">
 		<link refId="50"/>
 		<freespeed type="absolute" value="6.696443518847141"/>
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="17:00:00">
-		<link refId="50"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="50"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="50"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -5766,77 +1671,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="51"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="51"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="51"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="51"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="51"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="51"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="51"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="51"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="51"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="51"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="51"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="51"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="51"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="51"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="51"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -5886,41 +1726,6 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="52"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="52"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="52"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="52"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="52"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="52"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="52"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="52"/>
 		<freespeed type="absolute" value="1.2125459706491122"/>
@@ -5937,26 +1742,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="52"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="52"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="52"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="52"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="52"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -5986,57 +1771,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="52"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="52"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="52"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="53"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="53"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="53"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="53"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="53"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="53"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="53"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="53"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -6046,37 +1781,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="53"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="53"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="53"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="53"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="53"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="53"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="53"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -6086,37 +1791,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="53"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="53"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="19:00:00">
-		<link refId="53"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="53"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="53"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="53"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
 		<link refId="53"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -6126,52 +1801,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="54"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="54"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="54"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="54"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="54"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="54"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="54"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
-		<link refId="54"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="54"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
 		<link refId="54"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -6181,62 +1811,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="54"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="54"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="54"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="54"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="16:00:00">
 		<link refId="54"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="54"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="54"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="19:00:00">
-		<link refId="54"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="54"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="54"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="54"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
 		<link refId="54"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -6246,52 +1826,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="55"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="55"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="55"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="55"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="55"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="55"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="55"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
-		<link refId="55"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="55"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
 		<link refId="55"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -6301,57 +1836,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="55"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="55"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="55"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="55"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="55"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="55"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="55"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="55"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
-		<link refId="55"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="55"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
 		<link refId="55"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -6366,97 +1851,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="56"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="56"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="56"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="56"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="56"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="56"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="56"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="56"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="56"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="56"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="56"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="56"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="56"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="56"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="56"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="56"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="56"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="56"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="56"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -6466,57 +1866,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="56"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="56"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="56"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="57"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="57"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="57"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="57"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="57"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="57"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="57"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="57"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -6526,57 +1876,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="57"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="57"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="57"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="57"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="57"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="57"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="57"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="57"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="57"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="57"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="57"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -6586,57 +1886,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="57"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="57"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="57"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="58"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="58"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="58"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="58"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="58"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="58"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="58"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="58"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -6646,52 +1896,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="58"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="58"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
 		<link refId="58"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="58"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="58"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="58"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="58"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="16:00:00">
-		<link refId="58"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="58"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
 		<link refId="58"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -6706,57 +1916,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="58"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="58"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="58"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="59"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="59"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="59"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="59"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="59"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="59"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="59"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="59"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -6766,52 +1926,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="59"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="59"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
 		<link refId="59"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="59"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="59"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="59"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="59"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="16:00:00">
-		<link refId="59"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="59"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
 		<link refId="59"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -6846,77 +1966,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="60"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="60"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="60"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="60"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="60"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="60"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="60"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="60"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="60"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="60"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="60"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="60"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="60"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="60"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="60"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -6946,16 +2001,6 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="60"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="60"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="23:00:00">
 		<link refId="60"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
@@ -6966,52 +2011,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="61"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="61"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="61"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="61"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="61"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="61"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="61"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
-		<link refId="61"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="61"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
 		<link refId="61"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -7021,32 +2021,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="61"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="61"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="61"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="61"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="16:00:00">
-		<link refId="61"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
 		<link refId="61"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -7056,67 +2031,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="61"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="61"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="61"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="61"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="61"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="62"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="62"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="62"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="62"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="62"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="62"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="62"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="62"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -7126,37 +2041,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="62"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="62"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="62"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="62"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="62"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="62"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="62"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -7166,77 +2051,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="62"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
 		<link refId="62"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="62"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="62"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="62"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="62"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="62"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="63"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="63"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="63"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="63"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="63"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="63"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="63"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="63"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -7246,37 +2066,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="63"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="63"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="63"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="63"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="63"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="63"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="63"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -7286,77 +2076,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="63"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
 		<link refId="63"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="63"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="63"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="63"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="63"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="63"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="64"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="64"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="64"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="64"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="64"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="64"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="64"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="64"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -7377,46 +2102,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="64"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="64"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="64"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="64"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="64"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="64"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="64"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="64"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="64"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -7446,97 +2131,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="65"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="65"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="65"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="65"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="65"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="65"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="65"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="65"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="65"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="65"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="65"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="65"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="65"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="65"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="65"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="65"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="65"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="65"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="65"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -7546,57 +2146,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="65"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="65"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="65"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="66"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="66"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="66"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="66"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="66"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="66"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="66"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="66"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -7606,57 +2156,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="66"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="66"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="66"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="66"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="66"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="66"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="66"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="66"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="66"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="66"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="66"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -7666,57 +2166,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="66"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="66"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="66"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="67"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="67"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="67"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="67"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="67"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="67"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="67"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="67"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -7726,37 +2176,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="67"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="67"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="67"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="67"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="67"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="67"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="67"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -7766,17 +2186,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="67"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
-		<link refId="67"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="67"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -7786,57 +2196,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="67"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="67"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="67"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="68"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="68"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="68"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="68"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="68"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="68"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="68"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="68"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -7846,37 +2206,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="68"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="68"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="68"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="68"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="68"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="68"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="68"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -7886,17 +2216,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="68"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
-		<link refId="68"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="68"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -7926,77 +2246,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="69"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="69"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="69"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="69"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="69"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="69"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="69"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="69"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="69"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="69"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="69"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="69"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="69"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="69"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="69"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -8016,67 +2271,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="69"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="69"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="69"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="69"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="69"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="70"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="70"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="70"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="70"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="70"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="70"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="70"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="70"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -8086,37 +2281,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="70"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="70"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="70"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="70"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="70"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="70"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="70"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -8126,77 +2291,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="70"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
 		<link refId="70"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="70"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="70"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="70"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="70"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="70"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="71"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="71"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="71"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="71"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="71"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="71"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="71"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="71"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -8206,37 +2306,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="71"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="71"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="71"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="71"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="71"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="71"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="71"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -8246,77 +2316,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="71"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
 		<link refId="71"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="71"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="71"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="71"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="71"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="71"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="72"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="72"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="72"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="72"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="72"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="72"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="72"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="72"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -8326,37 +2331,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="72"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="72"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="72"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="72"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="72"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="72"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="72"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -8366,77 +2341,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="72"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
 		<link refId="72"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="72"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="72"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="72"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="72"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="72"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="73"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="73"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="73"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="73"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="73"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="73"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="73"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="73"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -8461,42 +2371,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="73"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
 		<link refId="73"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="14:00:00">
-		<link refId="73"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="73"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="73"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="73"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="73"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="73"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -8526,62 +2406,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="74"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="74"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="74"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="74"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="74"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="74"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="74"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="74"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="74"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="74"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="74"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
 		<link refId="74"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -8592,31 +2422,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="14:00:00">
-		<link refId="74"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="74"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="74"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="74"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="74"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="74"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -8626,57 +2431,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="74"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="74"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="74"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="75"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="75"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="75"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="75"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="75"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="75"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="75"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="75"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -8686,57 +2441,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="75"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="75"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="75"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="75"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="75"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="75"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="75"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="75"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="75"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="75"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="75"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -8746,57 +2451,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="75"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="75"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="75"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="76"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="76"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="76"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="76"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="76"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="76"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="76"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="76"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -8806,42 +2461,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="76"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="76"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="76"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="76"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="76"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="76"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="76"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
 		<link refId="76"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -8852,11 +2472,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="18:00:00">
-		<link refId="76"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="76"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -8866,57 +2481,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="76"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="76"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="76"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="77"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="77"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="77"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="77"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="77"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="77"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="77"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="77"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -8926,37 +2491,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="77"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="77"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="77"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="77"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="77"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="77"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="77"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -8966,17 +2501,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="77"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
-		<link refId="77"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="77"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -9006,77 +2531,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="78"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="78"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="78"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="78"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="78"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="78"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="78"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="78"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="78"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="78"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="78"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="78"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="78"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="78"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="78"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -9096,67 +2556,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="78"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="78"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="78"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="78"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="23:00:00">
 		<link refId="78"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="79"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="79"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="79"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="79"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="79"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="79"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="79"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="79"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -9166,37 +2571,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="79"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="10:00:00">
-		<link refId="79"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="79"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="79"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="79"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="79"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="79"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -9206,77 +2581,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="79"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
 		<link refId="79"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="79"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="79"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="79"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="79"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="79"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="80"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="80"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="80"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="80"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="80"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="80"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="80"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="80"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -9296,37 +2606,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="80"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="80"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="80"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="80"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="80"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="16:00:00">
-		<link refId="80"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
 		<link refId="80"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -9336,67 +2616,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="80"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="80"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="80"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="80"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="80"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="81"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="81"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="81"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="81"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="81"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="81"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="81"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="81"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -9406,37 +2626,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="81"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="10:00:00">
-		<link refId="81"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="81"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="81"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="81"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="81"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="81"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -9446,77 +2636,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="81"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
 		<link refId="81"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="81"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="81"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="81"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="81"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="81"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="82"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="82"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="82"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="82"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="82"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="82"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="82"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="82"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -9551,11 +2676,6 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="82"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="15:00:00">
 		<link refId="82"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
@@ -9567,16 +2687,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="17:00:00">
-		<link refId="82"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="82"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="82"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -9606,41 +2716,6 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="83"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="83"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="83"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="83"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="83"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="83"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="83"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="83"/>
 		<freespeed type="absolute" value="1.3888888888888888"/>
@@ -9651,52 +2726,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="83"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="83"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="83"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="83"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="83"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="15:00:00">
-		<link refId="83"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="83"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="83"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="83"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="83"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -9706,57 +2736,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="83"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="83"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="83"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="84"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="84"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="84"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="84"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="84"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="84"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="84"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="84"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -9811,72 +2791,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="84"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="84"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
 		<link refId="84"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="84"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="84"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="84"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="85"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="85"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="85"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="85"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="85"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="85"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="85"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="85"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -9891,52 +2811,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="85"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="85"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="85"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="85"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="85"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="15:00:00">
-		<link refId="85"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="85"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="85"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="85"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="85"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -9946,57 +2821,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="85"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="85"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="85"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="86"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="86"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="86"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="86"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="86"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="86"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="86"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="86"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -10036,11 +2861,6 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="86"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="16:00:00">
 		<link refId="86"/>
 		<freespeed type="absolute" value="0.6250003906252442"/>
@@ -10052,11 +2872,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="18:00:00">
-		<link refId="86"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="86"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -10086,41 +2901,6 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="87"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="87"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="87"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="87"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="87"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="87"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="87"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="87"/>
 		<freespeed type="absolute" value="0.46296296296296297"/>
@@ -10141,22 +2921,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="87"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
-		<link refId="87"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="87"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="87"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -10176,67 +2941,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="87"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="87"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="21:00:00">
 		<link refId="87"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="87"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="87"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="88"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="88"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="88"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="88"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="88"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="88"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="88"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="88"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -10271,32 +2981,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="88"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="88"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="16:00:00">
-		<link refId="88"/>
-		<freespeed type="absolute" value="0.30864197530864196"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="88"/>
-		<freespeed type="absolute" value="0.30864197530864196"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="88"/>
-		<freespeed type="absolute" value="0.30864197530864196"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="88"/>
 		<freespeed type="absolute" value="0.30864197530864196"/>
 	</networkChangeEvent>
@@ -10326,52 +3011,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="89"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="89"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="89"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="89"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="89"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="89"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="89"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
-		<link refId="89"/>
-		<freespeed type="absolute" value="0.46296296296296297"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="89"/>
-		<freespeed type="absolute" value="0.46296296296296297"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
 		<link refId="89"/>
 		<freespeed type="absolute" value="0.46296296296296297"/>
 	</networkChangeEvent>
@@ -10381,37 +3021,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="89"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="89"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="89"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="89"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="16:00:00">
-		<link refId="89"/>
-		<freespeed type="absolute" value="0.30864197530864196"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="89"/>
-		<freespeed type="absolute" value="0.30864197530864196"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
 		<link refId="89"/>
 		<freespeed type="absolute" value="0.30864197530864196"/>
 	</networkChangeEvent>
@@ -10421,72 +3031,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="89"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="89"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="89"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="89"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
 		<link refId="90"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="90"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="90"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="90"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="90"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="90"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="90"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="90"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
-		<link refId="90"/>
-		<freespeed type="absolute" value="0.30864197530864196"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="09:00:00">
 		<link refId="90"/>
 		<freespeed type="absolute" value="0.30864197530864196"/>
 	</networkChangeEvent>
@@ -10501,22 +3051,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="90"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="90"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="14:00:00">
-		<link refId="90"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="90"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -10526,17 +3061,7 @@
 		<freespeed type="absolute" value="0.30864197530864196"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="90"/>
-		<freespeed type="absolute" value="0.30864197530864196"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
-		<link refId="90"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="90"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -10546,62 +3071,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="90"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="90"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="90"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="92"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="92"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="92"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="92"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="92"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="92"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="92"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="92"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="08:00:00">
 		<link refId="92"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -10611,52 +3081,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="92"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="92"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="92"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="92"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="92"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="15:00:00">
-		<link refId="92"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="92"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="92"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="92"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="92"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -10666,57 +3091,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="92"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="92"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="92"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="93"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="93"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="93"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="93"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="93"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="93"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="93"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="93"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -10741,21 +3116,6 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="93"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="93"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="93"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="15:00:00">
 		<link refId="93"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
@@ -10767,16 +3127,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="17:00:00">
-		<link refId="93"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="93"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="93"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -10806,72 +3156,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="94"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="94"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="94"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="94"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="94"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="94"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="94"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="08:00:00">
-		<link refId="94"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="09:00:00">
-		<link refId="94"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="94"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="94"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="94"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="94"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
 		<link refId="94"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -10881,82 +3166,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="94"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="94"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="94"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="94"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
 		<link refId="94"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="94"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="94"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="94"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="95"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="95"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="95"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="95"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="95"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="95"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="95"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="95"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -11011,16 +3226,6 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="95"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="95"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
 		<link refId="95"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
@@ -11046,72 +3251,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="96"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="96"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="96"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="96"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="96"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="96"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="96"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="08:00:00">
-		<link refId="96"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="96"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="10:00:00">
-		<link refId="96"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="96"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="96"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="96"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
 		<link refId="96"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -11121,82 +3261,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="96"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="96"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="96"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="96"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="96"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="21:00:00">
 		<link refId="96"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="96"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="96"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="97"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="97"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="97"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="97"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="97"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="97"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="97"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="97"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -11251,16 +3321,6 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="97"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="97"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
 		<link refId="97"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
@@ -11286,41 +3346,6 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="98"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="98"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="98"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="98"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="98"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="98"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="98"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="98"/>
 		<freespeed type="absolute" value="0.6944444444444444"/>
@@ -11331,67 +3356,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="98"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="98"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="98"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="98"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="98"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="15:00:00">
 		<link refId="98"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="98"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="98"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="98"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="98"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
-		<link refId="98"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="98"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
 		<link refId="98"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -11402,41 +3372,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="99"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="99"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="99"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="99"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="99"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="99"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="99"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="99"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -11471,11 +3406,6 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="99"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="15:00:00">
 		<link refId="99"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
@@ -11486,17 +3416,7 @@
 		<freespeed type="absolute" value="0.30864197530864196"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="99"/>
-		<freespeed type="absolute" value="0.30864197530864196"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
-		<link refId="99"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="99"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -11506,57 +3426,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="99"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="99"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="99"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="100"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="100"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="100"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="100"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="100"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="100"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="100"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="100"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -11566,57 +3436,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="100"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="100"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="100"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="100"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
-		<link refId="100"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="100"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="100"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="100"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="100"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="100"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="100"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -11626,57 +3446,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="100"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="100"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="100"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="101"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="101"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="101"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="101"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="101"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="101"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="101"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="101"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -11686,62 +3456,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="101"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="101"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="101"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="101"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
-		<link refId="101"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="101"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="101"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="101"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="101"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="101"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="101"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
 		<link refId="101"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -11751,52 +3466,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="101"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="101"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="102"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="102"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="102"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="102"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="102"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="102"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="102"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="102"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -11806,62 +3476,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="102"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="102"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="102"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="102"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
-		<link refId="102"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="102"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="102"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="102"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="102"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="102"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="102"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
 		<link refId="102"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -11871,52 +3486,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="102"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="102"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="103"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="103"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="103"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="103"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="103"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="103"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="103"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="103"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -11926,72 +3496,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="103"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="103"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="103"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="103"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
 		<link refId="103"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="103"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="103"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="103"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="103"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="103"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="103"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="103"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="21:00:00">
-		<link refId="103"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
 		<link refId="103"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -12002,41 +3512,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="104"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="104"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="104"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="104"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="104"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="104"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="104"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="104"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -12046,72 +3521,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="104"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="104"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="104"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="104"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
 		<link refId="104"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="104"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="104"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="104"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="104"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="104"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="104"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="104"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="21:00:00">
-		<link refId="104"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
 		<link refId="104"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -12122,41 +3537,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="105"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="105"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="105"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="105"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="105"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="105"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="105"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="105"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -12166,72 +3546,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="105"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="105"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="105"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="105"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
 		<link refId="105"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="105"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="105"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="105"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="105"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="105"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="105"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="105"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="21:00:00">
-		<link refId="105"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
 		<link refId="105"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -12242,41 +3562,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="106"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="106"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="106"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="106"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="106"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="106"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="106"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="106"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -12286,72 +3571,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="106"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="106"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="106"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="106"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
 		<link refId="106"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="106"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="106"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="106"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="106"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="106"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="106"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="106"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="21:00:00">
-		<link refId="106"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
 		<link refId="106"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -12362,41 +3587,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="107"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="107"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="107"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="107"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="107"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="107"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="107"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="107"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -12421,47 +3611,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="107"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="107"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="14:00:00">
-		<link refId="107"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="107"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="107"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="107"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="107"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="107"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
 		<link refId="107"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -12476,47 +3626,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="107"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="108"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="108"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="108"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="108"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="108"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="108"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="108"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="108"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -12526,37 +3636,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="108"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="108"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="108"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="108"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="108"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="14:00:00">
-		<link refId="108"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="108"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -12566,22 +3646,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="108"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
-		<link refId="108"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="108"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
 		<link refId="108"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -12596,47 +3661,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="108"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="109"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="109"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="109"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="109"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="109"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="109"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="109"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="109"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -12646,62 +3671,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="109"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="109"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="109"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="12:00:00">
 		<link refId="109"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="109"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="109"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="109"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="16:00:00">
-		<link refId="109"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="109"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="109"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="109"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
 		<link refId="109"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -12726,77 +3701,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="110"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="110"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="110"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="110"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="110"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="110"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="110"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="110"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="110"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="110"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="110"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="12:00:00">
-		<link refId="110"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="110"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="110"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="110"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -12816,67 +3726,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="110"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="110"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="110"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="110"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="110"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="111"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="111"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="111"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="111"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="111"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="111"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="111"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="111"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -12886,37 +3736,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="111"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="111"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="111"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="12:00:00">
-		<link refId="111"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="111"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="111"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="111"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -12966,77 +3786,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="112"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="112"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="112"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="112"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="112"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="112"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="112"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="112"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="112"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="112"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="112"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="12:00:00">
-		<link refId="112"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="112"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="112"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="112"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -13071,52 +3826,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="112"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="112"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="113"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="113"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="113"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="113"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="113"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="113"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="113"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="113"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -13126,37 +3836,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="113"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="113"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="113"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="12:00:00">
-		<link refId="113"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="113"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="113"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="113"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -13206,77 +3886,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="114"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="114"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="114"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="114"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="114"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="114"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="114"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="114"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="114"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="114"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="114"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="12:00:00">
-		<link refId="114"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="114"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="114"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="114"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -13311,52 +3926,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="114"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="114"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="115"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="115"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="115"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="115"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="115"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="115"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="115"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="115"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -13366,37 +3936,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="115"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="115"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="115"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="12:00:00">
-		<link refId="115"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="115"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="115"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="115"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -13446,47 +3986,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="116"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="116"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="116"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="116"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="116"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="116"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="116"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
-		<link refId="116"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="09:00:00">
 		<link refId="116"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -13502,21 +4002,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="12:00:00">
-		<link refId="116"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="116"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="116"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="116"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -13566,77 +4051,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="117"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="117"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="117"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="117"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="117"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="117"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="117"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="117"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="117"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="117"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="117"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="12:00:00">
-		<link refId="117"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="117"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="117"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="117"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -13646,77 +4066,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="117"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="117"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="117"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="117"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="117"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="117"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="117"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="118"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="118"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="118"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="118"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="118"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="118"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="118"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="118"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -13726,62 +4076,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="118"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="118"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="118"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="118"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="118"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="118"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="118"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="118"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="118"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="118"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="118"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
 		<link refId="118"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -13791,52 +4086,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="118"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="118"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="119"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="119"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="119"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="119"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="119"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="119"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="119"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="119"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -13846,37 +4096,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="119"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="119"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="119"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="119"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="119"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="119"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="119"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -13896,26 +4116,6 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="119"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="119"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="119"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="119"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="23:00:00">
 		<link refId="119"/>
 		<freespeed type="absolute" value="6.172839506172839"/>
@@ -13926,52 +4126,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="120"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="120"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="120"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="120"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="120"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="120"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="120"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
-		<link refId="120"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="120"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
 		<link refId="120"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -13981,37 +4136,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="120"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="120"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="120"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="120"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="16:00:00">
-		<link refId="120"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="120"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
 		<link refId="120"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -14026,57 +4151,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="120"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="120"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="120"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="121"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="121"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="121"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="121"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="121"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="121"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="121"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="121"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -14086,37 +4161,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="121"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="121"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="121"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="121"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="121"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="121"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="121"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -14166,77 +4211,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="122"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="122"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="122"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="122"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="122"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="122"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="122"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="122"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="122"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="122"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="122"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="122"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="122"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="122"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="122"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -14266,57 +4246,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="122"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="122"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="122"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="123"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="123"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="123"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="123"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="123"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="123"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="123"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="123"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -14326,37 +4256,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="123"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="123"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="123"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="123"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="123"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="123"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="123"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -14406,41 +4306,6 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="124"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="124"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="124"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="124"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="124"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="124"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="124"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="124"/>
 		<freespeed type="absolute" value="4.4444641976186565"/>
@@ -14451,32 +4316,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="124"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="124"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="124"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="124"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="124"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="124"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -14501,16 +4341,6 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="124"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="124"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="22:00:00">
 		<link refId="124"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
@@ -14526,41 +4356,6 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="125"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="125"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="125"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="125"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="125"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="125"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="125"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="125"/>
 		<freespeed type="absolute" value="6.696488361503228"/>
@@ -14571,32 +4366,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="125"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="125"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="125"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="125"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="125"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="125"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -14626,57 +4396,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="125"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="125"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="125"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="126"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="126"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="126"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="126"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="126"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="126"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="126"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="126"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -14686,37 +4406,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="126"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="10:00:00">
-		<link refId="126"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="126"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="126"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="126"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="126"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="126"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -14726,77 +4416,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="126"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="126"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="126"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="126"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="21:00:00">
 		<link refId="126"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="126"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="126"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="128"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="128"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="128"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="128"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="128"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="128"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="128"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="128"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -14816,47 +4441,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="128"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="12:00:00">
-		<link refId="128"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="128"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="128"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="128"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="128"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="128"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="128"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="128"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -14886,57 +4471,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="129"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="129"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="129"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="129"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="129"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="129"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="129"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
-		<link refId="129"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="129"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="129"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
 		<link refId="129"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -14946,97 +4481,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="129"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="129"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="129"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="129"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="129"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="129"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="129"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
 		<link refId="129"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="129"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="129"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="129"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="130"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="130"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="130"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="130"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="130"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="130"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="130"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="130"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -15057,46 +4507,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="130"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="130"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="130"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="130"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="130"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="130"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="130"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="130"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="130"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -15126,52 +4536,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="131"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="131"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="131"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="131"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="131"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="131"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="131"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
-		<link refId="131"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="131"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
 		<link refId="131"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -15181,102 +4546,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="131"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="131"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="131"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="131"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="131"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="131"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="131"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="131"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
 		<link refId="131"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="131"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="131"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="131"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="132"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="132"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="132"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="132"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="132"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="132"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="132"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="132"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -15301,102 +4576,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="132"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="132"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="132"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="132"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="132"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="132"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="132"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="132"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
 		<link refId="132"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="132"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="132"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="132"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="133"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="133"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="133"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="133"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="133"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="133"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="133"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="133"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -15406,57 +4591,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="133"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="133"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="133"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="133"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="133"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="133"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="133"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="133"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="133"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="133"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="133"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -15476,47 +4611,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="133"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="134"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="134"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="134"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="134"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="134"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="134"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="134"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="134"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -15531,52 +4626,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="134"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="134"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="134"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="134"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="134"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="134"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="134"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="134"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="134"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="134"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -15596,47 +4646,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="134"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="135"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="135"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="135"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="135"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="135"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="135"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="135"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="135"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -15651,112 +4661,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="135"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="135"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="135"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="135"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="135"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="135"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="135"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="135"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="135"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="135"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="135"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="135"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="135"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="135"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="137"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="137"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="137"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="137"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="137"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="137"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="137"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="137"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -15776,47 +4681,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="137"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="12:00:00">
-		<link refId="137"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="137"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="137"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="137"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="137"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="137"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="137"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="137"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -15826,57 +4691,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="137"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="137"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="137"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="138"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="138"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="138"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="138"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="138"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="138"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="138"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="138"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -15886,57 +4701,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="138"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="138"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="138"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="12:00:00">
-		<link refId="138"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="138"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="138"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="138"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="138"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="138"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="138"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="138"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -15946,57 +4711,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="138"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="138"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="138"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="139"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="139"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="139"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="139"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="139"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="139"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="139"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="139"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -16026,41 +4741,6 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="139"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="139"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="139"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="139"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="139"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="139"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="139"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
 		<link refId="139"/>
 		<freespeed type="absolute" value="2.808988764044944"/>
@@ -16086,57 +4766,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="140"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="140"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="140"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="140"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="140"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="140"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="140"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
-		<link refId="140"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="140"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="140"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
 		<link refId="140"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -16146,97 +4776,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="140"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="140"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="140"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="140"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="140"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="140"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="140"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
 		<link refId="140"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="140"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="140"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="140"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="141"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="141"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="141"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="141"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="141"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="141"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="141"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="141"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -16266,52 +4811,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="141"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="141"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="141"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="141"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="141"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="141"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="141"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
 		<link refId="141"/>
 		<freespeed type="absolute" value="1.4925395411037927"/>
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="21:00:00">
-		<link refId="141"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
 		<link refId="141"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -16326,57 +4831,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="142"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="142"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="142"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="142"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="142"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="142"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="142"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
-		<link refId="142"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="142"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="142"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
 		<link refId="142"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -16386,52 +4841,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="142"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="142"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="142"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="142"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="142"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="142"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="142"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
-		<link refId="142"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="142"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
 		<link refId="142"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -16442,41 +4852,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="143"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="143"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="143"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="143"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="143"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="143"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="143"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="143"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -16496,47 +4871,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="143"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="12:00:00">
-		<link refId="143"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="143"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="143"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="143"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="143"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="143"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="143"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="143"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -16556,47 +4891,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="143"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="144"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="144"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="144"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="144"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="144"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="144"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="144"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="144"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -16606,57 +4901,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="144"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="144"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="144"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="12:00:00">
-		<link refId="144"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="144"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="144"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="144"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="144"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="144"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="144"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="144"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -16666,57 +4911,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="144"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="144"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="144"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="145"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="145"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="145"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="145"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="145"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="145"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="145"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="145"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -16726,37 +4921,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="145"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="145"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="145"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="145"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="145"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="145"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="145"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -16766,77 +4931,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="145"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="145"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="145"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="145"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="21:00:00">
 		<link refId="145"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="145"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="145"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="146"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="146"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="146"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="146"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="146"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="146"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="146"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="146"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -16857,26 +4957,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="146"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="146"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="146"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="146"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="146"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -16916,47 +4996,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="146"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="147"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="147"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="147"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="147"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="147"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="147"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="147"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="147"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -16966,37 +5006,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="147"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="147"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="147"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="147"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="147"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="147"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="147"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -17011,21 +5021,6 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="147"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="147"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="147"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="21:00:00">
 		<link refId="147"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
@@ -17036,47 +5031,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="147"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="148"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="148"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="148"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="148"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="148"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="148"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="148"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="148"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -17086,37 +5041,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="148"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="148"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
-		<link refId="148"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="148"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="148"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="148"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="148"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -17166,77 +5091,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="149"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="149"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="149"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="149"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="149"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="149"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="149"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="149"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="149"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="149"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="149"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="12:00:00">
-		<link refId="149"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="149"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="149"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="149"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -17256,67 +5116,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="149"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="149"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="149"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="149"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="149"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="150"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="150"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="150"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="150"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="150"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="150"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="150"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="150"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -17326,37 +5126,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="150"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="150"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="150"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="12:00:00">
-		<link refId="150"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="150"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="150"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="150"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -17372,11 +5142,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="18:00:00">
-		<link refId="150"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="150"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -17406,77 +5171,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="151"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="151"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="151"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="151"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="151"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="151"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="151"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="151"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="151"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="151"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="151"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="12:00:00">
-		<link refId="151"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="151"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="151"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="151"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -17496,67 +5196,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="151"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="151"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="151"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="151"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="151"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="152"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="152"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="152"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="152"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="152"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="152"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="152"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="152"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -17566,37 +5206,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="152"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="152"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="152"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="12:00:00">
-		<link refId="152"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="152"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="152"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="152"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -17616,67 +5226,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="152"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="152"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="152"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="152"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="152"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="153"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="153"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="153"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="153"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="153"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="153"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="153"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="153"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -17686,62 +5236,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="153"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="153"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="153"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="12:00:00">
-		<link refId="153"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="153"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="153"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="153"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="153"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="153"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="153"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="153"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
 		<link refId="153"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -17751,52 +5246,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="153"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="153"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="154"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="154"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="154"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="154"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="154"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="154"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="154"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="154"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -17806,37 +5256,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="154"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="154"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="154"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="154"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
-		<link refId="154"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="154"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="154"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -17846,77 +5266,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="154"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="154"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="154"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="154"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="154"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="154"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="154"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="155"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="155"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="155"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="155"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="155"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="155"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="155"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="155"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -17941,22 +5291,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="155"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
-		<link refId="155"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="155"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="155"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -17986,57 +5321,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="155"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="155"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="155"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="156"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="156"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="156"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="156"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="156"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="156"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="156"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="156"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -18046,37 +5331,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="156"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="156"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="156"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="156"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
-		<link refId="156"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="156"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="156"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -18126,77 +5381,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="157"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="157"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="157"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="157"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="157"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="157"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="157"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="157"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="157"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="157"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="157"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="157"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
-		<link refId="157"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="157"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="157"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -18221,62 +5411,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="157"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="157"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="157"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="157"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="158"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="158"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="158"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="158"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="158"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="158"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="158"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="158"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -18286,37 +5421,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="158"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="158"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="158"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="158"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
-		<link refId="158"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="158"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="158"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -18366,77 +5471,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="159"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="159"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="159"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="159"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="159"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="159"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="159"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="159"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="159"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="159"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="159"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="159"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
-		<link refId="159"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="159"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="159"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -18461,62 +5501,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="159"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="159"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="159"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="159"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="160"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="160"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="160"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="160"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="160"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="160"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="160"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="160"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -18526,37 +5511,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="160"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="160"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="160"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="160"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
-		<link refId="160"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="160"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="160"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -18606,77 +5561,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="161"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="161"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="161"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="161"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="161"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="161"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="161"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="161"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="161"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="161"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="161"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="161"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
-		<link refId="161"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="161"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="161"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -18686,77 +5576,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="161"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="161"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="161"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="161"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="161"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="161"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="161"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="162"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="162"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="162"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="162"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="162"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="162"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="162"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="162"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -18766,37 +5586,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="162"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="162"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="162"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="162"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
-		<link refId="162"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="162"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="162"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -18821,21 +5611,6 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="162"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="162"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="162"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="23:00:00">
 		<link refId="162"/>
 		<freespeed type="absolute" value="3.7675000376750005"/>
@@ -18846,62 +5621,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="163"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="163"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="163"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="163"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="163"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="163"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="163"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
-		<link refId="163"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="163"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="163"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="163"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
 		<link refId="163"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -18911,22 +5631,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="163"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="163"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="16:00:00">
-		<link refId="163"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
 		<link refId="163"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -18936,17 +5641,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="163"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
-		<link refId="163"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
 		<link refId="163"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -18956,47 +5651,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="163"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="165"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="165"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="165"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="165"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="165"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="165"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="165"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="165"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -19006,62 +5661,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="165"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="165"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="165"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="165"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
-		<link refId="165"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="165"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="165"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="165"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="165"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="165"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="165"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
 		<link refId="165"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -19076,47 +5676,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="165"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="166"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="166"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="166"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="166"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="166"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="166"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="166"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="166"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -19126,62 +5686,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="166"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="166"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="166"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="166"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
-		<link refId="166"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="166"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="166"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="166"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="166"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="166"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="166"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
 		<link refId="166"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -19196,47 +5701,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="166"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="167"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="167"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="167"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="167"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="167"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="167"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="167"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="167"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -19246,62 +5711,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="167"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="167"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="167"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="167"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
-		<link refId="167"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="167"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="167"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="167"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="167"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="167"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="167"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
 		<link refId="167"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -19311,52 +5721,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="167"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="167"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="168"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="168"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="168"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="168"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="168"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="168"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="168"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="168"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -19366,62 +5731,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="168"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="168"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="168"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="168"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
-		<link refId="168"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="168"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="168"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="168"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="168"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="168"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="168"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
 		<link refId="168"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -19431,52 +5741,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="168"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="168"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="169"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="169"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="169"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="169"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="169"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="169"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="169"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="169"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -19486,62 +5751,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="169"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="169"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="169"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="169"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="13:00:00">
-		<link refId="169"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="169"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="169"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="169"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="169"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="169"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="169"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
 		<link refId="169"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -19566,62 +5776,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="170"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="170"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="170"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="170"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="170"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="170"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="170"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
-		<link refId="170"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="170"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="170"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="170"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
 		<link refId="170"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -19631,52 +5786,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="170"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="170"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="170"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="170"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="170"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="170"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="170"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="21:00:00">
-		<link refId="170"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="170"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
 		<link refId="170"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -19686,62 +5796,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="171"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="171"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="171"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="171"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="171"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="171"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="171"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
-		<link refId="171"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="171"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="171"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="171"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
 		<link refId="171"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -19751,52 +5806,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="171"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
-		<link refId="171"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="171"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="171"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="171"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="171"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
-		<link refId="171"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="171"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="171"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
 		<link refId="171"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -19806,47 +5816,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="172"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="172"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="172"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="172"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="172"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="172"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="172"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
-		<link refId="172"/>
-		<freespeed type="absolute" value="0.30864197530864196"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="09:00:00">
 		<link refId="172"/>
 		<freespeed type="absolute" value="0.30864197530864196"/>
 	</networkChangeEvent>
@@ -19871,11 +5841,6 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="172"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="15:00:00">
 		<link refId="172"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
@@ -19886,17 +5851,7 @@
 		<freespeed type="absolute" value="0.30864197530864196"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="172"/>
-		<freespeed type="absolute" value="0.30864197530864196"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="18:00:00">
-		<link refId="172"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="172"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -19906,57 +5861,7 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="172"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="172"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="172"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="173"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="173"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="173"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="173"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="173"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="173"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="173"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="173"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -19966,72 +5871,12 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="09:00:00">
-		<link refId="173"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="173"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="173"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="173"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="173"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="173"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="15:00:00">
 		<link refId="173"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="173"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="173"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="173"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="173"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
-		<link refId="173"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="173"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
 		<link refId="173"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -20042,41 +5887,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="174"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="174"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="174"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="174"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="174"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="174"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="174"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="174"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -20131,16 +5941,6 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="174"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="174"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
 		<link refId="174"/>
 		<freespeed type="absolute" value="3.7313432835820897"/>
@@ -20166,72 +5966,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="175"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="175"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="175"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="175"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="175"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="175"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="175"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="08:00:00">
-		<link refId="175"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="09:00:00">
-		<link refId="175"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="175"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="175"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="175"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="175"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
 		<link refId="175"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -20241,82 +5976,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="175"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="175"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="175"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="175"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
 		<link refId="175"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="175"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="175"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="175"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="176"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="176"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="176"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="176"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="176"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="176"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="176"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="176"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -20371,16 +6036,6 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="176"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="176"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
 		<link refId="176"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
@@ -20406,72 +6061,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="177"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="177"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="177"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="177"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="177"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="177"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="177"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="08:00:00">
-		<link refId="177"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="09:00:00">
-		<link refId="177"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="177"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="177"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="177"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="177"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
 		<link refId="177"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -20481,82 +6071,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="177"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="177"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="177"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="177"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="20:00:00">
-		<link refId="177"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="21:00:00">
 		<link refId="177"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="177"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
-		<link refId="177"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="00:00:00">
-		<link refId="178"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="178"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="178"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="178"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="178"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="178"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="178"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
 		<link refId="178"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -20581,21 +6101,6 @@
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="178"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="178"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
-		<link refId="178"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="15:00:00">
 		<link refId="178"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
@@ -20607,16 +6112,6 @@
 	</networkChangeEvent>
 
 	<networkChangeEvent startTime="17:00:00">
-		<link refId="178"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="178"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
 		<link refId="178"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -20646,72 +6141,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="179"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="179"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="179"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="179"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="179"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="179"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="179"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="08:00:00">
-		<link refId="179"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="09:00:00">
-		<link refId="179"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="179"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="11:00:00">
-		<link refId="179"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="179"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="179"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="14:00:00">
 		<link refId="179"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -20721,42 +6151,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="16:00:00">
-		<link refId="179"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="17:00:00">
-		<link refId="179"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="179"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="179"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
-		<link refId="179"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="179"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="179"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
 		<link refId="179"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
@@ -20766,41 +6161,6 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="01:00:00">
-		<link refId="180"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="02:00:00">
-		<link refId="180"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="03:00:00">
-		<link refId="180"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="04:00:00">
-		<link refId="180"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="05:00:00">
-		<link refId="180"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="06:00:00">
-		<link refId="180"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="07:00:00">
-		<link refId="180"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="08:00:00">
 		<link refId="180"/>
 		<freespeed type="absolute" value="0.30864197530864196"/>
@@ -20811,32 +6171,12 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="10:00:00">
-		<link refId="180"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="11:00:00">
 		<link refId="180"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="12:00:00">
-		<link refId="180"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="13:00:00">
-		<link refId="180"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="14:00:00">
-		<link refId="180"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="15:00:00">
 		<link refId="180"/>
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
@@ -20851,32 +6191,7 @@
 		<freespeed type="absolute" value="7.500018750046875"/>
 	</networkChangeEvent>
 
-	<networkChangeEvent startTime="18:00:00">
-		<link refId="180"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="19:00:00">
-		<link refId="180"/>
-		<freespeed type="absolute" value="7.500018750046875"/>
-	</networkChangeEvent>
-
 	<networkChangeEvent startTime="20:00:00">
-		<link refId="180"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="21:00:00">
-		<link refId="180"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="22:00:00">
-		<link refId="180"/>
-		<freespeed type="absolute" value="7.462686567164179"/>
-	</networkChangeEvent>
-
-	<networkChangeEvent startTime="23:00:00">
 		<link refId="180"/>
 		<freespeed type="absolute" value="7.462686567164179"/>
 	</networkChangeEvent>


### PR DESCRIPTION
This PR improves the scenario cutout and adds functionality to remove invalid link ids from a population.

- New `PersonNetworkLinkCheck` class
   - When links are removed from a network, all occurrences of it must be removed from the population or the simulation will most likely crash.
   - Some previously existing classes only check network routes, but this implementation checks all routes and activities as well.
-  The `CreateScenarioCutOut` writes a lot less network change events, by only writing events when an actual change in speed has occurred.
 