### PR TITLE
chore(core): Ensure collection fields in cfgs are sorted

### DIFF
--- a/matsim/src/main/java/org/matsim/core/config/ReflectiveConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/ReflectiveConfigGroup.java
@@ -525,7 +525,7 @@ public abstract class ReflectiveConfigGroup extends ConfigGroup implements Matsi
 			Preconditions.checkArgument(collection.stream().noneMatch(String::isBlank),
 					"Collection %s contains blank elements. Only non-blank elements are supported.", collection);
 			return
-				collection.stream().sorted().collect(Collectors.joining(","));
+				collection.stream().sorted().collect(Collectors.joining(", "));
 		} else {
 			return result + "";
 		}

--- a/matsim/src/main/java/org/matsim/core/config/ReflectiveConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/ReflectiveConfigGroup.java
@@ -524,7 +524,8 @@ public abstract class ReflectiveConfigGroup extends ConfigGroup implements Matsi
 			var collection = ((Collection<String>)result);
 			Preconditions.checkArgument(collection.stream().noneMatch(String::isBlank),
 					"Collection %s contains blank elements. Only non-blank elements are supported.", collection);
-			return String.join(", ", collection);
+			return
+				collection.stream().sorted().collect(Collectors.joining(","));
 		} else {
 			return result + "";
 		}


### PR DESCRIPTION
This PR ensures that exported collection fields – e.g., modes = {car, bike, walk} – are written in alphabetical order. Otherwise it could happen that a checked in cfg looks different than a newly generated cfg only because the order of a collection field has randomly change.