### PR TITLE
fix: Ensure individual InsertionProvider instances for ParallelUnplannedRequestInserter

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/extensive/ExtensiveInsertionSearchQSimModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/extensive/ExtensiveInsertionSearchQSimModule.java
@@ -60,11 +60,16 @@ public class ExtensiveInsertionSearchQSimModule extends AbstractDvrpModeQSimModu
 
 		addModalComponent(DrtInsertionSearchManager.class, modalProvider(getter -> {
 			var insertionCostCalculator = getter.getModal(InsertionCostCalculator.class);
-			var provider = ExtensiveInsertionProvider.create(drtCfg, insertionCostCalculator,
-				getter.getModal(QsimScopeForkJoinPool.class).getPool(),
-				getter.getModal(StopTimeCalculator.class), getter.getModal(DetourTimeEstimator.class));
-			return new DrtInsertionSearchManager(() -> new ExtensiveInsertionSearch(provider, getter.getModal(MultiInsertionDetourPathCalculatorManager.class).create(),
-				insertionCostCalculator, getter.getModal(StopTimeCalculator.class)));
+
+			return new DrtInsertionSearchManager(() ->
+			{
+				// Each instance should have its own insertionProvider
+				var provider = ExtensiveInsertionProvider.create(drtCfg, insertionCostCalculator,
+					getter.getModal(QsimScopeForkJoinPool.class).getPool(),
+					getter.getModal(StopTimeCalculator.class), getter.getModal(DetourTimeEstimator.class));
+				return new ExtensiveInsertionSearch(provider, getter.getModal(MultiInsertionDetourPathCalculatorManager.class).create(),
+					insertionCostCalculator, getter.getModal(StopTimeCalculator.class));
+			});
 		}));
 
 		bindModal(DrtInsertionSearch.class).toProvider(modalProvider( getter -> getter.getModal(DrtInsertionSearchManager.class).create()));

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/parallel/RequestInsertWorker.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/parallel/RequestInsertWorker.java
@@ -42,7 +42,7 @@ import static org.matsim.contrib.drt.optimizer.insertion.selective.RequestDataCo
 public class RequestInsertWorker {
 	private final RequestFleetFilter requestFleetFilter;
 	private final DrtInsertionSearch insertionSearch;
-	private final Queue<RequestData> unplannedRequests = new ConcurrentLinkedQueue<>();
+	private final Queue<RequestData> unplannedRequests = new ArrayDeque<>();
 	private final Map<Id<DvrpVehicle>, SortedSet<RequestData>> solutions;
 	private final SortedSet<DrtRequest> noSolutions;
 


### PR DESCRIPTION
Further profiling showed that the new `ParallelUnplannedRequestInserter` benefits from indivudal InsertionProvider instances. Compared to PR #4102 runtime could be further reduced by 33 %.