### PR TITLE
hotfix stucked prebooking agents

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/prebooking/PrebookingManager.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/prebooking/PrebookingManager.java
@@ -436,14 +436,14 @@ public class PrebookingManager implements MobsimEngine, MobsimAfterSimStepListen
 			MobsimAgent agent = internalInterface.getMobsim().getAgents().get(personId);
 
 			if(agent != null) {
-				PlanElement planElement = WithinDayAgentUtils.getCurrentPlanElement(agent);
-				if (planElement instanceof Activity activity) {
+                if (WithinDayAgentUtils.getCurrentPlanElement(agent) instanceof Activity activity) {
 					abortAgent(agent, activity, now);
+					stuckIterator.remove();
 				}
 			} else {
 				// the agent no longer exists in the mobsim, we assume it is already been handled elsewhere. nkuehnel, march'25
+				stuckIterator.remove();
 			}
-			stuckIterator.remove();
 		}
 	}
 


### PR DESCRIPTION
follow up on #3758 which incorrectly removed the agents from the stuck on activity queue even if they haven't reached the activity yet