### PR TITLE
feat: make DvrpLoad comparable

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/load/DvrpLoad.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/load/DvrpLoad.java
@@ -30,7 +30,7 @@ package org.matsim.contrib.dvrp.load;
  * 
  * @author Tarek Chouaki (tkchouaki), IRT SystemX
  */
-public interface DvrpLoad {
+public interface DvrpLoad extends Comparable<DvrpLoad> {
 	/**
 	 * @param other : Another DvrpVehicleLoad of the same implementation as the
 	 *              current one.

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/load/IntegerLoad.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/load/IntegerLoad.java
@@ -54,6 +54,15 @@ public class IntegerLoad implements DvrpLoad {
 	}
 
 	@Override
+    public int compareTo(DvrpLoad other) {
+        if (other instanceof IntegerLoad otherLoad) {
+			return Integer.compare(value, otherLoad.value);
+        }
+
+        throw new IllegalStateException();
+    }
+
+	@Override
 	public boolean equals(Object other) {
 		if (other instanceof IntegerLoad otherLoad) {
 			return this.value == otherLoad.value;

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/load/IntegersLoad.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/load/IntegersLoad.java
@@ -69,6 +69,26 @@ public class IntegersLoad implements DvrpLoad {
     }
 
     @Override
+    public int compareTo(DvrpLoad other) {
+        if (other instanceof IntegersLoad otherLoad) {
+            if (values.length != otherLoad.values.length) {
+                return Integer.compare(values.length, otherLoad.values.length);
+            }
+
+            int result = 0;
+
+            for (int i = 0; i < values.length; i++) {
+                result = Integer.compare(values[i], otherLoad.values[i]);
+                if (result != 0) break;
+            }
+
+            return result;
+        }
+
+        throw new IllegalStateException();
+    }
+
+    @Override
     public boolean equals(Object other) {
         if (other instanceof IntegersLoad otherLoad) {
             if (values.length == otherLoad.values.length) {


### PR DESCRIPTION
Add `Comparable` interface to `DvrpLoad` and provide implementations for `IntegerLoad` and `IntegersLoad`.