### PR TITLE
fix(core): Fix TurnRestrictionsNetworkCleaner when other modes are present

### DIFF
--- a/matsim/src/main/java/org/matsim/core/network/turnRestrictions/TurnRestrictionsNetworkCleaner.java
+++ b/matsim/src/main/java/org/matsim/core/network/turnRestrictions/TurnRestrictionsNetworkCleaner.java
@@ -143,6 +143,11 @@ public class TurnRestrictionsNetworkCleaner {
             // copy all attributes except initial turn restrictions
             NetworkUtils.copyAttributesExceptDisallowedNextLinks(coloredLink.link, linkCopy);
 
+            // copy all other modes
+            for (String allowedMode : coloredLink.link.getAllowedModes()) {
+                NetworkUtils.addAllowedMode(linkCopy, allowedMode);
+            }
+
             // copy all turn restrictions of all other modes
             DisallowedNextLinks originalDisallowedNextLinks = NetworkUtils.getDisallowedNextLinks(coloredLink.link);
             if(originalDisallowedNextLinks != null) {

--- a/matsim/src/test/java/org/matsim/core/network/turnRestrictions/TurnRestrictionsNetworkCleanerTest.java
+++ b/matsim/src/test/java/org/matsim/core/network/turnRestrictions/TurnRestrictionsNetworkCleanerTest.java
@@ -42,6 +42,29 @@ class TurnRestrictionsNetworkCleanerTest {
 	}
 
 	@Test
+	void testNoChangeWithOtherMode() {
+
+		Network network = createNetwork();
+		addDisallowedNextLinks(network);
+		network.getLinks().values().forEach(link -> NetworkUtils.addAllowedMode(link, "bus"));
+		Verify.verify(DisallowedNextLinksUtils.isValid(network));
+
+		// * --------------------------------------------------
+
+		TurnRestrictionsNetworkCleaner trc = new TurnRestrictionsNetworkCleaner();
+		trc.run(network, TransportMode.car);
+
+		// * --------------------------------------------------
+
+		Network expectedNetwork = createNetwork();
+		addDisallowedNextLinks(expectedNetwork);
+		expectedNetwork.getLinks().values().forEach(link -> NetworkUtils.addAllowedMode(link, "bus"));
+
+		Assertions.assertTrue(NetworkUtils.compare(expectedNetwork, network));
+		Assertions.assertTrue(DisallowedNextLinksUtils.isValid(network));
+	}
+
+	@Test
 	void testWithIsland() {
 
 		Network network = createNetwork();
@@ -56,6 +79,32 @@ class TurnRestrictionsNetworkCleanerTest {
 		// * --------------------------------------------------
 
 		Network expectedNetwork = createNetwork();
+
+		Assertions.assertTrue(NetworkUtils.compare(expectedNetwork, network));
+		Assertions.assertTrue(DisallowedNextLinksUtils.isValid(network));
+
+	}
+
+	@Test
+	void testWithIslandAndOtherMode() {
+
+		Network network = createNetwork();
+		addNetworkIsland(network);
+		network.getLinks().values().forEach(link -> NetworkUtils.addAllowedMode(link, "bus"));
+		Verify.verify(DisallowedNextLinksUtils.isValid(network));
+
+		// * --------------------------------------------------
+
+		TurnRestrictionsNetworkCleaner trc = new TurnRestrictionsNetworkCleaner();
+		trc.run(network, TransportMode.car);
+
+		// * --------------------------------------------------
+
+		Network expectedNetwork = createNetwork();
+		addNetworkIsland(expectedNetwork);
+		expectedNetwork.getLinks().values().forEach(link -> NetworkUtils.addAllowedMode(link, "bus"));
+		NetworkUtils.removeAllowedMode(expectedNetwork.getLinks().get(Id.createLinkId("78")), TransportMode.car);
+		NetworkUtils.removeAllowedMode(expectedNetwork.getLinks().get(Id.createLinkId("87")), TransportMode.car);
 
 		Assertions.assertTrue(NetworkUtils.compare(expectedNetwork, network));
 		Assertions.assertTrue(DisallowedNextLinksUtils.isValid(network));

--- a/matsim/src/test/java/org/matsim/core/network/turnRestrictions/TurnRestrictionsNetworkCleanerTest.java
+++ b/matsim/src/test/java/org/matsim/core/network/turnRestrictions/TurnRestrictionsNetworkCleanerTest.java
@@ -112,16 +112,55 @@ class TurnRestrictionsNetworkCleanerTest {
 	}
 
 	@Test
-	void testNoExit() {
+	void testWithIslandAndOtherModeAndOtherDnl() {
 
 		Network network = createNetwork();
-		addNoExit(network);
+		addNetworkIsland(network);
+		network.getLinks().values().forEach(link -> NetworkUtils.addAllowedMode(link, "bus"));
+		NetworkUtils.getOrCreateDisallowedNextLinks(network.getLinks().get(Id.createLinkId("01")))
+				.addDisallowedLinkSequence("bus", List.of(Id.createLinkId("12")));
+		NetworkUtils.getOrCreateDisallowedNextLinks(network.getLinks().get(Id.createLinkId("12")))
+				.addDisallowedLinkSequence("bus", List.of(Id.createLinkId("23")));
 		Verify.verify(DisallowedNextLinksUtils.isValid(network));
+		NetworkUtils.writeNetwork(network, "0.xml"); // ! DEBUG
 
 		// * --------------------------------------------------
 
 		TurnRestrictionsNetworkCleaner trc = new TurnRestrictionsNetworkCleaner();
 		trc.run(network, TransportMode.car);
+		NetworkUtils.writeNetwork(network, "1.xml"); // ! DEBUG
+
+		// * --------------------------------------------------
+
+		Network expectedNetwork = createNetwork();
+		addNetworkIsland(expectedNetwork);
+		expectedNetwork.getLinks().values().forEach(link -> NetworkUtils.addAllowedMode(link, "bus"));
+		NetworkUtils.getOrCreateDisallowedNextLinks(expectedNetwork.getLinks().get(Id.createLinkId("01")))
+				.addDisallowedLinkSequence("bus", List.of(Id.createLinkId("12")));
+		NetworkUtils.getOrCreateDisallowedNextLinks(expectedNetwork.getLinks().get(Id.createLinkId("12")))
+				.addDisallowedLinkSequence("bus", List.of(Id.createLinkId("23")));
+		NetworkUtils.removeAllowedMode(expectedNetwork.getLinks().get(Id.createLinkId("78")), TransportMode.car);
+		NetworkUtils.removeAllowedMode(expectedNetwork.getLinks().get(Id.createLinkId("87")), TransportMode.car);
+		NetworkUtils.writeNetwork(expectedNetwork, "2.xml"); // ! DEBUG
+
+		Assertions.assertTrue(NetworkUtils.compare(expectedNetwork, network));
+		Assertions.assertTrue(DisallowedNextLinksUtils.isValid(network));
+
+	}
+
+	@Test
+	void testNoExit() {
+
+		Network network = createNetwork();
+		addNoExit(network);
+		Verify.verify(DisallowedNextLinksUtils.isValid(network));
+		NetworkUtils.writeNetwork(network, "0.xml"); // ! DEBUG
+
+		// * --------------------------------------------------
+
+		TurnRestrictionsNetworkCleaner trc = new TurnRestrictionsNetworkCleaner();
+		trc.run(network, TransportMode.car);
+		NetworkUtils.writeNetwork(network, "1.xml"); // ! DEBUG
 
 		// * --------------------------------------------------
 
@@ -134,6 +173,86 @@ class TurnRestrictionsNetworkCleanerTest {
 		Link l67 = expectedNetwork.getLinks().get(Id.createLinkId("67"));
 		NetworkUtils.removeDisallowedNextLinks(l67);
 		Verify.verify(DisallowedNextLinksUtils.isValid(expectedNetwork));
+		NetworkUtils.writeNetwork(expectedNetwork, "2.xml"); // ! DEBUG
+
+		Assertions.assertTrue(NetworkUtils.compare(expectedNetwork, network));
+		Assertions.assertTrue(DisallowedNextLinksUtils.isValid(network));
+
+	}
+
+	@Test
+	void testNoExitWithOtherMode() {
+
+		Network network = createNetwork();
+		addNoExit(network);
+		network.getLinks().values().forEach(link -> NetworkUtils.addAllowedMode(link, "bus"));
+		Verify.verify(DisallowedNextLinksUtils.isValid(network));
+		NetworkUtils.writeNetwork(network, "0.xml"); // ! DEBUG
+
+		// * --------------------------------------------------
+
+		TurnRestrictionsNetworkCleaner trc = new TurnRestrictionsNetworkCleaner();
+		trc.run(network, TransportMode.car);
+		NetworkUtils.writeNetwork(network, "1.xml"); // ! DEBUG
+
+		// * --------------------------------------------------
+
+		Network expectedNetwork = createNetwork();
+		addNoExit(expectedNetwork);
+		expectedNetwork.getLinks().values().forEach(link -> NetworkUtils.addAllowedMode(link, "bus"));
+		// some modes are removed, but bus stays everywhere
+		NetworkUtils.removeAllowedMode(expectedNetwork.getLinks().get(Id.createLinkId("78")), TransportMode.car);
+		NetworkUtils.removeAllowedMode(expectedNetwork.getLinks().get(Id.createLinkId("87")), TransportMode.car);
+		// ! DNL of link 67 is still there after cleaning!?
+		// (okay-ish, as it can be removed by DisallowedNextLinksUtils.clean)
+		NetworkUtils.removeDisallowedNextLinks(expectedNetwork.getLinks().get(Id.createLinkId("67")));
+		// ! link 76 has car removed wrongly!?
+		Verify.verify(DisallowedNextLinksUtils.isValid(expectedNetwork));
+		NetworkUtils.writeNetwork(expectedNetwork, "2.xml"); // ! DEBUG
+
+		Assertions.assertTrue(NetworkUtils.compare(expectedNetwork, network));
+		Assertions.assertTrue(DisallowedNextLinksUtils.isValid(network));
+
+	}
+
+	@Test
+	void testNoExitWithOtherModeAndOtherDnl() {
+
+		Network network = createNetwork();
+		addNoExit(network);
+		network.getLinks().values().forEach(link -> NetworkUtils.addAllowedMode(link, "bus"));
+		NetworkUtils.getOrCreateDisallowedNextLinks(network.getLinks().get(Id.createLinkId("67")))
+				.addDisallowedLinkSequence("bus", List.of(Id.createLinkId("78")));
+		NetworkUtils.getOrCreateDisallowedNextLinks(network.getLinks().get(Id.createLinkId("87")))
+				.addDisallowedLinkSequence("bus", List.of(Id.createLinkId("78")));
+		Verify.verify(DisallowedNextLinksUtils.isValid(network));
+		NetworkUtils.writeNetwork(network, "0.xml"); // ! DEBUG
+
+		// * --------------------------------------------------
+
+		TurnRestrictionsNetworkCleaner trc = new TurnRestrictionsNetworkCleaner();
+		trc.run(network, TransportMode.car);
+		NetworkUtils.writeNetwork(network, "1.xml"); // ! DEBUG
+
+		// * --------------------------------------------------
+
+		Network expectedNetwork = createNetwork();
+		addNoExit(expectedNetwork);
+		expectedNetwork.getLinks().values().forEach(link -> NetworkUtils.addAllowedMode(link, "bus"));
+		NetworkUtils.getOrCreateDisallowedNextLinks(expectedNetwork.getLinks().get(Id.createLinkId("67")))
+				.addDisallowedLinkSequence("bus", List.of(Id.createLinkId("78")));
+		NetworkUtils.getOrCreateDisallowedNextLinks(expectedNetwork.getLinks().get(Id.createLinkId("87")))
+				.addDisallowedLinkSequence("bus", List.of(Id.createLinkId("78")));
+		// some modes are removed, but bus stays everywhere
+		NetworkUtils.removeAllowedMode(expectedNetwork.getLinks().get(Id.createLinkId("78")), TransportMode.car);
+		NetworkUtils.removeAllowedMode(expectedNetwork.getLinks().get(Id.createLinkId("87")), TransportMode.car);
+		// ! DNL of link 67 is still there after cleaning!?
+		// (okay-ish, as it can be removed by DisallowedNextLinksUtils.clean)
+		NetworkUtils.getDisallowedNextLinks(expectedNetwork.getLinks().get(Id.createLinkId("67")))
+				.removeDisallowedLinkSequences(TransportMode.car);
+		// ! link 76 has car removed wrongly!?
+		Verify.verify(DisallowedNextLinksUtils.isValid(expectedNetwork));
+		NetworkUtils.writeNetwork(expectedNetwork, "2.xml"); // ! DEBUG
 
 		Assertions.assertTrue(NetworkUtils.compare(expectedNetwork, network));
 		Assertions.assertTrue(DisallowedNextLinksUtils.isValid(network));

--- a/matsim/src/test/java/org/matsim/core/network/turnRestrictions/TurnRestrictionsNetworkCleanerTest.java
+++ b/matsim/src/test/java/org/matsim/core/network/turnRestrictions/TurnRestrictionsNetworkCleanerTest.java
@@ -122,13 +122,11 @@ class TurnRestrictionsNetworkCleanerTest {
 		NetworkUtils.getOrCreateDisallowedNextLinks(network.getLinks().get(Id.createLinkId("12")))
 				.addDisallowedLinkSequence("bus", List.of(Id.createLinkId("23")));
 		Verify.verify(DisallowedNextLinksUtils.isValid(network));
-		NetworkUtils.writeNetwork(network, "0.xml"); // ! DEBUG
 
 		// * --------------------------------------------------
 
 		TurnRestrictionsNetworkCleaner trc = new TurnRestrictionsNetworkCleaner();
 		trc.run(network, TransportMode.car);
-		NetworkUtils.writeNetwork(network, "1.xml"); // ! DEBUG
 
 		// * --------------------------------------------------
 
@@ -141,7 +139,6 @@ class TurnRestrictionsNetworkCleanerTest {
 				.addDisallowedLinkSequence("bus", List.of(Id.createLinkId("23")));
 		NetworkUtils.removeAllowedMode(expectedNetwork.getLinks().get(Id.createLinkId("78")), TransportMode.car);
 		NetworkUtils.removeAllowedMode(expectedNetwork.getLinks().get(Id.createLinkId("87")), TransportMode.car);
-		NetworkUtils.writeNetwork(expectedNetwork, "2.xml"); // ! DEBUG
 
 		Assertions.assertTrue(NetworkUtils.compare(expectedNetwork, network));
 		Assertions.assertTrue(DisallowedNextLinksUtils.isValid(network));
@@ -154,13 +151,11 @@ class TurnRestrictionsNetworkCleanerTest {
 		Network network = createNetwork();
 		addNoExit(network);
 		Verify.verify(DisallowedNextLinksUtils.isValid(network));
-		NetworkUtils.writeNetwork(network, "0.xml"); // ! DEBUG
 
 		// * --------------------------------------------------
 
 		TurnRestrictionsNetworkCleaner trc = new TurnRestrictionsNetworkCleaner();
 		trc.run(network, TransportMode.car);
-		NetworkUtils.writeNetwork(network, "1.xml"); // ! DEBUG
 
 		// * --------------------------------------------------
 
@@ -173,7 +168,6 @@ class TurnRestrictionsNetworkCleanerTest {
 		Link l67 = expectedNetwork.getLinks().get(Id.createLinkId("67"));
 		NetworkUtils.removeDisallowedNextLinks(l67);
 		Verify.verify(DisallowedNextLinksUtils.isValid(expectedNetwork));
-		NetworkUtils.writeNetwork(expectedNetwork, "2.xml"); // ! DEBUG
 
 		Assertions.assertTrue(NetworkUtils.compare(expectedNetwork, network));
 		Assertions.assertTrue(DisallowedNextLinksUtils.isValid(network));
@@ -187,13 +181,11 @@ class TurnRestrictionsNetworkCleanerTest {
 		addNoExit(network);
 		network.getLinks().values().forEach(link -> NetworkUtils.addAllowedMode(link, "bus"));
 		Verify.verify(DisallowedNextLinksUtils.isValid(network));
-		NetworkUtils.writeNetwork(network, "0.xml"); // ! DEBUG
 
 		// * --------------------------------------------------
 
 		TurnRestrictionsNetworkCleaner trc = new TurnRestrictionsNetworkCleaner();
 		trc.run(network, TransportMode.car);
-		NetworkUtils.writeNetwork(network, "1.xml"); // ! DEBUG
 
 		// * --------------------------------------------------
 
@@ -203,12 +195,8 @@ class TurnRestrictionsNetworkCleanerTest {
 		// some modes are removed, but bus stays everywhere
 		NetworkUtils.removeAllowedMode(expectedNetwork.getLinks().get(Id.createLinkId("78")), TransportMode.car);
 		NetworkUtils.removeAllowedMode(expectedNetwork.getLinks().get(Id.createLinkId("87")), TransportMode.car);
-		// ! DNL of link 67 is still there after cleaning!?
-		// (okay-ish, as it can be removed by DisallowedNextLinksUtils.clean)
 		NetworkUtils.removeDisallowedNextLinks(expectedNetwork.getLinks().get(Id.createLinkId("67")));
-		// ! link 76 has car removed wrongly!?
 		Verify.verify(DisallowedNextLinksUtils.isValid(expectedNetwork));
-		NetworkUtils.writeNetwork(expectedNetwork, "2.xml"); // ! DEBUG
 
 		Assertions.assertTrue(NetworkUtils.compare(expectedNetwork, network));
 		Assertions.assertTrue(DisallowedNextLinksUtils.isValid(network));
@@ -226,13 +214,11 @@ class TurnRestrictionsNetworkCleanerTest {
 		NetworkUtils.getOrCreateDisallowedNextLinks(network.getLinks().get(Id.createLinkId("87")))
 				.addDisallowedLinkSequence("bus", List.of(Id.createLinkId("78")));
 		Verify.verify(DisallowedNextLinksUtils.isValid(network));
-		NetworkUtils.writeNetwork(network, "0.xml"); // ! DEBUG
 
 		// * --------------------------------------------------
 
 		TurnRestrictionsNetworkCleaner trc = new TurnRestrictionsNetworkCleaner();
 		trc.run(network, TransportMode.car);
-		NetworkUtils.writeNetwork(network, "1.xml"); // ! DEBUG
 
 		// * --------------------------------------------------
 
@@ -246,13 +232,9 @@ class TurnRestrictionsNetworkCleanerTest {
 		// some modes are removed, but bus stays everywhere
 		NetworkUtils.removeAllowedMode(expectedNetwork.getLinks().get(Id.createLinkId("78")), TransportMode.car);
 		NetworkUtils.removeAllowedMode(expectedNetwork.getLinks().get(Id.createLinkId("87")), TransportMode.car);
-		// ! DNL of link 67 is still there after cleaning!?
-		// (okay-ish, as it can be removed by DisallowedNextLinksUtils.clean)
 		NetworkUtils.getDisallowedNextLinks(expectedNetwork.getLinks().get(Id.createLinkId("67")))
 				.removeDisallowedLinkSequences(TransportMode.car);
-		// ! link 76 has car removed wrongly!?
 		Verify.verify(DisallowedNextLinksUtils.isValid(expectedNetwork));
-		NetworkUtils.writeNetwork(expectedNetwork, "2.xml"); // ! DEBUG
 
 		Assertions.assertTrue(NetworkUtils.compare(expectedNetwork, network));
 		Assertions.assertTrue(DisallowedNextLinksUtils.isValid(network));


### PR DESCRIPTION
We noticed some inconsistencies when cleaning networks with the new TurnRestrictionNetworkCleaner, for example other allowed modes besides the cleaning mode should stay untouched and their DisallowedNextLinks objects as well.
