### PR TITLE
Add additional columns to travel time validation

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/analysis/traffic/traveltime/TravelTimeComparison.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/traffic/traveltime/TravelTimeComparison.java
@@ -89,7 +89,9 @@ public class TravelTimeComparison implements MATSimAppCommand {
 
 		data.addColumns(
 			DoubleColumn.create("simulated", data.rowCount()),
-			DoubleColumn.create("free_flow", data.rowCount())
+			DoubleColumn.create("simulated_tt", data.rowCount()),
+			DoubleColumn.create("free_flow", data.rowCount()),
+			DoubleColumn.create("free_flow_tt", data.rowCount())
 		);
 
 		for (Row row : data) {
@@ -105,12 +107,14 @@ public class TravelTimeComparison implements MATSimAppCommand {
 			double speed = 3.6 * dist / congested.travelTime;
 
 			row.setDouble("simulated", speed);
+			row.setDouble("simulated_tt", congested.travelTime);
 
 			LeastCostPathCalculator.Path freeflow = computePath(network, freeflowRouter, row);
 			dist = freeflow.links.stream().mapToDouble(Link::getLength).sum();
 			speed = 3.6 * dist / freeflow.travelTime;
 
 			row.setDouble("free_flow", speed);
+			row.setDouble("free_flow_tt", freeflow.travelTime);
 		}
 
 		data = data.dropWhere(data.doubleColumn("simulated").isMissing());

--- a/contribs/application/src/main/java/org/matsim/application/prepare/network/params/NetworkParamsOpt.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/network/params/NetworkParamsOpt.java
@@ -141,16 +141,16 @@ class NetworkParamsOpt {
 	static Object2DoubleMap<SampleValidationRoutes.FromToNodes> readValidation(List<String> validationFiles, List<Integer> refHours) throws IOException {
 
 		// entry to hour and list of speeds
-		Map<SampleValidationRoutes.FromToNodes, Int2ObjectMap<DoubleList>> entries = SampleValidationRoutes.readValidation(validationFiles);
+		Map<SampleValidationRoutes.FromToNodes, Int2ObjectMap<SampleValidationRoutes.Data>> entries = SampleValidationRoutes.readValidation(validationFiles);
 
 		Object2DoubleMap<SampleValidationRoutes.FromToNodes> result = new Object2DoubleOpenHashMap<>();
 
 		// Target values
-		for (Map.Entry<SampleValidationRoutes.FromToNodes, Int2ObjectMap<DoubleList>> e : entries.entrySet()) {
+		for (Map.Entry<SampleValidationRoutes.FromToNodes, Int2ObjectMap<SampleValidationRoutes.Data>> e : entries.entrySet()) {
 
-			Int2ObjectMap<DoubleList> perHour = e.getValue();
+			Int2ObjectMap<SampleValidationRoutes.Data> perHour = e.getValue();
 
-			double avg = refHours.stream().map(h -> perHour.get((int) h).doubleStream())
+			double avg = refHours.stream().map(h -> perHour.get((int) h).speeds().doubleStream())
 				.flatMapToDouble(Function.identity()).average().orElseThrow();
 
 


### PR DESCRIPTION
The `TravelTimeComparison` will now also write out the distance and mean travel time, which can be used to calculate distance dependent travel time deviations.