### PR TITLE
fix: maintenance

### DIFF
--- a/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/AdditionalBicycleLinkScoreDefaultImpl.java
+++ b/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/AdditionalBicycleLinkScoreDefaultImpl.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.network.NetworkUtils;
 
 public final class AdditionalBicycleLinkScoreDefaultImpl implements AdditionalBicycleLinkScore {
 
@@ -24,9 +25,9 @@ public final class AdditionalBicycleLinkScoreDefaultImpl implements AdditionalBi
 
 	}
 	@Override public double computeLinkBasedScore( Link link ){
-		String surface = (String) link.getAttributes().getAttribute(BicycleUtils.SURFACE );
-		String type = (String) link.getAttributes().getAttribute("type" );
-		String cyclewaytype = (String) link.getAttributes().getAttribute(BicycleUtils.CYCLEWAY );
+		String surface = BicycleUtils.getSurface(link);
+		String type = NetworkUtils.getType( link );
+		String cyclewaytype = BicycleUtils.getCyclewaytype( link );
 
 		double distance = link.getLength();
 
@@ -39,6 +40,7 @@ public final class AdditionalBicycleLinkScoreDefaultImpl implements AdditionalBi
 		double gradient = BicycleUtils.getGradient( link );
 		double gradientScore = marginalUtilityOfGradient_m_100m * gradient * distance;
 
+		// I think that the "user defined material" should be removed.  If someone wants more flexibility, he/she should bind a custom AdditionalBicycleLinkScore.  kai, jun'25
 		String userDefinedNetworkAttributeString;
 		double userDefinedNetworkAttributeScore = 0.;
 		if ( nameOfUserDefinedNetworkAttribute != null) {

--- a/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/BicycleConfigGroup.java
+++ b/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/BicycleConfigGroup.java
@@ -33,9 +33,21 @@ public final class BicycleConfigGroup extends ReflectiveConfigGroup {
 	private static final String INPUT_COMFORT = "marginalUtilityOfComfort_m";
 	private static final String INPUT_INFRASTRUCTURE = "marginalUtilityOfInfrastructure_m";
 	private static final String INPUT_GRADIENT = "marginalUtilityOfGradient_m_100m";
+	/**
+	 * @deprecated  -- I think that the "user defined material" should be removed.  If someone wants more flexibility, he/she should bind a custom AdditionalBicycleLinkScore.  kai, jun'25
+	 * */
 	private static final String USER_DEFINED_NETWORK_ATTRIBUTE_MARGINAL_UTILITY = "marginalUtilityOfUserDefinedNetworkAttribute_m";
+	/**
+	 * @deprecated  -- I think that the "user defined material" should be removed.  If someone wants more flexibility, he/she should bind a custom AdditionalBicycleLinkScore.  kai, jun'25
+	 * */
 	private static final String USER_DEFINED_NETWORK_ATTRIBUTE_NAME = "userDefinedNetworkAttributeName";
+	/**
+	 * @deprecated  -- I think that the "user defined material" should be removed.  If someone wants more flexibility, he/she should bind a custom AdditionalBicycleLinkScore.  kai, jun'25
+	 * */
 	private static final String USER_DEFINED_NETWORK_ATTRIBUTE_DEFAULT_VALUE = "userDefinedNetworkAttributeDefaultValue";
+	/**
+	 * @deprecated  -- I think that this has been superseeded by mode vehicles.
+	 * */
 	private static final String MAX_BICYCLE_SPEED_FOR_ROUTING = "maxBicycleSpeedForRouting";
 	private static final String BICYCLE_MODE = "bicycleMode";
 	private static final String MOTORIZED_INTERACTION = "motorizedInteraction";
@@ -73,6 +85,9 @@ public final class BicycleConfigGroup extends ReflectiveConfigGroup {
 		map.put(MAX_BICYCLE_SPEED_FOR_ROUTING, "maxBicycleSpeed");
 		return map;
 	}
+	/**
+	 * This is something like "cobblestone" or "paved" or "sand".
+	 */
 	@StringSetter( INPUT_COMFORT )
 	public BicycleConfigGroup setMarginalUtilityOfComfort_m( final double value ) {
 		this.marginalUtilityOfComfort = value;
@@ -82,6 +97,9 @@ public final class BicycleConfigGroup extends ReflectiveConfigGroup {
 	public double getMarginalUtilityOfComfort_m() {
 		return this.marginalUtilityOfComfort;
 	}
+	/**
+	 * This is something like "arterial" or "residential road" or "has separate bicycle lane".
+	 */
 	@StringSetter( INPUT_INFRASTRUCTURE )
 	public BicycleConfigGroup setMarginalUtilityOfInfrastructure_m( final double value ) {
 		this.marginalUtilityOfInfrastructure = value;
@@ -93,6 +111,7 @@ public final class BicycleConfigGroup extends ReflectiveConfigGroup {
 	}
 	@StringSetter( INPUT_GRADIENT )
 	public BicycleConfigGroup setMarginalUtilityOfGradient_m_100m( final double value ) {
+		// yy I do not understand what the _m_100m exactly means.  IMO, there is a "per meter" missing (i.e. _m_100m_m, or maybe just _m and the rest in the documentation).
 		this.marginalUtilityOfGradient = value;
 		return this;
 	}
@@ -100,30 +119,55 @@ public final class BicycleConfigGroup extends ReflectiveConfigGroup {
 	public double getMarginalUtilityOfGradient_m_100m() {
 		return this.marginalUtilityOfGradient;
 	}
+
+	/**
+	 * @deprecated  -- I think that the "user defined material" should be removed.  If someone wants more flexibility, he/she should bind a custom AdditionalBicycleLinkScore.  kai, jun'25
+	 * */
 	@StringSetter(USER_DEFINED_NETWORK_ATTRIBUTE_MARGINAL_UTILITY)
+	@Deprecated
 	public BicycleConfigGroup setMarginalUtilityOfUserDefinedNetworkAttribute_m(final double value) {
 		this.marginalUtilityOfUserDefinedNetworkAttribute = value;
 		return this;
 	}
+	/**
+	 * @deprecated  -- I think that the "user defined material" should be removed.  If someone wants more flexibility, he/she should bind a custom AdditionalBicycleLinkScore.  kai, jun'25
+	 * */
 	@StringGetter(USER_DEFINED_NETWORK_ATTRIBUTE_MARGINAL_UTILITY)
+	@Deprecated
 	public double getMarginalUtilityOfUserDefinedNetworkAttribute_m() {
 		return this.marginalUtilityOfUserDefinedNetworkAttribute;
 	}
+	/**
+	 * @deprecated  -- I think that the "user defined material" should be removed.  If someone wants more flexibility, he/she should bind a custom AdditionalBicycleLinkScore.  kai, jun'25
+	 * */
 	@StringSetter(USER_DEFINED_NETWORK_ATTRIBUTE_NAME)
+	@Deprecated
 	public BicycleConfigGroup setUserDefinedNetworkAttributeName(String value) {
 		this.userDefinedNetworkAttributeName = value;
 		return this;
 	}
+	/**
+	 * @deprecated  -- I think that the "user defined material" should be removed.  If someone wants more flexibility, he/she should bind a custom AdditionalBicycleLinkScore.  kai, jun'25
+	 * */
 	@StringGetter(USER_DEFINED_NETWORK_ATTRIBUTE_NAME)
+	@Deprecated
 	public String getUserDefinedNetworkAttributeName() {
 		return this.userDefinedNetworkAttributeName;
 	}
+	/**
+	 * @deprecated  -- I think that the "user defined material" should be removed.  If someone wants more flexibility, he/she should bind a custom AdditionalBicycleLinkScore.  kai, jun'25
+	 * */
 	@StringSetter(USER_DEFINED_NETWORK_ATTRIBUTE_DEFAULT_VALUE)
+	@Deprecated
 	public BicycleConfigGroup setUserDefinedNetworkAttributeDefaultValue(double value) {
 		this.userDefinedNetworkAttributeDefaultValue = value;
 		return this;
 	}
+	/**
+	 * @deprecated  -- I think that the "user defined material" should be removed.  If someone wants more flexibility, he/she should bind a custom AdditionalBicycleLinkScore.  kai, jun'25
+	 * */
 	@StringGetter(USER_DEFINED_NETWORK_ATTRIBUTE_DEFAULT_VALUE)
+	@Deprecated
 	public double getUserDefinedNetworkAttributeDefaultValue() {
 		return this.userDefinedNetworkAttributeDefaultValue;
 	}

--- a/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/BicycleLinkSpeedCalculatorDefaultImpl.java
+++ b/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/BicycleLinkSpeedCalculatorDefaultImpl.java
@@ -46,6 +46,9 @@ public final class BicycleLinkSpeedCalculatorDefaultImpl implements BicycleLinkS
 
 		// prior to matsim 12.0 routers would not pass a vehicle. This is why we have a fallback for a default value from the config
 		double maxBicycleSpeed = vehicle == null ? bicycleConfigGroup.getMaxBicycleSpeedForRouting() : vehicle.getType().getMaximumVelocity();
+		// when using bicycle, one should always have vehicles with individual maximum speeds, possibly by using modeVehicleTypes.
+
+//		double maxBicycleSpeed = vehicle.getType().getMaximumVelocity();
 		double bicycleInfrastructureFactor = computeInfrastructureFactor(link);
 		double surfaceFactor = computeSurfaceFactor(link);
 		double gradientFactor = computeGradientFactor(link);

--- a/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/BicycleModule.java
+++ b/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/BicycleModule.java
@@ -104,9 +104,12 @@ public final class BicycleModule extends AbstractModule {
 					}
 				}
 			}
+
 			if (!scenario.getConfig().qsim().getMainModes().contains(bicycleConfigGroup.getBicycleMode())) {
 				LOG.warn(bicycleConfigGroup.getBicycleMode() + " not specified as main mode.");
 			}
+			// (yy should move into the config consistency checker)
+
 		}
 	}
 }

--- a/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/BicycleUtils.java
+++ b/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/BicycleUtils.java
@@ -51,9 +51,15 @@ public final class BicycleUtils {
 		return (String) link.getAttributes().getAttribute( nameOfUserDefinedNetworkAttribute );
 	}
 
+
+	/**
+	 * @deprecated -- should be injected, not directly instantiated
+	 */
+	@Deprecated
 	public static AdditionalBicycleLinkScore createDefaultBicycleLinkScore( Scenario scenario ) {
 		return new AdditionalBicycleLinkScoreDefaultImpl( scenario );
 	}
+
 	/* package */ static double getGradient(Link link ) {
 
 		if (!link.getFromNode().getCoord().hasZ() || !link.getToNode().getCoord().hasZ()) return 0.;

--- a/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/run/RunBicycleExample.java
+++ b/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/run/RunBicycleExample.java
@@ -85,7 +85,7 @@ public class RunBicycleExample {
 		bicycleConfigGroup.setUserDefinedNetworkAttributeName("quietness"); // needs to be defined as a value from 0 to 1, 1 being best, 0 being worst
 		bicycleConfigGroup.setUserDefinedNetworkAttributeDefaultValue(0.1); // used for those links that do not have a value for the user-defined attribute
 
-//		bicycleConfigGroup.setMaxBicycleSpeedForRouting(4.16666666);
+		bicycleConfigGroup.setMaxBicycleSpeedForRouting(4.16666666);
 
 
 		List<String> mainModeList = new ArrayList<>();

--- a/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/run/RunBicycleExample.java
+++ b/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/run/RunBicycleExample.java
@@ -25,10 +25,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Link;
-import org.matsim.contrib.bicycle.AdditionalBicycleLinkScore;
-import org.matsim.contrib.bicycle.BicycleConfigGroup;
-import org.matsim.contrib.bicycle.BicycleModule;
-import org.matsim.contrib.bicycle.BicycleUtils;
+import org.matsim.contrib.bicycle.*;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.groups.ScoringConfigGroup.ActivityParams;
@@ -88,7 +85,7 @@ public class RunBicycleExample {
 		bicycleConfigGroup.setUserDefinedNetworkAttributeName("quietness"); // needs to be defined as a value from 0 to 1, 1 being best, 0 being worst
 		bicycleConfigGroup.setUserDefinedNetworkAttributeDefaultValue(0.1); // used for those links that do not have a value for the user-defined attribute
 
-		bicycleConfigGroup.setMaxBicycleSpeedForRouting(4.16666666);
+//		bicycleConfigGroup.setMaxBicycleSpeedForRouting(4.16666666);
 
 
 		List<String> mainModeList = new ArrayList<>();
@@ -160,6 +157,7 @@ public class RunBicycleExample {
 		controler.addOverridingModule(new BicycleModule() );
 		controler.addOverridingModule( new AbstractModule(){
 			@Override public void install(){
+				this.bind( AdditionalBicycleLinkScoreDefaultImpl.class ); // so it can be used as delegate
 				this.bind( AdditionalBicycleLinkScore.class ).to( MyAdditionalBicycleLinkScore.class );
 			}
 		} );
@@ -169,10 +167,8 @@ public class RunBicycleExample {
 
 	private static class MyAdditionalBicycleLinkScore implements AdditionalBicycleLinkScore {
 
-		private final AdditionalBicycleLinkScore delegate;
-		@Inject MyAdditionalBicycleLinkScore( Scenario scenario ) {
-			this.delegate = BicycleUtils.createDefaultBicycleLinkScore( scenario );
-		}
+		@Inject private AdditionalBicycleLinkScoreDefaultImpl delegate;
+
 		@Override public double computeLinkBasedScore( Link link ){
 			double result = (double) link.getAttributes().getAttribute( "carFreeStatus" );  // from zero to one
 

--- a/matsim/src/main/java/org/matsim/vehicles/Vehicles.java
+++ b/matsim/src/main/java/org/matsim/vehicles/Vehicles.java
@@ -46,4 +46,13 @@ public interface Vehicles extends MatsimToplevelContainer {
 	public void addVehicleType(final VehicleType type);
 
 	public void removeVehicleType(final Id<VehicleType> vehicleTypeId);
+
+	/**
+	 * convenience method
+	 */
+	default public VehicleType addModeVehicleType( final String mode ) {
+		VehicleType vehicleType = this.getFactory().createVehicleType( Id.createVehicleTypeId( mode ) ).setNetworkMode( mode );
+		this.addVehicleType( vehicleType );
+		return vehicleType;
+	}
 }


### PR DESCRIPTION
This commit is setting a fair number of things within the bicycle contrib to deprecated (with comments), since I think that they are either no longer necessary, or they can now be done by the user without having to provide additional infrastructure.

adding a convenience method vehicles#addModeVehicleType( mode ) in passing