### PR TITLE
fix(pt): Fix a bug calculating pt routes using chained departures

### DIFF
--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/RaptorRoute.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/RaptorRoute.java
@@ -150,6 +150,19 @@ public class RaptorRoute {
 				return this.arrivalTime;
 			}
 			return this.chainedPart.getChainedArrivalTime();
-		}
     }
+
+			@Override
+			public String toString() {
+				return "RoutePart{" +
+					"fromStop=" + fromStop.getId() + " (" + fromStop.getName() + ")" +
+					", toStop=" + toStop.getId() + " (" + toStop.getName() + ")" +
+					", mode='" + mode + '\'' +
+					", depTime=" + depTime +
+					", line=" + line.getId() +
+					", route=" + route.getId() +
+					", chainedPart=" + chainedPart +
+					'}';
+			}
+		}
 }

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorCore.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorCore.java
@@ -719,6 +719,14 @@ public class SwissRailRaptorCore {
 		boolean hasChains = chains != null;
 
 		for (int toRouteStopIndex = firstRouteStopIndex + 1; toRouteStopIndex < route.indexFirstRouteStop + route.countRouteStops; toRouteStopIndex++) {
+			// In the original raptor algorithm, we step once through all route-stops in order,
+			// which ensures that we don't handle any stop or route twice.
+			// With chained departures, we actually jump out of this sequence,
+			// resulting in the state that the same stop or route might be handled a second time in the same round.
+			// To prevent this (as it could have unintended side-effects and even produce wrong results), we
+			// proactively clear the handled route stop. So if this a chained route, it already gets handled now
+			// and will not have to be handled (regularly) later on, thus we can just clear the corresponding bits.
+			this.improvedRouteStopIndices.clear(toRouteStopIndex);
 			RRouteStop toRouteStop = this.data.routeStops[toRouteStopIndex];
 			if (!toRouteStop.routeStop.isAllowAlighting()) {
 				continue;

--- a/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitStopFacilityImpl.java
+++ b/matsim/src/main/java/org/matsim/pt/transitSchedule/TransitStopFacilityImpl.java
@@ -38,7 +38,7 @@ import org.matsim.utils.objectattributes.attributable.AttributesImpl;
  * @author mrieser
  */
 public class TransitStopFacilityImpl implements TransitStopFacility {
-	
+
 	private final Id<TransitStopFacility> id;
 	private Id<TransitStopArea> stopAreaId;
 	private Coord coord;
@@ -68,7 +68,7 @@ public class TransitStopFacilityImpl implements TransitStopFacility {
 	public Coord getCoord() {
 		return this.coord;
 	}
-	
+
 	@Override
 	public void setCoord(Coord coord) {
 		this.coord = coord;
@@ -98,6 +98,9 @@ public class TransitStopFacilityImpl implements TransitStopFacility {
 	public String toString() {
 		StringBuilder strb = new StringBuilder(  ) ;
 		strb.append( "[ facility id=" ).append( id ) ;
+		if (name != null) {
+			strb.append( " | name=" ).append( name ) ;
+		}
 		strb.append ( " | coord=").append( coord ) ;
 		strb.append( " | linkId=" ).append( linkId ) ;
 
@@ -114,7 +117,7 @@ public class TransitStopFacilityImpl implements TransitStopFacility {
 	public void setStopAreaId(Id<TransitStopArea> stopAreaId) {
 		this.stopAreaId = stopAreaId;
 	}
-	
+
 	@Override
 	public Map<String, Object> getCustomAttributes() {
 		if (this.customizableDelegate == null) {


### PR DESCRIPTION
When a schedule contains chained departures, it could happen that a transit-route was expanded twice in one round, resulting in corrupted routes (e.g. switching from one train to another without a proper transfer in-between). This change should fix this.