### PR TITLE
chore: respect log level environment var

### DIFF
--- a/matsim/src/main/java/org/matsim/core/controler/ControllerUtils.java
+++ b/matsim/src/main/java/org/matsim/core/controler/ControllerUtils.java
@@ -21,6 +21,7 @@ package org.matsim.core.controler;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Scenario;
@@ -98,6 +99,12 @@ public final class ControllerUtils{
 	    String newline = System.lineSeparator();// use native line endings for logfile
 	    StringWriter writer = new StringWriter();
 	    new ConfigWriter(config).writeStream(new PrintWriter(writer), newline);
+
+		if (log.getLevel().isMoreSpecificThan(Level.DEBUG)) {
+			log.info("=== logging config.xml skipped ===");
+			log.info("To enable debug output, set an environment variable i.e. export LOG_LEVEL='debug', "
+				+ "or set log.setLogLevel(Level.DEBUG) in your run class.");
+		}
 	    log.debug(newline + newline + writer.getBuffer().toString());
 	    log.info("Complete config dump done.");
 	    log.info("Checking consistency of config...");

--- a/matsim/src/main/java/org/matsim/core/controler/Injector.java
+++ b/matsim/src/main/java/org/matsim/core/controler/Injector.java
@@ -77,7 +77,11 @@ public final class Injector {
 	}
 
 	public static void printInjector(com.google.inject.Injector injector, Logger log) {
-		Level level = Level.DEBUG ;
+		Level level = Level.DEBUG;
+		log.info("=== printInjector output skipped ===");
+		log.info("To enable debug output, set an environment variable i.e. export LOG_LEVEL='debug', "
+			+ "or set log.setLogLevel(Level.DEBUG) in your run class.");
+
 		log.log(level,"=== printInjector start ===") ;
 		for (Map.Entry<Key<?>, Binding<?>> entry : injector.getBindings().entrySet()) {
 			if ( entry.getKey().toString().contains("type=org.matsim") ) {

--- a/matsim/src/main/java/org/matsim/core/events/EventsManagerImpl.java
+++ b/matsim/src/main/java/org/matsim/core/events/EventsManagerImpl.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.events.*;
@@ -134,6 +135,11 @@ public final class EventsManagerImpl implements EventsManager {
 	public void addHandler (final EventHandler handler) {
 		Set<Class<?>> addedHandlers = new HashSet<>();
 		Class<?> test = handler.getClass();
+		if (log.getLevel().isMoreSpecificThan(Level.DEBUG)) {
+			log.info("=== Logging of event-handlers skipped ===");
+			log.info("To enable debug output, set an environment variable i.e. export LOG_LEVEL='debug', "
+				+ "or set log.setLogLevel(Level.DEBUG) in your run class.");
+		}
 		log.debug("adding Event-Handler: " + test.getName());
 		do {
 			for (Class<?> theInterface : test.getInterfaces()) {

--- a/matsim/src/main/java/org/matsim/core/router/PlanRouter.java
+++ b/matsim/src/main/java/org/matsim/core/router/PlanRouter.java
@@ -80,7 +80,6 @@ public final class PlanRouter implements PlanAlgorithm, PersonAlgorithm {
 			final String routingMode = TripStructureUtils.identifyMainMode( oldTrip.getTripElements() );
 			timeTracker.addActivity(oldTrip.getOriginActivity());
 
-			if (log.isDebugEnabled()) log.debug("about to call TripRouter with routingMode=" + routingMode);
 			final List<? extends PlanElement> newTripElements = tripRouter.calcRoute( //
 					routingMode, //
 					FacilitiesUtils.toFacility(oldTrip.getOriginActivity(), facilities), //

--- a/matsim/src/main/resources/log4j2.xml
+++ b/matsim/src/main/resources/log4j2.xml
@@ -17,7 +17,16 @@
 	</Appenders>
 
 	<Loggers>
-		<Root level="info">
+		<!--
+		Here we set the log level from an environment variable called LOG_LEVEL, or defaults
+		to 'info' if not set.
+		You can set this locally by putting this into your ~/.bash_profile:
+		# macOS
+		export LOG_LEVEL='debug|info|warn';
+		# linux
+		set LOG_LEVEL='debug|info|warn';
+		-->
+		<Root level="${env:LOG_LEVEL:-info}">
 			<AppenderRef ref="stdout" />
 			<AppenderRef ref="stderr" />
 		</Root>


### PR DESCRIPTION
## What?
Configure log4j to optionally override the log level of the root logger **if** the LOG_LEVEL environment variable is set, **if unset** it will continue to default to info.

## Why?
To make it easy to switch log levels when executing matsim remotely without recompiling code, for example to get more context on a crash. 

Relates to: #3801 