### PR TITLE
feat(aws): Add AWS contrib

### DIFF
--- a/contribs/aws/pom.xml
+++ b/contribs/aws/pom.xml
@@ -5,9 +5,8 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.matsim</groupId>
-        <artifactId>matsim-all</artifactId>
+        <artifactId>contrib</artifactId>
         <version>2026.0-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>aws</artifactId>
@@ -17,5 +16,25 @@
         <maven.compiler.target>22</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>2.25.57</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/contribs/aws/pom.xml
+++ b/contribs/aws/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.matsim</groupId>
+        <artifactId>matsim-all</artifactId>
+        <version>2026.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>aws</artifactId>
+
+    <properties>
+        <maven.compiler.source>22</maven.compiler.source>
+        <maven.compiler.target>22</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+</project>

--- a/contribs/aws/src/main/java/org/matsim/contrib/aws/AWSStartupHook.java
+++ b/contribs/aws/src/main/java/org/matsim/contrib/aws/AWSStartupHook.java
@@ -1,0 +1,62 @@
+package org.matsim.contrib.aws;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+
+/**
+ * @author nkuehnel / MOIA
+ */
+public class AWSStartupHook  {
+
+    private final static Logger logger = LogManager.getLogger(AWSStartupHook.class);
+
+
+    public static void registerS3UrlHandler() {
+        try {
+            S3Client S3 = S3Client.create();
+            URL.setURLStreamHandlerFactory(protocol -> {
+                if ("s3".equals(protocol)) {
+                    return new S3UrlStreamHandler(S3);
+                }
+                return null;
+            });
+        } catch (SdkClientException e) {
+            logger.warn("Make sure to provide valid AWS credentials in your environment variables:");
+            logger.warn("AWS_ACCESS_KEY_ID");
+            logger.warn("AWS_SECRET_ACCESS_KEY");
+            logger.warn("AWS_DEFAULT_REGION");
+            logger.warn("(opt.) AWS_SESSION_TOKEN");
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static class S3UrlStreamHandler extends URLStreamHandler {
+        private final S3Client s3;
+
+        public S3UrlStreamHandler(S3Client s3) { this.s3 = s3; }
+        @Override protected URLConnection openConnection(URL url) {
+            return new S3URLConnection(url, s3);
+        }
+    }
+
+    private static class S3URLConnection extends URLConnection {
+        private final S3Client s3;
+        public S3URLConnection(URL url, S3Client s3) { super(url); this.s3 = s3; }
+        @Override public void connect() { /* no-op */ }
+        @Override public InputStream getInputStream() {
+            ResponseInputStream<GetObjectResponse> resp = s3.getObject(GetObjectRequest.builder()
+                    .bucket(url.getHost()).key(url.getPath().substring(1)).build());
+            return resp;
+        }
+    }
+}

--- a/contribs/aws/src/main/java/org/matsim/contrib/aws/AwsS3Util.java
+++ b/contribs/aws/src/main/java/org/matsim/contrib/aws/AwsS3Util.java
@@ -1,0 +1,23 @@
+package org.matsim.contrib.aws;
+
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+/**
+ * @author nkuehnel / MOIA
+ */
+public class AwsS3Util {
+
+    private final static S3Client S3 = S3Client.create();
+
+    public static ResponseInputStream<GetObjectResponse> getS3InputStream(String bucket, String key) {
+        GetObjectRequest request = GetObjectRequest
+                .builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+        return S3.getObject(request);
+    }
+}

--- a/contribs/aws/src/test/java/org/matsim/contrib/aws/AWSStreamExceptionTest.java
+++ b/contribs/aws/src/test/java/org/matsim/contrib/aws/AWSStreamExceptionTest.java
@@ -1,0 +1,30 @@
+package org.matsim.contrib.aws;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.network.io.MatsimNetworkReader;
+import org.matsim.testcases.MatsimTestUtils;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class AWSStreamExceptionTest {
+
+    private final static String TEST_S3_URI = "s3://matsim-jobs-input-443370681674/input/mob1156/scenario0/nowel4_network.xml";
+
+
+    @RegisterExtension
+    private MatsimTestUtils utils = new MatsimTestUtils();
+
+    @Test
+    void testAWSException() {
+        Assertions.assertThrows(RuntimeException.class, AWSStartupHook::registerS3UrlHandler);
+    }
+
+    @Test
+    void testWithoutRegistration() {
+        Assertions.assertThrows(MalformedURLException.class, () -> new MatsimNetworkReader(NetworkUtils.createNetwork()).readURL(new URL(TEST_S3_URI)));
+    }
+}

--- a/contribs/aws/src/test/java/org/matsim/contrib/aws/AWSStreamTest.java
+++ b/contribs/aws/src/test/java/org/matsim/contrib/aws/AWSStreamTest.java
@@ -1,0 +1,115 @@
+package org.matsim.contrib.aws;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.network.TimeDependentNetwork;
+import org.matsim.core.network.io.MatsimNetworkReader;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.testcases.MatsimTestUtils;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+import java.net.URL;
+
+/**
+ * @author nkuehnel / MOIA
+ */
+public class AWSStreamTest {
+
+    private final static String NETWORK_TEST_S3_URI = "s3://../network.xml.gz";
+    private final static String PLANS_TEST_S3_URI = "s3://../plans.xml.gz";
+    private final static String VEHICLE_TEST_S3_URI = "s3://../vehicles.xml.gz";
+    private final static String TRANSIT_TEST_S3_URI = "s3://../schedule.xml.gz";
+    private final static String CHANGE_EVENTS_TEST_S3_URI = "s3://../nces.xml.gz";
+    private final static String TEST_S3_BUCKET = "bucket";
+    private final static String TEST_S3_KEY = "key/key/key/network.xml.gz";
+
+    @BeforeAll
+    static void installHandlerOnce() {
+        Assertions.assertDoesNotThrow(AWSStartupHook::registerS3UrlHandler);
+    }
+
+    @RegisterExtension
+    private MatsimTestUtils utils = new MatsimTestUtils();
+
+
+    @Test
+    @Disabled
+    /**
+     * Run with valid credentials and existing S3 URI only
+     */
+    void testWithRegistrationURL() {
+        Network network = NetworkUtils.createNetwork();
+        Assertions.assertDoesNotThrow(() -> new MatsimNetworkReader(network).readURL(new URL(NETWORK_TEST_S3_URI)));
+        Assertions.assertFalse(network.getLinks().isEmpty());
+    }
+
+    @Test
+    @Disabled
+    /**
+     * Run with valid credentials and existing S3 URI only
+     */
+    void testWithRegistrationURLConfig() {
+        Config config = ConfigUtils.createConfig();
+        config.network().setInputFile(NETWORK_TEST_S3_URI);
+
+        URL networkUrl = config.network().getInputFileURL(config.getContext());
+        String inputCRS = config.network().getInputCRS();
+
+        Network network = NetworkUtils.createNetwork();
+        MatsimNetworkReader reader =
+                new MatsimNetworkReader(
+                        inputCRS,
+                        config.global().getCoordinateSystem(),
+                        network);
+        reader.parse(networkUrl);
+        Assertions.assertFalse(network.getLinks().isEmpty());
+    }
+
+    @Test
+    @Disabled
+    /**
+     * Run with valid credentials and existing S3 URI only
+     */
+    void testWithRegistrationDirectStream() {
+        Network network = NetworkUtils.createNetwork();
+        ResponseInputStream<GetObjectResponse> s3InputStream = AwsS3Util.getS3InputStream(TEST_S3_BUCKET, TEST_S3_KEY);
+        new MatsimNetworkReader(network).parse(s3InputStream);
+        Assertions.assertFalse(network.getLinks().isEmpty());
+    }
+
+
+    @Test
+    @Disabled
+    /**
+     * Run with valid credentials and existing S3 URI only
+     */
+    void testWithRegistrationFullScenario() {
+        Config config = ConfigUtils.createConfig();
+
+        config.transit().setUseTransit(true);
+        config.transit().setTransitScheduleFile(TRANSIT_TEST_S3_URI);
+
+        config.plans().setInputFile(PLANS_TEST_S3_URI);
+
+        config.vehicles().setVehiclesFile(VEHICLE_TEST_S3_URI);
+
+        config.network().setInputFile(NETWORK_TEST_S3_URI);
+        config.network().setTimeVariantNetwork(true);
+        config.network().setChangeEventsInputFile(CHANGE_EVENTS_TEST_S3_URI);
+        Scenario scenario = ScenarioUtils.loadScenario(config);
+
+        Assertions.assertFalse(scenario.getTransitSchedule().getFacilities().isEmpty());
+        Assertions.assertFalse(scenario.getPopulation().getPersons().isEmpty());
+        Assertions.assertFalse(scenario.getNetwork().getLinks().isEmpty());
+        Assertions.assertFalse(((TimeDependentNetwork) scenario.getNetwork()).getNetworkChangeEvents().isEmpty());
+    }
+}

--- a/contribs/pom.xml
+++ b/contribs/pom.xml
@@ -61,6 +61,7 @@
 		<module>analysis</module>
 		<module>application</module>
 		<module>av</module>
+		<module>aws</module>
 		<module>bicycle</module>
 		<module>cadytsIntegration</module>
 		<module>carsharing</module>

--- a/matsim/src/main/java/org/matsim/core/utils/io/IOUtils.java
+++ b/matsim/src/main/java/org/matsim/core/utils/io/IOUtils.java
@@ -251,12 +251,13 @@ PR ist hier: https://github.com/matsim-org/matsim/pull/646
 		try {
 			new URL(url).toURI();
 			return true;
-		} catch (MalformedURLException e) {
-			return false;
-		} catch (URISyntaxException e) {
+		} catch (MalformedURLException | URISyntaxException e) {
+			if(url.startsWith("s3:")) {
+				logger.warn("S3 URI detected, please check if you properly initialized the AWS contrib startup hook.");
+			}
 			return false;
 		}
-	}
+    }
 
 	/**
 	 * Gets the compression of a certain URL by file extension. May return null if
@@ -521,6 +522,9 @@ PR ist hier: https://github.com/matsim-org/matsim/pull/646
 		try {
 			return new URL(context, extension);
 		} catch (MalformedURLException e) {
+			if(extension.startsWith("s3:")) {
+				logger.warn("S3 URI detected, please check if you properly initialized the AWS contrib");
+			}
 			// We cannot construct a URL for some reason (see respective unit test)
 			return getFileUrl(extension);
 		}


### PR DESCRIPTION
Adds a new small contrib with AWS SDK dependencies.

So far, it introduces 
- a startup hook to register a URI resolver which allows to use AWS S3 URIs as input paths in the config (see test for how it works)
- a static utility method to obtain an S3 input stream for further parsing

By doing that, a config may have paths like:
"s3://<bucket-name>/network.xml.gz"

..which allows streaming input from AWS on-the-fly without the need of manually syncing content before each simulation.


Syncing output back is not as straightforward, as there is no simple output stream writer. However, we will add a shutdown hook later, which can optionally sync back from the local output directory, if desired.

see also 
https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingObjects.html