### PR TITLE
Improve rejection handling with drt estimator

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/estimator/DrtEstimator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/estimator/DrtEstimator.java
@@ -10,7 +10,10 @@ import org.matsim.utils.objectattributes.attributable.Attributable;
  * Interface to estimate a DRT service's detour, waiting time and costs.
  */
 public interface DrtEstimator extends ControlerListener {
-
+	public static final String EST_RIDE_TIME = "est_ride_time";
+	public static final String EST_RIDE_DISTANCE = "est_ride_distance";
+	public static final String EST_WAIT_TIME = "est_wait_time";
+	public static final String EST_REJECTION_RATE = "est_rejection_rate";
 	/**
 	 * Provide an estimate for a drt route with specific pickup and dropoff point.
 	 *
@@ -38,9 +41,10 @@ public interface DrtEstimator extends ControlerListener {
 	 * Write estimate information into the leg attributes.
 	 */
 	static void setEstimateAttributes(Leg leg, Estimate estimate) {
-		leg.getAttributes().putAttribute("est_ride_time", estimate.rideTime());
-		leg.getAttributes().putAttribute("est_ride_distance", estimate.rideDistance());
-		leg.getAttributes().putAttribute("est_wait_time", estimate.waitingTime());
+		leg.getAttributes().putAttribute(EST_RIDE_TIME, estimate.rideTime());
+		leg.getAttributes().putAttribute(EST_RIDE_DISTANCE, estimate.rideDistance());
+		leg.getAttributes().putAttribute(EST_WAIT_TIME, estimate.waitingTime());
+		leg.getAttributes().putAttribute(EST_REJECTION_RATE, estimate.rejectionRate());
 	}
 
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/estimator/DrtEstimator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/estimator/DrtEstimator.java
@@ -10,10 +10,10 @@ import org.matsim.utils.objectattributes.attributable.Attributable;
  * Interface to estimate a DRT service's detour, waiting time and costs.
  */
 public interface DrtEstimator extends ControlerListener {
-	public static final String EST_RIDE_TIME = "est_ride_time";
-	public static final String EST_RIDE_DISTANCE = "est_ride_distance";
-	public static final String EST_WAIT_TIME = "est_wait_time";
-	public static final String EST_REJECTION_RATE = "est_rejection_rate";
+	String EST_RIDE_TIME = "est_ride_time";
+	String EST_RIDE_DISTANCE = "est_ride_distance";
+	String EST_WAIT_TIME = "est_wait_time";
+	String EST_REJECTION_RATE = "est_rejection_rate";
 	/**
 	 * Provide an estimate for a drt route with specific pickup and dropoff point.
 	 *

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/TeleportingEstimationPassengerEngine.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/passenger/TeleportingEstimationPassengerEngine.java
@@ -21,12 +21,9 @@
 package org.matsim.contrib.dvrp.passenger;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Verify;
 import it.unimi.dsi.fastutil.doubles.DoubleObjectPair;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
@@ -41,7 +38,6 @@ import org.matsim.core.mobsim.framework.*;
 import org.matsim.core.mobsim.qsim.DefaultTeleportationEngine;
 import org.matsim.core.mobsim.qsim.InternalInterface;
 import org.matsim.core.mobsim.qsim.TeleportationEngine;
-import org.matsim.core.mobsim.qsim.agents.WithinDayAgentUtils;
 import org.matsim.core.modal.ModalProviders;
 import org.matsim.utils.objectattributes.attributable.Attributable;
 import org.matsim.vis.snapshotwriters.AgentSnapshotInfo;
@@ -66,6 +62,8 @@ public class TeleportingEstimationPassengerEngine implements PassengerEngine, Vi
 	private final InternalPassengerHandling internalPassengerHandling;
 	private final TeleportationEngine teleportationEngine;
 
+	private final Random random = new Random(1);
+
 	/**
 	 * Request currently waiting for pickup.
 	 */
@@ -76,20 +74,20 @@ public class TeleportingEstimationPassengerEngine implements PassengerEngine, Vi
 	 * Request currently onboard a vehicle and waiting for drop-off.
 	 */
 	private final Queue<DoubleObjectPair<PassengerRequest>> ridingRequests = new PriorityQueue<>(
-			Comparator.comparingDouble(DoubleObjectPair::keyDouble));
+		Comparator.comparingDouble(DoubleObjectPair::keyDouble));
 
 	private InternalInterface internalInterface;
 
 	TeleportingEstimationPassengerEngine(String mode, EventsManager eventsManager, MobsimTimer mobsimTimer,
-                                         PassengerRequestCreator requestCreator,
-                                         Network network, PassengerRequestValidator requestValidator, Scenario scenario) {
+										 PassengerRequestCreator requestCreator,
+										 Network network, PassengerRequestValidator requestValidator, Scenario scenario) {
 		this(mode, eventsManager, mobsimTimer, requestCreator, network, requestValidator,
-				new DefaultTeleportationEngine(scenario, eventsManager, false));
+			new DefaultTeleportationEngine(scenario, eventsManager, false));
 	}
 
 	TeleportingEstimationPassengerEngine(String mode, EventsManager eventsManager, MobsimTimer mobsimTimer,
-                                         PassengerRequestCreator requestCreator,
-                                         Network network, PassengerRequestValidator requestValidator, TeleportationEngine teleportationEngine) {
+										 PassengerRequestCreator requestCreator,
+										 Network network, PassengerRequestValidator requestValidator, TeleportationEngine teleportationEngine) {
 		this.mode = mode;
 		this.eventsManager = eventsManager;
 		this.mobsimTimer = mobsimTimer;
@@ -120,8 +118,7 @@ public class TeleportingEstimationPassengerEngine implements PassengerEngine, Vi
 		while (!waitingRequests.isEmpty() && waitingRequests.peek().keyDouble() <= time) {
 			PassengerRequest request = waitingRequests.poll().value();
 			for (Id<Person> passenger : request.getPassengerIds()) {
-				//TODO: check whether to use first passenger Id
-				eventsManager.processEvent(new PassengerPickedUpEvent(time, mode, request.getId(), request.getPassengerIds().get(0), null));
+				eventsManager.processEvent(new PassengerPickedUpEvent(time, mode, request.getId(), passenger, null));
 			}
 		}
 
@@ -148,17 +145,18 @@ public class TeleportingEstimationPassengerEngine implements PassengerEngine, Vi
 			return false;
 		}
 
-		MobsimPassengerAgent passenger = (MobsimPassengerAgent)agent;
+		MobsimPassengerAgent passenger = (MobsimPassengerAgent) agent;
 		Id<Link> toLinkId = passenger.getDestinationLinkId();
 		Leg leg = (Leg) ((PlanAgent) passenger).getCurrentPlanElement();
 		Route route = leg.getRoute();
 		PassengerRequest request = requestCreator.createRequest(internalPassengerHandling.createRequestId(),
-				List.of(passenger.getId()), List.of(route), getLink(fromLinkId), getLink(toLinkId), now, now);
+			List.of(passenger.getId()), List.of(route), getLink(fromLinkId), getLink(toLinkId), now, now);
 
 		eventsManager.processEvent(new PassengerWaitingEvent(now, mode, request.getId(), request.getPassengerIds()));
 
-		if (internalPassengerHandling.validateRequest(request, requestValidator, now)) {
+		double probabilityOfRejection = getEstimatedRejectionRate(leg);
 
+		if (internalPassengerHandling.validateRequest(request, requestValidator, now) && isRequestAccepted(probabilityOfRejection, request, now)) {
 			double waitTime = getEstimatedWaitTime(leg);
 			double travelTime = waitTime + getEstimatedRideTime(leg);
 
@@ -174,7 +172,6 @@ public class TeleportingEstimationPassengerEngine implements PassengerEngine, Vi
 
 			waitingRequests.add(DoubleObjectPair.of(now + waitTime, request));
 			ridingRequests.add(DoubleObjectPair.of(now + travelTime, request));
-
 		} else {
 			//not much else can be done for immediate requests
 			//set the passenger agent to abort - the event will be thrown by the QSim
@@ -187,19 +184,19 @@ public class TeleportingEstimationPassengerEngine implements PassengerEngine, Vi
 
 	private Link getLink(Id<Link> linkId) {
 		return Preconditions.checkNotNull(network.getLinks().get(linkId),
-				"Link id=%s does not exist in network for mode %s. Agent departs from a link that does not belong to that network?",
-				linkId, mode);
+			"Link id=%s does not exist in network for mode %s. Agent departs from a link that does not belong to that network?",
+			linkId, mode);
 	}
 
 	@Override
 	public boolean notifyWaitForPassengers(PassengerPickupActivity pickupActivity, MobsimDriverAgent driver,
-			Id<Request> requestId) {
+										   Id<Request> requestId) {
 		throw new UnsupportedOperationException("No notifying when teleporting");
 	}
 
 	@Override
 	public boolean tryPickUpPassengers(PassengerPickupActivity pickupActivity, MobsimDriverAgent driver,
-			Id<Request> requestId, double now) {
+									   Id<Request> requestId, double now) {
 		throw new UnsupportedOperationException("No picking-up when teleporting");
 	}
 
@@ -227,23 +224,47 @@ public class TeleportingEstimationPassengerEngine implements PassengerEngine, Vi
 			@Override
 			public TeleportingEstimationPassengerEngine get() {
 				return new TeleportingEstimationPassengerEngine(getMode(), eventsManager, mobsimTimer,
-						getModalInstance(PassengerRequestCreator.class),
-						getModalInstance(Network.class),
-						getModalInstance(PassengerRequestValidator.class), scenario);
+					getModalInstance(PassengerRequestCreator.class),
+					getModalInstance(Network.class),
+					getModalInstance(PassengerRequestValidator.class), scenario);
 			}
 		};
 	}
 
 	static double getEstimatedRideTime(Attributable element) {
 		return (double) element.getAttributes().getAttribute("est_ride_time");
+		// Chengqi: there is a public static final String in the DRT contrib for est_ride_time. But it cannot be accessed here...
 	}
 
-	static double getEstimatedRideDistance(Attributable element){
+	static double getEstimatedRideDistance(Attributable element) {
 		return (double) element.getAttributes().getAttribute("est_ride_distance");
 	}
 
-	static double getEstimatedWaitTime(Attributable element){
-		return  (double) element.getAttributes().getAttribute("est_wait_time");
+	static double getEstimatedWaitTime(Attributable element) {
+		return (double) element.getAttributes().getAttribute("est_wait_time");
+	}
+
+	static double getEstimatedRejectionRate(Attributable element) {
+		return (double) element.getAttributes().getAttribute("est_rejection_rate");
+	}
+
+	/**
+	 * Simulate if a valid request will be accepted or not.
+	 *
+	 * @param probabilityOfRejection this information is read from the attribute est_rejection_rate in the leg, which is written by the
+	 *                               DRT estimator.
+	 * @param request                Passenger request
+	 * @param now                    time of the day
+	 * @return true if request is to be accepted, false otherwise.
+	 */
+	private boolean isRequestAccepted(double probabilityOfRejection, PassengerRequest request, double now) {
+		if (random.nextDouble() < probabilityOfRejection) {
+			eventsManager.processEvent(
+				new PassengerRequestRejectedEvent(now, mode, request.getId(), request.getPassengerIds(), "This passenger is rejected by " +
+					"chance, because the probability of rejection is greater than 0"));
+			return false;
+		}
+		return true;
 	}
 
 }


### PR DESCRIPTION
I just noticed that the rejection handling for DRT estimator is not complete. And now it is completed. 

Can you please briefly check about that? Thanks! 

Besides, it seems that it is not possible to use the public static String from another contrib. For example, I define the term 
public static final String EST_RIDE_TIME = "est_ride_time" in the drt-contrib. But I cannot use it in the dvrp-contrib. 
Is there a solution to that? 