### PR TITLE
fix(freight(carriers)): shutdown all (open) threads from the JspritThreadPoolExecutor

### DIFF
--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
@@ -266,6 +266,17 @@ public class CarriersUtils {
 		for (Future<?> future : futures) {
 			future.get();
 		}
+
+		// close all threads
+		executor.shutdown();
+		try {
+		    if (!executor.awaitTermination(60, TimeUnit.SECONDS)) {
+		        executor.shutdownNow();
+		    }
+		} catch (InterruptedException e) {
+		    executor.shutdownNow();
+		    Thread.currentThread().interrupt();
+		}
 	}
 
 	/**


### PR DESCRIPTION

This fix adds a call of executor.shutdown().
As a result, the threads are called to shutdown and do not stay open and block the shutdown of the java run.

Without this, I had the issue, that (at least since version 2025w02) the simple runs including CarrierUtils.runJsprit(..) does not finish, even if all the code is executed.