### PR TITLE
fix(core): LegHistogramListeners produced crashes

### DIFF
--- a/matsim/src/main/java/org/matsim/analysis/LegHistogram.java
+++ b/matsim/src/main/java/org/matsim/analysis/LegHistogram.java
@@ -66,7 +66,7 @@ public class LegHistogram implements PersonDepartureEventHandler, PersonArrivalE
 	private final Map<String, DataFrame> data = new TreeMap<>();
 
 	@Inject
-	LegHistogram(Population population, EventsManager eventsManager, Config config) {
+	LegHistogram(Population population, Config config) {
 		super();
 		this.binSize = DEFAULT_BIN_SIZE;
 		this.nofBins = ((int) config.qsim().getEndTime().orElse(DEFAULT_END_TIME) ) / this.binSize + 1;
@@ -76,8 +76,7 @@ public class LegHistogram implements PersonDepartureEventHandler, PersonArrivalE
 		} else {
 			this.personIds = population.getPersons().keySet();
 		}
-		eventsManager.addHandler(this);
-	}
+		}
 
 	/**
 	 * Creates a new LegHistogram with the specified binSize and the specified number of bins.

--- a/matsim/src/main/java/org/matsim/analysis/LegHistogramListener.java
+++ b/matsim/src/main/java/org/matsim/analysis/LegHistogramListener.java
@@ -67,6 +67,7 @@ final class LegHistogramListener implements IterationEndsListener, IterationStar
 					LegHistogramChart.writeGraphic(this.histogram, controllerIO.getIterationFilename(event.getIteration(), "legHistogram_" + legMode + ".png"), legMode);
 				}
 			}
+			event.getServices().getEvents().removeHandler(this.histogram);
 		}
 	}
 

--- a/matsim/src/main/java/org/matsim/analysis/LegHistogramModule.java
+++ b/matsim/src/main/java/org/matsim/analysis/LegHistogramModule.java
@@ -22,12 +22,13 @@
 
 package org.matsim.analysis;
 
+import com.google.inject.Singleton;
 import org.matsim.core.controler.AbstractModule;
 
 public final class LegHistogramModule extends AbstractModule {
 	@Override
 	public void install() {
-		bind(LegHistogram.class);
+		bind(LegHistogram.class).in(Singleton.class);
 		addControlerListenerBinding().to(LegHistogramListener.class);
 	}
 }


### PR DESCRIPTION
https://github.com/matsim-org/matsim-libs/pull/3897 introduced the option to create LegHistograms only in some iterations or disable them. However, the event handler was created now once per active iteration, plus once upon instantition. This lead to quirky results (and finally to crashes due to arrays being out of bound):

![27_kal_work_sec_mobtools_sc62 14 legHistogram_bike](https://github.com/user-attachments/assets/617bb821-15e2-4e3e-8379-5bf197e6ba18)

Unfortunately, this bug affects the 2026.0-release. If you rely on this one, disable leg histograms for the time being. 
