### PR TITLE
Freight (logistics): Load LSPs from setting in config. Make things more consistent with MATSim standard

### DIFF
--- a/contribs/application/src/main/java/org/matsim/freightDemandGeneration/CarrierReaderFromCSV.java
+++ b/contribs/application/src/main/java/org/matsim/freightDemandGeneration/CarrierReaderFromCSV.java
@@ -417,7 +417,7 @@ public final class CarrierReaderFromCSV {
 
 		Carriers carriers = CarriersUtils.addOrGetCarriers(scenario);
 		CarrierVehicleTypes carrierVehicleTypes = new CarrierVehicleTypes();
-		CarrierVehicleTypes usedCarrierVehicleTypes = CarriersUtils.getCarrierVehicleTypes(scenario);
+		CarrierVehicleTypes usedCarrierVehicleTypes = CarriersUtils.getOrAddCarrierVehicleTypes(scenario);
 		new CarrierVehicleTypeReader(carrierVehicleTypes).readFile(freightCarriersConfigGroup.getCarriersVehicleTypesFile());
 
 		for (CarrierInformationElement singleNewCarrier : allNewCarrierInformation) {

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierImpl.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierImpl.java
@@ -89,7 +89,7 @@ public final class CarrierImpl implements Carrier {
 	public boolean addPlan(CarrierPlan carrierPlan) {
 		// Make sure there is a selected carrierPlan if there is at least one carrierPlan
 		if (this.selectedPlan == null) this.selectedPlan = carrierPlan;
-		carrierPlan.setCarrier(this); //TODO Das hier eintragen
+//		carrierPlan.setCarrier(this); //TODO Add this here as backpointer. (Comment from Kai/Kai Mtg)
 		return this.plans.add(carrierPlan);
 	}
 

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierImpl.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierImpl.java
@@ -89,6 +89,7 @@ public final class CarrierImpl implements Carrier {
 	public boolean addPlan(CarrierPlan carrierPlan) {
 		// Make sure there is a selected carrierPlan if there is at least one carrierPlan
 		if (this.selectedPlan == null) this.selectedPlan = carrierPlan;
+		carrierPlan.setCarrier(this); //TODO Das hier eintragen
 		return this.plans.add(carrierPlan);
 	}
 

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/Carriers.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/Carriers.java
@@ -41,28 +41,29 @@ public class Carriers {
 
 	private final Map<Id<Carrier>, Carrier> carriers = new LinkedHashMap<>();
 
+	public Carriers() {}
+
 	public Carriers(Collection<Carrier> carriers) {
-		makeMap(carriers);
+		addCarriers(carriers);
 	}
 
-	public Carriers() {
-	}
-
-	private void makeMap(Collection<Carrier> carriers) {
+	private void addCarriers(Collection<Carrier> carriers) {
 		for (Carrier carrier : carriers) {
 			this.carriers.put(carrier.getId(), carrier);
 		}
-	}
-
-	public Map<Id<Carrier>, Carrier> getCarriers() {
-		return carriers;
 	}
 
 	public void addCarrier(Carrier carrier) {
 		if(!carriers.containsKey(carrier.getId())){
 			carriers.put(carrier.getId(), carrier);
 		}
-		else log.warn("carrier {} already exists", carrier.getId());
+		else log.warn("carrier {} already exists. It has NOT been added.", carrier.getId());
 	}
+
+	public Map<Id<Carrier>, Carrier> getCarriers() {
+		return carriers;
+	}
+
+
 
 }

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
@@ -377,9 +377,6 @@ public class CarriersUtils {
 	}
 
 	public static Carriers addOrGetCarriers(Scenario scenario) {
-		// I have separated getOrCreateCarriers and getCarriers, since when the
-		// controller is started, it is better to fail if the carriers are not found.
-		// kai, oct'19
 		Carriers carriers = (Carriers) scenario.getScenarioElement(CARRIERS);
 		if (carriers == null) {
 			carriers = new Carriers();
@@ -407,6 +404,8 @@ public class CarriersUtils {
 		return types;
 	}
 
+
+
 	/**
 	 * Use if carriers and carrierVehicleTypes are set by input file
 	 *
@@ -415,13 +414,23 @@ public class CarriersUtils {
 	public static void loadCarriersAccordingToFreightConfig(Scenario scenario) {
 		FreightCarriersConfigGroup freightCarriersConfigGroup = ConfigUtils.addOrGetModule(scenario.getConfig(), FreightCarriersConfigGroup.class);
 
-		CarrierVehicleTypes vehTypes = getCarrierVehicleTypes(scenario);
-		new CarrierVehicleTypeReader(vehTypes).readURL(
-			IOUtils.extendUrl(scenario.getConfig().getContext(), freightCarriersConfigGroup.getCarriersVehicleTypesFile()));
+		//Load VehicleTypes
 
-		Carriers carriers = addOrGetCarriers(scenario); // also registers with scenario
-		new CarrierPlanXmlReader(carriers, vehTypes).readURL(
-			IOUtils.extendUrl(scenario.getConfig().getContext(), freightCarriersConfigGroup.getCarriersFile()));
+		String carriersVehicleTypesFile = freightCarriersConfigGroup.getCarriersVehicleTypesFile();
+		if (carriersVehicleTypesFile == null ||carriersVehicleTypesFile.isEmpty()) {
+			throw new IllegalArgumentException("CarriersVehicleTypes file path should not be null or empty");
+		}
+		new CarrierVehicleTypeReader(getCarrierVehicleTypes(scenario)).readURL(
+			IOUtils.extendUrl(scenario.getConfig().getContext(), carriersVehicleTypesFile));
+
+		//Load Carriers
+		String carriersFile = freightCarriersConfigGroup.getCarriersFile();
+		if (carriersFile == null ||carriersFile.isEmpty()) {
+			throw new IllegalArgumentException("Carriers file path should not be null or empty");
+		}
+		// also registers with scenario
+		new CarrierPlanXmlReader(addOrGetCarriers(scenario), getCarrierVehicleTypes(scenario)).readURL(
+			IOUtils.extendUrl(scenario.getConfig().getContext(), carriersFile));
 	}
 
 	/**

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/analysis/FreightTimeAndDistanceAnalysisEventsHandler.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/analysis/FreightTimeAndDistanceAnalysisEventsHandler.java
@@ -314,7 +314,7 @@ public class FreightTimeAndDistanceAnalysisEventsHandler implements CarrierTourS
 		log.info("Writing out Time & Distance & Costs ... perVehicleType");
 
 		//----- All VehicleTypes in CarrierVehicleTypes container. Used so that even unused vehTypes appear in the output
-		TreeMap<Id<VehicleType>, VehicleType> vehicleTypesMap = new TreeMap<>(CarriersUtils.getCarrierVehicleTypes(scenario).getVehicleTypes());
+		TreeMap<Id<VehicleType>, VehicleType> vehicleTypesMap = new TreeMap<>(CarriersUtils.getOrAddCarrierVehicleTypes(scenario).getVehicleTypes());
 		//For the case that there are additional vehicle types found in the events.
 		for (VehicleType vehicleType : vehicleId2VehicleType.values()) {
 			vehicleTypesMap.putIfAbsent(vehicleType.getId(), vehicleType);

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/MatsimJspritFactory.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/MatsimJspritFactory.java
@@ -745,7 +745,7 @@ public final class MatsimJspritFactory {
 					ConstraintManager constraintManager = new ConstraintManager(problem, stateManager);
 					constraintManager.addConstraint(
 							new DistanceConstraint(
-									CarriersUtils.getCarrierVehicleTypes(scenario), netBasedCosts),
+									CarriersUtils.getOrAddCarrierVehicleTypes(scenario), netBasedCosts),
 							ConstraintManager.Priority.CRITICAL);
 					AlgorithmConfig algorithmConfig = new AlgorithmConfig();
 					AlgorithmConfigXmlReader xmlReader = new AlgorithmConfigXmlReader(algorithmConfig);
@@ -769,7 +769,7 @@ public final class MatsimJspritFactory {
 					ConstraintManager constraintManager = new ConstraintManager(problem, stateManager);
 					constraintManager.addConstraint(
 							new DistanceConstraint(
-									CarriersUtils.getCarrierVehicleTypes(scenario), netBasedCosts),
+									CarriersUtils.getOrAddCarrierVehicleTypes(scenario), netBasedCosts),
 							ConstraintManager.Priority.CRITICAL);
 					algorithm = Jsprit.Builder.newInstance(problem)
 							.setStateAndConstraintManager(stateManager, constraintManager).buildAlgorithm();

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/usecases/chessboard/RunChessboard.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/usecases/chessboard/RunChessboard.java
@@ -69,7 +69,7 @@ public final class RunChessboard {
 		CarriersUtils.loadCarriersAccordingToFreightConfig( scenario );
 
 		Carriers carriers = CarriersUtils.addOrGetCarriers( scenario );
-		CarrierVehicleTypes types = CarriersUtils.getCarrierVehicleTypes( scenario );
+		CarrierVehicleTypes types = CarriersUtils.getOrAddCarrierVehicleTypes( scenario );
 
 		Controller controller = ControllerUtils.createController( scenario );
 

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/LSPUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/LSPUtils.java
@@ -58,7 +58,7 @@ public final class LSPUtils {
     return new WaitingShipmentsImpl();
   }
 
-  public static void addLSPs(Scenario scenario, LSPs lsps) {
+  public static void loadLspsIntoScenario(Scenario scenario, LSPs lsps) {
     Carriers carriers = CarriersUtils.addOrGetCarriers(scenario);
     // Register carriers from all lsps
     for (LSP lsp : lsps.getLSPs().values()) {
@@ -74,10 +74,7 @@ public final class LSPUtils {
   public static LSPs getLSPs(Scenario scenario) {
     Object result = scenario.getScenarioElement(lspsString);
     if (result == null) {
-      throw new RuntimeException(
-          "there is no scenario element of type "
-              + lspsString
-              + ".  You will need something like LSPUtils.addLSPs( scenario, lsps) somewhere.");
+      throw new RuntimeException("there is no scenario element of type " + lspsString + ".  You will need something like LSPUtils.addLSPs( scenario, lsps) somewhere.");
     }
     return (LSPs) result;
   }

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/LSPUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/LSPUtils.java
@@ -22,6 +22,8 @@ package org.matsim.freight.logistics;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.freight.carriers.Carriers;
@@ -31,238 +33,239 @@ import org.matsim.freight.logistics.shipment.LspShipmentPlan;
 import org.matsim.utils.objectattributes.attributable.Attributable;
 
 public final class LSPUtils {
-  private static final String lspsString = "lsps";
+	private static final String lspsString = "lsps";
 
-  private LSPUtils() {} // do not instantiate
+	private LSPUtils() {} // do not instantiate
 
-  public static LSPPlan createLSPPlan() {
-    return new LSPPlanImpl();
-  }
+	public static LSPPlan createLSPPlan() {
+		return new LSPPlanImpl();
+	}
 
 
-  /**
-  * Checks, is the plan the selcted plan.
-  * (This is adapted copy from PersonUtils.isSelected(plan) )
-  * @param lspPlan the plan to check
-  * @return true if the plan is the selected plan. false, if not.
-  */
-  public static boolean isPlanTheSelectedPlan(LSPPlan lspPlan) {
-    return lspPlan.getLSP().getSelectedPlan() == lspPlan;
-  }
+	/**
+	 * Checks, is the plan the selcted plan.
+	 * (This is adapted copy from PersonUtils.isSelected(plan) )
+	 * @param lspPlan the plan to check
+	 * @return true if the plan is the selected plan. false, if not.
+	 */
+	public static boolean isPlanTheSelectedPlan(LSPPlan lspPlan) {
+		return lspPlan.getLSP().getSelectedPlan() == lspPlan;
+	}
 
-  public static LogisticChainScheduler createForwardLogisticChainScheduler() {
-    return new ForwardLogisticChainSchedulerImpl();
-  }
+	public static LogisticChainScheduler createForwardLogisticChainScheduler() {
+		return new ForwardLogisticChainSchedulerImpl();
+	}
 
-  public static WaitingShipments createWaitingShipments() {
-    return new WaitingShipmentsImpl();
-  }
+	public static WaitingShipments createWaitingShipments() {
+		return new WaitingShipmentsImpl();
+	}
 
-  public static void loadLspsIntoScenario(Scenario scenario, LSPs lsps) {
-    Carriers carriers = CarriersUtils.addOrGetCarriers(scenario);
-    // Register carriers from all lsps
-    for (LSP lsp : lsps.getLSPs().values()) {
-      for (LSPResource lspResource : lsp.getResources()) {
-        if (lspResource instanceof LSPCarrierResource lspCarrierResource) {
-          carriers.addCarrier(lspCarrierResource.getCarrier());
-        }
-      }
-    }
-    scenario.addScenarioElement(lspsString, lsps);
-  }
+	public static void loadLspsIntoScenario(Scenario scenario, LSPs lsps) {
+		Carriers carriers = CarriersUtils.addOrGetCarriers(scenario);
+		// Register carriers from all lsps
+		for (LSP lsp : lsps.getLSPs().values()) {
+			for (LSPResource lspResource : lsp.getResources()) {
+				if (lspResource instanceof LSPCarrierResource lspCarrierResource) {
+					carriers.addCarrier(lspCarrierResource.getCarrier());
+				}
+			}
+		}
+		scenario.addScenarioElement(lspsString, lsps);
+	}
 
-  public static LSPs getLSPs(Scenario scenario) {
-    Object result = scenario.getScenarioElement(lspsString);
-    if (result == null) {
-      throw new RuntimeException("there is no scenario element of type " + lspsString + ".  You will need something like LSPUtils.addLSPs( scenario, lsps) somewhere.");
-    }
-    return (LSPs) result;
-  }
+	public static LSPs getLSPs(Scenario scenario) {
+		Object result = scenario.getScenarioElement(lspsString);
+		if (result == null) {
+			throw new RuntimeException("there is no scenario element of type " + lspsString + ".  You will need something like LSPUtils.addLSPs( scenario, lsps) somewhere.");
+		}
+		return (LSPs) result;
+	}
 
-  public static Double getVariableCost(Attributable attributable) {
-    return (Double) attributable.getAttributes().getAttribute("variableCost");
-  }
+	public static Double getVariableCost(Attributable attributable) {
+		return (Double) attributable.getAttributes().getAttribute("variableCost");
+	}
 
-  public static void setVariableCost(Attributable attributable, Double variableCost) {
-    attributable.getAttributes().putAttribute("variableCost", variableCost);
-  }
+	public static void setVariableCost(Attributable attributable, Double variableCost) {
+		attributable.getAttributes().putAttribute("variableCost", variableCost);
+	}
 
-  public static Double getFixedCost(Attributable attributable) {
-    return (Double) attributable.getAttributes().getAttribute("fixedCost");
-  }
+	public static Double getFixedCost(Attributable attributable) {
+		return (Double) attributable.getAttributes().getAttribute("fixedCost");
+	}
 
-  //	The following would be closer to how we have done it elsewhere (scenario containers are
-  // mutable).  kai, may'22'
-  //	public static LSPs createOrGetLPSs( Scenario scenario ){
-  //		Object result = scenario.getScenarioElement( lspsString );
-  //		LSPs lsps;
-  //		if ( result != null ) {
-  //			lsps = (LSPs) result;
-  //		} else {
-  //			lsps = new LSPs(  );
-  //			scenario.addScenarioElement( lspsString, lsps );
-  //		}
-  //		return lsps;
-  //	}
+	/**
+	 * Will return the lsps container of the scenario.
+	 * If it does not exist, it will be created.
+	 *
+	 * @param scenario The scenario where the LSPs should be added.
+	 * @return the lsps container
+	 */
+	public static LSPs addOrGetLsps( Scenario scenario ) {
+		LSPs lsps = (LSPs) scenario.getScenarioElement(lspsString);
+		if (lsps == null) {
+			scenario.addScenarioElement(lspsString, new LSPs(Collections.EMPTY_LIST));
+		}
+		return lsps;
+	}
 
-  public static void setFixedCost(Attributable attributable, Double fixedCost) {
-    attributable.getAttributes().putAttribute("fixedCost", fixedCost);
-  }
+	public static void setFixedCost(Attributable attributable, Double fixedCost) {
+		attributable.getAttributes().putAttribute("fixedCost", fixedCost);
+	}
 
-  /**
-   * Gives back the {@link LspShipment} object of the {@link LSP}, which matches to the shipmentId
-   *
-   * @param lsp In this LSP this method tries to find the shipment.
-   * @param shipmentId Id of the shipment that should be found.
-   * @return the lspShipment object or null, if it is not found.
-   */
-  public static LspShipment findLspShipment(LSP lsp, Id<LspShipment> shipmentId) {
-    for (LspShipment lspShipment : lsp.getLspShipments()) {
-      if (lspShipment.getId().equals(shipmentId)) {
-        return lspShipment;
-      }
-    }
-    return null;
-  }
+	/**
+	 * Gives back the {@link LspShipment} object of the {@link LSP}, which matches to the shipmentId
+	 *
+	 * @param lsp In this LSP this method tries to find the shipment.
+	 * @param shipmentId Id of the shipment that should be found.
+	 * @return the lspShipment object or null, if it is not found.
+	 */
+	public static LspShipment findLspShipment(LSP lsp, Id<LspShipment> shipmentId) {
+		for (LspShipment lspShipment : lsp.getLspShipments()) {
+			if (lspShipment.getId().equals(shipmentId)) {
+				return lspShipment;
+			}
+		}
+		return null;
+	}
 
-  /**
-   * Returns the {@link LspShipmentPlan} of an {@link LspShipment}.
-   *
-   * @param lspPlan the lspPlan: It contains the information of its shipmentPlans
-   * @param shipmentId Id of the shipment that should be found.
-   * @return the shipmentPlan object or null, if it is not found.
-   */
-  public static LspShipmentPlan findLspShipmentPlan(LSPPlan lspPlan, Id<LspShipment> shipmentId) {
-    for (LspShipmentPlan lspShipmentPlan : lspPlan.getShipmentPlans()) {
-      if (lspShipmentPlan.getLspShipmentId().equals(shipmentId)) {
-        return lspShipmentPlan;
-      }
-    }
-    return null;
-  }
+	/**
+	 * Returns the {@link LspShipmentPlan} of an {@link LspShipment}.
+	 *
+	 * @param lspPlan the lspPlan: It contains the information of its shipmentPlans
+	 * @param shipmentId Id of the shipment that should be found.
+	 * @return the shipmentPlan object or null, if it is not found.
+	 */
+	public static LspShipmentPlan findLspShipmentPlan(LSPPlan lspPlan, Id<LspShipment> shipmentId) {
+		for (LspShipmentPlan lspShipmentPlan : lspPlan.getShipmentPlans()) {
+			if (lspShipmentPlan.getLspShipmentId().equals(shipmentId)) {
+				return lspShipmentPlan;
+			}
+		}
+		return null;
+	}
 
-    public enum LogicOfVrp {serviceBased, shipmentBased}
+	public enum LogicOfVrp {serviceBased, shipmentBased}
 
-    public static final class LSPBuilder {
-    final Collection<LSPResource> resources;
-    final Id<LSP> id;
-    LogisticChainScheduler logisticChainScheduler;
-    LSPPlan initialPlan;
+	public static final class LSPBuilder {
+		final Collection<LSPResource> resources;
+		final Id<LSP> id;
+		LogisticChainScheduler logisticChainScheduler;
+		LSPPlan initialPlan;
 
-    private LSPBuilder(Id<LSP> id) {
-      this.id = id; // this line was not there until today.  kai, may'22
-      this.resources = new ArrayList<>();
-    }
+		private LSPBuilder(Id<LSP> id) {
+			this.id = id; // this line was not there until today.  kai, may'22
+			this.resources = new ArrayList<>();
+		}
 
-    public static LSPBuilder getInstance(Id<LSP> id) {
-      return new LSPBuilder(id);
-    }
+		public static LSPBuilder getInstance(Id<LSP> id) {
+			return new LSPBuilder(id);
+		}
 
-    public LSPBuilder setLogisticChainScheduler(LogisticChainScheduler logisticChainScheduler) {
-      this.logisticChainScheduler = logisticChainScheduler;
-      return this;
-    }
+		public LSPBuilder setLogisticChainScheduler(LogisticChainScheduler logisticChainScheduler) {
+			this.logisticChainScheduler = logisticChainScheduler;
+			return this;
+		}
 
-    //		/**
-    //		 * @deprecated -- It feels attractive to attach this to the "agent".  A big disadvantage
-    // with this approach, however, is that
-    //		 * 		we cannot use injection ... since we cannot inject as many scorers as we have agents.
-    // (At least this is what I think.) Which means
-    //		 * 		that the approach in matsim core and in carriers to have XxxScoringFunctionFactory is
-    // better for what we are doing here.  yyyyyy So
-    //		 * 		this needs to be changed.  kai, jul'22
-    //		 */
-    //		public LSPBuilder setSolutionScorer(LSPScorer scorer) {
-    //			this.scorer = scorer;
-    //			return this;
-    //		}
+		//		/**
+		//		 * @deprecated -- It feels attractive to attach this to the "agent".  A big disadvantage
+		// with this approach, however, is that
+		//		 * 		we cannot use injection ... since we cannot inject as many scorers as we have agents.
+		// (At least this is what I think.) Which means
+		//		 * 		that the approach in matsim core and in carriers to have XxxScoringFunctionFactory is
+		// better for what we are doing here.  yyyyyy So
+		//		 * 		this needs to be changed.  kai, jul'22
+		//		 */
+		//		public LSPBuilder setSolutionScorer(LSPScorer scorer) {
+		//			this.scorer = scorer;
+		//			return this;
+		//		}
 
-    //		/**
-    //		 * @deprecated -- It feels attractive to attach this to the "agent".  A big disadvantage
-    // with this approach, however, is that
-    //		 * 		we cannot use injection ... since we cannot inject as many replanners as we have
-    // agents.  (At least this is what I think.)  yyyyyy So
-    //		 * 		this needs to be changed.  kai, jul'22
-    //		 */
-    //		public LSPBuilder setReplanner(LSPReplanner replanner) {
-    //			this.replanner = replanner;
-    //			return this;
-    //		}
-    // never used.  Thus disabling it.  kai, jul'22
+		//		/**
+		//		 * @deprecated -- It feels attractive to attach this to the "agent".  A big disadvantage
+		// with this approach, however, is that
+		//		 * 		we cannot use injection ... since we cannot inject as many replanners as we have
+		// agents.  (At least this is what I think.)  yyyyyy So
+		//		 * 		this needs to be changed.  kai, jul'22
+		//		 */
+		//		public LSPBuilder setReplanner(LSPReplanner replanner) {
+		//			this.replanner = replanner;
+		//			return this;
+		//		}
+		// never used.  Thus disabling it.  kai, jul'22
 
-    public LSPBuilder setInitialPlan(LSPPlan plan) {
-      this.initialPlan = plan;
-      for (LogisticChain solution : plan.getLogisticChains()) {
-        for (LogisticChainElement element : solution.getLogisticChainElements()) {
-          if (!resources.contains(element.getResource())) {
-            resources.add(element.getResource());
-          }
-        }
-      }
-      return this;
-    }
+		public LSPBuilder setInitialPlan(LSPPlan plan) {
+			this.initialPlan = plan;
+			for (LogisticChain solution : plan.getLogisticChains()) {
+				for (LogisticChainElement element : solution.getLogisticChainElements()) {
+					if (!resources.contains(element.getResource())) {
+						resources.add(element.getResource());
+					}
+				}
+			}
+			return this;
+		}
 
-    public LSP build() {
-      return new LSPImpl(this);
-    }
-  }
+		public LSP build() {
+			return new LSPImpl(this);
+		}
+	}
 
-  public static final class LogisticChainBuilder {
-    final Id<LogisticChain> id;
-    final Collection<LogisticChainElement> elements;
-    //		final Collection<EventHandler> eventHandlers;
-    final Collection<LSPSimulationTracker<LogisticChain>> trackers;
+	public static final class LogisticChainBuilder {
+		final Id<LogisticChain> id;
+		final Collection<LogisticChainElement> elements;
+		//		final Collection<EventHandler> eventHandlers;
+		final Collection<LSPSimulationTracker<LogisticChain>> trackers;
 
-    private LogisticChainBuilder(Id<LogisticChain> id) {
-      this.elements = new ArrayList<>();
-      this.trackers = new ArrayList<>();
-      this.id = id;
-    }
+		private LogisticChainBuilder(Id<LogisticChain> id) {
+			this.elements = new ArrayList<>();
+			this.trackers = new ArrayList<>();
+			this.id = id;
+		}
 
-    public static LogisticChainBuilder newInstance(Id<LogisticChain> id) {
-      return new LogisticChainBuilder(id);
-    }
+		public static LogisticChainBuilder newInstance(Id<LogisticChain> id) {
+			return new LogisticChainBuilder(id);
+		}
 
-    public LogisticChainBuilder addLogisticChainElement(LogisticChainElement element) {
-      elements.add(element);
-      return this;
-    }
+		public LogisticChainBuilder addLogisticChainElement(LogisticChainElement element) {
+			elements.add(element);
+			return this;
+		}
 
-    public LogisticChainBuilder addTracker(LSPSimulationTracker<LogisticChain> tracker) {
-      trackers.add(tracker);
-      return this;
-    }
+		public LogisticChainBuilder addTracker(LSPSimulationTracker<LogisticChain> tracker) {
+			trackers.add(tracker);
+			return this;
+		}
 
-    public LogisticChain build() {
-      //TODO: Prüfe of das alle Elemente Verbunden sind (in irgendeiner Art). Plus Hinweis auf die Änderung.
+		public LogisticChain build() {
+			//TODO: Prüfe of das alle Elemente Verbunden sind (in irgendeiner Art). Plus Hinweis auf die Änderung.
 
-      return new LogisticChainImpl(this);
-    }
-  }
+			return new LogisticChainImpl(this);
+		}
+	}
 
-  public static final class LogisticChainElementBuilder {
-    final Id<LogisticChainElement> id;
-    final WaitingShipments incomingShipments;
-    final WaitingShipments outgoingShipments;
-    LSPResource resource;
+	public static final class LogisticChainElementBuilder {
+		final Id<LogisticChainElement> id;
+		final WaitingShipments incomingShipments;
+		final WaitingShipments outgoingShipments;
+		LSPResource resource;
 
-    private LogisticChainElementBuilder(Id<LogisticChainElement> id) {
-      this.id = id;
-      this.incomingShipments = createWaitingShipments();
-      this.outgoingShipments = createWaitingShipments();
-    }
+		private LogisticChainElementBuilder(Id<LogisticChainElement> id) {
+			this.id = id;
+			this.incomingShipments = createWaitingShipments();
+			this.outgoingShipments = createWaitingShipments();
+		}
 
-    public static LogisticChainElementBuilder newInstance(Id<LogisticChainElement> id) {
-      return new LogisticChainElementBuilder(id);
-    }
+		public static LogisticChainElementBuilder newInstance(Id<LogisticChainElement> id) {
+			return new LogisticChainElementBuilder(id);
+		}
 
-    public LogisticChainElementBuilder setResource(LSPResource resource) {
-      this.resource = resource;
-      return this;
-    }
+		public LogisticChainElementBuilder setResource(LSPResource resource) {
+			this.resource = resource;
+			return this;
+		}
 
-    public LogisticChainElement build() {
-      return new LogisticChainElementImpl(this);
-    }
-  }
+		public LogisticChainElement build() {
+			return new LogisticChainElementImpl(this);
+		}
+	}
 }

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/LSPUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/LSPUtils.java
@@ -60,17 +60,33 @@ public final class LSPUtils {
 		return new WaitingShipmentsImpl();
 	}
 
-	public static void loadLspsIntoScenario(Scenario scenario, LSPs lsps) {
+	/**
+	 * Will return the lsps container of the scenario.
+	 * If it does not exist, it will be created.
+	 *
+	 * @param scenario The scenario where the LSPs should be added.
+	 * @return the lsps container
+	 */
+	public static LSPs addOrGetLsps( Scenario scenario ) {
+		LSPs lsps = (LSPs) scenario.getScenarioElement(lspsString);
+		if (lsps == null) {
+			lsps = new LSPs(Collections.emptyList());
+			scenario.addScenarioElement(lspsString, lsps);
+		}
+		return lsps;
+	}
+
+	public static void loadLspsIntoScenario(Scenario scenario, LSPs lspsToLoad) {
 		Carriers carriers = CarriersUtils.addOrGetCarriers(scenario);
-		// Register carriers from all lsps
-		for (LSP lsp : lsps.getLSPs().values()) {
+		// Register carriers from all lspsToLoad
+		for (LSP lsp : lspsToLoad.getLSPs().values()) {
 			for (LSPResource lspResource : lsp.getResources()) {
 				if (lspResource instanceof LSPCarrierResource lspCarrierResource) {
 					carriers.addCarrier(lspCarrierResource.getCarrier());
 				}
 			}
 		}
-		scenario.addScenarioElement(lspsString, lsps);
+		addOrGetLsps(scenario).putAllLsps(lspsToLoad.getLSPs().values());
 	}
 
 	public static LSPs getLSPs(Scenario scenario) {
@@ -93,20 +109,7 @@ public final class LSPUtils {
 		return (Double) attributable.getAttributes().getAttribute("fixedCost");
 	}
 
-	/**
-	 * Will return the lsps container of the scenario.
-	 * If it does not exist, it will be created.
-	 *
-	 * @param scenario The scenario where the LSPs should be added.
-	 * @return the lsps container
-	 */
-	public static LSPs addOrGetLsps( Scenario scenario ) {
-		LSPs lsps = (LSPs) scenario.getScenarioElement(lspsString);
-		if (lsps == null) {
-			scenario.addScenarioElement(lspsString, new LSPs(Collections.EMPTY_LIST));
-		}
-		return lsps;
-	}
+
 
 	public static void setFixedCost(Attributable attributable, Double fixedCost) {
 		attributable.getAttributes().putAttribute("fixedCost", fixedCost);

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/LSPUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/LSPUtils.java
@@ -76,17 +76,17 @@ public final class LSPUtils {
 		return lsps;
 	}
 
-	public static void loadLspsIntoScenario(Scenario scenario, LSPs lspsToLoad) {
+	public static void loadLspsIntoScenario(Scenario scenario, Collection<LSP> lspsToLoad) {
 		Carriers carriers = CarriersUtils.addOrGetCarriers(scenario);
 		// Register carriers from all lspsToLoad
-		for (LSP lsp : lspsToLoad.getLSPs().values()) {
+		for (LSP lsp : lspsToLoad) {
 			for (LSPResource lspResource : lsp.getResources()) {
 				if (lspResource instanceof LSPCarrierResource lspCarrierResource) {
 					carriers.addCarrier(lspCarrierResource.getCarrier());
 				}
 			}
 		}
-		addOrGetLsps(scenario).putAllLsps(lspsToLoad.getLSPs().values());
+		addOrGetLsps(scenario).putAllLsps(lspsToLoad);
 	}
 
 	public static LSPs getLSPs(Scenario scenario) {

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/LSPs.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/LSPs.java
@@ -23,23 +23,38 @@ package org.matsim.freight.logistics;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 
+/**
+ * A container that stores {@link LSP}s.
+ */
 public class LSPs {
 
-  private final Map<Id<LSP>, LSP> lsps = new LinkedHashMap<>();
+	private static final Logger log = LogManager.getLogger(LSPs.class);
+	private final Map<Id<LSP>, LSP> lsps = new LinkedHashMap<>();
 
-  public LSPs(Collection<LSP> lsps) {
-    putAllLsps(lsps);
-  }
+	public LSPs() {}
 
-  public void putAllLsps(Collection<LSP> lsps) {
-    for (LSP c : lsps) {
-      this.lsps.put(c.getId(), c);
-    }
-  }
+	public LSPs(Collection<LSP> lsps) {
+		addLsps(lsps);
+	}
 
-  public Map<Id<LSP>, LSP> getLSPs() {
-    return lsps;
-  }
+	public void addLsps(Collection<LSP> lsps) {
+		for (LSP lsp : lsps) {
+			this.lsps.put(lsp.getId(), lsp);
+		}
+	}
+	public void addLsp(LSP lsp) {
+		if (!lsps.containsKey(lsp.getId())) {
+			lsps.put(lsp.getId(), lsp);
+		}
+		else log.warn("LSP {} already exists. It has NOT been added.", lsp.getId());
+	}
+
+	public Map<Id<LSP>, LSP> getLSPs() {
+		return lsps;
+	}
 }

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/LSPs.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/LSPs.java
@@ -30,10 +30,10 @@ public class LSPs {
   private final Map<Id<LSP>, LSP> lsps = new LinkedHashMap<>();
 
   public LSPs(Collection<LSP> lsps) {
-    makeMap(lsps);
+    putAllLsps(lsps);
   }
 
-  private void makeMap(Collection<LSP> lsps) {
+  public void putAllLsps(Collection<LSP> lsps) {
     for (LSP c : lsps) {
       this.lsps.put(c.getId(), c);
     }

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirect.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirect.java
@@ -133,7 +133,7 @@ import org.matsim.vehicles.VehicleUtils;
     lsp.scheduleLogisticChains();
 
     log.info("Set up simulation controller and LSPModule");
-    LSPUtils.loadLspsIntoScenario(scenario, new LSPs(Collections.singletonList(lsp)));
+    LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(lsp));
 
     // @KMT: LSPModule ist vom Design her nur im Zusammenhang mit dem Controler sinnvoll. Damit kann
     // man dann auch vollständig auf

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirect.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleSchedulingOfTransportChainHubsVsDirect.java
@@ -133,7 +133,7 @@ import org.matsim.vehicles.VehicleUtils;
     lsp.scheduleLogisticChains();
 
     log.info("Set up simulation controller and LSPModule");
-    LSPUtils.addLSPs(scenario, new LSPs(Collections.singletonList(lsp)));
+    LSPUtils.loadLspsIntoScenario(scenario, new LSPs(Collections.singletonList(lsp)));
 
     // @KMT: LSPModule ist vom Design her nur im Zusammenhang mit dem Controler sinnvoll. Damit kann
     // man dann auch vollständig auf

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid.java
@@ -213,7 +213,7 @@ final class ExampleTwoEchelonGrid {
     }
 
     log.info("Add LSP to the scenario");
-    LSPUtils.addLSPs(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
+    LSPUtils.loadLspsIntoScenario(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
 
     return scenario;
   }

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid.java
@@ -213,7 +213,7 @@ final class ExampleTwoEchelonGrid {
     }
 
     log.info("Add LSP to the scenario");
-    LSPUtils.loadLspsIntoScenario(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
+    LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(createLSP(scenario)));
 
     return scenario;
   }

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid_NR.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid_NR.java
@@ -246,7 +246,7 @@ final class ExampleTwoEchelonGrid_NR {
     }
 
     log.info("Add LSP to the scenario");
-    LSPUtils.addLSPs(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
+    LSPUtils.loadLspsIntoScenario(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
 
     return scenario;
   }

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid_NR.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/initialPlans/ExampleTwoEchelonGrid_NR.java
@@ -246,7 +246,7 @@ final class ExampleTwoEchelonGrid_NR {
     }
 
     log.info("Add LSP to the scenario");
-    LSPUtils.loadLspsIntoScenario(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
+    LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(createLSP(scenario)));
 
     return scenario;
   }

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/lspScoring/ExampleLSPScoring.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/lspScoring/ExampleLSPScoring.java
@@ -210,7 +210,7 @@ import org.matsim.vehicles.VehicleUtils;
 
     // Prepare LSPModule and add the LSP
     LSPs lsps = new LSPs(Collections.singletonList(lsp));
-    LSPUtils.addLSPs(scenario, lsps);
+    LSPUtils.loadLspsIntoScenario(scenario, lsps);
     return scenario;
   }
 

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/lspScoring/ExampleLSPScoring.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/lspScoring/ExampleLSPScoring.java
@@ -209,8 +209,7 @@ import org.matsim.vehicles.VehicleUtils;
     lsp.scheduleLogisticChains();
 
     // Prepare LSPModule and add the LSP
-    LSPs lsps = new LSPs(Collections.singletonList(lsp));
-    LSPUtils.loadLspsIntoScenario(scenario, lsps);
+	  LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(lsp));
     return scenario;
   }
 

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfSimpleLSP.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfSimpleLSP.java
@@ -86,7 +86,7 @@ import org.matsim.vehicles.VehicleUtils;
     ArrayList<LSP> lspList = new ArrayList<>();
     lspList.add(lsp);
     LSPs lsps = new LSPs(lspList);
-    LSPUtils.addLSPs(scenario, lsps);
+    LSPUtils.loadLspsIntoScenario(scenario, lsps);
 
     config.controller().setFirstIteration(0);
     config.controller().setLastIteration(0);

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfSimpleLSP.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfSimpleLSP.java
@@ -83,10 +83,8 @@ import org.matsim.vehicles.VehicleUtils;
     lsp.scheduleLogisticChains();
 
     // set up simulation controller and LSPModule
-    ArrayList<LSP> lspList = new ArrayList<>();
-    lspList.add(lsp);
-    LSPs lsps = new LSPs(lspList);
-    LSPUtils.loadLspsIntoScenario(scenario, lsps);
+	LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(lsp));
+
 
     config.controller().setFirstIteration(0);
     config.controller().setLastIteration(0);

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfTransportChain.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfTransportChain.java
@@ -347,7 +347,7 @@ import org.matsim.vehicles.VehicleUtils;
     ArrayList<LSP> lspList = new ArrayList<>();
     lspList.add(lsp);
     LSPs lsps = new LSPs(lspList);
-    LSPUtils.addLSPs(scenario, lsps);
+    LSPUtils.loadLspsIntoScenario(scenario, lsps);
 
     Controller controller = ControllerUtils.createController(scenario);
     controller.addOverridingModule(

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfTransportChain.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/mobsimExamples/ExampleMobsimOfTransportChain.java
@@ -344,10 +344,7 @@ import org.matsim.vehicles.VehicleUtils;
     lsp.scheduleLogisticChains();
 
     // set up simulation controller and LSPModule
-    ArrayList<LSP> lspList = new ArrayList<>();
-    lspList.add(lsp);
-    LSPs lsps = new LSPs(lspList);
-    LSPUtils.loadLspsIntoScenario(scenario, lsps);
+    LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(lsp));
 
     Controller controller = ControllerUtils.createController(scenario);
     controller.addOverridingModule(

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleGroceryDeliveryMultipleChains.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleGroceryDeliveryMultipleChains.java
@@ -153,7 +153,7 @@ final class ExampleGroceryDeliveryMultipleChains {
     Scenario scenario = ScenarioUtils.loadScenario(config);
 
     log.info("Add LSP to the scenario");
-    LSPUtils.addLSPs(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
+    LSPUtils.loadLspsIntoScenario(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
 
     return scenario;
   }

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleGroceryDeliveryMultipleChains.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleGroceryDeliveryMultipleChains.java
@@ -153,7 +153,7 @@ final class ExampleGroceryDeliveryMultipleChains {
     Scenario scenario = ScenarioUtils.loadScenario(config);
 
     log.info("Add LSP to the scenario");
-    LSPUtils.loadLspsIntoScenario(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
+    LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(createLSP(scenario)));
 
     return scenario;
   }

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleMixedEchelonChains.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleMixedEchelonChains.java
@@ -187,7 +187,7 @@ final class ExampleMultipleMixedEchelonChains {
     }
 
     log.info("Add LSP to the scenario");
-    LSPUtils.addLSPs(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
+    LSPUtils.loadLspsIntoScenario(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
 
     return scenario;
   }

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleMixedEchelonChains.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleMixedEchelonChains.java
@@ -187,7 +187,7 @@ final class ExampleMultipleMixedEchelonChains {
     }
 
     log.info("Add LSP to the scenario");
-    LSPUtils.loadLspsIntoScenario(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
+    LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(createLSP(scenario)));
 
     return scenario;
   }

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChains.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChains.java
@@ -185,7 +185,7 @@ final class ExampleMultipleOneEchelonChains {
     }
 
     log.info("Add LSP to the scenario");
-    LSPUtils.addLSPs(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
+    LSPUtils.loadLspsIntoScenario(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
 
     return scenario;
   }

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChains.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChains.java
@@ -185,7 +185,7 @@ final class ExampleMultipleOneEchelonChains {
     }
 
     log.info("Add LSP to the scenario");
-    LSPUtils.loadLspsIntoScenario(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
+    LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(createLSP(scenario)));
 
     return scenario;
   }

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChainsReplanning.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChainsReplanning.java
@@ -201,7 +201,7 @@ final class ExampleMultipleOneEchelonChainsReplanning {
     }
 
     log.info("Add LSP to the scenario");
-    LSPUtils.addLSPs(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
+    LSPUtils.loadLspsIntoScenario(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
 
     return scenario;
   }

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChainsReplanning.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleOneEchelonChainsReplanning.java
@@ -201,7 +201,7 @@ final class ExampleMultipleOneEchelonChainsReplanning {
     }
 
     log.info("Add LSP to the scenario");
-    LSPUtils.loadLspsIntoScenario(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
+    LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(createLSP(scenario)));
 
     return scenario;
   }

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleTwoEchelonChainsReplanning.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleTwoEchelonChainsReplanning.java
@@ -187,7 +187,7 @@ final class ExampleMultipleTwoEchelonChainsReplanning {
     }
 
     log.info("Add LSP to the scenario");
-    LSPUtils.addLSPs(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
+    LSPUtils.loadLspsIntoScenario(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
 
     return scenario;
   }

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleTwoEchelonChainsReplanning.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleMultipleTwoEchelonChainsReplanning.java
@@ -187,7 +187,7 @@ final class ExampleMultipleTwoEchelonChainsReplanning {
     }
 
     log.info("Add LSP to the scenario");
-    LSPUtils.loadLspsIntoScenario(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
+    LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(createLSP(scenario)));
 
     return scenario;
   }

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChains.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChains.java
@@ -42,7 +42,6 @@
 
 package org.matsim.freight.logistics.examples.multipleChains;
 
-import java.io.IOException;
 import java.util.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -126,7 +125,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChains {
     lsps.add(createLspWithTwoChains(scenario, "Kaufland", MultipleChainsUtils.createLSPShipmentsFromCarrierShipments(carrierKaufland), getDepotLinkFromVehicle(carrierKaufland), HUB_LINK_ID_NEUKOELLN, vehicleTypes, vehicleTypes, vehicleTypes));
     lsps.add(createLspWithDirectChain(scenario, "Edeka_DIRECT", MultipleChainsUtils.createLSPShipmentsFromCarrierShipments(carrierEdeka), getDepotLinkFromVehicle(carrierEdeka), vehicleTypes));
     lsps.add(createLspWithDirectChain(scenario, "Kaufland_DIRECT", MultipleChainsUtils.createLSPShipmentsFromCarrierShipments(carrierKaufland), getDepotLinkFromVehicle(carrierKaufland), vehicleTypes));
-    LSPUtils.addLSPs(scenario, new LSPs(lsps));
+    LSPUtils.loadLspsIntoScenario(scenario, new LSPs(lsps));
 
     Controller controller = prepareController(scenario);
 

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChains.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChains.java
@@ -125,7 +125,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChains {
     lsps.add(createLspWithTwoChains(scenario, "Kaufland", MultipleChainsUtils.createLSPShipmentsFromCarrierShipments(carrierKaufland), getDepotLinkFromVehicle(carrierKaufland), HUB_LINK_ID_NEUKOELLN, vehicleTypes, vehicleTypes, vehicleTypes));
     lsps.add(createLspWithDirectChain(scenario, "Edeka_DIRECT", MultipleChainsUtils.createLSPShipmentsFromCarrierShipments(carrierEdeka), getDepotLinkFromVehicle(carrierEdeka), vehicleTypes));
     lsps.add(createLspWithDirectChain(scenario, "Kaufland_DIRECT", MultipleChainsUtils.createLSPShipmentsFromCarrierShipments(carrierKaufland), getDepotLinkFromVehicle(carrierKaufland), vehicleTypes));
-    LSPUtils.loadLspsIntoScenario(scenario, new LSPs(lsps));
+    LSPUtils.loadLspsIntoScenario(scenario, lsps);
 
     Controller controller = prepareController(scenario);
 

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll.java
@@ -111,7 +111,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll {
     lsps.add(createLspWithTwoChains(scenario, "Kaufland", MultipleChainsUtils.createLSPShipmentsFromCarrierShipments(carrierKaufland), getDepotLinkFromVehicle(carrierKaufland), HUB_LINK_ID_NEUKOELLN, vehicleTypes, vehicleTypes, vehicleTypes));
     lsps.add(createLspWithDirectChain(scenario, "Edeka_DIRECT", MultipleChainsUtils.createLSPShipmentsFromCarrierShipments(carrierEdeka), getDepotLinkFromVehicle(carrierEdeka), vehicleTypes));
     lsps.add(createLspWithDirectChain(scenario, "Kaufland_DIRECT", MultipleChainsUtils.createLSPShipmentsFromCarrierShipments(carrierKaufland), getDepotLinkFromVehicle(carrierKaufland), vehicleTypes));
-    LSPUtils.loadLspsIntoScenario(scenario, new LSPs(lsps));
+    LSPUtils.loadLspsIntoScenario(scenario, lsps);
 
 
     Controller controller = prepareController(scenario, rpScheme);

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll.java
@@ -21,7 +21,6 @@
 
 package org.matsim.freight.logistics.examples.multipleChains;
 
-import java.io.IOException;
 import java.util.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -112,7 +111,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll {
     lsps.add(createLspWithTwoChains(scenario, "Kaufland", MultipleChainsUtils.createLSPShipmentsFromCarrierShipments(carrierKaufland), getDepotLinkFromVehicle(carrierKaufland), HUB_LINK_ID_NEUKOELLN, vehicleTypes, vehicleTypes, vehicleTypes));
     lsps.add(createLspWithDirectChain(scenario, "Edeka_DIRECT", MultipleChainsUtils.createLSPShipmentsFromCarrierShipments(carrierEdeka), getDepotLinkFromVehicle(carrierEdeka), vehicleTypes));
     lsps.add(createLspWithDirectChain(scenario, "Kaufland_DIRECT", MultipleChainsUtils.createLSPShipmentsFromCarrierShipments(carrierKaufland), getDepotLinkFromVehicle(carrierKaufland), vehicleTypes));
-    LSPUtils.addLSPs(scenario, new LSPs(lsps));
+    LSPUtils.loadLspsIntoScenario(scenario, new LSPs(lsps));
 
 
     Controller controller = prepareController(scenario, rpScheme);

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/simulationTrackers/ExampleSimulationTrackers.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/simulationTrackers/ExampleSimulationTrackers.java
@@ -191,7 +191,7 @@ import org.matsim.vehicles.VehicleUtils;
     ArrayList<LSP> lspList = new ArrayList<>();
     lspList.add(lsp);
     LSPs lsps = new LSPs(lspList);
-    LSPUtils.addLSPs(scenario, lsps);
+    LSPUtils.loadLspsIntoScenario(scenario, lsps);
 
     // Start the Mobsim one iteration is sufficient for tracking
     Controler controler = new Controler(config);

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/simulationTrackers/ExampleSimulationTrackers.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/simulationTrackers/ExampleSimulationTrackers.java
@@ -188,10 +188,7 @@ import org.matsim.vehicles.VehicleUtils;
     lsp.scheduleLogisticChains();
 
     // Prepare LSPModule and add the LSP
-    ArrayList<LSP> lspList = new ArrayList<>();
-    lspList.add(lsp);
-    LSPs lsps = new LSPs(lspList);
-    LSPUtils.loadLspsIntoScenario(scenario, lsps);
+    LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(lsp));
 
     // Start the Mobsim one iteration is sufficient for tracking
     Controler controler = new Controler(config);

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/IntegrationIT.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/IntegrationIT.java
@@ -77,7 +77,7 @@ public class IntegrationIT {
 		for (Carrier carrier : CarriersUtils.getCarriers(scenario).getCarriers().values()) {
 			scoreWithRunJsprit = scoreWithRunJsprit + carrier.getSelectedPlan().getJspritScore();
 		}
-		double scoreRunWithOldStructure = generateCarrierPlans(scenario.getNetwork(), CarriersUtils.getCarriers(scenario), CarriersUtils.getCarrierVehicleTypes(scenario));
+		double scoreRunWithOldStructure = generateCarrierPlans(scenario.getNetwork(), CarriersUtils.getCarriers(scenario), CarriersUtils.getOrAddCarrierVehicleTypes(scenario));
 		Assertions.assertEquals(scoreWithRunJsprit, scoreRunWithOldStructure, MatsimTestUtils.EPSILON, "The score of both runs are not the same");
 
 		for (Carrier carrier : CarriersUtils.getCarriers(scenario).getCarriers().values()) {
@@ -126,7 +126,7 @@ public class IntegrationIT {
 		for (Carrier carrier : CarriersUtils.getCarriers(scenario).getCarriers().values()) {
 			scoreWithRunJsprit = scoreWithRunJsprit + carrier.getSelectedPlan().getJspritScore();
 		}
-		double scoreRunWithOldStructure = generateCarrierPlans(scenario.getNetwork(), CarriersUtils.getCarriers(scenario), CarriersUtils.getCarrierVehicleTypes(scenario));
+		double scoreRunWithOldStructure = generateCarrierPlans(scenario.getNetwork(), CarriersUtils.getCarriers(scenario), CarriersUtils.getOrAddCarrierVehicleTypes(scenario));
 		Assertions.assertEquals(scoreWithRunJsprit, scoreRunWithOldStructure, MatsimTestUtils.EPSILON, "The score of both runs are not the same");
 	}
 

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/lspReplanning/CollectionLSPReplanningTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/lspReplanning/CollectionLSPReplanningTest.java
@@ -194,7 +194,7 @@ public class CollectionLSPReplanningTest {
 //		collectionLSP.setReplanner(replanner);
 
 
-		LSPUtils.addLSPs(scenario, new LSPs(Collections.singletonList(collectionLSP)));
+		LSPUtils.loadLspsIntoScenario(scenario, new LSPs(Collections.singletonList(collectionLSP)));
 
 		Controller controller = ControllerUtils.createController(scenario);
 

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/lspReplanning/CollectionLSPReplanningTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/lspReplanning/CollectionLSPReplanningTest.java
@@ -194,7 +194,7 @@ public class CollectionLSPReplanningTest {
 //		collectionLSP.setReplanner(replanner);
 
 
-		LSPUtils.loadLspsIntoScenario(scenario, new LSPs(Collections.singletonList(collectionLSP)));
+		LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(collectionLSP));
 
 		Controller controller = ControllerUtils.createController(scenario);
 

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/lspScoring/CollectionLSPScoringTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/lspScoring/CollectionLSPScoringTest.java
@@ -156,7 +156,7 @@ public class CollectionLSPScoringTest {
 		lspList.add(collectionLSP);
 		LSPs lsps = new LSPs(lspList);
 
-		LSPUtils.addLSPs(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, lsps);
 
 		Controller controller = ControllerUtils.createController(scenario);
 

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/lspScoring/CollectionLSPScoringTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/lspScoring/CollectionLSPScoringTest.java
@@ -152,11 +152,7 @@ public class CollectionLSPScoringTest {
 
 		collectionLSP.scheduleLogisticChains();
 
-		ArrayList<LSP> lspList = new ArrayList<>();
-		lspList.add(collectionLSP);
-		LSPs lsps = new LSPs(lspList);
-
-		LSPUtils.loadLspsIntoScenario(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(collectionLSP));
 
 		Controller controller = ControllerUtils.createController(scenario);
 

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/lspScoring/MultipleIterationsCollectionLSPScoringTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/lspScoring/MultipleIterationsCollectionLSPScoringTest.java
@@ -164,16 +164,11 @@ public class MultipleIterationsCollectionLSPScoringTest {
 			LspShipment shipment = builder.build();
 			collectionLSP.assignShipmentToLSP(shipment);
 		}
-
 		collectionLSP.scheduleLogisticChains();
-
-		ArrayList<LSP> lspList = new ArrayList<>();
-		lspList.add(collectionLSP);
-		LSPs lsps = new LSPs(lspList);
 
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.loadLspsIntoScenario(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(collectionLSP));
 		controller.addOverridingModule( new LSPModule() );
 		controller.addOverridingModule( new AbstractModule(){
 			@Override public void install(){

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/lspScoring/MultipleIterationsCollectionLSPScoringTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/lspScoring/MultipleIterationsCollectionLSPScoringTest.java
@@ -173,7 +173,7 @@ public class MultipleIterationsCollectionLSPScoringTest {
 
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.addLSPs(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, lsps);
 		controller.addOverridingModule( new LSPModule() );
 		controller.addOverridingModule( new AbstractModule(){
 			@Override public void install(){

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsReplanningTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsReplanningTest.java
@@ -91,7 +91,7 @@ public class MultipleChainsReplanningTest {
 			link.setCapacity(1000);
 		}
 
-		LSPUtils.addLSPs(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
+		LSPUtils.loadLspsIntoScenario(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
 
 		return scenario;
 	}

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsReplanningTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/multipleChains/MultipleChainsReplanningTest.java
@@ -91,7 +91,7 @@ public class MultipleChainsReplanningTest {
 			link.setCapacity(1000);
 		}
 
-		LSPUtils.loadLspsIntoScenario(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
+		LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(createLSP(scenario)));
 
 		return scenario;
 	}

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/multipleChains/WorstPlanSelectorTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/multipleChains/WorstPlanSelectorTest.java
@@ -87,7 +87,7 @@ public class WorstPlanSelectorTest {
 			link.setCapacity(1000);
 		}
 
-		LSPUtils.loadLspsIntoScenario(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
+		LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(createLSP(scenario)));
 
 		return scenario;
 	}

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/multipleChains/WorstPlanSelectorTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/multipleChains/WorstPlanSelectorTest.java
@@ -87,7 +87,7 @@ public class WorstPlanSelectorTest {
 			link.setCapacity(1000);
 		}
 
-		LSPUtils.addLSPs(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
+		LSPUtils.loadLspsIntoScenario(scenario, new LSPs(Collections.singletonList(createLSP(scenario))));
 
 		return scenario;
 	}

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/simulationTrackers/CollectionTrackerTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/simulationTrackers/CollectionTrackerTest.java
@@ -179,12 +179,7 @@ public class CollectionTrackerTest {
 		}
 		collectionLSP.scheduleLogisticChains();
 
-
-		ArrayList<LSP> lspList = new ArrayList<>();
-		lspList.add(collectionLSP);
-		LSPs lsps = new LSPs(lspList);
-
-		LSPUtils.loadLspsIntoScenario(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(collectionLSP));
 
 		Controller controller = ControllerUtils.createController(scenario);
 

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/simulationTrackers/CollectionTrackerTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/examples/simulationTrackers/CollectionTrackerTest.java
@@ -184,7 +184,7 @@ public class CollectionTrackerTest {
 		lspList.add(collectionLSP);
 		LSPs lsps = new LSPs(lspList);
 
-		LSPUtils.addLSPs(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, lsps);
 
 		Controller controller = ControllerUtils.createController(scenario);
 

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/io/LSPReadWriteTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/io/LSPReadWriteTest.java
@@ -3,10 +3,13 @@ package org.matsim.freight.logistics.io;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.matsim.freight.carriers.CarrierPlanXmlReader;
-import org.matsim.freight.carriers.CarrierVehicleTypeReader;
-import org.matsim.freight.carriers.CarrierVehicleTypes;
-import org.matsim.freight.carriers.Carriers;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.freight.carriers.*;
+import org.matsim.freight.logistics.FreightLogisticsConfigGroup;
+import org.matsim.freight.logistics.LSPUtils;
 import org.matsim.freight.logistics.LSPs;
 import org.matsim.testcases.MatsimTestUtils;
 
@@ -25,14 +28,9 @@ public class LSPReadWriteTest {
 		String inputFilename = utils.getPackageInputDirectory() + "lsps.xml";
 		String outputFilename = utils.getOutputDirectory() + "/outputLsps.xml";
 
-		CarrierVehicleTypeReader vehicleTypeReader = new CarrierVehicleTypeReader(carrierVehicleTypes);
-		vehicleTypeReader.readFile(utils.getPackageInputDirectory() + "vehicles.xml");
-
-		CarrierPlanXmlReader carrierReader = new CarrierPlanXmlReader(carriers, carrierVehicleTypes);
-		carrierReader.readFile(utils.getPackageInputDirectory() + "carriers.xml");
-
-		LSPPlanXmlReader reader = new LSPPlanXmlReader(lsPs, carriers);
-		reader.readFile(inputFilename);
+		new CarrierVehicleTypeReader(carrierVehicleTypes).readFile(utils.getPackageInputDirectory() + "vehicles.xml");
+		new CarrierPlanXmlReader(carriers, carrierVehicleTypes).readFile(utils.getPackageInputDirectory() + "carriers.xml");
+		new LSPPlanXmlReader(lsPs, carriers).readFile(inputFilename);
 
 		new LSPPlanXmlWriter(lsPs).write(outputFilename);
 
@@ -50,29 +48,91 @@ public class LSPReadWriteTest {
 		String outputFilename = utils.getOutputDirectory() + "/outputLsps.xml";
 		String outputFilename2 = utils.getOutputDirectory() + "/outputLsps2.xml";
 
-		CarrierVehicleTypeReader vehicleTypeReader = new CarrierVehicleTypeReader(carrierVehicleTypes);
-		vehicleTypeReader.readFile(utils.getPackageInputDirectory() + "vehicles.xml");
-
-		CarrierPlanXmlReader carrierReader = new CarrierPlanXmlReader(carriers, carrierVehicleTypes);
-		carrierReader.readFile(utils.getPackageInputDirectory() + "carriers.xml");
-
-		LSPPlanXmlReader reader = new LSPPlanXmlReader(lsps, carriers);
-		reader.readFile(inputFilename);
+		new CarrierVehicleTypeReader(carrierVehicleTypes).readFile(utils.getPackageInputDirectory() + "vehicles.xml");
+		new CarrierPlanXmlReader(carriers, carrierVehicleTypes).readFile(utils.getPackageInputDirectory() + "carriers.xml");
+		new LSPPlanXmlReader(lsps, carriers).readFile(inputFilename);
 
 		new LSPPlanXmlWriter(lsps).write(outputFilename);
 
 		//clear and 2nd read - based on written file.
 		lsps.getLSPs().clear();
 
-		LSPPlanXmlReader reader2 = new LSPPlanXmlReader(lsps, carriers);
-		reader2.readFile(outputFilename);
+		new LSPPlanXmlReader(lsps, carriers).readFile(outputFilename);
 
 		new LSPPlanXmlWriter(lsps).write(outputFilename2);
 
 		MatsimTestUtils.assertEqualFilesLineByLine(inputFilename, outputFilename2);
 	}
 
+	/**
+	 * Tests if the LSPs are correctly read from the files set in the config file and written to a new file.
+	 */
+	@Test
+	public void readWriteFromConfigTest() {
 
+		String inputFilename = utils.getPackageInputDirectory() + "lsps.xml";
+		String outputFilename = utils.getOutputDirectory() + "/outputLsps.xml";
+
+		Config config = ConfigUtils.createConfig();
+
+		var carriersConfigGroup = ConfigUtils.addOrGetModule(config, FreightCarriersConfigGroup.class);
+		carriersConfigGroup.setCarriersFile(utils.getPackageInputDirectory() + "carriers.xml");
+		carriersConfigGroup.setCarriersVehicleTypesFile(utils.getPackageInputDirectory() + "vehicles.xml");
+
+		var logisticsConfigGroup = ConfigUtils.addOrGetModule(config, FreightLogisticsConfigGroup.class);
+		logisticsConfigGroup.setLspsFile(inputFilename);
+
+		Scenario scenario = ScenarioUtils.createScenario(config);
+		LSPUtils.loadLspsAccordingToConfig(scenario);
+
+		new LSPPlanXmlWriter(LSPUtils.getLSPs(scenario)).write(outputFilename);
+
+		MatsimTestUtils.assertEqualFilesLineByLine(inputFilename, outputFilename);
+	}
+
+	/**
+	 * Tests if the LSPs are correctly read from the files set in the config file and written to a new file.
+	 * Also tests if the LSPs are correctly read from the written file.
+	 */
+	@Test
+	public void readWriteReadFromConfigTest() {
+
+		String inputFilename = utils.getPackageInputDirectory() + "lsps.xml";
+		String outputFilename = utils.getOutputDirectory() + "/outputLsps.xml";
+
+		String carriersFile = utils.getPackageInputDirectory() + "carriers.xml";
+		String carriersVehicleTypesFile = utils.getPackageInputDirectory() + "vehicles.xml";
+
+		Config config = ConfigUtils.createConfig();
+
+		var carriersConfigGroup = ConfigUtils.addOrGetModule(config, FreightCarriersConfigGroup.class);
+		carriersConfigGroup.setCarriersFile(carriersFile);
+		carriersConfigGroup.setCarriersVehicleTypesFile(carriersVehicleTypesFile);
+
+		var logisticsConfigGroup = ConfigUtils.addOrGetModule(config, FreightLogisticsConfigGroup.class);
+		logisticsConfigGroup.setLspsFile(inputFilename);
+
+		Scenario scenario = ScenarioUtils.createScenario(config);
+		LSPUtils.loadLspsAccordingToConfig(scenario);
+
+		new LSPPlanXmlWriter(LSPUtils.getLSPs(scenario)).write(outputFilename);
+		MatsimTestUtils.assertEqualFilesLineByLine(inputFilename, outputFilename);
+
+		// 2nd read - based on written file. Use now the non config way for loading the data.
+		// write it out again and compare it to the original input
+		LSPs lsps = new LSPs();
+		Carriers carriers = new Carriers();
+		CarrierVehicleTypes carrierVehicleTypes = new CarrierVehicleTypes();
+
+		new CarrierVehicleTypeReader(carrierVehicleTypes).readFile(carriersVehicleTypesFile);
+		new CarrierPlanXmlReader(carriers, carrierVehicleTypes).readFile(carriersFile);
+		new LSPPlanXmlReader(lsps, carriers).readFile(outputFilename);
+
+		String outputFilename2 = utils.getOutputDirectory() + "/outputLsps2.xml";
+		new LSPPlanXmlWriter(lsps).write(outputFilename2);
+
+		MatsimTestUtils.assertEqualFilesLineByLine(inputFilename, outputFilename2);
+	}
 
 
 }

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CollectionLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CollectionLSPMobsimTest.java
@@ -193,7 +193,7 @@ public class CollectionLSPMobsimTest {
 			}
 		});
 
-		LSPUtils.addLSPs(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, lsps);
 		//The VSP default settings are designed for person transport simulation. After talking to Kai, they will be set to WARN here. Kai MT may'23
 		controller.getConfig().vspExperimental().setVspDefaultsCheckingLevel(VspExperimentalConfigGroup.VspDefaultsCheckingLevel.warn);
 		controller.run();

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CollectionLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CollectionLSPMobsimTest.java
@@ -177,12 +177,7 @@ public class CollectionLSPMobsimTest {
 			}
 			collectionLSP.scheduleLogisticChains();
 		}
-		final LSPs lsps;
-		{
-			ArrayList<LSP> lspList = new ArrayList<>();
-			lspList.add(collectionLSP);
-			lsps = new LSPs(lspList);
-		}
+
 		Controller controller = ControllerUtils.createController(scenario);
 		controller.getEvents().addHandler((BasicEventHandler) event -> log.warn(event));
 
@@ -193,7 +188,7 @@ public class CollectionLSPMobsimTest {
 			}
 		});
 
-		LSPUtils.loadLspsIntoScenario(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(collectionLSP));
 		//The VSP default settings are designed for person transport simulation. After talking to Kai, they will be set to WARN here. Kai MT may'23
 		controller.getConfig().vspExperimental().setVspDefaultsCheckingLevel(VspExperimentalConfigGroup.VspDefaultsCheckingLevel.warn);
 		controller.run();

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CompleteLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CompleteLSPMobsimTest.java
@@ -284,7 +284,7 @@ public class CompleteLSPMobsimTest {
 		lspList.add(completeLSP);
 		LSPs lsps = new LSPs(lspList);
 
-		LSPUtils.addLSPs(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, lsps);
 
 		Controller controller = ControllerUtils.createController(scenario);
 

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CompleteLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/CompleteLSPMobsimTest.java
@@ -280,21 +280,15 @@ public class CompleteLSPMobsimTest {
 		}
 		completeLSP.scheduleLogisticChains();
 
-		ArrayList<LSP> lspList = new ArrayList<>();
-		lspList.add(completeLSP);
-		LSPs lsps = new LSPs(lspList);
-
-		LSPUtils.loadLspsIntoScenario(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(completeLSP));
 
 		Controller controller = ControllerUtils.createController(scenario);
-
 		controller.addOverridingModule(new AbstractModule() {
 			@Override
 			public void install() {
 				install(new LSPModule());
 			}
 		});
-
 
 		config.controller().setFirstIteration(0);
 		config.controller().setLastIteration(0);

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstAndSecondReloadLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstAndSecondReloadLSPMobsimTest.java
@@ -254,11 +254,7 @@ public class FirstAndSecondReloadLSPMobsimTest {
 		}
 		lsp.scheduleLogisticChains();
 
-		ArrayList<LSP> lspList = new ArrayList<>();
-		lspList.add(lsp);
-		LSPs lsps = new LSPs(lspList);
-
-		LSPUtils.loadLspsIntoScenario(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(lsp));
 
 		Controller controller = ControllerUtils.createController(scenario);
 

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstAndSecondReloadLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstAndSecondReloadLSPMobsimTest.java
@@ -258,7 +258,7 @@ public class FirstAndSecondReloadLSPMobsimTest {
 		lspList.add(lsp);
 		LSPs lsps = new LSPs(lspList);
 
-		LSPUtils.addLSPs(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, lsps);
 
 		Controller controller = ControllerUtils.createController(scenario);
 

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstReloadLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstReloadLSPMobsimTest.java
@@ -200,10 +200,7 @@ public class FirstReloadLSPMobsimTest {
 		}
 		lsp.scheduleLogisticChains();
 
-		ArrayList<LSP> lspList = new ArrayList<>();
-		lspList.add(lsp);
-		LSPs lsps = new LSPs(lspList);
-		LSPUtils.loadLspsIntoScenario(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(lsp));
 
 		Controller controller = ControllerUtils.createController(scenario);
 

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstReloadLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/FirstReloadLSPMobsimTest.java
@@ -203,7 +203,7 @@ public class FirstReloadLSPMobsimTest {
 		ArrayList<LSP> lspList = new ArrayList<>();
 		lspList.add(lsp);
 		LSPs lsps = new LSPs(lspList);
-		LSPUtils.addLSPs(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, lsps);
 
 		Controller controller = ControllerUtils.createController(scenario);
 

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunLSPMobsimTest.java
@@ -230,11 +230,7 @@ public class MainRunLSPMobsimTest {
 		}
 		lsp.scheduleLogisticChains();
 
-		ArrayList<LSP> lspList = new ArrayList<>();
-		lspList.add(lsp);
-		LSPs lsps = new LSPs(lspList);
-
-		LSPUtils.loadLspsIntoScenario(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(lsp));
 
 		Controller controller = ControllerUtils.createController(scenario);
 

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunLSPMobsimTest.java
@@ -234,7 +234,7 @@ public class MainRunLSPMobsimTest {
 		lspList.add(lsp);
 		LSPs lsps = new LSPs(lspList);
 
-		LSPUtils.addLSPs(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, lsps);
 
 		Controller controller = ControllerUtils.createController(scenario);
 

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunOnlyLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunOnlyLSPMobsimTest.java
@@ -178,11 +178,8 @@ public class MainRunOnlyLSPMobsimTest {
 		}
 		lsp.scheduleLogisticChains();
 
-		ArrayList<LSP> lspList = new ArrayList<>();
-		lspList.add(lsp);
-		LSPs lsps = new LSPs(lspList);
 
-		LSPUtils.loadLspsIntoScenario(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(lsp));
 
 		Controller controller = ControllerUtils.createController(scenario);
 

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunOnlyLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MainRunOnlyLSPMobsimTest.java
@@ -182,7 +182,7 @@ public class MainRunOnlyLSPMobsimTest {
 		lspList.add(lsp);
 		LSPs lsps = new LSPs(lspList);
 
-		LSPUtils.addLSPs(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, lsps);
 
 		Controller controller = ControllerUtils.createController(scenario);
 

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCollectionLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCollectionLSPMobsimTest.java
@@ -173,7 +173,7 @@ public class MultipleIterationsCollectionLSPMobsimTest {
 
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.addLSPs(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, lsps);
 		controller.addOverridingModule(new AbstractModule() {
 			@Override
 			public void install() {

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCollectionLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCollectionLSPMobsimTest.java
@@ -167,13 +167,9 @@ public class MultipleIterationsCollectionLSPMobsimTest {
 		}
 		collectionLSP.scheduleLogisticChains();
 
-		ArrayList<LSP> lspList = new ArrayList<>();
-		lspList.add(collectionLSP);
-		LSPs lsps = new LSPs(lspList);
-
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.loadLspsIntoScenario(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(collectionLSP));
 		controller.addOverridingModule(new AbstractModule() {
 			@Override
 			public void install() {

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCompleteLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCompleteLSPMobsimTest.java
@@ -294,13 +294,9 @@ public class MultipleIterationsCompleteLSPMobsimTest {
 		}
 		completeLSP.scheduleLogisticChains();
 
-		ArrayList<LSP> lspList = new ArrayList<>();
-		lspList.add(completeLSP);
-		LSPs lsps = new LSPs(lspList);
-
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.loadLspsIntoScenario(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(completeLSP));
 		controller.addOverridingModule(new LSPModule());
 		controller.addOverridingModule( new AbstractModule(){
 			@Override public void install(){

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCompleteLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsCompleteLSPMobsimTest.java
@@ -300,7 +300,7 @@ public class MultipleIterationsCompleteLSPMobsimTest {
 
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.addLSPs(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, lsps);
 		controller.addOverridingModule(new LSPModule());
 		controller.addOverridingModule( new AbstractModule(){
 			@Override public void install(){

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstAndSecondReloadLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstAndSecondReloadLSPMobsimTest.java
@@ -266,7 +266,7 @@ public class MultipleIterationsFirstAndSecondReloadLSPMobsimTest {
 
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.addLSPs(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, lsps);
 		controller.addOverridingModule(new LSPModule());
 		controller.addOverridingModule( new AbstractModule(){
 			@Override public void install(){

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstAndSecondReloadLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstAndSecondReloadLSPMobsimTest.java
@@ -260,13 +260,9 @@ public class MultipleIterationsFirstAndSecondReloadLSPMobsimTest {
 		}
 		lsp.scheduleLogisticChains();
 
-		ArrayList<LSP> lspList = new ArrayList<>();
-		lspList.add(lsp);
-		LSPs lsps = new LSPs(lspList);
-
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.loadLspsIntoScenario(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(lsp));
 		controller.addOverridingModule(new LSPModule());
 		controller.addOverridingModule( new AbstractModule(){
 			@Override public void install(){

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstReloadLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstReloadLSPMobsimTest.java
@@ -210,7 +210,7 @@ public class MultipleIterationsFirstReloadLSPMobsimTest {
 
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.addLSPs(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, lsps);
 		controller.addOverridingModule(new LSPModule());
 		controller.addOverridingModule( new AbstractModule(){
 			@Override public void install(){

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstReloadLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsFirstReloadLSPMobsimTest.java
@@ -204,13 +204,9 @@ public class MultipleIterationsFirstReloadLSPMobsimTest {
 		}
 		lsp.scheduleLogisticChains();
 
-		ArrayList<LSP> lspList = new ArrayList<>();
-		lspList.add(lsp);
-		LSPs lsps = new LSPs(lspList);
-
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.loadLspsIntoScenario(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(lsp));
 		controller.addOverridingModule(new LSPModule());
 		controller.addOverridingModule( new AbstractModule(){
 			@Override public void install(){

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
@@ -245,7 +245,7 @@ public class MultipleIterationsMainRunLSPMobsimTest {
 
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.addLSPs(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, lsps);
 		controller.addOverridingModule(new LSPModule());
 		controller.addOverridingModule( new AbstractModule(){
 			@Override public void install(){

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleIterationsMainRunLSPMobsimTest.java
@@ -239,13 +239,9 @@ public class MultipleIterationsMainRunLSPMobsimTest {
 		}
 		lsp.scheduleLogisticChains();
 
-		ArrayList<LSP> lspList = new ArrayList<>();
-		lspList.add(lsp);
-		LSPs lsps = new LSPs(lspList);
-
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.loadLspsIntoScenario(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(lsp));
 		controller.addOverridingModule(new LSPModule());
 		controller.addOverridingModule( new AbstractModule(){
 			@Override public void install(){

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCollectionLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCollectionLSPMobsimTest.java
@@ -162,13 +162,9 @@ public class MultipleShipmentsCollectionLSPMobsimTest {
 		}
 		collectionLSP.scheduleLogisticChains();
 
-		ArrayList<LSP> lspList = new ArrayList<>();
-		lspList.add(collectionLSP);
-		LSPs lsps = new LSPs(lspList);
-
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.loadLspsIntoScenario(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(collectionLSP));
 		controller.addOverridingModule(new AbstractModule() {
 			@Override
 			public void install() {

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCollectionLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCollectionLSPMobsimTest.java
@@ -168,7 +168,7 @@ public class MultipleShipmentsCollectionLSPMobsimTest {
 
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.addLSPs(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, lsps);
 		controller.addOverridingModule(new AbstractModule() {
 			@Override
 			public void install() {

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
@@ -303,7 +303,7 @@ public class MultipleShipmentsCompleteLSPMobsimTest {
 
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.addLSPs(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, lsps);
 		controller.addOverridingModule(new LSPModule());
 		controller.addOverridingModule( new AbstractModule(){
             @Override public void install(){

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsCompleteLSPMobsimTest.java
@@ -297,13 +297,9 @@ public class MultipleShipmentsCompleteLSPMobsimTest {
 		}
 		completeLSP.scheduleLogisticChains();
 
-		ArrayList<LSP> lspList = new ArrayList<>();
-		lspList.add(completeLSP);
-		LSPs lsps = new LSPs(lspList);
-
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.loadLspsIntoScenario(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(completeLSP));
 		controller.addOverridingModule(new LSPModule());
 		controller.addOverridingModule( new AbstractModule(){
             @Override public void install(){

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstAndSecondReloadLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstAndSecondReloadLSPMobsimTest.java
@@ -259,13 +259,9 @@ public class MultipleShipmentsFirstAndSecondReloadLSPMobsimTest {
 		}
 		lsp.scheduleLogisticChains();
 
-		ArrayList<LSP> lspList = new ArrayList<>();
-		lspList.add(lsp);
-		LSPs lsps = new LSPs(lspList);
-
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.loadLspsIntoScenario(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(lsp));
 		controller.addOverridingModule(new LSPModule());
 		controller.addOverridingModule( new AbstractModule(){
 			@Override public void install(){

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstAndSecondReloadLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstAndSecondReloadLSPMobsimTest.java
@@ -265,7 +265,7 @@ public class MultipleShipmentsFirstAndSecondReloadLSPMobsimTest {
 
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.addLSPs(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, lsps);
 		controller.addOverridingModule(new LSPModule());
 		controller.addOverridingModule( new AbstractModule(){
 			@Override public void install(){

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstReloadLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstReloadLSPMobsimTest.java
@@ -200,13 +200,9 @@ public class MultipleShipmentsFirstReloadLSPMobsimTest {
 		}
 		lsp.scheduleLogisticChains();
 
-		ArrayList<LSP> lspList = new ArrayList<>();
-		lspList.add(lsp);
-		LSPs lsps = new LSPs(lspList);
-
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.loadLspsIntoScenario(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(lsp));
 		controller.addOverridingModule(new AbstractModule() {
 			@Override
 			public void install() {

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstReloadLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsFirstReloadLSPMobsimTest.java
@@ -206,7 +206,7 @@ public class MultipleShipmentsFirstReloadLSPMobsimTest {
 
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.addLSPs(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, lsps);
 		controller.addOverridingModule(new AbstractModule() {
 			@Override
 			public void install() {

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsMainRunLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsMainRunLSPMobsimTest.java
@@ -234,13 +234,9 @@ public class MultipleShipmentsMainRunLSPMobsimTest {
 		}
 		lsp.scheduleLogisticChains();
 
-		ArrayList<LSP> lspList = new ArrayList<>();
-		lspList.add(lsp);
-		LSPs lsps = new LSPs(lspList);
-
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.loadLspsIntoScenario(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(lsp));
 		controller.addOverridingModule(new AbstractModule() {
 			@Override
 			public void install() {

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsMainRunLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/MultipleShipmentsMainRunLSPMobsimTest.java
@@ -240,7 +240,7 @@ public class MultipleShipmentsMainRunLSPMobsimTest {
 
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.addLSPs(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, lsps);
 		controller.addOverridingModule(new AbstractModule() {
 			@Override
 			public void install() {

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/RepeatedMultipleShipmentsCompleteLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/RepeatedMultipleShipmentsCompleteLSPMobsimTest.java
@@ -288,13 +288,9 @@ public class RepeatedMultipleShipmentsCompleteLSPMobsimTest {
 		}
 		completeLSP.scheduleLogisticChains();
 
-		ArrayList<LSP> lspList = new ArrayList<>();
-		lspList.add(completeLSP);
-		LSPs lsps = new LSPs(lspList);
-
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.loadLspsIntoScenario(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, Collections.singletonList(completeLSP));
 		controller.addOverridingModule(new AbstractModule() {
 			@Override
 			public void install() {

--- a/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/RepeatedMultipleShipmentsCompleteLSPMobsimTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/logistics/lspMobsimTests/RepeatedMultipleShipmentsCompleteLSPMobsimTest.java
@@ -294,7 +294,7 @@ public class RepeatedMultipleShipmentsCompleteLSPMobsimTest {
 
 		Controller controller = ControllerUtils.createController(scenario);
 
-		LSPUtils.addLSPs(scenario, lsps);
+		LSPUtils.loadLspsIntoScenario(scenario, lsps);
 		controller.addOverridingModule(new AbstractModule() {
 			@Override
 			public void install() {

--- a/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/DefaultIntegrateExistingTrafficToSmallScaleCommercialImpl.java
+++ b/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/DefaultIntegrateExistingTrafficToSmallScaleCommercialImpl.java
@@ -292,7 +292,7 @@ public class DefaultIntegrateExistingTrafficToSmallScaleCommercialImpl implement
 				}
 			}
 			carrierToRemove.forEach(carrier -> carriers.getCarriers().remove(carrier.getId()));
-			CarriersUtils.getCarrierVehicleTypes(scenario).getVehicleTypes().putAll(usedVehicleTypes.getVehicleTypes());
+			CarriersUtils.getOrAddCarrierVehicleTypes(scenario).getVehicleTypes().putAll(usedVehicleTypes.getVehicleTypes());
 
 			carriers.getCarriers().values().forEach(carrier -> {
 				Carrier newCarrier = CarriersUtils

--- a/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/GenerateSmallScaleCommercialTrafficDemand.java
+++ b/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/GenerateSmallScaleCommercialTrafficDemand.java
@@ -263,7 +263,7 @@ public class GenerateSmallScaleCommercialTrafficDemand implements MATSimAppComma
 				CarriersUtils.loadCarriersAccordingToFreightConfig(scenario);
 
 				// Remove vehicle types which are not used by the carriers
-				Map<Id<VehicleType>, VehicleType> readVehicleTypes = CarriersUtils.getCarrierVehicleTypes(scenario).getVehicleTypes();
+				Map<Id<VehicleType>, VehicleType> readVehicleTypes = CarriersUtils.getOrAddCarrierVehicleTypes(scenario).getVehicleTypes();
 				List<Id<VehicleType>> usedCarrierVehicleTypes = CarriersUtils.getCarriers(scenario).getCarriers().values().stream()
 					.flatMap(carrier -> carrier.getCarrierCapabilities().getCarrierVehicles().values().stream())
 					.map(vehicle -> vehicle.getType().getId())
@@ -580,7 +580,7 @@ public class GenerateSmallScaleCommercialTrafficDemand implements MATSimAppComma
 			@Override
 			public void install() {
 				bind(CarrierStrategyManager.class).toProvider(
-					new MyCarrierPlanStrategyManagerFactory(CarriersUtils.getCarrierVehicleTypes(scenario)));
+					new MyCarrierPlanStrategyManagerFactory(CarriersUtils.getOrAddCarrierVehicleTypes(scenario)));
 				bind(CarrierScoringFunctionFactory.class).toInstance(new MyCarrierScoringFunctionFactory());
 			}
 		});
@@ -610,7 +610,7 @@ public class GenerateSmallScaleCommercialTrafficDemand implements MATSimAppComma
 
 		serviceDurationTimeSelector = commercialTourSpecifications.createStopDurationDistributionPerCategory(rng);
 
-		CarrierVehicleTypes carrierVehicleTypes = CarriersUtils.getCarrierVehicleTypes(scenario);
+		CarrierVehicleTypes carrierVehicleTypes = CarriersUtils.getOrAddCarrierVehicleTypes(scenario);
 		Map<Id<VehicleType>, VehicleType> additionalCarrierVehicleTypes = scenario.getVehicles().getVehicleTypes();
 
 		// Only a vehicle with cost information will work properly
@@ -651,7 +651,7 @@ public class GenerateSmallScaleCommercialTrafficDemand implements MATSimAppComma
 						assert odMatrixEntry.possibleVehicleTypes != null;
 
 						for (String possibleVehicleType : odMatrixEntry.possibleVehicleTypes) {
-							if (CarriersUtils.getCarrierVehicleTypes(scenario).getVehicleTypes().containsKey(
+							if (CarriersUtils.getOrAddCarrierVehicleTypes(scenario).getVehicleTypes().containsKey(
 								Id.create(possibleVehicleType, VehicleType.class)))
 								vehicleTypes.add(possibleVehicleType);
 						}
@@ -806,7 +806,7 @@ public class GenerateSmallScaleCommercialTrafficDemand implements MATSimAppComma
 													int fixedNumberOfVehiclePerTypeAndLocation) {
 
 		Carriers carriers = CarriersUtils.addOrGetCarriers(scenario);
-		CarrierVehicleTypes carrierVehicleTypes = CarriersUtils.getCarrierVehicleTypes(scenario);
+		CarrierVehicleTypes carrierVehicleTypes = CarriersUtils.getOrAddCarrierVehicleTypes(scenario);
 
 		CarrierCapabilities carrierCapabilities;
 

--- a/contribs/small-scale-traffic-generation/src/test/java/org/matsim/smallScaleCommercialTrafficGeneration/TrafficVolumeGenerationTest.java
+++ b/contribs/small-scale-traffic-generation/src/test/java/org/matsim/smallScaleCommercialTrafficGeneration/TrafficVolumeGenerationTest.java
@@ -412,7 +412,7 @@ public class TrafficVolumeGenerationTest {
 		integratedExistingModels.readExistingCarriersFromFolder(scenario, sample, linksPerZone);
 
 		Assertions.assertEquals(3, CarriersUtils.getCarriers(scenario).getCarriers().size(), MatsimTestUtils.EPSILON);
-		Assertions.assertEquals(1, CarriersUtils.getCarrierVehicleTypes(scenario).getVehicleTypes().size(), MatsimTestUtils.EPSILON);
+		Assertions.assertEquals(1, CarriersUtils.getOrAddCarrierVehicleTypes(scenario).getVehicleTypes().size(), MatsimTestUtils.EPSILON);
 		Assertions.assertTrue(CarriersUtils.getCarriers(scenario).getCarriers().containsKey(Id.create("exampleServiceCarrier_carrier1", Carrier.class)));
 		Assertions.assertTrue(CarriersUtils.getCarriers(scenario).getCarriers().containsKey(Id.create("exampleServiceCarrier_carrier2", Carrier.class)));
 		Assertions.assertTrue(CarriersUtils.getCarriers(scenario).getCarriers().containsKey(Id.create("exampleShipmentCarrier_carrier1", Carrier.class)));
@@ -481,7 +481,7 @@ public class TrafficVolumeGenerationTest {
 		integratedExistingModels.readExistingCarriersFromFolder(scenario, sample, linksPerZone);
 
 		Assertions.assertEquals(2, CarriersUtils.getCarriers(scenario).getCarriers().size(), MatsimTestUtils.EPSILON);
-		Assertions.assertEquals(1, CarriersUtils.getCarrierVehicleTypes(scenario).getVehicleTypes().size(), MatsimTestUtils.EPSILON);
+		Assertions.assertEquals(1, CarriersUtils.getOrAddCarrierVehicleTypes(scenario).getVehicleTypes().size(), MatsimTestUtils.EPSILON);
 		Assertions.assertTrue(CarriersUtils.getCarriers(scenario).getCarriers().containsKey(Id.create("exampleServiceCarrier_carrier1", Carrier.class)));
 		Assertions.assertTrue(CarriersUtils.getCarriers(scenario).getCarriers().containsKey(Id.create("exampleShipmentCarrier_carrier1", Carrier.class)));
 


### PR DESCRIPTION
This PR has two main changes: 

1. It now adds the functionality, to load LSPs from file based on the settings in the LogisticsConfigGroup.
This was missing until now, making the `lspFile` setting in the config useless. This is now fixed. 
I also add a readWrite(read) test for it.

1. I make some getOrAdd methods more MATSim standard in `LspUtils` as well as in `CarrierUtils`
**This will bring one maybe code-breaking change** : getCarrierVehicles(scenario) will now fail, if the container does not exist. So please use getOrAdd... instead

Minor changes:
1. Slightly simplification how to load(in code created)  Lsps into the scenario: `LSPUtils.loadLspsIntoScenario(...)`
1. some documentation was added