### PR TITLE
chore: use TimeInterpretation for determination of leg travel time

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/StrategicChargingModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/StrategicChargingModule.java
@@ -117,9 +117,9 @@ public class StrategicChargingModule extends AbstractModule {
 	@Provides
 	@Singleton
 	ChargingPlanScoring provideChargingPlanScoring(EventsManager eventsManager, Population population, Network network,
-			ElectricFleetSpecification fleet, ChargingCostCalculator costCalculator,
+			TimeInterpretation timeInterpretation, ElectricFleetSpecification fleet, ChargingCostCalculator costCalculator,
 			StrategicChargingConfigGroup scConfig, WithinDayEvConfigGroup withinConfig, ScoringTracker tracker) {
-		return new ChargingPlanScoring(eventsManager, population, network, fleet, costCalculator, scConfig.getScoringParameters(),
+		return new ChargingPlanScoring(eventsManager, population, network, timeInterpretation, fleet, costCalculator, scConfig.getScoringParameters(),
 				withinConfig.getCarMode(), tracker);
 	}
 

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/replanning/innovator/RandomChargingPlanInnovator.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/replanning/innovator/RandomChargingPlanInnovator.java
@@ -137,7 +137,7 @@ public class RandomChargingPlanInnovator implements ChargingPlanInnovator {
 
 		// remove if too short
 		legBased.removeIf(candidate -> {
-			return candidate.leg().getTravelTime().seconds() < minimumEnrouteDriveTime;
+			return timeInterpretation.decideOnLegTravelTime(candidate.leg()).seconds() < minimumEnrouteDriveTime;
 		});
 
 		// reduce slots that are incompatible with the selected activity-based ones

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/scoring/ChargingPlanScoring.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/scoring/ChargingPlanScoring.java
@@ -86,13 +86,15 @@ public class ChargingPlanScoring implements IterationStartsListener, ScoringList
 	private final String chargingMode;
 
 	private final ScoringTracker tracker;
+	private final TimeInterpretation timeInterpretation;
 
 	public ChargingPlanScoring(EventsManager eventsManager, Population population, Network network,
-			ElectricFleetSpecification fleet, ChargingCostCalculator costCalculator,
+							   TimeInterpretation timeInterpretation, ElectricFleetSpecification fleet, ChargingCostCalculator costCalculator,
 			ChargingPlanScoringParameters parameters, String chargingMode, ScoringTracker tracker) {
 		this.eventsManager = eventsManager;
 		this.population = population;
 		this.network = network;
+		this.timeInterpretation = timeInterpretation;
 		this.fleet = fleet;
 		this.costCalculator = costCalculator;
 		this.parameters = parameters;
@@ -453,12 +455,7 @@ public class ChargingPlanScoring implements IterationStartsListener, ScoringList
 				// TODO: include detour of access and egress in ChargingPlanScoring !?
 				if (! leg.getMode().equals(chargingMode)) continue;
 
-				//would be better to use a TimeInterpretation object here, but we would need the MATSim config to instantiate it.
-				OptionalTime plannedLegTravelTime =  leg.getRoute().getTravelTime().or(leg.getTravelTime());
-				if (plannedLegTravelTime.isUndefined()){
-					throw new IllegalStateException("Leg " + leg + "  of person + " + person + " has no travel time.");
-				}
-				plannedTotalTravelTime.addAndGet(plannedLegTravelTime.seconds());
+				plannedTotalTravelTime.addAndGet(this.timeInterpretation.decideOnLegTravelTime(leg).seconds());
 				plannedTotalTravelDistance.addAndGet(-leg.getRoute().getDistance());
 			}
 


### PR DESCRIPTION
Use the central TimeInterpretation object when determining the travel time of a leg.
This ensures that 

1. the leg's route is queried in case that the travel time attribute of the leg itself is not set
2. the same logic is used as in other places/contribs

