### PR TITLE
refactor(freight(carriers)): Use try-with-ressources block instead of manually call executor.shutdown

### DIFF
--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
@@ -249,34 +249,25 @@ public class CarriersUtils {
 		int nThreads = Runtime.getRuntime().availableProcessors();
 		log.info("Starting VRP solving for {} carriers in parallel with {} threads.", carrierActivityCounterMap.size(), nThreads);
 
-		ThreadPoolExecutor executor = new JspritTreadPoolExecutor(new PriorityBlockingQueue<>(), nThreads);
+		List<Future<?>> futures;
+		try (ThreadPoolExecutor executor = new JspritTreadPoolExecutor(new PriorityBlockingQueue<>(), nThreads)) {
+			futures = new ArrayList<>();
+			List<Map.Entry<Id<Carrier>, Integer>> sorted = carrierActivityCounterMap.entrySet().stream()
+				.sorted(Map.Entry.comparingByValue((o1, o2) -> o2 - o1))
+				.toList();
 
-		List<Future<?>> futures = new ArrayList<>();
-		List<Map.Entry<Id<Carrier>, Integer>> sorted = carrierActivityCounterMap.entrySet().stream()
-			.sorted(Map.Entry.comparingByValue((o1, o2) -> o2 - o1))
-			.toList();
-
-		for (Map.Entry<Id<Carrier>, Integer> entry : sorted) {
-			JspritCarrierTask task = new JspritCarrierTask(entry.getValue(), carriers.getCarriers().get(entry.getKey()), scenario, netBasedCosts,
-				startedVRPCounter, carriers.getCarriers().size());
-			log.info("Adding task for carrier {} with priority {}", entry.getKey(), entry.getValue());
-			futures.add(executor.submit(task));
+			for (Map.Entry<Id<Carrier>, Integer> entry : sorted) {
+				JspritCarrierTask task = new JspritCarrierTask(entry.getValue(), carriers.getCarriers().get(entry.getKey()), scenario, netBasedCosts,
+					startedVRPCounter, carriers.getCarriers().size());
+				log.info("Adding task for carrier {} with priority {}", entry.getKey(), entry.getValue());
+				futures.add(executor.submit(task));
+			}
 		}
 
 		for (Future<?> future : futures) {
 			future.get();
 		}
 
-		// close all threads
-		executor.shutdown();
-		try {
-		    if (!executor.awaitTermination(60, TimeUnit.SECONDS)) {
-		        executor.shutdownNow();
-		    }
-		} catch (InterruptedException e) {
-		    executor.shutdownNow();
-		    Thread.currentThread().interrupt();
-		}
 	}
 
 	/**


### PR DESCRIPTION
This PR reverts the changes in #3965 and uses another solution: Try-with-ressources.
After talking to KN, this is the better way and it also makes sure, that the threads gets closed.

