### PR TITLE
chore(drt): Reduce memory consumption of AdaptiveTravelTimeMatrixImpl

### DIFF
--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/AdaptiveTravelTimeMatrixImpl.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/AdaptiveTravelTimeMatrixImpl.java
@@ -43,7 +43,7 @@ public class AdaptiveTravelTimeMatrixImpl implements AdaptiveTravelTimeMatrix {
 	private final Map<Zone, Node> centralNodes;
 	private final int numberOfBins;
 	private final DvrpTravelTimeMatrixParams params;
-	private final Map<SparseTravelTimeKey, Double> sparseTravelTimeCache = new ConcurrentHashMap<>();
+	private final Map<IntSparseKey, Double> sparseTravelTimeCache = new ConcurrentHashMap<>();
 
 	public AdaptiveTravelTimeMatrixImpl(double maxTime, Network dvrpNetwork, ZoneSystem zoneSystem, DvrpTravelTimeMatrixParams params,
 										TravelTimeMatrix freeSpeedMatrix, double alpha) {
@@ -58,8 +58,6 @@ public class AdaptiveTravelTimeMatrixImpl implements AdaptiveTravelTimeMatrix {
 		this.initializeSparseTravelTimeCache(freeSpeedMatrix);
 	}
 
-	record SparseTravelTimeKey(Node fromNode, Node toNode, double timeBin) {
-	}
 
 	int numberOfBins(double maxTime) {
 		return (int) (maxTime / TIME_INTERVAL);
@@ -76,7 +74,7 @@ public class AdaptiveTravelTimeMatrixImpl implements AdaptiveTravelTimeMatrix {
 					Node destinationNode = destinationZoneEntry.getValue();
 					if (DistanceUtils.calculateSquaredDistance(originNode.getCoord(),
 							destinationNode.getCoord()) < (params.getMaxNeighborDistance() * params.getMaxNeighborDistance())) {
-						SparseTravelTimeKey key = getSparseTravelTimeKey(originNode, destinationNode, bin);
+						IntSparseKey key = getSparseTravelTimeKey(originNode, destinationNode, bin);
 						double freeSpeedTravelTime = freeSpeedMatrix.getTravelTime(originNode, destinationNode, Double.NaN);
 						this.sparseTravelTimeCache.computeIfAbsent(key, k -> freeSpeedTravelTime);
 					}
@@ -85,9 +83,10 @@ public class AdaptiveTravelTimeMatrixImpl implements AdaptiveTravelTimeMatrix {
 		}
 	}
 
-	SparseTravelTimeKey getSparseTravelTimeKey(Node originNode, Node destinationNode, int bin) {
-		return new SparseTravelTimeKey(originNode, destinationNode, bin);
+	IntSparseKey getSparseTravelTimeKey(Node fromNode, Node toNode, int bin) {
+		return new IntSparseKey(fromNode.getId().index(), toNode.getId().index(), bin);
 	}
+
 
 	// Matrix needs to be filled otherwise we have -1 exceptions
 	// We fill the matrix with already calculated free speed travel times
@@ -123,7 +122,7 @@ public class AdaptiveTravelTimeMatrixImpl implements AdaptiveTravelTimeMatrix {
 	@Override
 	public void setTravelTime(Node fromNode, Node toNode, double routeEstimate, double departureTime) {
 		int bin = this.getBin(departureTime);
-		SparseTravelTimeKey key = this.getSparseTravelTimeKey(fromNode, toNode, bin);
+		IntSparseKey key = this.getSparseTravelTimeKey(fromNode, toNode, bin);
 		Double sparseValue = this.sparseTravelTimeCache.get(this.getSparseTravelTimeKey(fromNode, toNode, bin));
 
 		// Update sparseTravelTimeCache
@@ -143,6 +142,29 @@ public class AdaptiveTravelTimeMatrixImpl implements AdaptiveTravelTimeMatrix {
 
 	static double getUpdatedValue(double currentValue, double newValue, double alpha) {
 		return currentValue * (1 - alpha) + alpha * newValue;
+	}
+
+
+	public static class IntSparseKey {
+		private final long key;
+
+		public IntSparseKey(int fromIndex, int toIndex, int timeBin) {
+			// 20 Bit for fromIndex, 20 Bit for toIndex, 24 Bit for timeBin
+			this.key = (((long) timeBin) << 40) | (((long) fromIndex & 0xFFFFF) << 20) | ((long) toIndex & 0xFFFFF);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) return true;
+			if (!(obj instanceof IntSparseKey)) return false;
+			IntSparseKey other = (IntSparseKey) obj;
+			return this.key == other.key;
+		}
+
+		@Override
+		public int hashCode() {
+			return Long.hashCode(key);
+		}
 	}
 
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/AdaptiveTravelTimeMatrixImpl.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/zone/skims/AdaptiveTravelTimeMatrixImpl.java
@@ -149,8 +149,19 @@ public class AdaptiveTravelTimeMatrixImpl implements AdaptiveTravelTimeMatrix {
 		private final long key;
 
 		public IntSparseKey(int fromIndex, int toIndex, int timeBin) {
-			// 20 Bit for fromIndex, 20 Bit for toIndex, 24 Bit for timeBin
 			this.key = (((long) timeBin) << 40) | (((long) fromIndex & 0xFFFFF) << 20) | ((long) toIndex & 0xFFFFF);
+		}
+
+		public int getFromIndex() {
+			return (int) ((key >> 20) & 0xFFFFF);
+		}
+
+		public int getToIndex() {
+			return (int) (key & 0xFFFFF);
+		}
+
+		public int getTimeBin() {
+			return (int) ((key >> 40) & 0xFFFFFF);
 		}
 
 		@Override
@@ -166,5 +177,6 @@ public class AdaptiveTravelTimeMatrixImpl implements AdaptiveTravelTimeMatrix {
 			return Long.hashCode(key);
 		}
 	}
+
 
 }

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/zone/skims/SparseTravelTimeCacheTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/zone/skims/SparseTravelTimeCacheTest.java
@@ -1,0 +1,79 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2025 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+
+package org.matsim.contrib.zone.skims;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SparseTravelTimeCacheTest {
+
+    private Map<AdaptiveTravelTimeMatrixImpl.IntSparseKey, Double> cache;
+
+    @BeforeEach
+    void setUp() {
+        cache = new ConcurrentHashMap<>();
+    }
+
+    @Test
+    void testPutAndGetTravelTime() {
+        int fromIndex = 123;
+        int toIndex = 456;
+        int timeBin = 5;
+        double travelTime = 321.5;
+
+        AdaptiveTravelTimeMatrixImpl.IntSparseKey key = new AdaptiveTravelTimeMatrixImpl.IntSparseKey(fromIndex, toIndex, timeBin);
+        cache.put(key, travelTime);
+
+        assertTrue(cache.containsKey(key), "Key should exist in cache");
+        assertEquals(travelTime, cache.get(key), 1e-6, "Travel time should match");
+    }
+
+    @Test
+    void testDifferentBinsAreDifferentKeys() {
+        AdaptiveTravelTimeMatrixImpl.IntSparseKey key1 = new AdaptiveTravelTimeMatrixImpl.IntSparseKey(1, 2, 3);
+        AdaptiveTravelTimeMatrixImpl.IntSparseKey key2 = new AdaptiveTravelTimeMatrixImpl.IntSparseKey(1, 2, 4);
+
+        cache.put(key1, 100.0);
+        cache.put(key2, 200.0);
+
+        assertNotEquals(key1, key2, "Keys with different bins should not be equal");
+        assertEquals(100.0, cache.get(key1), 1e-6);
+        assertEquals(200.0, cache.get(key2), 1e-6);
+    }
+
+    @Test
+    void testSymmetry() {
+        AdaptiveTravelTimeMatrixImpl.IntSparseKey key1 = new AdaptiveTravelTimeMatrixImpl.IntSparseKey(10, 20, 1);
+        AdaptiveTravelTimeMatrixImpl.IntSparseKey key2 = new AdaptiveTravelTimeMatrixImpl.IntSparseKey(20, 10, 1);
+
+        cache.put(key1, 50.0);
+        cache.put(key2, 75.0);
+
+        assertNotEquals(key1, key2, "Direction matters: keys should not be equal");
+        assertEquals(50.0, cache.get(key1), 1e-6);
+        assertEquals(75.0, cache.get(key2), 1e-6);
+    }
+}

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/zone/skims/SparseTravelTimeCacheTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/zone/skims/SparseTravelTimeCacheTest.java
@@ -76,4 +76,18 @@ class SparseTravelTimeCacheTest {
         assertEquals(50.0, cache.get(key1), 1e-6);
         assertEquals(75.0, cache.get(key2), 1e-6);
     }
+
+	@Test
+	void testBitPackingAndUnpacking() {
+		int fromIndex = 123456;
+		int toIndex = 654321;
+		int timeBin = 17;
+
+		AdaptiveTravelTimeMatrixImpl.IntSparseKey key = new AdaptiveTravelTimeMatrixImpl.IntSparseKey(fromIndex, toIndex, timeBin);
+
+		assertEquals(fromIndex, key.getFromIndex(), "fromIndex should match after unpacking");
+		assertEquals(toIndex, key.getToIndex(), "toIndex should match after unpacking");
+		assertEquals(timeBin, key.getTimeBin(), "timeBin should match after unpacking");
+	}
+
 }


### PR DESCRIPTION
Use a bitpacking approach to implement a IntSparseKey that saves memory when working with large spatial areas or simulating more than 24 h 