### PR TITLE
revert (QSim): multiplying the inflow capacity with the flow capacity factor

### DIFF
--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QueueWithBuffer.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/QueueWithBuffer.java
@@ -394,10 +394,14 @@ final class QueueWithBuffer implements QLaneI, SignalizeableItem {
 				// yyyyyy this should possibly be getFreespeed(now). But if that's the case, then maxFlowFromFdiag would
 				// also have to be re-computed with each freespeed change. kai, feb'18
 
-				/* We think the maxFlowFromFdiag must be scaled with the flow capacity factor because this scales how much flow can be send/received per time.
+				/* We think the maxFlowFromFdiag should be scaled with the flow capacity factor because this scales how much flow can be send/received per time.
 				* It's unit is (veh/m) / (1/ m/s) = (veh/m) / (s/m) = veh/s
-				* tilmann + theresa, feb'25 */
-				final double maxFlowFromFdiag = (context.qsimConfig.getFlowCapFactor() * this.effectiveNumberOfLanes/context.effectiveCellSize)
+				* Unfortunately, there are no tests failing when we make changes here, i.e. the qsim behavior with kinematic waves seems to be not
+				* suitable covered by tests. Still, simulation outcome of the Berlin scenario differs a lot when we multiply the flow capacity factor
+				* here (car mode shares go significantly down!). This has to be investigated further! For now, we leave the inflow capacity (unscaled)
+				* as before.
+				* tilmann, theresa + christian, feb+mar'25 */
+				final double maxFlowFromFdiag = (this.effectiveNumberOfLanes/context.effectiveCellSize)
 					/ ( 1./(HOLE_SPEED_KM_H/3.6) + 1/this.qLinkInternalInterface.getFreespeed() ) ;
 				final double minimumNumberOfLanesFromFdiag = this.flowCapacityPerTimeStep * context.effectiveCellSize * ( 1./(HOLE_SPEED_KM_H/3.6) + 1/this.qLinkInternalInterface.getFreespeed() );
 


### PR DESCRIPTION
We think the maxFlowFromFdiag in QueueWithBuffer should be scaled with the flow capacity factor because this scales how much flow can be send/received per time.
Unfortunately, there are no tests failing when we make changes here, i.e. the qsim behavior with kinematic waves seems to be not suitable covered by tests. Still, simulation outcome of the Berlin scenario differs a lot when we scale the inflow capacity (car mode shares go significantly down!). This has to be investigated further! For now, we leave the inflow capacity (unscaled) as before.