### PR TITLE
fix(drt): fix stats bug introduced in previous PR

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
@@ -262,7 +262,7 @@ public class DrtAnalysisControlerListener implements IterationEndsListener, Shut
 					format.format(leg.toCoord.getY()),//
 					leg.waitTime + "",//
 					leg.arrivalTime + "",//
-					(leg.arrivalTime - leg.pickupTime - leg.waitTime) + "",//
+					(leg.arrivalTime - leg.pickupTime) + "",//
 					format.format(drtVehicleStats.getTravelDistances().get(leg.request)),//
 					format.format(leg.unsharedDistanceEstimate_m),//
 					format.format(leg.fare), //


### PR DESCRIPTION
travel time calculation is now based on actual pickup time instead of beginning of the time window, so no longer need to subtract wait time
