### PR TITLE
feat(freight:carriers): Take roadpricing into account when running jsprit from CarrierUtils.runJsprit(...)

### DIFF
--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
@@ -40,7 +40,6 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.population.Plan;
 import org.matsim.contrib.roadpricing.RoadPricingScheme;
 import org.matsim.contrib.roadpricing.RoadPricingUtils;
@@ -51,7 +50,6 @@ import org.matsim.freight.carriers.consistency_checkers.CarrierConsistencyChecke
 import org.matsim.freight.carriers.jsprit.MatsimJspritFactory;
 import org.matsim.freight.carriers.jsprit.NetworkBasedTransportCosts;
 import org.matsim.freight.carriers.jsprit.NetworkRouter;
-import org.matsim.freight.logistics.resourceImplementations.ResourceImplementationUtils;
 import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
@@ -231,7 +231,7 @@ public class CarriersUtils {
 		try {
 			roadPricingScheme = RoadPricingUtils.getRoadPricingScheme(scenario);
 		} catch (Exception e) {
-			log.debug("Was not able to get a RoadPricingScheme from sceanrio. Tolls cannot be considered.", e);
+			log.debug("Was not able to get a RoadPricingScheme from scenario. Tolls cannot be considered.", e);
 		}
 
 		final NetworkBasedTransportCosts netBasedCosts = NetworkBasedTransportCosts.Builder.newInstance(scenario.getNetwork(), getOrAddCarrierVehicleTypes(scenario).getVehicleTypes().values())

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
@@ -235,7 +235,7 @@ public class CarriersUtils {
 		}
 
 		final NetworkBasedTransportCosts netBasedCosts = NetworkBasedTransportCosts.Builder.newInstance(scenario.getNetwork(), getOrAddCarrierVehicleTypes(scenario).getVehicleTypes().values())
-				.setRoadPricingScheme(roadPricingScheme != null ? roadPricingScheme : null)
+				.setRoadPricingScheme(roadPricingScheme)
 				.build();
 
 

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/NetworkBasedTransportCosts.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/NetworkBasedTransportCosts.java
@@ -28,6 +28,9 @@ import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
@@ -42,6 +45,7 @@ import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.utils.misc.Counter;
 import org.matsim.freight.carriers.CarrierVehicle;
+import org.matsim.freight.carriers.CarriersUtils;
 import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.utils.objectattributes.attributable.AttributesImpl;
 import org.matsim.vehicles.VehicleType;
@@ -83,6 +87,8 @@ import org.matsim.vehicles.VehicleUtils;
  *
  */
 public class NetworkBasedTransportCosts implements VRPTransportCosts {
+
+	private static final Logger log = LogManager.getLogger(NetworkBasedTransportCosts.class);
 
 	public interface InternalLeastCostPathCalculatorListener {
 

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/NetworkBasedTransportCosts.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/NetworkBasedTransportCosts.java
@@ -435,8 +435,12 @@ public class NetworkBasedTransportCosts implements VRPTransportCosts {
 		}
 
 		public Builder setRoadPricingScheme( RoadPricingScheme roadPricingScheme) {
-			withToll = true;
-			this.roadPricingScheme = roadPricingScheme;
+			if (roadPricingScheme != null) {
+				withToll = true;
+				this.roadPricingScheme = roadPricingScheme;
+			} else {
+				log.debug("RoadPricingScheme is null. Tolls cannot be considered.");
+			}
 			return this;
 		}
 


### PR DESCRIPTION
With this PR the Utils class `CarrierUtils.runJsprit(...)` now looks whether a `RoadPricingScheme` exists or not.
If it exists, it will be considered in the calculation of the `NetworkBasedCosts`.
If not, nothing changes.

This allows, to use the utils method also when running scenarios with tolls. (Before that, I used a copy of it and manually added the rpScheme -.-)

Closes #1367 