### PR TITLE
Freight (Carrier): CarrierPlan does not need the Carrier in the constructor 

### DIFF
--- a/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/TourPlanning.java
+++ b/contribs/commercialTrafficApplications/src/main/java/org/matsim/contrib/commercialTrafficApplications/jointDemand/TourPlanning.java
@@ -165,7 +165,7 @@ class TourPlanning {
 			log.info("tour planning for carrier " + carrier.getId() + " took "
 					+ (System.currentTimeMillis() - start) / 1000 + " seconds.");
 			// get the CarrierPlan
-			CarrierPlan carrierPlan = MatsimJspritFactory.createPlan(carrier, bestSolution);
+			CarrierPlan carrierPlan = MatsimJspritFactory.createPlan(bestSolution);
 
 			log.info("routing plan for carrier " + carrier.getId());
 			NetworkRouter.routePlan(carrierPlan, transportCosts); // we need to route

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierImpl.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierImpl.java
@@ -89,7 +89,7 @@ public final class CarrierImpl implements Carrier {
 	public boolean addPlan(CarrierPlan carrierPlan) {
 		// Make sure there is a selected carrierPlan if there is at least one carrierPlan
 		if (this.selectedPlan == null) this.selectedPlan = carrierPlan;
-//		carrierPlan.setCarrier(this); //TODO Add this here as backpointer. (Comment from Kai/Kai Mtg)
+		carrierPlan.setCarrier(this); //TODO Add this here as backpointer. (Comment from Kai/Kai Mtg)
 		return this.plans.add(carrierPlan);
 	}
 

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlan.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlan.java
@@ -36,7 +36,7 @@ import org.matsim.utils.objectattributes.attributable.AttributesImpl;
  */
 public class CarrierPlan implements BasicPlan, Attributable {
 
-	private final Carrier carrier;
+	private Carrier carrier;
 	private final Collection<ScheduledTour> scheduledTours;
 	private Double score = null;
 
@@ -47,13 +47,36 @@ public class CarrierPlan implements BasicPlan, Attributable {
 		return "carrierPlan=[carrierId=" + carrier.getId() + "][score=" + score + "][#tours=" + scheduledTours.size() + "]";
 	}
 
+	/**
+	 * @deprecated Use the constructor without carrier argument.
+	 * The carrier is set automatically when using Carrier.addPlan().
+	 */
+	@Deprecated(since = "Feb 2025", forRemoval = true)
 	public CarrierPlan(final Carrier carrier, final Collection<ScheduledTour> scheduledTours) {
+		this(scheduledTours);
+		setCarrier(carrier);
+	}
+
+	/**
+	 * Creates a new plan for a carrier based on its scheduled tours.
+	 */
+	public CarrierPlan(final Collection<ScheduledTour> scheduledTours) {
 		this.scheduledTours = scheduledTours;
-		this.carrier = carrier;
+
 	}
 
 	public Carrier getCarrier() {
 		return carrier;
+	}
+
+	/**
+	 * Sets the reference to the carrier.
+	 * This is done automatically if using Carrier.addPlan().
+	 * <p
+	 * <b>!! Make sure that the bidirectional reference is set correctly if you are using this method!! </b>
+	 */
+	public void setCarrier(final Carrier carrier) {
+		this.carrier = carrier;
 	}
 
 	/**

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanReaderV1.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanReaderV1.java
@@ -268,9 +268,9 @@ class CarrierPlanReaderV1 extends MatsimXmlParser {
 			carriers.getCarriers().put(currentCarrier.getId(), currentCarrier);
 		}
 		if (name.equals("plan")) {
-			CarrierPlan currentPlan = new CarrierPlan( currentCarrier, scheduledTours );
+			CarrierPlan currentPlan = new CarrierPlan(scheduledTours );
 			currentPlan.setScore(currentScore );
-			currentCarrier.getPlans().add( currentPlan );
+			currentCarrier.addPlan(currentPlan);
 			if(this.selected){
 				currentCarrier.setSelectedPlan( currentPlan );
 			}

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanReaderV1.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanReaderV1.java
@@ -270,7 +270,10 @@ class CarrierPlanReaderV1 extends MatsimXmlParser {
 		if (name.equals("plan")) {
 			CarrierPlan currentPlan = new CarrierPlan(scheduledTours );
 			currentPlan.setScore(currentScore );
-			currentCarrier.addPlan(currentPlan);
+			//The following is done instead of currentCarrier.addPlan(currentPlan), because addPlan() sets the selected plan, if now plan is already selected.
+			//In this version here it seems to be ok, to have also plans without any decision if they are selected or not.
+			currentCarrier.getPlans().add(currentPlan); // Just add the plan without making it the selected one.
+			currentPlan.setCarrier(currentCarrier); // This is necessary for the bidirectional reference.
 			if(this.selected){
 				currentCarrier.setSelectedPlan( currentPlan );
 			}

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2.java
@@ -324,9 +324,9 @@ class CarrierPlanXmlParserV2 extends MatsimXmlParser {
 				currentCarrier = null;
 			}
 			case "plan" -> {
-				CarrierPlan currentPlan = new CarrierPlan(currentCarrier, scheduledTours);
+				CarrierPlan currentPlan = new CarrierPlan(scheduledTours);
 				currentPlan.setScore(currentScore);
-				currentCarrier.getPlans().add(currentPlan);
+				currentCarrier.addPlan(currentPlan);
 				if (this.selected) {
 					currentCarrier.setSelectedPlan(currentPlan);
 				}

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2_1.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlParserV2_1.java
@@ -225,7 +225,7 @@ class CarrierPlanXmlParserV2_1 extends MatsimXmlParser {
 				if (selected == null) this.selected = false;
 				else this.selected = selected.equals("true");
 				scheduledTours = new ArrayList<>();
-				currentPlan = new CarrierPlan(currentCarrier, scheduledTours);
+				currentPlan = new CarrierPlan(scheduledTours);
 				break;
 			case "tour":
 				String tourId = atts.getValue("tourId");

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
@@ -863,7 +863,7 @@ public class CarriersUtils {
 
 			log.info("tour planning for carrier {} took {} seconds.", carrier.getId(), (System.currentTimeMillis() - start) / 1000);
 
-			CarrierPlan newPlan = MatsimJspritFactory.createPlan(carrier, solution);
+			CarrierPlan newPlan = MatsimJspritFactory.createPlan(solution);
 			// yy In principle, the carrier should know the vehicle types that it can deploy.
 
 			log.info("routing plan for carrier {}", carrier.getId());

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
@@ -148,7 +148,7 @@ public class CarriersUtils {
 			Tour tour = sTour.getTour().duplicate();
 			tours.add(ScheduledTour.newInstance(tour, vehicle, depTime));
 		}
-		CarrierPlan copiedPlan = new CarrierPlan(plan2copy.getCarrier(), tours);
+		CarrierPlan copiedPlan = new CarrierPlan(tours);;
 		double initialScoreOfCopiedPlan = plan2copy.getScore();
 		copiedPlan.setScore(initialScoreOfCopiedPlan);
 		return copiedPlan;

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/controller/CarrierVehicleReRouter.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/controller/CarrierVehicleReRouter.java
@@ -134,7 +134,7 @@ class CarrierVehicleReRouter implements GenericPlanStrategyModule<CarrierPlan>{
         //		SolutionPlotter.plotSolutionAsPNG(vrp, solution, "output/sol_"+System.currentTimeMillis()+".png", "sol");
 
         //create carrierPlan from solution
-        CarrierPlan plan = MatsimJspritFactory.createPlan(carrier, solution);
+        CarrierPlan plan = MatsimJspritFactory.createPlan(solution);
 
         //route plan (currently jsprit does not memorize the routes, thus route the plan)
 //		NetworkRouter.routePlan(plan, networkBasedTransportCosts);

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/MatsimJspritFactory.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/MatsimJspritFactory.java
@@ -703,7 +703,7 @@ public final class MatsimJspritFactory {
 	 * The input parameter {@link Carrier} is just required to initialize the plan.
 	 * </br>
 	 */
-	public static CarrierPlan createPlan(Carrier carrier, VehicleRoutingProblemSolution solution) {
+	public static CarrierPlan createPlan(VehicleRoutingProblemSolution solution) {
 		Collection<ScheduledTour> tours = new ArrayList<>();
 		int tourIdIndex = 1;
 		for (VehicleRoute route : solution.getRoutes()) {
@@ -711,7 +711,7 @@ public final class MatsimJspritFactory {
 			tourIdIndex++;
 			tours.add(scheduledTour);
 		}
-		CarrierPlan carrierPlan = new CarrierPlan(carrier, tours);
+		CarrierPlan carrierPlan = new CarrierPlan(tours); //
 		carrierPlan.setJspritScore(solution.getCost() * (-1));
 		return carrierPlan;
 	}

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/usecases/chessboard/InitialCarrierPlanCreator.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/usecases/chessboard/InitialCarrierPlanCreator.java
@@ -147,7 +147,7 @@ final class InitialCarrierPlanCreator {
         //		SolutionPlotter.plotSolutionAsPNG(vrp, solution, "output/sol_"+System.currentTimeMillis()+".png", "sol");
 
         //create carrierPlan from solution
-        CarrierPlan plan = MatsimJspritFactory.createPlan(carrier, solution);
+        CarrierPlan plan = MatsimJspritFactory.createPlan(solution);
         NetworkRouter.routePlan(plan, netbasedTransportcosts);
         return plan;
     }

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/usecases/chessboard/SelectBestPlanAndOptimizeItsVehicleRouteFactory.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/usecases/chessboard/SelectBestPlanAndOptimizeItsVehicleRouteFactory.java
@@ -143,7 +143,7 @@ final class SelectBestPlanAndOptimizeItsVehicleRouteFactory {
 //				SolutionPlotter.plotSolutionAsPNG(vrp, solution, "output/sol_"+System.currentTimeMillis()+".png", "sol");
 
 				//create carrierPlan from solution
-				CarrierPlan plan = MatsimJspritFactory.createPlan(carrier, solution);
+				CarrierPlan plan = MatsimJspritFactory.createPlan(solution);
 
 				//route plan (currently jsprit does not memorize the routes, thus route the plan)
 				NetworkRouter.routePlan(plan, netbasedTransportcosts);

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/resourceImplementations/CarrierSchedulerUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/resourceImplementations/CarrierSchedulerUtils.java
@@ -82,7 +82,7 @@ public class CarrierSchedulerUtils {
     vra.setMaxIterations(jspritIterations);
     VehicleRoutingProblemSolution solution = Solutions.bestOf(vra.searchSolutions());
 
-    CarrierPlan plan = MatsimJspritFactory.createPlan(carrier, solution);
+    CarrierPlan plan = MatsimJspritFactory.createPlan(solution);
     NetworkRouter.routePlan(plan, netbasedTransportCosts);
     carrier.addPlan(plan);
     carrier.setSelectedPlan(plan);

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/resourceImplementations/DistributionCarrierScheduler.java
@@ -132,7 +132,7 @@ import org.matsim.vehicles.VehicleType;
       shipmentsInCurrentTour.clear();
     }
 
-    CarrierPlan plan = new CarrierPlan(carrier, unifyTourIds(scheduledPlans));
+    CarrierPlan plan = new CarrierPlan(unifyTourIds(scheduledPlans));
     plan.setScore(CarrierSchedulerUtils.sumUpScore(scheduledPlans));
     plan.setJspritScore(CarrierSchedulerUtils.sumUpJspritScore(scheduledPlans));
     carrier.addPlan(plan);

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/resourceImplementations/MainRunCarrierScheduler.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/resourceImplementations/MainRunCarrierScheduler.java
@@ -93,7 +93,7 @@ import org.matsim.vehicles.VehicleType;
       if ((load + lspShipment.getSize())
           > vehicleType.getCapacity().getOther().intValue()) {
         load = 0;
-        CarrierPlan plan = createPlan(carrier, shipmentsInCurrentTour);
+        CarrierPlan plan = createCarrierPlan(carrier, shipmentsInCurrentTour);
         scheduledPlans.add(plan);
         shipmentsInCurrentTour.clear();
       }
@@ -101,7 +101,7 @@ import org.matsim.vehicles.VehicleType;
       load = load + lspShipment.getSize();
     }
     if (!shipmentsInCurrentTour.isEmpty()) {
-      CarrierPlan plan = createPlan(carrier, shipmentsInCurrentTour);
+      CarrierPlan plan = createCarrierPlan(carrier, shipmentsInCurrentTour);
       scheduledPlans.add(plan);
       shipmentsInCurrentTour.clear();
     }
@@ -110,13 +110,13 @@ import org.matsim.vehicles.VehicleType;
     for (CarrierPlan scheduledPlan : scheduledPlans) {
       scheduledTours.addAll(scheduledPlan.getScheduledTours());
     }
-    CarrierPlan plan = new CarrierPlan(carrier, scheduledTours);
+    CarrierPlan plan = new CarrierPlan(scheduledTours);
     plan.setScore(CarrierSchedulerUtils.sumUpScore(scheduledPlans));
     carrier.addPlan(plan);
     carrier.setSelectedPlan(plan);
   }
 
-  private CarrierPlan createPlan(Carrier carrier, List<LspShipment> lspShipments) {
+  private CarrierPlan createCarrierPlan(Carrier carrier, List<LspShipment> lspShipments) {
 
     // TODO: Allgemein: Hier ist alles manuell zusammen gesetzt; es findet KEINE Tourenplanung
     // statt!
@@ -163,7 +163,7 @@ import org.matsim.vehicles.VehicleType;
     ScheduledTour sTour = ScheduledTour.newInstance(vehicleTour, vehicle, tourStartTime);
 
     tours.add(sTour);
-    CarrierPlan plan = new CarrierPlan(carrier, tours);
+    CarrierPlan plan = new CarrierPlan(tours);
     NetworkRouter.routePlan(plan, netbasedTransportcosts);
     plan.setScore(scorePlanManually(plan));
     return plan;

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/FixedCostsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/FixedCostsTest.java
@@ -164,7 +164,7 @@ public class FixedCostsTest  {
 			VehicleRoutingProblemSolution bestSolution = Solutions.bestOf(solutions);
 
 			//Routing bestPlan to Network
-			CarrierPlan carrierPlan = MatsimJspritFactory.createPlan(carrier, bestSolution) ;
+			CarrierPlan carrierPlan = MatsimJspritFactory.createPlan(bestSolution) ;
 			NetworkRouter.routePlan(carrierPlan,netBasedCosts) ;
 			carrier.addPlan(carrierPlan) ;
 			carriersPlannedAndRouted.addCarrier(carrier);

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/IntegrationIT.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/IntegrationIT.java
@@ -149,7 +149,7 @@ public class IntegrationIT {
 			VehicleRoutingAlgorithm algorithm = new SchrimpfFactory().createAlgorithm(problem);
 
 			VehicleRoutingProblemSolution solution = Solutions.bestOf(algorithm.searchSolutions());
-			CarrierPlan newPlan = MatsimJspritFactory.createPlan(carrier, solution);
+			CarrierPlan newPlan = MatsimJspritFactory.createPlan(solution);
 
 			NetworkRouter.routePlan(newPlan, netBasedCosts);
 			// (maybe not optimal, but since re-routing is a matsim strategy,

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/MatsimTransformerTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/MatsimTransformerTest.java
@@ -322,7 +322,7 @@ public class MatsimTransformerTest {
 		VehicleRoutingProblem vehicleRoutingProblem = VehicleRoutingProblem.Builder.newInstance().addAllJobs(services1)
 				.addAllJobs(services2).addVehicle(v1).addVehicle(v2).build();
 
-		CarrierPlan plan = new CarrierPlan(CarriersUtils.createCarrier(Id.create("myCarrier", Carrier.class)), sTours);
+		CarrierPlan plan = new CarrierPlan(sTours);
 		plan.setScore(-100.0);
 		VehicleRoutingProblemSolution solution = MatsimJspritFactory.createSolution(plan, vehicleRoutingProblem);
 		assertNotNull(solution);

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/SkillsIT.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/SkillsIT.java
@@ -90,7 +90,7 @@ public class SkillsIT {
 		VehicleRoutingAlgorithm algorithm = new SchrimpfFactory().createAlgorithm(problem);
 
 		VehicleRoutingProblemSolution solution = Solutions.bestOf(algorithm.searchSolutions());
-		CarrierPlan newPlan = MatsimJspritFactory.createPlan(carrier, solution);
+		CarrierPlan newPlan = MatsimJspritFactory.createPlan(solution);
 
 		NetworkRouter.routePlan(newPlan, networkBasedTransportCosts);
 		carrier.addPlan(newPlan);

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsIT.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsIT.java
@@ -131,7 +131,7 @@ public class CarrierControllerUtilsIT{
 			VehicleRoutingProblemSolution bestSolution = Solutions.bestOf(solutions);
 
 				//Routing bestPlan to Network
-			CarrierPlan carrierPlanServicesAndShipments = MatsimJspritFactory.createPlan(carrier, bestSolution) ;
+			CarrierPlan carrierPlanServicesAndShipments = MatsimJspritFactory.createPlan(bestSolution) ;
 			NetworkRouter.routePlan(carrierPlanServicesAndShipments,netBasedCosts) ;
 			carrier.addPlan(carrierPlanServicesAndShipments) ;
 		}
@@ -156,7 +156,7 @@ public class CarrierControllerUtilsIT{
 			VehicleRoutingProblemSolution bestSolution = Solutions.bestOf(solutions);
 
 				//Routing bestPlan to Network
-			CarrierPlan carrierPlanServicesAndShipments = MatsimJspritFactory.createPlan(carrier, bestSolution) ;
+			CarrierPlan carrierPlanServicesAndShipments = MatsimJspritFactory.createPlan(bestSolution) ;
 			NetworkRouter.routePlan(carrierPlanServicesAndShipments,netBasedCosts) ;
 			carrier.addPlan(carrierPlanServicesAndShipments) ;
 		}

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/utils/CarrierControllerUtilsTest.java
@@ -143,7 +143,7 @@ public class CarrierControllerUtilsTest{
 		VehicleRoutingProblemSolution bestSolution = Solutions.bestOf(solutions);
 
 			//Routing bestPlan to Network
-		CarrierPlan carrierPlanServicesAndShipments = MatsimJspritFactory.createPlan(carrierWServices, bestSolution) ;
+		CarrierPlan carrierPlanServicesAndShipments = MatsimJspritFactory.createPlan(bestSolution) ;
 		NetworkRouter.routePlan(carrierPlanServicesAndShipments,netBasedCosts) ;
 		carrierWServices.addPlan(carrierPlanServicesAndShipments) ;
 

--- a/contribs/freightreceiver/src/main/java/org/matsim/freight/receiver/ReceiverTriggersCarrierReplanningListener.java
+++ b/contribs/freightreceiver/src/main/java/org/matsim/freight/receiver/ReceiverTriggersCarrierReplanningListener.java
@@ -109,7 +109,7 @@ class ReceiverTriggersCarrierReplanningListener implements IterationStartsListen
             Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
 
             //create a new carrierPlan from the best solution
-            CarrierPlan newPlan = MatsimJspritFactory.createPlan(carrier, Solutions.bestOf( solutions ) );
+            CarrierPlan newPlan = MatsimJspritFactory.createPlan(Solutions.bestOf( solutions ) );
 
             //route plan
             NetworkRouter.routePlan(newPlan, netBasedCosts);


### PR DESCRIPTION
The backpointer to the carrier will be set, when using the addPlan() method.
This method is called anyway when creating a Carrier with a CarrierPlan. 
So one now can create a `CarrierPlan` and then add it later to a `Carrier.`

This is now analogous as it is done with Persons and their Plans.