### PR TITLE
ev: improve documentation, provide utility function and comments

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricFleet.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricFleet.java
@@ -28,7 +28,7 @@ import com.google.common.collect.ImmutableMap;
 /**
  * Contains all ElectricVehicles generated for a given iteration. Its lifespan is limited to a single QSim simulation.
  * <p>
- * Fleet (ond the contained ElectricVehicles) are created from ElectricFleetSpecification (and the contained ElectricVehicleSpecifications)
+ * Fleet (and the contained ElectricVehicles) are created from ElectricFleetSpecification (and the contained ElectricVehicleSpecifications)
  *
  * @author michalm
  */

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricFleetUtils.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/fleet/ElectricFleetUtils.java
@@ -23,6 +23,7 @@ package org.matsim.contrib.ev.fleet;
 import java.util.Collection;
 import java.util.Objects;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import org.matsim.api.core.v01.Id;
 import org.matsim.contrib.ev.charging.ChargingPower;
@@ -36,13 +37,36 @@ public final class ElectricFleetUtils {
 	public static final String CHARGER_TYPES = "chargerTypes";
 	private static final String INITIAL_ENERGY_kWh = "initialEnergyInKWh";
 	private ElectricFleetUtils(){} // do not instantiate
+
+	/**
+	 * Sets the the state of charge at the beginning of the simulation for the vehicle.
+	 * The value must be provided in the range [0, 1].
+	 * @param vehicle
+	 * @param initialSoc
+	 */
 	public static void setInitialSoc(Vehicle vehicle, double initialSoc) {
+		Preconditions.checkArgument(initialSoc >= 0 && initialSoc <= 1,
+				"Trying to set invalid initialSoc value for vehicle: %s. Please provide a value in [0, 1] or batteryCapacity of ", vehicle.getId());
 		vehicle.getAttributes().putAttribute( INITIAL_SOC, initialSoc );
 	}
 
-	public static void setChargerTypes(EngineInformation engineInformation, Collection<String> chargerTypes) {
-		engineInformation.getAttributes().putAttribute( CHARGER_TYPES, chargerTypes );
+	/**
+	 * Sets the charger types the vehicle type is compatible with.
+	 * @param vehicleType
+	 * @param chargerTypes
+	 */
+	public static void setChargerTypes(VehicleType vehicleType, Collection<String> chargerTypes) {
+		vehicleType.getEngineInformation().getAttributes().putAttribute( CHARGER_TYPES, chargerTypes );
 	}
+
+	/**
+	 * Changes the attribute of the vehicle type's engine information such that the vehicle type is considered to be electric (by the EV contrib).
+	 * @param vehicleType
+	 */
+	public static void setElectricVehicleType(VehicleType vehicleType) {
+		VehicleUtils.setHbefaTechnology(vehicleType.getEngineInformation(), EV_ENGINE_HBEFA_TECHNOLOGY);
+	}
+
 	public static void run(String file) {
 		var vehicles = VehicleUtils.createVehiclesContainer();
 		var reader = new MatsimVehicleReader(vehicles);

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/README.md
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/README.md
@@ -108,9 +108,11 @@ Additional attributes:
 
 ### Persons
 
-For a person to be covered by the SEVC contrib, it needs to be activated. Also, access to chargers can be defined:
+For a person to be covered by the SEVC contrib (i.e. for strategic replanning and scoring), it needs to be activated. This can be done by WithinDayEVEngine.activate(). Note that this does not necessarily activate within-day behavior for the agent.
 
-- `sevc:active` (*Boolean*, default `false`): only if set to true, an agent is simulated in SEVC, otherwise they are ignored
+- `wevc:active` (*Boolean*, default `false`): only if set to true, an agent performs strategic charging replanning and scoring in SEVC, otherwise they are ignored
+
+Further, the person's access to chargers can be defined:
 
 - `sevc:subscriptions` (*String*, comma-separated, optional): a list of subscription that the persons owns. In case a charger requires a subscription, it must be present in the list for the person to be eligible.
 

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/StrategicChargingUtils.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/StrategicChargingUtils.java
@@ -287,11 +287,11 @@ public class StrategicChargingUtils {
     }
 
     /**
-     * Sets up the controller
+     * Sets up the controler
      */
-    static public void configureController(Controler controller) {
-        controller.addOverridingModule(new WithinDayEvModule());
-        controller.addOverridingModule(new StrategicChargingModule());
+    static public void configureControler(Controler controler) {
+        controler.addOverridingModule(new WithinDayEvModule());
+        controler.addOverridingModule(new StrategicChargingModule());
     }
 
     /**

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/StrategicChargingUtils.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/StrategicChargingUtils.java
@@ -274,7 +274,7 @@ public class StrategicChargingUtils {
      * <li>Agents still need to be activated using the `activate` method</li>
      * </ul>
      */
-    static public void configureStanadlone(Config config) {
+    static public void configureStandalone(Config config) {
         configure(config);
 
         config.replanning().setMaxAgentPlanMemorySize(1);

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/StrategicChargingUtils.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/StrategicChargingUtils.java
@@ -290,11 +290,11 @@ public class StrategicChargingUtils {
     }
 
     /**
-     * Sets up the controler
+     * Sets up the controller
      */
-    static public void configureControler(Controler controler) {
-        controler.addOverridingModule(new WithinDayEvModule());
-        controler.addOverridingModule(new StrategicChargingModule());
+    static public void configureController (Controler controller) {
+        controller.addOverridingModule(new WithinDayEvModule());
+        controller.addOverridingModule(new StrategicChargingModule());
     }
 
     /**

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/StrategicChargingUtils.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/StrategicChargingUtils.java
@@ -233,7 +233,8 @@ public class StrategicChargingUtils {
     }
 
     /**
-     * Sets up scoring for a SEVC simulation
+     * Adds the activity scoring parameters to the 'normal' MATSim scoring config group.
+     * You still need to configure the ChargingPlanScoringParameters yourself!
      */
     static public void configureScoring(Config config) {
         for (String activityType : Arrays.asList(WithinDayEvEngine.PLUG_ACTIVITY_TYPE,
@@ -246,10 +247,12 @@ public class StrategicChargingUtils {
     }
 
     /**
-     * Sets up configuration for a SEVC simulation
-     * 
+     * Sets up configuration for a SEVC simulation.
+     *
+     * Things that still need to be done by the user:
      * <ul>
      * <li>Agents still need to be activated using the `activate` method</li>
+     * <li>The ChargingPlanScoringParameters still need to be added</li>
      * </ul>
      */
     static public void configure(Config config) {

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/scoring/ChargingPlanScoring.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/scoring/ChargingPlanScoring.java
@@ -50,6 +50,8 @@ import org.matsim.core.controler.listener.ScoringListener;
 import org.matsim.core.mobsim.qsim.InternalInterface;
 import org.matsim.core.mobsim.qsim.interfaces.MobsimEngine;
 import org.matsim.core.router.TripStructureUtils;
+import org.matsim.core.utils.misc.OptionalTime;
+import org.matsim.core.utils.timing.TimeInterpretation;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleUtils;
 
@@ -257,10 +259,8 @@ public class ChargingPlanScoring implements IterationStartsListener, ScoringList
 		EnergyEntry entry = this.energy.get(vehicleId);
 		double initialSoc = entry.current / entry.total;
 
-		//wouldn't an NPE be thrown above (and below) if entry was null? ts, march 2025
-		if (entry != null) {
-			entry.current = endCharge;
-		}
+		//entry can not be null because we initialize the energy map with all vehicles, see initializeEnergy()
+		entry.current = endCharge;
 
 		double finalSoc = entry.current / entry.total;
 		handleChangeSoc(now, vehicleId, initialSoc, finalSoc);
@@ -441,22 +441,28 @@ public class ChargingPlanScoring implements IterationStartsListener, ScoringList
 		for (Person person : activePersons) {
 			Id<Vehicle> vehicleId = VehicleUtils.getVehicleId(person, chargingMode);
 
-			AtomicDouble travelTime = new AtomicDouble(0.0);
-			AtomicDouble travelDistance = new AtomicDouble(0.0);
+			AtomicDouble plannedTotalTravelTime = new AtomicDouble(0.0);
+			AtomicDouble plannedTotalTravelDistance = new AtomicDouble(0.0);
 
 			for (Leg leg : TripStructureUtils.getLegs(person.getSelectedPlan())) {
-				// don't we need to filter for legs with the EV, i.e. of the chargingMode?
-				// while the finalizeDetour() method takes max(0,observedDetour) and observedDetour considers trips with EV only,
-				// the fact that we do not filter here means that detours with EV are first compensated by legs with other modes, before they are scored, right?
-				// ts, march 2025
-				Double legTravelTime = leg.getRoute().getTravelTime().isDefined() ? leg.getRoute().getTravelTime().seconds() :
-						leg.getTravelTime().isDefined() ? leg.getTravelTime().seconds() : null;
-				if (legTravelTime == null) throw new IllegalStateException("Leg " + leg + "  of person + " + person + " has no travel time.");
-				travelTime.addAndGet(legTravelTime);
-				travelDistance.addAndGet(-leg.getRoute().getDistance());
+				// Here, we determine the planned travel time.
+				// Later, we track the actual travel time by listening to events on links.
+				// This means, we can not compare access and egress legs.
+				// (otherwise we would include all legs with _routing_Mode.equals(chargingMode) in the following filter)
+				// tschlenther, march '24
+				// TODO: include detour of access and egress in ChargingPlanScoring !?
+				if (! leg.getMode().equals(chargingMode)) continue;
+
+				//would be better to use a TimeInterpretation object here, but we would need the MATSim config to instantiate it.
+				OptionalTime plannedLegTravelTime =  leg.getRoute().getTravelTime().or(leg.getTravelTime());
+				if (plannedLegTravelTime.isUndefined()){
+					throw new IllegalStateException("Leg " + leg + "  of person + " + person + " has no travel time.");
+				}
+				plannedTotalTravelTime.addAndGet(plannedLegTravelTime.seconds());
+				plannedTotalTravelDistance.addAndGet(-leg.getRoute().getDistance());
 			}
 
-			detours.put(vehicleId, new DetourPair(travelTime, travelDistance));
+			detours.put(vehicleId, new DetourPair(plannedTotalTravelTime, plannedTotalTravelDistance));
 		}
 	}
 

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/scoring/ChargingPlanScoring.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/scoring/ChargingPlanScoring.java
@@ -448,10 +448,11 @@ public class ChargingPlanScoring implements IterationStartsListener, ScoringList
 				// don't we need to filter for legs with the EV, i.e. of the chargingMode?
 				// while the finalizeDetour() method takes max(0,observedDetour) and observedDetour considers trips with EV only,
 				// the fact that we do not filter here means that detours with EV are first compensated by legs with other modes, before they are scored, right?
-				// Moreover, I ran into situations where leg.getTravelTime was undefined, even though that the travel time was set in the route (e.g. walk) -
-				// maybe that doesn't belong here, but should we handle undefined times here?
 				// ts, march 2025
-				travelTime.addAndGet(-leg.getTravelTime().seconds());
+				Double legTravelTime = leg.getRoute().getTravelTime().isDefined() ? leg.getRoute().getTravelTime().seconds() :
+						leg.getTravelTime().isDefined() ? leg.getTravelTime().seconds() : null;
+				if (legTravelTime == null) throw new IllegalStateException("Leg " + leg + "  of person + " + person + " has no travel time.");
+				travelTime.addAndGet(legTravelTime);
 				travelDistance.addAndGet(-leg.getRoute().getDistance());
 			}
 

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/scoring/ChargingPlanScoring.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/scoring/ChargingPlanScoring.java
@@ -257,6 +257,7 @@ public class ChargingPlanScoring implements IterationStartsListener, ScoringList
 		EnergyEntry entry = this.energy.get(vehicleId);
 		double initialSoc = entry.current / entry.total;
 
+		//wouldn't an NPE be thrown above (and below) if entry was null? ts, march 2025
 		if (entry != null) {
 			entry.current = endCharge;
 		}
@@ -444,6 +445,12 @@ public class ChargingPlanScoring implements IterationStartsListener, ScoringList
 			AtomicDouble travelDistance = new AtomicDouble(0.0);
 
 			for (Leg leg : TripStructureUtils.getLegs(person.getSelectedPlan())) {
+				// don't we need to filter for legs with the EV, i.e. of the chargingMode?
+				// while the finalizeDetour() method takes max(0,observedDetour) and observedDetour considers trips with EV only,
+				// the fact that we do not filter here means that detours with EV are first compensated by legs with other modes, before they are scored, right?
+				// Moreover, I ran into situations where leg.getTravelTime was undefined, even though that the travel time was set in the route (e.g. walk) -
+				// maybe that doesn't belong here, but should we handle undefined times here?
+				// ts, march 2025
 				travelTime.addAndGet(-leg.getTravelTime().seconds());
 				travelDistance.addAndGet(-leg.getRoute().getDistance());
 			}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/scoring/ChargingPlanScoringParameters.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/scoring/ChargingPlanScoringParameters.java
@@ -32,7 +32,7 @@ public class ChargingPlanScoringParameters extends ReflectiveConfigGroup {
 	public double detourDistance_km = 0.0;
 
 	@Parameter
-	@Comment("scorign utility applied every time the SoC goes to zero")
+	@Comment("scoring utility applied every time the SoC goes to zero")
 	public double zeroSoc = -100.0;
 
 	@Parameter

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/withinday/WithinDayEvEngine.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/withinday/WithinDayEvEngine.java
@@ -637,8 +637,7 @@ public class WithinDayEvEngine implements MobsimEngine, ActivityStartEventHandle
 						// no upcoming plug activity is found, this is a completely spantaneous charging
 						// attempt
 
-						Id<Vehicle> vehicleId = VehicleUtils.getVehicleId(plan.getPerson(), chargingMode);
-						ElectricVehicle vehicle = electricFleet.getElectricVehicles().get(vehicleId);
+						ElectricVehicle vehicle = getElectricVehicle(plan);
 
 						ChargingAlternative alternative = alternativeProvider.findEnrouteAlternative(time,
 								plan.getPerson(), plan, vehicle, null);
@@ -659,6 +658,17 @@ public class WithinDayEvEngine implements MobsimEngine, ActivityStartEventHandle
 		}
 
 		approaching.clear();
+	}
+
+	private ElectricVehicle getElectricVehicle(Plan plan) {
+		Id<Vehicle> vehicleId = VehicleUtils.getVehicleId(plan.getPerson(), chargingMode);
+		if  (!electricFleet.getElectricVehicles().containsKey(vehicleId)){
+			throw new IllegalArgumentException("You have configured agent " + plan.getPerson().getId() + " to be active for charging" +
+					", and the mode " + chargingMode + " to be an electric vehicle mode, but the vehicle " + vehicleId + " is not an electric vehicle. " +
+					"In order to change that, you can call VehicleUtils.setHbefaTechnology(vehicle.getType().getEngineInformation(), ElectricFleetUtils.EV_ENGINE_HBEFA_TECHNOLOGY (see ElectricFleetUtils)." );
+		};
+		ElectricVehicle vehicle = electricFleet.getElectricVehicles().get(vehicleId);
+		return vehicle;
 	}
 
 	private void processPluggingProcesses(double now) {

--- a/contribs/ev/src/test/java/org/matsim/contrib/ev/strategic/utils/TestScenarioBuilder.java
+++ b/contribs/ev/src/test/java/org/matsim/contrib/ev/strategic/utils/TestScenarioBuilder.java
@@ -486,11 +486,11 @@ public class TestScenarioBuilder {
 		return scenario;
 	}
 
-	private Controler prepareControler(Scenario scenario) {
-		Controler controler = new Controler(scenario);
+	private Controler prepareController(Scenario scenario) {
+		Controler controller = new Controler(scenario);
 
-		controler.addOverridingModule(new EvModule());
-		controler.addOverridingModule(new AbstractModule() {
+		controller.addOverridingModule(new EvModule());
+		controller.addOverridingModule(new AbstractModule() {
 			@Override
 			public void install() {
 				bind(DriveEnergyConsumption.Factory.class).toInstance(vehicle -> {
@@ -503,21 +503,21 @@ public class TestScenarioBuilder {
 			}
 		});
 
-		prepareInfrastructure(controler);
+		prepareInfrastructure(controller);
 
-		controler.addOverridingModule(new WithinDayEvModule());
+		controller.addOverridingModule(new WithinDayEvModule());
 
 		if (enableStrategicCharging) {
-			controler.addOverridingModule(new StrategicChargingModule());
+			controller.addOverridingModule(new StrategicChargingModule());
 		}
 
-		return controler;
+		return controller;
 	}
 
 	public TestScenario build() {
 		Config config = prepareConfig();
 		Scenario scenario = prepareScenario(config);
-		Controler controller = prepareControler(scenario);
+		Controler controller = prepareController(scenario);
 
 		Tracker tracker = prepareTracker(controller);
 

--- a/contribs/ev/src/test/java/org/matsim/contrib/ev/strategic/utils/TestScenarioBuilder.java
+++ b/contribs/ev/src/test/java/org/matsim/contrib/ev/strategic/utils/TestScenarioBuilder.java
@@ -486,11 +486,11 @@ public class TestScenarioBuilder {
 		return scenario;
 	}
 
-	private Controler prepareController(Scenario scenario) {
-		Controler controller = new Controler(scenario);
+	private Controler prepareControler(Scenario scenario) {
+		Controler controler = new Controler(scenario);
 
-		controller.addOverridingModule(new EvModule());
-		controller.addOverridingModule(new AbstractModule() {
+		controler.addOverridingModule(new EvModule());
+		controler.addOverridingModule(new AbstractModule() {
 			@Override
 			public void install() {
 				bind(DriveEnergyConsumption.Factory.class).toInstance(vehicle -> {
@@ -503,21 +503,21 @@ public class TestScenarioBuilder {
 			}
 		});
 
-		prepareInfrastructure(controller);
+		prepareInfrastructure(controler);
 
-		controller.addOverridingModule(new WithinDayEvModule());
+		controler.addOverridingModule(new WithinDayEvModule());
 
 		if (enableStrategicCharging) {
-			controller.addOverridingModule(new StrategicChargingModule());
+			controler.addOverridingModule(new StrategicChargingModule());
 		}
 
-		return controller;
+		return controler;
 	}
 
 	public TestScenario build() {
 		Config config = prepareConfig();
 		Scenario scenario = prepareScenario(config);
-		Controler controller = prepareController(scenario);
+		Controler controller = prepareControler(scenario);
 
 		Tracker tracker = prepareTracker(controller);
 

--- a/contribs/vsp/src/main/java/playground/vsp/ev/RunUrbanEVExample.java
+++ b/contribs/vsp/src/main/java/playground/vsp/ev/RunUrbanEVExample.java
@@ -142,9 +142,10 @@ public class RunUrbanEVExample {
 
 			VehicleType carVehicleType = vehicleFactory.createVehicleType(Id.create(person.getId().toString(),
 					VehicleType.class)); //TODO should at least have a suffix "_car"
-			VehicleUtils.setHbefaTechnology(carVehicleType.getEngineInformation(), "electricity");
+
+			ElectricFleetUtils.setElectricVehicleType(carVehicleType);	//alternatively you can do VehicleUtils.setHbefaTechnology(carVehicleType.getEngineInformation(), "electricity");
 			VehicleUtils.setEnergyCapacity(carVehicleType.getEngineInformation(), CAR_BATTERY_CAPACITY_kWh);
-			ElectricFleetUtils.setChargerTypes(carVehicleType.getEngineInformation(), Arrays.asList("a", "b", "default" ) );
+			ElectricFleetUtils.setChargerTypes(carVehicleType, Arrays.asList("a", "b", "default" ) );
 			scenario.getVehicles().addVehicleType(carVehicleType);
 			carVehicleType.setNetworkMode(TransportMode.car);
 			Vehicle carVehicle = vehicleFactory.createVehicle(VehicleUtils.createVehicleId(person, TransportMode.car),


### PR DESCRIPTION
1. This PR mainly provides additional documentation on the `ev` contrib.
2. Some typos are fixed.
3. A utility method to define a vehicle type to be electric is introduced in `ElectricFleetUtils.setElectricVehicleType` (which delegates to `VehicleUtils`).
4. Some potential bugs in the sevc packages are commented. I will point out those below.
5. The ReadMe is updated. 

It does feel a little ... confusing that one has to call the` _Within_DayEVEngine` to activate strategic charging behavior (to me and to people from Lund TH). Having said that, it does make sense that the charging behavior functionality resides in the within-day package, rather than in the strategic package. I wonder whether it should be in its own package, but probably not.