### PR TITLE
fix(core): Color network mode-independent in TurnRestrictionsNetworkCleaner

### DIFF
--- a/matsim/src/main/java/org/matsim/core/network/turnRestrictions/TurnRestrictionsNetworkCleaner.java
+++ b/matsim/src/main/java/org/matsim/core/network/turnRestrictions/TurnRestrictionsNetworkCleaner.java
@@ -27,13 +27,13 @@ public class TurnRestrictionsNetworkCleaner {
     @SuppressWarnings("deprecation")
     public void run(Network network, String mode) {
         TurnRestrictionsContext turnRestrictions = TurnRestrictionsContext.build(network, mode);
-        colorNetwork(network, turnRestrictions);
+        colorNetwork(network, turnRestrictions, mode);
         new MultimodalNetworkCleaner(network).run(Set.of(mode));
         collapseNetwork(network, turnRestrictions, mode);
         reapplyRestrictions(network, turnRestrictions, mode);
     }
 
-    public void colorNetwork(Network network, TurnRestrictionsContext turnRestrictions) {
+    public void colorNetwork(Network network, TurnRestrictionsContext turnRestrictions, String mode) {
 
         for (Link link : network.getLinks().values()) {
             if (turnRestrictions.replacedLinks.containsKey(link.getId())) {
@@ -47,6 +47,7 @@ public class TurnRestrictionsNetworkCleaner {
             coloredCopy.getAttributes().putAttribute("colored", coloredNode.node().getId());
         }
 
+        Set<String> modeSingletonSet = Set.of(mode);
         for (TurnRestrictionsContext.ColoredLink coloredLink : turnRestrictions.coloredLinks) {
             Node fromNode;
             if (coloredLink.fromColoredNode != null) {
@@ -76,6 +77,7 @@ public class TurnRestrictionsNetworkCleaner {
                     coloredLink.link.getCapacity(),
                     coloredLink.link.getNumberOfLanes()
             );
+            link.setAllowedModes(modeSingletonSet);
             link.getAttributes().putAttribute("colored", coloredLink.link.getId());
             network.addLink(link);
         }

--- a/matsim/src/test/java/org/matsim/core/network/turnRestrictions/TurnRestrictionsNetworkCleanerTest.java
+++ b/matsim/src/test/java/org/matsim/core/network/turnRestrictions/TurnRestrictionsNetworkCleanerTest.java
@@ -5,6 +5,8 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.TransportMode;
@@ -19,6 +21,34 @@ import com.google.common.base.Verify;
  * @author hrewald
  */
 class TurnRestrictionsNetworkCleanerTest {
+
+	private static final String CAR = "car";
+	private static final String BUS = "bus";
+	private static final String BIKE = "bike";
+	private static final Set<String> MODES = Set.of(CAR, BUS, BIKE);
+
+	@ParameterizedTest
+	@ValueSource(strings = { CAR, BUS, BIKE }) // ! DEBUG: works only with car!?
+	void cleanTest(String dnlMode) {
+
+		Network network = crossingWithForbiddenUTurn(MODES, dnlMode);
+		Verify.verify(DisallowedNextLinksUtils.isValid(network));
+		NetworkUtils.writeNetwork(network, "0" + dnlMode + ".xml"); // ! DEBUG
+
+		// * --------------------------------------------------
+
+		TurnRestrictionsNetworkCleaner trc = new TurnRestrictionsNetworkCleaner();
+		trc.run(network, dnlMode);
+		NetworkUtils.writeNetwork(network, "1" + dnlMode + ".xml"); // ! DEBUG
+
+		// * --------------------------------------------------
+
+		Network expectedNetwork = crossingWithForbiddenUTurn(MODES, dnlMode);
+		Verify.verify(DisallowedNextLinksUtils.isValid(expectedNetwork));
+
+		Assertions.assertTrue(DisallowedNextLinksUtils.isValid(network));
+		Assertions.assertTrue(NetworkUtils.compare(expectedNetwork, network));
+	}
 
 	@Test
 	void testNoChange() {
@@ -242,6 +272,49 @@ class TurnRestrictionsNetworkCleanerTest {
 	}
 
 	// Helpers
+
+	static Network crossingWithForbiddenUTurn(Set<String> modes, String dnlMode) {
+		Verify.verify(modes.contains(dnlMode));
+
+		Network network = NetworkUtils.createNetwork();
+
+		Node n0 = NetworkUtils.createNode(Id.createNodeId("0"), new Coord(0, 0));
+		Node n1 = NetworkUtils.createNode(Id.createNodeId("1"), new Coord(-1, 0));
+		Node n2 = NetworkUtils.createNode(Id.createNodeId("2"), new Coord(0, -1));
+		Node n3 = NetworkUtils.createNode(Id.createNodeId("3"), new Coord(1, 0));
+		Node n4 = NetworkUtils.createNode(Id.createNodeId("4"), new Coord(0, 1));
+		network.addNode(n0);
+		network.addNode(n1);
+		network.addNode(n2);
+		network.addNode(n3);
+		network.addNode(n4);
+
+		Link l01 = NetworkUtils.createLink(Id.createLinkId("01"), n0, n1, network, 1, 1, 300, 1);
+		Link l10 = NetworkUtils.createLink(Id.createLinkId("10"), n1, n0, network, 1, 1, 300, 1);
+		Link l02 = NetworkUtils.createLink(Id.createLinkId("02"), n0, n2, network, 1, 1, 300, 1);
+		Link l20 = NetworkUtils.createLink(Id.createLinkId("20"), n2, n0, network, 1, 1, 300, 1);
+		Link l03 = NetworkUtils.createLink(Id.createLinkId("03"), n0, n3, network, 1, 1, 300, 1);
+		Link l30 = NetworkUtils.createLink(Id.createLinkId("30"), n3, n0, network, 1, 1, 300, 1);
+		Link l04 = NetworkUtils.createLink(Id.createLinkId("04"), n0, n4, network, 1, 1, 300, 1);
+		Link l40 = NetworkUtils.createLink(Id.createLinkId("40"), n4, n0, network, 1, 1, 300, 1);
+		network.addLink(l01);
+		network.addLink(l10);
+		network.addLink(l02);
+		network.addLink(l20);
+		network.addLink(l03);
+		network.addLink(l30);
+		network.addLink(l04);
+		network.addLink(l40);
+
+		for (Link link : network.getLinks().values()) {
+			link.setAllowedModes(modes);
+		}
+
+		NetworkUtils.getOrCreateDisallowedNextLinks(network.getLinks().get(Id.createLinkId("10")))
+				.addDisallowedLinkSequence(dnlMode, List.of(Id.createLinkId("01"))); // no uturn
+
+		return network;
+	}
 
 	static Network createNetwork() {
 		Network network = NetworkUtils.createNetwork();

--- a/matsim/src/test/java/org/matsim/core/network/turnRestrictions/TurnRestrictionsNetworkCleanerTest.java
+++ b/matsim/src/test/java/org/matsim/core/network/turnRestrictions/TurnRestrictionsNetworkCleanerTest.java
@@ -28,18 +28,16 @@ class TurnRestrictionsNetworkCleanerTest {
 	private static final Set<String> MODES = Set.of(CAR, BUS, BIKE);
 
 	@ParameterizedTest
-	@ValueSource(strings = { CAR, BUS, BIKE }) // ! DEBUG: works only with car!?
+	@ValueSource(strings = { CAR, BUS, BIKE })
 	void cleanTest(String dnlMode) {
 
 		Network network = crossingWithForbiddenUTurn(MODES, dnlMode);
 		Verify.verify(DisallowedNextLinksUtils.isValid(network));
-		NetworkUtils.writeNetwork(network, "0" + dnlMode + ".xml"); // ! DEBUG
 
 		// * --------------------------------------------------
 
 		TurnRestrictionsNetworkCleaner trc = new TurnRestrictionsNetworkCleaner();
 		trc.run(network, dnlMode);
-		NetworkUtils.writeNetwork(network, "1" + dnlMode + ".xml"); // ! DEBUG
 
 		// * --------------------------------------------------
 


### PR DESCRIPTION
When coloring the network when expanding turn restrictions of the cleaning mode, new links are created. which had "car" as their default mode. This resulted in incorrect behavior when cleaning networks with cleaning modes other than car.