### PR TITLE
test(railsim): Add 'micro junction flat' integration test case

### DIFF
--- a/contribs/railsim/src/test/java/ch/sbb/matsim/contrib/railsim/integration/RailsimIntegrationTest.java
+++ b/contribs/railsim/src/test/java/ch/sbb/matsim/contrib/railsim/integration/RailsimIntegrationTest.java
@@ -305,6 +305,50 @@ public class RailsimIntegrationTest {
 	}
 
 	@Test
+	void testMicroJunctionFlat() {
+		EventsCollector collector = runSimulation(new File(utils.getPackageInputDirectory(), "microJunctionFlat"));
+
+		Map<Id<Vehicle>, Double> actualArrivals = new HashMap<>();
+		for (Event event : collector.getEvents()) {
+			if (event instanceof VehicleArrivesAtFacilityEvent e) {
+				actualArrivals.put(e.getVehicleId(), e.getTime());
+			}
+		}
+
+		// check that all 32 trains arrived and were not stuck.
+		Assertions.assertEquals(32, actualArrivals.size(),
+			"Expected 32 trains to arrive, but some seem to be stuck or did not complete their routes.");
+
+		// check the arrival times for the most critical trains.
+		Map<Id<Vehicle>, Double> expectedArrivals = new HashMap<>();
+
+		// first trains of each line
+		expectedArrivals.put(Id.createVehicleId("trainAB0"), 30877.0);
+		expectedArrivals.put(Id.createVehicleId("trainBA0"), 30869.0);
+		expectedArrivals.put(Id.createVehicleId("trainAC0"), 33135.0);
+		expectedArrivals.put(Id.createVehicleId("trainCA0"), 31543.0);
+
+		// last trains of each line
+		expectedArrivals.put(Id.createVehicleId("trainAB7"), 31042.0);
+		expectedArrivals.put(Id.createVehicleId("trainBA7"), 32099.0);
+		expectedArrivals.put(Id.createVehicleId("trainAC7"), 31197.0);
+		expectedArrivals.put(Id.createVehicleId("trainCA7"), 32946.0);
+
+		for (Map.Entry<Id<Vehicle>, Double> entry : expectedArrivals.entrySet()) {
+			Id<Vehicle> vehicleId = entry.getKey();
+			double expectedTime = entry.getValue();
+
+			Assertions.assertTrue(actualArrivals.containsKey(vehicleId), "Critical train " + vehicleId + " did not arrive.");
+
+			double actualTime = actualArrivals.get(vehicleId);
+
+			Assertions.assertEquals(expectedTime, actualTime, MatsimTestUtils.EPSILON,
+				"Arrival time for critical train " + vehicleId + " has changed.");
+		}
+
+	}
+
+	@Test
 	void testMicroJunctionY() {
 		EventsCollector collector = runSimulation(new File(utils.getPackageInputDirectory(), "microJunctionY"));
 	}

--- a/contribs/railsim/test/input/ch/sbb/matsim/contrib/railsim/integration/microJunctionFlat/config.xml
+++ b/contribs/railsim/test/input/ch/sbb/matsim/contrib/railsim/integration/microJunctionFlat/config.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" ?>
+<!DOCTYPE config SYSTEM "http://www.matsim.org/files/dtd/config_v2.dtd">
+<config>
+
+	<module name="global">
+		<param name="randomSeed" value="4711"/>
+		<param name="coordinateSystem" value="Atlantis"/>
+	</module>
+
+	<module name="controler">
+
+		<param name="runId" value="test"/>
+		<param name="firstIteration" value="0"/>
+	</module>
+
+	<module name="qsim">
+		<!-- "start/endTime" of MobSim (00:00:00 == take earliest activity time/ run as long as active vehicles exist) -->
+		<param name="startTime" value="00:00:00"/>
+		<param name="endTime" value="24:00:00"/>
+
+		<param name="snapshotperiod" value="00:00:00"/> <!-- 00:00:00 means NO snapshot writing -->
+		<param name="mainMode" value="car"/>
+
+		<!-- time in seconds.  Time after which the frontmost vehicle on a link is called `stuck' if it does not move. -->
+		<param name="stuckTime" value="999999."/>
+	</module>
+
+	<module name="transit">
+		<param name="routingAlgorithmType" value="SwissRailRaptor"/>
+		<param name="transitScheduleFile" value="transitSchedule.xml"/>
+		<param name="useTransit" value="true"/>
+		<param name="usingTransitInMobsim" value="true"/>
+		<param name="vehiclesFile" value="transitVehicles.xml"/>
+	</module>
+
+	<module name="network">
+		<param name="inputNetworkFile" value="trainNetwork.xml"/>
+	</module>
+
+	<module name="railsim">
+		<param name="updateInterval" value="1.0"/>
+	</module>
+
+</config>

--- a/contribs/railsim/test/input/ch/sbb/matsim/contrib/railsim/integration/microJunctionFlat/trainNetwork.xml
+++ b/contribs/railsim/test/input/ch/sbb/matsim/contrib/railsim/integration/microJunctionFlat/trainNetwork.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE network SYSTEM "http://www.matsim.org/files/dtd/network_v2.dtd">
+<network name="drawn_network">
+
+	<attributes>
+		<attribute name="coordinateReferenceSystem" class="java.lang.String">Atlantis</attribute>
+	</attributes>
+
+	<nodes>
+		<node id="A1" x="-1505.0" y="0.0">
+		</node>
+		<node id="A2" x="-1227.5" y="0.0">
+		</node>
+		<node id="A3" x="-1230.0" y="-20.0">
+		</node>
+		<node id="A4" x="-1505.0" y="-20.0">
+		</node>
+		<node id="Abzw1" x="1030.0" y="0.0">
+		</node>
+		<node id="Abzw1Post" x="1050.0" y="0.0">
+		</node>
+		<node id="Abzw2" x="1025.0" y="-20.0">
+		</node>
+		<node id="Abzw3" x="1067.5" y="0.0">
+		</node>
+		<node id="Abzw3Post" x="1047.5" y="-10.0">
+		</node>
+		<node id="B1" x="3780.0" y="0.0">
+		</node>
+		<node id="B2" x="4030.0" y="0.0">
+		</node>
+		<node id="B3" x="4030.0" y="-20.0">
+		</node>
+		<node id="B4" x="3775.0" y="-20.0">
+		</node>
+		<node id="C1" x="3045.0" y="1070.0">
+		</node>
+		<node id="C2" x="3225.0" y="1167.5">
+		</node>
+		<node id="C3" x="3265.0" y="1160.0">
+		</node>
+		<node id="C4" x="3090.0" y="1065.0">
+		</node>
+		<node id="SigA" x="952.5" y="0.0">
+		</node>
+		<node id="SigB" x="1125.0" y="-20.0">
+		</node>
+		<node id="SigC" x="1105.0" y="20.0">
+		</node>
+		<node id="ToA" x="750.0" y="-20.0">
+		</node>
+		<node id="ToB" x="1350.0" y="0.0">
+		</node>
+		<node id="ToC" x="1222.5" y="102.5">
+		</node>
+	</nodes>
+
+	<links capperiod="01:00:00">
+		<link id="A1-A2" from="A1" to="A2" length="277.5" freespeed="33.3" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">999</attribute>
+			</attributes>
+		</link>
+		<link id="A2-SigA" from="A2" to="SigA" length="2180.0" freespeed="33.3" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">1</attribute>
+			</attributes>
+		</link>
+		<link id="A3-A4" from="A3" to="A4" length="275.0" freespeed="33.3" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">999</attribute>
+			</attributes>
+		</link>
+		<link id="Abzw1-Abzw1Post" from="Abzw1" to="Abzw1Post" length="20.0" freespeed="20" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">1</attribute>
+				<attribute name="railsimResourceId" class="java.lang.String">R3</attribute>
+			</attributes>
+		</link>
+		<link id="Abzw1-ToC" from="Abzw1" to="ToC" length="218.1" freespeed="20" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">1</attribute>
+			</attributes>
+		</link>
+		<link id="Abzw1Post-Abzw3" from="Abzw1Post" to="Abzw3" length="17.5" freespeed="20" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">1</attribute>
+				<attribute name="railsimResourceId" class="java.lang.String">R3</attribute>
+			</attributes>
+		</link>
+		<link id="Abzw2-ToA" from="Abzw2" to="ToA" length="275.0" freespeed="20" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">1</attribute>
+			</attributes>
+		</link>
+		<link id="Abzw3-Abzw3Post" from="Abzw3" to="Abzw3Post" length="22.4" freespeed="20" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">1</attribute>
+				<attribute name="railsimResourceId" class="java.lang.String">R3</attribute>
+			</attributes>
+		</link>
+		<link id="Abzw3-ToB" from="Abzw3" to="ToB" length="282.5" freespeed="20" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">1</attribute>
+				<attribute name="railsimResourceId" class="java.lang.String">R3</attribute>
+			</attributes>
+		</link>
+		<link id="Abzw3Post-Abzw2" from="Abzw3Post" to="Abzw2" length="24.6" freespeed="20" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">1</attribute>
+				<attribute name="railsimResourceId" class="java.lang.String">R3</attribute>
+			</attributes>
+		</link>
+		<link id="B1-B2" from="B1" to="B2" length="250.0" freespeed="33.3" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">999</attribute>
+			</attributes>
+		</link>
+		<link id="B3-B4" from="B3" to="B4" length="255.0" freespeed="33.3" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">999</attribute>
+			</attributes>
+		</link>
+		<link id="B4-SigB" from="B4" to="SigB" length="2650.0" freespeed="33.3" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">1</attribute>
+			</attributes>
+		</link>
+		<link id="C1-C2" from="C1" to="C2" length="204.7" freespeed="33.3" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">999</attribute>
+			</attributes>
+		</link>
+		<link id="C3-C4" from="C3" to="C4" length="199.1" freespeed="33.3" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">999</attribute>
+			</attributes>
+		</link>
+		<link id="C4-SigC" from="C4" to="SigC" length="2243.3" freespeed="33" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">1</attribute>
+			</attributes>
+		</link>
+		<link id="SigA-Abzw1" from="SigA" to="Abzw1" length="77.5" freespeed="33" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">1</attribute>
+			</attributes>
+		</link>
+		<link id="SigB-Abzw2" from="SigB" to="Abzw2" length="100.0" freespeed="33" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">1</attribute>
+			</attributes>
+		</link>
+		<link id="SigC-Abzw3" from="SigC" to="Abzw3" length="42.5" freespeed="22" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">1</attribute>
+				<attribute name="railsimResourceId" class="java.lang.String">R3</attribute>
+			</attributes>
+		</link>
+		<link id="ToA-A3" from="ToA" to="A3" length="1980.0" freespeed="20" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">1</attribute>
+			</attributes>
+		</link>
+		<link id="ToB-B1" from="ToB" to="B1" length="2430.0" freespeed="20" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">1</attribute>
+			</attributes>
+		</link>
+		<link id="ToC-C1" from="ToC" to="C1" length="2063.4" freespeed="20" capacity="3600.0" permlanes="1.0" oneway="1" modes="rail">
+			<attributes>
+				<attribute name="railsimTrainCapacity" class="java.lang.Integer">1</attribute>
+			</attributes>
+		</link>
+	</links>
+
+</network>

--- a/contribs/railsim/test/input/ch/sbb/matsim/contrib/railsim/integration/microJunctionFlat/transitSchedule.xml
+++ b/contribs/railsim/test/input/ch/sbb/matsim/contrib/railsim/integration/microJunctionFlat/transitSchedule.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE transitSchedule SYSTEM "http://www.matsim.org/files/dtd/transitSchedule_v2.dtd">
+
+<transitSchedule>
+
+	<transitStops>
+		<stopFacility id="A12" name="Platform A Outbound" x="-1227.5" y="0.0" linkRefId="A1-A2" stopAreaId="station_A"/>
+		<stopFacility id="A34" name="Platform A Inbound" x="-1505.0" y="-20.0" linkRefId="A3-A4" stopAreaId="station_A"/>
+
+		<stopFacility id="B12" name="Platform B Inbound" x="4030.0" y="0.0" linkRefId="B1-B2" stopAreaId="station_B"/>
+		<stopFacility id="B34" name="Platform B Outbound" x="3775.0" y="-20.0" linkRefId="B3-B4" stopAreaId="station_B"/>
+
+		<stopFacility id="C12" name="Platform C Inbound" x="3225.0" y="1167.5" linkRefId="C1-C2" stopAreaId="station_C"/>
+		<stopFacility id="C34" name="Platform C Outbound" x="3090.0" y="1065.0" linkRefId="C3-C4" stopAreaId="station_C"/>
+	</transitStops>
+
+	<transitLine id="linie_AB">
+		<transitRoute id="linie_AB_route1">
+			<transportMode>rail</transportMode>
+			<routeProfile>
+				<stop refId="A12" departureOffset="00:00:00" awaitDeparture="false"/>
+				<stop refId="B12" arrivalOffset="01:00:00" awaitDeparture="false"/>
+			</routeProfile>
+			<route>
+				<link refId="A1-A2"/>
+				<link refId="A2-SigA"/>
+				<link refId="SigA-Abzw1"/>
+				<link refId="Abzw1-Abzw1Post"/>
+				<link refId="Abzw1Post-Abzw3"/>
+				<link refId="Abzw3-ToB"/>
+				<link refId="ToB-B1"/>
+				<link refId="B1-B2"/>
+			</route>
+			<departures>
+				<departure id="AB0" departureTime="08:30:00" vehicleRefId="trainAB0"/>
+				<departure id="AB1" departureTime="08:30:05" vehicleRefId="trainAB1"/>
+				<departure id="AB2" departureTime="08:30:10" vehicleRefId="trainAB2"/>
+				<departure id="AB3" departureTime="08:30:15" vehicleRefId="trainAB3"/>
+				<departure id="AB4" departureTime="08:30:20" vehicleRefId="trainAB4"/>
+				<departure id="AB5" departureTime="08:30:25" vehicleRefId="trainAB5"/>
+				<departure id="AB6" departureTime="08:30:30" vehicleRefId="trainAB6"/>
+				<departure id="AB7" departureTime="08:30:33" vehicleRefId="trainAB7"/>
+			</departures>
+		</transitRoute>
+	</transitLine>
+
+	<transitLine id="linie_BA">
+		<transitRoute id="linie_BA_route1">
+			<transportMode>rail</transportMode>
+			<routeProfile>
+				<stop refId="B34" arrivalOffset="01:00:00" awaitDeparture="false"/>
+				<stop refId="A34" departureOffset="00:00:00" awaitDeparture="false"/>
+			</routeProfile>
+			<route>
+				<link refId="B3-B4"/>
+				<link refId="B4-SigB"/>
+				<link refId="SigB-Abzw2"/>
+				<link refId="Abzw2-ToA"/>
+				<link refId="ToA-A3"/>
+				<link refId="A3-A4"/>
+			</route>
+			<departures>
+				<!-- Departure times for all vehicles from B to A-->
+				<departure id="BA0" departureTime="08:30:01" vehicleRefId="trainBA0"/>
+				<departure id="BA1" departureTime="08:30:03" vehicleRefId="trainBA1"/>
+				<departure id="BA2" departureTime="08:30:11" vehicleRefId="trainBA2"/>
+				<departure id="BA3" departureTime="08:30:14" vehicleRefId="trainBA3"/>
+				<departure id="BA4" departureTime="08:30:20" vehicleRefId="trainBA4"/>
+				<departure id="BA5" departureTime="08:30:23" vehicleRefId="trainBA5"/>
+				<departure id="BA6" departureTime="08:30:27" vehicleRefId="trainBA6"/>
+				<departure id="BA7" departureTime="08:30:33" vehicleRefId="trainBA7"/>
+			</departures>
+		</transitRoute>
+	</transitLine>
+
+	<transitLine id="linie_AC">
+		<transitRoute id="linie_CA_route1">
+			<transportMode>rail</transportMode>
+			<routeProfile>
+				<stop refId="A12" departureOffset="00:00:00" awaitDeparture="false"/>
+				<stop refId="C12" arrivalOffset="00:01:00" awaitDeparture="false"/>
+			</routeProfile>
+			<route>
+				<link refId="A1-A2"/>
+				<link refId="A2-SigA"/>
+				<link refId="SigA-Abzw1"/>
+				<link refId="Abzw1-ToC"/>
+				<link refId="ToC-C1"/>
+				<link refId="C1-C2"/>
+			</route>
+			<departures>
+				<departure id="AC0" departureTime="08:30:02" vehicleRefId="trainAC0"/>
+				<departure id="AC1" departureTime="08:30:07" vehicleRefId="trainAC1"/>
+				<departure id="AC2" departureTime="08:30:12" vehicleRefId="trainAC2"/>
+				<departure id="AC3" departureTime="08:30:17" vehicleRefId="trainAC3"/>
+				<departure id="AC4" departureTime="08:30:23" vehicleRefId="trainAC4"/>
+				<departure id="AC5" departureTime="08:30:28" vehicleRefId="trainAC5"/>
+				<departure id="AC6" departureTime="08:30:33" vehicleRefId="trainAC6"/>
+				<departure id="AC7" departureTime="08:30:36" vehicleRefId="trainAC7"/>
+			</departures>
+		</transitRoute>
+	</transitLine>
+
+	<transitLine id="linie_CA">
+		<transitRoute id="linie_CA_route1">
+			<transportMode>rail</transportMode>
+			<routeProfile>
+				<stop refId="C34" arrivalOffset="00:00:00" awaitDeparture="false"/>
+				<stop refId="A34" departureOffset="00:01:00" awaitDeparture="false"/>
+			</routeProfile>
+			<route>
+				<link refId="C3-C4"/>
+				<link refId="C4-SigC"/>
+				<link refId="SigC-Abzw3"/>
+				<link refId="Abzw3-Abzw3Post"/>
+				<link refId="Abzw3Post-Abzw2"/>
+				<link refId="Abzw2-ToA"/>
+				<link refId="ToA-A3"/>
+				<link refId="A3-A4"/>
+			</route>
+			<departures>
+				<departure id="CA0" departureTime="08:30:02" vehicleRefId="trainCA0"/>
+				<departure id="CA1" departureTime="08:30:07" vehicleRefId="trainCA1"/>
+				<departure id="CA2" departureTime="08:30:11" vehicleRefId="trainCA2"/>
+				<departure id="CA3" departureTime="08:30:15" vehicleRefId="trainCA3"/>
+				<departure id="CA4" departureTime="08:30:25" vehicleRefId="trainCA4"/>
+				<departure id="CA5" departureTime="08:30:27" vehicleRefId="trainCA5"/>
+				<departure id="CA6" departureTime="08:30:35" vehicleRefId="trainCA6"/>
+				<departure id="CA7" departureTime="08:30:38" vehicleRefId="trainCA7"/>
+			</departures>
+		</transitRoute>
+	</transitLine>
+
+</transitSchedule>

--- a/contribs/railsim/test/input/ch/sbb/matsim/contrib/railsim/integration/microJunctionFlat/transitVehicles.xml
+++ b/contribs/railsim/test/input/ch/sbb/matsim/contrib/railsim/integration/microJunctionFlat/transitVehicles.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<vehicleDefinitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.matsim.org/files/dtd" xsi:schemaLocation="http://www.matsim.org/files/dtd http://www.matsim.org/files/dtd/vehicleDefinitions_v2.0.xsd">
+
+	<vehicleType id="trainType1">
+		<attributes>
+			<attribute name="accessTimeInSecondsPerPerson" class="java.lang.Double">5.0</attribute>
+			<attribute name="doorOperationMode" class="org.matsim.vehicles.VehicleType$DoorOperationMode">serial</attribute>
+			<attribute name="egressTimeInSecondsPerPerson" class="java.lang.Double">5.0</attribute>
+			<attribute name="railsimAcceleration" class="java.lang.Double">0.5</attribute>
+			<attribute name="railsimDeceleration" class="java.lang.Double">0.5</attribute>
+		</attributes>
+		<capacity seats="40" standingRoomInPersons="0">
+		</capacity>
+		<length meter="200"/>
+		<width meter="1.0"/>
+		<maximumVelocity meterPerSecond="50."/>
+		<costInformation>
+
+		</costInformation>
+		<passengerCarEquivalents pce="0.0"/>
+		<networkMode networkMode="rail"/>
+		<flowEfficiencyFactor factor="1.0"/>
+	</vehicleType>
+
+	<vehicle id="trainAB0" type="trainType1"/>
+	<vehicle id="trainAB1" type="trainType1"/>
+	<vehicle id="trainAB2" type="trainType1"/>
+	<vehicle id="trainAB3" type="trainType1"/>
+	<vehicle id="trainAB4" type="trainType1"/>
+	<vehicle id="trainAB5" type="trainType1"/>
+	<vehicle id="trainAB6" type="trainType1"/>
+	<vehicle id="trainAB7" type="trainType1"/>
+
+	<vehicle id="trainBA0" type="trainType1"/>
+	<vehicle id="trainBA1" type="trainType1"/>
+	<vehicle id="trainBA2" type="trainType1"/>
+	<vehicle id="trainBA3" type="trainType1"/>
+	<vehicle id="trainBA4" type="trainType1"/>
+	<vehicle id="trainBA5" type="trainType1"/>
+	<vehicle id="trainBA6" type="trainType1"/>
+	<vehicle id="trainBA7" type="trainType1"/>
+
+	<vehicle id="trainCA0" type="trainType1"/>
+	<vehicle id="trainCA1" type="trainType1"/>
+	<vehicle id="trainCA2" type="trainType1"/>
+	<vehicle id="trainCA3" type="trainType1"/>
+	<vehicle id="trainCA4" type="trainType1"/>
+	<vehicle id="trainCA5" type="trainType1"/>
+	<vehicle id="trainCA6" type="trainType1"/>
+	<vehicle id="trainCA7" type="trainType1"/>
+
+	<vehicle id="trainAC0" type="trainType1"/>
+	<vehicle id="trainAC1" type="trainType1"/>
+	<vehicle id="trainAC2" type="trainType1"/>
+	<vehicle id="trainAC3" type="trainType1"/>
+	<vehicle id="trainAC4" type="trainType1"/>
+	<vehicle id="trainAC5" type="trainType1"/>
+	<vehicle id="trainAC6" type="trainType1"/>
+	<vehicle id="trainAC7" type="trainType1"/>
+
+</vehicleDefinitions>


### PR DESCRIPTION
This pull request introduces a new micro-scenario, `microJunctionFlat`, to the **railsim** contrib integration test suite.

All credit for this excellent and detailed test case goes to the author, @raproth.

**Test Case: Micro Junction Flat (At-Grade Junction)**

https://github.com/user-attachments/assets/bfcb685c-592b-4cb8-b975-b25951b44504

This test is designed to verify the correct handling of a complex, at-grade rail junction with conflicting, bidirectional traffic.

The scenario models a 3-way "flat junction" where three lines (A, B, and C) meet. Key characteristics include:
- Bidirectional traffic, with routes from A to B/C and from B/C back to A.
- Conflicting paths that require crossing the tracks of opposing traffic (e.g., the route from C to A crosses the path from A to B).
- A dense schedule with very short headways to stress-test the railsim conflict resolution and resource locking mechanisms.