### PR TITLE
chore: code cleanup in discrete_mode_choice contrib

### DIFF
--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/constraints/LinkAttributeConstraint.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/constraints/LinkAttributeConstraint.java
@@ -15,7 +15,7 @@ import org.matsim.contribs.discrete_mode_choice.model.trip_based.candidates.Trip
 /**
  * This constraint forbids or allows a certain mode depending on whether a
  * certain link attribute is available for the origin and/or destination.
- * 
+ *
  * @author sebhoerl
  */
 public class LinkAttributeConstraint implements TripConstraint {
@@ -26,7 +26,7 @@ public class LinkAttributeConstraint implements TripConstraint {
 	private final String linkAttributeValue;
 
 	public enum Requirement {
-		ORIGIN, DESTINATION, BOTH, ANY, NONE;
+		ORIGIN, DESTINATION, BOTH, ANY, NONE
 	}
 
 	private final Requirement requirement;
@@ -57,18 +57,13 @@ public class LinkAttributeConstraint implements TripConstraint {
 			boolean originValid = checkAttribute(trip.getOriginActivity().getLinkId());
 			boolean destinationValid = checkAttribute(trip.getDestinationActivity().getLinkId());
 
-			switch (requirement) {
-			case ANY:
-				return originValid || destinationValid;
-			case BOTH:
-				return originValid && destinationValid;
-			case DESTINATION:
-				return destinationValid;
-			case ORIGIN:
-				return originValid;
-			case NONE:
-				return !(originValid || destinationValid);
-			}
+			return switch (requirement) {
+				case ANY -> originValid || destinationValid;
+				case BOTH -> originValid && destinationValid;
+				case DESTINATION -> destinationValid;
+				case ORIGIN -> originValid;
+				case NONE -> !(originValid || destinationValid);
+			};
 		}
 
 		return true;
@@ -97,7 +92,7 @@ public class LinkAttributeConstraint implements TripConstraint {
 		}
 
 		@Override
-		public TripConstraint createConstraint(Person person, List<DiscreteModeChoiceTrip> trips,
+		public LinkAttributeConstraint createConstraint(Person person, List<DiscreteModeChoiceTrip> trips,
 				Collection<String> availableModes) {
 			return new LinkAttributeConstraint(network, restrictedModes, linkAttributeName, linkAttributeValue,
 					requirement);

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/constraints/ShapeFileConstraint.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/constraints/ShapeFileConstraint.java
@@ -32,7 +32,7 @@ import org.matsim.contribs.discrete_mode_choice.model.trip_based.candidates.Trip
  * This constraint decides whether a mode is allowed for a certain trip by
  * checking whether the origin and/or destination location are within a feature
  * of a given shape file.
- * 
+ *
  * @author sebhoerl
  */
 public class ShapeFileConstraint implements TripConstraint {
@@ -43,7 +43,7 @@ public class ShapeFileConstraint implements TripConstraint {
 	private final Set<Geometry> shapes;
 
 	public enum Requirement {
-		ORIGIN, DESTINATION, BOTH, ANY, NONE;
+		ORIGIN, DESTINATION, BOTH, ANY, NONE
 	}
 
 	private final Requirement requirement;
@@ -77,18 +77,13 @@ public class ShapeFileConstraint implements TripConstraint {
 			boolean originValid = checkLinkId(trip.getOriginActivity().getLinkId());
 			boolean destinationValid = checkLinkId(trip.getDestinationActivity().getLinkId());
 
-			switch (requirement) {
-			case ANY:
-				return originValid || destinationValid;
-			case BOTH:
-				return originValid && destinationValid;
-			case DESTINATION:
-				return destinationValid;
-			case ORIGIN:
-				return originValid;
-			case NONE:
-				return !(originValid || destinationValid);
-			}
+			return switch (requirement) {
+				case ANY -> originValid || destinationValid;
+				case BOTH -> originValid && destinationValid;
+				case DESTINATION -> destinationValid;
+				case ORIGIN -> originValid;
+				case NONE -> !(originValid || destinationValid);
+			};
 		}
 
 		return true;
@@ -131,7 +126,7 @@ public class ShapeFileConstraint implements TripConstraint {
 		}
 
 		@Override
-		public TripConstraint createConstraint(Person person, List<DiscreteModeChoiceTrip> trips,
+		public ShapeFileConstraint createConstraint(Person person, List<DiscreteModeChoiceTrip> trips,
 				Collection<String> availableModes) {
 			return new ShapeFileConstraint(network, restrictedModes, requirement, shapes);
 		}

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/constraints/SubtourModeConstraint.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/constraints/SubtourModeConstraint.java
@@ -11,7 +11,6 @@ import org.matsim.contribs.discrete_mode_choice.components.utils.IndexUtils;
 import org.matsim.contribs.discrete_mode_choice.components.utils.LocationUtils;
 import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceTrip;
 import org.matsim.contribs.discrete_mode_choice.model.constraints.AbstractTourConstraint;
-import org.matsim.contribs.discrete_mode_choice.model.tour_based.TourConstraint;
 import org.matsim.contribs.discrete_mode_choice.model.tour_based.TourConstraintFactory;
 
 /**
@@ -23,7 +22,7 @@ import org.matsim.contribs.discrete_mode_choice.model.tour_based.TourConstraintF
  * covered by one and a single mode. If singleLegProbability was > 0.0, then
  * only the "chain based" modes should be set as constrained modes. In that case
  * only those tours cannot be interrupted by other modes.
- * 
+ *
  * @author sebhoerl
  *
  */
@@ -82,7 +81,7 @@ public class SubtourModeConstraint extends AbstractTourConstraint {
 		}
 
 		@Override
-		public TourConstraint createConstraint(Person person, List<DiscreteModeChoiceTrip> trips,
+		public SubtourModeConstraint createConstraint(Person person, List<DiscreteModeChoiceTrip> trips,
 				Collection<String> availableModes) {
 			List<Id<? extends BasicLocation>> originLocations = new ArrayList<>(trips.size());
 			List<Id<? extends BasicLocation>> destinationLocations = new ArrayList<>(trips.size());

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/constraints/TransitWalkConstraint.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/constraints/TransitWalkConstraint.java
@@ -9,7 +9,6 @@ import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceTrip;
 import org.matsim.contribs.discrete_mode_choice.model.constraints.AbstractTripConstraint;
-import org.matsim.contribs.discrete_mode_choice.model.trip_based.TripConstraint;
 import org.matsim.contribs.discrete_mode_choice.model.trip_based.TripConstraintFactory;
 import org.matsim.contribs.discrete_mode_choice.model.trip_based.candidates.RoutedTripCandidate;
 import org.matsim.contribs.discrete_mode_choice.model.trip_based.candidates.TripCandidate;
@@ -18,7 +17,7 @@ import org.matsim.pt.routes.TransitPassengerRoute;
 /**
  * This contraint forbids "pt" trips that only consist of walk legs, i.e. there
  * is no "pt" leg included.
- * 
+ *
  * @author sebhoerl
  */
 public class TransitWalkConstraint extends AbstractTripConstraint {
@@ -49,7 +48,7 @@ public class TransitWalkConstraint extends AbstractTripConstraint {
 
 	static public class Factory implements TripConstraintFactory {
 		@Override
-		public TripConstraint createConstraint(Person person, List<DiscreteModeChoiceTrip> trips,
+		public TransitWalkConstraint createConstraint(Person person, List<DiscreteModeChoiceTrip> trips,
 				Collection<String> availableModes) {
 			return new TransitWalkConstraint();
 		}

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/constraints/VehicleTourConstraint.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/constraints/VehicleTourConstraint.java
@@ -146,7 +146,7 @@ public class VehicleTourConstraint implements TourConstraint {
 		}
 
 		@Override
-		public TourConstraint createConstraint(Person person, List<DiscreteModeChoiceTrip> planTrips,
+		public VehicleTourConstraint createConstraint(Person person, List<DiscreteModeChoiceTrip> planTrips,
 											   Collection<String> availableModes) {
 			return new VehicleTourConstraint(restrictedModes, homeFinder.getHomeLocationId(planTrips));
 		}

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/constraints/VehicleTripConstraint.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/components/constraints/VehicleTripConstraint.java
@@ -20,12 +20,12 @@ import org.matsim.contribs.discrete_mode_choice.model.trip_based.candidates.Trip
  * level. Here the case is more difficult than on the tour-level and not all of
  * the dynamic can be enforced. Have a look at the code for the exact
  * implementation.
- * 
+ *
  * Attention! This is not tested and may be faulty. Feel free to add some test
  * cases to see if this actually does what it is supposed to do.
- * 
+ *
  * TODO: Revise this and check if it makes sense!
- * 
+ *
  * This class ensures that the vehicle needs to be returned home if it was taken
  * in the first place. However, it must be noted that if the person start a tour
  * with a certain vehicle it needs to bring it back at the end of the tour. This
@@ -34,7 +34,7 @@ import org.matsim.contribs.discrete_mode_choice.model.trip_based.candidates.Trip
  * take a car back home. The agent will be forced to being the car back home in
  * the first tour. This was done in order to have easier implementation. If this
  * has an effect on the results is not clear.
- * 
+ *
  * @author Milos Balac <milos.balac@ivt.baug.ethz.ch>
  * @author Sebastian Hörl <sebastian.hoerl@ivt.baug.ethz.ch>
  */
@@ -127,8 +127,8 @@ public class VehicleTripConstraint implements TripConstraint {
 	}
 
 	static public class Factory implements TripConstraintFactory {
-		private Collection<String> restrictedModes;
-		private boolean isAdvanced;
+		private final Collection<String> restrictedModes;
+		private final boolean isAdvanced;
 		private final HomeFinder homeFinder;
 
 		public Factory(Collection<String> restrictedModes, boolean isAdvanced, HomeFinder homeFinder) {
@@ -138,7 +138,7 @@ public class VehicleTripConstraint implements TripConstraint {
 		}
 
 		@Override
-		public TripConstraint createConstraint(Person person, List<DiscreteModeChoiceTrip> planTrips,
+		public VehicleTripConstraint createConstraint(Person person, List<DiscreteModeChoiceTrip> planTrips,
 				Collection<String> availableModes) {
 			logger.warn("VehicleTripConstraint is not tested. Use at own risk!");
 

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/constraints/CompositeTourConstraintFactory.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/constraints/CompositeTourConstraintFactory.java
@@ -7,12 +7,11 @@ import java.util.stream.Collectors;
 
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceTrip;
-import org.matsim.contribs.discrete_mode_choice.model.tour_based.TourConstraint;
 import org.matsim.contribs.discrete_mode_choice.model.tour_based.TourConstraintFactory;
 
 /**
  * Creates a CompositeTourConstraint.
- * 
+ *
  * @author sebhoerl
  */
 public class CompositeTourConstraintFactory implements TourConstraintFactory {
@@ -30,7 +29,7 @@ public class CompositeTourConstraintFactory implements TourConstraintFactory {
 	}
 
 	@Override
-	public TourConstraint createConstraint(Person person, List<DiscreteModeChoiceTrip> planTrips,
+	public CompositeTourConstraint createConstraint(Person person, List<DiscreteModeChoiceTrip> planTrips,
 			Collection<String> availableModes) {
 		return new CompositeTourConstraint(factories.stream()
 				.map(f -> f.createConstraint(person, planTrips, availableModes)).collect(Collectors.toList()));

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/constraints/CompositeTripConstraintFactory.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/constraints/CompositeTripConstraintFactory.java
@@ -12,7 +12,7 @@ import org.matsim.contribs.discrete_mode_choice.model.trip_based.TripConstraintF
 
 /**
  * Creates a CompositeTripConstraint.
- * 
+ *
  * @author sebhoerl
  */
 public class CompositeTripConstraintFactory implements TripConstraintFactory {
@@ -30,7 +30,7 @@ public class CompositeTripConstraintFactory implements TripConstraintFactory {
 	}
 
 	@Override
-	public TripConstraint createConstraint(Person person, List<DiscreteModeChoiceTrip> planTrips,
+	public CompositeTripConstraint createConstraint(Person person, List<DiscreteModeChoiceTrip> planTrips,
 			Collection<String> availableModes) {
 		List<TripConstraint> constraints = new ArrayList<>(factories.size());
 		factories.forEach(f -> constraints.add(f.createConstraint(person, planTrips, availableModes)));

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/constraints/TourFromTripConstraintFactory.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/constraints/TourFromTripConstraintFactory.java
@@ -5,14 +5,13 @@ import java.util.List;
 
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceTrip;
-import org.matsim.contribs.discrete_mode_choice.model.tour_based.TourConstraint;
 import org.matsim.contribs.discrete_mode_choice.model.tour_based.TourConstraintFactory;
 import org.matsim.contribs.discrete_mode_choice.model.trip_based.TripConstraint;
 import org.matsim.contribs.discrete_mode_choice.model.trip_based.TripConstraintFactory;
 
 /**
  * Creates a TourFromTripConstraint.
- * 
+ *
  * @author sebhoerl
  */
 public class TourFromTripConstraintFactory implements TourConstraintFactory {
@@ -23,7 +22,7 @@ public class TourFromTripConstraintFactory implements TourConstraintFactory {
 	}
 
 	@Override
-	public TourConstraint createConstraint(Person person, List<DiscreteModeChoiceTrip> planTrips,
+	public TourFromTripConstraint createConstraint(Person person, List<DiscreteModeChoiceTrip> planTrips,
 			Collection<String> availableModes) {
 		TripConstraint constraint = factory.createConstraint(person, planTrips, availableModes);
 		return new TourFromTripConstraint(constraint);

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/mode_chain/DefaultModeChainGenerator.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/mode_chain/DefaultModeChainGenerator.java
@@ -11,7 +11,7 @@ import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceTrip;
 /**
  * This is the default mode chain generator. It can be used right away or as a
  * template for more specialized implementatons.
- * 
+ *
  * It works as follows: Since the available modes are known and the number of
  * trips in the requested mode chain it is possible to calculate the total
  * amount of chains that can be created: modes ^ trips. Therefore, each distinct
@@ -19,7 +19,7 @@ import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceTrip;
  * increased every time a new mode chain is requested and a new chain
  * corresponding to that integer is created. This way this generator has a very
  * low memory footprint.
- * 
+ *
  * @author sebhoerl
  *
  */
@@ -71,7 +71,7 @@ public class DefaultModeChainGenerator implements ModeChainGenerator {
 
 	static public class Factory implements ModeChainGeneratorFactory {
 		@Override
-		public ModeChainGenerator createModeChainGenerator(Collection<String> modes, Person person,
+		public DefaultModeChainGenerator createModeChainGenerator(Collection<String> modes, Person person,
 				List<DiscreteModeChoiceTrip> trips) {
 			return new DefaultModeChainGenerator(modes, trips.size());
 		}

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/nested/NestedLogitSelector.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/nested/NestedLogitSelector.java
@@ -51,7 +51,7 @@ public class NestedLogitSelector implements UtilitySelector {
 	@Override
 	public Optional<UtilityCandidate> select(Random random) {
 		// I) If not candidates are available, give back nothing
-		if (candidates.size() == 0) {
+		if (candidates.isEmpty()) {
 			return Optional.empty();
 		}
 
@@ -73,8 +73,8 @@ public class NestedLogitSelector implements UtilitySelector {
 		List<Double> cumulativeDensity = new ArrayList<>(density.size());
 		double totalDensity = 0.0;
 
-		for (int i = 0; i < density.size(); i++) {
-			totalDensity += density.get(i);
+		for (Double obs : density) {
+			totalDensity += obs;
 			cumulativeDensity.add(totalDensity);
 		}
 
@@ -97,7 +97,7 @@ public class NestedLogitSelector implements UtilitySelector {
 		}
 
 		@Override
-		public UtilitySelector createUtilitySelector() {
+		public NestedLogitSelector createUtilitySelector() {
 			return new NestedLogitSelector(structure, minimumUtility, maximumUtility);
 		}
 	}

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/MultinomialLogitSelector.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/MultinomialLogitSelector.java
@@ -5,7 +5,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
-import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -14,13 +13,13 @@ import org.apache.logging.log4j.Logger;
  * The MultinomialLogitSelector collects a set of candidates with given
  * utilities and then selects on according to the multinomial logit model. For
  * each candidate (i) a utility is calculated as:
- * 
+ *
  * <code>P(i) = exp( Ui ) / Sum( U1 + U2 + ... + Un )</code>
- * 
+ *
  * For large utilities the exponential terms can exceed the value range of a
  * double. Therefore, the selector has a cutoff value, which is a maximum of
  * 700.0 by default. If this value is reached a warning will be shown.
- * 
+ *
  * @author sebhoerl
  */
 public class MultinomialLogitSelector implements UtilitySelector {
@@ -50,7 +49,7 @@ public class MultinomialLogitSelector implements UtilitySelector {
 	@Override
 	public Optional<UtilityCandidate> select(Random random) {
 		// I) If not candidates are available, give back nothing
-		if (candidates.size() == 0) {
+		if (candidates.isEmpty()) {
 			return Optional.empty();
 		}
 
@@ -60,9 +59,9 @@ public class MultinomialLogitSelector implements UtilitySelector {
 		if (considerMinimumUtility) {
 			filteredCandidates = candidates.stream() //
 					.filter(c -> c.getUtility() > minimumUtility) //
-					.collect(Collectors.toList());
+					.toList();
 
-			if (filteredCandidates.size() == 0) {
+			if (filteredCandidates.isEmpty()) {
 				logger.warn(String.format(
 						"Encountered choice where all utilities were smaller than %f (minimum configured utility)",
 						minimumUtility));
@@ -91,8 +90,8 @@ public class MultinomialLogitSelector implements UtilitySelector {
 		List<Double> cumulativeDensity = new ArrayList<>(density.size());
 		double totalDensity = 0.0;
 
-		for (int i = 0; i < density.size(); i++) {
-			totalDensity += density.get(i);
+		for (Double obs : density) {
+			totalDensity += obs;
 			cumulativeDensity.add(totalDensity);
 		}
 
@@ -115,7 +114,7 @@ public class MultinomialLogitSelector implements UtilitySelector {
 		}
 
 		@Override
-		public UtilitySelector createUtilitySelector() {
+		public MultinomialLogitSelector createUtilitySelector() {
 			return new MultinomialLogitSelector(maximumUtility, minimumUtility, considerMinimumUtility);
 		}
 	}

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/RandomSelector.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/RandomSelector.java
@@ -8,7 +8,7 @@ import java.util.Random;
 /**
  * The RandomSelector does what the name says: It collects a set of candidates
  * and then selects one randomly.
- * 
+ *
  * @author sebhoerl
  */
 public class RandomSelector implements UtilitySelector {
@@ -21,7 +21,7 @@ public class RandomSelector implements UtilitySelector {
 
 	@Override
 	public Optional<UtilityCandidate> select(Random random) {
-		if (candidates.size() == 0) {
+		if (candidates.isEmpty()) {
 			return Optional.empty();
 		}
 
@@ -30,7 +30,7 @@ public class RandomSelector implements UtilitySelector {
 
 	static public class Factory implements UtilitySelectorFactory {
 		@Override
-		public UtilitySelector createUtilitySelector() {
+		public RandomSelector createUtilitySelector() {
 			return new RandomSelector();
 		}
 	}


### PR DESCRIPTION
This PR proposes some code cleanups in the discrete_mode_choice contrib. Mainly, the signatures of methods in Factory classes were modified to declare the specific implementation as a return type rather than the generic interface.