### PR TITLE
fix: Improve shp reading

### DIFF
--- a/matsim/src/main/java/org/matsim/application/options/ShpOptions.java
+++ b/matsim/src/main/java/org/matsim/application/options/ShpOptions.java
@@ -200,12 +200,12 @@ public final class ShpOptions {
 	public List<SimpleFeature> readFeatures() {
 		if (shp == null)
 			throw new IllegalStateException("Shape file path not specified");
-		if (!Files.exists(Path.of(shp)))
-			throw new RuntimeException(shp + " does not exist! Please double check the path for the shp!");
-			// I wanted to throw a FileNotFoundException, but it requires all the methods that call readFeatures() to include throw
-			// FileNotFoundException statement at the beginning.
 
 		try {
+			// throw FileNotFoundException if the path is wrong
+			if (!Files.exists(Path.of(shp)))
+				throw new FileNotFoundException(shp + " does not exist! Please double check the path for the shp!");
+
 			DataStore ds = openDataStore(shp);
 			if (shpCharset != null && ds instanceof ShapefileDataStore shpDs)
 				shpDs.setCharset(shpCharset);


### PR DESCRIPTION
This PR addresses the issue #3840. A FileNotFoundException will be thrown if the path to the Shapefile is not correctly specified. This is clearer than the error message it is returned currently. 