### PR TITLE
build(deps): bump tech.tablesaw:tablesaw-core and tech.tablesaw:tablesaw-jsplot from 0.43.1 to 0.44.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,13 +360,13 @@
 			<dependency>
 				<groupId>tech.tablesaw</groupId>
 				<artifactId>tablesaw-core</artifactId>
-				<version>0.43.1</version>
+				<version>0.44.1</version>
 			</dependency>
 
 			<dependency>
 				<groupId>tech.tablesaw</groupId>
 				<artifactId>tablesaw-jsplot</artifactId>
-				<version>0.43.1</version>
+				<version>0.44.1</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
Might make https://github.com/matsim-org/matsim-libs/pull/4015 obsolete.