### PR TITLE
build: Allow to manually start the weekly-build workflow

### DIFF
--- a/.github/workflows/deploy-weekly.yaml
+++ b/.github/workflows/deploy-weekly.yaml
@@ -1,6 +1,7 @@
 name: deploy-weekly
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '30 0 * * 1' # Mon 0:30 UTC
 


### PR DESCRIPTION
**Problem:**
A rerun of a scheduled workflow seems to always use the same commit. (see #4153)
This leads to a situation where issues that let the build fail will prevent us from having a weekly release.

**Solution:**
I added the trigger `workflow_dispatch` to the `build-weekly` workflow. 
This enables the "run workflow" button for the workflow in GH actions, so we can start the workflow manually.
See: https://docs.github.com/de/actions/how-tos/manage-workflow-runs/manually-run-a-workflow