### PR TITLE
fix(simwrapper): add missing "Vehicles" DRT animation

### DIFF
--- a/contribs/simwrapper/src/main/java/org/matsim/simwrapper/Header.java
+++ b/contribs/simwrapper/src/main/java/org/matsim/simwrapper/Header.java
@@ -17,7 +17,7 @@ public final class Header {
 	public String description;
 
 	/**
-	 * Enable dashboard to fill the whole screen.
+	 * Fill/stretch dashboard to the full window size instead of scrolling vertically.
 	 */
 	public Boolean fullScreen;
 

--- a/contribs/simwrapper/src/main/java/org/matsim/simwrapper/viz/Vehicles.java
+++ b/contribs/simwrapper/src/main/java/org/matsim/simwrapper/viz/Vehicles.java
@@ -1,0 +1,39 @@
+package org.matsim.simwrapper.viz;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Creates a vehicle (DRT) animation visualization for simwrapper.
+ */
+public class Vehicles extends Viz {
+
+	/**
+	 * Sets the path of the processed trips file in JSON format
+	 */
+	@JsonProperty(required = true)
+	public String drtTrips;
+
+	/**
+	 * Sets the projection of the map. E.g. EPSG:31468
+	 */
+	public String projection;
+
+	/**
+	 * Sets the long/lat center coordinates.
+	 */
+	public double[] center;
+
+	/**
+	 * Sets the map zoom level.
+	 */
+	public Double zoom;
+
+	/**
+	 * Set to true for this map to have independent center/zoom/motion
+	 */
+	public Boolean mapIsIndependent;
+
+	public Vehicles() {
+		super("vehicles");
+	}
+}

--- a/contribs/simwrapper/src/test/java/org/matsim/simwrapper/SimWrapperTest.java
+++ b/contribs/simwrapper/src/test/java/org/matsim/simwrapper/SimWrapperTest.java
@@ -28,7 +28,6 @@ public class SimWrapperTest {
 			header.description = "Test All Simwrapper Plug-Ins Dashboard";
 			header.tab = "Header Tab";
 			header.triggerPattern = "*example.csv";
-
 			layout.row("first")
 					.el(Area.class, (viz, data) -> {
 						viz.title = "Area";
@@ -127,6 +126,17 @@ public class SimWrapperTest {
 					viz.metrics.setColorScheme("BurgYl");
 					viz.metrics.setValueTransform(FlowMap.Metrics.ValueTransform.NORMAL);
 				}));
+			layout.row("fourteenth")
+				.el(Vehicles.class, ((viz, data) -> {
+					viz.title = "DRT Vehicle Animation";
+					viz.description = "drt animation";
+					viz.center = new double[]{13.45, 52.5};
+					viz.zoom = 11.0;
+					viz.drtTrips = "drt-vehicles.json";
+					viz.projection = "EPSG:25832";
+					viz.mapIsIndependent = true;
+				}));
+
 		});
 
 		String outputDirectory = utils.getOutputDirectory();

--- a/contribs/simwrapper/test/input/org/matsim/simwrapper/dashboard-0.yaml
+++ b/contribs/simwrapper/test/input/org/matsim/simwrapper/dashboard-0.yaml
@@ -94,3 +94,14 @@ layout:
       colorScheme: BurgYl
       valueTransform: normal
     zoom: 9.5
+  fourteenth:
+  - type: vehicles
+    title: DRT Vehicle Animation
+    description: drt animation
+    drtTrips: drt-vehicles.json
+    projection: EPSG:25832
+    center:
+    - 13.45
+    - 52.5
+    zoom: 11.0
+    mapIsIndependent: true


### PR DESCRIPTION
The DRT vehicles animation class was missing from the set of available visualizations. This meant that users could not create a DRT dashboard from inside the simwrapper contrib.

This PR adds the Vehicle class and tests the proper creation of a DRT vehicles panel in a dashboard.
