### PR TITLE
fix(drt): fix timing bugs when using custom stop durations

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/ConfigurableCostCalculatorStrategy.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/ConfigurableCostCalculatorStrategy.java
@@ -24,7 +24,7 @@ public class ConfigurableCostCalculatorStrategy implements CostCalculationStrate
 	}
 
 	private boolean checkHardInsertion(DrtRequest request, DetourTimeInfo detourTimeInfo) {
-		return detourTimeInfo.pickupDetourInfo.departureTime <= request.getLatestStartTime()
+		return detourTimeInfo.pickupDetourInfo.requestPickupTime <= request.getLatestStartTime()
 				&& detourTimeInfo.dropoffDetourInfo.requestDropoffTime <= request.getLatestArrivalTime();
 	}
 
@@ -33,7 +33,7 @@ public class ConfigurableCostCalculatorStrategy implements CostCalculationStrate
 			return 0.0;
 		} else {
 			double pickupDelay = Math.max(0,
-					detourTimeInfo.pickupDetourInfo.departureTime - request.getLatestStartTime());
+					detourTimeInfo.pickupDetourInfo.requestPickupTime - request.getLatestStartTime());
 
 			double dropoffDelay = Math.max(0,
 					detourTimeInfo.dropoffDetourInfo.requestDropoffTime - request.getLatestArrivalTime());

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/ConfigurableCostCalculatorStrategy.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/ConfigurableCostCalculatorStrategy.java
@@ -25,7 +25,7 @@ public class ConfigurableCostCalculatorStrategy implements CostCalculationStrate
 
 	private boolean checkHardInsertion(DrtRequest request, DetourTimeInfo detourTimeInfo) {
 		return detourTimeInfo.pickupDetourInfo.departureTime <= request.getLatestStartTime()
-				&& detourTimeInfo.dropoffDetourInfo.arrivalTime <= request.getLatestArrivalTime();
+				&& detourTimeInfo.dropoffDetourInfo.requestDropoffTime <= request.getLatestArrivalTime();
 	}
 
 	private double calculateSoftInsertionPenalty(DrtRequest request, DetourTimeInfo detourTimeInfo) {
@@ -36,7 +36,7 @@ public class ConfigurableCostCalculatorStrategy implements CostCalculationStrate
 					detourTimeInfo.pickupDetourInfo.departureTime - request.getLatestStartTime());
 
 			double dropoffDelay = Math.max(0,
-					detourTimeInfo.dropoffDetourInfo.arrivalTime - request.getLatestArrivalTime());
+					detourTimeInfo.dropoffDetourInfo.requestDropoffTime - request.getLatestArrivalTime());
 
 			return softInsertionParams.pickupWeight * pickupDelay + softInsertionParams.dropoffWeight * dropoffDelay;
 		}

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/distances/InsertionDistanceCalculator.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/distances/InsertionDistanceCalculator.java
@@ -154,7 +154,7 @@ public class InsertionDistanceCalculator {
 			beforeDropoffOccupancy = beforePickupOccupancy.add(insertion.insertedLoad);
 		}
 
-		double afterDropoffDistance = distanceEstimator.calculateDistance(detourTimeInfo.dropoffDetourInfo.arrivalTime,
+		double afterDropoffDistance = distanceEstimator.calculateDistance(detourTimeInfo.dropoffDetourInfo.vehicleArrivalTime,
 				dropoffNewLink, dropoffToLink);
 		addedDistances.add(new DistanceEntry(afterDropoffDistance, beforeDropoffOccupancy.subtract(insertion.insertedLoad)));
 

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/distances/InsertionDistanceCalculator.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/distances/InsertionDistanceCalculator.java
@@ -88,7 +88,7 @@ public class InsertionDistanceCalculator {
 		double beforePickupDistance = distanceEstimator
 				.calculateDistance(insertion.pickup.previousWaypoint.getDepartureTime(), pickupFromLink, pickupNewLink);
 
-		double afterPickupDistance = distanceEstimator.calculateDistance(detourTimeInfo.pickupDetourInfo.departureTime,
+		double afterPickupDistance = distanceEstimator.calculateDistance(detourTimeInfo.pickupDetourInfo.vehicleDepartureTime,
 				pickupNewLink, pickupToLink);
 
 		addedDistances.add(new DistanceEntry(beforePickupDistance, beforePickupOccupancy));

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/objectives/PassengerDelayObjective.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/objectives/PassengerDelayObjective.java
@@ -22,7 +22,7 @@ public class PassengerDelayObjective implements DrtInsertionObjective {
 	public double calculateObjective(DrtRequest request, Insertion insertion, DetourTimeInfo detourTimeInfo) {
 		VehicleEntry vehicleEntry = insertion.vehicleEntry;
 
-		double totalPickupValue = detourTimeInfo.pickupDetourInfo.departureTime - request.getEarliestStartTime();
+		double totalPickupValue = detourTimeInfo.pickupDetourInfo.requestPickupTime - request.getEarliestStartTime();
 		double totalDropoffValue = detourTimeInfo.dropoffDetourInfo.requestDropoffTime - request.getEarliestStartTime();
 
 		double remainingTimeLoss = detourTimeInfo.pickupDetourInfo.pickupTimeLoss;

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/objectives/PassengerDelayObjective.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/objectives/PassengerDelayObjective.java
@@ -23,7 +23,7 @@ public class PassengerDelayObjective implements DrtInsertionObjective {
 		VehicleEntry vehicleEntry = insertion.vehicleEntry;
 
 		double totalPickupValue = detourTimeInfo.pickupDetourInfo.departureTime - request.getEarliestStartTime();
-		double totalDropoffValue = detourTimeInfo.dropoffDetourInfo.arrivalTime - request.getEarliestStartTime();
+		double totalDropoffValue = detourTimeInfo.dropoffDetourInfo.requestDropoffTime - request.getEarliestStartTime();
 
 		double remainingTimeLoss = detourTimeInfo.pickupDetourInfo.pickupTimeLoss;
 

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/optimizer/insertion/ShiftInsertionCostCalculator.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/optimizer/insertion/ShiftInsertionCostCalculator.java
@@ -12,6 +12,7 @@ import org.matsim.contrib.drt.extension.operations.shifts.shift.DrtShiftBreak;
 import org.matsim.contrib.drt.optimizer.VehicleEntry;
 import org.matsim.contrib.drt.optimizer.Waypoint;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionDetourTimeCalculator.DropoffDetourInfo;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
 import org.matsim.contrib.dvrp.schedule.Task;
@@ -55,6 +56,15 @@ public class ShiftInsertionCostCalculator implements InsertionCostCalculator {
 		return delegate.calculate(drtRequest, insertion, detourTimeInfo);
 	}
 
+	/*
+	 * @Nico: I replaced the use of that info object with this function. 
+	 * You assume zero dropoff duration here, I think. What you probably 
+	 * would want to add is to take into account the duration of the stop. 
+	 */
+	private double calculateStopEnd(DropoffDetourInfo info) {
+		return info.vehicleArrivalTime;
+	}
+
 	boolean checkShiftTimeConstraintsForScheduledRequests(Insertion insertion, DetourTimeInfo detourTimeInfo) {
 		VehicleEntry vEntry = insertion.vehicleEntry;
 		final int pickupIdx = insertion.pickup.index;
@@ -62,7 +72,7 @@ public class ShiftInsertionCostCalculator implements InsertionCostCalculator {
 
 		DrtShift currentShift = ((ShiftDvrpVehicle) vEntry.vehicle).getShifts().peek();
 		double shiftEndTime = currentShift.getEndTime();
-		if(shiftEndTime < detourTimeInfo.dropoffDetourInfo.arrivalTime) {
+		if(shiftEndTime < calculateStopEnd(detourTimeInfo.dropoffDetourInfo)) {
 			// fast fail which also captures requests that are prebooked for times outside of the shift.
 			return false;
 		}
@@ -151,14 +161,14 @@ public class ShiftInsertionCostCalculator implements InsertionCostCalculator {
 			DrtShiftBreak drtShiftBreak = currentShift.getBreak().get();
 			if(!drtShiftBreak.isScheduled()) {
 
-				if(detourTimeInfo.dropoffDetourInfo.arrivalTime < drtShiftBreak.getEarliestBreakStartTime()) {
+				if(calculateStopEnd(detourTimeInfo.dropoffDetourInfo) < drtShiftBreak.getEarliestBreakStartTime()) {
 					// insertion finished before break corridor
 					//ok
 				} else if(detourTimeInfo.pickupDetourInfo.departureTime > drtShiftBreak.getLatestBreakEndTime()) {
 					// insertion start after break corridor
 					//ok
 				} else {
-					double remainingTime = drtShiftBreak.getLatestBreakEndTime() - detourTimeInfo.dropoffDetourInfo.arrivalTime;
+					double remainingTime = drtShiftBreak.getLatestBreakEndTime() - calculateStopEnd(detourTimeInfo.dropoffDetourInfo);
 					if (remainingTime < drtShiftBreak.getDuration()) {
 						// no meaningful break possible after insertion
 						// (there could still be enough time before a prebooking though)
@@ -178,7 +188,7 @@ public class ShiftInsertionCostCalculator implements InsertionCostCalculator {
 				if(dropoffIdx == vEntry.stops.size()) {
 					// last stop is the new stop
 					lastLink = insertion.dropoff.newWaypoint.getLink();
-					potentialReturnToHubDepartureTime = detourTimeInfo.dropoffDetourInfo.arrivalTime;
+					potentialReturnToHubDepartureTime = calculateStopEnd(detourTimeInfo.dropoffDetourInfo);
 				} else {
 					// last stop is an existing stop
 					lastLink = vEntry.stops.getLast().getLink();

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/optimizer/insertion/ShiftInsertionCostCalculator.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/operations/shifts/optimizer/insertion/ShiftInsertionCostCalculator.java
@@ -13,6 +13,7 @@ import org.matsim.contrib.drt.optimizer.VehicleEntry;
 import org.matsim.contrib.drt.optimizer.Waypoint;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionCostCalculator;
 import org.matsim.contrib.drt.optimizer.insertion.InsertionDetourTimeCalculator.DropoffDetourInfo;
+import org.matsim.contrib.drt.optimizer.insertion.InsertionDetourTimeCalculator.PickupDetourInfo;
 import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.schedule.DrtStayTask;
 import org.matsim.contrib.dvrp.schedule.Task;
@@ -63,6 +64,10 @@ public class ShiftInsertionCostCalculator implements InsertionCostCalculator {
 	 */
 	private double calculateStopEnd(DropoffDetourInfo info) {
 		return info.vehicleArrivalTime;
+	}
+
+	private double calculateStopEnd(PickupDetourInfo info) {
+		return info.vehicleDepartureTime;
 	}
 
 	boolean checkShiftTimeConstraintsForScheduledRequests(Insertion insertion, DetourTimeInfo detourTimeInfo) {
@@ -164,7 +169,7 @@ public class ShiftInsertionCostCalculator implements InsertionCostCalculator {
 				if(calculateStopEnd(detourTimeInfo.dropoffDetourInfo) < drtShiftBreak.getEarliestBreakStartTime()) {
 					// insertion finished before break corridor
 					//ok
-				} else if(detourTimeInfo.pickupDetourInfo.departureTime > drtShiftBreak.getLatestBreakEndTime()) {
+				} else if(calculateStopEnd(detourTimeInfo.pickupDetourInfo) > drtShiftBreak.getLatestBreakEndTime()) {
 					// insertion start after break corridor
 					//ok
 				} else {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/constraints/DrtOptimizationConstraintsSetImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/constraints/DrtOptimizationConstraintsSetImpl.java
@@ -11,7 +11,7 @@ public class DrtOptimizationConstraintsSetImpl extends DrtOptimizationConstraint
     @Comment("Defines the slope of the maxTravelTime estimation function (optimisation constraint), i.e. "
             + "min(unsharedRideTime + maxAbsoluteDetour, maxTravelTimeAlpha * unsharedRideTime + maxTravelTimeBeta). "
             + "Alpha should not be smaller than 1.")
-    @DecimalMin("1.0")
+    @PositiveOrZero
     public double maxTravelTimeAlpha = Double.NaN;// [-]
 
     @Parameter

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategy.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategy.java
@@ -42,7 +42,7 @@ public interface CostCalculationStrategy {
 		public double calcCost(DrtRequest request, InsertionGenerator.Insertion insertion,
 				DetourTimeInfo detourTimeInfo) {
 			double totalTimeLoss = detourTimeInfo.getTotalTimeLoss();
-			if (detourTimeInfo.pickupDetourInfo.departureTime > request.getLatestStartTime()
+			if (detourTimeInfo.pickupDetourInfo.requestPickupTime > request.getLatestStartTime()
 					|| detourTimeInfo.dropoffDetourInfo.requestDropoffTime > request.getLatestArrivalTime()) {
 				//no extra time is lost => do not check if the current slack time is long enough (can be even negative)
 				return InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
@@ -50,7 +50,7 @@ public interface CostCalculationStrategy {
 
 			// check if the max riding time constraints is violated (with default config, the max ride duration
 			// is infinity)
-			double rideDuration = detourTimeInfo.dropoffDetourInfo.requestDropoffTime - detourTimeInfo.pickupDetourInfo.departureTime;
+			double rideDuration = detourTimeInfo.dropoffDetourInfo.requestDropoffTime - detourTimeInfo.pickupDetourInfo.requestPickupTime;
 			if (rideDuration > request.getMaxRideDuration()) {
 				return InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
 			}
@@ -92,13 +92,13 @@ public interface CostCalculationStrategy {
 			double totalTimeLoss = detourTimeInfo.getTotalTimeLoss();
 			// (additional time vehicle will operate if insertion is accepted)
 
-			double waitTimeViolation = Math.max(0, detourTimeInfo.pickupDetourInfo.departureTime - request.getLatestStartTime());
+			double waitTimeViolation = Math.max(0, detourTimeInfo.pickupDetourInfo.requestPickupTime - request.getLatestStartTime());
 			// (if drt vehicle picks up too late) (max wait time (often 600 sec) after submission)
 
 			double travelTimeViolation = Math.max(0, detourTimeInfo.dropoffDetourInfo.requestDropoffTime - request.getLatestArrivalTime());
 			// (if drt vehicle drops off too late) (submission time + alpha * directTravelTime + beta)
 
-			double detourViolation = Math.max(0, (detourTimeInfo.dropoffDetourInfo.requestDropoffTime - detourTimeInfo.pickupDetourInfo.departureTime) - request.getMaxRideDuration());
+			double detourViolation = Math.max(0, (detourTimeInfo.dropoffDetourInfo.requestDropoffTime - detourTimeInfo.pickupDetourInfo.requestPickupTime) - request.getMaxRideDuration());
 
 			double lateDiversionViolation = 0;
 			if(insertion != null) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategy.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategy.java
@@ -43,14 +43,14 @@ public interface CostCalculationStrategy {
 				DetourTimeInfo detourTimeInfo) {
 			double totalTimeLoss = detourTimeInfo.getTotalTimeLoss();
 			if (detourTimeInfo.pickupDetourInfo.departureTime > request.getLatestStartTime()
-					|| detourTimeInfo.dropoffDetourInfo.arrivalTime > request.getLatestArrivalTime()) {
+					|| detourTimeInfo.dropoffDetourInfo.requestDropoffTime > request.getLatestArrivalTime()) {
 				//no extra time is lost => do not check if the current slack time is long enough (can be even negative)
 				return InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
 			}
 
 			// check if the max riding time constraints is violated (with default config, the max ride duration
 			// is infinity)
-			double rideDuration = detourTimeInfo.dropoffDetourInfo.arrivalTime - detourTimeInfo.pickupDetourInfo.departureTime;
+			double rideDuration = detourTimeInfo.dropoffDetourInfo.requestDropoffTime - detourTimeInfo.pickupDetourInfo.departureTime;
 			if (rideDuration > request.getMaxRideDuration()) {
 				return InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
 			}
@@ -95,10 +95,10 @@ public interface CostCalculationStrategy {
 			double waitTimeViolation = Math.max(0, detourTimeInfo.pickupDetourInfo.departureTime - request.getLatestStartTime());
 			// (if drt vehicle picks up too late) (max wait time (often 600 sec) after submission)
 
-			double travelTimeViolation = Math.max(0, detourTimeInfo.dropoffDetourInfo.arrivalTime - request.getLatestArrivalTime());
+			double travelTimeViolation = Math.max(0, detourTimeInfo.dropoffDetourInfo.requestDropoffTime - request.getLatestArrivalTime());
 			// (if drt vehicle drops off too late) (submission time + alpha * directTravelTime + beta)
 
-			double detourViolation = Math.max(0, (detourTimeInfo.dropoffDetourInfo.arrivalTime - detourTimeInfo.pickupDetourInfo.departureTime) - request.getMaxRideDuration());
+			double detourViolation = Math.max(0, (detourTimeInfo.dropoffDetourInfo.requestDropoffTime - detourTimeInfo.pickupDetourInfo.departureTime) - request.getMaxRideDuration());
 
 			double lateDiversionViolation = 0;
 			if(insertion != null) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
@@ -136,7 +136,7 @@ public class DefaultUnplannedRequestInserter implements UnplannedRequestInserter
 			// accept offered drt ride
 			var acceptedRequest = drtOfferAcceptor.acceptDrtOffer(req,
 					insertion.detourTimeInfo.pickupDetourInfo.departureTime,
-					insertion.detourTimeInfo.dropoffDetourInfo.arrivalTime);
+					insertion.detourTimeInfo.dropoffDetourInfo.requestDropoffTime);
 
 			if(acceptedRequest.isPresent()) {
 				var vehicle = insertion.insertion.vehicleEntry.vehicle;

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserter.java
@@ -135,7 +135,7 @@ public class DefaultUnplannedRequestInserter implements UnplannedRequestInserter
 
 			// accept offered drt ride
 			var acceptedRequest = drtOfferAcceptor.acceptDrtOffer(req,
-					insertion.detourTimeInfo.pickupDetourInfo.departureTime,
+					insertion.detourTimeInfo.pickupDetourInfo.requestPickupTime,
 					insertion.detourTimeInfo.dropoffDetourInfo.requestDropoffTime);
 
 			if(acceptedRequest.isPresent()) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourTimeEstimator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourTimeEstimator.java
@@ -24,6 +24,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.common.util.DistanceUtils;
 import org.matsim.contrib.dvrp.path.VrpPaths;
 import org.matsim.contrib.zone.skims.TravelTimeMatrix;
+import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelTime;
 
 /**
@@ -45,6 +46,15 @@ public interface DetourTimeEstimator {
 			duration += matrix.getTravelTime(from.getToNode(), to.getFromNode(), departureTime + duration);
 			duration += VrpPaths.getLastLinkTT(travelTime, to, departureTime + duration);
 			return duration / speedFactor;
+		};
+	}
+
+	static DetourTimeEstimator createExactEstimator(LeastCostPathCalculator router) {
+		return (from, to, departureTime) -> {
+			synchronized(router) {
+				return router.calcLeastCostPath(from.getToNode(), to.getFromNode(), departureTime, 
+					null, null).travelTime;
+			}
 		};
 	}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourTimeEstimator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourTimeEstimator.java
@@ -51,9 +51,15 @@ public interface DetourTimeEstimator {
 
 	static DetourTimeEstimator createExactEstimator(LeastCostPathCalculator router) {
 		return (from, to, departureTime) -> {
+			return router.calcLeastCostPath(from.getToNode(), to.getFromNode(), departureTime, null, null).travelTime;
+		};
+	}
+
+	static DetourTimeEstimator createExactEstimatorUsingVrp(LeastCostPathCalculator router, TravelTime travelTime) {
+		return (from, to, departureTime) -> {
 			synchronized(router) {
-				return router.calcLeastCostPath(from.getToNode(), to.getFromNode(), departureTime, 
-					null, null).travelTime;
+				return VrpPaths.calcAndCreatePath(from, to, departureTime,
+					router, travelTime).getTravelTime();
 			}
 		};
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourTimeEstimator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/DetourTimeEstimator.java
@@ -49,13 +49,7 @@ public interface DetourTimeEstimator {
 		};
 	}
 
-	static DetourTimeEstimator createExactEstimator(LeastCostPathCalculator router) {
-		return (from, to, departureTime) -> {
-			return router.calcLeastCostPath(from.getToNode(), to.getFromNode(), departureTime, null, null).travelTime;
-		};
-	}
-
-	static DetourTimeEstimator createExactEstimatorUsingVrp(LeastCostPathCalculator router, TravelTime travelTime) {
+	static DetourTimeEstimator createExactEstimator(LeastCostPathCalculator router, TravelTime travelTime) {
 		return (from, to, departureTime) -> {
 			synchronized(router) {
 				return VrpPaths.calcAndCreatePath(from, to, departureTime,

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculator.java
@@ -12,6 +12,7 @@ import org.matsim.contrib.drt.passenger.DrtRequest;
 import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.drt.stops.StopTimeCalculator;
 import org.matsim.contrib.drt.stops.StopTimeCalculator.Dropoff;
+import org.matsim.contrib.drt.stops.StopTimeCalculator.Pickup;
 
 import com.google.common.base.MoreObjects;
 
@@ -59,16 +60,16 @@ public class InsertionDetourTimeCalculator {
 		double toPickupDepartureTime = pickup.previousWaypoint.getDepartureTime();
 		if (pickup.newWaypoint.getLink() == pickup.previousWaypoint.getLink()) {
 			// no detour, but possible additional stop duration
-			var times = calculatePickupIfSameLink(vEntry, pickup.index, toPickupDepartureTime, drtRequest);
-			return new PickupDetourInfo(times.departureTime, times.additionalStopDuration);
+			var info = calculatePickupIfSameLink(vEntry, pickup.index, toPickupDepartureTime, drtRequest);
+			return new PickupDetourInfo(info.vehicleDepartureTime, info.requestPickupTime, info.additionalStopDuration);
 		}
 		
 		double arrivalTime = toPickupDepartureTime + toPickupTT;
-		double departureTime = stopTimeCalculator.initEndTimeForPickup(vEntry.vehicle, arrivalTime, drtRequest);
-		double stopDuration = departureTime - arrivalTime;
+		Pickup pickupTime = stopTimeCalculator.initEndTimeForPickup(vEntry.vehicle, arrivalTime, drtRequest);
+		double stopDuration = pickupTime.endTime() - arrivalTime;
 		double replacedDriveTT = calculateReplacedDriveDuration(vEntry, pickup.index, toPickupDepartureTime);
 		double pickupTimeLoss = toPickupTT + stopDuration + fromPickupTT - replacedDriveTT;
-		return new PickupDetourInfo(departureTime, pickupTimeLoss);
+		return new PickupDetourInfo(pickupTime.endTime(), pickupTime.pickupTime(), pickupTimeLoss);
 	}
 
 	public DropoffDetourInfo calcDropoffDetourInfo(Insertion insertion, double toDropoffTT, double fromDropoffTT,
@@ -110,27 +111,25 @@ public class InsertionDetourTimeCalculator {
 			double toPickupTT, double fromPickupTT, DrtRequest drtRequest) {
 		double toPickupDepartureTime = pickup.previousWaypoint.getDepartureTime();
 
-		final double departureTime;
-		final double additionalStopDuration;
+		PickupTimeInfo info;
 		
 		if (pickup.newWaypoint.getLink() == pickup.previousWaypoint.getLink()) {
 			// no drive to pickup, but possible additional stop duration
-			var times = calculatePickupIfSameLink(vEntry, pickup.index, toPickupDepartureTime, drtRequest);
-			departureTime = times.departureTime;
-			additionalStopDuration = times.additionalStopDuration;
+			info = calculatePickupIfSameLink(vEntry, pickup.index, toPickupDepartureTime, drtRequest);
 		} else {
-			departureTime = stopTimeCalculator.initEndTimeForPickup(vEntry.vehicle, toPickupDepartureTime + toPickupTT, drtRequest);
-			additionalStopDuration = departureTime - toPickupDepartureTime - toPickupTT;
+			Pickup pickupTime = stopTimeCalculator.initEndTimeForPickup(vEntry.vehicle, toPickupDepartureTime + toPickupTT, drtRequest);
+			double additionalStopDuration = pickupTime.endTime() - toPickupDepartureTime - toPickupTT;
+			info = new PickupTimeInfo(pickupTime.endTime(), pickupTime.pickupTime(), additionalStopDuration);
 		}
 		
 		double replacedDriveTT = calculateReplacedDriveDuration(vEntry, pickup.index, toPickupDepartureTime);
-		double pickupTimeLoss = toPickupTT + additionalStopDuration + fromPickupTT - replacedDriveTT;
-		return new PickupDetourInfo(departureTime, pickupTimeLoss);
+		double pickupTimeLoss = toPickupTT + info.additionalStopDuration + fromPickupTT - replacedDriveTT;
+		return new PickupDetourInfo(info.vehicleDepartureTime, info.requestPickupTime, pickupTimeLoss);
 	}
 
 	private DropoffDetourInfo calcDropoffDetourInfoIfPickupToDropoffDetour(double fromPickupToDropoffTT,
 			double fromDropoffTT, PickupDetourInfo pickupDetourInfo, VehicleEntry vEntry, DrtRequest drtRequest) {
-		double arrivalTime = pickupDetourInfo.departureTime + fromPickupToDropoffTT;
+		double arrivalTime = pickupDetourInfo.vehicleDepartureTime + fromPickupToDropoffTT;
 		Dropoff dropoffTime = stopTimeCalculator.initEndTimeForDropoff(vEntry.vehicle, arrivalTime, drtRequest);
 		double departureTime = dropoffTime.endTime();
 		double stopDuration = departureTime - arrivalTime;
@@ -144,10 +143,10 @@ public class InsertionDetourTimeCalculator {
 		if (stopTask == null) {
 			// case 1: previous waypoint is a drive, we create a new stop
 			// insertion time is the end time of previous waypoint
-			double departureTime = stopTimeCalculator.initEndTimeForPickup(vEntry.vehicle, toPickupDepartureTime,
+			Pickup pickupTime = stopTimeCalculator.initEndTimeForPickup(vEntry.vehicle, toPickupDepartureTime,
 					request);
-			double stopDuration = departureTime - toPickupDepartureTime;
-			return new PickupTimeInfo(departureTime, stopDuration);
+			double stopDuration = pickupTime.endTime() - toPickupDepartureTime;
+			return new PickupTimeInfo(pickupTime.endTime(), pickupTime.pickupTime(), stopDuration);
 		} else if (pickupIndex > 0) {
 			// case 2: previous waypoint is a planned stop, not started yet
 			// insertion time is the beginning of the planned stop
@@ -155,13 +154,15 @@ public class InsertionDetourTimeCalculator {
 			double departureTime = stopTimeCalculator.updateEndTimeForPickup(vEntry.vehicle, stopTask,
 					insertionTime, request);
 			double additionalStopDuration = departureTime - stopTask.getEndTime();
-			return new PickupTimeInfo(departureTime, additionalStopDuration);
+			double todoReplace = departureTime;
+			return new PickupTimeInfo(departureTime, todoReplace, additionalStopDuration);
 		} else {
 			// case 3: previous waypoint is an ongoing (started) stop
 			// insertion is a soon as possible (now)
 			double departureTime = stopTimeCalculator.updateEndTimeForPickup(vEntry.vehicle, stopTask, vEntry.createTime, request);
 			double additionalStopDuration = departureTime - stopTask.getEndTime();
-			return new PickupTimeInfo(departureTime, additionalStopDuration);
+			double todoReplace = departureTime;
+			return new PickupTimeInfo(departureTime, todoReplace, additionalStopDuration);
 		}
 	}
 	
@@ -224,20 +225,24 @@ public class InsertionDetourTimeCalculator {
 	}
 
 	public static class PickupDetourInfo {
-		// expected departure time for the new request
-		public final double departureTime;
+		// expected departure time for the vehicle from the stop
+		public final double vehicleDepartureTime;
+		// expected pickup time for the inserted request
+		public final double requestPickupTime;
 		// time delay of each stop placed after the pickup insertion point
 		public final double pickupTimeLoss;
 
-		public PickupDetourInfo(double departureTime, double pickupTimeLoss) {
-			this.departureTime = departureTime;
+		public PickupDetourInfo(double vehicleDepartureTime, double requestPickupTime, double pickupTimeLoss) {
+			this.vehicleDepartureTime = vehicleDepartureTime;
+			this.requestPickupTime = requestPickupTime;
 			this.pickupTimeLoss = pickupTimeLoss;
 		}
 
 		@Override
 		public String toString() {
 			return MoreObjects.toStringHelper(this)
-					.add("departureTime", departureTime)
+					.add("vehicleDepartureTime", vehicleDepartureTime)
+					.add("requestPickupTime", requestPickupTime)
 					.add("pickupTimeLoss", pickupTimeLoss)
 					.toString();
 		}
@@ -294,6 +299,6 @@ public class InsertionDetourTimeCalculator {
 		}
 	}
 	
-	private record PickupTimeInfo(double departureTime, double additionalStopDuration) {
+	private record PickupTimeInfo(double vehicleDepartureTime, double requestPickupTime, double additionalStopDuration) {
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculator.java
@@ -87,13 +87,13 @@ public class InsertionDetourTimeCalculator {
 			double arrivalTime = dropoff.previousWaypoint.getArrivalTime() + remainingPickupTimeLoss;
 			
 			DrtStopTask stopTask = findStopTaskIfSameLinkAsPrevious(vEntry, dropoff.index);
-			double departureTime = stopTimeCalculator.updateEndTimeForDropoff(vEntry.vehicle, stopTask, arrivalTime, drtRequest);
+			Dropoff dropoffTime = stopTimeCalculator.updateEndTimeForDropoff(vEntry.vehicle, stopTask, arrivalTime, drtRequest);
+			double departureTime = dropoffTime.endTime();
 			
 			double initialStopDuration = stopTask.getEndTime() - stopTask.getBeginTime();
 			double additionalStopDuration = departureTime - arrivalTime - initialStopDuration;
 			
-			double todoReplace = arrivalTime;
-			return new DropoffDetourInfo(arrivalTime, todoReplace, additionalStopDuration);
+			return new DropoffDetourInfo(arrivalTime, dropoffTime.dropoffTime(), additionalStopDuration);
 		}
 
 		double toDropoffDepartureTime = dropoff.previousWaypoint.getDepartureTime();

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculator.java
@@ -151,18 +151,18 @@ public class InsertionDetourTimeCalculator {
 			// case 2: previous waypoint is a planned stop, not started yet
 			// insertion time is the beginning of the planned stop
 			double insertionTime = stopTask.getBeginTime();
-			double departureTime = stopTimeCalculator.updateEndTimeForPickup(vEntry.vehicle, stopTask,
-					insertionTime, request);
+			Pickup pickupTime = stopTimeCalculator.updateEndTimeForPickup(vEntry.vehicle, stopTask,
+				insertionTime, request);
+			double departureTime = pickupTime.endTime();
 			double additionalStopDuration = departureTime - stopTask.getEndTime();
-			double todoReplace = departureTime;
-			return new PickupTimeInfo(departureTime, todoReplace, additionalStopDuration);
+			return new PickupTimeInfo(departureTime, pickupTime.pickupTime(), additionalStopDuration);
 		} else {
 			// case 3: previous waypoint is an ongoing (started) stop
 			// insertion is a soon as possible (now)
-			double departureTime = stopTimeCalculator.updateEndTimeForPickup(vEntry.vehicle, stopTask, vEntry.createTime, request);
+			Pickup pickupTime = stopTimeCalculator.updateEndTimeForPickup(vEntry.vehicle, stopTask, vEntry.createTime, request);
+			double departureTime = pickupTime.endTime();
 			double additionalStopDuration = departureTime - stopTask.getEndTime();
-			double todoReplace = departureTime;
-			return new PickupTimeInfo(departureTime, todoReplace, additionalStopDuration);
+			return new PickupTimeInfo(departureTime, pickupTime.pickupTime(), additionalStopDuration);
 		}
 	}
 	

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGenerator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGenerator.java
@@ -381,7 +381,7 @@ public class InsertionGenerator {
 			return true;
 		}
 
-		return vEntry.getStartSlackTime() >= pickupDetourInfo.departureTime - stopTask.getEndTime();
+		return vEntry.getStartSlackTime() >= pickupDetourInfo.vehicleDepartureTime - stopTask.getEndTime();
 	}
 
 	private DvrpLoad getVehicleCapacityAtStop(VehicleEntry vEntry, int stopIndex) {
@@ -400,7 +400,7 @@ public class InsertionGenerator {
 		var insertion = new Insertion(vehicleEntry, pickupInsertion, dropoffInsertion, request.getLoad());
 
 		double toDropoffDepartureTime = pickupInsertion.index == dropoffIdx ?
-				pickupDetourInfo.departureTime :
+				pickupDetourInfo.vehicleDepartureTime :
 				dropoffInsertion.previousWaypoint.getDepartureTime() + pickupDetourInfo.pickupTimeLoss;
 		double toDropoffTT = pickupInsertion.index == dropoffIdx ?
 				fromPickupTT :

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/MaxDetourInsertionCostCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/MaxDetourInsertionCostCalculator.java
@@ -26,7 +26,7 @@ public class MaxDetourInsertionCostCalculator implements InsertionCostCalculator
 
 	private boolean violatesDetour(DrtRequest drtRequest, InsertionDetourTimeCalculator.DetourTimeInfo detourTimeInfo) {
 		// Check if the max travel time constraint for the newly inserted request is violated
-		double rideDuration = detourTimeInfo.dropoffDetourInfo.arrivalTime - detourTimeInfo.pickupDetourInfo.departureTime;
+		double rideDuration = detourTimeInfo.dropoffDetourInfo.requestDropoffTime - detourTimeInfo.pickupDetourInfo.departureTime;
 		return drtRequest.getMaxRideDuration() < rideDuration;
 	}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/MaxDetourInsertionCostCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/MaxDetourInsertionCostCalculator.java
@@ -26,7 +26,7 @@ public class MaxDetourInsertionCostCalculator implements InsertionCostCalculator
 
 	private boolean violatesDetour(DrtRequest drtRequest, InsertionDetourTimeCalculator.DetourTimeInfo detourTimeInfo) {
 		// Check if the max travel time constraint for the newly inserted request is violated
-		double rideDuration = detourTimeInfo.dropoffDetourInfo.requestDropoffTime - detourTimeInfo.pickupDetourInfo.departureTime;
+		double rideDuration = detourTimeInfo.dropoffDetourInfo.requestDropoffTime - detourTimeInfo.pickupDetourInfo.requestPickupTime;
 		return drtRequest.getMaxRideDuration() < rideDuration;
 	}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/extensive/KNearestInsertionsAtEndFilter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/extensive/KNearestInsertionsAtEndFilter.java
@@ -49,7 +49,7 @@ class KNearestInsertionsAtEndFilter {
 			if (!vEntry.isAfterLastStop(pickup.index)) {
 				filteredInsertions.add(insertion);
 			} else if (k > 0) {
-				nearestInsertionsAtEnd.add(new InsertionWithCost(i, i.detourTimeInfo.pickupDetourInfo.departureTime));
+				nearestInsertionsAtEnd.add(new InsertionWithCost(i, i.detourTimeInfo.pickupDetourInfo.requestPickupTime));
 			}
 		}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/RepeatedSelectiveInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/RepeatedSelectiveInsertionSearch.java
@@ -116,7 +116,7 @@ final class RepeatedSelectiveInsertionSearch implements DrtInsertionSearch, Mobs
 
 	private void collectDifferences(DrtRequest request, DetourTimeInfo matrixTimeInfo, DetourTimeInfo networkTimeInfo) {
 		addRelativeDiff(matrixTimeInfo.pickupDetourInfo.pickupTimeLoss, networkTimeInfo.pickupDetourInfo.pickupTimeLoss,
-				networkTimeInfo.pickupDetourInfo.departureTime, pickupTimeLossStats);
+				networkTimeInfo.pickupDetourInfo.requestPickupTime, pickupTimeLossStats);
 		addRelativeDiff(matrixTimeInfo.dropoffDetourInfo.dropoffTimeLoss,
 				networkTimeInfo.dropoffDetourInfo.dropoffTimeLoss, networkTimeInfo.dropoffDetourInfo.requestDropoffTime,
 				dropoffTimeLossStats);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/RepeatedSelectiveInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/RepeatedSelectiveInsertionSearch.java
@@ -118,7 +118,7 @@ final class RepeatedSelectiveInsertionSearch implements DrtInsertionSearch, Mobs
 		addRelativeDiff(matrixTimeInfo.pickupDetourInfo.pickupTimeLoss, networkTimeInfo.pickupDetourInfo.pickupTimeLoss,
 				networkTimeInfo.pickupDetourInfo.departureTime, pickupTimeLossStats);
 		addRelativeDiff(matrixTimeInfo.dropoffDetourInfo.dropoffTimeLoss,
-				networkTimeInfo.dropoffDetourInfo.dropoffTimeLoss, networkTimeInfo.dropoffDetourInfo.arrivalTime,
+				networkTimeInfo.dropoffDetourInfo.dropoffTimeLoss, networkTimeInfo.dropoffDetourInfo.requestDropoffTime,
 				dropoffTimeLossStats);
 	}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/selective/SelectiveInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/selective/SelectiveInsertionSearch.java
@@ -91,7 +91,7 @@ final class SelectiveInsertionSearch implements DrtInsertionSearch, MobsimBefore
 
 	private void collectDifferences(DrtRequest request, DetourTimeInfo matrixTimeInfo, DetourTimeInfo networkTimeInfo) {
 		addRelativeDiff(matrixTimeInfo.pickupDetourInfo.pickupTimeLoss, networkTimeInfo.pickupDetourInfo.pickupTimeLoss,
-				networkTimeInfo.pickupDetourInfo.departureTime, pickupTimeLossStats);
+				networkTimeInfo.pickupDetourInfo.requestPickupTime, pickupTimeLossStats);
 		addRelativeDiff(matrixTimeInfo.dropoffDetourInfo.dropoffTimeLoss,
 				networkTimeInfo.dropoffDetourInfo.dropoffTimeLoss, networkTimeInfo.dropoffDetourInfo.requestDropoffTime,
 				dropoffTimeLossStats);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/selective/SelectiveInsertionSearch.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/selective/SelectiveInsertionSearch.java
@@ -93,7 +93,7 @@ final class SelectiveInsertionSearch implements DrtInsertionSearch, MobsimBefore
 		addRelativeDiff(matrixTimeInfo.pickupDetourInfo.pickupTimeLoss, networkTimeInfo.pickupDetourInfo.pickupTimeLoss,
 				networkTimeInfo.pickupDetourInfo.departureTime, pickupTimeLossStats);
 		addRelativeDiff(matrixTimeInfo.dropoffDetourInfo.dropoffTimeLoss,
-				networkTimeInfo.dropoffDetourInfo.dropoffTimeLoss, networkTimeInfo.dropoffDetourInfo.arrivalTime,
+				networkTimeInfo.dropoffDetourInfo.dropoffTimeLoss, networkTimeInfo.dropoffDetourInfo.requestDropoffTime,
 				dropoffTimeLossStats);
 	}
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
@@ -253,7 +253,7 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 
 				// potentially extend task
 				stopTask.setEndTime(stopTimeCalculator.updateEndTimeForPickup(vehicleEntry.vehicle, stopTask,
-						now, request.getRequest()));
+						now, request.getRequest()).endTime());
 
 				// add drive from pickup
 				if (pickupIdx == dropoffIdx) {

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
@@ -36,6 +36,7 @@ import org.matsim.contrib.drt.schedule.DrtStopTask;
 import org.matsim.contrib.drt.schedule.DrtTaskBaseType;
 import org.matsim.contrib.drt.schedule.DrtTaskFactory;
 import org.matsim.contrib.drt.stops.StopTimeCalculator;
+import org.matsim.contrib.drt.stops.StopTimeCalculator.Dropoff;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.path.DivertedVrpPath;
@@ -95,7 +96,7 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 				pickupTask.getEndTime());
 
 		var dropoffTask = insertDropoff(request, insertion, pickupTask);
-		verifyTimes("Inconsistent dropoff arrival time", insertion.detourTimeInfo.dropoffDetourInfo.arrivalTime,
+		verifyTimes("Inconsistent dropoff arrival time", insertion.detourTimeInfo.dropoffDetourInfo.vehicleArrivalTime,
 				dropoffTask.getBeginTime());
 
 		verifyTaskContinuity(insertion);
@@ -400,7 +401,8 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 		// insert dropoff stop task
 		double startTime = driveToDropoffTask.getEndTime();
 		int taskIdx = driveToDropoffTask.getTaskIdx() + 1;
-		double stopEndTime = stopTimeCalculator.initEndTimeForDropoff(vehicleEntry.vehicle, startTime, request.getRequest());
+		Dropoff dropoffTime = stopTimeCalculator.initEndTimeForDropoff(vehicleEntry.vehicle, startTime, request.getRequest());
+		double stopEndTime = dropoffTime.endTime();
 		DrtStopTask dropoffStopTask = taskFactory.createStopTask(vehicleEntry.vehicle, startTime,
 				stopEndTime, request.getToLink());
 		schedule.addTask(taskIdx, dropoffStopTask);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
@@ -376,7 +376,7 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 
 				// potentially extend task
 				stopTask.setEndTime(stopTimeCalculator.updateEndTimeForDropoff(vehicleEntry.vehicle, stopTask,
-						now, request.getRequest()));
+						now, request.getRequest()).endTime());
 				scheduleTimingUpdater.updateTimingsStartingFromTaskIdx(vehicleEntry.vehicle,
 						stopTask.getTaskIdx() + 1, stopTask.getEndTime());
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionScheduler.java
@@ -92,7 +92,7 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 	@Override
 	public PickupDropoffTaskPair scheduleRequest(AcceptedDrtRequest request, InsertionWithDetourData insertion) {
 		var pickupTask = insertPickup(request, insertion);
-		verifyTimes("Inconsistent pickup departure time", insertion.detourTimeInfo.pickupDetourInfo.departureTime,
+		verifyTimes("Inconsistent pickup departure time", insertion.detourTimeInfo.pickupDetourInfo.vehicleDepartureTime,
 				pickupTask.getEndTime());
 
 		var dropoffTask = insertDropoff(request, insertion, pickupTask);
@@ -303,7 +303,7 @@ public class DefaultRequestInsertionScheduler implements RequestInsertionSchedul
 
 		// insert pickup stop task
 		int taskIdx = beforePickupTask.getTaskIdx() + 1;
-		double stopEndTime = stopTimeCalculator.initEndTimeForPickup(vehicleEntry.vehicle, beforePickupTask.getEndTime(), request.getRequest());
+		double stopEndTime = stopTimeCalculator.initEndTimeForPickup(vehicleEntry.vehicle, beforePickupTask.getEndTime(), request.getRequest()).endTime();
 		DrtStopTask pickupStopTask = taskFactory.createStopTask(vehicleEntry.vehicle, beforePickupTask.getEndTime(),
 				stopEndTime, request.getFromLink());
 		schedule.addTask(taskIdx, pickupStopTask);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/CorrectedStopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/CorrectedStopTimeCalculator.java
@@ -17,9 +17,9 @@ public class CorrectedStopTimeCalculator implements StopTimeCalculator {
 	}
 
 	@Override
-	public double initEndTimeForPickup(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
-		// stop ends when pickup time has elapsed
-		return beginTime + stopDuration;
+	public Pickup initEndTimeForPickup(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
+		// pickup at the end of the stop
+		return new Pickup(beginTime + stopDuration, beginTime + stopDuration);
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/CorrectedStopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/CorrectedStopTimeCalculator.java
@@ -30,9 +30,10 @@ public class CorrectedStopTimeCalculator implements StopTimeCalculator {
 	}
 
 	@Override
-	public double initEndTimeForDropoff(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
+	public Dropoff initEndTimeForDropoff(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
 		// stop ends after stopDuration has elapsed (dropoff happens at beginning)
-		return beginTime + stopDuration;
+		double endTime = beginTime + stopDuration;
+		return new Dropoff(endTime, endTime);
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/CorrectedStopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/CorrectedStopTimeCalculator.java
@@ -23,10 +23,12 @@ public class CorrectedStopTimeCalculator implements StopTimeCalculator {
 	}
 
 	@Override
-	public double updateEndTimeForPickup(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
+	public Pickup updateEndTimeForPickup(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
 			DrtRequest request) {
 		// an additional stop may extend the stop duration
-		return Math.max(stop.getEndTime(), insertionTime + stopDuration);
+		double beginTime = Math.max(stop.getBeginTime(), insertionTime);
+		double endTime = beginTime + stopDuration;
+		return new Pickup(endTime, endTime);
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/CorrectedStopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/CorrectedStopTimeCalculator.java
@@ -33,7 +33,7 @@ public class CorrectedStopTimeCalculator implements StopTimeCalculator {
 	public Dropoff initEndTimeForDropoff(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
 		// stop ends after stopDuration has elapsed (dropoff happens at beginning)
 		double endTime = beginTime + stopDuration;
-		return new Dropoff(endTime, endTime);
+		return new Dropoff(endTime, beginTime);
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/CorrectedStopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/CorrectedStopTimeCalculator.java
@@ -37,10 +37,13 @@ public class CorrectedStopTimeCalculator implements StopTimeCalculator {
 	}
 
 	@Override
-	public double updateEndTimeForDropoff(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
+	public Dropoff updateEndTimeForDropoff(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
 			DrtRequest request) {
-		// adding a dropoff may extend the stop duration
-		return Math.max(stop.getEndTime(), insertionTime + stopDuration);
+		// adding a dropoff does not change the end time, but the whole task may be
+		// shifted due to a previous pickup insertion
+		double beginTime = Math.max(insertionTime, stop.getBeginTime());
+		double endTime = beginTime + stopDuration;
+		return new Dropoff(endTime, beginTime);
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/CumulativeStopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/CumulativeStopTimeCalculator.java
@@ -25,9 +25,10 @@ public class CumulativeStopTimeCalculator implements StopTimeCalculator {
 	}
 
 	@Override
-	public double initEndTimeForDropoff(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
+	public Dropoff initEndTimeForDropoff(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
 		// dropoff takes the indicated duration
-		return beginTime + provider.calcDropoffDuration(vehicle, request);
+		double endTime = beginTime + provider.calcDropoffDuration(vehicle, request);
+		return new Dropoff(endTime, endTime);
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/CumulativeStopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/CumulativeStopTimeCalculator.java
@@ -33,18 +33,17 @@ public class CumulativeStopTimeCalculator implements StopTimeCalculator {
 	}
 
 	@Override
-	public double updateEndTimeForDropoff(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
+	public Dropoff updateEndTimeForDropoff(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
 			DrtRequest request) {
-		double stopDuration = provider.calcDropoffDuration(vehicle, request);
+		// stop may have been shifted
+		double initialDuration = stop.getEndTime() - stop.getBeginTime();
+		double endTime = Math.max(stop.getEndTime(), insertionTime + initialDuration);
 
-		if (insertionTime > stop.getBeginTime()) {
-			// insertion has shifted the stop
-			double initialDuration = stop.getEndTime() - stop.getBeginTime();
-			return insertionTime + initialDuration + stopDuration;
-		} else {
-			// no shift, we simply add the new duration
-			return stop.getEndTime() + stopDuration;
-		}
+		// add dropoff
+		double stopDuration = provider.calcDropoffDuration(vehicle, request);
+		endTime += stopDuration;
+
+		return new Dropoff(endTime, endTime);
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/CumulativeStopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/CumulativeStopTimeCalculator.java
@@ -12,9 +12,10 @@ public class CumulativeStopTimeCalculator implements StopTimeCalculator {
 	}
 
 	@Override
-	public double initEndTimeForPickup(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
+	public Pickup initEndTimeForPickup(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
 		// pickup takes the indicated duration
-		return beginTime + provider.calcPickupDuration(vehicle, request);
+		double endTime = beginTime + provider.calcPickupDuration(vehicle, request);
+		return new Pickup(endTime, endTime);
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/CumulativeStopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/CumulativeStopTimeCalculator.java
@@ -19,10 +19,12 @@ public class CumulativeStopTimeCalculator implements StopTimeCalculator {
 	}
 
 	@Override
-	public double updateEndTimeForPickup(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
+	public Pickup updateEndTimeForPickup(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
 			DrtRequest request) {
 		// pickup extends the stop duration
-		return stop.getEndTime() + provider.calcPickupDuration(vehicle, request);
+		insertionTime = Math.max(stop.getEndTime(), insertionTime);
+		double endTime = insertionTime + provider.calcPickupDuration(vehicle, request);
+		return new Pickup(endTime, endTime);
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/DefaultPassengerStopDurationProvider.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/DefaultPassengerStopDurationProvider.java
@@ -1,25 +1,7 @@
 package org.matsim.contrib.drt.stops;
 
-import org.matsim.contrib.drt.passenger.DrtRequest;
-import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
-
-public class DefaultPassengerStopDurationProvider implements PassengerStopDurationProvider {
-	private final double stopDuration;
-
+public class DefaultPassengerStopDurationProvider extends StaticPassengerStopDurationProvider {
 	public DefaultPassengerStopDurationProvider(double stopDuration) {
-		this.stopDuration = stopDuration;
-	}
-
-	@Override
-	public double calcPickupDuration(DvrpVehicle vehicle, DrtRequest request) {
-		// pickups happen after this time from the stop beginning
-		return stopDuration;
-	}
-
-	@Override
-	public double calcDropoffDuration(DvrpVehicle vehicle, DrtRequest request) {
-		// dropoffs happen at the beginning of the stop, but extend the stop duration by
-		// this amount
-		return stopDuration;
+		super(stopDuration, 0.0);
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/DefaultStopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/DefaultStopTimeCalculator.java
@@ -36,9 +36,10 @@ public class DefaultStopTimeCalculator implements StopTimeCalculator {
 	}
 
 	@Override
-	public double initEndTimeForDropoff(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
+	public Dropoff initEndTimeForDropoff(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
 		// stop ends after stopDuration has elapsed (dropoff happens at beginning)
-		return beginTime + stopDuration;
+		// dropoff happens at the beginning
+		return new Dropoff(beginTime + stopDuration, beginTime);
 	}
 
 	@Override
@@ -52,7 +53,7 @@ public class DefaultStopTimeCalculator implements StopTimeCalculator {
 	@Override
 	public double shiftEndTime(DvrpVehicle vehicle, DrtStopTask stop, double beginTime) {
 		// When shifting, we make sure the new duration is the same as the previous one
-		double stopDuration  = stop.getEndTime() - stop.getBeginTime();
+		double stopDuration = stop.getEndTime() - stop.getBeginTime();
 		return beginTime + stopDuration;
 	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/DefaultStopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/DefaultStopTimeCalculator.java
@@ -25,14 +25,16 @@ public class DefaultStopTimeCalculator implements StopTimeCalculator {
 	@Override
 	public Pickup initEndTimeForPickup(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
 		// pickup at the end of the stop
-		return new Pickup(beginTime + stopDuration, beginTime + stopDuration);
+		double endTime = beginTime + stopDuration;
+		return new Pickup(endTime, endTime);
 	}
 
 	@Override
-	public double updateEndTimeForPickup(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
+	public Pickup updateEndTimeForPickup(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
 			DrtRequest request) {
 		// an additional stop does not change the end time
-		return stop.getEndTime();
+		double endTime = stop.getEndTime();
+		return new Pickup(endTime, endTime);
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/DefaultStopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/DefaultStopTimeCalculator.java
@@ -23,9 +23,9 @@ public class DefaultStopTimeCalculator implements StopTimeCalculator {
 	}
 
 	@Override
-	public double initEndTimeForPickup(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
-		// stop ends when pickup time has elapsed
-		return beginTime + stopDuration;
+	public Pickup initEndTimeForPickup(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
+		// pickup at the end of the stop
+		return new Pickup(beginTime + stopDuration, beginTime + stopDuration);
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/DefaultStopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/DefaultStopTimeCalculator.java
@@ -43,11 +43,13 @@ public class DefaultStopTimeCalculator implements StopTimeCalculator {
 	}
 
 	@Override
-	public double updateEndTimeForDropoff(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
+	public Dropoff updateEndTimeForDropoff(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
 			DrtRequest request) {
 		// adding a dropoff does not change the end time, but the whole task may be
 		// shifted due to a previous pickup insertion
-		return Math.max(stop.getEndTime(), insertionTime + stopDuration);
+		double beginTime = Math.max(insertionTime, stop.getBeginTime());
+		double endTime = beginTime + stopDuration;
+		return new Dropoff(endTime, beginTime);
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/MinimumStopDurationAdapter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/MinimumStopDurationAdapter.java
@@ -14,8 +14,11 @@ public class MinimumStopDurationAdapter implements StopTimeCalculator {
 	}
 
 	@Override
-	public double initEndTimeForPickup(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
-		return Math.max(beginTime + minimumStopDuration, delegate.initEndTimeForPickup(vehicle, beginTime, request));
+	public Pickup initEndTimeForPickup(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
+		Pickup delegate = this.delegate.initEndTimeForPickup(vehicle, beginTime, request);
+		double endTime = Math.max(beginTime + minimumStopDuration, delegate.endTime());
+
+		return new Pickup(endTime, delegate.pickupTime());
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/MinimumStopDurationAdapter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/MinimumStopDurationAdapter.java
@@ -37,10 +37,12 @@ public class MinimumStopDurationAdapter implements StopTimeCalculator {
 	}
 
 	@Override
-	public double updateEndTimeForDropoff(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
+	public Dropoff updateEndTimeForDropoff(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
 			DrtRequest request) {
-		return Math.max(insertionTime + minimumStopDuration,
-				delegate.updateEndTimeForDropoff(vehicle, stop, insertionTime, request));
+		Dropoff delegate = this.delegate.updateEndTimeForDropoff(vehicle, stop, insertionTime, request);
+		double endTime = Math.max(stop.getBeginTime() + minimumStopDuration, delegate.endTime());
+		
+		return new Dropoff(endTime, delegate.dropoffTime());
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/MinimumStopDurationAdapter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/MinimumStopDurationAdapter.java
@@ -26,8 +26,11 @@ public class MinimumStopDurationAdapter implements StopTimeCalculator {
 	}
 
 	@Override
-	public double initEndTimeForDropoff(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
-		return Math.max(beginTime + minimumStopDuration, delegate.initEndTimeForDropoff(vehicle, beginTime, request));
+	public Dropoff initEndTimeForDropoff(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
+		Dropoff delegate = this.delegate.initEndTimeForDropoff(vehicle, beginTime, request);
+		double endTime = Math.max(beginTime + minimumStopDuration, delegate.endTime());
+
+		return new Dropoff(endTime, delegate.dropoffTime());
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/MinimumStopDurationAdapter.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/MinimumStopDurationAdapter.java
@@ -22,10 +22,12 @@ public class MinimumStopDurationAdapter implements StopTimeCalculator {
 	}
 
 	@Override
-	public double updateEndTimeForPickup(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
+	public Pickup updateEndTimeForPickup(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
 			DrtRequest request) {
-		return Math.max(stop.getBeginTime() + minimumStopDuration,
-				delegate.updateEndTimeForPickup(vehicle, stop, insertionTime, request));
+		Pickup delegate = this.delegate.updateEndTimeForPickup(vehicle, stop, insertionTime, request);
+		double endTime = Math.max(stop.getBeginTime() + minimumStopDuration, delegate.endTime());
+
+		return new Pickup(endTime, delegate.pickupTime());
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/ParallelStopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/ParallelStopTimeCalculator.java
@@ -32,9 +32,10 @@ public class ParallelStopTimeCalculator implements StopTimeCalculator {
 	}
 
 	@Override
-	public double initEndTimeForDropoff(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
+	public Dropoff initEndTimeForDropoff(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
 		// stop ends after stopDuration has elapsed (dropoff happens at beginning)
-		return beginTime + stopDurationProvider.calcDropoffDuration(vehicle, request);
+		double endTime = beginTime + stopDurationProvider.calcDropoffDuration(vehicle, request);
+		return new Dropoff(endTime, endTime);
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/ParallelStopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/ParallelStopTimeCalculator.java
@@ -26,10 +26,14 @@ public class ParallelStopTimeCalculator implements StopTimeCalculator {
 	}
 
 	@Override
-	public double updateEndTimeForPickup(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
+	public Pickup updateEndTimeForPickup(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
 			DrtRequest request) {
 		// an additional stop may extend the stop duration
-		return Math.max(stop.getEndTime(), insertionTime + stopDurationProvider.calcPickupDuration(vehicle, request));
+		double beginTime = Math.max(stop.getBeginTime(), insertionTime);
+		double pickupTime = beginTime + stopDurationProvider.calcPickupDuration(vehicle, request);
+		double endTime = Math.max(stop.getEndTime(), pickupTime);
+
+		return new Pickup(endTime, pickupTime);
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/ParallelStopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/ParallelStopTimeCalculator.java
@@ -33,7 +33,7 @@ public class ParallelStopTimeCalculator implements StopTimeCalculator {
 
 	@Override
 	public Dropoff initEndTimeForDropoff(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
-		// stop ends after stopDuration has elapsed (dropoff happens at beginning)
+		// stop ends after dropoff duration
 		double endTime = beginTime + stopDurationProvider.calcDropoffDuration(vehicle, request);
 		return new Dropoff(endTime, endTime);
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/ParallelStopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/ParallelStopTimeCalculator.java
@@ -40,10 +40,17 @@ public class ParallelStopTimeCalculator implements StopTimeCalculator {
 	}
 
 	@Override
-	public double updateEndTimeForDropoff(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
+	public Dropoff updateEndTimeForDropoff(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
 			DrtRequest request) {
-		// adding a dropoff may extend the stop duration
-		return Math.max(stop.getEndTime(), insertionTime + stopDurationProvider.calcDropoffDuration(vehicle, request));
+		// update end time
+		double initialDuration = stop.getEndTime() - stop.getBeginTime();
+		double endTime = Math.max(stop.getEndTime(), initialDuration + insertionTime);
+
+		// add the dropoff
+		double dropoffTime = insertionTime + stopDurationProvider.calcDropoffDuration(vehicle, request);
+		endTime = Math.max(endTime, dropoffTime);
+
+		return new Dropoff(endTime, dropoffTime);
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/ParallelStopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/ParallelStopTimeCalculator.java
@@ -19,9 +19,10 @@ public class ParallelStopTimeCalculator implements StopTimeCalculator {
 	}
 
 	@Override
-	public double initEndTimeForPickup(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
+	public Pickup initEndTimeForPickup(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
 		// stop ends when pickup time has elapsed
-		return beginTime + stopDurationProvider.calcPickupDuration(vehicle, request);
+		double endTime = beginTime + stopDurationProvider.calcPickupDuration(vehicle, request);
+		return new Pickup(endTime, endTime);
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/PrebookingStopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/PrebookingStopTimeCalculator.java
@@ -40,11 +40,12 @@ public class PrebookingStopTimeCalculator implements StopTimeCalculator {
 	}
 
 	@Override
-	public double initEndTimeForDropoff(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
+	public Dropoff initEndTimeForDropoff(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
 		double stopDuration = provider.calcDropoffDuration(vehicle, request);
 
 		// dropoff duration starts at the planned stop begin time
-		return beginTime + stopDuration;
+		double endTime = beginTime + stopDuration;
+		return new Dropoff(endTime, endTime);
 	}
 
 	@Override
@@ -55,7 +56,7 @@ public class PrebookingStopTimeCalculator implements StopTimeCalculator {
 		// first, check when we can start with the dropoff
 		double earliestStartTime = stop.getBeginTime();
 		earliestStartTime = Math.max(earliestStartTime, insertionTime);
-		
+
 		// second, we add the dropoff
 		return Math.max(stop.getEndTime(), earliestStartTime + stopDuration);
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/PrebookingStopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/PrebookingStopTimeCalculator.java
@@ -12,12 +12,13 @@ public class PrebookingStopTimeCalculator implements StopTimeCalculator {
 	}
 
 	@Override
-	public double initEndTimeForPickup(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
+	public Pickup initEndTimeForPickup(DvrpVehicle vehicle, double beginTime, DrtRequest request) {
 		double stopDuration = provider.calcPickupDuration(vehicle, request);
 
 		// pickup duration starts either at the earliest departure time or when stop
 		// beginning is planned
-		return Math.max(request.getEarliestStartTime(), beginTime) + stopDuration;
+		double endTime = Math.max(request.getEarliestStartTime(), beginTime) + stopDuration;
+		return new Pickup(endTime, endTime);
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/PrebookingStopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/PrebookingStopTimeCalculator.java
@@ -22,7 +22,7 @@ public class PrebookingStopTimeCalculator implements StopTimeCalculator {
 	}
 
 	@Override
-	public double updateEndTimeForPickup(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
+	public Pickup updateEndTimeForPickup(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
 			DrtRequest request) {
 		double stopDuration = provider.calcPickupDuration(vehicle, request);
 
@@ -37,7 +37,10 @@ public class PrebookingStopTimeCalculator implements StopTimeCalculator {
 
 		// from that point on, we add the stop duration, and we never shrink the stop to
 		// account for other assigned requests
-		return Math.max(stop.getEndTime(), earliestStartTime + stopDuration);
+		double pickupTime = earliestStartTime + stopDuration;
+		double endTime = Math.max(stop.getEndTime(), pickupTime);
+
+		return new Pickup(endTime, pickupTime);
 	}
 
 	@Override

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/PrebookingStopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/PrebookingStopTimeCalculator.java
@@ -50,16 +50,21 @@ public class PrebookingStopTimeCalculator implements StopTimeCalculator {
 	}
 
 	@Override
-	public double updateEndTimeForDropoff(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
+	public Dropoff updateEndTimeForDropoff(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime,
 			DrtRequest request) {
+		// start time
+		double startTime = Math.max(stop.getBeginTime(), insertionTime);
+
+		// stop may have benen shifted
+		double initialDuration = stop.getEndTime() - stop.getBeginTime();
+		double endTime = Math.max(stop.getEndTime(), initialDuration + startTime);
+
+		// add dropoff
 		double stopDuration = provider.calcDropoffDuration(vehicle, request);
+		double dropoffTime = startTime + stopDuration;
+		endTime = Math.max(endTime, dropoffTime);
 
-		// first, check when we can start with the dropoff
-		double earliestStartTime = stop.getBeginTime();
-		earliestStartTime = Math.max(earliestStartTime, insertionTime);
-
-		// second, we add the dropoff
-		return Math.max(stop.getEndTime(), earliestStartTime + stopDuration);
+		return new Dropoff(endTime, dropoffTime);
 	}
 
 	/**

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/StopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/StopTimeCalculator.java
@@ -60,11 +60,17 @@ public interface StopTimeCalculator {
 	double updateEndTimeForPickup(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime, DrtRequest request);
 
 	// a new stop with a dropoff is created
-	double initEndTimeForDropoff(DvrpVehicle vehicle, double beginTime, DrtRequest request);
+	Dropoff initEndTimeForDropoff(DvrpVehicle vehicle, double beginTime, DrtRequest request);
 
 	// a dropoff is added to an existing stop
 	double updateEndTimeForDropoff(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime, DrtRequest request);
 
 	// the begin time of an existing stop is shifted
 	double shiftEndTime(DvrpVehicle vehicle, DrtStopTask stop, double beginTime);
+
+	public record Pickup(double endTime, double pickupTime) {
+	}
+
+	public record Dropoff(double endTime, double dropoffTime) {
+	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/StopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/StopTimeCalculator.java
@@ -63,7 +63,7 @@ public interface StopTimeCalculator {
 	Dropoff initEndTimeForDropoff(DvrpVehicle vehicle, double beginTime, DrtRequest request);
 
 	// a dropoff is added to an existing stop
-	double updateEndTimeForDropoff(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime, DrtRequest request);
+	Dropoff updateEndTimeForDropoff(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime, DrtRequest request);
 
 	// the begin time of an existing stop is shifted
 	double shiftEndTime(DvrpVehicle vehicle, DrtStopTask stop, double beginTime);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/StopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/StopTimeCalculator.java
@@ -54,7 +54,7 @@ import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
  */
 public interface StopTimeCalculator {
 	// a new stop with a pickup is created
-	double initEndTimeForPickup(DvrpVehicle vehicle, double beginTime, DrtRequest request);
+	Pickup initEndTimeForPickup(DvrpVehicle vehicle, double beginTime, DrtRequest request);
 
 	// a pickup is added to an existing stop
 	double updateEndTimeForPickup(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime, DrtRequest request);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/StopTimeCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/stops/StopTimeCalculator.java
@@ -57,7 +57,7 @@ public interface StopTimeCalculator {
 	Pickup initEndTimeForPickup(DvrpVehicle vehicle, double beginTime, DrtRequest request);
 
 	// a pickup is added to an existing stop
-	double updateEndTimeForPickup(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime, DrtRequest request);
+	Pickup updateEndTimeForPickup(DvrpVehicle vehicle, DrtStopTask stop, double insertionTime, DrtRequest request);
 
 	// a new stop with a dropoff is created
 	Dropoff initEndTimeForDropoff(DvrpVehicle vehicle, double beginTime, DrtRequest request);

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategyTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategyTest.java
@@ -38,20 +38,20 @@ public class CostCalculationStrategyTest {
 	@Test
 	void RejectSoftConstraintViolations_tooLongWaitTime() {
 		assertRejectSoftConstraintViolations(10, 9999,
-				new DetourTimeInfo(new PickupDetourInfo(11, 0), new DropoffDetourInfo(22, 22, 0)),
+				new DetourTimeInfo(new PickupDetourInfo(11, 11, 0), new DropoffDetourInfo(22, 22, 0)),
 				INFEASIBLE_SOLUTION_COST);
 	}
 
 	@Test
 	void RejectSoftConstraintViolations_tooLongTravelTime() {
 		assertRejectSoftConstraintViolations(9999, 10,
-				new DetourTimeInfo(new PickupDetourInfo(0, 0), new DropoffDetourInfo(11, 11, 0)), INFEASIBLE_SOLUTION_COST);
+				new DetourTimeInfo(new PickupDetourInfo(0, 0, 0), new DropoffDetourInfo(11, 11, 0)), INFEASIBLE_SOLUTION_COST);
 	}
 
 	@Test
 	void RejectSoftConstraintViolations_allConstraintSatisfied() {
 		assertRejectSoftConstraintViolations(9999, 9999,
-				new DetourTimeInfo(new PickupDetourInfo(11, 33), new DropoffDetourInfo(22, 22, 44)), 33 + 44);
+				new DetourTimeInfo(new PickupDetourInfo(11, 11, 33), new DropoffDetourInfo(22, 22, 44)), 33 + 44);
 	}
 
 	private void assertRejectSoftConstraintViolations(double latestStartTime, double latestArrivalTime,
@@ -68,21 +68,21 @@ public class CostCalculationStrategyTest {
 	@Test
 	void DiscourageSoftConstraintViolations_tooLongWaitTime() {
 		assertDiscourageSoftConstraintViolations(10, 9999,
-				new DetourTimeInfo(new PickupDetourInfo(11, 0), new DropoffDetourInfo(22, 22, 0)),
+				new DetourTimeInfo(new PickupDetourInfo(11, 11, 0), new DropoffDetourInfo(22, 22, 0)),
 				MAX_WAIT_TIME_VIOLATION_PENALTY);
 	}
 
 	@Test
 	void DiscourageSoftConstraintViolations_tooLongTravelTime() {
 		assertDiscourageSoftConstraintViolations(9999, 10,
-				new DetourTimeInfo(new PickupDetourInfo(0, 0), new DropoffDetourInfo(11, 11, 0)),
+				new DetourTimeInfo(new PickupDetourInfo(0, 0, 0), new DropoffDetourInfo(11, 11, 0)),
 				MAX_TRAVEL_TIME_VIOLATION_PENALTY);
 	}
 
 	@Test
 	void DiscourageSoftConstraintViolations_allConstraintSatisfied() {
 		assertDiscourageSoftConstraintViolations(9999, 9999,
-				new DetourTimeInfo(new PickupDetourInfo(11, 33), new DropoffDetourInfo(22, 22, 44)), 33 + 44);
+				new DetourTimeInfo(new PickupDetourInfo(11, 11, 33), new DropoffDetourInfo(22, 22, 44)), 33 + 44);
 	}
 
 	private void assertDiscourageSoftConstraintViolations(double latestStartTime, double latestArrivalTime,

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategyTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategyTest.java
@@ -38,20 +38,20 @@ public class CostCalculationStrategyTest {
 	@Test
 	void RejectSoftConstraintViolations_tooLongWaitTime() {
 		assertRejectSoftConstraintViolations(10, 9999,
-				new DetourTimeInfo(new PickupDetourInfo(11, 0), new DropoffDetourInfo(22, 0)),
+				new DetourTimeInfo(new PickupDetourInfo(11, 0), new DropoffDetourInfo(22, 22, 0)),
 				INFEASIBLE_SOLUTION_COST);
 	}
 
 	@Test
 	void RejectSoftConstraintViolations_tooLongTravelTime() {
 		assertRejectSoftConstraintViolations(9999, 10,
-				new DetourTimeInfo(new PickupDetourInfo(0, 0), new DropoffDetourInfo(11, 0)), INFEASIBLE_SOLUTION_COST);
+				new DetourTimeInfo(new PickupDetourInfo(0, 0), new DropoffDetourInfo(11, 11, 0)), INFEASIBLE_SOLUTION_COST);
 	}
 
 	@Test
 	void RejectSoftConstraintViolations_allConstraintSatisfied() {
 		assertRejectSoftConstraintViolations(9999, 9999,
-				new DetourTimeInfo(new PickupDetourInfo(11, 33), new DropoffDetourInfo(22, 44)), 33 + 44);
+				new DetourTimeInfo(new PickupDetourInfo(11, 33), new DropoffDetourInfo(22, 22, 44)), 33 + 44);
 	}
 
 	private void assertRejectSoftConstraintViolations(double latestStartTime, double latestArrivalTime,
@@ -68,21 +68,21 @@ public class CostCalculationStrategyTest {
 	@Test
 	void DiscourageSoftConstraintViolations_tooLongWaitTime() {
 		assertDiscourageSoftConstraintViolations(10, 9999,
-				new DetourTimeInfo(new PickupDetourInfo(11, 0), new DropoffDetourInfo(22, 0)),
+				new DetourTimeInfo(new PickupDetourInfo(11, 0), new DropoffDetourInfo(22, 22, 0)),
 				MAX_WAIT_TIME_VIOLATION_PENALTY);
 	}
 
 	@Test
 	void DiscourageSoftConstraintViolations_tooLongTravelTime() {
 		assertDiscourageSoftConstraintViolations(9999, 10,
-				new DetourTimeInfo(new PickupDetourInfo(0, 0), new DropoffDetourInfo(11, 0)),
+				new DetourTimeInfo(new PickupDetourInfo(0, 0), new DropoffDetourInfo(11, 11, 0)),
 				MAX_TRAVEL_TIME_VIOLATION_PENALTY);
 	}
 
 	@Test
 	void DiscourageSoftConstraintViolations_allConstraintSatisfied() {
 		assertDiscourageSoftConstraintViolations(9999, 9999,
-				new DetourTimeInfo(new PickupDetourInfo(11, 33), new DropoffDetourInfo(22, 44)), 33 + 44);
+				new DetourTimeInfo(new PickupDetourInfo(11, 33), new DropoffDetourInfo(22, 22, 44)), 33 + 44);
 	}
 
 	private void assertDiscourageSoftConstraintViolations(double latestStartTime, double latestArrivalTime,

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
@@ -60,22 +60,22 @@ public class InsertionCostCalculatorTest {
 
 		//feasible solution
 		final DrtConfigGroup drtConfigGroup = new DrtConfigGroup();
-		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(0, 11), new DropoffDetourInfo(0, 22)),
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(0, 11), new DropoffDetourInfo(0, 0, 22)),
 				11 + 22, drtRequest, drtConfigGroup.addOrGetDrtOptimizationConstraintsParams().addOrGetDefaultDrtOptimizationConstraintsSet());
 
 		//feasible solution - longest possible pickup and dropoff time losses
 		final DrtConfigGroup drtConfigGroup1 = new DrtConfigGroup();
-		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(0, 20), new DropoffDetourInfo(0, 30)),
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(0, 20), new DropoffDetourInfo(0, 0, 30)),
 				20 + 30, drtRequest, drtConfigGroup1.addOrGetDrtOptimizationConstraintsParams().addOrGetDefaultDrtOptimizationConstraintsSet());
 
 		//infeasible solution - time constraints at stop 0
 		final DrtConfigGroup drtConfigGroup2 = new DrtConfigGroup();
-		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(0, 21), new DropoffDetourInfo(0, 29)),
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(0, 21), new DropoffDetourInfo(0, 0, 29)),
 				INFEASIBLE_SOLUTION_COST, drtRequest, drtConfigGroup2.addOrGetDrtOptimizationConstraintsParams().addOrGetDefaultDrtOptimizationConstraintsSet());
 
 		//infeasible solution - vehicle time constraints
 		final DrtConfigGroup drtConfigGroup3 = new DrtConfigGroup();
-		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(0, 20), new DropoffDetourInfo(0, 31)),
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(0, 20), new DropoffDetourInfo(0, 0, 31)),
 				INFEASIBLE_SOLUTION_COST, drtRequest, drtConfigGroup3.addOrGetDrtOptimizationConstraintsParams().addOrGetDefaultDrtOptimizationConstraintsSet());
 	}
 
@@ -115,11 +115,11 @@ public class InsertionCostCalculatorTest {
 		DrtOptimizationConstraintsSet drtOptimizationConstraintsSet = drtConfigGroup.addOrGetDrtOptimizationConstraintsParams().addOrGetDefaultDrtOptimizationConstraintsSet();
 
 		// new insertion before dropoff of boarded passenger within threshold - infeasible solution
-		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 30), new DropoffDetourInfo(300, 30)),
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 30), new DropoffDetourInfo(300, 300, 30)),
 				INFEASIBLE_SOLUTION_COST, drtRequest, drtOptimizationConstraintsSet);
 
 		// new insertion before dropoff of boarded passenger, inside of threshold but no additional delay - feasible solution
-		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(120, 0), new DropoffDetourInfo(300, 30)),
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(120, 0), new DropoffDetourInfo(300, 300, 30)),
 				30, drtRequest, drtOptimizationConstraintsSet);
 
 		DrtRequest drtRequest2 = builder
@@ -132,13 +132,13 @@ public class InsertionCostCalculatorTest {
 				.build();
 
 		// new insertion before dropoff of boarded passenger, but outside of threshold - feasible solution
-		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 30), new DropoffDetourInfo(300, 30)),
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 30), new DropoffDetourInfo(300, 300, 30)),
 				60, drtRequest2, drtOptimizationConstraintsSet);
 
 
 		// new insertion after dropoff of boarded passenger - feasible solution
 		insertion = insertion(entry, 1, 1);
-		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 30), new DropoffDetourInfo(300, 30)),
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 30), new DropoffDetourInfo(300, 300, 30)),
 				60, drtRequest, drtOptimizationConstraintsSet);
 	}
 
@@ -182,7 +182,7 @@ public class InsertionCostCalculatorTest {
 
 		// new insertion before dropoff of boarded passenger within threshold - infeasible solution
 		DrtOptimizationConstraintsSet constraintsSet = drtConfigGroup.addOrGetDrtOptimizationConstraintsParams().addOrGetDefaultDrtOptimizationConstraintsSet();
-		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 60), new DropoffDetourInfo(300, 60)),
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 60), new DropoffDetourInfo(300, 300, 60)),
 				INFEASIBLE_SOLUTION_COST, drtRequest, constraintsSet);
 
 		DrtRequest drtRequest2 = builder
@@ -195,7 +195,7 @@ public class InsertionCostCalculatorTest {
 				.build();
 
 		// new insertion before dropoff of boarded passenger outside of threshold - feasible solution
-		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 60), new DropoffDetourInfo(300, 60)),
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 60), new DropoffDetourInfo(300, 300, 60)),
 				120, drtRequest2, constraintsSet);
 	}
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
@@ -60,22 +60,22 @@ public class InsertionCostCalculatorTest {
 
 		//feasible solution
 		final DrtConfigGroup drtConfigGroup = new DrtConfigGroup();
-		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(0, 11), new DropoffDetourInfo(0, 0, 22)),
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(0, 0, 11), new DropoffDetourInfo(0, 0, 22)),
 				11 + 22, drtRequest, drtConfigGroup.addOrGetDrtOptimizationConstraintsParams().addOrGetDefaultDrtOptimizationConstraintsSet());
 
 		//feasible solution - longest possible pickup and dropoff time losses
 		final DrtConfigGroup drtConfigGroup1 = new DrtConfigGroup();
-		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(0, 20), new DropoffDetourInfo(0, 0, 30)),
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(0, 0, 20), new DropoffDetourInfo(0, 0, 30)),
 				20 + 30, drtRequest, drtConfigGroup1.addOrGetDrtOptimizationConstraintsParams().addOrGetDefaultDrtOptimizationConstraintsSet());
 
 		//infeasible solution - time constraints at stop 0
 		final DrtConfigGroup drtConfigGroup2 = new DrtConfigGroup();
-		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(0, 21), new DropoffDetourInfo(0, 0, 29)),
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(0, 0, 21), new DropoffDetourInfo(0, 0, 29)),
 				INFEASIBLE_SOLUTION_COST, drtRequest, drtConfigGroup2.addOrGetDrtOptimizationConstraintsParams().addOrGetDefaultDrtOptimizationConstraintsSet());
 
 		//infeasible solution - vehicle time constraints
 		final DrtConfigGroup drtConfigGroup3 = new DrtConfigGroup();
-		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(0, 20), new DropoffDetourInfo(0, 0, 31)),
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(0, 0, 20), new DropoffDetourInfo(0, 0, 31)),
 				INFEASIBLE_SOLUTION_COST, drtRequest, drtConfigGroup3.addOrGetDrtOptimizationConstraintsParams().addOrGetDefaultDrtOptimizationConstraintsSet());
 	}
 
@@ -115,11 +115,11 @@ public class InsertionCostCalculatorTest {
 		DrtOptimizationConstraintsSet drtOptimizationConstraintsSet = drtConfigGroup.addOrGetDrtOptimizationConstraintsParams().addOrGetDefaultDrtOptimizationConstraintsSet();
 
 		// new insertion before dropoff of boarded passenger within threshold - infeasible solution
-		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 30), new DropoffDetourInfo(300, 300, 30)),
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 60, 30), new DropoffDetourInfo(300, 300, 30)),
 				INFEASIBLE_SOLUTION_COST, drtRequest, drtOptimizationConstraintsSet);
 
 		// new insertion before dropoff of boarded passenger, inside of threshold but no additional delay - feasible solution
-		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(120, 0), new DropoffDetourInfo(300, 300, 30)),
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(120, 120, 0), new DropoffDetourInfo(300, 300, 30)),
 				30, drtRequest, drtOptimizationConstraintsSet);
 
 		DrtRequest drtRequest2 = builder
@@ -132,13 +132,13 @@ public class InsertionCostCalculatorTest {
 				.build();
 
 		// new insertion before dropoff of boarded passenger, but outside of threshold - feasible solution
-		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 30), new DropoffDetourInfo(300, 300, 30)),
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 60, 30), new DropoffDetourInfo(300, 300, 30)),
 				60, drtRequest2, drtOptimizationConstraintsSet);
 
 
 		// new insertion after dropoff of boarded passenger - feasible solution
 		insertion = insertion(entry, 1, 1);
-		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 30), new DropoffDetourInfo(300, 300, 30)),
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 60, 30), new DropoffDetourInfo(300, 300, 30)),
 				60, drtRequest, drtOptimizationConstraintsSet);
 	}
 
@@ -182,7 +182,7 @@ public class InsertionCostCalculatorTest {
 
 		// new insertion before dropoff of boarded passenger within threshold - infeasible solution
 		DrtOptimizationConstraintsSet constraintsSet = drtConfigGroup.addOrGetDrtOptimizationConstraintsParams().addOrGetDefaultDrtOptimizationConstraintsSet();
-		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 60), new DropoffDetourInfo(300, 300, 60)),
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 60, 60), new DropoffDetourInfo(300, 300, 60)),
 				INFEASIBLE_SOLUTION_COST, drtRequest, constraintsSet);
 
 		DrtRequest drtRequest2 = builder
@@ -195,7 +195,7 @@ public class InsertionCostCalculatorTest {
 				.build();
 
 		// new insertion before dropoff of boarded passenger outside of threshold - feasible solution
-		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 60), new DropoffDetourInfo(300, 300, 60)),
+		assertCalculate(insertion, new DetourTimeInfo(new PickupDetourInfo(60, 60, 60), new DropoffDetourInfo(300, 300, 60)),
 				120, drtRequest2, constraintsSet);
 	}
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
@@ -71,7 +71,7 @@ public class InsertionDetourTimeCalculatorTest {
 				+ detour.detourFromPickup.getTravelTime();
 		double arrivalTime = departureTime + detour.detourFromPickup.getTravelTime();
 		double dropoffTimeLoss = STOP_DURATION;
-		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
+		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, departureTime, pickupTimeLoss),
 				new DropoffDetourInfo(arrivalTime, arrivalTime, dropoffTimeLoss)));
 	}
 
@@ -88,7 +88,7 @@ public class InsertionDetourTimeCalculatorTest {
 		double pickupTimeLoss = detour.detourFromPickup.getTravelTime();
 		double arrivalTime = departureTime + detour.detourFromPickup.getTravelTime();
 		double dropoffTimeLoss = STOP_DURATION;
-		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
+		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, departureTime, pickupTimeLoss),
 				new DropoffDetourInfo(arrivalTime, arrivalTime, dropoffTimeLoss)));
 	}
 
@@ -106,7 +106,7 @@ public class InsertionDetourTimeCalculatorTest {
 				+ detour.detourFromPickup.getTravelTime() - timeBetween(start, stop0);
 		double arrivalTime = departureTime + detour.detourFromPickup.getTravelTime();
 		double dropoffTimeLoss = STOP_DURATION + detour.detourFromDropoff.getTravelTime();
-		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
+		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, departureTime, pickupTimeLoss),
 				new DropoffDetourInfo(arrivalTime, arrivalTime, dropoffTimeLoss)));
 	}
 
@@ -124,7 +124,7 @@ public class InsertionDetourTimeCalculatorTest {
 				+ detour.detourFromPickup.getTravelTime() - timeBetween(start, stop0);
 		double arrivalTime = stop0.getDepartureTime() + pickupTimeLoss + detour.detourToDropoff.getTravelTime();
 		double dropoffTimeLoss = detour.detourToDropoff.getTravelTime() + STOP_DURATION;
-		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
+		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, departureTime, pickupTimeLoss),
 				new DropoffDetourInfo(arrivalTime, arrivalTime, dropoffTimeLoss)));
 	}
 
@@ -145,7 +145,7 @@ public class InsertionDetourTimeCalculatorTest {
 		double dropoffTimeLoss = detour.detourToDropoff.getTravelTime()
 				+ STOP_DURATION
 				+ detour.detourFromDropoff.getTravelTime() - timeBetween(stop0, stop1);
-		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
+		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, departureTime, pickupTimeLoss),
 				new DropoffDetourInfo(arrivalTime, arrivalTime, dropoffTimeLoss)));
 	}
 
@@ -162,7 +162,7 @@ public class InsertionDetourTimeCalculatorTest {
 		double pickupTimeLoss = STOP_DURATION;
 		double arrivalTime = stop0.getArrivalTime() + pickupTimeLoss;
 		double dropoffTimeLoss = 0;
-		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
+		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, departureTime, pickupTimeLoss),
 				new DropoffDetourInfo(arrivalTime, arrivalTime, dropoffTimeLoss)));
 	}
 
@@ -179,7 +179,7 @@ public class InsertionDetourTimeCalculatorTest {
 		double pickupTimeLoss = 0;
 		double arrivalTime = stop1.getArrivalTime();
 		double dropoffTimeLoss = 0;
-		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
+		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, departureTime, pickupTimeLoss),
 				new DropoffDetourInfo(arrivalTime, arrivalTime, dropoffTimeLoss)));
 	}
 
@@ -213,7 +213,7 @@ public class InsertionDetourTimeCalculatorTest {
 				+ STOP_DURATION
 				+ detour.detourFromDropoff.getTravelTime() - dropoffDetourReplacedDriveEstimate;
 		assertThat(actualDetourTimeInfo).usingRecursiveComparison()
-				.isEqualTo(new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
+				.isEqualTo(new DetourTimeInfo(new PickupDetourInfo(departureTime, departureTime, pickupTimeLoss),
 						new DropoffDetourInfo(arrivalTime, arrivalTime, dropoffTimeLoss)));
 	}
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorTest.java
@@ -72,7 +72,7 @@ public class InsertionDetourTimeCalculatorTest {
 		double arrivalTime = departureTime + detour.detourFromPickup.getTravelTime();
 		double dropoffTimeLoss = STOP_DURATION;
 		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
-				new DropoffDetourInfo(arrivalTime, dropoffTimeLoss)));
+				new DropoffDetourInfo(arrivalTime, arrivalTime, dropoffTimeLoss)));
 	}
 
 	@Test
@@ -89,7 +89,7 @@ public class InsertionDetourTimeCalculatorTest {
 		double arrivalTime = departureTime + detour.detourFromPickup.getTravelTime();
 		double dropoffTimeLoss = STOP_DURATION;
 		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
-				new DropoffDetourInfo(arrivalTime, dropoffTimeLoss)));
+				new DropoffDetourInfo(arrivalTime, arrivalTime, dropoffTimeLoss)));
 	}
 
 	@Test
@@ -107,7 +107,7 @@ public class InsertionDetourTimeCalculatorTest {
 		double arrivalTime = departureTime + detour.detourFromPickup.getTravelTime();
 		double dropoffTimeLoss = STOP_DURATION + detour.detourFromDropoff.getTravelTime();
 		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
-				new DropoffDetourInfo(arrivalTime, dropoffTimeLoss)));
+				new DropoffDetourInfo(arrivalTime, arrivalTime, dropoffTimeLoss)));
 	}
 
 	@Test
@@ -125,7 +125,7 @@ public class InsertionDetourTimeCalculatorTest {
 		double arrivalTime = stop0.getDepartureTime() + pickupTimeLoss + detour.detourToDropoff.getTravelTime();
 		double dropoffTimeLoss = detour.detourToDropoff.getTravelTime() + STOP_DURATION;
 		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
-				new DropoffDetourInfo(arrivalTime, dropoffTimeLoss)));
+				new DropoffDetourInfo(arrivalTime, arrivalTime, dropoffTimeLoss)));
 	}
 
 	@Test
@@ -146,7 +146,7 @@ public class InsertionDetourTimeCalculatorTest {
 				+ STOP_DURATION
 				+ detour.detourFromDropoff.getTravelTime() - timeBetween(stop0, stop1);
 		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
-				new DropoffDetourInfo(arrivalTime, dropoffTimeLoss)));
+				new DropoffDetourInfo(arrivalTime, arrivalTime, dropoffTimeLoss)));
 	}
 
 	@Test
@@ -163,7 +163,7 @@ public class InsertionDetourTimeCalculatorTest {
 		double arrivalTime = stop0.getArrivalTime() + pickupTimeLoss;
 		double dropoffTimeLoss = 0;
 		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
-				new DropoffDetourInfo(arrivalTime, dropoffTimeLoss)));
+				new DropoffDetourInfo(arrivalTime, arrivalTime, dropoffTimeLoss)));
 	}
 
 	@Test
@@ -180,7 +180,7 @@ public class InsertionDetourTimeCalculatorTest {
 		double arrivalTime = stop1.getArrivalTime();
 		double dropoffTimeLoss = 0;
 		assertDetourTimeInfo(insertion, new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
-				new DropoffDetourInfo(arrivalTime, dropoffTimeLoss)));
+				new DropoffDetourInfo(arrivalTime, arrivalTime, dropoffTimeLoss)));
 	}
 
 	@Test
@@ -214,7 +214,7 @@ public class InsertionDetourTimeCalculatorTest {
 				+ detour.detourFromDropoff.getTravelTime() - dropoffDetourReplacedDriveEstimate;
 		assertThat(actualDetourTimeInfo).usingRecursiveComparison()
 				.isEqualTo(new DetourTimeInfo(new PickupDetourInfo(departureTime, pickupTimeLoss),
-						new DropoffDetourInfo(arrivalTime, dropoffTimeLoss)));
+						new DropoffDetourInfo(arrivalTime, arrivalTime, dropoffTimeLoss)));
 	}
 
 	private void assertDetourTimeInfo(InsertionWithDetourData insertion, DetourTimeInfo expected) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorWithVariableDurationTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorWithVariableDurationTest.java
@@ -208,12 +208,13 @@ public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 		double departureTime = start.getDepartureTime() + STOP_DURATION_ADDED;
 		double requestPickupTime = departureTime;
 		double pickupTimeLoss = STOP_DURATION_ADDED;
-		double arrivalTime = stop0.getArrivalTime() + pickupTimeLoss;
+		double vehicleArrivalTime = stop0.getArrivalTime() + pickupTimeLoss;
+		double requestDropoffTime = vehicleArrivalTime + STOP_DURATION_ADDED + STOP_DURATION_INITIAL;
 		double dropoffTimeLoss = STOP_DURATION_ADDED;
 
 		assertDetourTimeInfo(insertion,
 				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, requestPickupTime, pickupTimeLoss),
-						new InsertionDetourTimeCalculator.DropoffDetourInfo(arrivalTime, arrivalTime, dropoffTimeLoss)));
+						new InsertionDetourTimeCalculator.DropoffDetourInfo(vehicleArrivalTime, requestDropoffTime, dropoffTimeLoss)));
 	}
 
 	@Test
@@ -228,12 +229,13 @@ public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 		double departureTime = stop0.getDepartureTime() + STOP_DURATION_ADDED;
 		double pickupTimeLoss = STOP_DURATION_ADDED;
 		double requestPickupTime = departureTime;
-		double arrivalTime = stop1.getArrivalTime() + STOP_DURATION_ADDED;
+		double vehicleArrivalTime = stop1.getArrivalTime() + STOP_DURATION_ADDED;
+		double requestDropoffTime = vehicleArrivalTime + STOP_DURATION_ADDED + STOP_DURATION_INITIAL;
 		double dropoffTimeLoss = STOP_DURATION_ADDED;
 
 		assertDetourTimeInfo(insertion,
 				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, requestPickupTime, pickupTimeLoss),
-						new InsertionDetourTimeCalculator.DropoffDetourInfo(arrivalTime, arrivalTime, dropoffTimeLoss)));
+						new InsertionDetourTimeCalculator.DropoffDetourInfo(vehicleArrivalTime, requestDropoffTime, dropoffTimeLoss)));
 	}
 
 	@Test

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorWithVariableDurationTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorWithVariableDurationTest.java
@@ -21,6 +21,7 @@
 package org.matsim.contrib.drt.optimizer.insertion;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.STOP;
 
 import java.util.Collections;
 import java.util.List;
@@ -101,13 +102,14 @@ public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 
 		double departureTime = start.getDepartureTime() + detour.toPickup + STOP_DURATION_ADDED;
 		double pickupTimeLoss = detour.toPickup + STOP_DURATION_ADDED + detour.fromPickup;
-		double arrivalTime = departureTime + detour.fromPickup;
+		double vehicleArrivalTime = departureTime + detour.fromPickup;
+		double requestDropoffTime = vehicleArrivalTime + STOP_DURATION_ADDED;
 		double dropoffTimeLoss = STOP_DURATION_ADDED;
 
 
 		assertDetourTimeInfo(insertion,
 				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, pickupTimeLoss),
-						new InsertionDetourTimeCalculator.DropoffDetourInfo(arrivalTime, dropoffTimeLoss)));
+						new InsertionDetourTimeCalculator.DropoffDetourInfo(vehicleArrivalTime, requestDropoffTime, dropoffTimeLoss)));
 	}
 
 	@Test
@@ -123,11 +125,13 @@ public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 
 		double departureTime = start.getDepartureTime() + STOP_DURATION_ADDED;
 		double pickupTimeLoss = detour.fromPickup + STOP_DURATION_ADDED;
-		double arrivalTime = departureTime + detour.fromPickup;
+		double vehicleArrivalTime = departureTime + detour.fromPickup;
+		double requestDropoffTime = vehicleArrivalTime + STOP_DURATION_ADDED;
 		double dropoffTimeLoss = STOP_DURATION_ADDED;
+
 		assertDetourTimeInfo(insertion,
 				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, pickupTimeLoss),
-						new InsertionDetourTimeCalculator.DropoffDetourInfo(arrivalTime, dropoffTimeLoss)));
+						new InsertionDetourTimeCalculator.DropoffDetourInfo(vehicleArrivalTime, requestDropoffTime, dropoffTimeLoss)));
 	}
 
 	@Test
@@ -140,11 +144,13 @@ public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 
 		double departureTime = start.getDepartureTime() + detour.toPickup + STOP_DURATION_ADDED;
 		double pickupTimeLoss = detour.toPickup + STOP_DURATION_ADDED + detour.fromPickup - timeBetween(start, stop0);
-		double arrivalTime = departureTime + detour.fromPickup;
+		double vehicleArrivalTime = departureTime + detour.fromPickup;
+		double requestDropoffTime = vehicleArrivalTime + STOP_DURATION_ADDED;
 		double dropoffTimeLoss = STOP_DURATION_ADDED + detour.fromDropoff;
+
 		assertDetourTimeInfo(insertion,
 				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, pickupTimeLoss),
-						new InsertionDetourTimeCalculator.DropoffDetourInfo(arrivalTime, dropoffTimeLoss)));
+						new InsertionDetourTimeCalculator.DropoffDetourInfo(vehicleArrivalTime, requestDropoffTime, dropoffTimeLoss)));
 	}
 
 	@Test
@@ -157,11 +163,13 @@ public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 
 		double departureTime = start.getDepartureTime() + detour.toPickup + STOP_DURATION_ADDED;
 		double pickupTimeLoss = detour.toPickup + STOP_DURATION_ADDED + detour.fromPickup - timeBetween(start, stop0);
-		double arrivalTime = stop0.getDepartureTime() + pickupTimeLoss + detour.toDropoff;
+		double vehicleArrivalTime = stop0.getDepartureTime() + pickupTimeLoss + detour.toDropoff;
+		double requestDropoffTime = vehicleArrivalTime + STOP_DURATION_ADDED;
 		double dropoffTimeLoss = detour.toDropoff + STOP_DURATION_ADDED;
+
 		assertDetourTimeInfo(insertion,
 				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, pickupTimeLoss),
-						new InsertionDetourTimeCalculator.DropoffDetourInfo(arrivalTime, dropoffTimeLoss)));
+						new InsertionDetourTimeCalculator.DropoffDetourInfo(vehicleArrivalTime, requestDropoffTime, dropoffTimeLoss)));
 	}
 
 	@Test
@@ -175,11 +183,13 @@ public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 
 		double departureTime = start.getDepartureTime() + detour.toPickup + STOP_DURATION_ADDED;
 		double pickupTimeLoss = detour.toPickup + STOP_DURATION_ADDED + detour.fromPickup - timeBetween(start, stop0);
-		double arrivalTime = stop0.getDepartureTime() + pickupTimeLoss + detour.toDropoff;
+		double vehicleArrivalTime = stop0.getDepartureTime() + pickupTimeLoss + detour.toDropoff;
+		double requestDropoffTime = vehicleArrivalTime + STOP_DURATION_ADDED;
 		double dropoffTimeLoss = detour.toDropoff + STOP_DURATION_ADDED + detour.fromDropoff - timeBetween(stop0, stop1);
+		
 		assertDetourTimeInfo(insertion,
 				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, pickupTimeLoss),
-						new InsertionDetourTimeCalculator.DropoffDetourInfo(arrivalTime, dropoffTimeLoss)));
+						new InsertionDetourTimeCalculator.DropoffDetourInfo(vehicleArrivalTime, requestDropoffTime, dropoffTimeLoss)));
 	}
 
 	@Test
@@ -197,7 +207,7 @@ public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 		double dropoffTimeLoss = STOP_DURATION_ADDED;
 		assertDetourTimeInfo(insertion,
 				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, pickupTimeLoss),
-						new InsertionDetourTimeCalculator.DropoffDetourInfo(arrivalTime, dropoffTimeLoss)));
+						new InsertionDetourTimeCalculator.DropoffDetourInfo(arrivalTime, arrivalTime, dropoffTimeLoss)));
 	}
 
 	@Test
@@ -215,7 +225,7 @@ public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 		double dropoffTimeLoss = STOP_DURATION_ADDED;
 		assertDetourTimeInfo(insertion,
 				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, pickupTimeLoss),
-						new InsertionDetourTimeCalculator.DropoffDetourInfo(arrivalTime, dropoffTimeLoss)));
+						new InsertionDetourTimeCalculator.DropoffDetourInfo(arrivalTime, arrivalTime, dropoffTimeLoss)));
 	}
 
 	@Test
@@ -245,11 +255,12 @@ public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 
 		double departureTime = start.getDepartureTime() + detour.toPickup + STOP_DURATION_INITIAL;
 		double pickupTimeLoss = detour.toPickup + STOP_DURATION_INITIAL + detour.fromPickup - pickupDetourReplacedDriveEstimate;
-		double arrivalTime = stop0.getDepartureTime() + pickupTimeLoss + detour.toDropoff;
+		double vehicleArrivalTime = stop0.getDepartureTime() + pickupTimeLoss + detour.toDropoff;
+		double requestDropoffTime = vehicleArrivalTime + STOP_DURATION_INITIAL;
 		double dropoffTimeLoss = detour.toDropoff + STOP_DURATION_INITIAL + detour.fromDropoff
 				- dropoffDetourReplacedDriveEstimate;
 		DetourTimeInfo detourTimeInfo = new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, pickupTimeLoss),
-				new InsertionDetourTimeCalculator.DropoffDetourInfo(arrivalTime, dropoffTimeLoss));
+				new InsertionDetourTimeCalculator.DropoffDetourInfo(vehicleArrivalTime, requestDropoffTime, dropoffTimeLoss));
 		assertThat(actualDetourTimeInfo.pickupDetourInfo).isEqualToComparingFieldByField(
 				detourTimeInfo.pickupDetourInfo);
 		assertThat(actualDetourTimeInfo.dropoffDetourInfo).isEqualToComparingFieldByField(
@@ -289,7 +300,7 @@ public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 				getPath(detour.fromPickup), getPath(detour.toDropoff), getPath(detour.fromDropoff));
 
 		DetourTimeInfo detourTimeInfo = new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(0, detour.fromPickup + detour.toPickup),
-				new InsertionDetourTimeCalculator.DropoffDetourInfo(0, detour.fromDropoff + detour.toDropoff));
+				new InsertionDetourTimeCalculator.DropoffDetourInfo(0, 0, detour.fromDropoff + detour.toDropoff));
 		return new InsertionWithDetourData(insertion, insertionDetourData, detourTimeInfo);
 	}
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorWithVariableDurationTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorWithVariableDurationTest.java
@@ -237,6 +237,27 @@ public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, requestPickupTime, pickupTimeLoss),
 						new InsertionDetourTimeCalculator.DropoffDetourInfo(vehicleArrivalTime, requestDropoffTime, dropoffTimeLoss)));
 	}
+	
+	@Test
+	void calculatePickupDetourTimeLoss_start_stop_pickupAppended_stop_dropoffNotAppended() {
+		Waypoint.Start start = start(null, 5, link("start"));
+		Waypoint.Stop stop0 = stop(10, fromLink);
+		Waypoint.Stop stop1 = stop(200, link("other"));
+		VehicleEntry entry = entry(start, stop0, stop1);
+		var detour = new Detour(0., 0., 0., 0.);//all unused
+		var insertion = insertion(entry, 1, 2, detour);
+
+		double departureTime = stop0.getDepartureTime() + STOP_DURATION_ADDED;
+		double pickupTimeLoss = STOP_DURATION_ADDED;
+		double requestPickupTime = departureTime;
+		double vehicleArrivalTime = stop1.getArrivalTime() + STOP_DURATION_ADDED + STOP_DURATION_INITIAL;
+		double requestDropoffTime = vehicleArrivalTime + STOP_DURATION_ADDED;
+		double dropoffTimeLoss = STOP_DURATION_ADDED;
+
+		assertDetourTimeInfo(insertion,
+				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, requestPickupTime, pickupTimeLoss),
+						new InsertionDetourTimeCalculator.DropoffDetourInfo(vehicleArrivalTime, requestDropoffTime, dropoffTimeLoss)));
+	}
 
 	@Test
 	void replacedDriveTimeEstimator() {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorWithVariableDurationTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionDetourTimeCalculatorWithVariableDurationTest.java
@@ -101,14 +101,14 @@ public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 		var insertion = insertion(entry, 0, 0, detour);
 
 		double departureTime = start.getDepartureTime() + detour.toPickup + STOP_DURATION_ADDED;
+		double requestPickupTime = start.getDepartureTime() + detour.toPickup + STOP_DURATION_ADDED;
 		double pickupTimeLoss = detour.toPickup + STOP_DURATION_ADDED + detour.fromPickup;
 		double vehicleArrivalTime = departureTime + detour.fromPickup;
 		double requestDropoffTime = vehicleArrivalTime + STOP_DURATION_ADDED;
 		double dropoffTimeLoss = STOP_DURATION_ADDED;
 
-
 		assertDetourTimeInfo(insertion,
-				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, pickupTimeLoss),
+				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, requestPickupTime, pickupTimeLoss),
 						new InsertionDetourTimeCalculator.DropoffDetourInfo(vehicleArrivalTime, requestDropoffTime, dropoffTimeLoss)));
 	}
 
@@ -125,12 +125,13 @@ public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 
 		double departureTime = start.getDepartureTime() + STOP_DURATION_ADDED;
 		double pickupTimeLoss = detour.fromPickup + STOP_DURATION_ADDED;
+		double requestPickupTime = departureTime;
 		double vehicleArrivalTime = departureTime + detour.fromPickup;
 		double requestDropoffTime = vehicleArrivalTime + STOP_DURATION_ADDED;
 		double dropoffTimeLoss = STOP_DURATION_ADDED;
 
 		assertDetourTimeInfo(insertion,
-				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, pickupTimeLoss),
+				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, requestPickupTime, pickupTimeLoss),
 						new InsertionDetourTimeCalculator.DropoffDetourInfo(vehicleArrivalTime, requestDropoffTime, dropoffTimeLoss)));
 	}
 
@@ -144,12 +145,13 @@ public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 
 		double departureTime = start.getDepartureTime() + detour.toPickup + STOP_DURATION_ADDED;
 		double pickupTimeLoss = detour.toPickup + STOP_DURATION_ADDED + detour.fromPickup - timeBetween(start, stop0);
+		double requestPickupTime = departureTime;
 		double vehicleArrivalTime = departureTime + detour.fromPickup;
 		double requestDropoffTime = vehicleArrivalTime + STOP_DURATION_ADDED;
 		double dropoffTimeLoss = STOP_DURATION_ADDED + detour.fromDropoff;
 
 		assertDetourTimeInfo(insertion,
-				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, pickupTimeLoss),
+				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, requestPickupTime, pickupTimeLoss),
 						new InsertionDetourTimeCalculator.DropoffDetourInfo(vehicleArrivalTime, requestDropoffTime, dropoffTimeLoss)));
 	}
 
@@ -163,12 +165,13 @@ public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 
 		double departureTime = start.getDepartureTime() + detour.toPickup + STOP_DURATION_ADDED;
 		double pickupTimeLoss = detour.toPickup + STOP_DURATION_ADDED + detour.fromPickup - timeBetween(start, stop0);
+		double requestPickupTime = departureTime;
 		double vehicleArrivalTime = stop0.getDepartureTime() + pickupTimeLoss + detour.toDropoff;
 		double requestDropoffTime = vehicleArrivalTime + STOP_DURATION_ADDED;
 		double dropoffTimeLoss = detour.toDropoff + STOP_DURATION_ADDED;
 
 		assertDetourTimeInfo(insertion,
-				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, pickupTimeLoss),
+				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, requestPickupTime ,pickupTimeLoss),
 						new InsertionDetourTimeCalculator.DropoffDetourInfo(vehicleArrivalTime, requestDropoffTime, dropoffTimeLoss)));
 	}
 
@@ -183,12 +186,13 @@ public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 
 		double departureTime = start.getDepartureTime() + detour.toPickup + STOP_DURATION_ADDED;
 		double pickupTimeLoss = detour.toPickup + STOP_DURATION_ADDED + detour.fromPickup - timeBetween(start, stop0);
+		double requestPickupTime = departureTime;
 		double vehicleArrivalTime = stop0.getDepartureTime() + pickupTimeLoss + detour.toDropoff;
 		double requestDropoffTime = vehicleArrivalTime + STOP_DURATION_ADDED;
 		double dropoffTimeLoss = detour.toDropoff + STOP_DURATION_ADDED + detour.fromDropoff - timeBetween(stop0, stop1);
 		
 		assertDetourTimeInfo(insertion,
-				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, pickupTimeLoss),
+				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, requestPickupTime, pickupTimeLoss),
 						new InsertionDetourTimeCalculator.DropoffDetourInfo(vehicleArrivalTime, requestDropoffTime, dropoffTimeLoss)));
 	}
 
@@ -202,11 +206,13 @@ public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 		var insertion = insertion(entry, 0, 1, detour);
 
 		double departureTime = start.getDepartureTime() + STOP_DURATION_ADDED;
+		double requestPickupTime = departureTime;
 		double pickupTimeLoss = STOP_DURATION_ADDED;
 		double arrivalTime = stop0.getArrivalTime() + pickupTimeLoss;
 		double dropoffTimeLoss = STOP_DURATION_ADDED;
+
 		assertDetourTimeInfo(insertion,
-				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, pickupTimeLoss),
+				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, requestPickupTime, pickupTimeLoss),
 						new InsertionDetourTimeCalculator.DropoffDetourInfo(arrivalTime, arrivalTime, dropoffTimeLoss)));
 	}
 
@@ -221,10 +227,12 @@ public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 
 		double departureTime = stop0.getDepartureTime() + STOP_DURATION_ADDED;
 		double pickupTimeLoss = STOP_DURATION_ADDED;
+		double requestPickupTime = departureTime;
 		double arrivalTime = stop1.getArrivalTime() + STOP_DURATION_ADDED;
 		double dropoffTimeLoss = STOP_DURATION_ADDED;
+
 		assertDetourTimeInfo(insertion,
-				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, pickupTimeLoss),
+				new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, requestPickupTime, pickupTimeLoss),
 						new InsertionDetourTimeCalculator.DropoffDetourInfo(arrivalTime, arrivalTime, dropoffTimeLoss)));
 	}
 
@@ -255,11 +263,12 @@ public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 
 		double departureTime = start.getDepartureTime() + detour.toPickup + STOP_DURATION_INITIAL;
 		double pickupTimeLoss = detour.toPickup + STOP_DURATION_INITIAL + detour.fromPickup - pickupDetourReplacedDriveEstimate;
+		double requestPickupTime = departureTime;
 		double vehicleArrivalTime = stop0.getDepartureTime() + pickupTimeLoss + detour.toDropoff;
 		double requestDropoffTime = vehicleArrivalTime + STOP_DURATION_INITIAL;
 		double dropoffTimeLoss = detour.toDropoff + STOP_DURATION_INITIAL + detour.fromDropoff
 				- dropoffDetourReplacedDriveEstimate;
-		DetourTimeInfo detourTimeInfo = new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, pickupTimeLoss),
+		DetourTimeInfo detourTimeInfo = new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(departureTime, requestPickupTime, pickupTimeLoss),
 				new InsertionDetourTimeCalculator.DropoffDetourInfo(vehicleArrivalTime, requestDropoffTime, dropoffTimeLoss));
 		assertThat(actualDetourTimeInfo.pickupDetourInfo).isEqualToComparingFieldByField(
 				detourTimeInfo.pickupDetourInfo);
@@ -299,7 +308,7 @@ public class InsertionDetourTimeCalculatorWithVariableDurationTest {
 		InsertionWithDetourData.InsertionDetourData insertionDetourData = new InsertionWithDetourData.InsertionDetourData(getPath(detour.toPickup),
 				getPath(detour.fromPickup), getPath(detour.toDropoff), getPath(detour.fromDropoff));
 
-		DetourTimeInfo detourTimeInfo = new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(0, detour.fromPickup + detour.toPickup),
+		DetourTimeInfo detourTimeInfo = new DetourTimeInfo(new InsertionDetourTimeCalculator.PickupDetourInfo(0, 0, detour.fromPickup + detour.toPickup),
 				new InsertionDetourTimeCalculator.DropoffDetourInfo(0, 0, detour.fromDropoff + detour.toDropoff));
 		return new InsertionWithDetourData(insertion, insertionDetourData, detourTimeInfo);
 	}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
@@ -108,7 +108,8 @@ public class InsertionGeneratorTest {
 			var insertion = new Insertion(drtRequest, entry, 0, 0);
 			var pickup = new PickupDetourInfo(start.time + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP);
-			var dropoff = new DropoffDetourInfo(start.time + pickup.pickupTimeLoss, STOP_DURATION);
+			var dropoff = new DropoffDetourInfo(start.time + pickup.pickupTimeLoss,
+				start.time + pickup.pickupTimeLoss, STOP_DURATION);
 			insertions.add(insertion(insertion, pickup, dropoff));
 		}
 		assertInsertionsWithDetour(drtRequest, entry, insertions);
@@ -126,6 +127,7 @@ public class InsertionGeneratorTest {
 			var pickup = new PickupDetourInfo(start.time + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP - TIME_REPLACED_DRIVE);
 			var dropoff = new DropoffDetourInfo(pickup.departureTime + TIME_FROM_PICKUP,
+					pickup.departureTime + TIME_FROM_PICKUP,
 					STOP_DURATION + TIME_FROM_DROPOFF);
 			insertions.add(insertion(insertion, pickup, dropoff));
 		}
@@ -134,6 +136,7 @@ public class InsertionGeneratorTest {
 			var pickup = new PickupDetourInfo(start.time + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP - TIME_REPLACED_DRIVE);
 			var dropoff = new DropoffDetourInfo(stop0.getDepartureTime() + pickup.pickupTimeLoss + TIME_TO_DROPOFF,
+					stop0.getDepartureTime() + pickup.pickupTimeLoss + TIME_TO_DROPOFF,
 					TIME_TO_DROPOFF + STOP_DURATION);
 			insertions.add(insertion(insertion, pickup, dropoff));
 		}
@@ -141,7 +144,8 @@ public class InsertionGeneratorTest {
 			var insertion = new Insertion(drtRequest, entry, 1, 1);
 			var pickup = new PickupDetourInfo(stop0.getDepartureTime() + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP);
-			var dropoff = new DropoffDetourInfo(stop0.getDepartureTime() + pickup.pickupTimeLoss, STOP_DURATION);
+			var dropoff = new DropoffDetourInfo(stop0.getDepartureTime() + pickup.pickupTimeLoss, 
+					stop0.getDepartureTime() + pickup.pickupTimeLoss, STOP_DURATION);
 			insertions.add(insertion(insertion, pickup, dropoff));
 		}
 		assertInsertionsWithDetour(drtRequest, entry, insertions);
@@ -158,7 +162,8 @@ public class InsertionGeneratorTest {
 			var insertion = new Insertion(drtRequest, entry, 1, 1);
 			var pickup = new PickupDetourInfo(stop0.getDepartureTime() + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP);
-			var dropoff = new DropoffDetourInfo(stop0.getDepartureTime() + pickup.pickupTimeLoss, STOP_DURATION);
+			var dropoff = new DropoffDetourInfo(stop0.getDepartureTime() + pickup.pickupTimeLoss, 
+					stop0.getDepartureTime() + pickup.pickupTimeLoss, STOP_DURATION);
 			insertions.add(insertion(insertion, pickup, dropoff));
 		}
 		assertInsertionsWithDetour(drtRequest, entry, insertions);
@@ -177,6 +182,7 @@ public class InsertionGeneratorTest {
 			var pickup = new PickupDetourInfo(start.time + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP - TIME_REPLACED_DRIVE);
 			var dropoff = new DropoffDetourInfo(pickup.departureTime + TIME_FROM_PICKUP,
+					pickup.departureTime + TIME_FROM_PICKUP,
 					STOP_DURATION + TIME_FROM_DROPOFF);
 			insertions.add(insertion(insertion, pickup, dropoff));
 		}
@@ -185,6 +191,7 @@ public class InsertionGeneratorTest {
 			var pickup = new PickupDetourInfo(start.time + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP - TIME_REPLACED_DRIVE);
 			var dropoff = new DropoffDetourInfo(stop0.getDepartureTime() + pickup.pickupTimeLoss + TIME_TO_DROPOFF,
+					stop0.getDepartureTime() + pickup.pickupTimeLoss + TIME_TO_DROPOFF,
 					TIME_TO_DROPOFF + STOP_DURATION + TIME_FROM_DROPOFF - TIME_REPLACED_DRIVE);
 			insertions.add(insertion(insertion, pickup, dropoff));
 		}
@@ -193,6 +200,7 @@ public class InsertionGeneratorTest {
 			var pickup = new PickupDetourInfo(start.time + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP - TIME_REPLACED_DRIVE);
 			var dropoff = new DropoffDetourInfo(stop1.getDepartureTime() + pickup.pickupTimeLoss + TIME_TO_DROPOFF,
+					stop1.getDepartureTime() + pickup.pickupTimeLoss + TIME_TO_DROPOFF,
 					TIME_TO_DROPOFF + STOP_DURATION);
 			insertions.add(insertion(insertion, pickup, dropoff));
 		}
@@ -201,6 +209,7 @@ public class InsertionGeneratorTest {
 			var pickup = new PickupDetourInfo(stop0.getDepartureTime() + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP - TIME_REPLACED_DRIVE);
 			var dropoff = new DropoffDetourInfo(pickup.departureTime + TIME_FROM_PICKUP,
+					pickup.departureTime + TIME_FROM_PICKUP,
 					STOP_DURATION + TIME_FROM_DROPOFF);
 			insertions.add(insertion(insertion, pickup, dropoff));
 		}
@@ -209,6 +218,7 @@ public class InsertionGeneratorTest {
 			var pickup = new PickupDetourInfo(stop0.getDepartureTime() + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP - TIME_REPLACED_DRIVE);
 			var dropoff = new DropoffDetourInfo(stop1.getDepartureTime() + pickup.pickupTimeLoss + TIME_TO_DROPOFF,
+					stop1.getDepartureTime() + pickup.pickupTimeLoss + TIME_TO_DROPOFF,
 					TIME_TO_DROPOFF + STOP_DURATION);
 			insertions.add(insertion(insertion, pickup, dropoff));
 		}
@@ -216,7 +226,8 @@ public class InsertionGeneratorTest {
 			var insertion = new Insertion(drtRequest, entry, 2, 2);
 			var pickup = new PickupDetourInfo(stop1.getDepartureTime() + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP);
-			var dropoff = new DropoffDetourInfo(stop1.getDepartureTime() + pickup.pickupTimeLoss, STOP_DURATION);
+			var dropoff = new DropoffDetourInfo(stop1.getDepartureTime() + pickup.pickupTimeLoss, 
+					stop1.getDepartureTime() + pickup.pickupTimeLoss, STOP_DURATION);
 			insertions.add(insertion(insertion, pickup, dropoff));
 		}
 		assertInsertionsWithDetour(drtRequest, entry, insertions);
@@ -243,6 +254,7 @@ public class InsertionGeneratorTest {
 			var pickup = new PickupDetourInfo(stop0.getDepartureTime() + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP - TIME_REPLACED_DRIVE);
 			var dropoff = new DropoffDetourInfo(stop1.getDepartureTime() + pickup.pickupTimeLoss + TIME_TO_DROPOFF,
+					stop1.getDepartureTime() + pickup.pickupTimeLoss + TIME_TO_DROPOFF,
 					TIME_TO_DROPOFF + STOP_DURATION);
 			insertions.add(insertion(insertion, pickup, dropoff));
 		}
@@ -250,7 +262,8 @@ public class InsertionGeneratorTest {
 			var insertion = new Insertion(drtRequest, entry, 2, 2);
 			var pickup = new PickupDetourInfo(stop1.getDepartureTime() + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP);
-			var dropoff = new DropoffDetourInfo(stop1.getDepartureTime() + pickup.pickupTimeLoss, STOP_DURATION);
+			var dropoff = new DropoffDetourInfo(stop1.getDepartureTime() + pickup.pickupTimeLoss, 
+					stop1.getDepartureTime() + pickup.pickupTimeLoss, STOP_DURATION);
 			insertions.add(insertion(insertion, pickup, dropoff));
 		}
 		assertInsertionsWithDetour(drtRequest, entry, insertions);

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
@@ -107,6 +107,7 @@ public class InsertionGeneratorTest {
 		{//00
 			var insertion = new Insertion(drtRequest, entry, 0, 0);
 			var pickup = new PickupDetourInfo(start.time + TIME_TO_PICKUP + STOP_DURATION,
+					start.time + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP);
 			var dropoff = new DropoffDetourInfo(start.time + pickup.pickupTimeLoss,
 				start.time + pickup.pickupTimeLoss, STOP_DURATION);
@@ -125,15 +126,17 @@ public class InsertionGeneratorTest {
 		{//00
 			var insertion = new Insertion(drtRequest, entry, 0, 0);
 			var pickup = new PickupDetourInfo(start.time + TIME_TO_PICKUP + STOP_DURATION,
+					start.time + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP - TIME_REPLACED_DRIVE);
-			var dropoff = new DropoffDetourInfo(pickup.departureTime + TIME_FROM_PICKUP,
-					pickup.departureTime + TIME_FROM_PICKUP,
+			var dropoff = new DropoffDetourInfo(pickup.vehicleDepartureTime + TIME_FROM_PICKUP,
+					pickup.vehicleDepartureTime + TIME_FROM_PICKUP,
 					STOP_DURATION + TIME_FROM_DROPOFF);
 			insertions.add(insertion(insertion, pickup, dropoff));
 		}
 		{//01
 			var insertion = new Insertion(drtRequest, entry, 0, 1);
 			var pickup = new PickupDetourInfo(start.time + TIME_TO_PICKUP + STOP_DURATION,
+					start.time + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP - TIME_REPLACED_DRIVE);
 			var dropoff = new DropoffDetourInfo(stop0.getDepartureTime() + pickup.pickupTimeLoss + TIME_TO_DROPOFF,
 					stop0.getDepartureTime() + pickup.pickupTimeLoss + TIME_TO_DROPOFF,
@@ -143,6 +146,7 @@ public class InsertionGeneratorTest {
 		{//11
 			var insertion = new Insertion(drtRequest, entry, 1, 1);
 			var pickup = new PickupDetourInfo(stop0.getDepartureTime() + TIME_TO_PICKUP + STOP_DURATION,
+					stop0.getDepartureTime() + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP);
 			var dropoff = new DropoffDetourInfo(stop0.getDepartureTime() + pickup.pickupTimeLoss, 
 					stop0.getDepartureTime() + pickup.pickupTimeLoss, STOP_DURATION);
@@ -161,6 +165,7 @@ public class InsertionGeneratorTest {
 		{//11
 			var insertion = new Insertion(drtRequest, entry, 1, 1);
 			var pickup = new PickupDetourInfo(stop0.getDepartureTime() + TIME_TO_PICKUP + STOP_DURATION,
+					stop0.getDepartureTime() + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP);
 			var dropoff = new DropoffDetourInfo(stop0.getDepartureTime() + pickup.pickupTimeLoss, 
 					stop0.getDepartureTime() + pickup.pickupTimeLoss, STOP_DURATION);
@@ -180,15 +185,17 @@ public class InsertionGeneratorTest {
 		{//00
 			var insertion = new Insertion(drtRequest, entry, 0, 0);
 			var pickup = new PickupDetourInfo(start.time + TIME_TO_PICKUP + STOP_DURATION,
+					start.time + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP - TIME_REPLACED_DRIVE);
-			var dropoff = new DropoffDetourInfo(pickup.departureTime + TIME_FROM_PICKUP,
-					pickup.departureTime + TIME_FROM_PICKUP,
+			var dropoff = new DropoffDetourInfo(pickup.vehicleDepartureTime + TIME_FROM_PICKUP,
+					pickup.vehicleDepartureTime + TIME_FROM_PICKUP,
 					STOP_DURATION + TIME_FROM_DROPOFF);
 			insertions.add(insertion(insertion, pickup, dropoff));
 		}
 		{//01
 			var insertion = new Insertion(drtRequest, entry, 0, 1);
 			var pickup = new PickupDetourInfo(start.time + TIME_TO_PICKUP + STOP_DURATION,
+					start.time + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP - TIME_REPLACED_DRIVE);
 			var dropoff = new DropoffDetourInfo(stop0.getDepartureTime() + pickup.pickupTimeLoss + TIME_TO_DROPOFF,
 					stop0.getDepartureTime() + pickup.pickupTimeLoss + TIME_TO_DROPOFF,
@@ -198,6 +205,7 @@ public class InsertionGeneratorTest {
 		{//02
 			var insertion = new Insertion(drtRequest, entry, 0, 2);
 			var pickup = new PickupDetourInfo(start.time + TIME_TO_PICKUP + STOP_DURATION,
+					start.time + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP - TIME_REPLACED_DRIVE);
 			var dropoff = new DropoffDetourInfo(stop1.getDepartureTime() + pickup.pickupTimeLoss + TIME_TO_DROPOFF,
 					stop1.getDepartureTime() + pickup.pickupTimeLoss + TIME_TO_DROPOFF,
@@ -207,15 +215,17 @@ public class InsertionGeneratorTest {
 		{//11
 			var insertion = new Insertion(drtRequest, entry, 1, 1);
 			var pickup = new PickupDetourInfo(stop0.getDepartureTime() + TIME_TO_PICKUP + STOP_DURATION,
+					stop0.getDepartureTime() + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP - TIME_REPLACED_DRIVE);
-			var dropoff = new DropoffDetourInfo(pickup.departureTime + TIME_FROM_PICKUP,
-					pickup.departureTime + TIME_FROM_PICKUP,
+			var dropoff = new DropoffDetourInfo(pickup.vehicleDepartureTime + TIME_FROM_PICKUP,
+					pickup.vehicleDepartureTime + TIME_FROM_PICKUP,
 					STOP_DURATION + TIME_FROM_DROPOFF);
 			insertions.add(insertion(insertion, pickup, dropoff));
 		}
 		{//12
 			var insertion = new Insertion(drtRequest, entry, 1, 2);
 			var pickup = new PickupDetourInfo(stop0.getDepartureTime() + TIME_TO_PICKUP + STOP_DURATION,
+					stop0.getDepartureTime() + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP - TIME_REPLACED_DRIVE);
 			var dropoff = new DropoffDetourInfo(stop1.getDepartureTime() + pickup.pickupTimeLoss + TIME_TO_DROPOFF,
 					stop1.getDepartureTime() + pickup.pickupTimeLoss + TIME_TO_DROPOFF,
@@ -225,6 +235,7 @@ public class InsertionGeneratorTest {
 		{//22
 			var insertion = new Insertion(drtRequest, entry, 2, 2);
 			var pickup = new PickupDetourInfo(stop1.getDepartureTime() + TIME_TO_PICKUP + STOP_DURATION,
+					stop1.getDepartureTime() + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP);
 			var dropoff = new DropoffDetourInfo(stop1.getDepartureTime() + pickup.pickupTimeLoss, 
 					stop1.getDepartureTime() + pickup.pickupTimeLoss, STOP_DURATION);
@@ -252,6 +263,7 @@ public class InsertionGeneratorTest {
 		{//12
 			var insertion = new Insertion(drtRequest, entry, 1, 2);
 			var pickup = new PickupDetourInfo(stop0.getDepartureTime() + TIME_TO_PICKUP + STOP_DURATION,
+					stop0.getDepartureTime() + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP - TIME_REPLACED_DRIVE);
 			var dropoff = new DropoffDetourInfo(stop1.getDepartureTime() + pickup.pickupTimeLoss + TIME_TO_DROPOFF,
 					stop1.getDepartureTime() + pickup.pickupTimeLoss + TIME_TO_DROPOFF,
@@ -261,6 +273,7 @@ public class InsertionGeneratorTest {
 		{//22
 			var insertion = new Insertion(drtRequest, entry, 2, 2);
 			var pickup = new PickupDetourInfo(stop1.getDepartureTime() + TIME_TO_PICKUP + STOP_DURATION,
+					stop1.getDepartureTime() + TIME_TO_PICKUP + STOP_DURATION,
 					TIME_TO_PICKUP + STOP_DURATION + TIME_FROM_PICKUP);
 			var dropoff = new DropoffDetourInfo(stop1.getDepartureTime() + pickup.pickupTimeLoss, 
 					stop1.getDepartureTime() + pickup.pickupTimeLoss, STOP_DURATION);

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/extensive/ExtensiveInsertionProviderTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/extensive/ExtensiveInsertionProviderTest.java
@@ -113,6 +113,6 @@ public class ExtensiveInsertionProviderTest {
 
 	private InsertionWithDetourData insertionWithDetourData(Insertion insertion) {
 		return new InsertionWithDetourData(insertion, new InsertionDetourData(null, null, null, null),
-				new DetourTimeInfo(new PickupDetourInfo(11, Double.NaN), null));
+				new DetourTimeInfo(new PickupDetourInfo(11, 11, Double.NaN), null));
 	}
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/extensive/KNearestInsertionsAtEndFilterTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/extensive/KNearestInsertionsAtEndFilterTest.java
@@ -113,7 +113,7 @@ public class KNearestInsertionsAtEndFilterTest {
 		return new InsertionWithDetourData(new Insertion(vehicleEntry,
 				new InsertionPoint(pickupIdx, vehicleEntry.getWaypoint(pickupIdx), null,
 						vehicleEntry.getWaypoint(pickupIdx + 1)), null, loadType.fromInt(1)), null,
-				new DetourTimeInfo(new PickupDetourInfo(pickupDepartureTime, Double.NaN), null));
+				new DetourTimeInfo(new PickupDetourInfo(pickupDepartureTime, pickupDepartureTime, Double.NaN), null));
 	}
 
 	private Waypoint.Start start(double endTime) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/prebooking/PrebookingTestEnvironment.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/prebooking/PrebookingTestEnvironment.java
@@ -23,6 +23,7 @@ import org.matsim.api.core.v01.population.Population;
 import org.matsim.api.core.v01.population.PopulationFactory;
 import org.matsim.contrib.common.zones.systems.grid.square.SquareGridZoneSystemParams;
 import org.matsim.contrib.drt.optimizer.constraints.DrtOptimizationConstraintsSetImpl;
+import org.matsim.contrib.drt.optimizer.insertion.DetourTimeEstimator;
 import org.matsim.contrib.drt.optimizer.insertion.DrtInsertionSearchParams;
 import org.matsim.contrib.drt.optimizer.insertion.selective.SelectiveInsertionSearchParams;
 import org.matsim.contrib.drt.passenger.events.DrtRequestSubmittedEvent;
@@ -47,6 +48,7 @@ import org.matsim.contrib.dvrp.passenger.PassengerPickedUpEventHandler;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestRejectedEvent;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestRejectedEventHandler;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
+import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
 import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
 import org.matsim.contrib.dvrp.run.DvrpModule;
 import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
@@ -64,6 +66,11 @@ import org.matsim.core.config.groups.ScoringConfigGroup.ModeParams;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
+import org.matsim.core.router.costcalculators.OnlyTimeDependentTravelDisutility;
+import org.matsim.core.router.speedy.SpeedyALTFactory;
+import org.matsim.core.router.util.LeastCostPathCalculator;
+import org.matsim.core.router.util.TravelDisutility;
+import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.testcases.MatsimTestUtils;
 
@@ -84,6 +91,8 @@ public class PrebookingTestEnvironment {
 	private double detourAbsolute = 300.0;
 	private double stopDuration = 60.0;
 	private double endTime = 30.0 * 3600.0;
+
+	private boolean useExactTravelTimeEstimates = false;
 
 	public PrebookingTestEnvironment(MatsimTestUtils utils) {
 		this.utils = utils;
@@ -166,6 +175,11 @@ public class PrebookingTestEnvironment {
 		return this;
 	}
 
+	public PrebookingTestEnvironment useExactTravelTimeEstimates() {
+		this.useExactTravelTimeEstimates = true;
+		return this;
+	}
+
 	public Controler build() {
 		Config config = ConfigUtils.createConfig();
 		buildConfig(config);
@@ -188,6 +202,7 @@ public class PrebookingTestEnvironment {
 
 		return controller;
 	}
+
 
 	private void buildFleet(Controler controller) {
 		FleetSpecification fleetSpecification = new FleetSpecificationImpl();
@@ -217,6 +232,24 @@ public class PrebookingTestEnvironment {
 
 		MultiModeDrtConfigGroup multiModeDrtConfigGroup = MultiModeDrtConfigGroup.get(controller.getConfig());
 		controller.configureQSimComponents(DvrpQSimComponents.activateAllModes(multiModeDrtConfigGroup));
+
+		if (useExactTravelTimeEstimates) {
+			for (var mode : MultiModeDrtConfigGroup.get(controller.getConfig()).getModalElements()) {
+				controller.addOverridingQSimModule(new AbstractDvrpModeQSimModule(mode.getMode()) {
+					@Override
+					protected void configureQSim() {
+						bindModal(DetourTimeEstimator.class).toProvider(modalProvider(getter -> {
+							Network network = getter.getModal(Network.class);
+							TravelTime travelTime = getter.getModal(TravelTime.class);
+							TravelDisutility travelDisutility = new OnlyTimeDependentTravelDisutility(travelTime);
+
+							LeastCostPathCalculator router = new SpeedyALTFactory().createPathCalculator(network, travelDisutility, travelTime);
+							return DetourTimeEstimator.createExactEstimator(router);
+						}));
+					}
+				});
+			}
+		}
 	}
 
 	private void buildConfig(Config config) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/prebooking/PrebookingTestEnvironment.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/prebooking/PrebookingTestEnvironment.java
@@ -244,7 +244,7 @@ public class PrebookingTestEnvironment {
 							TravelDisutility travelDisutility = new OnlyTimeDependentTravelDisutility(travelTime);
 
 							LeastCostPathCalculator router = new SpeedyALTFactory().createPathCalculator(network, travelDisutility, travelTime);
-							return DetourTimeEstimator.createExactEstimator(router);
+							return DetourTimeEstimator.createExactEstimator(router, travelTime);
 						}));
 					}
 				});

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/prebooking/VariableStopDurationTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/prebooking/VariableStopDurationTest.java
@@ -1,0 +1,391 @@
+package org.matsim.contrib.drt.prebooking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.matsim.contrib.drt.passenger.DrtRequest;
+import org.matsim.contrib.drt.prebooking.PrebookingTestEnvironment.RequestInfo;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.drt.stops.PassengerStopDurationProvider;
+import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
+import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
+import org.matsim.core.controler.Controler;
+import org.matsim.core.utils.collections.Tuple;
+import org.matsim.testcases.MatsimTestUtils;
+
+/**
+ * @author Sebastian Hörl (sebhoerl) / IRT SystemX
+ */
+public class VariableStopDurationTest {
+	@RegisterExtension
+	private MatsimTestUtils utils = new MatsimTestUtils();
+
+	static void prepare(Controler controller) {
+		DrtConfigGroup drtConfig = DrtConfigGroup.getSingleModeDrtConfig(controller.getConfig());
+		drtConfig.addParameterSet(new PrebookingParams());
+	}
+
+	private class CustomStopDurationProvider implements PassengerStopDurationProvider {
+		private final Map<String, Tuple<Double, Double>> data = new HashMap<>();
+
+		@Override
+		public double calcPickupDuration(DvrpVehicle vehicle, DrtRequest request) {
+			return data.get(request.getPassengerIds().get(0).toString()).getFirst();
+		}
+
+		@Override
+		public double calcDropoffDuration(DvrpVehicle vehicle, DrtRequest request) {
+			return data.get(request.getPassengerIds().get(0).toString()).getSecond();
+		}
+
+		public CustomStopDurationProvider define(String personId, double pickupDuration, double dropoffDuration) {
+			data.put(personId, Tuple.of(pickupDuration, dropoffDuration));
+			return this;
+		}
+
+		public void install(Controler controller) {
+			DrtConfigGroup drtConfig = DrtConfigGroup.getSingleModeDrtConfig(controller.getConfig());
+			PassengerStopDurationProvider self = this;
+
+			controller.addOverridingModule(new AbstractDvrpModeModule(drtConfig.getMode()) {
+				@Override
+				public void install() {
+					bindModal(PassengerStopDurationProvider.class).toInstance(self);
+				}
+			});
+		}
+	}
+
+	@Test
+	void oneRequestAtDetourLimit() {
+		/*-
+		 * One agent is dispatched and we set the absolute allowed detour 
+		 * such that he can just arrive, one second later, and we need to reject him.
+		 * 
+		 * This means if we increase the pickup duration or the dropoff duration, the
+		 * request should be rejected (see following tests).
+		 */
+		double absoluteDetour = 232.0;
+
+		PrebookingTestEnvironment environment = new PrebookingTestEnvironment(utils) //
+				.configure(600.0, 1.0, absoluteDetour, 60.0) //
+				.addVehicle("vehicleA", 0, 0) //
+				.addRequest("personA", 1, 0, 7, 0, 1000.0) //
+				.endTime(10.0 * 3600.0);
+
+		Controler controller = environment.build();
+		prepare(controller);
+
+		new CustomStopDurationProvider() //
+				.define("personA", 60.0, 60.0) //
+				.install(controller);
+
+		controller.run();
+
+		RequestInfo requestA = environment.getRequestInfo().get("personA");
+		assertEquals(1000.0, requestA.submissionTime, 1e-3);
+		assertEquals(1083.0, requestA.pickupTime, 1e-3);
+		assertEquals(1270.0, requestA.dropoffTime, 1e-3);
+	}
+
+	@Test
+	void oneRequestExceedingDetourLimitThroughPickup() {
+		// see previous test
+		double absoluteDetour = 232.0;
+
+		PrebookingTestEnvironment environment = new PrebookingTestEnvironment(utils) //
+				.configure(600.0, 1.0, absoluteDetour, 60.0) //
+				.addVehicle("vehicleA", 0, 0) //
+				.addRequest("personA", 1, 0, 7, 0, 1000.0) //
+				.endTime(10.0 * 3600.0);
+
+		Controler controller = environment.build();
+		prepare(controller);
+
+		new CustomStopDurationProvider() //
+				.define("personA", 60.0 + 1.0, 60.0) //
+				.install(controller);
+
+		controller.run();
+
+		RequestInfo requestA = environment.getRequestInfo().get("personA");
+		assertTrue(Double.isNaN(requestA.pickupTime));
+	}
+
+	@Test
+	void oneRequestExceedingDetourLimitThroughDropoff() {
+		// see previous test
+		double absoluteDetour = 232.0;
+
+		PrebookingTestEnvironment environment = new PrebookingTestEnvironment(utils) //
+				.configure(600.0, 1.0, absoluteDetour, 60.0) //
+				.addVehicle("vehicleA", 0, 0) //
+				.addRequest("personA", 1, 0, 7, 0, 1000.0) //
+				.endTime(10.0 * 3600.0);
+
+		Controler controller = environment.build();
+		prepare(controller);
+
+		new CustomStopDurationProvider() //
+				.define("personA", 60.0, 60.0 + 1.0) //
+				.install(controller);
+
+		controller.run();
+
+		RequestInfo requestA = environment.getRequestInfo().get("personA");
+		assertTrue(Double.isNaN(requestA.pickupTime));
+	}
+
+	@Test
+	void oneRequestAtWaitTimeLimit() {
+		/*-
+		 * One agent is dispatched and we set the allowed wait time
+		 * such that he can just be picked up. One second later, and we need to reject him.
+		 * 
+		 * This means if we increase the pickup duration, the
+		 * request should be rejected (see following test).
+		 */
+		double maximumWaitTime = 105.0;
+
+		PrebookingTestEnvironment environment = new PrebookingTestEnvironment(utils) //
+				.configure(maximumWaitTime, 1.0, 1000.0, 60.0) //
+				.addVehicle("vehicleA", 0, 0) //
+				.addRequest("personA", 1, 0, 7, 0, 1000.0) //
+				.endTime(10.0 * 3600.0);
+
+		Controler controller = environment.build();
+		prepare(controller);
+
+		new CustomStopDurationProvider() //
+				.define("personA", 60.0, 60.0) //
+				.install(controller);
+
+		controller.run();
+
+		RequestInfo requestA = environment.getRequestInfo().get("personA");
+		assertEquals(1000.0, requestA.submissionTime, 1e-3);
+		assertEquals(1083.0, requestA.pickupTime, 1e-3);
+		assertEquals(1270.0, requestA.dropoffTime, 1e-3);
+	}
+
+	@Test
+	void oneRequestOverWaitTimeLimit() {
+		// see above
+		double maximumWaitTime = 105.0;
+
+		PrebookingTestEnvironment environment = new PrebookingTestEnvironment(utils) //
+				.configure(maximumWaitTime, 1.0, 1000.0, 60.0) //
+				.addVehicle("vehicleA", 0, 0) //
+				.addRequest("personA", 1, 0, 7, 0, 1000.0) //
+				.endTime(10.0 * 3600.0);
+
+		Controler controller = environment.build();
+		prepare(controller);
+
+		new CustomStopDurationProvider() //
+				.define("personA", 60.0 + 1.0, 60.0) //
+				.install(controller);
+
+		controller.run();
+
+		RequestInfo requestA = environment.getRequestInfo().get("personA");
+		assertTrue(Double.isNaN(requestA.pickupTime));
+	}
+
+	@Test
+	void twoParallelRequests() {
+		/*-
+		 * - We dispatch the first request
+		 * - Another request is picked up and dropped off along the way
+		 * - We adjust the maximum detour of the first request such that
+		 *   we find a viable insertion of the second one (with fixed dropoff time)
+		 * - If we now increase the dropoff time of the second request, we should not 
+		 *   find an insertion anymore (see next test).
+		 * 
+		 * - Same concept for the wait time
+		 */
+		double absoluteDetour = 267.0;
+
+		PrebookingTestEnvironment environment = new PrebookingTestEnvironment(utils) //
+				.configure(600.0, 1.0, absoluteDetour, 60.0) //
+				.addVehicle("vehicleA", 0, 0) //
+				.addRequest("personA", 1, 0, 7, 0, 1000.0) //
+				.addRequest("personB", 3, 0, 5, 0, 1005.0) //
+				.endTime(10.0 * 3600.0);
+
+		Controler controller = environment.build();
+		prepare(controller);
+
+		new CustomStopDurationProvider() //
+				.define("personA", 60.0, 60.0) //
+				.define("personB", 60.0, 60.0) //
+				.install(controller);
+
+		controller.run();
+
+		RequestInfo requestA = environment.getRequestInfo().get("personA");
+		assertEquals(1083.0, requestA.pickupTime, 1e-3);
+
+		RequestInfo requestB = environment.getRequestInfo().get("personB");
+		assertEquals(1186.0, requestB.pickupTime, 1e-3);
+	}
+
+	@Test
+	void twoParallelRequestsPushingDropoffViaIncreasingDropoff() {
+		// see above
+		double absoluteDetour = 267.0;
+
+		PrebookingTestEnvironment environment = new PrebookingTestEnvironment(utils) //
+				.configure(600.0, 1.0, absoluteDetour, 60.0) //
+				.addVehicle("vehicleA", 0, 0) //
+				.addRequest("personA", 1, 0, 7, 0, 1000.0) //
+				.addRequest("personB", 3, 0, 5, 0, 1005.0) //
+				.endTime(10.0 * 3600.0);
+
+		Controler controller = environment.build();
+		prepare(controller);
+
+		new CustomStopDurationProvider() //
+				.define("personA", 60.0, 60.0) //
+				.define("personB", 60.0, 60.0 + 5.0) //
+				.install(controller);
+
+		controller.run();
+
+		RequestInfo requestA = environment.getRequestInfo().get("personA");
+		assertEquals(1083.0, requestA.pickupTime, 1e-3);
+
+		RequestInfo requestB = environment.getRequestInfo().get("personB");
+		assertTrue(Double.isNaN(requestB.pickupTime)); // expecting rejection
+	}
+
+	@Test
+	void twoParallelRequestsPushingDropoffViaIncreasingPickup() {
+		// see above
+		double absoluteDetour = 267.0;
+
+		PrebookingTestEnvironment environment = new PrebookingTestEnvironment(utils) //
+				.configure(600.0, 1.0, absoluteDetour, 60.0) //
+				.addVehicle("vehicleA", 0, 0) //
+				.addRequest("personA", 1, 0, 7, 0, 1000.0) //
+				.addRequest("personB", 3, 0, 5, 0, 1005.0) //
+				.endTime(10.0 * 3600.0);
+
+		Controler controller = environment.build();
+		prepare(controller);
+
+		new CustomStopDurationProvider() //
+				.define("personA", 60.0, 60.0) //
+				.define("personB", 60.0 + 5.0, 60.0) //
+				.install(controller);
+
+		controller.run();
+
+		RequestInfo requestA = environment.getRequestInfo().get("personA");
+		assertEquals(1083.0, requestA.pickupTime, 1e-3);
+
+		RequestInfo requestB = environment.getRequestInfo().get("personB");
+		assertTrue(Double.isNaN(requestB.pickupTime)); // expecting rejection
+	}
+
+	@Test
+	void twoSequentialRequests() {
+		/*-
+		 * - We dispatch the first request
+		 * - Another request is picked up and dropped off before
+		 * - We adjust the maximum wait time of the first request such that
+		 *   we find a viable insertion of the second one (with fixed dropoff time)
+		 * - If we now increase the dropoff time of the second request, we should not 
+		 *   find an insertion anymore (see next test).
+		 * 
+		 * - Same concept for the wait time
+		 */
+		double maximumWaitTime = 315.0;
+
+		PrebookingTestEnvironment environment = new PrebookingTestEnvironment(utils) //
+				.configure(maximumWaitTime, 1.0, 1000.0, 60.0) //
+				.addVehicle("vehicleA", 0, 0) //
+				.addRequest("personA", 6, 0, 8, 0, 1000.0) //
+				.addRequest("personB", 3, 0, 5, 0, 1001.0) //
+				.endTime(10.0 * 3600.0);
+
+		Controler controller = environment.build();
+		prepare(controller);
+
+		new CustomStopDurationProvider() //
+				.define("personA", 60.0, 60.0) //
+				.define("personB", 60.0, 60.0) //
+				.install(controller);
+
+		controller.run();
+
+		RequestInfo requestA = environment.getRequestInfo().get("personA");
+		assertEquals(1310.0, requestA.pickupTime, 1e-3);
+
+		RequestInfo requestB = environment.getRequestInfo().get("personB");
+		assertEquals(1125.0, requestB.pickupTime, 1e-3);
+	}
+
+	@Test
+	void twoSequentialRequestsPushingPickupViaIncreasingDropoff() {
+		// see above
+		double maximumWaitTime = 315.0;
+
+		PrebookingTestEnvironment environment = new PrebookingTestEnvironment(utils) //
+				.configure(maximumWaitTime, 1.0, 1000.0, 60.0) //
+				.addVehicle("vehicleA", 0, 0) //
+				.addRequest("personA", 6, 0, 8, 0, 1000.0) //
+				.addRequest("personB", 3, 0, 5, 0, 1001.0) //
+				.endTime(10.0 * 3600.0);
+
+		Controler controller = environment.build();
+		prepare(controller);
+
+		new CustomStopDurationProvider() //
+				.define("personA", 60.0, 60.0) //
+				.define("personB", 60.0, 60.0 + 1.0) //
+				.install(controller);
+
+		controller.run();
+
+		RequestInfo requestA = environment.getRequestInfo().get("personA");
+		assertEquals(1311.0, requestA.pickupTime, 1e-3); // expecting no delay
+
+		RequestInfo requestB = environment.getRequestInfo().get("personB");
+		assertTrue(Double.isNaN(requestB.pickupTime)); // expecting rejection
+	}
+
+	@Test
+	void twoSequentialRequestsPushingPickupViaIncreasingPickup() {
+		// see above
+		double maximumWaitTime = 315.0;
+
+		PrebookingTestEnvironment environment = new PrebookingTestEnvironment(utils) //
+				.configure(maximumWaitTime, 1.0, 1000.0, 60.0) //
+				.addVehicle("vehicleA", 0, 0) //
+				.addRequest("personA", 6, 0, 8, 0, 1000.0) //
+				.addRequest("personB", 3, 0, 5, 0, 1001.0) //
+				.endTime(10.0 * 3600.0);
+
+		Controler controller = environment.build();
+		prepare(controller);
+
+		new CustomStopDurationProvider() //
+				.define("personA", 60.0, 60.0) //
+				.define("personB", 60.0 + 1.0, 60.0) //
+				.install(controller);
+
+		controller.run();
+
+		RequestInfo requestA = environment.getRequestInfo().get("personA");
+		assertEquals(1310.0, requestA.pickupTime, 1e-3); // expecting no delay
+
+		RequestInfo requestB = environment.getRequestInfo().get("personB");
+		assertTrue(Double.isNaN(requestB.pickupTime)); // expecting rejection
+	}
+}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/prebooking/VariableStopDurationTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/prebooking/VariableStopDurationTest.java
@@ -70,7 +70,7 @@ public class VariableStopDurationTest {
 		 * This means if we increase the pickup duration or the dropoff duration, the
 		 * request should be rejected (see following tests).
 		 */
-		double absoluteDetour = 232.0;
+		double absoluteDetour = 292.0;
 
 		PrebookingTestEnvironment environment = new PrebookingTestEnvironment(utils) //
 				.configure(600.0, 1.0, absoluteDetour, 60.0) //
@@ -96,7 +96,7 @@ public class VariableStopDurationTest {
 	@Test
 	void oneRequestExceedingDetourLimitThroughPickup() {
 		// see previous test
-		double absoluteDetour = 232.0;
+		double absoluteDetour = 292.0;
 
 		PrebookingTestEnvironment environment = new PrebookingTestEnvironment(utils) //
 				.configure(600.0, 1.0, absoluteDetour, 60.0) //
@@ -120,7 +120,7 @@ public class VariableStopDurationTest {
 	@Test
 	void oneRequestExceedingDetourLimitThroughDropoff() {
 		// see previous test
-		double absoluteDetour = 232.0;
+		double absoluteDetour = 292.0;
 
 		PrebookingTestEnvironment environment = new PrebookingTestEnvironment(utils) //
 				.configure(600.0, 1.0, absoluteDetour, 60.0) //
@@ -209,7 +209,7 @@ public class VariableStopDurationTest {
 		 * 
 		 * - Same concept for the wait time
 		 */
-		double absoluteDetour = 267.0;
+		double absoluteDetour = 327.0;
 
 		PrebookingTestEnvironment environment = new PrebookingTestEnvironment(utils) //
 				.configure(600.0, 1.0, absoluteDetour, 60.0) //
@@ -238,7 +238,7 @@ public class VariableStopDurationTest {
 	@Test
 	void twoParallelRequestsPushingDropoffViaIncreasingDropoff() {
 		// see above
-		double absoluteDetour = 267.0;
+		double absoluteDetour = 327.0;
 
 		PrebookingTestEnvironment environment = new PrebookingTestEnvironment(utils) //
 				.configure(600.0, 1.0, absoluteDetour, 60.0) //
@@ -267,7 +267,7 @@ public class VariableStopDurationTest {
 	@Test
 	void twoParallelRequestsPushingDropoffViaIncreasingPickup() {
 		// see above
-		double absoluteDetour = 267.0;
+		double absoluteDetour = 327.0;
 
 		PrebookingTestEnvironment environment = new PrebookingTestEnvironment(utils) //
 				.configure(600.0, 1.0, absoluteDetour, 60.0) //
@@ -331,7 +331,7 @@ public class VariableStopDurationTest {
 		assertEquals(1125.0, requestB.pickupTime, 1e-3);
 	}
 
-	@Test
+	@Test // FAILING
 	void twoSequentialRequestsPushingPickupViaIncreasingDropoff() {
 		// see above
 		double maximumWaitTime = 315.0;
@@ -360,7 +360,7 @@ public class VariableStopDurationTest {
 		assertTrue(Double.isNaN(requestB.pickupTime)); // expecting rejection
 	}
 
-	@Test
+	@Test // FAILING
 	void twoSequentialRequestsPushingPickupViaIncreasingPickup() {
 		// see above
 		double maximumWaitTime = 315.0;

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/run/examples/RunDrtExampleIT.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/run/examples/RunDrtExampleIT.java
@@ -349,11 +349,11 @@ public class RunDrtExampleIT {
 		controller.run();
 
 		var expectedStats = Stats.newBuilder()
-				.rejectionRate(0.05)
-				.rejections(18)
-				.waitAverage(276.95)
-				.inVehicleTravelTimeMean(384.72)
-				.totalTravelTimeMean(661.66)
+				.rejectionRate(0.07)
+				.rejections(26)
+				.waitAverage(276.37)
+				.inVehicleTravelTimeMean(381.99)
+				.totalTravelTimeMean(658.36)
 				.build();
 
 		verifyDrtCustomerStatsCloseToExpectedStats(utils.getOutputDirectory(), expectedStats);

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionSchedulerTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionSchedulerTest.java
@@ -189,7 +189,10 @@ public class DefaultRequestInsertionSchedulerTest {
     private InsertionDetourTimeCalculator.DetourTimeInfo detourTimeInfo() {
         return new InsertionDetourTimeCalculator.DetourTimeInfo(
                 new InsertionDetourTimeCalculator.PickupDetourInfo(R1_PU_TIME + STOP_DURATION, 0.),
-                new InsertionDetourTimeCalculator.DropoffDetourInfo(R1_PU_TIME + STOP_DURATION + DRIVE_TIME, 20.)
+                new InsertionDetourTimeCalculator.DropoffDetourInfo(
+                    R1_PU_TIME + STOP_DURATION + DRIVE_TIME,
+                    R1_PU_TIME + STOP_DURATION + DRIVE_TIME,
+                    20.)
         );
     }
 

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionSchedulerTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionSchedulerTest.java
@@ -188,7 +188,7 @@ public class DefaultRequestInsertionSchedulerTest {
 
     private InsertionDetourTimeCalculator.DetourTimeInfo detourTimeInfo() {
         return new InsertionDetourTimeCalculator.DetourTimeInfo(
-                new InsertionDetourTimeCalculator.PickupDetourInfo(R1_PU_TIME + STOP_DURATION, 0.),
+                new InsertionDetourTimeCalculator.PickupDetourInfo(R1_PU_TIME + STOP_DURATION, R1_PU_TIME + STOP_DURATION, 0.),
                 new InsertionDetourTimeCalculator.DropoffDetourInfo(
                     R1_PU_TIME + STOP_DURATION + DRIVE_TIME,
                     R1_PU_TIME + STOP_DURATION + DRIVE_TIME,


### PR DESCRIPTION
Currently, when using custom stop durations (only available when prebooking is active), pickup and dropoff times can be slightly exceeded. The cause of this is that the `InsertionGenerator` and (more severly) the `DefaultInsertionCostCalculator` make the assumption that pickups happen at the end of a stop task and dropoffs happen at the beginning of a stop task. This is not the case any more when custom stop durations are used, so the "vehicle arrival time" at a stop is not any more necessary equal to the "request dropoff time", and the "vehicle departure time" at a stop is not any more necessarily equal to the "request pickup time". 

The present PR fixes the issue by renaming the old departure/arrival times to vehicleDepartureTime and vehicleArrivalTime, and by dragging the requestPickupTiome and requestDropoffTime along the dispatching process.

A comprehensive set of unit tests (`VariableStopDurationTest`) has been added.

Fixes #3757.
Ping #3922.

**TODO**
- [ ] I left some small comments in the `shifts` package. It would be great if you can have a look, I don't really have the deep understanding to say whether, in some places, you'd rather like to test for the "vehicle arrival time" or the "request dropoff time". I think it is the former and implemented it this way, but please verify.