### PR TITLE
do not write trips and legs in every iteration

### DIFF
--- a/matsim/src/main/java/org/matsim/analysis/IterationTravelStatsControlerListener.java
+++ b/matsim/src/main/java/org/matsim/analysis/IterationTravelStatsControlerListener.java
@@ -99,7 +99,7 @@ class IterationTravelStatsControlerListener implements IterationEndsListener, Sh
 		// This uses the same logic as in PlansDumpingImpl
 		int writeTripsInterval = config.controller().getWriteTripsInterval();
 		final boolean writingTripsAtAll = writeTripsInterval > 0;
-		final boolean earlyIteration = event.getIteration() <= config.controller().getWritePlansInterval() ;
+		final boolean earlyIteration = event.getIteration()-config.controller().getFirstIteration()==1;
 
 		if (!writingTripsAtAll) {
 			return false;


### PR DESCRIPTION
A rather nasty bug, as trips and legs were written in every iteration.