### PR TITLE
feat: detailed utilities writer

### DIFF
--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/nested/NestedLogitSelector.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/nested/NestedLogitSelector.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceTrip;
 import org.matsim.contribs.discrete_mode_choice.model.utilities.UtilityCandidate;
 import org.matsim.contribs.discrete_mode_choice.model.utilities.UtilitySelector;
 import org.matsim.contribs.discrete_mode_choice.model.utilities.UtilitySelectorFactory;
@@ -63,7 +65,7 @@ public class NestedLogitSelector implements UtilitySelector {
 
 			if (!Double.isFinite(probability)) {
 				probability = 0.0; // Revise this, maybe it is better to cosntruct the process so we don't have
-									// them at all. TODO.
+				// them at all. TODO.
 			}
 
 			density.add(probability);
@@ -97,7 +99,7 @@ public class NestedLogitSelector implements UtilitySelector {
 		}
 
 		@Override
-		public NestedLogitSelector createUtilitySelector() {
+		public NestedLogitSelector createUtilitySelector(Person person, List<DiscreteModeChoiceTrip> tourTrips) {
 			return new NestedLogitSelector(structure, minimumUtility, maximumUtility);
 		}
 	}

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/tour_based/TourBasedModel.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/tour_based/TourBasedModel.java
@@ -27,7 +27,7 @@ import org.matsim.core.utils.timing.TimeTracker;
  * A choice model that makes decision on a tour basis. The major difference over
  * the trip-based model is, that it additionally relies on a TourFinder to
  * determine the tours in an agent's plan.
- * 
+ *
  * @author sebhoerl
  */
 public class TourBasedModel implements DiscreteModeChoiceModel {
@@ -44,9 +44,9 @@ public class TourBasedModel implements DiscreteModeChoiceModel {
 	final private TimeInterpretation timeInterpretation;
 
 	public TourBasedModel(TourEstimator estimator, ModeAvailability modeAvailability,
-			TourConstraintFactory constraintFactory, TourFinder tourFinder, TourFilter tourFilter,
-			UtilitySelectorFactory selectorFactory, ModeChainGeneratorFactory modeChainGeneratorFactory,
-			FallbackBehaviour fallbackBehaviour, TimeInterpretation timeInterpretation) {
+						  TourConstraintFactory constraintFactory, TourFinder tourFinder, TourFilter tourFilter,
+						  UtilitySelectorFactory selectorFactory, ModeChainGeneratorFactory modeChainGeneratorFactory,
+						  FallbackBehaviour fallbackBehaviour, TimeInterpretation timeInterpretation) {
 		this.estimator = estimator;
 		this.modeAvailability = modeAvailability;
 		this.constraintFactory = constraintFactory;
@@ -60,7 +60,7 @@ public class TourBasedModel implements DiscreteModeChoiceModel {
 
 	@Override
 	public List<TripCandidate> chooseModes(Person person, List<DiscreteModeChoiceTrip> trips, Random random)
-			throws NoFeasibleChoiceException {
+		throws NoFeasibleChoiceException {
 		List<String> modes = new ArrayList<>(modeAvailability.getAvailableModes(person, trips));
 		TourConstraint constraint = constraintFactory.createConstraint(person, trips, modes);
 
@@ -80,8 +80,8 @@ public class TourBasedModel implements DiscreteModeChoiceModel {
 
 			if (tourFilter.filter(person, tourTrips)) {
 				ModeChainGenerator generator = modeChainGeneratorFactory.createModeChainGenerator(modes, person,
-						tourTrips);
-				UtilitySelector selector = selectorFactory.createUtilitySelector();
+					tourTrips);
+				UtilitySelector selector = selectorFactory.createUtilitySelector(person, tourTrips);
 
 				while (generator.hasNext()) {
 					List<String> tourModes = generator.next();
@@ -108,15 +108,15 @@ public class TourBasedModel implements DiscreteModeChoiceModel {
 
 				if (!selectedCandidate.isPresent()) {
 					switch (fallbackBehaviour) {
-					case INITIAL_CHOICE:
-						logger.warn(
+						case INITIAL_CHOICE:
+							logger.warn(
 								buildFallbackMessage(tripIndex, person, "Setting tour modes back to initial choice."));
-						selectedCandidate = Optional.of(createFallbackCandidate(person, tourTrips, tourCandidates));
-						break;
-					case IGNORE_AGENT:
-						return handleIgnoreAgent(tripIndex, person, tourTrips);
-					case EXCEPTION:
-						throw new NoFeasibleChoiceException(buildFallbackMessage(tripIndex, person, ""));
+							selectedCandidate = Optional.of(createFallbackCandidate(person, tourTrips, tourCandidates));
+							break;
+						case IGNORE_AGENT:
+							return handleIgnoreAgent(tripIndex, person, tourTrips);
+						case EXCEPTION:
+							throw new NoFeasibleChoiceException(buildFallbackMessage(tripIndex, person, ""));
 					}
 				}
 
@@ -127,7 +127,7 @@ public class TourBasedModel implements DiscreteModeChoiceModel {
 
 			tourCandidates.add(finalTourCandidate);
 			tourCandidateModes.add(
-					finalTourCandidate.getTripCandidates().stream().map(c -> c.getMode()).collect(Collectors.toList()));
+				finalTourCandidate.getTripCandidates().stream().map(c -> c.getMode()).collect(Collectors.toList()));
 
 			tripIndex += tourTrips.size();
 
@@ -144,15 +144,15 @@ public class TourBasedModel implements DiscreteModeChoiceModel {
 	}
 
 	private TourCandidate createFallbackCandidate(Person person, List<DiscreteModeChoiceTrip> tourTrips,
-			List<TourCandidate> tourCandidates) {
+												  List<TourCandidate> tourCandidates) {
 		List<String> initialModes = tourTrips.stream().map(DiscreteModeChoiceTrip::getInitialMode)
-				.collect(Collectors.toList());
+			.collect(Collectors.toList());
 		return estimator.estimateTour(person, initialModes, tourTrips, tourCandidates);
 	}
 
 	private List<TripCandidate> createTripCandidates(List<TourCandidate> tourCandidates) {
 		return tourCandidates.stream().map(TourCandidate::getTripCandidates).flatMap(List::stream)
-				.collect(Collectors.toList());
+			.collect(Collectors.toList());
 	}
 
 	private List<TripCandidate> handleIgnoreAgent(int tripIndex, Person person, List<DiscreteModeChoiceTrip> trips) {
@@ -160,7 +160,7 @@ public class TourBasedModel implements DiscreteModeChoiceModel {
 
 		for (List<DiscreteModeChoiceTrip> tourTrips : tourFinder.findTours(trips)) {
 			List<String> tourModes = tourTrips.stream().map(DiscreteModeChoiceTrip::getInitialMode)
-					.collect(Collectors.toList());
+				.collect(Collectors.toList());
 			tourCandidates.add(estimator.estimateTour(person, tourModes, tourTrips, tourCandidates));
 		}
 
@@ -170,14 +170,14 @@ public class TourBasedModel implements DiscreteModeChoiceModel {
 
 	private String buildFallbackMessage(int tripIndex, Person person, String appendix) {
 		return String.format("No feasible mode choice candidate for tour starting at trip %d of agent %s. %s",
-				tripIndex, person.getId().toString(), appendix);
+			tripIndex, person.getId().toString(), appendix);
 	}
 
 	private String buildIllegalUtilityMessage(int tripIndex, Person person, TourCandidate candidate) {
 		TripCandidate trip = candidate.getTripCandidates().get(tripIndex);
-		
+
 		return String.format(
-				"Received illegal utility for for tour starting at trip %d (%s) of agent %s. Continuing with next candidate.",
-				tripIndex, trip.getMode(), person.getId().toString());
+			"Received illegal utility for for tour starting at trip %d (%s) of agent %s. Continuing with next candidate.",
+			tripIndex, trip.getMode(), person.getId().toString());
 	}
 }

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/MaximumSelector.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/MaximumSelector.java
@@ -1,5 +1,9 @@
 package org.matsim.contribs.discrete_mode_choice.model.utilities;
 
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceTrip;
+
+import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 
@@ -7,7 +11,7 @@ import java.util.Random;
  * The maximum utility selector collects a set of candidates with a given
  * utility value and then selects the one with the highest utility. Internally,
  * always only the best candidate is held.
- * 
+ *
  * @author sebhoerl
  */
 public class MaximumSelector implements UtilitySelector {
@@ -33,7 +37,7 @@ public class MaximumSelector implements UtilitySelector {
 
 	public static class Factory implements UtilitySelectorFactory {
 		@Override
-		public UtilitySelector createUtilitySelector() {
+		public UtilitySelector createUtilitySelector(Person person, List<DiscreteModeChoiceTrip> tourTrips) {
 			return new MaximumSelector();
 		}
 	}

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/MultinomialLogitSelector.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/MultinomialLogitSelector.java
@@ -8,6 +8,9 @@ import java.util.Random;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceTrip;
 
 /**
  * The MultinomialLogitSelector collects a set of candidates with given
@@ -30,15 +33,21 @@ public class MultinomialLogitSelector implements UtilitySelector {
 	private final double maximumUtility;
 	private final double minimumUtility;
 	private final boolean considerMinimumUtility;
-
+	private final boolean writeDetailedUtilities;
+	private final Id<Person> personId;
+	private final List<DiscreteModeChoiceTrip> tourTrips;
 	/**
 	 * Creates a MultinomialSelector. The utility cutoff value defines the maximum
 	 * utility possible.
 	 */
-	public MultinomialLogitSelector(double maximumUtility, double minimumUtility, boolean considerMinimumUtility) {
+	public MultinomialLogitSelector(double maximumUtility, double minimumUtility, boolean considerMinimumUtility, boolean writeDetailedUtilities,
+									Person person, List<DiscreteModeChoiceTrip> tourTrips) {
 		this.maximumUtility = maximumUtility;
 		this.minimumUtility = minimumUtility;
 		this.considerMinimumUtility = considerMinimumUtility;
+		this.writeDetailedUtilities = writeDetailedUtilities;
+		this.personId = person.getId();
+		this.tourTrips = tourTrips;
 	}
 
 	@Override
@@ -58,13 +67,13 @@ public class MultinomialLogitSelector implements UtilitySelector {
 
 		if (considerMinimumUtility) {
 			filteredCandidates = candidates.stream() //
-					.filter(c -> c.getUtility() > minimumUtility) //
-					.toList();
+				.filter(c -> c.getUtility() > minimumUtility) //
+				.toList();
 
 			if (filteredCandidates.isEmpty()) {
 				logger.warn(String.format(
-						"Encountered choice where all utilities were smaller than %f (minimum configured utility)",
-						minimumUtility));
+					"Encountered choice where all utilities were smaller than %f (minimum configured utility)",
+					minimumUtility));
 				return Optional.empty();
 			}
 		}
@@ -78,12 +87,13 @@ public class MultinomialLogitSelector implements UtilitySelector {
 			// Warn if there is a utility that is exceeding the feasible range
 			if (utility > maximumUtility) {
 				logger.warn(String.format(
-						"Encountered choice where a utility (%f) is larger than %f (maximum configured utility)",
-						utility, maximumUtility));
+					"Encountered choice where a utility (%f) is larger than %f (maximum configured utility)",
+					utility, maximumUtility));
 				utility = maximumUtility;
 			}
 
 			density.add(Math.exp(utility));
+			//For better Numerical stability, one could use exp(utilities - max(utilities)) which in used in ML
 		}
 
 		// IV) Build a cumulative density of the distribution
@@ -99,23 +109,38 @@ public class MultinomialLogitSelector implements UtilitySelector {
 		double pointer = random.nextDouble() * totalDensity;
 
 		int selection = (int) cumulativeDensity.stream().filter(f -> f < pointer).count();
-		return Optional.of(filteredCandidates.get(selection));
+		UtilityCandidate selectedCandidate = filteredCandidates.get(selection);
+
+		// ===== WRITE TO CSV HERE IF REQUESTED IN THE CONFIG =====
+		if (writeDetailedUtilities && UtilityWriter.isWriterInitialized()) {
+			UtilityWriter.writeCandidate(personId, tourTrips, filteredCandidates, selection);
+		}
+		// ================== END OF CSV WRITING ==================
+
+		return Optional.of(selectedCandidate);
 	}
 
 	public static class Factory implements UtilitySelectorFactory {
 		private final double minimumUtility;
 		private final double maximumUtility;
 		private final boolean considerMinimumUtility;
+		private final boolean writeDetailedUtilities;
 
-		public Factory(double minimumUtility, double maximumUtility, boolean considerMinimumUtility) {
+		public Factory(double minimumUtility, double maximumUtility,
+					   boolean considerMinimumUtility, boolean writeDetailedUtilities) {
 			this.minimumUtility = minimumUtility;
 			this.maximumUtility = maximumUtility;
 			this.considerMinimumUtility = considerMinimumUtility;
+			this.writeDetailedUtilities = writeDetailedUtilities;
+		}
+
+		public Factory(double minimumUtility, double maximumUtility, boolean considerMinimumUtility) {
+			this(minimumUtility, maximumUtility, considerMinimumUtility, false);
 		}
 
 		@Override
-		public MultinomialLogitSelector createUtilitySelector() {
-			return new MultinomialLogitSelector(maximumUtility, minimumUtility, considerMinimumUtility);
+		public MultinomialLogitSelector createUtilitySelector(Person person, List<DiscreteModeChoiceTrip> tourTrips) {
+			return new MultinomialLogitSelector(maximumUtility, minimumUtility, considerMinimumUtility, writeDetailedUtilities, person, tourTrips);
 		}
 	}
 }

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/RandomSelector.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/RandomSelector.java
@@ -1,5 +1,8 @@
 package org.matsim.contribs.discrete_mode_choice.model.utilities;
 
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceTrip;
+
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -30,7 +33,7 @@ public class RandomSelector implements UtilitySelector {
 
 	static public class Factory implements UtilitySelectorFactory {
 		@Override
-		public RandomSelector createUtilitySelector() {
+		public RandomSelector createUtilitySelector(Person person, List<DiscreteModeChoiceTrip> tourTrips) {
 			return new RandomSelector();
 		}
 	}

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/UtilitySelectorFactory.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/UtilitySelectorFactory.java
@@ -1,10 +1,15 @@
 package org.matsim.contribs.discrete_mode_choice.model.utilities;
 
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceTrip;
+
+import java.util.List;
+
 /**
  * Creates a UtilitySelector.
- * 
+ *
  * @author sebhoerl
  */
 public interface UtilitySelectorFactory {
-	UtilitySelector createUtilitySelector();
+	UtilitySelector createUtilitySelector(Person person, List<DiscreteModeChoiceTrip> tourTrips);
 }

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/UtilityWriter.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/UtilityWriter.java
@@ -1,0 +1,146 @@
+package org.matsim.contribs.discrete_mode_choice.model.utilities;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceTrip;
+import org.matsim.contribs.discrete_mode_choice.model.tour_based.DefaultTourCandidate;
+import org.matsim.contribs.discrete_mode_choice.model.trip_based.candidates.DefaultTripCandidate;
+import org.matsim.contribs.discrete_mode_choice.model.trip_based.candidates.TripCandidate;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+/**
+ * UtilityWriter is responsible for logging utility candidates and their selection status
+ * to a CSV file in a thread-safe manner.
+ */
+public class UtilityWriter {
+
+	private final static Logger logger = LogManager.getLogger(UtilityWriter.class);
+
+	private static final Object LOCK = new Object();
+	private static BufferedWriter writer = null;
+	private static final AtomicInteger selectionCounter = new AtomicInteger(0);
+	private static String csvFilePath = null;
+
+	/**
+	 * Initializes the writer by creating a BufferedWriter for the given file path.
+	 *
+	 * @param filePath the path to the output CSV file
+	 */
+	public static void init(String filePath) {
+		if (filePath == null) {
+			return;
+		}
+
+		synchronized (LOCK) {
+			if (filePath.equals(csvFilePath)) {return;} // if it is the same file, do nothing.
+			try {
+				Path path = Path.of(filePath);
+				writer = Files.newBufferedWriter(path);
+				logger.info("Writer initialized for file: " + path.toAbsolutePath());
+				writeHeader();
+				csvFilePath = filePath;
+			} catch (IOException e) {
+				throw new RuntimeException("Failed to initialize CSV writer", e);
+			}
+		}
+	}
+
+	public static boolean isWriterInitialized() {
+		return writer != null;
+	}
+
+	private static void writeHeader() throws IOException {
+		writer.write("person_id;trips_index;selection_id;candidate_mode;utilities;utility;selected\n");
+		writer.flush();
+		logger.info("Head is written");
+	}
+
+	/**
+	 * Writes a list of utility candidates to the CSV file, indicating which candidate was selected.
+	 *
+	 * @param personId     the ID of the person
+	 * @param tourTrips    the list of trips in the tour
+	 * @param candidates   the list of utility candidates
+	 * @param selectedIndex   the index of the selected candidate in the list of candidates
+	 */
+	public static void writeCandidate(Id<Person> personId, List<DiscreteModeChoiceTrip> tourTrips,
+									  List<UtilityCandidate> candidates, int selectedIndex) {
+		if (writer == null) return;
+
+		int selectionId = selectionCounter.incrementAndGet();
+		UtilityCandidate selectedCandidate = candidates.get(selectedIndex);
+
+		synchronized (LOCK) {
+			try {
+				String index = tourTrips.stream()
+					.map(t -> String.valueOf(t.getIndex()))
+					.collect(Collectors.joining(","));
+
+				for (UtilityCandidate candidate : candidates) {
+					String line = String.format("%s;%s;%d;%s;%s;%.4f;%b\n",
+						personId.toString(),
+						// startTime,
+						index,
+						selectionId,
+						getModes(candidate),
+						getUtilities(candidate),
+						candidate.getUtility(),
+						candidate.equals(selectedCandidate));
+					writer.write(line);
+				}
+				writer.flush(); // Consider buffering writes for large volumes
+			} catch (IOException e) {
+				logger.error("Failed to write to CSV: " + e.getMessage());
+			}
+		}
+	}
+
+	public static String getModes(UtilityCandidate candidate){
+		if (candidate instanceof DefaultTourCandidate){
+			List<String> modes = ((DefaultTourCandidate) candidate).getTripCandidates().stream()
+				.map(TripCandidate::getMode)
+				.collect(Collectors.toList());
+			return String.join(",", modes);
+		}
+		if (candidate instanceof DefaultTripCandidate){
+			return ((DefaultTripCandidate) candidate).getMode();
+		}
+		return "";
+	}
+
+	public static String getUtilities(UtilityCandidate candidate){
+		if (candidate instanceof DefaultTourCandidate){
+			return ((DefaultTourCandidate) candidate).getTripCandidates().stream()
+				.map(t -> String.format("%.4f", t.getUtility())) // Formats to 3 decimal places
+				.collect(Collectors.joining(","));
+		}
+		if (candidate instanceof DefaultTripCandidate){
+			return Double.toString(((DefaultTripCandidate) candidate).getUtility());
+		}
+		return "";
+	}
+
+	/**
+	 * Closes the writer, releasing any system resources.
+	 */
+	public static void close() {
+		synchronized (LOCK) {
+			if (writer != null) {
+				try {
+					writer.close();
+				} catch (IOException e) {
+					logger.error("Failed to close CSV writer: " + e.getMessage());
+				}
+			}
+		}
+	}
+}

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/DiscreteModeChoiceModule.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/DiscreteModeChoiceModule.java
@@ -23,14 +23,14 @@ public class DiscreteModeChoiceModule extends AbstractModule {
 	@Override
 	public void install() {
 		addPlanStrategyBinding(STRATEGY_NAME).toProvider(DiscreteModeChoiceStrategyProvider.class);
-		addControllerListenerBinding().to(UtilitiesWriterHandler.class);
+		addControlerListenerBinding().to(UtilitiesWriterHandler.class);
 
 		if (getConfig().replanning().getPlanSelectorForRemoval().equals(NonSelectedPlanSelector.NAME)) {
 			bindPlanSelectorForRemoval().to(NonSelectedPlanSelector.class);
 		}
 
 		if (dmcConfig.getEnforceSinglePlan()) {
-			addControllerListenerBinding().to(ModeChoiceInTheLoopChecker.class);
+			addControlerListenerBinding().to(ModeChoiceInTheLoopChecker.class);
 		}
 
 		install(new ModelModule());

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/SelectorModule.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/SelectorModule.java
@@ -17,7 +17,7 @@ import com.google.inject.Singleton;
 
 /**
  * Internal module that manages all built-in selectors.
- * 
+ *
  * @author sebhoerl
  *
  */
@@ -37,14 +37,14 @@ public class SelectorModule extends AbstractDiscreteModeChoiceExtension {
 
 	@Provides
 	public UtilitySelectorFactory provideTourSelectorFactory(DiscreteModeChoiceConfigGroup dmcConfig,
-			Map<String, Provider<UtilitySelectorFactory>> components) {
+															 Map<String, Provider<UtilitySelectorFactory>> components) {
 		Provider<UtilitySelectorFactory> provider = components.get(dmcConfig.getSelector());
 
 		if (provider != null) {
 			return provider.get();
 		} else {
 			throw new IllegalStateException(String
-					.format("There is no UtilitySelector component for tours called '%s',", dmcConfig.getSelector()));
+				.format("There is no UtilitySelector component for tours called '%s',", dmcConfig.getSelector()));
 		}
 	}
 
@@ -57,10 +57,10 @@ public class SelectorModule extends AbstractDiscreteModeChoiceExtension {
 	@Provides
 	@Singleton
 	public MultinomialLogitSelector.Factory provideMultinomialLogitTripSelector(
-			DiscreteModeChoiceConfigGroup dmcConfig) {
+		DiscreteModeChoiceConfigGroup dmcConfig) {
 		MultinomialLogitSelectorConfigGroup config = dmcConfig.getMultinomialLogitSelectorConfig();
 		return new MultinomialLogitSelector.Factory(config.getMinimumUtility(), config.getMaximumUtility(),
-				config.getConsiderMinimumUtility());
+			config.getConsiderMinimumUtility(), config.getWriteDetailedUtilities());
 	}
 
 	@Provides

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/UtilitiesWriterHandler.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/UtilitiesWriterHandler.java
@@ -2,18 +2,21 @@ package org.matsim.contribs.discrete_mode_choice.modules;
 
 import com.google.inject.Inject;
 import org.matsim.api.core.v01.population.Population;
+import org.matsim.contribs.discrete_mode_choice.model.utilities.UtilityWriter;
 import org.matsim.contribs.discrete_mode_choice.modules.config.DiscreteModeChoiceConfigGroup;
 import org.matsim.contribs.discrete_mode_choice.modules.utils.ExtractPlanUtilities;
 import org.matsim.core.config.groups.ControllerConfigGroup;
 import org.matsim.core.controler.OutputDirectoryHierarchy;
+import org.matsim.core.controler.events.IterationEndsEvent;
 import org.matsim.core.controler.events.IterationStartsEvent;
 import org.matsim.core.controler.events.ShutdownEvent;
+import org.matsim.core.controler.listener.IterationEndsListener;
 import org.matsim.core.controler.listener.IterationStartsListener;
 import org.matsim.core.controler.listener.ShutdownListener;
 
 import java.io.IOException;
 
-public class UtilitiesWriterHandler implements ShutdownListener, IterationStartsListener {
+public class UtilitiesWriterHandler implements ShutdownListener, IterationStartsListener, IterationEndsListener {
 	private final OutputDirectoryHierarchy outputDirectoryHierarchy;
 	private final ControllerConfigGroup controllerConfigGroup;
 	private final Population population;
@@ -39,6 +42,11 @@ public class UtilitiesWriterHandler implements ShutdownListener, IterationStarts
 
 	@Override
 	public void notifyIterationStarts(IterationStartsEvent event) {
+		if (this.discreteModeChoiceConfigGroup.getMultinomialLogitSelectorConfig().getWriteDetailedUtilities()) {
+			String detailedUtilitiesFilePath = this.outputDirectoryHierarchy.getIterationFilename(event.getIteration(), "detailed_utilities.csv");
+			UtilityWriter.init(detailedUtilitiesFilePath);
+		}
+
 		if(event.getIteration() == controllerConfigGroup.getFirstIteration() ||  this.discreteModeChoiceConfigGroup.getWriteUtilitiesInterval() % event.getIteration() != 0) {
 			return;
 		}
@@ -47,6 +55,13 @@ public class UtilitiesWriterHandler implements ShutdownListener, IterationStarts
 			ExtractPlanUtilities.writePlanUtilities(population, filePath);
 		} catch (IOException e) {
 			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public void notifyIterationEnds(IterationEndsEvent iterationEndsEvent) {
+		if (this.discreteModeChoiceConfigGroup.getMultinomialLogitSelectorConfig().getWriteDetailedUtilities()) {
+			UtilityWriter.close();
 		}
 	}
 }

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/config/MultinomialLogitSelectorConfigGroup.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/config/MultinomialLogitSelectorConfigGroup.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 /**
  * Config group for the MultinomialLogitSelector
- * 
+ *
  * @author sebhoerl
  *
  */
@@ -13,10 +13,12 @@ public class MultinomialLogitSelectorConfigGroup extends ComponentConfigGroup {
 	private double minimumUtility = -700.0;
 	private double maximumUtility = 700.0;
 	private boolean considerMinimumUtility = false;
+	private boolean writeDetailedUtilities = false;
 
 	public static final String MINIMUM_UTILITY = "minimumUtility";
 	public static final String MAXIMUM_UTILITY = "maximumUtility";
 	public static final String CONSIDER_MINIMUM_UTILITY = "considerMinimumUtility";
+	public static final String WRITE_DETAILED_UTILITIES = "writeDetailedUtilities";
 
 	public MultinomialLogitSelectorConfigGroup(String componentType, String componentName) {
 		super(componentType, componentName);
@@ -27,11 +29,12 @@ public class MultinomialLogitSelectorConfigGroup extends ComponentConfigGroup {
 		Map<String, String> comments = new HashMap<>();
 
 		comments.put(MINIMUM_UTILITY,
-				"Candidates with a utility lower than that threshold will not be considered by default.");
+			"Candidates with a utility lower than that threshold will not be considered by default.");
 		comments.put(MAXIMUM_UTILITY, "Candidates with a utility above that threshold will be cut off to this value.");
 		comments.put(CONSIDER_MINIMUM_UTILITY,
-				"Defines whether candidates with a utility lower than the minimum utility should be filtered out.");
-
+			"Defines whether candidates with a utility lower than the minimum utility should be filtered out.");
+		comments.put(WRITE_DETAILED_UTILITIES,
+			"If True, the selector writes the utilities of the tour candidates to a csv file called detailed config." );
 		return comments;
 	}
 
@@ -63,5 +66,13 @@ public class MultinomialLogitSelectorConfigGroup extends ComponentConfigGroup {
 	@StringGetter(CONSIDER_MINIMUM_UTILITY)
 	public boolean getConsiderMinimumUtility() {
 		return considerMinimumUtility;
+	}
+
+	@StringSetter(WRITE_DETAILED_UTILITIES)
+	public void setWriteDetailedUtilities(boolean writeDetailedUtilities) {this.writeDetailedUtilities = writeDetailedUtilities;}
+
+	@StringGetter(WRITE_DETAILED_UTILITIES)
+	public boolean getWriteDetailedUtilities() {
+		return writeDetailedUtilities;
 	}
 }


### PR DESCRIPTION
**Summary**
This PR introduces a new **UtilityWriter** that can be called by the `MultinomialLogitSelector` to output detailed information about trips or tours, including their utilities, into the simulation’s output directory.

**Details**

* For each evaluated tour or trip, if there are *n* possible options, the writer outputs all *n* options along with:

  * The corresponding modes
  * Utility values
  * Person ID
  * Trip index
  * This feature is controlled via the configuration:

  ```
  DiscreteModeChoice.selector:MultinomialLogit.writeDetailedUtilities = true  
  ```
* When enabled, it provides full visibility into the choice set evaluated by the selector.

**Use Cases**

* Inspecting and validating utility values for trips or tours.
* Supporting calibration of the discrete mode choice model by enabling detailed utility analysis.

