### PR TITLE
DVRP: swap variable names in DVRP load from trip

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/DefaultDvrpLoadFromTrip.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/DefaultDvrpLoadFromTrip.java
@@ -34,8 +34,8 @@ public class DefaultDvrpLoadFromTrip implements DvrpLoadFromTrip {
 
 	@Override
 	public DvrpLoad getLoad(Person person, Attributes tripAttributes) {
-		DvrpLoad tripLoad = processAttributes(person.getAttributes(), person);
-		DvrpLoad personLoad = processAttributes(tripAttributes, person);
+		DvrpLoad personLoad = processAttributes(person.getAttributes(), person);
+		DvrpLoad tripLoad = processAttributes(tripAttributes, person);
 
 		Preconditions.checkState(!(tripLoad != null && personLoad != null),
 				String.format("Cannot define load on person and trip level for person %s",


### PR DESCRIPTION
very minor thing, but I believe the variable names were supposed to be swapped