### PR TITLE
fix(core): correctly list registered params when adding unknown param

### DIFF
--- a/matsim/src/main/java/org/matsim/core/config/ReflectiveConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/ReflectiveConfigGroup.java
@@ -305,7 +305,7 @@ public abstract class ReflectiveConfigGroup extends ConfigGroup implements Matsi
 	public void handleAddUnknownParam(final String paramName, final String value) {
 		Preconditions.checkArgument(this.storeUnknownParameters, "Module %s of type %s doesn't accept unknown parameters."
 				+ " Parameter %s is not part of the valid parameters: %s", getName(), getClass().getName(), paramName,
-			this.setters.keySet());
+			this.registeredParams);
 
 		log.warn(
 			"Unknown parameter {} for group {}. Here are the valid parameter names: {}. Only the string value will be remembered.",


### PR DESCRIPTION
Previously, the annotation-based parameters were not listed in the error message.