### PR TITLE
chore: reduce logging of config, eventsmanager, injector [3801]

### DIFF
--- a/matsim/src/main/java/org/matsim/core/controler/ControllerUtils.java
+++ b/matsim/src/main/java/org/matsim/core/controler/ControllerUtils.java
@@ -98,7 +98,7 @@ public final class ControllerUtils{
 	    String newline = System.lineSeparator();// use native line endings for logfile
 	    StringWriter writer = new StringWriter();
 	    new ConfigWriter(config).writeStream(new PrintWriter(writer), newline);
-	    log.info(newline + newline + writer.getBuffer().toString());
+	    log.debug(newline + newline + writer.getBuffer().toString());
 	    log.info("Complete config dump done.");
 	    log.info("Checking consistency of config...");
 	    config.checkConsistency();

--- a/matsim/src/main/java/org/matsim/core/controler/Injector.java
+++ b/matsim/src/main/java/org/matsim/core/controler/Injector.java
@@ -77,7 +77,7 @@ public final class Injector {
 	}
 
 	public static void printInjector(com.google.inject.Injector injector, Logger log) {
-		Level level = Level.INFO ;
+		Level level = Level.DEBUG ;
 		log.log(level,"=== printInjector start ===") ;
 		for (Map.Entry<Key<?>, Binding<?>> entry : injector.getBindings().entrySet()) {
 			if ( entry.getKey().toString().contains("type=org.matsim") ) {

--- a/matsim/src/main/java/org/matsim/core/events/EventsManagerImpl.java
+++ b/matsim/src/main/java/org/matsim/core/events/EventsManagerImpl.java
@@ -135,13 +135,13 @@ public final class EventsManagerImpl implements EventsManager {
 	public void addHandler (final EventHandler handler) {
 		Set<Class<?>> addedHandlers = new HashSet<>();
 		Class<?> test = handler.getClass();
-		log.info("adding Event-Handler: " + test.getName());
+		log.debug("adding Event-Handler: " + test.getName());
 		do {
 			for (Class<?> theInterface : test.getInterfaces()) {
 				if (EventHandler.class.isAssignableFrom(theInterface)) {
 					Class<? extends EventHandler> eventHandlerInterface = (Class<? extends EventHandler>)theInterface;
 					if (!addedHandlers.contains(theInterface)) {
-						log.info("  " + theInterface.getName());
+						log.debug("  " + theInterface.getName());
 						addHandlerInterfaces(handler, eventHandlerInterface);
 						addedHandlers.add(theInterface);
 					}
@@ -151,7 +151,7 @@ public final class EventsManagerImpl implements EventsManager {
 		} while ((EventHandler.class.isAssignableFrom(test)));
 
 		this.cacheHandlers.clear();
-		log.info("");
+		log.debug("");
 	}
 
 	@Override

--- a/matsim/src/main/java/org/matsim/core/events/EventsManagerImpl.java
+++ b/matsim/src/main/java/org/matsim/core/events/EventsManagerImpl.java
@@ -130,7 +130,6 @@ public final class EventsManagerImpl implements EventsManager {
 		}
 	}
 
-
 	@Override
 	public void addHandler (final EventHandler handler) {
 		Set<Class<?>> addedHandlers = new HashSet<>();


### PR DESCRIPTION
This PR makes it so that the config file and the exhaustive logging of every individual event handler is only logged for debug level DEBUG or higher. This can be changed manually via environment variable and manually by the programmer.
Relates to: #3801 