### PR TITLE
feat(pt): route cost in DefaultTransitPassengerRoute

### DIFF
--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/RaptorUtils.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/RaptorUtils.java
@@ -162,7 +162,10 @@ public final class RaptorUtils {
                 ptLeg.setDepartureTime(part.depTime);
                 ptLeg.setTravelTime(part.getChainedArrivalTime() - part.depTime);
 
-                ptLeg.setRoute(convertRoutePart(part));
+				DefaultTransitPassengerRoute defaultTransitPassengerRoute = convertRoutePart(part);
+				defaultTransitPassengerRoute.totalRouteCost = route.getTotalCosts();
+
+                ptLeg.setRoute(defaultTransitPassengerRoute);
 
 				legs.add(ptLeg);
                 lastArrivalTime = part.getChainedArrivalTime();

--- a/matsim/src/main/java/org/matsim/pt/routes/DefaultTransitPassengerRoute.java
+++ b/matsim/src/main/java/org/matsim/pt/routes/DefaultTransitPassengerRoute.java
@@ -121,6 +121,7 @@ public class DefaultTransitPassengerRoute extends AbstractRoute implements Trans
 			this.transitLineIndex = parsed.transitLineId == null ? NULL_ID : parsed.transitLineId.index();
 			this.transitRouteIndex = parsed.transitRouteId == null ? NULL_ID : parsed.transitRouteId.index();
 			this.chainedRoute = createChainedRoutes(parsed.chainedRoute);
+			this.totalRouteCost = parsed.totalRouteCost;
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}

--- a/matsim/src/main/java/org/matsim/pt/routes/DefaultTransitPassengerRoute.java
+++ b/matsim/src/main/java/org/matsim/pt/routes/DefaultTransitPassengerRoute.java
@@ -33,8 +33,10 @@ public class DefaultTransitPassengerRoute extends AbstractRoute implements Trans
 
 	public DefaultTransitPassengerRoute chainedRoute = null;
 
+	public double totalRouteCost = Double.NaN;
+
 	DefaultTransitPassengerRoute(final Id<Link> startLinkId, final Id<Link> endLinkId) {
-		this(startLinkId, endLinkId, null, null, null, null);
+		this(startLinkId, endLinkId, null, null, null, null, Double.NaN);
 	}
 
 	public DefaultTransitPassengerRoute(TransitStopFacility accessFacility, TransitLine line, TransitRoute route,
@@ -42,7 +44,8 @@ public class DefaultTransitPassengerRoute extends AbstractRoute implements Trans
 		this( //
 			accessFacility.getLinkId(), egressFacility.getLinkId(), //
 			accessFacility.getId(), egressFacility.getId(), //
-			line != null ? line.getId() : null, route != null ? route.getId() : null);
+			line != null ? line.getId() : null, route != null ? route.getId() : null,
+			Double.NaN);
 	}
 
 	public DefaultTransitPassengerRoute(TransitStopFacility accessFacility, TransitLine line, TransitRoute route,
@@ -50,7 +53,8 @@ public class DefaultTransitPassengerRoute extends AbstractRoute implements Trans
 		this( //
 			accessFacility.getLinkId(), egressFacility.getLinkId(), //
 			accessFacility.getId(), egressFacility.getId(), //
-			line != null ? line.getId() : null, route != null ? route.getId() : null);
+			line != null ? line.getId() : null, route != null ? route.getId() : null,
+			Double.NaN);
 		this.chainedRoute = chainedRoute;
 	}
 
@@ -58,19 +62,29 @@ public class DefaultTransitPassengerRoute extends AbstractRoute implements Trans
 										 final Id<Link> accessLinkId, final Id<Link> egressLinkId, //
 										 Id<TransitStopFacility> accessFacilityId, Id<TransitStopFacility> egressFacilityId, //
 										 Id<TransitLine> transitLineId, Id<TransitRoute> transitRouteId) {
+		this(accessLinkId, egressLinkId, accessFacilityId, egressFacilityId, transitLineId, transitRouteId, Double.NaN);
+	}
+
+	public DefaultTransitPassengerRoute( //
+										 final Id<Link> accessLinkId, final Id<Link> egressLinkId, //
+										 Id<TransitStopFacility> accessFacilityId, Id<TransitStopFacility> egressFacilityId, //
+										 Id<TransitLine> transitLineId, Id<TransitRoute> transitRouteId,
+										 double totalRouteCost) {
 		super(accessLinkId, egressLinkId);
 
 		this.transitLineIndex = Objects.isNull(transitLineId) ? NULL_ID : transitLineId.index();
 		this.transitRouteIndex = Objects.isNull(transitRouteId) ? NULL_ID : transitRouteId.index();
 		this.accessFacilityIndex = Objects.isNull(accessFacilityId) ? NULL_ID : accessFacilityId.index();
 		this.egressFacilityIndex = Objects.isNull(egressFacilityId) ? NULL_ID : egressFacilityId.index();
+		this.totalRouteCost = totalRouteCost;
 	}
 
 	/**
 	 * Construct for data read from JSON.
 	 */
 	private DefaultTransitPassengerRoute(double boardingTime, int accessFacilityIndex, int egressFacilityIndex,
-										 int transitLineIndex, int transitRouteIndex, DefaultTransitPassengerRoute chainedRoute) {
+										 int transitLineIndex, int transitRouteIndex, DefaultTransitPassengerRoute chainedRoute,
+										 double  totalRouteCost) {
 		super(null, null);
 		this.boardingTime = boardingTime;
 		this.accessFacilityIndex = accessFacilityIndex;
@@ -78,6 +92,7 @@ public class DefaultTransitPassengerRoute extends AbstractRoute implements Trans
 		this.transitLineIndex = transitLineIndex;
 		this.transitRouteIndex = transitRouteIndex;
 		this.chainedRoute = chainedRoute;
+		this.totalRouteCost = totalRouteCost;
 	}
 
 	@Override
@@ -128,7 +143,7 @@ public class DefaultTransitPassengerRoute extends AbstractRoute implements Trans
 
 		return new DefaultTransitPassengerRoute(
 			boardingTime, accessFacilityIndex, egressFacilityIndex, transitLineIndex, transitRouteIndex,
-			createChainedRoutes(r.chainedRoute)
+			createChainedRoutes(r.chainedRoute), r.totalRouteCost
 		);
 	}
 
@@ -172,7 +187,8 @@ public class DefaultTransitPassengerRoute extends AbstractRoute implements Trans
 		DefaultTransitPassengerRoute copy = new DefaultTransitPassengerRoute( //
 			getStartLinkId(), getEndLinkId(), //
 			getAccessStopId(), getEgressStopId(), //
-			getLineId(), getRouteId());
+			getLineId(), getRouteId(),
+			totalRouteCost);
 
 		// Perform deep copy of the chained route
 		if (this.chainedRoute != null) {
@@ -197,6 +213,8 @@ public class DefaultTransitPassengerRoute extends AbstractRoute implements Trans
 
 		public RouteDescription chainedRoute;
 
+		public double totalRouteCost = Double.NaN;
+
 		public RouteDescription() {
 		}
 
@@ -206,6 +224,7 @@ public class DefaultTransitPassengerRoute extends AbstractRoute implements Trans
 			egressFacilityId = r.egressFacilityIndex == NULL_ID ? null : Id.get(r.egressFacilityIndex, TransitStopFacility.class);
 			transitLineId = r.transitLineIndex == NULL_ID ? null : Id.get(r.transitLineIndex, TransitLine.class);
 			transitRouteId = r.transitRouteIndex == NULL_ID ? null : Id.get(r.transitRouteIndex, TransitRoute.class);
+			totalRouteCost = r.totalRouteCost;
 
 			if (r.chainedRoute != null) {
 				this.chainedRoute = new RouteDescription(r.chainedRoute);
@@ -235,6 +254,11 @@ public class DefaultTransitPassengerRoute extends AbstractRoute implements Trans
 		@JsonProperty("transitRouteId")
 		public String getRouteLineId() {
 			return this.transitRouteId == null ? null : this.transitRouteId.toString();
+		}
+
+		@JsonProperty("totalRouteCost")
+		public String getTotalRouteCost() {
+			return String.valueOf(this.totalRouteCost);
 		}
 
 		@JsonProperty("boardingTime")
@@ -271,6 +295,11 @@ public class DefaultTransitPassengerRoute extends AbstractRoute implements Trans
 		@JsonProperty("chainedRoute")
 		public void setChainedRoute(RouteDescription chainedRoute) {
 			this.chainedRoute = chainedRoute;
+		}
+
+		@JsonProperty("totalRouteCost")
+		public void setTotalRouteCost(String totalRouteCost) {
+			this.totalRouteCost = Double.parseDouble(totalRouteCost);
 		}
 	}
 }

--- a/matsim/src/test/java/org/matsim/pt/routes/DefaultTransitPassengerRouteTest.java
+++ b/matsim/src/test/java/org/matsim/pt/routes/DefaultTransitPassengerRouteTest.java
@@ -139,14 +139,16 @@ public class DefaultTransitPassengerRouteTest {
 					"\"accessFacilityId\" : \"5\"," +
 					"\"egressFacilityId\" : \"1055\"," +
 					"\"transitLineId\" : \"11\"," +
-					"\"transitRouteId\" : \"1980\"" +
+					"\"transitRouteId\" : \"1980\"," +
+					"\"totalRouteCost\": \"50\"" +
 				"}"
 		);
 		assertEquals("5", route.getAccessStopId().toString());
 		assertEquals("11", route.getLineId().toString());
 		assertEquals("1980", route.getRouteId().toString());
 		assertEquals("1055", route.getEgressStopId().toString());
-		assertEquals("{\"transitRouteId\":\"1980\",\"boardingTime\":\"undefined\",\"transitLineId\":\"11\",\"accessFacilityId\":\"5\",\"egressFacilityId\":\"1055\"}", route.getRouteDescription());
+		assertEquals(50.0, route.totalRouteCost);
+		assertEquals("{\"transitRouteId\":\"1980\",\"boardingTime\":\"undefined\",\"transitLineId\":\"11\",\"accessFacilityId\":\"5\",\"egressFacilityId\":\"1055\",\"totalRouteCost\":\"50.0\"}", route.getRouteDescription());
 	}
 
 	@Test


### PR DESCRIPTION
This PR proposes writing adding the routing cost optimized by raptor during the computation of the shortest PT path as an attribute to the DefaultTransitPassengerRoute objects in the resulting legs. They are then written in the JSON description of the route in the output plans. 
As one raptor route can result in multiple PT legs, we write the same information in each leg. 