### PR TITLE
docs(GitHub): Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+We are using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), so that we are able to auto generate a changelog. The format is described below:
+
+#### Title
+`<type>[optional scope]: <description>` e.g.: fix(QSim): Correctly calculate travel times on links
+
+#### Body
+Optionally, describe the change in more detail.
+
+If the PR introduces a breaking change write: BREAKING CHANGE at the bottom of the message


### PR DESCRIPTION
Add a PR template that describes that we are using conventional commits. Start with the bare minimum.