### PR TITLE
fix(drt): Handle negative departure time corner case

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/DetourTimeEstimatorWithAdaptiveTravelTimes.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/repeatedselective/DetourTimeEstimatorWithAdaptiveTravelTimes.java
@@ -51,6 +51,7 @@ public class DetourTimeEstimatorWithAdaptiveTravelTimes implements DetourTimeEst
 
 	@Override
 	public double estimateTime(Link from, Link to, double departureTime) {
+		departureTime = Math.max(0, departureTime);
 
 		if (from == to) {
 			return 0;

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/AdaptiveTravelTimeMatrixImpl.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/AdaptiveTravelTimeMatrixImpl.java
@@ -108,7 +108,7 @@ public class AdaptiveTravelTimeMatrixImpl implements AdaptiveTravelTimeMatrix {
 
 	@Override
 	public double getTravelTime(Node fromNode, Node toNode, double departureTime) {
-		int bin = this.getBin(departureTime);
+		int bin = this.getBin(Math.max(0,departureTime));
 		Double sparseValue = this.sparseTravelTimeCache.get(this.getSparseTravelTimeKey(fromNode, toNode, bin));
 		if (sparseValue != null) {
 			return sparseValue;

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/AdaptiveTravelTimeMatrixImpl.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/AdaptiveTravelTimeMatrixImpl.java
@@ -108,7 +108,7 @@ public class AdaptiveTravelTimeMatrixImpl implements AdaptiveTravelTimeMatrix {
 
 	@Override
 	public double getTravelTime(Node fromNode, Node toNode, double departureTime) {
-		int bin = this.getBin(Math.max(0,departureTime));
+		int bin = this.getBin(departureTime);
 		Double sparseValue = this.sparseTravelTimeCache.get(this.getSparseTravelTimeKey(fromNode, toNode, bin));
 		if (sparseValue != null) {
 			return sparseValue;


### PR DESCRIPTION
Fix for a rare corner case situation, that can create index out of bounds error. DepartureTime might get negative caused by a large negative pickupDetourInfo.pickupTimeLoss.
