### PR TITLE
fix: adjust use of marker in otfvis

### DIFF
--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/AbstractAgentSnapshotInfoBuilder.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/AbstractAgentSnapshotInfoBuilder.java
@@ -359,8 +359,9 @@ abstract class AbstractAgentSnapshotInfoBuilder {
 	private AgentState getAgentStateForActivity(Id<Person> id) {
 
 		// I don't know whether I have gotten this right, but I think this is tested in every case in every method
-		var marker = getMarkerFromAttributes(id);
-		if (marker != null) return AgentState.MARKER;
+//		var marker = getMarkerFromAttributes(id);
+//		if (marker != null) return AgentState.MARKER;
+		// (if we return the marker state here, the agents are also visualized at activities.  kai, jun'25`)
 
 		return AgentState.PERSON_AT_ACTIVITY;
 	}


### PR DESCRIPTION
There is a "marker" facility to separately mark vehicles in OTFVis.  (I use this for teaching telematics; it is presumably not used elsewhere, and also not necessarily a stable feature.)

This was programmed in a way that agents with marker would be plotted at activities, even if plotting at activity was switched off.

I now changed that such that, if the general setting is such, agents at activities are not plotted, even if they are marked.