### PR TITLE
chore: add messages to some assert statements

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/prepare/freight/optimization/DetermineAverageTruckLoad.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/freight/optimization/DetermineAverageTruckLoad.java
@@ -107,7 +107,7 @@ public class DetermineAverageTruckLoad implements MATSimAppCommand {
 				relevantNutsIds.add(nutsId);
 				Coord coord = new Coord(Double.parseDouble(record.get(5)), Double.parseDouble(record.get(6)));
 				Link link = NetworkUtils.getNearestLink(network, ct.transform(coord));
-				assert link != null;
+				assert link != null : "getNearestLink link to " + coord + " is null.";
 				cellToLinkIdMapping.put(cell, link.getId());
 			}
 		}
@@ -131,7 +131,7 @@ public class DetermineAverageTruckLoad implements MATSimAppCommand {
 					Coord coord = new Coord(Double.parseDouble(xString),
 						Double.parseDouble(yString)); // This coord is in EPSG:25832, which is same as the network coordinate
 					Link link = NetworkUtils.getNearestLink(network, coord);
-					assert link != null;
+					assert link != null : "link nearest to " + coord + " is null.";
 					double distance = CoordUtils.distancePointLinesegment
 						(link.getFromNode().getCoord(), link.getToNode().getCoord(), coord);
 					if (distance > 1000 || referenceCounts.containsKey(link.getId())) {

--- a/contribs/application/src/main/java/org/matsim/application/prepare/freight/optimization/PrepareCountingData.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/freight/optimization/PrepareCountingData.java
@@ -81,7 +81,7 @@ public class PrepareCountingData implements MATSimAppCommand {
 					Coord coord = crs.getTransformation().transform(originalCoord);
 
 					Link link = NetworkUtils.getNearestLink(network, coord);
-					assert link != null;
+					assert link != null : "link nearest to " + coord + " is null.";
 					double distance = CoordUtils.distancePointLinesegment
 						(link.getFromNode().getCoord(), link.getToNode().getCoord(), coord);
 

--- a/contribs/application/src/main/java/org/matsim/application/prepare/freight/tripGeneration/DefaultLocationCalculator.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/freight/tripGeneration/DefaultLocationCalculator.java
@@ -105,7 +105,7 @@ public class DefaultLocationCalculator implements FreightAgentGenerator.Location
 				CoordinateTransformation ct = new GeotoolsTransformation("EPSG:4326", "EPSG:25832");
 				Coord transformedCoord = ct.transform(backupCoord);
 				Link backupLink = NetworkUtils.getNearestLink(network, transformedCoord);
-				assert backupLink != null;
+				assert backupLink != null : "link closest to " + transformedCoord + "is null";
 				mapping.put(verkehrszelle, List.of(backupLink.getId()));
 			}
 		}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/VehicleDataEntryFactoryImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/VehicleDataEntryFactoryImpl.java
@@ -99,7 +99,7 @@ public class VehicleDataEntryFactoryImpl implements VehicleEntry.EntryFactory {
 
 		for (int i = stops.length - 1; i >= 0; i--) {
 			if(stopTasks.get(i) instanceof DrtCapacityChangeTask capacityChangeTask) {
-				assert outgoingOccupancy.isEmpty();
+				assert outgoingOccupancy.isEmpty() : "occupancy SHOULD be empty at this point.";
 				outgoingOccupancy = loadType.getEmptyLoad();
 				stops[i] = new Waypoint.Stop(capacityChangeTask, loadType);
 			} else {

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierTourStartEventCreator.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/events/CarrierTourStartEventCreator.java
@@ -74,7 +74,7 @@ import org.matsim.vehicles.Vehicle;
 	 * @return CarrierTourStartEvent
 	 */
 	private CarrierTourStartEvent createFreightTourStartsEvent(Id<Person> personId, Carrier carrier, ScheduledTour scheduledTour) {
-		assert endEventMap.containsKey(personId);
+		assert endEventMap.containsKey(personId) : "endEventMap does not contain personId: " + personId;
 		final var endEvent = endEventMap.get(personId);
 
 		assert personEntersVehicleEventMap.containsKey(personId);

--- a/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/search/ModeChoiceSearch.java
+++ b/contribs/informed-mode-choice/src/main/java/org/matsim/modechoice/search/ModeChoiceSearch.java
@@ -56,7 +56,7 @@ final class ModeChoiceSearch {
 	 */
 	public ModeIterator iter(String[] result) {
 
-		assert result.length == estimates.length;
+		assert result.length == estimates.length : String.format("result.length (%d) != estimates.length (%d)", result.length, estimates.length);
 
 		byte[] path = new byte[result.length];
 

--- a/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/GenerateSmallScaleCommercialTrafficDemand.java
+++ b/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/GenerateSmallScaleCommercialTrafficDemand.java
@@ -648,7 +648,7 @@ public class GenerateSmallScaleCommercialTrafficDemand implements MATSimAppComma
 
 						// use only types of the possibleTypes which are in the given types file
 						List<String> vehicleTypes = new ArrayList<>();
-						assert odMatrixEntry.possibleVehicleTypes != null;
+						assert odMatrixEntry.possibleVehicleTypes != null: "possibleVehicleTypes is null for odMatrixEntry:" + odMatrixEntry;
 
 						for (String possibleVehicleType : odMatrixEntry.possibleVehicleTypes) {
 							if (CarriersUtils.getOrAddCarrierVehicleTypes(scenario).getVehicleTypes().containsKey(

--- a/matsim/src/main/java/org/matsim/core/events/EventArray.java
+++ b/matsim/src/main/java/org/matsim/core/events/EventArray.java
@@ -33,8 +33,8 @@ public class EventArray {
 		return size;
 	}
 	public Event get(int index) {
-		assert index < size;
-		assert array[index] != null;
+		assert index < size : "Index " + index + " out of bounds, for array size " + size + ".";
+		assert array[index] != null : "Index " + index + " is null.";
 		return array[index];
 	}
 

--- a/matsim/src/main/java/org/matsim/core/events/EventsConverterXML.java
+++ b/matsim/src/main/java/org/matsim/core/events/EventsConverterXML.java
@@ -128,7 +128,7 @@ public final class EventsConverterXML extends MatsimXmlParser{
 					final Id<Link> linkId = Id.create(atts.getValue(LinkLeaveEvent.ATTRIBUTE_LINK), Link.class);
 					assert linkId != null;
 					vehicleId = driverToVeh.get(personId);
-					assert vehicleId != null;
+					assert vehicleId != null : "vehicleId is null for personId: " + personId;
 					this.events.processEvent(new LinkLeaveEvent(time, vehicleId, linkId));
 				} else {
 					// the event already contains the vehicle id and can be processed normally

--- a/matsim/src/main/java/org/matsim/core/scoring/EventsToLegs.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/EventsToLegs.java
@@ -260,7 +260,7 @@ public final class EventsToLegs
 				+ leg.getTravelTime().seconds() - leg.getDepartureTime().seconds();
 		leg.setTravelTime(travelTime);
 		List<Id<Link>> experiencedRoute = experiencedRoutes.get(event.getPersonId());
-		assert !experiencedRoute.isEmpty();
+		assert !experiencedRoute.isEmpty() : "Experienced route for personId: " + event.getPersonId() + " is empty.";
 		PendingTransitTravel pendingTransitTravel;
 		PendingVehicleTravel pendingVehicleTravel;
 		if (experiencedRoute.size() > 1) { // different links processed
@@ -282,26 +282,26 @@ public final class EventsToLegs
 			// i.e. experiencedRoute.size()==1 && pending transit travel (= person has entered a vehicle)
 
 			final LineAndRoute lineAndRoute = transitVehicle2currentRoute.get(pendingTransitTravel.vehicleId);
-			assert lineAndRoute != null;
+			assert lineAndRoute != null : "lineAndRoute for vehicle " + pendingTransitTravel.vehicleId + "is null";
 
 			final TransitStopFacility accessFacility = transitSchedule.getFacilities()
 					.get(pendingTransitTravel.accessStop);
-			assert accessFacility != null;
+			assert accessFacility != null : "accessFacility for " + pendingTransitTravel.accessStop + " is null.";
 
 			final TransitLine line = transitSchedule.getTransitLines().get(lineAndRoute.transitLineId);
-			assert line != null;
+			assert line != null : "Transit line for transitLineId " + lineAndRoute.transitLineId + " is null.";
 
 			final TransitRoute route = line.getRoutes().get(lineAndRoute.transitRouteId);
-			assert route != null;
+			assert route != null : "route for transitRouteId " + lineAndRoute.transitRouteId + " is null.";
 
 			final Id<TransitStopFacility> lastFacilityId = lineAndRoute.lastFacilityId;
 			if (lastFacilityId == null) {
 				LogManager.getLogger(this.getClass()).warn("breakpoint");
 			}
-			assert lastFacilityId != null;
+			assert lastFacilityId != null : "lastFacilityId for " + lineAndRoute + "is null";
 
 			final TransitStopFacility egressFacility = transitSchedule.getFacilities().get(lastFacilityId);
-			assert egressFacility != null;
+			assert egressFacility != null : "egressFacility for lastFacilityId " + lastFacilityId + " is null.";
 
 			DefaultTransitPassengerRoute passengerRoute = new DefaultTransitPassengerRoute(accessFacility, line, route, egressFacility);
 			passengerRoute.setBoardingTime(pendingTransitTravel.boardingTime);

--- a/matsim/src/main/resources/log4j2.xml
+++ b/matsim/src/main/resources/log4j2.xml
@@ -17,7 +17,16 @@
 	</Appenders>
 
 	<Loggers>
-		<Root level="info">
+		<!--
+		Here we set the log level from an environment variable called LOG_LEVEL, or defaults
+		to 'info' if not set.
+		You can set this locally by putting this into your ~/.bash_profile:
+		# macOS
+		export LOG_LEVEL='debug|info|warn';
+		# linux
+		set LOG_LEVEL='debug|info|warn';
+		-->
+		<Root level="${env:LOG_LEVEL:-info}">
 			<AppenderRef ref="stdout" />
 			<AppenderRef ref="stderr" />
 		</Root>


### PR DESCRIPTION
## What?
This PR attempts to add useful messages to some of the many assertions in the matsim codebase to aid in log-based debugging.

## Why?
The matsim codebase contains many assert statements which prevent unwanted behaviour, for many there is no explanatory message attached as to which invariant was violated. Often invariants are failed lookups (!= null asserts) and adding a little context about which id lead to the null may be useful. 

