### PR TITLE
refactor(parking): make the parkingPenalty attribute name publicly visible

### DIFF
--- a/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingproxy/CarEgressWalkChanger.java
+++ b/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingproxy/CarEgressWalkChanger.java
@@ -51,8 +51,6 @@ import org.matsim.core.controler.listener.BeforeMobsimListener;
  */
 class CarEgressWalkChanger implements BeforeMobsimListener {
 	
-	public static final String PENALTY_ATTRIBUTE = "parkingPenalty";
-	
 	private final CarEgressWalkObserver observer;
 	private final AccessEgressFinder egressFinder = new AccessEgressFinder(TransportMode.car);
 	private final Iter0Method iter0Method;
@@ -126,7 +124,7 @@ class CarEgressWalkChanger implements BeforeMobsimListener {
 					setTimes(walkActPair, -penalty);
 				} else {
 					setTimes(walkActPair, penalty);
-					walkActPair.leg.getAttributes().putAttribute(PENALTY_ATTRIBUTE, penalty);
+					walkActPair.leg.getAttributes().putAttribute(ParkingProxyModule.PENALTY_ATTRIBUTE, penalty);
 				}
 			}
 		}
@@ -145,7 +143,7 @@ class CarEgressWalkChanger implements BeforeMobsimListener {
 		int sign = reverse ? -1 : 1;
 		for (Person p : population) {
 			for (LegActPair walkActPair : this.egressFinder.findEgressWalks(p.getSelectedPlan())) {
-				Object penalty = walkActPair.leg.getAttributes().getAttribute(PENALTY_ATTRIBUTE);
+				Object penalty = walkActPair.leg.getAttributes().getAttribute(ParkingProxyModule.PENALTY_ATTRIBUTE);
 				if (penalty == null) {
 					throw new RuntimeException("Leg with departure time " +  walkActPair.leg.getDepartureTime() + " of person " + p.getId().toString() + " has no penalty!");
 				} else {

--- a/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingproxy/ParkingProxyModule.java
+++ b/contribs/parking/src/main/java/org/matsim/contrib/parking/parkingproxy/ParkingProxyModule.java
@@ -44,6 +44,8 @@ import org.matsim.contrib.parking.parkingproxy.config.ParkingProxyConfigGroup;
  */
 public /*deliberately non-final*/ class ParkingProxyModule extends AbstractModule {
 	
+	public static final String PENALTY_ATTRIBUTE = "parkingPenalty";
+	
 	private final static int GRIDSIZE = 500;
 	private final Scenario scenario;
 	


### PR DESCRIPTION
Moves the `PENALTY_ATTRIBUTE` String of the Parking Proxy to a class that is publicly accessible so the attribute name also can be accessed from other classes who need to work with it. This was originally intended that way but got lost once some classes were made package private.