### PR TITLE
Consolidate PreviousIterationDrtDemandEstimator at the end of the iteration

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/DrtModeMinCostFlowRebalancingModule.java
@@ -101,6 +101,7 @@ public class DrtModeMinCostFlowRebalancingModule extends AbstractDvrpModeModule 
 								strategyParams.demandEstimationPeriod))).asEagerSingleton();
 				bindModal(ZonalDemandEstimator.class).to(modalKey(PreviousIterationDrtDemandEstimator.class));
 				addEventHandlerBinding().to(modalKey(PreviousIterationDrtDemandEstimator.class));
+				addControlerListenerBinding().to(modalKey(PreviousIterationDrtDemandEstimator.class));
 				break;
 
 			case None:

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/PreviousIterationDrtDemandEstimatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/demandestimator/PreviousIterationDrtDemandEstimatorTest.java
@@ -70,7 +70,7 @@ public class PreviousIterationDrtDemandEstimatorTest {
 		PreviousIterationDrtDemandEstimator estimator = createEstimator();
 
 		//no events in previous iterations
-		estimator.reset(1);
+		estimator.notifyIterationEnds(null);
 
 		assertDemand(estimator, 0, zone1, 0);
 		assertDemand(estimator, 2000, zone1, 0);
@@ -96,7 +96,7 @@ public class PreviousIterationDrtDemandEstimatorTest {
 		//time bin 5400-7200
 		estimator.handleEvent(departureEvent(7000, link1, TransportMode.drt));
 		estimator.handleEvent(departureEvent(7100, link2, TransportMode.drt));
-		estimator.reset(1);
+		estimator.notifyIterationEnds(null);
 
 		//time bin 0-1800
 		assertDemand(estimator, 0, zone1, 3);
@@ -121,7 +121,7 @@ public class PreviousIterationDrtDemandEstimatorTest {
 
 		estimator.handleEvent(departureEvent(100, link1, "mode X"));
 		estimator.handleEvent(departureEvent(200, link2, TransportMode.car));
-		estimator.reset(1);
+		estimator.notifyIterationEnds(null);
 
 		assertDemand(estimator, 0, zone1, 0);
 		assertDemand(estimator, 0, zone2, 0);
@@ -137,7 +137,7 @@ public class PreviousIterationDrtDemandEstimatorTest {
 		assertDemand(estimator, 0, zone1, 0);
 		assertDemand(estimator, 0, zone2, 0);
 
-		estimator.reset(1);
+		estimator.notifyIterationEnds(null);
 
 		assertDemand(estimator, 0, zone1, 1);
 		assertDemand(estimator, 0, zone2, 1);
@@ -149,7 +149,7 @@ public class PreviousIterationDrtDemandEstimatorTest {
 
 		estimator.handleEvent(departureEvent(100, link1, TransportMode.drt));
 		estimator.handleEvent(departureEvent(2200, link2, TransportMode.drt));
-		estimator.reset(1);
+		estimator.notifyIterationEnds(null);
 
 		assertDemand(estimator, 0, zone1, 1);
 		assertDemand(estimator, 1799, zone1, 1);
@@ -166,7 +166,7 @@ public class PreviousIterationDrtDemandEstimatorTest {
 		PreviousIterationDrtDemandEstimator estimator = createEstimator();
 
 		estimator.handleEvent(departureEvent(10000000, link1, TransportMode.drt));
-		estimator.reset(1);
+		estimator.notifyIterationEnds(null);
 
 		assertDemand(estimator, 10000000, zone1, 1);
 	}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategyTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/mincostflow/MinCostFlowRebalancingStrategyTest.java
@@ -109,7 +109,7 @@ public class MinCostFlowRebalancingStrategyTest {
         estimator.handleEvent(departureEvent(200, link1, TransportMode.drt));
         estimator.handleEvent(departureEvent(500, link2, TransportMode.drt));
         estimator.handleEvent(departureEvent(1500, link1, TransportMode.drt));
-        estimator.reset(1);
+        estimator.notifyIterationEnds(null);
 
         Map<Zone, List<DvrpVehicle>> rebalanceableVehicles = new HashMap<>();
         List<RebalancingStrategy.Relocation> relocations = strategy.calculateMinCostRelocations(0, rebalanceableVehicles, Collections.emptyMap());
@@ -137,7 +137,7 @@ public class MinCostFlowRebalancingStrategyTest {
         estimator.handleEvent(departureEvent(300, link1, TransportMode.drt));
         // 1 expected trip in zone 2
         estimator.handleEvent(departureEvent(100, link2, TransportMode.drt));
-        estimator.reset(1);
+        estimator.notifyIterationEnds(null);
 
         Map<Zone, List<DvrpVehicle>> rebalanceableVehicles = new HashMap<>();
 
@@ -199,7 +199,7 @@ public class MinCostFlowRebalancingStrategyTest {
         estimator.handleEvent(departureEvent(300, link1, TransportMode.drt));
         // 1 expected trip in zone 2
         estimator.handleEvent(departureEvent(100, link2, TransportMode.drt));
-        estimator.reset(1);
+        estimator.notifyIterationEnds(null);
 
         Map<Zone, List<DvrpVehicle>> rebalanceableVehicles = new HashMap<>();
 


### PR DESCRIPTION
The PreviousIterationDrtDemandEstimator is a very mysterious and powerful class and it's mystery is exceeded only by it's power.

We identified other cases where an estimation of the drt demand of the previous iteration may be helpful (besides min cost flow rebalancing, that is). To avoid duplication we would like to re-use the class in other places.

However, one of our use case needs the demand in the replanning step, i.e., between the iterations. We would therefore like to change the behavior such that the estimator consolidates _after_ an iteration instead of _before_ the next one by adding the IterationEndsListener interface


Let me know if there is any objection