### PR TITLE
feat(drt): explicit max ride constraints in drt

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/edrt/run/EDrtModeOptimizerQSimModule.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/edrt/run/EDrtModeOptimizerQSimModule.java
@@ -40,6 +40,7 @@ import org.matsim.contrib.drt.passenger.DrtOfferAcceptor;
 import org.matsim.contrib.drt.prebooking.PrebookingActionCreator;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.schedule.DrtRoutingDriveTaskUpdater;
+import org.matsim.contrib.drt.schedule.DrtScheduleTimingUpdater;
 import org.matsim.contrib.drt.schedule.DrtTaskFactory;
 import org.matsim.contrib.drt.scheduler.DefaultRequestInsertionScheduler;
 import org.matsim.contrib.drt.scheduler.DrtScheduleInquiry;
@@ -55,6 +56,7 @@ import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpModes;
 import org.matsim.contrib.dvrp.schedule.DriveTaskUpdater;
 import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
+import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdaterImpl;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
 import org.matsim.contrib.dvrp.vrpagent.VrpLegFactory;
 import org.matsim.contrib.ev.charging.ChargingStrategy;
@@ -90,7 +92,7 @@ public class EDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 				getter ->  {
 					return new DefaultDrtOptimizer(drtCfg, getter.getModal(Fleet.class), getter.get(MobsimTimer.class),
 						getter.getModal(DepotFinder.class), getter.getModal(RebalancingStrategy.class),
-						getter.getModal(DrtScheduleInquiry.class), getter.getModal(ScheduleTimingUpdater.class),
+						getter.getModal(DrtScheduleInquiry.class), getter.getModal(ScheduleTimingUpdaterImpl.class),
 						getter.getModal(EmptyVehicleRelocator.class), getter.getModal(UnplannedRequestInserter.class),
 						getter.getModal(DrtRequestInsertionRetryQueue.class));
 				})).asEagerSingleton();
@@ -175,7 +177,7 @@ public class EDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 		bindModal(RequestInsertionScheduler.class).toProvider(modalProvider(
 						getter -> new DefaultRequestInsertionScheduler(getter.getModal(Fleet.class),
 								getter.get(MobsimTimer.class), getter.getModal(TravelTime.class),
-								getter.getModal(ScheduleTimingUpdater.class), getter.getModal(DrtTaskFactory.class),
+								getter.getModal(ScheduleTimingUpdaterImpl.class), getter.getModal(DrtTaskFactory.class),
 								getter.getModal(StopTimeCalculator.class), scheduleWaitBeforeDrive)))
 				.asEagerSingleton();
 
@@ -198,9 +200,9 @@ public class EDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 		}
 
 		bindModal(ScheduleTimingUpdater.class).toProvider(modalProvider(
-				getter -> new ScheduleTimingUpdater(getter.get(MobsimTimer.class),
+				getter -> new DrtScheduleTimingUpdater(new ScheduleTimingUpdaterImpl(getter.get(MobsimTimer.class),
 						new EDrtStayTaskEndTimeCalculator(getter.getModal(StopTimeCalculator.class)),
-						getter.getModal(DriveTaskUpdater.class)))).asEagerSingleton();
+						getter.getModal(DriveTaskUpdater.class)), getter.getModal(PassengerStopDurationProvider.class)))).asEagerSingleton();
 
 		bindModal(VrpLegFactory.class).toProvider(modalProvider(getter -> {
 			DvrpConfigGroup dvrpCfg = getter.get(DvrpConfigGroup.class);

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/run/ShiftDrtModeOptimizerQSimModule.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/run/ShiftDrtModeOptimizerQSimModule.java
@@ -28,11 +28,13 @@ import org.matsim.contrib.drt.optimizer.insertion.UnplannedRequestInserter;
 import org.matsim.contrib.drt.optimizer.rebalancing.RebalancingStrategy;
 import org.matsim.contrib.drt.prebooking.PrebookingActionCreator;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.drt.schedule.DrtScheduleTimingUpdater;
 import org.matsim.contrib.drt.schedule.DrtStayTaskEndTimeCalculator;
 import org.matsim.contrib.drt.schedule.DrtTaskFactory;
 import org.matsim.contrib.drt.schedule.DrtTaskFactoryImpl;
 import org.matsim.contrib.drt.scheduler.DrtScheduleInquiry;
 import org.matsim.contrib.drt.scheduler.EmptyVehicleRelocator;
+import org.matsim.contrib.drt.stops.PassengerStopDurationProvider;
 import org.matsim.contrib.drt.stops.StopTimeCalculator;
 import org.matsim.contrib.drt.vrpagent.DrtActionCreator;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicleImpl;
@@ -46,6 +48,7 @@ import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpModes;
 import org.matsim.contrib.dvrp.schedule.DriveTaskUpdater;
 import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
+import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdaterImpl;
 import org.matsim.contrib.dvrp.tracker.OnlineTrackerListener;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
 import org.matsim.contrib.dvrp.vrpagent.VrpLegFactory;
@@ -80,12 +83,12 @@ public class ShiftDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule 
 					return new ShiftDrtOptimizer(
 							new DefaultDrtOptimizer(drtCfg, getter.getModal(Fleet.class), getter.get(MobsimTimer.class),
 									getter.getModal(DepotFinder.class), getter.getModal(RebalancingStrategy.class),
-									getter.getModal(DrtScheduleInquiry.class), getter.getModal(ScheduleTimingUpdater.class),
+									getter.getModal(DrtScheduleInquiry.class), getter.getModal(ScheduleTimingUpdaterImpl.class),
 									getter.getModal(EmptyVehicleRelocator.class), getter.getModal(UnplannedRequestInserter.class),
 									getter.getModal(DrtRequestInsertionRetryQueue.class)
 							),
 							getter.getModal(DrtShiftDispatcher.class),
-							getter.getModal(ScheduleTimingUpdater.class));
+							getter.getModal(ScheduleTimingUpdaterImpl.class));
 				}));
 
 		bindModal(AssignShiftToVehicleLogic.class).toProvider(modalProvider(getter ->
@@ -126,11 +129,11 @@ public class ShiftDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule 
 		bindModal(DrtScheduleInquiry.class).to(ShiftDrtScheduleInquiry.class).asEagerSingleton();
 
 		bindModal(ScheduleTimingUpdater.class).toProvider(modalProvider(
-				getter -> new ScheduleTimingUpdater(getter.get(MobsimTimer.class),
+				getter -> new DrtScheduleTimingUpdater(new ScheduleTimingUpdaterImpl(getter.get(MobsimTimer.class),
 						new ShiftDrtStayTaskEndTimeCalculator(shiftsParams,
 								new DrtStayTaskEndTimeCalculator(getter.getModal(StopTimeCalculator.class))),
-						getter.getModal(DriveTaskUpdater.class)))
-		).asEagerSingleton();
+						getter.getModal(DriveTaskUpdater.class)), getter.getModal(PassengerStopDurationProvider.class))
+		)).asEagerSingleton();
 
 		// see DrtModeOptimizerQSimModule
 		bindModal(VrpLegFactory.class).toProvider(modalProvider(getter -> {

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preplanned/optimizer/PreplannedDrtModeOptimizerQSimModule.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preplanned/optimizer/PreplannedDrtModeOptimizerQSimModule.java
@@ -23,10 +23,8 @@ package org.matsim.contrib.drt.extension.preplanned.optimizer;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.drt.optimizer.DrtOptimizer;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
-import org.matsim.contrib.drt.schedule.DrtRoutingDriveTaskUpdater;
-import org.matsim.contrib.drt.schedule.DrtStayTaskEndTimeCalculator;
-import org.matsim.contrib.drt.schedule.DrtTaskFactory;
-import org.matsim.contrib.drt.schedule.DrtTaskFactoryImpl;
+import org.matsim.contrib.drt.schedule.*;
+import org.matsim.contrib.drt.stops.PassengerStopDurationProvider;
 import org.matsim.contrib.drt.stops.StopTimeCalculator;
 import org.matsim.contrib.drt.vrpagent.DrtActionCreator;
 import org.matsim.contrib.dvrp.fleet.Fleet;
@@ -35,6 +33,7 @@ import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.schedule.DriveTaskUpdater;
 import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
+import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdaterImpl;
 import org.matsim.contrib.dvrp.tracker.OnlineTrackerListener;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
 import org.matsim.contrib.dvrp.vrpagent.VrpLegFactory;
@@ -100,8 +99,8 @@ public class PreplannedDrtModeOptimizerQSimModule extends AbstractDvrpModeQSimMo
 		}
 
 		bindModal(ScheduleTimingUpdater.class).toProvider(modalProvider(
-				getter -> new ScheduleTimingUpdater(getter.get(MobsimTimer.class),
+				getter -> new DrtScheduleTimingUpdater(new ScheduleTimingUpdaterImpl(getter.get(MobsimTimer.class),
 						new DrtStayTaskEndTimeCalculator(getter.getModal(StopTimeCalculator.class)),
-						getter.getModal(DriveTaskUpdater.class)))).asEagerSingleton();
+						getter.getModal(DriveTaskUpdater.class)), getter.getModal(PassengerStopDurationProvider.class)))).asEagerSingleton();
 	}
 }

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/services/optimizer/DrtServiceOptimizerQSimModule.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/services/optimizer/DrtServiceOptimizerQSimModule.java
@@ -40,7 +40,7 @@ import org.matsim.contrib.drt.vrpagent.DrtActionCreator;
 import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.load.DvrpLoadType;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
-import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
+import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdaterImpl;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 
@@ -78,12 +78,12 @@ public class DrtServiceOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 			getter -> {
 				var delegate = new DefaultDrtOptimizer(drtConfigGroup, getter.getModal(Fleet.class), getter.get(MobsimTimer.class),
 					getter.getModal(DepotFinder.class), getter.getModal(RebalancingStrategy.class),
-					getter.getModal(DrtScheduleInquiry.class), getter.getModal(ScheduleTimingUpdater.class),
+					getter.getModal(DrtScheduleInquiry.class), getter.getModal(ScheduleTimingUpdaterImpl.class),
 					getter.getModal(EmptyVehicleRelocator.class), getter.getModal(UnplannedRequestInserter.class),
 					getter.getModal(DrtRequestInsertionRetryQueue.class));
 				return new DrtServiceTaskOptimizer(getter.getModal(ServiceTaskDispatcher.class),
 					delegate,
-					getter.getModal(ScheduleTimingUpdater.class),
+					getter.getModal(ScheduleTimingUpdaterImpl.class),
 					getter.get(MobsimTimer.class));
 			}));
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtModeOptimizerQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtModeOptimizerQSimModule.java
@@ -42,10 +42,7 @@ import org.matsim.contrib.drt.passenger.DefaultOfferAcceptor;
 import org.matsim.contrib.drt.passenger.DrtOfferAcceptor;
 import org.matsim.contrib.drt.prebooking.PrebookingActionCreator;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
-import org.matsim.contrib.drt.schedule.DrtRoutingDriveTaskUpdater;
-import org.matsim.contrib.drt.schedule.DrtStayTaskEndTimeCalculator;
-import org.matsim.contrib.drt.schedule.DrtTaskFactory;
-import org.matsim.contrib.drt.schedule.DrtTaskFactoryImpl;
+import org.matsim.contrib.drt.schedule.*;
 import org.matsim.contrib.drt.scheduler.DefaultRequestInsertionScheduler;
 import org.matsim.contrib.drt.scheduler.DrtScheduleInquiry;
 import org.matsim.contrib.drt.scheduler.EmptyVehicleRelocator;
@@ -61,6 +58,7 @@ import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpModes;
 import org.matsim.contrib.dvrp.schedule.DriveTaskUpdater;
 import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
+import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdaterImpl;
 import org.matsim.contrib.dvrp.tracker.OnlineTrackerListener;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
 import org.matsim.contrib.dvrp.vrpagent.VrpLegFactory;
@@ -185,9 +183,9 @@ public class DrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 		}
 
 		bindModal(ScheduleTimingUpdater.class).toProvider(modalProvider(
-				getter -> new ScheduleTimingUpdater(getter.get(MobsimTimer.class),
+				getter -> new DrtScheduleTimingUpdater(new ScheduleTimingUpdaterImpl(getter.get(MobsimTimer.class),
 						new DrtStayTaskEndTimeCalculator(getter.getModal(StopTimeCalculator.class)),
-						getter.getModal(DriveTaskUpdater.class)))).asEagerSingleton();
+						getter.getModal(DriveTaskUpdater.class)), getter.getModal(PassengerStopDurationProvider.class)))).asEagerSingleton();
 
 		bindModal(VrpLegFactory.class).toProvider(modalProvider(getter -> {
 			DvrpConfigGroup dvrpCfg = getter.get(DvrpConfigGroup.class);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/VehicleDataEntryFactoryImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/VehicleDataEntryFactoryImpl.java
@@ -25,6 +25,7 @@ import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.getBaseTypeOrElseT
 import java.util.ArrayList;
 import java.util.List;
 
+import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
 import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.drt.schedule.DrtCapacityChangeTask;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
@@ -118,20 +119,40 @@ public class VehicleDataEntryFactoryImpl implements VehicleEntry.EntryFactory {
 				ImmutableList.copyOf(stops), slackTimes, precedingStayTimes, currentTime);
 	}
 
-	static double[] computeSlackTimes(DvrpVehicle vehicle, double now, Waypoint.Stop[] stops, Waypoint.Stop start, List<Double> precedingStayTimes) {
+	static double[] computeSlackTimes(DvrpVehicle vehicle, double now, Waypoint.Stop[] stops, Waypoint.Stop start,
+									  List<Double> precedingStayTimes) {
 		double[] slackTimes = new double[stops.length + 2];
 
 		//vehicle
 		double slackTime = calcVehicleSlackTime(vehicle, now);
 		slackTimes[stops.length + 1] = slackTime;
 
+		List<AcceptedDrtRequest> onboard = new ArrayList<>();
+
 		//stops
 		for (int i = stops.length - 1; i >= 0; i--) {
+
 			var stop = stops[i];
+
+			onboard.addAll(stop.task.getDropoffRequests().values());
+
 			slackTime = Math.min(stop.latestArrivalTime - stop.task.getBeginTime(), slackTime);
 			slackTime = Math.min(stop.latestDepartureTime - stop.task.getEndTime(), slackTime);
+
+			for (AcceptedDrtRequest req : onboard) {
+				double plannedPickupTime = req.getPickupTime().orElseThrow(()
+						-> new IllegalStateException("Accepted request should have a (planned) pickup time at this point."));
+				double plannedDropoffTime = req.getDropoffTime().orElseThrow(()
+						-> new IllegalStateException("Accepted request should have a (planned) dropoff time at this point."));
+				double currentRideDuration = plannedDropoffTime - plannedPickupTime;
+				double currentRideSlack = Math.max(0, req.getMaxRideDuration() - currentRideDuration);
+				slackTime = Math.min(slackTime, currentRideSlack);
+			}
+
 			slackTime += precedingStayTimes.get(i); // reset slack before prebooked request
 			slackTimes[i + 1] = slackTime;
+
+			onboard.removeAll(stop.task.getPickupRequests().values());
 		}
 
 		// start

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/constraints/DrtOptimizationConstraintsSet.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/constraints/DrtOptimizationConstraintsSet.java
@@ -27,8 +27,9 @@ public abstract class DrtOptimizationConstraintsSet extends ReflectiveConfigGrou
             + " violates one of the constraints is allowed, but its cost is increased by additional penalty to make"
             + " it relatively less attractive). Penalisation of insertions can be customised by injecting a customised"
             + " InsertionCostCalculator.PenaltyCalculator")
-    public boolean rejectRequestIfMaxWaitOrTravelTimeViolated = true;//TODO consider renaming maxWalkDistance to max access/egress distance (or even have 2 separate params)
+    public boolean rejectRequestIfMaxWaitOrTravelTimeViolated = true;
 
+    //TODO consider renaming maxWalkDistance to max access/egress distance (or even have 2 separate params)
     @Parameter
     @Comment(
             "Maximum beeline distance (in meters) to next stop location in stopbased system for access/egress walk leg to/from drt."

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategy.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategy.java
@@ -83,7 +83,7 @@ public interface CostCalculationStrategy {
 		static final double MAX_WAIT_TIME_VIOLATION_PENALTY = 1;// 1 second of penalty per 1 second of late departure
 		static final double MAX_TRAVEL_TIME_VIOLATION_PENALTY = 10;// 10 seconds of penalty per 1 second of late arrival
 		static final double MAX_RIDE_TIME_VIOLATION_PENALTY = 10;// 10 seconds of penalty per 1 second of exceeded detour
-		static final double LATE_DIVERSION_VIOLATION_PENALTY = 10;// 1 second of penalty per 1 second of late diversion of onboard requests
+		static final double LATE_DIVERSION_VIOLATION_PENALTY = 10;// 10 second of penalty per 1 second of late diversion of onboard requests
 
 		@Override
 		public double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion,
@@ -114,7 +114,7 @@ public interface CostCalculationStrategy {
             return MAX_WAIT_TIME_VIOLATION_PENALTY * waitTimeViolation
 					+ MAX_TRAVEL_TIME_VIOLATION_PENALTY * travelTimeViolation
 					+ MAX_RIDE_TIME_VIOLATION_PENALTY * detourViolation
-					+ MAX_RIDE_TIME_VIOLATION_PENALTY * lateDiversionViolation
+					+ LATE_DIVERSION_VIOLATION_PENALTY * lateDiversionViolation
 					+ totalTimeLoss;
 		}
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
@@ -142,19 +142,21 @@ public class DefaultUnplannedRequestInserter implements UnplannedRequestInserter
 				var vehicle = insertion.insertion.vehicleEntry.vehicle;
 				var pickupDropoffTaskPair = insertionScheduler.scheduleRequest(acceptedRequest.get(), insertion);
 
+				double expectedPickupTime = pickupDropoffTaskPair.pickupTask.getBeginTime();
+				expectedPickupTime = Math.max(expectedPickupTime, acceptedRequest.get().getEarliestStartTime());
+				expectedPickupTime += stopDurationProvider.calcPickupDuration(vehicle, req);
+				acceptedRequest.get().setPickupTime(expectedPickupTime);
+
+				double expectedDropoffTime = pickupDropoffTaskPair.dropoffTask.getBeginTime();
+				expectedDropoffTime += stopDurationProvider.calcDropoffDuration(vehicle, req);
+				acceptedRequest.get().setDropoffTime(expectedDropoffTime);
+
 				VehicleEntry newVehicleEntry = vehicleEntryFactory.create(vehicle, now);
 				if (newVehicleEntry != null) {
 					vehicleEntries.put(vehicle.getId(), newVehicleEntry);
 				} else {
 					vehicleEntries.remove(vehicle.getId());
 				}
-
-				double expectedPickupTime = pickupDropoffTaskPair.pickupTask.getBeginTime();
-				expectedPickupTime = Math.max(expectedPickupTime, acceptedRequest.get().getEarliestStartTime());
-				expectedPickupTime += stopDurationProvider.calcPickupDuration(vehicle, req);
-
-				double expectedDropoffTime = pickupDropoffTaskPair.dropoffTask.getBeginTime();
-				expectedDropoffTime += stopDurationProvider.calcDropoffDuration(vehicle, req);
 
 				eventsManager.processEvent(
 						new PassengerRequestScheduledEvent(now, mode, req.getId(), req.getPassengerIds(), vehicle.getId(),

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/AcceptedDrtRequest.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/AcceptedDrtRequest.java
@@ -28,6 +28,7 @@ import org.matsim.contrib.dvrp.load.DvrpLoad;
 import org.matsim.contrib.dvrp.optimizer.Request;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -49,6 +50,12 @@ public class AcceptedDrtRequest {
 	private final double latestStartTime;
 	private final double latestArrivalTime;
 	private final double maxRideDuration;
+
+	// allow null to ensure we realize it hasn't been set
+	private Double pickupTime = null;
+
+	// allow null to ensure we realize it hasn't been set
+	private Double dropoffTime = null;
 
 	private AcceptedDrtRequest(Builder builder) {
 		request = builder.request;
@@ -117,6 +124,22 @@ public class AcceptedDrtRequest {
 
 	public String getMode() {
 		return request.getMode();
+	}
+
+	public void setPickupTime(double pickupTime) {
+		this.pickupTime = pickupTime;
+	}
+
+	public Optional<Double> getPickupTime() {
+		return Optional.ofNullable(pickupTime);
+	}
+
+	public void setDropoffTime(double dropoffTime) {
+		this.dropoffTime = dropoffTime;
+	}
+
+	public Optional<Double> getDropoffTime() {
+		return Optional.ofNullable(dropoffTime);
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DefaultOfferAcceptor.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DefaultOfferAcceptor.java
@@ -32,7 +32,7 @@ public class DefaultOfferAcceptor implements DrtOfferAcceptor{
 			.request(request)
 			.earliestStartTime(request.getEarliestStartTime())
 			.maxRideDuration(request.getMaxRideDuration())
-			.latestArrivalTime(Math.min(updatedLatestStartTime + request.getMaxRideDuration(), request.getLatestArrivalTime()))
+			.latestArrivalTime(request.getLatestArrivalTime())
 			.latestStartTime(updatedLatestStartTime)
 			.build());
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtScheduleTimingUpdater.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/schedule/DrtScheduleTimingUpdater.java
@@ -1,0 +1,69 @@
+package org.matsim.contrib.drt.schedule;
+
+import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
+import org.matsim.contrib.drt.stops.PassengerStopDurationProvider;
+import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
+import org.matsim.contrib.dvrp.schedule.Schedule;
+import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
+import org.matsim.contrib.dvrp.schedule.Task;
+
+import java.util.List;
+
+/**
+ * Drt specific timing updater that also updates current timing estimates on accepted requests.
+ */
+public class DrtScheduleTimingUpdater implements ScheduleTimingUpdater {
+
+    private final ScheduleTimingUpdater delegate;
+    private final PassengerStopDurationProvider stopDurationProvider;
+
+    public DrtScheduleTimingUpdater(ScheduleTimingUpdater delegate,
+                                    PassengerStopDurationProvider stopDurationProvider) {
+        this.delegate = delegate;
+        this.stopDurationProvider = stopDurationProvider;
+    }
+
+    @Override
+    public void updateBeforeNextTask(DvrpVehicle vehicle) {
+        if (vehicle.getSchedule().getStatus() != Schedule.ScheduleStatus.STARTED) {
+            return;
+        }
+        delegate.updateBeforeNextTask(vehicle);
+        updatePuDoTimes(vehicle, vehicle.getSchedule().getCurrentTask().getTaskIdx());
+    }
+
+    @Override
+    public void updateTimings(DvrpVehicle vehicle) {
+        if (vehicle.getSchedule().getStatus() != Schedule.ScheduleStatus.STARTED) {
+            return;
+        }
+        delegate.updateTimings(vehicle);
+        updatePuDoTimes(vehicle, vehicle.getSchedule().getCurrentTask().getTaskIdx());
+    }
+
+
+    @Override
+    public void updateTimingsStartingFromTaskIdx(DvrpVehicle vehicle, int startIdx, double newBeginTime) {
+        delegate.updateTimingsStartingFromTaskIdx(vehicle, startIdx, newBeginTime);
+        updatePuDoTimes(vehicle, startIdx);
+    }
+
+    private void updatePuDoTimes(DvrpVehicle vehicle, int startIdx) {
+
+        Schedule schedule = vehicle.getSchedule();
+        List<? extends Task> tasks = schedule.getTasks();
+
+        for (int i = startIdx; i < tasks.size(); i++) {
+            if(tasks.get(i) instanceof DrtStopTask stopTask) {
+                for (AcceptedDrtRequest pickup : stopTask.getPickupRequests().values()) {
+                    double expectedPickupTime = Math.max(stopTask.getBeginTime(), pickup.getEarliestStartTime());
+                    expectedPickupTime += stopDurationProvider.calcPickupDuration(vehicle, pickup.getRequest());
+                    pickup.setPickupTime(expectedPickupTime);
+                }
+                for (AcceptedDrtRequest dropoff : stopTask.getDropoffRequests().values()) {
+                    dropoff.setDropoffTime(stopTask.getBeginTime() + stopDurationProvider.calcDropoffDuration(vehicle, dropoff.getRequest()));
+                }
+            }
+        }
+    }
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
@@ -116,7 +116,8 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 		for (int i = 1; i < schedule.getTaskCount(); i++) {
 			Task first = schedule.getTasks().get(i - 1);
 			Task second = schedule.getTasks().get(i);
-			Verify.verify(first.getEndTime() == second.getBeginTime());
+			Verify.verify(first.getEndTime() == second.getBeginTime(), "End time of task %s not aligned " +
+					"with begin time %s of following task.", first.getEndTime(), second.getBeginTime());
 		}
 	}
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/VehicleDataEntryFactoryImplTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/VehicleDataEntryFactoryImplTest.java
@@ -30,12 +30,15 @@ import org.junit.jupiter.api.Test;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.drt.optimizer.Waypoint.Stop;
+import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
+import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicleImpl;
 import org.matsim.contrib.dvrp.fleet.ImmutableDvrpVehicleSpecification;
 import org.matsim.contrib.dvrp.load.IntegerLoadType;
+import org.matsim.contrib.dvrp.optimizer.Request;
 import org.matsim.testcases.fakes.FakeLink;
 
 /**
@@ -65,6 +68,77 @@ public class VehicleDataEntryFactoryImplTest {
 		//final stay task not started - vehicle slack time is 10 and limits the slack times at all stops
 		assertThat(computeSlackTimes(vehicle(500, 490), 100, new Stop[] { stop0, stop1 }, null, precedingStayTimes)).containsExactly(10, 10, 10, 10);
 	}
+
+	@Test
+	void computeSlackTimes_withRideDurationConstraints_a() {
+
+		//time slack: 20 (arrival is the constraint)
+		Waypoint.Stop pickupStop =  stop(100, 120, 200, 230);
+		//time slack: 30 (departure is the constraint)
+		Waypoint.Stop dropoffStop = stop(300, 340, 400, 430);
+
+		AcceptedDrtRequest mockRequest = AcceptedDrtRequest.newBuilder()
+				.request(DrtRequest.newBuilder().id(Id.create("mock", Request.class)).build())
+				.latestArrivalTime(340)
+				.maxRideDuration(200)
+				.earliestStartTime(100)
+				.latestStartTime(230)
+				.build();
+
+		// stop duration == 0 --> pickup time == stop begin time
+		mockRequest.setPickupTime(100);
+		mockRequest.setDropoffTime(300);
+		// ---> ride duration == 200 == max ride duration --> slack should be == 0
+
+		pickupStop.task.addPickupRequest(mockRequest);
+		dropoffStop.task.addDropoffRequest(mockRequest);
+
+		Stop[] stops = new Stop[] {pickupStop, dropoffStop};
+
+		var precedingStayTimes = List.of(0.0, 0.0);
+
+		// initial vehicle slack == 1000
+		DvrpVehicle vehicle = vehicle(2000, 1000);
+
+		double[] slackTimes = computeSlackTimes(vehicle, 0, stops, null, precedingStayTimes);
+		assertThat(slackTimes).containsExactly(0, 0, 0, 1000);
+	}
+
+	@Test
+	void computeSlackTimes_withRideDurationConstraints_b() {
+
+		//time slack: 20 (arrival is the constraint)
+		Waypoint.Stop pickupStop =  stop(100, 120, 200, 230);
+		//time slack: 30 (departure is the constraint)
+		Waypoint.Stop dropoffStop = stop(300, 340, 400, 430);
+
+		AcceptedDrtRequest mockRequest = AcceptedDrtRequest.newBuilder()
+				.request(DrtRequest.newBuilder().id(Id.create("mock", Request.class)).build())
+				.latestArrivalTime(340)
+				.maxRideDuration(210)
+				.earliestStartTime(100)
+				.latestStartTime(230)
+				.build();
+
+		// stop duration == 0 --> pickup time == stop begin time
+		mockRequest.setPickupTime(100);
+		mockRequest.setDropoffTime(300);
+		// ---> ride duration == 200 == max ride duration --> slack should be == 0
+
+		pickupStop.task.addPickupRequest(mockRequest);
+		dropoffStop.task.addDropoffRequest(mockRequest);
+
+		Stop[] stops = new Stop[] {pickupStop, dropoffStop};
+
+		var precedingStayTimes = List.of(0.0, 0.0);
+
+		// initial vehicle slack == 1000
+		DvrpVehicle vehicle = vehicle(2000, 1000);
+
+		double[] slackTimes = computeSlackTimes(vehicle, 0, stops, null, precedingStayTimes);
+		assertThat(slackTimes).containsExactly(10, 10, 10, 1000);
+	}
+
 
 	@Test
 	void computeSlackTimes_withoutStops() {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/prebooking/ComplexUnschedulerTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/prebooking/ComplexUnschedulerTest.java
@@ -36,11 +36,7 @@ import org.matsim.contrib.dvrp.optimizer.Request;
 import org.matsim.contrib.dvrp.path.DivertedVrpPath;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.path.VrpPaths;
-import org.matsim.contrib.dvrp.schedule.DriveTask;
-import org.matsim.contrib.dvrp.schedule.Schedule;
-import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
-import org.matsim.contrib.dvrp.schedule.StayTask;
-import org.matsim.contrib.dvrp.schedule.Task;
+import org.matsim.contrib.dvrp.schedule.*;
 import org.matsim.contrib.dvrp.tracker.OnlineDriveTaskTracker;
 import org.matsim.contrib.dvrp.util.LinkTimePair;
 import org.matsim.core.network.NetworkUtils;
@@ -632,7 +628,7 @@ public class ComplexUnschedulerTest {
 
 			this.entryFactory = new VehicleDataEntryFactoryImpl(integerLoadType);
 
-			this.timingUpdater = Mockito.mock(ScheduleTimingUpdater.class);
+			this.timingUpdater = Mockito.mock(ScheduleTimingUpdaterImpl.class);
 		}
 
 		AcceptedDrtRequest createRequest() {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionSchedulerTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionSchedulerTest.java
@@ -1,13 +1,6 @@
 package org.matsim.contrib.drt.scheduler;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.matsim.contrib.dvrp.path.VrpPaths.NODE_TRANSITION_TIME;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-
+import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.matsim.api.core.v01.Id;
@@ -19,37 +12,31 @@ import org.matsim.contrib.drt.optimizer.insertion.InsertionGenerator;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionWithDetourData;
 import org.matsim.contrib.drt.passenger.AcceptedDrtRequest;
 import org.matsim.contrib.drt.passenger.DrtRequest;
-import org.matsim.contrib.drt.schedule.DefaultDrtStopTask;
-import org.matsim.contrib.drt.schedule.DrtDriveTask;
-import org.matsim.contrib.drt.schedule.DrtStayTask;
-import org.matsim.contrib.drt.schedule.DrtStayTaskEndTimeCalculator;
-import org.matsim.contrib.drt.schedule.DrtStopTask;
-import org.matsim.contrib.drt.schedule.DrtTaskFactoryImpl;
+import org.matsim.contrib.drt.schedule.*;
 import org.matsim.contrib.drt.stops.MinimumStopDurationAdapter;
 import org.matsim.contrib.drt.stops.PrebookingStopTimeCalculator;
 import org.matsim.contrib.drt.stops.StaticPassengerStopDurationProvider;
-import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
-import org.matsim.contrib.dvrp.fleet.Fleet;
-import org.matsim.contrib.dvrp.fleet.FleetSpecificationImpl;
-import org.matsim.contrib.dvrp.fleet.Fleets;
-import org.matsim.contrib.dvrp.fleet.ImmutableDvrpVehicleSpecification;
+import org.matsim.contrib.dvrp.fleet.*;
 import org.matsim.contrib.dvrp.load.DvrpLoad;
 import org.matsim.contrib.dvrp.load.IntegerLoadType;
 import org.matsim.contrib.dvrp.optimizer.Request;
 import org.matsim.contrib.dvrp.path.OneToManyPathSearch;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.path.VrpPaths;
-import org.matsim.contrib.dvrp.schedule.DriveTaskUpdater;
-import org.matsim.contrib.dvrp.schedule.Schedule;
-import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
-import org.matsim.contrib.dvrp.schedule.Task;
+import org.matsim.contrib.dvrp.schedule.*;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.testcases.fakes.FakeLink;
 
-import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.matsim.contrib.dvrp.path.VrpPaths.NODE_TRANSITION_TIME;
 
 /**
  * @author nkuehnel / MOIA
@@ -195,7 +182,7 @@ public class DefaultRequestInsertionSchedulerTest {
 
     private static DefaultRequestInsertionScheduler getDefaultRequestInsertionScheduler(Fleet fleet, MobsimTimer timer) {
         MinimumStopDurationAdapter stopDuration = new MinimumStopDurationAdapter(new PrebookingStopTimeCalculator(StaticPassengerStopDurationProvider.of(STOP_DURATION, 0.0)), 60.);
-        ScheduleTimingUpdater scheduleTimingUpdater = new ScheduleTimingUpdater(timer, new DrtStayTaskEndTimeCalculator(stopDuration), DriveTaskUpdater.NOOP);
+        ScheduleTimingUpdater scheduleTimingUpdater = new ScheduleTimingUpdaterImpl(timer, new DrtStayTaskEndTimeCalculator(stopDuration), DriveTaskUpdater.NOOP);
         DefaultRequestInsertionScheduler insertionScheduler = new DefaultRequestInsertionScheduler(fleet, timer, TRAVEL_TIME, scheduleTimingUpdater,
                 new DrtTaskFactoryImpl(), stopDuration, true);
         return insertionScheduler;

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/schedule/ScheduleTimingUpdater.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/schedule/ScheduleTimingUpdater.java
@@ -2,7 +2,7 @@
  * project: org.matsim.*
  * *********************************************************************** *
  *                                                                         *
- * copyright       : (C) 2007 by the members listed in the COPYING,        *
+ * copyright       : (C) 2025 by the members listed in the COPYING,        *
  *                   LICENSE and WARRANTY file.                            *
  * email           : info at matsim dot org                                *
  *                                                                         *
@@ -15,103 +15,20 @@
  *   See also COPYING, LICENSE and WARRANTY file                           *
  *                                                                         *
  * *********************************************************************** */
-
 package org.matsim.contrib.dvrp.schedule;
 
-import static org.matsim.contrib.dvrp.schedule.Schedule.ScheduleStatus;
-
-import java.util.List;
-
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
-import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
-import org.matsim.contrib.dvrp.tracker.TaskTrackers;
-import org.matsim.core.mobsim.framework.MobsimTimer;
 
-public class ScheduleTimingUpdater {
-	public interface StayTaskEndTimeCalculator {
-		double calcNewEndTime(DvrpVehicle vehicle, StayTask task, double newBeginTime);
-	}
+public interface ScheduleTimingUpdater {
+    double REMOVE_STAY_TASK = Double.NEGATIVE_INFINITY;
 
-	private final MobsimTimer timer;
-	private final StayTaskEndTimeCalculator stayTaskEndTimeCalculator;
-	private final DriveTaskUpdater driveTaskUpdater;
+    void updateBeforeNextTask(DvrpVehicle vehicle);
 
-	public final static double REMOVE_STAY_TASK = Double.NEGATIVE_INFINITY;
+    void updateTimings(DvrpVehicle vehicle);
 
-	public ScheduleTimingUpdater(MobsimTimer timer, StayTaskEndTimeCalculator stayTaskEndTimeCalculator, DriveTaskUpdater driveTaskUpdater) {
-		this.timer = timer;
-		this.stayTaskEndTimeCalculator = stayTaskEndTimeCalculator;
-		this.driveTaskUpdater = driveTaskUpdater;
-	}
+    void updateTimingsStartingFromTaskIdx(DvrpVehicle vehicle, int startIdx, double newBeginTime);
 
-	/**
-	 * This method should be called inside {@code VrpOptimizer.nextTask()} before anything else is done.
-	 * Check and decide if the schedule should be updated due to if vehicle is Update timings (i.e. beginTime and
-	 * endTime) of all tasks in the schedule.
-	 */
-	public void updateBeforeNextTask(DvrpVehicle vehicle) {
-		Schedule schedule = vehicle.getSchedule();
-		// Assumption: there is no delay as long as the schedule has not been started (PLANNED)
-		if (schedule.getStatus() != ScheduleStatus.STARTED) {
-			return;
-		}
-
-		updateTimingsStartingFromCurrentTask(vehicle, timer.getTimeOfDay());
-	}
-
-	public void updateTimings(DvrpVehicle vehicle) {
-		Schedule schedule = vehicle.getSchedule();
-		if (schedule.getStatus() != ScheduleStatus.STARTED) {
-			return;
-		}
-
-		if (schedule.getCurrentTask() instanceof DriveTask driveTask) {
-			driveTaskUpdater.updateCurrentDriveTask(vehicle, driveTask);
-		}
-
-		double predictedEndTime = TaskTrackers.predictEndTime(schedule.getCurrentTask(), timer.getTimeOfDay());
-		updateTimingsStartingFromCurrentTask(vehicle, predictedEndTime);
-	}
-
-	private void updateTimingsStartingFromCurrentTask(DvrpVehicle vehicle, double newEndTime) {
-		Schedule schedule = vehicle.getSchedule();
-		Task currentTask = schedule.getCurrentTask();
-		if (currentTask.getEndTime() != newEndTime || driveTaskUpdater != DriveTaskUpdater.NOOP) {
-			currentTask.setEndTime(newEndTime);
-			updateTimingsStartingFromTaskIdx(vehicle, currentTask.getTaskIdx() + 1, newEndTime);
-		}
-	}
-
-	public void updateTimingsStartingFromTaskIdx(DvrpVehicle vehicle, int startIdx, double newBeginTime) {
-		Schedule schedule = vehicle.getSchedule();
-		List<? extends Task> tasks = schedule.getTasks();
-
-		for (int i = startIdx; i < tasks.size(); i++) {
-			double calcEndTime = calcNewEndTime(vehicle, tasks.get(i), newBeginTime);
-
-			Task task = tasks.get(i);
-			if (calcEndTime == REMOVE_STAY_TASK) {
-				schedule.removeTask(task);
-				i--;
-			} else if (calcEndTime < newBeginTime) {// 0 s is fine (e.g. last 'wait')
-				throw new IllegalStateException();
-			} else {
-				task.setBeginTime(newBeginTime);
-				task.setEndTime(calcEndTime);
-				newBeginTime = calcEndTime;
-			}
-		}
-	}
-
-	private double calcNewEndTime(DvrpVehicle vehicle, Task task, double newBeginTime) {
-		if (task instanceof DriveTask driveTask) {
-			// depending on the implementation, update the path
-			driveTaskUpdater.updatePlannedDriveTask(vehicle, driveTask, newBeginTime);
-			
-			VrpPathWithTravelData path = (VrpPathWithTravelData)((DriveTask)task).getPath();
-			return newBeginTime + path.getTravelTime();
-		} else {
-			return stayTaskEndTimeCalculator.calcNewEndTime(vehicle, (StayTask)task, newBeginTime);
-		}
-	}
+    interface StayTaskEndTimeCalculator {
+        double calcNewEndTime(DvrpVehicle vehicle, StayTask task, double newBeginTime);
+    }
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/schedule/ScheduleTimingUpdaterImpl.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/schedule/ScheduleTimingUpdaterImpl.java
@@ -1,0 +1,117 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2007 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.contrib.dvrp.schedule;
+
+import static org.matsim.contrib.dvrp.schedule.Schedule.ScheduleStatus;
+
+import java.util.List;
+
+import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
+import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
+import org.matsim.contrib.dvrp.tracker.TaskTrackers;
+import org.matsim.core.mobsim.framework.MobsimTimer;
+
+public class ScheduleTimingUpdaterImpl implements ScheduleTimingUpdater {
+
+
+	private final MobsimTimer timer;
+	private final StayTaskEndTimeCalculator stayTaskEndTimeCalculator;
+	private final DriveTaskUpdater driveTaskUpdater;
+
+	public ScheduleTimingUpdaterImpl(MobsimTimer timer, StayTaskEndTimeCalculator stayTaskEndTimeCalculator, DriveTaskUpdater driveTaskUpdater) {
+		this.timer = timer;
+		this.stayTaskEndTimeCalculator = stayTaskEndTimeCalculator;
+		this.driveTaskUpdater = driveTaskUpdater;
+	}
+
+	/**
+	 * This method should be called inside {@code VrpOptimizer.nextTask()} before anything else is done.
+	 * Check and decide if the schedule should be updated due to if vehicle is Update timings (i.e. beginTime and
+	 * endTime) of all tasks in the schedule.
+	 */
+	@Override
+	public void updateBeforeNextTask(DvrpVehicle vehicle) {
+		Schedule schedule = vehicle.getSchedule();
+		// Assumption: there is no delay as long as the schedule has not been started (PLANNED)
+		if (schedule.getStatus() != ScheduleStatus.STARTED) {
+			return;
+		}
+
+		updateTimingsStartingFromCurrentTask(vehicle, timer.getTimeOfDay());
+	}
+
+	@Override
+	public void updateTimings(DvrpVehicle vehicle) {
+		Schedule schedule = vehicle.getSchedule();
+		if (schedule.getStatus() != ScheduleStatus.STARTED) {
+			return;
+		}
+
+		if (schedule.getCurrentTask() instanceof DriveTask driveTask) {
+			driveTaskUpdater.updateCurrentDriveTask(vehicle, driveTask);
+		}
+
+		double predictedEndTime = TaskTrackers.predictEndTime(schedule.getCurrentTask(), timer.getTimeOfDay());
+		updateTimingsStartingFromCurrentTask(vehicle, predictedEndTime);
+	}
+
+	private void updateTimingsStartingFromCurrentTask(DvrpVehicle vehicle, double newEndTime) {
+		Schedule schedule = vehicle.getSchedule();
+		Task currentTask = schedule.getCurrentTask();
+		if (currentTask.getEndTime() != newEndTime || driveTaskUpdater != DriveTaskUpdater.NOOP) {
+			currentTask.setEndTime(newEndTime);
+			updateTimingsStartingFromTaskIdx(vehicle, currentTask.getTaskIdx() + 1, newEndTime);
+		}
+	}
+
+	@Override
+	public void updateTimingsStartingFromTaskIdx(DvrpVehicle vehicle, int startIdx, double newBeginTime) {
+		Schedule schedule = vehicle.getSchedule();
+		List<? extends Task> tasks = schedule.getTasks();
+
+		for (int i = startIdx; i < tasks.size(); i++) {
+			double calcEndTime = calcNewEndTime(vehicle, tasks.get(i), newBeginTime);
+
+			//retreive freshly from list, as it may be a replaced task
+			Task task = tasks.get(i);
+			if (calcEndTime == REMOVE_STAY_TASK) {
+				schedule.removeTask(task);
+				i--;
+			} else if (calcEndTime < newBeginTime) {// 0 s is fine (e.g. last 'wait')
+				throw new IllegalStateException();
+			} else {
+				task.setBeginTime(newBeginTime);
+				task.setEndTime(calcEndTime);
+				newBeginTime = calcEndTime;
+			}
+		}
+	}
+
+	private double calcNewEndTime(DvrpVehicle vehicle, Task task, double newBeginTime) {
+		if (task instanceof DriveTask driveTask) {
+			// depending on the implementation, update the path
+			driveTaskUpdater.updatePlannedDriveTask(vehicle, driveTask, newBeginTime);
+
+			VrpPathWithTravelData path = (VrpPathWithTravelData) ((DriveTask) task).getPath();
+			return newBeginTime + path.getTravelTime();
+		} else {
+			return stayTaskEndTimeCalculator.calcNewEndTime(vehicle, (StayTask) task, newBeginTime);
+		}
+	}
+}

--- a/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/ETaxiModeOptimizerQSimModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/etaxi/optimizer/ETaxiModeOptimizerQSimModule.java
@@ -31,6 +31,7 @@ import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpModes;
 import org.matsim.contrib.dvrp.schedule.DriveTaskUpdater;
 import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
+import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdaterImpl;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
 import org.matsim.contrib.etaxi.ETaxiActionCreator;
 import org.matsim.contrib.etaxi.ETaxiScheduler;
@@ -122,7 +123,7 @@ public class ETaxiModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 				});
 
 		bindModal(ScheduleTimingUpdater.class).toProvider(modalProvider(
-				getter -> new ScheduleTimingUpdater(getter.get(MobsimTimer.class),
+				getter -> new ScheduleTimingUpdaterImpl(getter.get(MobsimTimer.class),
 						new ETaxiStayTaskEndTimeCalculator(taxiCfg), DriveTaskUpdater.NOOP))).asEagerSingleton();
 
 		bindModal(VrpAgentLogic.DynActionCreator.class).toProvider(

--- a/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/TaxiModeOptimizerQSimModule.java
+++ b/contribs/taxi/src/main/java/org/matsim/contrib/taxi/optimizer/TaxiModeOptimizerQSimModule.java
@@ -31,6 +31,7 @@ import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpModes;
 import org.matsim.contrib.dvrp.schedule.DriveTaskUpdater;
 import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdater;
+import org.matsim.contrib.dvrp.schedule.ScheduleTimingUpdaterImpl;
 import org.matsim.contrib.dvrp.vrpagent.VrpAgentLogic;
 import org.matsim.contrib.taxi.analysis.TaxiEventSequenceCollector;
 import org.matsim.contrib.taxi.run.TaxiConfigGroup;
@@ -112,7 +113,7 @@ public class TaxiModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 				});
 
 		bindModal(ScheduleTimingUpdater.class).toProvider(modalProvider(
-				getter -> new ScheduleTimingUpdater(getter.get(MobsimTimer.class),
+				getter -> new ScheduleTimingUpdaterImpl(getter.get(MobsimTimer.class),
 						new TaxiStayTaskEndTimeCalculator(taxiCfg), DriveTaskUpdater.NOOP))).asEagerSingleton();
 
 		bindModal(VrpAgentLogic.DynActionCreator.class).toProvider(


### PR DESCRIPTION
Explicitly consider max ride duration constraints in the slack time calculation.
Previously, max ride duration was mainly accounted for in the insertion of new trips only but not for existing trips. The workaround was to also set the maximum pickup delay, such that accepted rides pickups were not changing too much after insertion anymore.

To account for max ride durations explicitly, accepted requests now have additional fields for current (expected) pickup and dropoff times. These need to be updated, which is why I extracted the schedule timing updater interface that also updates these times for DRT...

@sebhoerl could you please also have a quick look, as I saw that sometimes for more complicated stop durations the max ride duration is exceeded by roughly the stop duration which might not be accounted for correctly in the updating of pickup and dropoff times (and, hence, slack times in the vehicle data entry).

Leaving this as a draft for now, feedback welcome 
