### PR TITLE
refactor(core): update memory and qsim logging

### DIFF
--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSim.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/QSim.java
@@ -550,7 +550,7 @@ public final class QSim implements VisMobsim, Netsim, ActivityEndRescheduler {
 					.getTime()) / 1000;
 			double diffsim = time - this.simTimer.getSimStartTime();
 			log.info("SIMULATION (NEW QSim) AT " + Time.writeTime(time)
-					+ " : #Veh=" + this.agentCounter.getLiving() + " lost="
+					+ " : #active agents=" + this.agentCounter.getLiving() + " lost="
 					+ this.agentCounter.getLost() + " simT=" + diffsim
 					+ "s realT=" + (diffreal) + "s; (s/r): "
 					+ (diffsim / (diffreal + Double.MIN_VALUE)));

--- a/matsim/src/main/java/org/matsim/utils/MemoryObserver.java
+++ b/matsim/src/main/java/org/matsim/utils/MemoryObserver.java
@@ -39,7 +39,8 @@ public class MemoryObserver {
 		long totalMem = Runtime.getRuntime().totalMemory();
 		long freeMem = Runtime.getRuntime().freeMemory();
 		long usedMem = totalMem - freeMem;
-		LOG.info("used RAM: " + (usedMem/1024/1024) + " MB  free: " + (freeMem/1024/1024) + " MB  total: " + (totalMem/1024/1024) + " MB");
+		long maxMem = Runtime.getRuntime().maxMemory();
+		LOG.info("used RAM: " + (usedMem/1024/1024) + " MB  free: " + (freeMem/1024/1024) + " MB  total: " + (totalMem/1024/1024) + " MB max: " + (maxMem/1024/1024));
 	}
 
 	private static class MemoryPrinter implements Runnable {

--- a/matsim/src/main/java/org/matsim/utils/MemoryObserver.java
+++ b/matsim/src/main/java/org/matsim/utils/MemoryObserver.java
@@ -40,7 +40,7 @@ public class MemoryObserver {
 		long freeMem = Runtime.getRuntime().freeMemory();
 		long usedMem = totalMem - freeMem;
 		long maxMem = Runtime.getRuntime().maxMemory();
-		LOG.info("used RAM: " + (usedMem/1024/1024) + " MB  free: " + (freeMem/1024/1024) + " MB  total: " + (totalMem/1024/1024) + " MB max: " + (maxMem/1024/1024));
+		LOG.info("used RAM: " + (usedMem/1024/1024) + " MB  free: " + (freeMem/1024/1024) + " MB  total: " + (totalMem/1024/1024) + " MB  max: " + (maxMem/1024/1024) + " MB");
 	}
 
 	private static class MemoryPrinter implements Runnable {


### PR DESCRIPTION
Updates two of the common MATSim log statements:

1. renames "#veh:" to "#active agents" as this likely reflects better what is expressed. After all not every agent is a vehicular one
2. adds max memory statement to the memory observer to immediately see the upper bound of potential memory allocation
