### PR TITLE
DRT shifts: add shift type

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/dispatcher/AssignShiftToVehicleLogic.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/dispatcher/AssignShiftToVehicleLogic.java
@@ -1,10 +1,21 @@
 /*
- * Copyright (C) 2022 MOIA GmbH - All Rights Reserved
- *
- * You may use, distribute and modify this code under the terms
- * of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License,
- * or (at your option) any later version.
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2025 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
  */
 package org.matsim.contrib.drt.extension.operations.shifts.dispatcher;
 

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/dispatcher/DefaultAssignShiftToVehicleLogic.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/dispatcher/DefaultAssignShiftToVehicleLogic.java
@@ -1,10 +1,21 @@
 /*
- * Copyright (C) 2022 MOIA GmbH - All Rights Reserved
- *
- * You may use, distribute and modify this code under the terms
- * of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License,
- * or (at your option) any later version.
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2025 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
  */
 package org.matsim.contrib.drt.extension.operations.shifts.dispatcher;
 

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/dispatcher/DefaultShiftScheduler.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/dispatcher/DefaultShiftScheduler.java
@@ -1,3 +1,22 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2025 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
 package org.matsim.contrib.drt.extension.operations.shifts.dispatcher;
 
 import com.google.common.collect.ImmutableMap;
@@ -26,7 +45,7 @@ public final class DefaultShiftScheduler implements ShiftScheduler {
         }
         return (DrtShift) new DrtShiftImpl(spec.getId(), spec.getStartTime(), spec.getEndTime(),
                 spec.getOperationFacilityId().orElse(null), spec.getDesignatedVehicleId().orElse(null),
-                shiftBreak);
+                shiftBreak, spec.getShiftType().orElse(null));
     };
 
     public DefaultShiftScheduler(DrtShiftsSpecification shiftsSpecification) {

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/dispatcher/DefaultShiftStartLogic.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/dispatcher/DefaultShiftStartLogic.java
@@ -1,10 +1,21 @@
 /*
- * Copyright (C) 2022 MOIA GmbH - All Rights Reserved
- *
- * You may use, distribute and modify this code under the terms
- * of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License,
- * or (at your option) any later version.
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2025 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
  */
 package org.matsim.contrib.drt.extension.operations.shifts.dispatcher;
 

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/dispatcher/DrtShiftDispatcher.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/dispatcher/DrtShiftDispatcher.java
@@ -1,3 +1,22 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2025 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
 package org.matsim.contrib.drt.extension.operations.shifts.dispatcher;
 
 import org.matsim.api.core.v01.Id;

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/dispatcher/DrtShiftDispatcherImpl.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/dispatcher/DrtShiftDispatcherImpl.java
@@ -1,3 +1,22 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2025 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
 package org.matsim.contrib.drt.extension.operations.shifts.dispatcher;
 
 import com.google.common.base.Verify;

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/dispatcher/ShiftScheduler.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/dispatcher/ShiftScheduler.java
@@ -1,3 +1,22 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2025 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
 package org.matsim.contrib.drt.extension.operations.shifts.dispatcher;
 
 import com.google.common.collect.ImmutableMap;

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/dispatcher/ShiftStartLogic.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/dispatcher/ShiftStartLogic.java
@@ -1,10 +1,21 @@
 /*
- * Copyright (C) 2022 MOIA GmbH - All Rights Reserved
- *
- * You may use, distribute and modify this code under the terms
- * of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License,
- * or (at your option) any later version.
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2025 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
  */
 package org.matsim.contrib.drt.extension.operations.shifts.dispatcher;
 

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/io/DrtShiftsReader.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/io/DrtShiftsReader.java
@@ -25,14 +25,18 @@ public class DrtShiftsReader extends MatsimXmlParser {
     private final static String BREAK_NAME = "break";
 
     public static final String ID = "id";
+
     public static final String START_TIME = "start";
     public static final String END_TIME = "end";
+
     public static final String OPERATION_FACILITY_ID = "operationFacilityId";
     public static final String DESIGNATED_VEHICLE_ID = "designatedVehicleId";
 
     public static final String EARLIEST_BREAK_START_TIME = "earliestStart";
     public static final String LATEST_BREAK_END_TIME = "latestEnd";
     public static final String BREAK_DURATION = "duration";
+
+    public static final String TYPE = "type";
 
     private static final Logger log = LogManager.getLogger( DrtShiftsReader.class ) ;
 
@@ -62,6 +66,10 @@ public class DrtShiftsReader extends MatsimXmlParser {
                 String designatedVehicleId = atts.getValue(DESIGNATED_VEHICLE_ID);
                 if(designatedVehicleId != null) {
                     builder.designatedVehicle(Id.create(designatedVehicleId, DvrpVehicle.class));
+                }
+                String type = atts.getValue(TYPE);
+                if(type != null) {
+                    builder.type(type);
                 }
                 currentBuilder = builder;
                 break;

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/io/DrtShiftsWriter.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/io/DrtShiftsWriter.java
@@ -28,14 +28,18 @@ public class DrtShiftsWriter extends MatsimXmlWriter {
     private final static String BREAK_NAME = "break";
 
     public static final String ID = "id";
+
     public static final String START_TIME = "start";
     public static final String END_TIME = "end";
+
     public static final String OPERATION_FACILITY_ID = "operationFacilityId";
     public static final String DESIGNATED_VEHICLE_ID = "designatedVehicleId";
 
     public static final String EARLIEST_BREAK_START_TIME = "earliestStart";
     public static final String LATEST_BREAK_END_TIME = "latestEnd";
     public static final String BREAK_DURATION = "duration";
+
+    public static final String TYPE = "type";
 
     private static final Logger log = LogManager.getLogger(DrtShiftsWriter.class);
 
@@ -64,7 +68,7 @@ public class DrtShiftsWriter extends MatsimXmlWriter {
         List<DrtShiftSpecification> sortedShifts = shifts.values()
                 .stream()
                 .sorted(Comparator.comparing(Identifiable::getId))
-                .collect(Collectors.toList());
+                .toList();
         for (DrtShiftSpecification shift : sortedShifts) {
             atts.clear();
             atts.add(createTuple(ID, shift.getId().toString()));
@@ -74,6 +78,8 @@ public class DrtShiftsWriter extends MatsimXmlWriter {
 					atts.add(createTuple(OPERATION_FACILITY_ID, operationFacilityId.toString())));
             shift.getDesignatedVehicleId().ifPresent(designatedVehicleId ->
                     atts.add(createTuple(DESIGNATED_VEHICLE_ID, designatedVehicleId.toString())));
+            shift.getShiftType().ifPresent(shiftType ->
+                    atts.add(createTuple(TYPE, shiftType)));
             this.writeStartTag(SHIFT_NAME, atts);
 
             //Write break, if present

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/shift/DrtShift.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/shift/DrtShift.java
@@ -29,4 +29,6 @@ public interface DrtShift extends Identifiable<DrtShift>, Comparable<DrtShift> {
 	Optional<DrtShiftBreak> getBreak();
 
 	Optional<Id<DvrpVehicle>> getDesignatedVehicleId();
+
+	Optional<String> getShiftType();
 }

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/shift/DrtShiftImpl.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/shift/DrtShiftImpl.java
@@ -15,8 +15,11 @@ public class DrtShiftImpl implements DrtShift {
 
 	private final double start;
 	private final double end;
+
 	private final Id<OperationFacility> operationFacilityId;
 	private final Id<DvrpVehicle> designatedVehicleId;
+
+	private final String type;
 
 	private final DrtShiftBreak shiftBreak;
 
@@ -24,13 +27,14 @@ public class DrtShiftImpl implements DrtShift {
 	private boolean ended = false;
 
 	public DrtShiftImpl(Id<DrtShift> id, double start, double end, Id<OperationFacility> operationFacilityId,
-						Id<DvrpVehicle> designatedVehicleId, DrtShiftBreak shiftBreak) {
+                        Id<DvrpVehicle> designatedVehicleId, DrtShiftBreak shiftBreak, String type) {
 		this.id = id;
 		this.start = start;
 		this.end = end;
 		this.operationFacilityId = operationFacilityId;
         this.designatedVehicleId = designatedVehicleId;
         this.shiftBreak = shiftBreak;
+        this.type = type;
 	}
 
 	@Override
@@ -51,6 +55,11 @@ public class DrtShiftImpl implements DrtShift {
 	@Override
 	public Optional<Id<DvrpVehicle>> getDesignatedVehicleId() {
 		return Optional.ofNullable(designatedVehicleId);
+	}
+
+	@Override
+	public Optional<String> getShiftType() {
+		return Optional.ofNullable(type);
 	}
 
 	@Override

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/shift/DrtShiftSpecification.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/shift/DrtShiftSpecification.java
@@ -12,13 +12,33 @@ import java.util.Optional;
  */
 public interface DrtShiftSpecification extends Identifiable<DrtShift> {
 
+	/**
+	 * The shift's start time
+	 */
 	double getStartTime();
 
+	/**
+	 * The shift's end time.
+	 */
 	double getEndTime();
 
+	/**
+	 * Returns an optional break during the shift.
+	 */
 	Optional<DrtShiftBreakSpecification> getBreak();
 
+	/**
+	 * Indicates whether the shift should start and end at a specific operation facility
+	 */
 	Optional<Id<OperationFacility>> getOperationFacilityId();
 
+	/**
+	 * Indicates whether the shift is already predefined to operate an a given vehicle
+	 */
     Optional<Id<DvrpVehicle>> getDesignatedVehicleId();
+
+	/**
+	 * Type may beu sed to distinguish various specifications of the shift, e.g., for specifically trained drivers/operators
+	 */
+	Optional<String> getShiftType();
 }

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/shift/DrtShiftSpecification.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/shift/DrtShiftSpecification.java
@@ -38,7 +38,7 @@ public interface DrtShiftSpecification extends Identifiable<DrtShift> {
     Optional<Id<DvrpVehicle>> getDesignatedVehicleId();
 
 	/**
-	 * Type may beu sed to distinguish various specifications of the shift, e.g., for specifically trained drivers/operators
+	 * Type may be used to distinguish various specifications of the shift, e.g., for specifically trained drivers/operators
 	 */
 	Optional<String> getShiftType();
 }

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/shift/DrtShiftSpecificationImpl.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/shift/DrtShiftSpecificationImpl.java
@@ -14,9 +14,13 @@ public class DrtShiftSpecificationImpl implements DrtShiftSpecification {
 	private final Id<DrtShift> id;
 	private final double start;
 	private final double end;
+
 	private final DrtShiftBreakSpecification shiftBreak;
+
 	private final Id<OperationFacility> operationFacilityId;
 	private final Id<DvrpVehicle> designatedVehicleId;
+
+	private final String type;
 
 	private DrtShiftSpecificationImpl(Builder builder) {
 		this.id = builder.id;
@@ -25,6 +29,7 @@ public class DrtShiftSpecificationImpl implements DrtShiftSpecification {
 		this.shiftBreak = builder.shiftBreak;
 		this.operationFacilityId = builder.operationFacilityId;
 		this.designatedVehicleId = builder.designatedVehicleId;
+		this.type = builder.type;
 	}
 
 	@Override
@@ -53,6 +58,11 @@ public class DrtShiftSpecificationImpl implements DrtShiftSpecification {
 	}
 
 	@Override
+	public Optional<String> getShiftType() {
+		return Optional.ofNullable(type);
+	}
+
+	@Override
 	public Id<DrtShift> getId() {
 		return id;
 	}
@@ -68,16 +78,22 @@ public class DrtShiftSpecificationImpl implements DrtShiftSpecification {
 		builder.end = copy.getEndTime();
 		builder.shiftBreak = copy.getBreak().orElse(null);
 		builder.operationFacilityId = copy.getOperationFacilityId().orElse(null);
+		builder.type = copy.type;
 		return builder;
 	}
 
 	public static final class Builder {
 		private Id<DrtShift> id;
+
 		private double start;
 		private double end;
+
 		private DrtShiftBreakSpecification shiftBreak;
+
 		private Id<OperationFacility> operationFacilityId;
-		public Id<DvrpVehicle> designatedVehicleId;
+		private Id<DvrpVehicle> designatedVehicleId;
+
+		private String type;
 
 		private Builder() {
 		}
@@ -108,6 +124,11 @@ public class DrtShiftSpecificationImpl implements DrtShiftSpecification {
 		}
 		public Builder designatedVehicle(Id<DvrpVehicle> designatedVehicleId) {
 			this.designatedVehicleId = designatedVehicleId;
+			return this;
+		}
+
+		public Builder type(String type) {
+			this.type = type;
 			return this;
 		}
 

--- a/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/operations/shifts/ShiftsIOTest.java
+++ b/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/operations/shifts/ShiftsIOTest.java
@@ -1,10 +1,5 @@
 package org.matsim.contrib.drt.extension.operations.shifts;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.io.File;
-import java.util.Optional;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.matsim.api.core.v01.Id;
@@ -18,6 +13,11 @@ import org.matsim.contrib.drt.extension.operations.shifts.shift.DrtShiftsSpecifi
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.testcases.MatsimTestUtils;
 
+import java.io.File;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 /**
  * @author nkuehnel / MOIA
  */
@@ -26,13 +26,14 @@ public class ShiftsIOTest {
 	@RegisterExtension
 	private MatsimTestUtils utils = new MatsimTestUtils();
 
-
 	private static final String TESTSHIFTSINPUT  = "testShifts.xml";
 	private static final String TESTXMLOUTPUT  = "testShiftsOut.xml";
 
 	private final Id<DrtShift> sid11 = Id.create("11", DrtShift.class);
 	private final Id<DrtShift> sid22 = Id.create("22", DrtShift.class);
 	private final Id<DrtShift> sid33 = Id.create("33", DrtShift.class);
+	private final Id<DrtShift> sid44 = Id.create("44", DrtShift.class);
+
 	private final Id<OperationFacility> oid1 = Id.create("op1", OperationFacility.class);
 	private final Id<OperationFacility> oid2 = Id.create("op2", OperationFacility.class);
 
@@ -64,7 +65,7 @@ public class ShiftsIOTest {
 	}
 
 	private void checkContent(DrtShiftsSpecification shiftsSpecification) {
-		assertEquals(3, shiftsSpecification.getShiftSpecifications().size());
+		assertEquals(4, shiftsSpecification.getShiftSpecifications().size());
 
 		DrtShiftSpecification shiftSpecification1 = shiftsSpecification.getShiftSpecifications().get(sid11);
 		assertNotNull(shiftSpecification1);
@@ -99,5 +100,16 @@ public class ShiftsIOTest {
 		assertEquals(Optional.empty(), shiftSpecification3.getOperationFacilityId());
 		assertEquals(Optional.empty(), shiftSpecification3.getDesignatedVehicleId());
 		assertTrue(shiftSpecification3.getBreak().isEmpty());
+
+		DrtShiftSpecification shiftSpecification4 = shiftsSpecification.getShiftSpecifications().get(sid44);
+		assertNotNull(shiftSpecification4);
+		assertEquals(sid44, shiftSpecification4.getId());
+		assertEquals(22400., shiftSpecification3.getStartTime(), 0);
+		assertEquals(53000., shiftSpecification3.getEndTime(), 0);
+		assertFalse(shiftSpecification4.getOperationFacilityId().isPresent());
+		assertEquals(Optional.empty(), shiftSpecification4.getOperationFacilityId());
+		assertEquals(Optional.empty(), shiftSpecification4.getDesignatedVehicleId());
+		assertTrue(shiftSpecification4.getBreak().isEmpty());
+		assertEquals("wav", shiftSpecification4.getShiftType().orElseThrow());
 	}
 }

--- a/contribs/drt-extensions/test/input/org/matsim/contrib/drt/extension/operations/shifts/testShifts.xml
+++ b/contribs/drt-extensions/test/input/org/matsim/contrib/drt/extension/operations/shifts/testShifts.xml
@@ -7,4 +7,6 @@
     </shift>
     <shift id="33" start="22400" end="53000">
     </shift>
+    <shift id="44" start="22400" end="53000" type="wav">
+    </shift>
 </shifts>


### PR DESCRIPTION
adds the option to define a shift type.
this may be used for specialized (driver) shifts, e.g., for wheelchair accessible vehicles or otherwise specialized personnel

in addition, this can also be used to model remote operator or maintenance shifts in autonomous settings 