### PR TITLE
ci(deps): raise open pr limit for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 15
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Dependabot stopped suggesting dependency updates as we reached its internal limit of 5 open PRs, see https://github.com/matsim-org/matsim-libs/network/updates/1028643323. This raises this limit to 15.