### PR TITLE
feat(drt-extension): preemptive rejection

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/DrtWithExtensionsConfigGroup.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/DrtWithExtensionsConfigGroup.java
@@ -19,17 +19,19 @@
 
 package org.matsim.contrib.drt.extension;
 
+import java.util.Optional;
+import java.util.function.Supplier;
+
 import org.matsim.contrib.drt.extension.companions.DrtCompanionParams;
 import org.matsim.contrib.drt.extension.insertion.spatialFilter.DrtSpatialRequestFleetFilterParams;
 import org.matsim.contrib.drt.extension.operations.DrtOperationsParams;
+import org.matsim.contrib.drt.extension.preemptive_rejection.PreemptiveRejectionParams;
 import org.matsim.contrib.drt.extension.services.services.params.DrtServicesParams;
-import org.matsim.contrib.drt.optimizer.constraints.DrtOptimizationConstraintsSetImpl;
 import org.matsim.contrib.drt.optimizer.constraints.DrtOptimizationConstraintsSet;
+import org.matsim.contrib.drt.optimizer.constraints.DrtOptimizationConstraintsSetImpl;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 
 import jakarta.annotation.Nullable;
-import java.util.Optional;
-import java.util.function.Supplier;
 
 /**
  * @author Steffen Axer
@@ -49,6 +51,9 @@ public class DrtWithExtensionsConfigGroup extends DrtConfigGroup {
 
 	@Nullable
 	private DrtSpatialRequestFleetFilterParams drtSpatialRequestFleetFilterParams;
+
+	@Nullable
+	private PreemptiveRejectionParams preemptiveRejectionParams;
 
 	public DrtWithExtensionsConfigGroup() {
 		this(DrtOptimizationConstraintsSetImpl::new);
@@ -71,6 +76,10 @@ public class DrtWithExtensionsConfigGroup extends DrtConfigGroup {
 		// Optional
 		addDefinition(DrtSpatialRequestFleetFilterParams.SET_NAME, DrtSpatialRequestFleetFilterParams::new, () -> drtSpatialRequestFleetFilterParams,
 			params -> drtSpatialRequestFleetFilterParams = (DrtSpatialRequestFleetFilterParams) params);
+
+		// Optional
+		addDefinition(PreemptiveRejectionParams.SET_NAME, PreemptiveRejectionParams::new, 
+			() -> preemptiveRejectionParams, params -> preemptiveRejectionParams = (PreemptiveRejectionParams) params);
 	}
 
 	public Optional<DrtCompanionParams> getDrtCompanionParams() {
@@ -87,5 +96,9 @@ public class DrtWithExtensionsConfigGroup extends DrtConfigGroup {
 
 	public Optional<DrtSpatialRequestFleetFilterParams> getSpatialRequestFleetFilterParams() {
 		return Optional.ofNullable(drtSpatialRequestFleetFilterParams);
+	}
+
+	public Optional<PreemptiveRejectionParams> getPreemptiveRejectionParams() {
+		return Optional.ofNullable(preemptiveRejectionParams);
 	}
 }

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preemptive_rejection/PreemptiveRejectionHandler.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preemptive_rejection/PreemptiveRejectionHandler.java
@@ -1,0 +1,109 @@
+package org.matsim.contrib.drt.extension.preemptive_rejection;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang.mutable.MutableInt;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.contrib.drt.passenger.events.DrtRequestSubmittedEvent;
+import org.matsim.contrib.drt.passenger.events.DrtRequestSubmittedEventHandler;
+import org.matsim.contrib.dvrp.passenger.PassengerRequestRejectedEvent;
+import org.matsim.contrib.dvrp.passenger.PassengerRequestRejectedEventHandler;
+import org.matsim.core.controler.events.IterationEndsEvent;
+import org.matsim.core.controler.events.ShutdownEvent;
+import org.matsim.core.controler.listener.IterationEndsListener;
+import org.matsim.core.controler.listener.ShutdownListener;
+import org.matsim.core.utils.io.IOUtils;
+
+public class PreemptiveRejectionHandler
+        implements DrtRequestSubmittedEventHandler, PassengerRequestRejectedEventHandler, IterationEndsListener,
+        ShutdownListener {
+    private final Population population;
+    private final BufferedWriter writer;
+    private final String mode;
+
+    private final Map<String, MutableInt> submitted = new HashMap<>();
+    private final Map<String, MutableInt> rejected = new HashMap<>();
+    private final Map<String, MutableInt> rejectedPreemptive = new HashMap<>();
+    private boolean writeHeader = true;
+
+    public PreemptiveRejectionHandler(String mode, Population population, String outputPath) {
+        this.mode = mode;
+        this.population = population;
+        this.writer = IOUtils.getBufferedWriter(outputPath.toString());
+    }
+
+    @Override
+    public void handleEvent(PassengerRequestRejectedEvent event) {
+        if (event.getMode().equals(mode)) {
+            String bookingClass = PreemptiveRejectionOptimizer.getBookingClass(population, event.getPersonIds());
+
+            synchronized (rejected) {
+                rejected.computeIfAbsent(bookingClass, c -> new MutableInt()).increment();
+            }
+
+            if (PreemptiveRejectionOptimizer.CAUSE.equals(event.getCause())) {
+                synchronized (rejectedPreemptive) {
+                    rejectedPreemptive.computeIfAbsent(bookingClass, c -> new MutableInt()).increment();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void handleEvent(DrtRequestSubmittedEvent event) {
+        if (event.getMode().equals(mode)) {
+            String bookingClass = PreemptiveRejectionOptimizer.getBookingClass(population, event.getPersonIds());
+
+            synchronized (submitted) {
+                submitted.computeIfAbsent(bookingClass, c -> new MutableInt()).increment();
+            }
+        }
+    }
+
+    @Override
+    public void notifyIterationEnds(IterationEndsEvent event) {
+        int iteration = event.getIteration();
+
+        try {
+            if (writeHeader) {
+                writer.write(String.join(";", new String[] {
+                        "iteration",
+                        "booking_class",
+                        "submitted",
+                        "rejected",
+                        "preemptive"
+                }) + "\n");
+            }
+
+            for (String bookingClass : submitted.keySet()) {
+                writer.write(String.join(";", new String[] {
+                        String.valueOf(iteration),
+                        bookingClass,
+                        String.valueOf(submitted.get(bookingClass).intValue()),
+                        String.valueOf(rejected.getOrDefault(bookingClass, new MutableInt()).intValue()),
+                        String.valueOf(rejectedPreemptive.getOrDefault(bookingClass, new MutableInt()).intValue())
+                }) + "\n");
+            }
+
+            writer.flush();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        writeHeader = false;
+        submitted.clear();
+        rejected.clear();
+        rejectedPreemptive.clear();
+    }
+
+    @Override
+    public void notifyShutdown(ShutdownEvent event) {
+        try {
+            writer.close();
+        } catch (IOException e) {
+        }
+    }
+}

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preemptive_rejection/PreemptiveRejectionHandler.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preemptive_rejection/PreemptiveRejectionHandler.java
@@ -3,14 +3,18 @@ package org.matsim.contrib.drt.extension.preemptive_rejection;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.apache.commons.lang.mutable.MutableInt;
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.population.Population;
 import org.matsim.contrib.drt.passenger.events.DrtRequestSubmittedEvent;
 import org.matsim.contrib.drt.passenger.events.DrtRequestSubmittedEventHandler;
+import org.matsim.contrib.dvrp.optimizer.Request;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestRejectedEvent;
 import org.matsim.contrib.dvrp.passenger.PassengerRequestRejectedEventHandler;
+import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.core.controler.events.IterationEndsEvent;
 import org.matsim.core.controler.events.ShutdownEvent;
 import org.matsim.core.controler.listener.IterationEndsListener;
@@ -20,6 +24,7 @@ import org.matsim.core.utils.io.IOUtils;
 public class PreemptiveRejectionHandler
         implements DrtRequestSubmittedEventHandler, PassengerRequestRejectedEventHandler, IterationEndsListener,
         ShutdownListener {
+    private final OutputDirectoryHierarchy outputHierarchy;
     private final Population population;
     private final BufferedWriter writer;
     private final String mode;
@@ -27,12 +32,32 @@ public class PreemptiveRejectionHandler
     private final Map<String, MutableInt> submitted = new HashMap<>();
     private final Map<String, MutableInt> rejected = new HashMap<>();
     private final Map<String, MutableInt> rejectedPreemptive = new HashMap<>();
+    private final LinkedHashMap<Id<Request>, RequestRecord> requests = new LinkedHashMap<>();
+
     private boolean writeHeader = true;
 
-    public PreemptiveRejectionHandler(String mode, Population population, String outputPath) {
+    public PreemptiveRejectionHandler(String mode, Population population, OutputDirectoryHierarchy outputHierarchy) {
         this.mode = mode;
         this.population = population;
-        this.writer = IOUtils.getBufferedWriter(outputPath.toString());
+        this.outputHierarchy = outputHierarchy;
+
+        String summaryPath = outputHierarchy.getOutputFilename(getSummaryOutputFile(mode));
+        this.writer = IOUtils.getBufferedWriter(summaryPath);
+    }
+
+    @Override
+    public void handleEvent(DrtRequestSubmittedEvent event) {
+        if (event.getMode().equals(mode)) {
+            String bookingClass = PreemptiveRejectionOptimizer.getBookingClass(population, event.getPersonIds());
+
+            synchronized (submitted) {
+                submitted.computeIfAbsent(bookingClass, c -> new MutableInt()).increment();
+            }
+
+            synchronized (requests) {
+                requests.put(event.getRequestId(), new RequestRecord(event.getTime(), bookingClass));
+            }
+        }
     }
 
     @Override
@@ -44,21 +69,14 @@ public class PreemptiveRejectionHandler
                 rejected.computeIfAbsent(bookingClass, c -> new MutableInt()).increment();
             }
 
+            synchronized (requests) {
+                requests.get(event.getRequestId()).rejected = true;
+            }
+
             if (PreemptiveRejectionOptimizer.CAUSE.equals(event.getCause())) {
                 synchronized (rejectedPreemptive) {
                     rejectedPreemptive.computeIfAbsent(bookingClass, c -> new MutableInt()).increment();
                 }
-            }
-        }
-    }
-
-    @Override
-    public void handleEvent(DrtRequestSubmittedEvent event) {
-        if (event.getMode().equals(mode)) {
-            String bookingClass = PreemptiveRejectionOptimizer.getBookingClass(population, event.getPersonIds());
-
-            synchronized (submitted) {
-                submitted.computeIfAbsent(bookingClass, c -> new MutableInt()).increment();
             }
         }
     }
@@ -94,9 +112,33 @@ public class PreemptiveRejectionHandler
         }
 
         writeHeader = false;
+
+        String detailedPath = outputHierarchy.getIterationFilename(iteration, getDetailedOutputFile(mode));
+        BufferedWriter writer = IOUtils.getBufferedWriter(detailedPath);
+
+        try {
+            writer.write(String.join(";", new String[] {
+                    "request_id", "submission_time", "booking_class", "rejected"
+            }) + "\n");
+
+            for (var entry : requests.entrySet()) {
+                RequestRecord request = entry.getValue();
+
+                writer.write(String.join(";", new String[] {
+                        entry.getKey().toString(), String.valueOf(request.submissionTime),
+                        request.bookingClass, String.valueOf(request.rejected)
+                }) + "\n");
+            }
+
+            writer.close();
+        } catch (IOException e) {
+            throw new IllegalStateException();
+        }
+
         submitted.clear();
         rejected.clear();
         rejectedPreemptive.clear();
+        requests.clear();
     }
 
     @Override
@@ -105,5 +147,24 @@ public class PreemptiveRejectionHandler
             writer.close();
         } catch (IOException e) {
         }
+    }
+
+    private class RequestRecord {
+        RequestRecord(double submissionTime, String bookingClass) {
+            this.submissionTime = submissionTime;
+            this.bookingClass = bookingClass;
+        }
+
+        double submissionTime;
+        String bookingClass;
+        boolean rejected = false;
+    }
+
+    static public String getSummaryOutputFile(String mode) {
+        return "drt_preemptive_rejection_" + mode + ".csv";
+    }
+
+    static public String getDetailedOutputFile(String mode) {
+        return "drt_booking_classes_" + mode + ".csv";
     }
 }

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preemptive_rejection/PreemptiveRejectionModeQSimModule.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preemptive_rejection/PreemptiveRejectionModeQSimModule.java
@@ -1,0 +1,38 @@
+package org.matsim.contrib.drt.extension.preemptive_rejection;
+
+import java.io.IOException;
+import java.net.URL;
+
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.contrib.drt.optimizer.DefaultDrtOptimizer;
+import org.matsim.contrib.drt.optimizer.DrtOptimizer;
+import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
+import org.matsim.core.api.experimental.events.EventsManager;
+
+public class PreemptiveRejectionModeQSimModule extends AbstractDvrpModeQSimModule {
+    private final URL source;
+
+    PreemptiveRejectionModeQSimModule(String mode, URL source) {
+        super(mode);
+        this.source = source;
+    }
+
+    @Override
+    protected void configureQSim() {
+        bindModal(PreemptiveRejectionOptimizer.class).toProvider(modalProvider(getter -> {
+            DrtOptimizer delegate = getter.getModal(DefaultDrtOptimizer.class);
+
+            EventsManager eventsManager = getter.get(EventsManager.class);
+            Population population = getter.get(Population.class);
+
+            try {
+                return new PreemptiveRejectionOptimizer(getMode(), delegate, eventsManager, population, source);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }));
+
+        addModalComponent(DrtOptimizer.class,
+            modalKey(PreemptiveRejectionOptimizer.class));
+    }
+}

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preemptive_rejection/PreemptiveRejectionModule.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preemptive_rejection/PreemptiveRejectionModule.java
@@ -1,0 +1,51 @@
+package org.matsim.contrib.drt.extension.preemptive_rejection;
+
+import java.net.URL;
+import java.util.Optional;
+
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.contrib.drt.extension.DrtWithExtensionsConfigGroup;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
+import org.matsim.contrib.dvrp.run.AbstractDvrpModeModule;
+import org.matsim.core.config.ConfigGroup;
+import org.matsim.core.controler.AbstractModule;
+import org.matsim.core.controler.OutputDirectoryHierarchy;
+
+import com.google.inject.Singleton;
+
+public class PreemptiveRejectionModule extends AbstractModule {
+    @Override
+    public void install() {
+        MultiModeDrtConfigGroup multiConfig = MultiModeDrtConfigGroup.get(getConfig());
+
+        for (DrtConfigGroup drtConfig : multiConfig.getModalElements()) {
+            if (drtConfig instanceof DrtWithExtensionsConfigGroup extendedConfig) {
+                Optional<PreemptiveRejectionParams> params = extendedConfig.getPreemptiveRejectionParams();
+
+                if (params.isPresent()) {
+                    URL source = ConfigGroup.getInputFileURL(getConfig().getContext(), params.get().getInputPath());
+                    installOverridingQSimModule(new PreemptiveRejectionModeQSimModule(drtConfig.getMode(), source));
+
+                    install(new AbstractDvrpModeModule(drtConfig.getMode()) {
+                        @Override
+                        public void install() {
+                            bindModal(PreemptiveRejectionHandler.class).toProvider(modalProvider(getter -> {
+                                Population population = getter.get(Population.class);
+
+                                OutputDirectoryHierarchy output = getter.get(OutputDirectoryHierarchy.class);
+                                String outputPath = output
+                                        .getOutputFilename("drt_preemptive_rejection." + getMode() + ".csv");
+
+                                return new PreemptiveRejectionHandler(getMode(), population, outputPath);
+                            })).in(Singleton.class);
+
+                            addControlerListenerBinding().to(modalKey(PreemptiveRejectionHandler.class));
+                            addEventHandlerBinding().to(modalKey(PreemptiveRejectionHandler.class));
+                        }
+                    });
+                }
+            }
+        }
+    }
+}

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preemptive_rejection/PreemptiveRejectionModule.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preemptive_rejection/PreemptiveRejectionModule.java
@@ -32,12 +32,9 @@ public class PreemptiveRejectionModule extends AbstractModule {
                         public void install() {
                             bindModal(PreemptiveRejectionHandler.class).toProvider(modalProvider(getter -> {
                                 Population population = getter.get(Population.class);
+                                OutputDirectoryHierarchy outputHierarchy = getter.get(OutputDirectoryHierarchy.class);
 
-                                OutputDirectoryHierarchy output = getter.get(OutputDirectoryHierarchy.class);
-                                String outputPath = output
-                                        .getOutputFilename("drt_preemptive_rejection." + getMode() + ".csv");
-
-                                return new PreemptiveRejectionHandler(getMode(), population, outputPath);
+                                return new PreemptiveRejectionHandler(getMode(), population, outputHierarchy);
                             })).in(Singleton.class);
 
                             addControlerListenerBinding().to(modalKey(PreemptiveRejectionHandler.class));

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preemptive_rejection/PreemptiveRejectionOptimizer.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preemptive_rejection/PreemptiveRejectionOptimizer.java
@@ -1,0 +1,149 @@
+package org.matsim.contrib.drt.extension.preemptive_rejection;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Population;
+import org.matsim.contrib.drt.optimizer.DrtOptimizer;
+import org.matsim.contrib.drt.passenger.DrtRequest;
+import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
+import org.matsim.contrib.dvrp.optimizer.Request;
+import org.matsim.contrib.dvrp.passenger.PassengerRequestRejectedEvent;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.gbl.MatsimRandom;
+import org.matsim.core.mobsim.framework.events.MobsimBeforeSimStepEvent;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.exc.StreamReadException;
+import com.fasterxml.jackson.databind.DatabindException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
+
+public class PreemptiveRejectionOptimizer implements DrtOptimizer {
+    static public final String CAUSE = "preemptive rejection";
+    static public final String BOOKING_CLASS = "drt:bookingClass";
+
+    private final String mode;
+    private final DrtOptimizer delegate;
+
+    private final Population population;
+    private final EventsManager eventsManager;
+
+    private final Random random;
+
+    private final RejectionEntryContainer container;
+
+    private double now;
+
+    public PreemptiveRejectionOptimizer(String mode, DrtOptimizer delegate, EventsManager eventsManager,
+            Population population, URL source) throws StreamReadException, DatabindException, IOException {
+        this.mode = mode;
+        this.delegate = delegate;
+        this.eventsManager = eventsManager;
+        this.population = population;
+        this.random = MatsimRandom.getLocalInstance();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        container = objectMapper.readValue(source, RejectionEntryContainer.class);
+    }
+
+    @Override
+    public void requestSubmitted(Request rawRequest) {
+        DrtRequest request = (DrtRequest) rawRequest;
+
+        String bookingClass = getBookingClass(request);
+        double rejectionRate = getPreemptiveRejectionRate(now, bookingClass);
+
+        double u = random.nextDouble();
+        boolean reject = u < rejectionRate;
+
+        if (reject) {
+            eventsManager.processEvent(new PassengerRequestRejectedEvent(now, mode, request.getId(),
+                    ((DrtRequest) request).getPassengerIds(), CAUSE));
+        } else {
+            delegate.requestSubmitted(request);
+        }
+    }
+
+    private double getPreemptiveRejectionRate(double time, String bookingClass) {
+        RejectionEntry entry = null;
+
+        for (RejectionEntry candidate : container.rejections) {
+            if (time >= candidate.startTime && time < candidate.endTime) {
+                if (candidate.bookingClass.equals(bookingClass)) {
+                    Preconditions.checkState(entry == null,
+                            "Duplicate entry for time " + time + " and booking class " + bookingClass);
+                    entry = candidate;
+                }
+            }
+        }
+
+        return entry == null ? 0.0 : entry.rejectionRate;
+    }
+
+    @Override
+    public void nextTask(DvrpVehicle vehicle) {
+        delegate.nextTask(vehicle);
+    }
+
+    @Override
+    public void notifyMobsimBeforeSimStep(@SuppressWarnings("rawtypes") MobsimBeforeSimStepEvent e) {
+        now = e.getSimulationTime();
+        delegate.notifyMobsimBeforeSimStep(e);
+    }
+
+    private String getBookingClass(DrtRequest request) {
+        return getBookingClass(population, request.getPassengerIds());
+    }
+
+    static public String getBookingClass(Population population, Collection<Id<Person>> personIds) {
+        String bookingClass = null;
+
+        for (Id<Person> personId : personIds) {
+            Person person = population.getPersons().get(personId);
+
+            String personAttribute = getBookingClass(person);
+            Preconditions.checkNotNull(personAttribute, "Person " + personId + " does not have a booking class");
+            Preconditions.checkState(bookingClass == null || bookingClass.equals(personAttribute),
+                    "Inconsistent booking classes for {"
+                            + personIds.stream().map(Id::toString).collect(Collectors.joining(",")) + "}");
+
+            bookingClass = personAttribute;
+        }
+
+        return bookingClass;
+    }
+
+    static public String getBookingClass(Person person) {
+        return (String) person.getAttributes().getAttribute(BOOKING_CLASS);
+    }
+
+    static public void setBookingClass(Person person, String bookingClass) {
+        person.getAttributes().putAttribute(BOOKING_CLASS, bookingClass);
+    }
+
+    static public class RejectionEntry {
+        @JsonProperty("booking_class")
+        public String bookingClass;
+
+        @JsonProperty("start_time")
+        public double startTime = Double.NEGATIVE_INFINITY;
+
+        @JsonProperty("end_time")
+        public double endTime = Double.POSITIVE_INFINITY;
+
+        @JsonProperty("rejection_rate")
+        public double rejectionRate = 0.0;
+    }
+
+    static public class RejectionEntryContainer {
+        public List<RejectionEntry> rejections = new LinkedList<>();
+    }
+}

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preemptive_rejection/PreemptiveRejectionParams.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preemptive_rejection/PreemptiveRejectionParams.java
@@ -1,0 +1,22 @@
+package org.matsim.contrib.drt.extension.preemptive_rejection;
+
+import org.matsim.contrib.common.util.ReflectiveConfigGroupWithConfigurableParameterSets;
+
+public class PreemptiveRejectionParams extends ReflectiveConfigGroupWithConfigurableParameterSets {
+	public static final String SET_NAME = "preemptiveRejection";
+
+	@Parameter
+	private String inputPath;
+
+	public PreemptiveRejectionParams() {
+		super(SET_NAME);
+	}
+
+	public String getInputPath() {
+		return inputPath;
+	}
+
+	public void setInputPath(String val) {
+		inputPath = val;
+	}
+}

--- a/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/preemptive_rejection/RunPreemptiveRejectionIT.java
+++ b/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/preemptive_rejection/RunPreemptiveRejectionIT.java
@@ -1,0 +1,93 @@
+package org.matsim.contrib.drt.extension.preemptive_rejection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.net.URL;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contrib.drt.extension.DrtWithExtensionsConfigGroup;
+import org.matsim.contrib.drt.run.DrtConfigGroup;
+import org.matsim.contrib.drt.run.DrtControlerCreator;
+import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
+import org.matsim.contrib.dvrp.passenger.PassengerRequestRejectedEvent;
+import org.matsim.contrib.dvrp.passenger.PassengerRequestRejectedEventHandler;
+import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.controler.AbstractModule;
+import org.matsim.core.controler.Controler;
+import org.matsim.core.controler.OutputDirectoryHierarchy;
+import org.matsim.core.utils.io.IOUtils;
+import org.matsim.examples.ExamplesUtils;
+import org.matsim.testcases.MatsimTestUtils;
+import org.matsim.vis.otfvis.OTFVisConfigGroup;
+
+import scala.util.Random;
+
+public class RunPreemptiveRejectionIT {
+    @RegisterExtension
+    public final MatsimTestUtils utils = new MatsimTestUtils();
+
+    @Test
+    void testPreemptiveRejection() {
+        URL configUrl = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("mielec"), "mielec_drt_config.xml");
+
+        Config config = ConfigUtils.loadConfig(configUrl,
+                new MultiModeDrtConfigGroup(DrtWithExtensionsConfigGroup::new), new DvrpConfigGroup(),
+                new OTFVisConfigGroup());
+
+        config.controller()
+                .setOverwriteFileSetting(OutputDirectoryHierarchy.OverwriteFileSetting.deleteDirectoryIfExists);
+        config.controller().setOutputDirectory(utils.getOutputDirectory());
+        config.controller().setLastIteration(0);
+
+        DrtConfigGroup drtConfig = (DrtWithExtensionsConfigGroup) DrtConfigGroup.getSingleModeDrtConfig(config);
+        drtConfig.setVehiclesFile("vehicles-5-cap-2.xml");
+
+        PreemptiveRejectionParams preemptiveParams = new PreemptiveRejectionParams();
+        drtConfig.addParameterSet(preemptiveParams);
+
+        String path = RunPreemptiveRejectionIT.class.getResource("example.json").toString();
+        preemptiveParams.setInputPath(path);
+
+        Controler controller = DrtControlerCreator.createControler(config, false);
+        controller.addOverridingModule(new PreemptiveRejectionModule());
+
+        Random random = new Random(0);
+        for (Person person : controller.getScenario().getPopulation().getPersons().values()) {
+            String bookingClass = random.nextDouble() < 0.5 ? "business" : "leisure";
+            PreemptiveRejectionOptimizer.setBookingClass(person, bookingClass);
+        }
+
+        AtomicInteger leisureRejections = new AtomicInteger();
+        AtomicInteger businessRejections = new AtomicInteger();
+
+        controller.addOverridingModule(new AbstractModule() {
+            @Override
+            public void install() {
+                addEventHandlerBinding().toInstance(new PassengerRequestRejectedEventHandler() {
+                    @Override
+                    public void handleEvent(PassengerRequestRejectedEvent event) {
+                        String bookingClass = PreemptiveRejectionOptimizer
+                                .getBookingClass(controller.getScenario().getPopulation(), event.getPersonIds());
+                        (bookingClass.equals("leisure") ? leisureRejections : businessRejections).incrementAndGet();
+                    }
+                });
+            }
+        });
+
+        controller.run();
+
+        // values without preemptive rejection
+        assertNotEquals(56, leisureRejections.get());
+        assertNotEquals(71, businessRejections.get());
+
+        // values with preemptive rejection
+        assertEquals(46, leisureRejections.get());
+        assertEquals(108, businessRejections.get());
+    }
+}

--- a/contribs/drt-extensions/src/test/resources/org/matsim/contrib/drt/extension/preemptive_rejection/example.json
+++ b/contribs/drt-extensions/src/test/resources/org/matsim/contrib/drt/extension/preemptive_rejection/example.json
@@ -1,0 +1,16 @@
+{
+    "rejections": [
+        {
+            "start_time": 21600.0,
+            "end_time": 43200.0,
+            "booking_class": "business",
+            "rejection_rate": 0.25
+        },
+        {
+            "start_time": 46800.0,
+            "end_time": 72000.0,
+            "booking_class": "business",
+            "rejection_rate": 0.5
+        }
+    ]
+}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtModeOptimizerQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtModeOptimizerQSimModule.java
@@ -89,14 +89,16 @@ public class DrtModeOptimizerQSimModule extends AbstractDvrpModeQSimModule {
 
 	@Override
 	protected void configureQSim() {
-		addModalComponent(DrtOptimizer.class, modalProvider(
-				getter -> {
-					return new DefaultDrtOptimizer(drtCfg, getter.getModal(Fleet.class), getter.get(MobsimTimer.class),
-						getter.getModal(DepotFinder.class), getter.getModal(RebalancingStrategy.class),
-						getter.getModal(DrtScheduleInquiry.class), getter.getModal(ScheduleTimingUpdater.class),
-						getter.getModal(EmptyVehicleRelocator.class), getter.getModal(UnplannedRequestInserter.class),
-						getter.getModal(DrtRequestInsertionRetryQueue.class));
-					}));
+		addModalComponent(DrtOptimizer.class,
+			modalKey(DefaultDrtOptimizer.class));
+
+		bindModal(DefaultDrtOptimizer.class).toProvider(modalProvider(getter -> {
+			return new DefaultDrtOptimizer(drtCfg, getter.getModal(Fleet.class), getter.get(MobsimTimer.class),
+				getter.getModal(DepotFinder.class), getter.getModal(RebalancingStrategy.class),
+				getter.getModal(DrtScheduleInquiry.class), getter.getModal(ScheduleTimingUpdater.class),
+				getter.getModal(EmptyVehicleRelocator.class), getter.getModal(UnplannedRequestInserter.class),
+				getter.getModal(DrtRequestInsertionRetryQueue.class));
+			}));
 
 		bindModal(DepotFinder.class).toProvider(
 				modalProvider(getter -> new NearestStartLinkAsDepot(getter.getModal(Fleet.class)))).asEagerSingleton();

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGenerator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGenerator.java
@@ -421,4 +421,8 @@ public class InsertionGenerator {
 
 		return new InsertionWithDetourData(insertion, null, new DetourTimeInfo(pickupDetourInfo, dropoffDetourInfo));
 	}
+
+	public static interface Constraint {
+		boolean isValid(Insertion insertion);
+	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGenerator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGenerator.java
@@ -421,8 +421,4 @@ public class InsertionGenerator {
 
 		return new InsertionWithDetourData(insertion, null, new DetourTimeInfo(pickupDetourInfo, dropoffDetourInfo));
 	}
-
-	public static interface Constraint {
-		boolean isValid(Insertion insertion);
-	}
 }

--- a/examples/scenarios/mielec/vehicles-5-cap-2.xml
+++ b/examples/scenarios/mielec/vehicles-5-cap-2.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<!DOCTYPE vehicles SYSTEM "http://matsim.org/files/dtd/dvrp_vehicles_v1.dtd">
+
+<vehicles>
+	<vehicle id="drt_veh_1_1" start_link="385" t_0="21600" t_1="104400" capacity="2"/>
+	<vehicle id="drt_veh_1_2" start_link="385" t_0="21600" t_1="104400" capacity="2"/>
+	<vehicle id="drt_veh_1_3" start_link="385" t_0="21600" t_1="104400" capacity="2"/>
+	<vehicle id="drt_veh_1_4" start_link="385" t_0="21600" t_1="104400" capacity="2"/>
+	<vehicle id="drt_veh_2_1" start_link="499" t_0="21600" t_1="104400" capacity="2"/>
+</vehicles>


### PR DESCRIPTION
This PR adds **preemptive rejections** to the DRT extensions. They are an efficient way of controlling overall rejection rates in the following situations:

- *Service segmentation:* A couple of requests in *business class* are rejected more frequently than others because the dispatching constraints are stronger (no pooling, shorter wait time, ...). In that case, the new code allows rejecting requests of other booking classes *preemptively* to decrease business class rejections.

- *Equity:* There exist certain requests that are rejected with higher probability because they are harder to dispatch than others (wheelchair users, larger groups, ...). Then they can be defined as an individual booking class and the new feature can be used to *preemptively* reject standard requests to reduce rejection rates of the special requests.

Technically, the following steps need to be followed:

- Preemptive rejections need to be activated by adding the module:

```java
controller.addOverridingModule(new PreemptiveRejectionModule());
```

- Preemptive rejections need to be activated via configuration:

```java
PreemptiveRejectionParams preemptiveParams = new PreemptiveRejectionParams();
preemptiveParams.setInputPath(path);
drtConfig.addParameterSet(preemptiveParams);
```

- A booking class must be defined per person as a person attribute or by calling `PreemptiveRejectionOptimizer.setBookingClass(person, bookingClass)`

- The input file for preemptive rejections is a JSON file with the following structure:

```json
{
    "rejections": [
        { "start_time": 21600.0, "end_time": 43200.0, "booking_class": "business", "rejection_rate": 0.25 },
        { "start_time": 46800.0, "end_time": 72000.0, "booking_class": "business", "rejection_rate": 0.5 }
    ]
}
```

Requests of the indicated *booking class* during the indicated *time slot* are then rejected *preemptively* according to the rejection rate. This means that the indicated share is rejected by default regardless of whether insertions of the incoming requests can be found or not.

The whole system works best if the preemptive rejection instructions are calibrated by an outside algorithm, but the framework could be extended to self-calibrate, for instance, by trying to reach certain rejection rate thresholds by booking class.