### PR TITLE
fix: small fixes in SpatialRequestFleetFilter

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/spatialFilter/SpatialRequestFleetFilter.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/spatialFilter/SpatialRequestFleetFilter.java
@@ -28,6 +28,8 @@ import org.matsim.contrib.drt.optimizer.VehicleEntry;
 import org.matsim.contrib.drt.optimizer.insertion.RequestFleetFilter;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.schedule.DrtStopTask;
+import org.matsim.contrib.drt.schedule.DrtTaskBaseType;
+import org.matsim.contrib.drt.schedule.DrtTaskType;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.schedule.DriveTask;
@@ -57,6 +59,7 @@ import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.getBaseTypeOrElseT
  */
 public class SpatialRequestFleetFilter implements RequestFleetFilter {
 
+    private double lastTreeUpdate = Double.NEGATIVE_INFINITY;
     private STRtree tree = new STRtree();
 
     private final Fleet fleet;
@@ -85,20 +88,24 @@ public class SpatialRequestFleetFilter implements RequestFleetFilter {
 
     @Override
     public Collection<VehicleEntry> filter(DrtRequest drtRequest, Map<Id<DvrpVehicle>, VehicleEntry> vehicleEntries, double now) {
-        if ((mobsimTimer.getTimeOfDay() % updateInterval) == 0) {
+        if (now >= lastTreeUpdate + updateInterval) {
             buildTree();
+            // Alternative (to stick cadence to a "grid"):
+            // lastTreeUpdate = Math.floor(now / updateInterval) * updateInterval;
+            lastTreeUpdate = now;
         }
         return filterEntries(vehicleEntries, drtRequest);
     }
 
     private Collection<VehicleEntry> filterEntries(Map<Id<DvrpVehicle>, VehicleEntry> vehicleEntries, DrtRequest drtRequest) {
-        List<Id<DvrpVehicle>> result = Collections.emptyList();
+        Collection<VehicleEntry> result = Collections.emptyList();
         Point point = GeometryUtils.createGeotoolsPoint(drtRequest.getFromLink().getToNode().getCoord());
 
         for (double expansion = minExpansion; expansion <= maxExpansion && result.size() < minCandidates; expansion*= expansionIncrementFactor) {
             Envelope envelopeInternal = point.getEnvelopeInternal();
             envelopeInternal.expandBy(expansion);
-            result = tree.query(envelopeInternal);
+            var ids = tree.query(envelopeInternal);
+            result = extract(vehicleEntries, ids);
         }
 
         if(result.size() < minCandidates) {
@@ -107,36 +114,46 @@ public class SpatialRequestFleetFilter implements RequestFleetFilter {
             }
             return Collections.emptySet();
         }
-        return extract(vehicleEntries, result);
+
+        return result;
     }
 
     private Collection<VehicleEntry> extract(Map<Id<DvrpVehicle>, VehicleEntry> vehicleEntries, List<Id<DvrpVehicle>> result) {
         Set<VehicleEntry> extracted = new LinkedHashSet<>();
         for (Id<DvrpVehicle> dvrpVehicleId : result) {
-            extracted.add(vehicleEntries.get(dvrpVehicleId));
+            // VehicleEntries only contains available vehicles. The spatial tree might be out of sync with this set of
+            // vehicles and contain vehicles that are not available anymore. Hence, the need to check.
+            if (vehicleEntries.containsKey(dvrpVehicleId)) {
+                extracted.add(vehicleEntries.get(dvrpVehicleId));
+            }
         }
         return extracted;
     }
 
     private void buildTree() {
         tree = new STRtree();
-        for (DvrpVehicle vehicle : fleet.getVehicles().values()) {
+        for (DvrpVehicle vehicle : fleet.getVehicles()) {
             Schedule schedule = vehicle.getSchedule();
             Task startTask;
-            Link start;
+
             if (schedule.getStatus() == Schedule.ScheduleStatus.STARTED) {
                 startTask = schedule.getCurrentTask();
-                start = switch (getBaseTypeOrElseThrow(startTask)) {
-                    case DRIVE -> {
-                        var driveTask = (DriveTask) startTask;
-                        var diversionPoint = ((OnlineDriveTaskTracker) driveTask.getTaskTracker()).getDiversionPoint();
-                        yield diversionPoint != null ? diversionPoint.link : //diversion possible
+                Optional<DrtTaskBaseType> startTaskBaseType = ((DrtTaskType) startTask.getTaskType()).baseType();
+
+                // In case a task type does not have a base type, we suppose that it is not "available" and ignore it
+                startTaskBaseType.ifPresent(type -> {
+                    var start = switch (type) {
+                        case DRIVE -> {
+                            var driveTask = (DriveTask) startTask;
+                            var diversionPoint = ((OnlineDriveTaskTracker) driveTask.getTaskTracker()).getDiversionPoint();
+                            yield diversionPoint != null ? diversionPoint.link : //diversion possible
                                 driveTask.getPath().getToLink();// too late for diversion
-                    }
-                    case STOP -> ((DrtStopTask) startTask).getLink();
-                    case STAY -> ((StayTask) startTask).getLink();
-                };
-                tree.insert(GeometryUtils.createGeotoolsPoint(start.getCoord()).getEnvelopeInternal(), vehicle.getId());
+                        }
+                        case STOP -> ((DrtStopTask) startTask).getLink();
+                        case STAY -> ((StayTask) startTask).getLink();
+                    };
+                    tree.insert(GeometryUtils.createGeotoolsPoint(start.getCoord()).getEnvelopeInternal(), vehicle.getId());
+                });
             }
         }
     }

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/spatialFilter/SpatialRequestFleetFilter.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/spatialFilter/SpatialRequestFleetFilter.java
@@ -132,7 +132,7 @@ public class SpatialRequestFleetFilter implements RequestFleetFilter {
 
     private void buildTree() {
         tree = new STRtree();
-        for (DvrpVehicle vehicle : fleet.getVehicles()) {
+        for (DvrpVehicle vehicle : fleet.getVehicles().values()) {
             Schedule schedule = vehicle.getSchedule();
             Task startTask;
 


### PR DESCRIPTION
Details:
- in some simulations it happened that the vehicles kept in the spatial tree were not available anymore in the simulation, resulting in an NPE
- not all DrtTastTypes have a baseType. This case is now handled by ignoring those tasks, rather than crashing.

