### PR TITLE
feat(core): Simplify network with turn restrictions

### DIFF
--- a/contribs/signals/src/main/java/org/matsim/codeexamples/runSignalsAndLanesOsmNetworkReader/RunSignalsAndLanesOsmNetworkReader.java
+++ b/contribs/signals/src/main/java/org/matsim/codeexamples/runSignalsAndLanesOsmNetworkReader/RunSignalsAndLanesOsmNetworkReader.java
@@ -91,7 +91,7 @@ public class RunSignalsAndLanesOsmNetworkReader {
 		reader.parse(inputOSM);
 
         // Simplify the network except the junctions with signals as this might mess up already created plans
-		NetworkSimplifier netSimplify = new NetworkSimplifier();
+		NetworkSimplifier netSimplify = NetworkSimplifier.createNetworkSimplifier(network);
 		netSimplify.setNodesNotToMerge(reader.getNodesNotToMerge());
 		netSimplify.run(network);
 

--- a/contribs/signals/src/test/java/org/matsim/contrib/signals/network/SignalsAndLanesOsmNetworkReaderTest.java
+++ b/contribs/signals/src/test/java/org/matsim/contrib/signals/network/SignalsAndLanesOsmNetworkReaderTest.java
@@ -389,7 +389,7 @@ public class SignalsAndLanesOsmNetworkReaderTest {
 
         signalReader.parse(inputfile.toString());
 
-        NetworkSimplifier netsimplify = new NetworkSimplifier();
+		NetworkSimplifier netsimplify = NetworkSimplifier.createNetworkSimplifier(network);
         netsimplify.setNodesNotToMerge(signalReader.getNodesNotToMerge());
         netsimplify.run(network);
 

--- a/contribs/vsp/src/main/java/playground/vsp/andreas/utils/net/OSM2MATSim.java
+++ b/contribs/vsp/src/main/java/playground/vsp/andreas/utils/net/OSM2MATSim.java
@@ -122,7 +122,7 @@ public class OSM2MATSim {
 		network = (Network) scenario.getNetwork();
 		new MatsimNetworkReader(scenario.getNetwork()).readFile(outputFile + "_cl.xml.gz");
 
-		NetworkSimplifier nsimply = new NetworkSimplifier();
+		NetworkSimplifier nsimply = NetworkSimplifier.createNetworkSimplifier(network);
 		Set<Integer> nodeTypesToMerge = new TreeSet<Integer>();
 		nodeTypesToMerge.add(new Integer(4));
 		nodeTypesToMerge.add(new Integer(5));

--- a/matsim/src/main/java/org/matsim/core/network/NetworkUtils.java
+++ b/matsim/src/main/java/org/matsim/core/network/NetworkUtils.java
@@ -887,8 +887,17 @@ public final class NetworkUtils {
 				.collect(Collectors.toSet());
 	}
 
-	public static void runNetworkSimplifier( Network network ) {
-		new NetworkSimplifier().run(network) ;
+	/**
+	 * Simplifies the network considering turn restrictions aka
+	 * {@link DisallowedNextLinks}
+	 * 
+	 * @param network
+	 * @see {@link DisallowedNextLinksUtils#clean(Network)},
+	 *      {@link #cleanNetwork(Network, Set)},
+	 *      {@link NetworkSimplifier#createNetworkSimplifier(Network)}
+	 */
+	public static void simplifyNetwork(Network network) {
+		NetworkSimplifier.createNetworkSimplifier(network).run(network);
 	}
 
 	public static void writeNetwork(Network network, String string) {

--- a/matsim/src/main/java/org/matsim/core/network/algorithms/intersectionSimplifier/RunIntersectionSimplifier.java
+++ b/matsim/src/main/java/org/matsim/core/network/algorithms/intersectionSimplifier/RunIntersectionSimplifier.java
@@ -61,7 +61,7 @@ public class RunIntersectionSimplifier {
 		nct.run(newNetwork);
 
 		LOG.info("Simplifying the network...");
-		new NetworkSimplifier().run(newNetwork);
+		NetworkUtils.simplifyNetwork(newNetwork);
 		LOG.info("Cleaning the network...");
 		NetworkUtils.cleanNetwork(newNetwork, Set.of(TransportMode.car));
 

--- a/matsim/src/main/java/org/matsim/core/network/turnRestrictions/DisallowedNextLinksUtils.java
+++ b/matsim/src/main/java/org/matsim/core/network/turnRestrictions/DisallowedNextLinksUtils.java
@@ -115,6 +115,30 @@ public final class DisallowedNextLinksUtils {
 	}
 
 	/**
+	 * Copy link sequences of DisallowedNextLinks attributes from one mode to
+	 * another e.g., from car to ride.
+	 * 
+	 * @param network
+	 * @param fromMode
+	 * @param toMode
+	 * @see {@link #clean(Network)}
+	 */
+	public static void copy(Network network, String fromMode, String toMode) {
+		network.getLinks().values().forEach(link -> {
+
+			DisallowedNextLinks dnl = NetworkUtils.getDisallowedNextLinks(link);
+			if (dnl == null) {
+				return;
+			}
+
+			for (List<Id<Link>> linkSequence : dnl.getDisallowedLinkSequences(fromMode)) {
+				dnl.addDisallowedLinkSequence(toMode, linkSequence);
+			}
+
+		});
+	}
+
+	/**
 	 * Returns a list of link id sequences that are not allowed to be traveled due
 	 * to turn restrictions.
 	 * 

--- a/matsim/src/main/java/org/matsim/core/network/turnRestrictions/DisallowedNextLinksUtils.java
+++ b/matsim/src/main/java/org/matsim/core/network/turnRestrictions/DisallowedNextLinksUtils.java
@@ -2,9 +2,16 @@ package org.matsim.core.network.turnRestrictions;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BiPredicate;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -13,6 +20,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.utils.collections.Tuple;
 
 /**
  * Some methods to validate DisallowedNextLinks attributes of a network.
@@ -22,6 +30,8 @@ import org.matsim.core.network.NetworkUtils;
 public final class DisallowedNextLinksUtils {
 
 	private static final Logger LOG = LogManager.getLogger(DisallowedNextLinksUtils.class);
+
+	private static final String I_AM_A_NEXT_LINK_OF_THESE_FROM_LINKS_ATTRIBUTE = "iAmANextLinkOfTheseFromLinks";
 
 	private DisallowedNextLinksUtils() {
 		throw new IllegalStateException("Utility class");
@@ -171,6 +181,200 @@ public final class DisallowedNextLinksUtils {
 				.toList();
 	}
 
+	/**
+	 * Write from link of disallowed link object to its next links. This is required
+	 * for being able to simplify a network with {@link DisallowedNextLinks} objects
+	 * correctly.
+	 * 
+	 * @param network
+	 * @see #removeAnnotation(Network)
+	 */
+	public static void annotateNetworkForSimplification(Network network) {
+
+		LOG.info("Call removeAnnotation() to remove temporarily added attributes after simplification.");
+
+		for (Link link : network.getLinks().values()) {
+			DisallowedNextLinks disallowedNextLinks = NetworkUtils.getDisallowedNextLinks(link);
+			if (disallowedNextLinks != null) {
+				disallowedNextLinks.getAsMap().values().stream()
+						.flatMap(List::stream)
+						.flatMap(List::stream)
+						.map(network.getLinks()::get)
+						.forEach(l -> {
+							Set<Id<Link>> fromLinks = (Set<Id<Link>>) l.getAttributes()
+									.getAttribute(I_AM_A_NEXT_LINK_OF_THESE_FROM_LINKS_ATTRIBUTE);
+							if (fromLinks == null) {
+								fromLinks = new HashSet<>();
+							}
+							fromLinks.add(link.getId());
+							l.getAttributes().putAttribute(I_AM_A_NEXT_LINK_OF_THESE_FROM_LINKS_ATTRIBUTE, fromLinks);
+						});
+			}
+		}
+	}
+
+	/**
+	 * Removes annotation from {@link #annotateNetworkForSimplification(Network)}.
+	 * 
+	 * @param network
+	 */
+	public static void removeAnnotation(Network network) {
+		for (Link link : network.getLinks().values()) {
+			link.getAttributes().removeAttribute(I_AM_A_NEXT_LINK_OF_THESE_FROM_LINKS_ATTRIBUTE);
+		}
+	}
+
+	/**
+	 * Create a predicate that prevents merging links that would destroy turn
+	 * restriction info of {@link DisallowedNextLinks} attributes.
+	 * 
+	 * @param network
+	 * @return
+	 * @see #createTransferAttributesConsumer(Network)
+	 */
+	public static BiPredicate<Link, Link> createIsMergeablePredicate(Network network) {
+		return (link1, link2) -> {
+
+			DisallowedNextLinks dnl1 = NetworkUtils.getDisallowedNextLinks(link1);
+			DisallowedNextLinks dnl2 = NetworkUtils.getDisallowedNextLinks(link2);
+			@SuppressWarnings("unchecked")
+			Set<Id<Link>> fromLinkIds1 = (Set<Id<Link>>) link1.getAttributes()
+					.getAttribute(I_AM_A_NEXT_LINK_OF_THESE_FROM_LINKS_ATTRIBUTE);
+			@SuppressWarnings("unchecked")
+			Set<Id<Link>> fromLinkIds2 = (Set<Id<Link>>) link2.getAttributes()
+					.getAttribute(I_AM_A_NEXT_LINK_OF_THESE_FROM_LINKS_ATTRIBUTE);
+
+			// links are themselves from links of dnl
+			// -> do not merge
+			if (dnl1 != null || dnl2 != null) {
+				return false;
+			}
+
+			// no disallowed next link involvement at all
+			// -> safe merge
+			if (fromLinkIds1 == null && fromLinkIds2 == null) {
+				return true;
+			}
+
+			// both are subsequent links in all dnls they are part of, and are not from
+			// links
+			// -> can merge, but need to adjust DNL objects
+
+			// get set of from links where these links are in those dnls
+			Set<Id<Link>> commonFromLinkIds = new HashSet<>();
+			if (fromLinkIds1 != null) {
+				commonFromLinkIds.addAll(fromLinkIds1);
+			}
+			if (fromLinkIds2 != null) {
+				commonFromLinkIds.addAll(fromLinkIds2);
+			}
+			List<DisallowedNextLinks> dnls = commonFromLinkIds.stream()
+					.map(network.getLinks()::get)
+					.map(NetworkUtils::getDisallowedNextLinks)
+					.filter(Objects::nonNull)
+					.toList();
+
+			// check, that both links are subsequent in all dnls
+			for (DisallowedNextLinks dnl : dnls) {
+				Map<String, List<List<Id<Link>>>> dnlMap = dnl.getAsMap();
+				for (Entry<String, List<List<Id<Link>>>> entry : dnlMap.entrySet()) {
+					for (List<Id<Link>> linkIdList : entry.getValue()) {
+						int firstLinkIdx = -1;
+						int secondLinkIdx = -1;
+						for (ListIterator<Id<Link>> it = linkIdList.listIterator(); it.hasNext();) {
+							int idx = it.nextIndex();
+							Id<Link> linkId = it.next();
+							if (firstLinkIdx < 0 && linkId.equals(link1.getId())) {
+								firstLinkIdx = idx;
+							} else if (firstLinkIdx >= 0 && secondLinkIdx < 0 && linkId.equals(link2.getId())) {
+								secondLinkIdx = idx;
+							} else {
+								break; // both found
+							}
+						}
+
+						if (!(firstLinkIdx == linkIdList.size() - 1 && secondLinkIdx < 0) // first link is not last
+																							// link
+								&& !(firstLinkIdx >= 0 && secondLinkIdx == firstLinkIdx + 1) // links are not
+																								// subsequent
+						) {
+							return false;
+						}
+					}
+				}
+			}
+			return true;
+		};
+	}
+
+	/**
+	 * Create a BiConsumer that merges two links, considering turn restrictions.
+	 * 
+	 * @param network
+	 * @return
+	 * @see #createIsMergeablePredicate(Network)
+	 */
+	public static BiConsumer<Tuple<Link, Link>, Link> createTransferAttributesConsumer(Network network) {
+		return (t, newLink) -> {
+
+			// isMergeableWithDisallowedLinks does not allow merging of from links of
+			// DisallowedNextLinks, so we only need to consider these cases:
+			// a) the first link is the last link of a next links-list
+			// b) both links are subsequent in the list of next links
+			// In both cases, we need to update the list of next links of the respective DNL
+			// object with the new link id
+
+			Link link1 = t.getFirst();
+			Link link2 = t.getSecond();
+
+			@SuppressWarnings("unchecked")
+			Set<Id<Link>> fromLinkIds1 = (Set<Id<Link>>) link1.getAttributes()
+					.getAttribute(I_AM_A_NEXT_LINK_OF_THESE_FROM_LINKS_ATTRIBUTE);
+			@SuppressWarnings("unchecked")
+			Set<Id<Link>> fromLinkIds2 = (Set<Id<Link>>) link2.getAttributes()
+					.getAttribute(I_AM_A_NEXT_LINK_OF_THESE_FROM_LINKS_ATTRIBUTE);
+			// get set of from links where these links are in those dnls
+			Map<Link, DisallowedNextLinks> linkDnl = getLinkDnlMap(network, fromLinkIds1, fromLinkIds2);
+
+			// change disallowed next links
+			for (Entry<Link, DisallowedNextLinks> linkDnlEntry : linkDnl.entrySet()) {
+				final Link fromLink = linkDnlEntry.getKey();
+				Map<String, List<List<Id<Link>>>> dnlMap = linkDnlEntry.getValue().getAsMap();
+
+				// create new DisallowedNextLink object
+				DisallowedNextLinks newDnl = new DisallowedNextLinks();
+				for (Entry<String, List<List<Id<Link>>>> entry : dnlMap.entrySet()) {
+					final String mode = entry.getKey();
+					for (List<Id<Link>> linkIdList : entry.getValue()) {
+						List<Id<Link>> newLInkIdList = new ArrayList<>();
+						for (Id<Link> linkId : linkIdList) {
+							if (linkId.equals(link1.getId())) {
+								// add new link instead of (old) first link
+								newLInkIdList.add(newLink.getId());
+							} else if (linkId.equals(link2.getId())) {
+								// do not add (old) second link
+							} else {
+								newLInkIdList.add(linkId);
+							}
+						}
+						newDnl.addDisallowedLinkSequence(mode, newLInkIdList);
+					}
+				}
+				NetworkUtils.setDisallowedNextLinks(fromLink, newDnl);
+			}
+			// add attribute to new link, that remembers for which from links this new link
+			// is in the next
+			// links-list
+			if (!linkDnl.isEmpty()) {
+				newLink.getAttributes().putAttribute(I_AM_A_NEXT_LINK_OF_THESE_FROM_LINKS_ATTRIBUTE,
+						linkDnl.keySet().stream()
+								.map(Link::getId)
+								.collect(Collectors.toSet()));
+			}
+
+		};
+	}
+
 	// Helpers
 
 	private static List<String> getErrors(Map<Id<Link>, ? extends Link> links, Id<Link> linkId,
@@ -243,6 +447,22 @@ public final class DisallowedNextLinksUtils {
 		}
 
 		return messages;
+	}
+
+	private static Map<Link, DisallowedNextLinks> getLinkDnlMap(Network network, Set<Id<Link>> fromLinkIds1,
+			Set<Id<Link>> fromLinkIds2) {
+		Set<Id<Link>> commonFromLinkIds = new HashSet<>();
+		if (fromLinkIds1 != null) {
+			commonFromLinkIds.addAll(fromLinkIds1);
+		}
+		if (fromLinkIds2 != null) {
+			commonFromLinkIds.addAll(fromLinkIds2);
+		}
+		return commonFromLinkIds.stream()
+				.map(network.getLinks()::get)
+				.map(l -> Map.entry(l, NetworkUtils.getDisallowedNextLinks(l)))
+				.filter(e -> e.getValue() != null)
+				.collect(Collectors.toMap(Entry::getKey, Entry::getValue));
 	}
 
 }


### PR DESCRIPTION
When simplifying networks with turn restrictions #2855 we need to ensure that the `DisallowedNextLinks` objects are adjusted when merging links.

This change adds the required logic for merging links with turn restriction info and makes it the default through a new method `NetworkUtils.simplifyNetwork(Network)` at most places where the `NetworkSimplifier` has been used without these adaptions.
https://github.com/matsim-org/matsim-libs/blob/583570c48ff5828452e053bdd6a4b05199cf1461/matsim/src/main/java/org/matsim/core/network/NetworkUtils.java#L890-L901
