### PR TITLE
build(deps): bump org.mockito:mockito-junit-jupiter from 5.12.0 to 5.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -347,7 +347,7 @@
 			<dependency>
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-junit-jupiter</artifactId>
-				<version>5.12.0</version>
+				<version>5.18.0</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
https://github.com/matsim-org/matsim-libs/pull/3458 somehow does not get updated from dependabot anymore (?)