### PR TITLE
refactor(pt): Make RouteDescription public again

### DIFF
--- a/matsim/src/main/java/org/matsim/pt/routes/DefaultTransitPassengerRoute.java
+++ b/matsim/src/main/java/org/matsim/pt/routes/DefaultTransitPassengerRoute.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class DefaultTransitPassengerRoute extends AbstractRoute implements TransitPassengerRoute {
 	protected final static int NULL_ID = -1;
-	private final static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
 	final public static String ROUTE_TYPE = "default_pt";
 
@@ -90,7 +89,7 @@ public class DefaultTransitPassengerRoute extends AbstractRoute implements Trans
 
 		try {
 			RouteDescription routeDescription = new RouteDescription(this);
-			return OBJECT_MAPPER.writeValueAsString(routeDescription);
+			return RouteDescription.toJson(routeDescription);
 		} catch (JsonProcessingException e) {
 			throw new RuntimeException(e);
 		}
@@ -99,7 +98,7 @@ public class DefaultTransitPassengerRoute extends AbstractRoute implements Trans
 	@Override
 	public void setRouteDescription(String routeDescription) {
 		try {
-			RouteDescription parsed = OBJECT_MAPPER.readValue(routeDescription, RouteDescription.class);
+			RouteDescription parsed = RouteDescription.fromJson(routeDescription);
 			this.boardingTime = parsed.boardingTime;
 			this.accessFacilityIndex = parsed.accessFacilityId == null ? NULL_ID : parsed.accessFacilityId.index();
 			this.egressFacilityIndex = parsed.egressFacilityId == null ? NULL_ID : parsed.egressFacilityId.index();
@@ -187,6 +186,9 @@ public class DefaultTransitPassengerRoute extends AbstractRoute implements Trans
 	}
 
 	public static final class RouteDescription {
+
+		private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
 		public double boardingTime = UNDEFINED_TIME;
 
 		public Id<TransitLine> transitLineId;
@@ -210,6 +212,14 @@ public class DefaultTransitPassengerRoute extends AbstractRoute implements Trans
 			if (r.chainedRoute != null) {
 				this.chainedRoute = new RouteDescription(r.chainedRoute);
 			}
+		}
+
+		public static String toJson(RouteDescription routeDescription) throws JsonProcessingException {
+			return OBJECT_MAPPER.writeValueAsString(routeDescription);
+		}
+
+		public static RouteDescription fromJson(String json) throws JsonProcessingException {
+			return OBJECT_MAPPER.readValue(json, RouteDescription.class);
 		}
 
 		@JsonProperty("boardingTime")

--- a/matsim/src/main/java/org/matsim/pt/routes/DefaultTransitPassengerRoute.java
+++ b/matsim/src/main/java/org/matsim/pt/routes/DefaultTransitPassengerRoute.java
@@ -186,7 +186,7 @@ public class DefaultTransitPassengerRoute extends AbstractRoute implements Trans
 		return copy;
 	}
 
-	private static final class RouteDescription {
+	public static final class RouteDescription {
 		public double boardingTime = UNDEFINED_TIME;
 
 		public Id<TransitLine> transitLineId;

--- a/matsim/src/test/java/org/matsim/pt/routes/RouteDescriptionTest.java
+++ b/matsim/src/test/java/org/matsim/pt/routes/RouteDescriptionTest.java
@@ -1,0 +1,52 @@
+package org.matsim.pt.routes;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.matsim.pt.routes.DefaultTransitPassengerRoute.RouteDescription;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+
+class RouteDescriptionTest {
+
+	private static final String JSON = """
+			{"transitRouteId":"routeLineId","boardingTime":"00:00:02","transitLineId":"transitLineId","accessFacilityId":"accessFacility","egressFacilityId":"egressFacilityId","chainedRoute":{"transitRouteId":null,"boardingTime":"00:00:04","transitLineId":null,"accessFacilityId":null,"egressFacilityId":null}}""";
+
+	@Test
+	void deserializeTest() throws JsonProcessingException {
+
+		RouteDescription rd = RouteDescription.fromJson(JSON);
+		RouteDescription expectedRd = createRouteDescription();
+
+		Assertions.assertEquals(expectedRd.boardingTime, rd.boardingTime);
+		Assertions.assertEquals(expectedRd.accessFacilityId, rd.accessFacilityId);
+		Assertions.assertEquals(expectedRd.egressFacilityId, rd.egressFacilityId);
+		Assertions.assertEquals(expectedRd.transitLineId, rd.transitLineId);
+		Assertions.assertEquals(expectedRd.transitRouteId, rd.transitRouteId);
+
+		Assertions.assertEquals(expectedRd.chainedRoute.boardingTime, rd.chainedRoute.boardingTime);
+		Assertions.assertEquals(expectedRd.chainedRoute.accessFacilityId, rd.chainedRoute.accessFacilityId);
+		Assertions.assertEquals(expectedRd.chainedRoute.egressFacilityId, rd.chainedRoute.egressFacilityId);
+		Assertions.assertEquals(expectedRd.chainedRoute.transitLineId, rd.chainedRoute.transitLineId);
+		Assertions.assertEquals(expectedRd.chainedRoute.transitRouteId, rd.chainedRoute.transitRouteId);
+	}
+
+	@Test
+	void serializeTest() throws JsonProcessingException {
+		RouteDescription rd = createRouteDescription();
+		String json = RouteDescription.toJson(rd);
+		Assertions.assertEquals(JSON, json);
+	}
+
+	private static RouteDescription createRouteDescription() {
+		RouteDescription rd = new RouteDescription();
+		rd.setAccessFacilityId("accessFacility");
+		rd.setBoardingTime("2.0");
+		rd.setEgressFacilityId("egressFacilityId");
+		rd.setRouteLineId("routeLineId");
+		rd.setTransitLineId("transitLineId");
+		rd.setChainedRoute(new RouteDescription());
+		rd.chainedRoute.setBoardingTime("4.0");
+		return rd;
+	}
+}


### PR DESCRIPTION
@rakow The `RouteDescription` class was made private in #3913 without a comment, however, it is quite useful for analyzing transit vehicle usage during simulation time. Thus, I would suggest to make it public again.