### PR TITLE
feat(core): add option to add "scale" attribute to MATSim containers and introduce helper methods for population

### DIFF
--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSim.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSim.java
@@ -434,7 +434,7 @@ public final class QSim implements VisMobsim, Netsim, ActivityEndRescheduler {
 		this.agents.put(agent.getId(), agent);
 		this.agentCounter.incLiving();
 		if ( agent instanceof HasPerson ){
-			final Population allpersons = PopulationUtils.getOrCreateAllpersons( scenario );
+			final Population allpersons = PopulationUtils.getOrCreateAllPersons( scenario );
 			if ( !allpersons.getPersons().containsKey( ((HasPerson) agent).getPerson().getId() ) ){
 				allpersons.addPerson( ((HasPerson) agent).getPerson() );
 			}

--- a/matsim/src/main/java/org/matsim/core/population/PopulationImpl.java
+++ b/matsim/src/main/java/org/matsim/core/population/PopulationImpl.java
@@ -28,6 +28,7 @@ import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Population;
 import org.matsim.api.core.v01.population.PopulationFactory;
 import org.matsim.core.scenario.Lockable;
+import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.utils.objectattributes.attributable.AttributesImpl;
 
@@ -45,8 +46,9 @@ import org.matsim.utils.objectattributes.attributable.AttributesImpl;
 	private long counter = 0;
 	private long nextMsg = 1;
 
-	PopulationImpl(PopulationFactory populationFactory2) {
-		this.populationFactory = populationFactory2 ;
+	PopulationImpl(PopulationFactory populationFactory, Double scale) {
+		this.populationFactory = populationFactory ;
+		ScenarioUtils.putScale(this, scale);
 	}
 
 	@Override

--- a/matsim/src/main/java/org/matsim/core/population/PopulationImpl.java
+++ b/matsim/src/main/java/org/matsim/core/population/PopulationImpl.java
@@ -48,7 +48,9 @@ import org.matsim.utils.objectattributes.attributable.AttributesImpl;
 
 	PopulationImpl(PopulationFactory populationFactory, Double scale) {
 		this.populationFactory = populationFactory ;
-		ScenarioUtils.putScale(this, scale);
+		if(scale != null) {
+			ScenarioUtils.putScale(this, scale);
+		}
 	}
 
 	@Override

--- a/matsim/src/main/java/org/matsim/core/population/PopulationUtils.java
+++ b/matsim/src/main/java/org/matsim/core/population/PopulationUtils.java
@@ -87,7 +87,8 @@ import org.matsim.vehicles.VehicleUtils;
  */
 public final class PopulationUtils {
 	private static final Logger log = LogManager.getLogger(PopulationUtils.class);
-	private static final PopulationFactory populationFactory = createPopulation(new PlansConfigGroup(), null).getFactory();
+	private static final PopulationFactory populationFactory = createPopulation(
+			new PlansConfigGroup(), null, null).getFactory();
 
 	/**
 	 * @deprecated -- this is public only because it is needed in the also deprecated method {@link PlansConfigGroup#getSubpopulationAttributeName()}
@@ -110,7 +111,19 @@ public final class PopulationUtils {
 	 * @return the new Population instance
 	 */
 	public static Population createPopulation(Config config) {
-		return createPopulation(config, null);
+		return createPopulation(config, null, null);
+	}
+
+	/**
+	 * Creates a new Population container. Population instances need a Config, because they need to know
+	 * about the modes of transport.
+	 *
+	 * @param config the configuration which is used to create the Population.
+	 * @param scale the scale (or sample fraction) of the population which is added as a container attribute.
+	 * @return the new Population instance
+	 */
+	public static Population createPopulation(Config config, Double scale) {
+		return createPopulation(config, null, scale);
 	}
 
 	/**
@@ -123,10 +136,34 @@ public final class PopulationUtils {
 	 * @return the new Population instance
 	 */
 	public static Population createPopulation(Config config, Network network) {
-		return createPopulation(config.plans(), network);
+		return createPopulation(config.plans(), network, null);
 	}
 
-	public static Population createPopulation(PlansConfigGroup plansConfigGroup, Network network) {
+	/**
+	 * Creates a new Population container which, depending on
+	 * configuration, may make use of the specified Network instance to store routes
+	 * more efficiently.
+	 *
+	 * @param config  the configuration which is used to create the Population.
+	 * @param network the Network to which Plans in this Population will refer.
+	 * @param scale the scale (or sample fraction) of the population which is added as a container attribute.
+	 * @return the new Population instance
+	 */
+	public static Population createPopulation(Config config, Network network, Double scale) {
+		return createPopulation(config.plans(), network, scale);
+	}
+
+	/**
+	 * Creates a new Population container which, depending on
+	 * configuration, may make use of the specified Network instance to store routes
+	 * more efficiently.
+	 *
+	 * @param plansConfigGroup  the configuration which is used to create the Population.
+	 * @param network the Network to which Plans in this Population will refer.
+	 * @param scale the scale (or sample fraction) of the population which is added as a container attribute.
+	 * @return the new Population instance
+	 */
+	public static Population createPopulation(PlansConfigGroup plansConfigGroup, Network network, Double scale) {
 		// yyyy my intuition would be to rather get this out of a standard scenario. kai, jun'16
 		RouteFactories routeFactory = new RouteFactories();
 		String networkRouteType = plansConfigGroup.getNetworkRouteType();
@@ -143,7 +180,7 @@ public final class PopulationUtils {
 			throw new IllegalArgumentException("The type \"" + networkRouteType + "\" is not a supported type for network routes.");
 		}
 		routeFactory.setRouteFactory(NetworkRoute.class, factory);
-		return new PopulationImpl(new PopulationFactoryImpl(routeFactory));
+        return new PopulationImpl(new PopulationFactoryImpl(routeFactory), scale);
 	}
 
 	public static Leg unmodifiableLeg(Leg leg) {
@@ -1265,11 +1302,11 @@ public final class PopulationUtils {
 		person.getAttributes().removeAttribute(SUBPOPULATION_ATTRIBUTE_NAME);
 	}
 
-	public static Population getOrCreateAllpersons(Scenario scenario) {
+	public static Population getOrCreateAllPersons(Scenario scenario) {
 		Population map = (Population) scenario.getScenarioElement("allpersons");
 		if (map == null) {
 			log.info("adding scenario element for allpersons container");
-			map = new PopulationImpl(scenario.getPopulation().getFactory());
+			map = new PopulationImpl(scenario.getPopulation().getFactory(), null);
 			scenario.addScenarioElement("allpersons", map);
 		}
 		return map;
@@ -1278,7 +1315,7 @@ public final class PopulationUtils {
 	private static int tryStdCnt = 5;
 
 	public static Person findPerson(Id<Person> personId, Scenario scenario) {
-		Person person = getOrCreateAllpersons(scenario).getPersons().get(personId);
+		Person person = getOrCreateAllPersons(scenario).getPersons().get(personId);
 		if (person == null) {
 			if (tryStdCnt > 0) {
 				tryStdCnt--;

--- a/matsim/src/main/java/org/matsim/core/scenario/ScenarioUtils.java
+++ b/matsim/src/main/java/org/matsim/core/scenario/ScenarioUtils.java
@@ -27,12 +27,14 @@ import java.util.Map;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Population;
+import org.matsim.core.api.internal.MatsimToplevelContainer;
 import org.matsim.core.config.Config;
 import org.matsim.facilities.ActivityFacilities;
 import org.matsim.households.Households;
 import org.matsim.lanes.Lanes;
 import org.matsim.pt.transitSchedule.api.TransitSchedule;
 import org.matsim.utils.objectattributes.AttributeConverter;
+import org.matsim.utils.objectattributes.attributable.Attributable;
 import org.matsim.vehicles.Vehicles;
 
 
@@ -158,6 +160,27 @@ public final class ScenarioUtils {
 			this.scenario.setLocked(); // prevents that one can cast to ScenarioImpl and change the containers again. kai, nov'14
 			return this.scenario ;
 		}
+	}
+
+	/**
+	 * Name of the attribute to add to top-level containers to specify the scale.
+	 * When possible, the utility methods should be used instead of directly querying the attributes.
+	 */
+	public static final String INPUT_SCALE_ATT = "scale";
+
+	public static <T extends MatsimToplevelContainer & Attributable> Double getScale(T container) {
+		return (Double) container.getAttributes().getAttribute(INPUT_SCALE_ATT);
+	}
+
+	/**
+	 * Adds scale metadata to the given container. The scale is meant for documentation and could be considered when
+	 * consuming the data. Potential meaningful containers:
+	 * - population (fraction of agents)
+	 * - network (flow capacities)
+	 * - vehicles (pce definition)
+	 */
+	public static <T extends MatsimToplevelContainer & Attributable> void putScale(T container, Double scale) {
+		container.getAttributes().putAttribute(INPUT_SCALE_ATT, scale);
 	}
 
 }


### PR DESCRIPTION
The scale attribute introduced here is meant for documentation purposes for now but could be consumed for analyses or for code consuming the data.