### PR TITLE
feat(srr): cacheless transfer calculation

### DIFF
--- a/matsim/src/main/java/ch/sbb/matsim/config/SwissRailRaptorConfigGroup.java
+++ b/matsim/src/main/java/ch/sbb/matsim/config/SwissRailRaptorConfigGroup.java
@@ -65,7 +65,7 @@ public class SwissRailRaptorConfigGroup extends ReflectiveConfigGroup {
     private static final String PARAM_INTERMODAL_LEG_ONLYHANDLING = "intermodalLegOnlyHandling";
     private static final String PARAM_INTERMODAL_LEG_ONLYHANDLING_DESC = "Define how routes containing only intermodal legs are handled: Useful options: alllow, avoid, forbid";
     private static final String PARAM_TRANSFER_CALCULATION = "transferCalculation";
-    private static final String PARAM_TRANFER_CALCULATION_DESC = "Defines whether all potential transfers are precomputed at the beginning of the simulation (Initial) or whether they are constructed on-demand when needed (Adaptive). The former incurs potentially long up-front caclulations, but quicker routing. The latter avoids any initial computation, but may require longer routing time.";
+    private static final String PARAM_TRANFER_CALCULATION_DESC = "Defines whether all potential transfers are precomputed at the beginning of the simulation (Initial) or whether they are constructed on-demand when needed (Adaptive). The former incurs potentially long up-front caclulations, but quicker routing. The latter avoids any initial computation, but may require longer routing time. Additionally, you may use Online, which will not cache adaptively calculated transfers. This will lead to largely reduced memory use, but drastically increased routing times.";
 
     private boolean useRangeQuery = false;
     private boolean useIntermodality = false;

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/RaptorStaticConfig.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/RaptorStaticConfig.java
@@ -65,7 +65,14 @@ public class RaptorStaticConfig {
 		 * which avoids any simulation start-up time but may increase the routing time
 		 * itself.
 		 */
-		Adaptive
+		Adaptive,
+
+        /**
+         * Use this option if you wnat the algorithm to calculate transfers on demand,
+         * but not cache them. This allows for a large reduction in memory use, but may
+         * drastically increase processing times.
+         */
+        Online
 	}
 
 

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorData.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorData.java
@@ -98,7 +98,8 @@ public class SwissRailRaptorData {
 
         // data needed if cached transfer construction is activated
         this.staticTransferTimes = staticTransferTimes;
-        this.transferCache = new RTransfer[routeStops.length][];
+        this.transferCache = config.getTransferCalculation().equals(RaptorTransferCalculation.Adaptive) ? 
+            new RTransfer[routeStops.length][] : null;
     }
 
     public static SwissRailRaptorData create(TransitSchedule schedule, @Nullable Vehicles transitVehicles, RaptorStaticConfig staticConfig, Network network, OccupancyData occupancyData) {
@@ -238,7 +239,7 @@ public class SwissRailRaptorData {
 
         // if adaptive transfer calculation is used, build a map for quick lookup of and collection of minimal transfer times
 		IdMap<TransitStopFacility, Map<TransitStopFacility, Double>> staticTransferTimes = null;
-		if (staticConfig.getTransferCalculation().equals(RaptorTransferCalculation.Adaptive)) {
+		if (!staticConfig.getTransferCalculation().equals(RaptorTransferCalculation.Initial)) {
 			staticTransferTimes = new IdMap<>(TransitStopFacility.class);
 
 			MinimalTransferTimes.MinimalTransferTimesIterator iterator = schedule.getMinimalTransferTimes().iterator();
@@ -654,8 +655,10 @@ public class SwissRailRaptorData {
 		// using a lock in some way. But so far, we didn't experience any problem. /sh
 		// may 2024
 
-    	RTransfer[] cache = transferCache[fromRouteStop.index];
-    	if (cache != null) return cache; // we had a cache hit
+        if (transferCache != null) {
+            RTransfer[] cache = transferCache[fromRouteStop.index];
+            if (cache != null) return cache; // we had a cache hit
+        }
 
     	// setting up useful constants
     	final double minimalTransferTime = config.getMinimalTransferTime();
@@ -705,8 +708,11 @@ public class SwissRailRaptorData {
         // convert to array
         RTransfer[] stopTransfers = transfers.toArray(new RTransfer[transfers.size()]);
 
-        // save to cache (no issue regarding parallel execution because we simply set an element)
-        transferCache[fromRouteStop.index] = stopTransfers;
+        if (transferCache != null) {
+            // save to cache (no issue regarding parallel execution because we simply set an element)
+            transferCache[fromRouteStop.index] = stopTransfers;
+        }
+
         return stopTransfers;
     }
 }


### PR DESCRIPTION
This PR adds yet another mode of calculating transfers in SRR (`Online`). It works like the `Adaptive` mode, which doesn't calculate all possible transfers upfront. However, contrary to the `Adaptive` mode, it doesn't cache any previously calculated transfers. This means that processing times go up quite a lot, but one can perform routing with little memory on very large schedules.