### PR TITLE
fix: (freightGeneration): make classes public because they are used in other repositories

### DIFF
--- a/contribs/small-scale-traffic-generation/src/main/java/org/matsim/commercialDemandGenerationBasic/DemandGenerationSpecification.java
+++ b/contribs/small-scale-traffic-generation/src/main/java/org/matsim/commercialDemandGenerationBasic/DemandGenerationSpecification.java
@@ -8,7 +8,7 @@ import org.matsim.core.controler.Controller;
 
 import java.util.HashMap;
 
-interface DemandGenerationSpecification {
+public interface DemandGenerationSpecification {
 
 	/**
 	 * Gets the demand to distribute for this demand information element.

--- a/contribs/small-scale-traffic-generation/src/main/java/org/matsim/commercialDemandGenerationBasic/DemandGenerationSpecificationForParcelDelivery.java
+++ b/contribs/small-scale-traffic-generation/src/main/java/org/matsim/commercialDemandGenerationBasic/DemandGenerationSpecificationForParcelDelivery.java
@@ -27,7 +27,7 @@ import static org.matsim.commercialDemandGenerationBasic.DemandReaderFromCSV.get
  * @see BasicCommercialDemandGeneration
  * @Author Ricardo Ewert (based on the work of the master thesis of Ana Ueberhorst)
  */
-class DemandGenerationSpecificationForParcelDelivery extends DefaultDemandGenerationSpecification {
+public class DemandGenerationSpecificationForParcelDelivery extends DefaultDemandGenerationSpecification {
 	//	private static double PACKAGES_PER_PERSON = 0.0686; //default value
 	private static double PACKAGES_PER_PERSON = 0.14; //default value
 


### PR DESCRIPTION
The interface and the specific implementation are used in zeroCUTS repository. That's why they still need to be public.
