### PR TITLE
feat(core): teleported mode speed by person

### DIFF
--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/DrtRoutingModuleTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/DrtRoutingModuleTest.java
@@ -82,7 +82,7 @@ public class DrtRoutingModuleTest {
 		final double networkTravelSpeed = 0.83333;
 		final double beelineFactor = 1.3;
 		TeleportationRoutingModule walkRouter = new TeleportationRoutingModule(TransportMode.walk, scenario,
-				networkTravelSpeed, beelineFactor);
+				networkTravelSpeed, beelineFactor, null);
 		DrtConfigGroup drtCfg = DrtConfigGroup.getSingleModeDrtConfig(scenario.getConfig());
 		String drtMode = "DrtX";
 		drtCfg.setMode(drtMode);

--- a/matsim/src/main/java/org/matsim/core/config/groups/RoutingConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/RoutingConfigGroup.java
@@ -145,6 +145,7 @@ public final class RoutingConfigGroup extends ConfigGroup {
 		public static final String SET_TYPE = "teleportedModeParameters";
 		public static final String MODE = "mode";
 		public static final String TELEPORTED_MODE_FREESPEED_FACTOR = "teleportedModeFreespeedFactor";
+		public static final String PERSON_SPEED_ATTRIBUTE = "personSpeedAttribute";
 
 		private String mode = null;
 
@@ -156,6 +157,9 @@ public final class RoutingConfigGroup extends ConfigGroup {
 		private Double teleportedModeFreespeedFactor = null;
 		private Double teleportedModeFreespeedLimit = Double.POSITIVE_INFINITY ;
 
+		// individual person attribute
+		private String personSpeedAttribute = null;
+
 		private static final String TELEPORTED_MODE_FREESPEED_FACTOR_CMT = "Free-speed factor for a teleported mode. " +
 		"Travel time = teleportedModeFreespeedFactor * <freespeed car travel time>. Insert a line like this for every such mode. " +
 		"Please do not set teleportedModeFreespeedFactor as well as teleportedModeSpeed for the same mode, but if you do, +" +
@@ -163,6 +167,8 @@ public final class RoutingConfigGroup extends ConfigGroup {
 
 		private static final String TELEPORTED_MODE_FREESPEED_LIMIT_CMT = "When using freespeed factor, a speed limit on the free speed. "
 				+ "Link travel time will be $= factor * [ min( link_freespeed, freespeed_limit) ]" ;
+
+		private static final String PERSON_SPEED_ATTRIBUTE_CMT = "The name of a person attribute that indicates their individual travel speed. Falling back to teleportedModeSpeed.";
 
 		public TeleportedModeParams( final String mode ) {
 			super( SET_TYPE );
@@ -185,6 +191,11 @@ public final class RoutingConfigGroup extends ConfigGroup {
 				// this should not happen anyway as the setters forbid it
 				throw new RuntimeException( "both teleported mode speed or freespeed factor are set for mode "+mode );
 			}
+
+			if ( teleportedModeFreespeedFactor != null && personSpeedAttribute != null ) {
+				// this should not happen anyway as the setters forbid it
+				throw new RuntimeException( "cannot combine per-person speed attribute and freespeed factor for "+mode );
+			}
 		}
 
 		@Override
@@ -195,7 +206,7 @@ public final class RoutingConfigGroup extends ConfigGroup {
 					"Speed for a teleported mode. " +
 					"Travel time = (<beeline distance> * beelineDistanceFactor) / teleportedModeSpeed. Insert a line like this for every such mode.");
 			map.put( TELEPORTED_MODE_FREESPEED_FACTOR, TELEPORTED_MODE_FREESPEED_FACTOR_CMT);
-
+			map.put(PERSON_SPEED_ATTRIBUTE, PERSON_SPEED_ATTRIBUTE_CMT);
 			return map;
 		}
 
@@ -276,6 +287,18 @@ public final class RoutingConfigGroup extends ConfigGroup {
 		@StringGetter("beelineDistanceFactor")
 		public Double getBeelineDistanceFactor() {
 			return this.beelineDistanceFactorForMode ;
+		}
+		
+		@StringSetter(PERSON_SPEED_ATTRIBUTE)
+		public TeleportedModeParams setPersonSpeedAttribute(String val) {
+			testForLocked();
+			this.personSpeedAttribute = val;
+			return this;
+		}
+
+		@StringGetter(PERSON_SPEED_ATTRIBUTE)
+		public String getPersonSpeedAttribute() {
+			return this.personSpeedAttribute;
 		}
 
 	}

--- a/matsim/src/main/java/org/matsim/core/router/DefaultRoutingModules.java
+++ b/matsim/src/main/java/org/matsim/core/router/DefaultRoutingModules.java
@@ -54,7 +54,8 @@ public final class DefaultRoutingModules {
 				mode,
 			  scenario,
 				params.getTeleportedModeSpeed(),
-                params.getBeelineDistanceFactor() );
+                params.getBeelineDistanceFactor(),
+				params.getPersonSpeedAttribute() );
 	}
 
 	/**

--- a/matsim/src/main/java/org/matsim/core/router/TeleportationRoutingModule.java
+++ b/matsim/src/main/java/org/matsim/core/router/TeleportationRoutingModule.java
@@ -38,6 +38,7 @@ import org.matsim.facilities.Facility;
 
 /**
  * @author thibautd
+ * @author sebhoerl
  */
 public class TeleportationRoutingModule implements RoutingModule {
 
@@ -45,15 +46,18 @@ public class TeleportationRoutingModule implements RoutingModule {
 
 	private final double beelineDistanceFactor;
 	private final double networkTravelSpeed;
+	private final String personSpeedAttribute;
 	private final Scenario scenario;
 
 	public TeleportationRoutingModule(
 			final String mode,
 			final Scenario scenario,
 			final double networkTravelSpeed,
-			final double beelineDistanceFactor) {
+			final double beelineDistanceFactor,
+			final String personSpeedAttribute) {
 		this.networkTravelSpeed = networkTravelSpeed;
 		this.beelineDistanceFactor = beelineDistanceFactor;
+		this.personSpeedAttribute = personSpeedAttribute;
 		this.mode = mode;
 		this.scenario = scenario ;
 	}
@@ -113,7 +117,7 @@ public class TeleportationRoutingModule implements RoutingModule {
 
 		Route route = this.scenario.getPopulation().getFactory().getRouteFactories().createRoute(Route.class, fromFacilityLinkId, toFacilityLinkId );
 		double estimatedNetworkDistance = dist * this.beelineDistanceFactor;
-		int travTime = (int) (estimatedNetworkDistance / this.networkTravelSpeed);
+		int travTime = (int) (estimatedNetworkDistance / getTravelSpeed(person));
 		route.setTravelTime(travTime);
 		route.setDistance(estimatedNetworkDistance);
 		leg.setRoute(route);
@@ -122,6 +126,18 @@ public class TeleportationRoutingModule implements RoutingModule {
 		Leg r = (leg);
 		r.setTravelTime( depTime + travTime - r.getDepartureTime().seconds()); // yy something needs to be done once there are alternative implementations of the interface.  kai, apr'10
 		return travTime;
+	}
+
+	private double getTravelSpeed(Person person) {
+		if (personSpeedAttribute != null) {
+			Double personSpeed = (Double) person.getAttributes().getAttribute(personSpeedAttribute);
+			
+			if (personSpeed != null) {
+				return personSpeed;
+			}
+		}
+
+		return this.networkTravelSpeed;
 	}
 
 }

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/RaptorStopFinderTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/RaptorStopFinderTest.java
@@ -88,7 +88,7 @@ public class RaptorStopFinderTest {
             StopFinderFixture f0 = new StopFinderFixture(1., 1., 1., 1.);
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0, null));
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -116,7 +116,7 @@ public class RaptorStopFinderTest {
             StopFinderFixture f0 = new StopFinderFixture(600., 1., 1., 1.);
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0, null));
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -160,7 +160,7 @@ public class RaptorStopFinderTest {
             StopFinderFixture f1 = new StopFinderFixture(20*60., 20.*60, 10*60., 1.);
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f1.scenario, 1000.0, 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f1.scenario, 1000.0, 1.0, null));
 
             f1.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -215,7 +215,7 @@ public class RaptorStopFinderTest {
 
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0, null));
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -251,7 +251,7 @@ public class RaptorStopFinderTest {
             }
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0, null));
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -300,7 +300,7 @@ public class RaptorStopFinderTest {
             }
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0, null));
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -355,7 +355,7 @@ public class RaptorStopFinderTest {
 
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0, null));
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -404,7 +404,7 @@ public class RaptorStopFinderTest {
             StopFinderFixture f0 = new StopFinderFixture(1., 1., 1., 1.);
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0, null));
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -433,7 +433,7 @@ public class RaptorStopFinderTest {
             StopFinderFixture f0 = new StopFinderFixture(600., 1., 1., 1.);
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0, null));
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -478,7 +478,7 @@ public class RaptorStopFinderTest {
             StopFinderFixture f1 = new StopFinderFixture(20*60., 20.*60, 10*60., 1.);
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f1.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f1.scenario, 1000., 1.0, null));
 
             f1.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -533,7 +533,7 @@ public class RaptorStopFinderTest {
 
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0, null));
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -569,7 +569,7 @@ public class RaptorStopFinderTest {
             }
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0, null));
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -619,7 +619,7 @@ public class RaptorStopFinderTest {
             }
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0, null));
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -675,7 +675,7 @@ public class RaptorStopFinderTest {
 
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0, null));
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -739,7 +739,7 @@ public class RaptorStopFinderTest {
             StopFinderFixture f1 = new StopFinderFixture(20 * 60., 1., 1., 1.);
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f1.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f1.scenario, 1000., 1.0, null));
 
             f1.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -784,7 +784,7 @@ public class RaptorStopFinderTest {
             StopFinderFixture f1 = new StopFinderFixture(20 * 60., 10. * 60, 1., 1.);
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f1.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f1.scenario, 1000., 1.0, null));
 
             f1.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -829,7 +829,7 @@ public class RaptorStopFinderTest {
             StopFinderFixture f1 = new StopFinderFixture(20 * 60., 1., 1., 1.);
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f1.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f1.scenario, 1000., 1.0, null));
 
             f1.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -881,7 +881,7 @@ public class RaptorStopFinderTest {
             }
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0, null));
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -933,7 +933,7 @@ public class RaptorStopFinderTest {
             }
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0, null));
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -982,7 +982,7 @@ public class RaptorStopFinderTest {
             StopFinderFixture f1 = new StopFinderFixture(20 * 60., 1., 1., 1.);
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f1.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f1.scenario, 1000., 1.0, null));
 
             f1.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -1028,7 +1028,7 @@ public class RaptorStopFinderTest {
             StopFinderFixture f1 = new StopFinderFixture(20 * 60., 10. * 60, 1., 1.);
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f1.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f1.scenario, 1000., 1.0, null));
 
             f1.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -1074,7 +1074,7 @@ public class RaptorStopFinderTest {
             StopFinderFixture f1 = new StopFinderFixture(20 * 60., 1., 1., 1.);
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f1.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f1.scenario, 1000., 1.0, null));
 
             f1.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -1127,7 +1127,7 @@ public class RaptorStopFinderTest {
             }
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0, null));
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -1180,7 +1180,7 @@ public class RaptorStopFinderTest {
             }
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0, null));
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -1246,7 +1246,7 @@ public class RaptorStopFinderTest {
             StopFinderFixture f0 = new StopFinderFixture(10 * 60., 20 * 60., 1., 1.);
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0, null));
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -1293,7 +1293,7 @@ public class RaptorStopFinderTest {
             StopFinderFixture f1 = new StopFinderFixture(20 * 60., 10 * 60., 1., 1.);
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f1.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f1.scenario, 1000., 1.0, null));
 
             f1.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -1349,7 +1349,7 @@ public class RaptorStopFinderTest {
             }
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0, null));
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -1404,7 +1404,7 @@ public class RaptorStopFinderTest {
             }
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0, null));
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -1457,7 +1457,7 @@ public class RaptorStopFinderTest {
             StopFinderFixture f0 = new StopFinderFixture(10 * 60., 20 * 60., 1., 1.);
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0, null));
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -1505,7 +1505,7 @@ public class RaptorStopFinderTest {
             StopFinderFixture f1 = new StopFinderFixture(20 * 60., 10 * 60., 1., 1.);
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f1.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f1.scenario, 1000., 1.0, null));
 
             f1.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -1562,7 +1562,7 @@ public class RaptorStopFinderTest {
             }
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0, null));
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -1618,7 +1618,7 @@ public class RaptorStopFinderTest {
             }
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 1000., 1.0, null));
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();
@@ -1679,9 +1679,9 @@ public class RaptorStopFinderTest {
 
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 5, 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 5, 1.0, null));
             routingModules.put("zoomer",
-                    new TeleportationRoutingModule("zoomer", f0.scenario, 1000., 1.));
+                    new TeleportationRoutingModule("zoomer", f0.scenario, 1000., 1., null));
 
             ScoringConfigGroup.ModeParams modeParams = new ScoringConfigGroup.ModeParams("zoomer");
             modeParams.setMarginalUtilityOfTraveling(0.);
@@ -1745,9 +1745,9 @@ public class RaptorStopFinderTest {
 
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 5, 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 5, 1.0, null));
             routingModules.put("zoomer",
-                    new TeleportationRoutingModule("zoomer", f0.scenario, 1000., 1.));
+                    new TeleportationRoutingModule("zoomer", f0.scenario, 1000., 1., null));
 
             ScoringConfigGroup.ModeParams modeParams = new ScoringConfigGroup.ModeParams("zoomer");
             modeParams.setMarginalUtilityOfTraveling(0.);
@@ -1812,9 +1812,9 @@ public class RaptorStopFinderTest {
             StopFinderFixture f0 = new StopFinderFixture(10*60., 20*60., 1., 1.);
             Map<String, RoutingModule> routingModules = new HashMap<>();
             routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 5., 1.0));
+                    new TeleportationRoutingModule(TransportMode.walk, f0.scenario, 5., 1.0, null));
             routingModules.put(TransportMode.bike,
-                    new TeleportationRoutingModule(TransportMode.bike, f0.scenario, 50., 1.0));
+                    new TeleportationRoutingModule(TransportMode.bike, f0.scenario, 50., 1.0, null));
 
             f0.srrConfig.setUseIntermodalAccessEgress(true);
             SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet walkAccess = new SwissRailRaptorConfigGroup.IntermodalAccessEgressParameterSet();

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorIntermodalTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorIntermodalTest.java
@@ -79,9 +79,9 @@ public class SwissRailRaptorIntermodalTest {
 
         Map<String, RoutingModule> routingModules = new HashMap<>();
         routingModules.put(TransportMode.walk,
-            new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3));
+            new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3, null));
         routingModules.put(TransportMode.bike,
-            new TeleportationRoutingModule(TransportMode.bike, f.scenario, 3, 1.4));
+            new TeleportationRoutingModule(TransportMode.bike, f.scenario, 3, 1.4, null));
 
         f.srrConfig.setUseIntermodalAccessEgress(true);
         IntermodalAccessEgressParameterSet walkAccess = new IntermodalAccessEgressParameterSet();
@@ -137,8 +137,8 @@ public class SwissRailRaptorIntermodalTest {
 	void testIntermodalTrip_TripRouterIntegration() {
         IntermodalFixture f = new IntermodalFixture();
 
-        RoutingModule walkRoutingModule = new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3);
-        RoutingModule bikeRoutingModule = new TeleportationRoutingModule(TransportMode.bike, f.scenario, 3, 1.4);
+        RoutingModule walkRoutingModule = new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3, null);
+        RoutingModule bikeRoutingModule = new TeleportationRoutingModule(TransportMode.bike, f.scenario, 3, 1.4, null);
 
         Map<String, RoutingModule> routingModules = new HashMap<>();
         routingModules.put(TransportMode.walk, walkRoutingModule);
@@ -224,9 +224,9 @@ public class SwissRailRaptorIntermodalTest {
 
         Map<String, RoutingModule> routingModules = new HashMap<>();
         routingModules.put(TransportMode.walk,
-                new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3));
+                new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3, null));
         routingModules.put(TransportMode.bike,
-                new TeleportationRoutingModule(TransportMode.bike, f.scenario, 3, 1.4));
+                new TeleportationRoutingModule(TransportMode.bike, f.scenario, 3, 1.4, null));
 
         f.srrConfig.setUseIntermodalAccessEgress(true);
         IntermodalAccessEgressParameterSet walkAccess = new IntermodalAccessEgressParameterSet();
@@ -276,9 +276,9 @@ public class SwissRailRaptorIntermodalTest {
 
         Map<String, RoutingModule> routingModules = new HashMap<>();
         routingModules.put(TransportMode.walk,
-                new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3));
+                new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3, null));
         routingModules.put(TransportMode.bike,
-                new TeleportationRoutingModule(TransportMode.bike, f.scenario, 3, 1.4));
+                new TeleportationRoutingModule(TransportMode.bike, f.scenario, 3, 1.4, null));
 
         f.srrConfig.setUseIntermodalAccessEgress(true);
         IntermodalAccessEgressParameterSet bikeAccess = new IntermodalAccessEgressParameterSet();
@@ -316,11 +316,11 @@ public class SwissRailRaptorIntermodalTest {
 
         Map<String, RoutingModule> routingModules = new HashMap<>();
         routingModules.put(TransportMode.walk,
-            new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3));
+            new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3, null));
         routingModules.put(TransportMode.walk,
-                new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3));
+                new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3, null));
         routingModules.put(TransportMode.bike,
-            new TeleportationRoutingModule(TransportMode.bike, f.scenario, 3.0, 1.4));
+            new TeleportationRoutingModule(TransportMode.bike, f.scenario, 3.0, 1.4, null));
         f.srrConfig.setUseIntermodalAccessEgress(true);
         IntermodalAccessEgressParameterSet walkAccess = new IntermodalAccessEgressParameterSet();
         walkAccess.setMode(TransportMode.walk);
@@ -408,9 +408,9 @@ public class SwissRailRaptorIntermodalTest {
 
         Map<String, RoutingModule> routingModules = new HashMap<>();
         routingModules.put(TransportMode.walk,
-            new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3));
+            new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3, null));
         routingModules.put(TransportMode.bike,
-            new TeleportationRoutingModule(TransportMode.bike, f.scenario, 100.0, 1.4));
+            new TeleportationRoutingModule(TransportMode.bike, f.scenario, 100.0, 1.4, null));
 
         f.srrConfig.setUseIntermodalAccessEgress(true);
         IntermodalAccessEgressParameterSet walkAccess = new IntermodalAccessEgressParameterSet();
@@ -492,9 +492,9 @@ public class SwissRailRaptorIntermodalTest {
 
         Map<String, RoutingModule> routingModules = new HashMap<>();
         routingModules.put(TransportMode.walk,
-                new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3));
+                new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3, null));
         routingModules.put(TransportMode.bike,
-                new TeleportationRoutingModule(TransportMode.bike, f.scenario, 3, 1.4));
+                new TeleportationRoutingModule(TransportMode.bike, f.scenario, 3, 1.4, null));
 
         // we need to set special values for walk and bike as the defaults are the same for walk, bike and waiting
         // which would result in all options having the same cost in the end.
@@ -552,7 +552,7 @@ public class SwissRailRaptorIntermodalTest {
         // do the test this way to insure it is not accidentally correct due to the accidentally correct order the modes are initialized
         {
             routingModules.put(TransportMode.bike,
-                new TeleportationRoutingModule(TransportMode.bike, f.scenario, 1.0, 1.4));
+                new TeleportationRoutingModule(TransportMode.bike, f.scenario, 1.0, 1.4, null));
 
             SwissRailRaptorData data = SwissRailRaptorData.create(f.scenario.getTransitSchedule(), null, RaptorUtils.createStaticConfig(f.config), f.scenario.getNetwork(), null);
             DefaultRaptorStopFinder stopFinder = new DefaultRaptorStopFinder(new DefaultRaptorIntermodalAccessEgress(), routingModules);
@@ -587,9 +587,9 @@ public class SwissRailRaptorIntermodalTest {
 
         Map<String, RoutingModule> routingModules = new HashMap<>();
         routingModules.put(TransportMode.walk,
-                new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3));
+                new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3, null));
         routingModules.put(TransportMode.bike,
-                new TeleportationRoutingModule(TransportMode.bike, f.scenario, 3, 1.4));
+                new TeleportationRoutingModule(TransportMode.bike, f.scenario, 3, 1.4, null));
 
         // we need to set special values for walk and bike as the defaults are the same for walk, bike and waiting
         // which would result in all options having the same cost in the end.
@@ -938,9 +938,9 @@ public class SwissRailRaptorIntermodalTest {
 
         Map<String, RoutingModule> routingModules = new HashMap<>();
         routingModules.put(TransportMode.walk,
-            new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3));
+            new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3, null));
         routingModules.put(TransportMode.bike,
-            new TeleportationRoutingModule(TransportMode.bike, f.scenario, 60, 1.0));
+            new TeleportationRoutingModule(TransportMode.bike, f.scenario, 60, 1.0, null));
 
         f.srrConfig.setUseIntermodalAccessEgress(true);
         IntermodalAccessEgressParameterSet walkAccess = new IntermodalAccessEgressParameterSet();
@@ -1008,7 +1008,7 @@ public class SwissRailRaptorIntermodalTest {
 
         Map<String, RoutingModule> routingModules = new HashMap<>();
         routingModules.put(TransportMode.walk,
-            new TeleportationRoutingModule(TransportMode.walk, f.scenario, walkSpeed, 1.3));
+            new TeleportationRoutingModule(TransportMode.walk, f.scenario, walkSpeed, 1.3, null));
 
 
         routingModules.put(TransportMode.bike,
@@ -1129,7 +1129,7 @@ public class SwissRailRaptorIntermodalTest {
 
         Map<String, RoutingModule> routingModules = new HashMap<>();
         routingModules.put(TransportMode.walk,
-            new TeleportationRoutingModule(TransportMode.walk, f.scenario, walkSpeed, 1.3));
+            new TeleportationRoutingModule(TransportMode.walk, f.scenario, walkSpeed, 1.3, null));
 
 
         routingModules.put(TransportMode.bike,
@@ -1248,9 +1248,9 @@ public class SwissRailRaptorIntermodalTest {
 
 		Map<String, RoutingModule> routingModules = new HashMap<>();
 		routingModules.put(TransportMode.walk,
-				new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3));
+				new TeleportationRoutingModule(TransportMode.walk, f.scenario, 1.1, 1.3, null));
 		routingModules.put(TransportMode.bike,
-				new TeleportationRoutingModule(TransportMode.bike, f.scenario, 3, 1.4));
+				new TeleportationRoutingModule(TransportMode.bike, f.scenario, 3, 1.4, null));
 
 		f.srrConfig.setUseIntermodalAccessEgress(true);
 		IntermodalAccessEgressParameterSet walkAccess = new IntermodalAccessEgressParameterSet();
@@ -1478,9 +1478,9 @@ public class SwissRailRaptorIntermodalTest {
 
             this.routingModules = new HashMap<>();
             this.routingModules.put(TransportMode.walk,
-                    new TeleportationRoutingModule(TransportMode.walk, this.scenario, 1.1, 1.3));
+                    new TeleportationRoutingModule(TransportMode.walk, this.scenario, 1.1, 1.3, null));
             this.routingModules.put(TransportMode.bike,
-                    new TeleportationRoutingModule(TransportMode.bike, this.scenario, 10, 1.4)); // make bike very fast
+                    new TeleportationRoutingModule(TransportMode.bike, this.scenario, 10, 1.4, null)); // make bike very fast
 
             // we need to set special values for walk and bike as the defaults are the same for walk, bike and waiting
             // which would result in all options having the same cost in the end.

--- a/matsim/src/test/java/org/matsim/core/router/TeleportationRoutingModuleTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/TeleportationRoutingModuleTest.java
@@ -57,7 +57,7 @@ public class TeleportationRoutingModuleTest {
 		TeleportationRoutingModule router =
 				new TeleportationRoutingModule(
 						"mode",
-						scenario, 10.0, 1.0);
+						scenario, 10.0, 1.0, null);
 		double tt = router.routeLeg(person, leg, fromAct, toAct, 7.0 * 3600);
 		Assertions.assertEquals(100.0, tt, 10e-7);
 		Assertions.assertEquals(100.0, leg.getTravelTime().seconds(), 10e-7);
@@ -68,7 +68,7 @@ public class TeleportationRoutingModuleTest {
 						"mode",
 					  scenario,
 						20.0,
-						1.0);
+						1.0, null);
 		tt = router.routeLeg(person, leg, fromAct, toAct, 7.0 * 3600);
 		Assertions.assertEquals(50.0, tt, 10e-7);
 		Assertions.assertEquals(50.0, leg.getTravelTime().seconds(), 10e-7);
@@ -83,10 +83,60 @@ public class TeleportationRoutingModuleTest {
 						"mode",
 				scenario,
 						10.0,
-						manhattanBeelineDistanceFactor);
+						manhattanBeelineDistanceFactor, null);
 		tt = router.routeLeg(person, leg, fromAct, otherToAct, 7.0 * 3600);
 		Assertions.assertEquals(200.0, tt, 10e-7);
 		Assertions.assertEquals(200.0, leg.getTravelTime().seconds(), 10e-7);
 		Assertions.assertEquals(200.0, leg.getRoute().getTravelTime().seconds(), 10e-7);
+	}
+
+	@Test
+	void testRouteLegWithAttribute() {
+		final Scenario scenario = ScenarioUtils.createScenario( ConfigUtils.createConfig() );
+		PopulationFactory populationFactory = scenario.getPopulation().getFactory();
+		RouteFactories routeFactory = new RouteFactories();
+		Person person = PopulationUtils.getFactory().createPerson(Id.create(1, Person.class));
+		Leg leg = PopulationUtils.createLeg(TransportMode.walk);
+		Facility fromAct = scenario.getActivityFacilities().getFactory().createActivityFacility( Id.create( "h", ActivityFacility.class ),
+				new Coord(0,0), Id.createLinkId( "h" ) ) ;
+		Facility toAct = scenario.getActivityFacilities().getFactory().createActivityFacility( Id.create( "h", ActivityFacility.class ),
+				new Coord(1000,0), Id.createLinkId( "h" ) ) ;
+
+		{ // without attribute
+			TeleportationRoutingModule router =
+					new TeleportationRoutingModule(
+							"mode",
+							scenario, 10.0, 1.0, null);
+			double tt = router.routeLeg(person, leg, fromAct, toAct, 7.0 * 3600);
+			Assertions.assertEquals(100.0, tt, 10e-7);
+			Assertions.assertEquals(100.0, leg.getTravelTime().seconds(), 10e-7);
+			Assertions.assertEquals(100.0, leg.getRoute().getTravelTime().seconds(), 10e-7);
+		}
+		
+		{ // with attribute
+			person.getAttributes().putAttribute("customSpeed", 20.0);
+
+			TeleportationRoutingModule router =
+					new TeleportationRoutingModule(
+							"mode",
+							scenario, 10.0, 1.0, "customSpeed");
+			double tt = router.routeLeg(person, leg, fromAct, toAct, 7.0 * 3600);
+			Assertions.assertEquals(200.0, tt, 10e-7);
+			Assertions.assertEquals(200.0, leg.getTravelTime().seconds(), 10e-7);
+			Assertions.assertEquals(200.0, leg.getRoute().getTravelTime().seconds(), 10e-7);
+		}
+
+		{ // fallback
+			person.getAttributes().removeAttribute("customSpeed");
+
+			TeleportationRoutingModule router =
+					new TeleportationRoutingModule(
+							"mode",
+							scenario, 30.0, 1.0, "customSpeed");
+			double tt = router.routeLeg(person, leg, fromAct, toAct, 7.0 * 3600);
+			Assertions.assertEquals(300.0, tt, 10e-7);
+			Assertions.assertEquals(300.0, leg.getTravelTime().seconds(), 10e-7);
+			Assertions.assertEquals(300.0, leg.getRoute().getTravelTime().seconds(), 10e-7);
+		}
 	}
 }

--- a/matsim/src/test/java/org/matsim/core/router/TeleportationRoutingModuleTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/TeleportationRoutingModuleTest.java
@@ -121,9 +121,9 @@ public class TeleportationRoutingModuleTest {
 							"mode",
 							scenario, 10.0, 1.0, "customSpeed");
 			double tt = router.routeLeg(person, leg, fromAct, toAct, 7.0 * 3600);
-			Assertions.assertEquals(200.0, tt, 10e-7);
-			Assertions.assertEquals(200.0, leg.getTravelTime().seconds(), 10e-7);
-			Assertions.assertEquals(200.0, leg.getRoute().getTravelTime().seconds(), 10e-7);
+			Assertions.assertEquals(50.0, tt, 10e-7);
+			Assertions.assertEquals(50.0, leg.getTravelTime().seconds(), 10e-7);
+			Assertions.assertEquals(50.0, leg.getRoute().getTravelTime().seconds(), 10e-7);
 		}
 
 		{ // fallback
@@ -134,9 +134,9 @@ public class TeleportationRoutingModuleTest {
 							"mode",
 							scenario, 30.0, 1.0, "customSpeed");
 			double tt = router.routeLeg(person, leg, fromAct, toAct, 7.0 * 3600);
-			Assertions.assertEquals(300.0, tt, 10e-7);
-			Assertions.assertEquals(300.0, leg.getTravelTime().seconds(), 10e-7);
-			Assertions.assertEquals(300.0, leg.getRoute().getTravelTime().seconds(), 10e-7);
+			Assertions.assertEquals(33.0, tt, 10e-7);
+			Assertions.assertEquals(33.0, leg.getTravelTime().seconds(), 10e-7);
+			Assertions.assertEquals(33.0, leg.getRoute().getTravelTime().seconds(), 10e-7);
 		}
 	}
 }


### PR DESCRIPTION
This PR allows users to define a `personSpeedAttribute` in the `RoutingParameter`s. If the option is set and a person has the corresponding attribute, the value will be used for teleportation routing instead of the global parameter, which was the only option previously. This allows to define speeds, for instance, based on the age of the person.