### PR TITLE
feat: allow transit_walk or non_network_work teleportation params instead of walk teleportation params

### DIFF
--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/RaptorUtils.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/RaptorUtils.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Link;
@@ -34,6 +36,7 @@ import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.groups.ScoringConfigGroup;
 import org.matsim.core.config.groups.RoutingConfigGroup;
+import org.matsim.core.gbl.Gbl;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.population.routes.RouteUtils;
 import org.matsim.pt.router.TransitRouterConfig;
@@ -45,20 +48,37 @@ import ch.sbb.matsim.config.SwissRailRaptorConfigGroup;
  * @author mrieser / SBB
  */
 public final class RaptorUtils {
-
+    private static final Logger log = LogManager.getLogger( RaptorUtils.class );
 
     private RaptorUtils() {
     }
 
     public static RaptorStaticConfig createStaticConfig(Config config) {
-        RoutingConfigGroup pcrConfig = config.routing();
+        RoutingConfigGroup routingConfig = config.routing();
         SwissRailRaptorConfigGroup srrConfig = ConfigUtils.addOrGetModule(config, SwissRailRaptorConfigGroup.class);
 
         RaptorStaticConfig staticConfig = new RaptorStaticConfig();
 
 		staticConfig.setBeelineWalkConnectionDistance(config.transitRouter().getMaxBeelineWalkConnectionDistance());
-		RoutingConfigGroup.TeleportedModeParams walk = pcrConfig.getModeRoutingParams().get(TransportMode.walk );
-		staticConfig.setBeelineWalkSpeed(walk.getTeleportedModeSpeed() / walk.getBeelineDistanceFactor());
+//		RoutingConfigGroup.TeleportedModeParams walk = routingConfig.getModeRoutingParams().get(TransportMode.walk );
+
+        // the code below also exists in TransitRouterConfig.  kai, mar'25
+        RoutingConfigGroup.TeleportedModeParams params = routingConfig.getTeleportedModeParams().get( TransportMode.transit_walk );
+        if ( params==null ) {
+            params = routingConfig.getTeleportedModeParams().get( TransportMode.non_network_walk );
+        }
+        if ( params==null ) {
+            params = routingConfig.getTeleportedModeParams().get( TransportMode.walk) ;
+        }
+        if ( params==null ) {
+            log.error( "teleported mode params do not exist for " + TransportMode.transit_walk + ", " + TransportMode.non_network_walk + ", nor "
+                               + TransportMode.walk + ".  At least one of them needs to be defined for TransitRouterConfig.  Aborting ...");
+            // yyyy I do not know which of this is conceptually the correct one.  It should _not_ be walk since that may be routed on the network, see TransitRouterConfig.  kai, mar'25
+        }
+        Gbl.assertNotNull( params );
+        RoutingConfigGroup.TeleportedModeParams walk = params;
+
+        staticConfig.setBeelineWalkSpeed(walk.getTeleportedModeSpeed() / walk.getBeelineDistanceFactor());
 		staticConfig.setBeelineWalkDistanceFactor(walk.getBeelineDistanceFactor());
 		staticConfig.setTransferWalkMargin(srrConfig.getTransferWalkMargin());
 		staticConfig.setIntermodalLegOnlyHandling(srrConfig.getIntermodalLegOnlyHandling());

--- a/matsim/src/main/java/org/matsim/pt/router/TransitRouterConfig.java
+++ b/matsim/src/main/java/org/matsim/pt/router/TransitRouterConfig.java
@@ -106,10 +106,10 @@ public class TransitRouterConfig implements MatsimParameters {
 		this(config.scoring(), config.routing(), config.transitRouter(), config.vspExperimental());
 	}
 
-	public TransitRouterConfig(final ScoringConfigGroup pcsConfig, final RoutingConfigGroup pcrConfig,
+	public TransitRouterConfig(final ScoringConfigGroup pcsConfig, final RoutingConfigGroup routingConfig,
 														 final TransitRouterConfigGroup trConfig, final VspExperimentalConfigGroup vspConfig )
 	{
-		pcsConfig.setLocked(); pcrConfig.setLocked() ; trConfig.setLocked() ; vspConfig.setLocked() ;
+		pcsConfig.setLocked(); routingConfig.setLocked() ; trConfig.setLocked() ; vspConfig.setLocked() ;
 
 		if (pcsConfig.getScoringParametersPerSubpopulation().size()>1){
 			LogManager.getLogger(getClass()).warn("More than one subpopulation is used in plansCalcScore. "
@@ -119,7 +119,18 @@ public class TransitRouterConfig implements MatsimParameters {
 
 		// walk:
 		{
-			TeleportedModeParams params = pcrConfig.getModeRoutingParams().get( TransportMode.walk );
+			TeleportedModeParams params = routingConfig.getTeleportedModeParams().get( TransportMode.transit_walk );
+			if ( params==null ) {
+				params = routingConfig.getTeleportedModeParams().get( TransportMode.non_network_walk );
+			}
+			if ( params==null ) {
+				params = routingConfig.getTeleportedModeParams().get( TransportMode.walk) ;
+			}
+			if ( params==null ) {
+				log.error( "teleported mode params do not exist for " + TransportMode.transit_walk + ", " + TransportMode.non_network_walk + ", nor "
+				+ TransportMode.walk + ".  At least one of them needs to be defined for TransitRouterConfig.  Aborting ...");
+				// yyyy I do not know which of this is conceptually the correct one.  It should _not_ be walk since that may be routed on the network, see below.  kai, mar'25
+			}
 			Gbl.assertNotNull( params );
 			this.beelineDistanceFactor = params.getBeelineDistanceFactor();
 			this.beelineWalkSpeed = params.getTeleportedModeSpeed() / beelineDistanceFactor;


### PR DESCRIPTION
The SwissRailRaptor needs teleportation walk params.  It takes them from the `walk` mode.  However, if one wants to route walk on the network, then these params do not exist.  I now first check `transit_walk` and then `non_network_walk` before checking walk ... so one can set one of the other two to meaningful values and then it will not check the walk teleportation param at al.