### PR TITLE
feat(discrete_mode_choice): detailed utilities writer

### DIFF
--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/nested/NestedLogitSelector.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/nested/NestedLogitSelector.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceTrip;
 import org.matsim.contribs.discrete_mode_choice.model.utilities.UtilityCandidate;
 import org.matsim.contribs.discrete_mode_choice.model.utilities.UtilitySelector;
 import org.matsim.contribs.discrete_mode_choice.model.utilities.UtilitySelectorFactory;
@@ -97,7 +99,7 @@ public class NestedLogitSelector implements UtilitySelector {
 		}
 
 		@Override
-		public NestedLogitSelector createUtilitySelector() {
+		public NestedLogitSelector createUtilitySelector(Person person, List<DiscreteModeChoiceTrip> tourTrips) {
 			return new NestedLogitSelector(structure, minimumUtility, maximumUtility);
 		}
 	}

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/tour_based/EfficientTourBasedModel.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/tour_based/EfficientTourBasedModel.java
@@ -92,7 +92,7 @@ public class EfficientTourBasedModel implements DiscreteModeChoiceModel {
 
             if (tourFilter.filter(person, tourTrips)) {
 				ModeChoiceModelTree modeChoiceModelTree = new ModeChoiceModelTree(person, tourTrips, constraint, estimator.getDelegate(), modes, tourCandidates, timeInterpretation);
-                UtilitySelector selector = selectorFactory.createUtilitySelector();
+                UtilitySelector selector = selectorFactory.createUtilitySelector(person, tourTrips);
                 modeChoiceModelTree.build();
                 for(TourCandidate tourCandidate: modeChoiceModelTree.getTourCandidates()) {
                     selector.addCandidate(tourCandidate);

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/tour_based/TourBasedModel.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/tour_based/TourBasedModel.java
@@ -27,7 +27,7 @@ import org.matsim.core.utils.timing.TimeTracker;
  * A choice model that makes decision on a tour basis. The major difference over
  * the trip-based model is, that it additionally relies on a TourFinder to
  * determine the tours in an agent's plan.
- * 
+ *
  * @author sebhoerl
  */
 public class TourBasedModel implements DiscreteModeChoiceModel {
@@ -81,7 +81,7 @@ public class TourBasedModel implements DiscreteModeChoiceModel {
 			if (tourFilter.filter(person, tourTrips)) {
 				ModeChainGenerator generator = modeChainGeneratorFactory.createModeChainGenerator(modes, person,
 						tourTrips);
-				UtilitySelector selector = selectorFactory.createUtilitySelector();
+				UtilitySelector selector = selectorFactory.createUtilitySelector(person, tourTrips);
 
 				while (generator.hasNext()) {
 					List<String> tourModes = generator.next();
@@ -175,7 +175,7 @@ public class TourBasedModel implements DiscreteModeChoiceModel {
 
 	private String buildIllegalUtilityMessage(int tripIndex, Person person, TourCandidate candidate) {
 		TripCandidate trip = candidate.getTripCandidates().get(tripIndex);
-		
+
 		return String.format(
 				"Received illegal utility for for tour starting at trip %d (%s) of agent %s. Continuing with next candidate.",
 				tripIndex, trip.getMode(), person.getId().toString());

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/trip_based/TripBasedModel.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/trip_based/TripBasedModel.java
@@ -21,7 +21,7 @@ import org.matsim.core.utils.timing.TimeTracker;
 
 /**
  * This class defines a trip-based discrete choice model.
- * 
+ *
  * @author sebhoerl
  *
  */
@@ -67,7 +67,7 @@ public class TripBasedModel implements DiscreteModeChoiceModel {
 			TripCandidate finalTripCandidate = null;
 
 			if (tripFilter.filter(person, trip)) {
-				UtilitySelector selector = selectorFactory.createUtilitySelector();
+				UtilitySelector selector = selectorFactory.createUtilitySelector(person, List.of(trip));
 				tripIndex++;
 
 				for (String mode : modes) {

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/MaximumSelector.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/MaximumSelector.java
@@ -1,5 +1,9 @@
 package org.matsim.contribs.discrete_mode_choice.model.utilities;
 
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceTrip;
+
+import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 
@@ -7,7 +11,7 @@ import java.util.Random;
  * The maximum utility selector collects a set of candidates with a given
  * utility value and then selects the one with the highest utility. Internally,
  * always only the best candidate is held.
- * 
+ *
  * @author sebhoerl
  */
 public class MaximumSelector implements UtilitySelector {
@@ -33,7 +37,7 @@ public class MaximumSelector implements UtilitySelector {
 
 	public static class Factory implements UtilitySelectorFactory {
 		@Override
-		public UtilitySelector createUtilitySelector() {
+		public UtilitySelector createUtilitySelector(Person person, List<DiscreteModeChoiceTrip> tourTrips) {
 			return new MaximumSelector();
 		}
 	}

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/MultinomialLogitSelector.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/MultinomialLogitSelector.java
@@ -46,7 +46,7 @@ public class MultinomialLogitSelector implements UtilitySelector {
 		this.minimumUtility = minimumUtility;
 		this.considerMinimumUtility = considerMinimumUtility;
 		this.writeDetailedUtilities = writeDetailedUtilities;
-		this.personId = person.getId();
+		this.personId = (person!=null)? person.getId(): Id.create("unknown", Person.class);
 		this.tourTrips = tourTrips;
 	}
 

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/MultinomialLogitSelector.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/MultinomialLogitSelector.java
@@ -8,6 +8,9 @@ import java.util.Random;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceTrip;
 
 /**
  * The MultinomialLogitSelector collects a set of candidates with given
@@ -30,15 +33,21 @@ public class MultinomialLogitSelector implements UtilitySelector {
 	private final double maximumUtility;
 	private final double minimumUtility;
 	private final boolean considerMinimumUtility;
-
+	private final boolean writeDetailedUtilities;
+	private final Id<Person> personId;
+	private final List<DiscreteModeChoiceTrip> tourTrips;
 	/**
 	 * Creates a MultinomialSelector. The utility cutoff value defines the maximum
 	 * utility possible.
 	 */
-	public MultinomialLogitSelector(double maximumUtility, double minimumUtility, boolean considerMinimumUtility) {
+	public MultinomialLogitSelector(double maximumUtility, double minimumUtility, boolean considerMinimumUtility, boolean writeDetailedUtilities,
+									Person person, List<DiscreteModeChoiceTrip> tourTrips) {
 		this.maximumUtility = maximumUtility;
 		this.minimumUtility = minimumUtility;
 		this.considerMinimumUtility = considerMinimumUtility;
+		this.writeDetailedUtilities = writeDetailedUtilities;
+		this.personId = person.getId();
+		this.tourTrips = tourTrips;
 	}
 
 	@Override
@@ -99,23 +108,37 @@ public class MultinomialLogitSelector implements UtilitySelector {
 		double pointer = random.nextDouble() * totalDensity;
 
 		int selection = (int) cumulativeDensity.stream().filter(f -> f < pointer).count();
-		return Optional.of(filteredCandidates.get(selection));
+		UtilityCandidate selectedCandidate = filteredCandidates.get(selection);
+
+		// ===== WRITE TO CSV HERE IF REQUESTED IN THE CONFIG =====
+		if (writeDetailedUtilities && UtilityWriter.isWriterInitialized()) {
+			UtilityWriter.writeCandidate(personId, tourTrips, filteredCandidates, selection);
+		}
+		// ================== END OF CSV WRITING ==================
+
+		return Optional.of(selectedCandidate);
 	}
 
 	public static class Factory implements UtilitySelectorFactory {
 		private final double minimumUtility;
 		private final double maximumUtility;
 		private final boolean considerMinimumUtility;
+		private final boolean writeDetailedUtilities;
 
-		public Factory(double minimumUtility, double maximumUtility, boolean considerMinimumUtility) {
+		public Factory(double minimumUtility, double maximumUtility, boolean considerMinimumUtility, boolean writeDetailedUtilities) {
 			this.minimumUtility = minimumUtility;
 			this.maximumUtility = maximumUtility;
 			this.considerMinimumUtility = considerMinimumUtility;
+			this.writeDetailedUtilities = writeDetailedUtilities;
+		}
+
+		public Factory(double minimumUtility, double maximumUtility, boolean considerMinimumUtility) {
+			this(minimumUtility, maximumUtility, considerMinimumUtility, false);
 		}
 
 		@Override
-		public MultinomialLogitSelector createUtilitySelector() {
-			return new MultinomialLogitSelector(maximumUtility, minimumUtility, considerMinimumUtility);
+		public MultinomialLogitSelector createUtilitySelector(Person person, List<DiscreteModeChoiceTrip> tourTrips) {
+			return new MultinomialLogitSelector(maximumUtility, minimumUtility, considerMinimumUtility, writeDetailedUtilities, person, tourTrips);
 		}
 	}
 }

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/RandomSelector.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/RandomSelector.java
@@ -1,5 +1,8 @@
 package org.matsim.contribs.discrete_mode_choice.model.utilities;
 
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceTrip;
+
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -30,7 +33,7 @@ public class RandomSelector implements UtilitySelector {
 
 	static public class Factory implements UtilitySelectorFactory {
 		@Override
-		public RandomSelector createUtilitySelector() {
+		public RandomSelector createUtilitySelector(Person person, List<DiscreteModeChoiceTrip> tourTrips) {
 			return new RandomSelector();
 		}
 	}

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/UtilitySelectorFactory.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/UtilitySelectorFactory.java
@@ -1,10 +1,15 @@
 package org.matsim.contribs.discrete_mode_choice.model.utilities;
 
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceTrip;
+
+import java.util.List;
+
 /**
  * Creates a UtilitySelector.
- * 
+ *
  * @author sebhoerl
  */
 public interface UtilitySelectorFactory {
-	UtilitySelector createUtilitySelector();
+	UtilitySelector createUtilitySelector(Person person, List<DiscreteModeChoiceTrip> tourTrips);
 }

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/UtilityWriter.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/utilities/UtilityWriter.java
@@ -1,0 +1,146 @@
+package org.matsim.contribs.discrete_mode_choice.model.utilities;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceTrip;
+import org.matsim.contribs.discrete_mode_choice.model.tour_based.DefaultTourCandidate;
+import org.matsim.contribs.discrete_mode_choice.model.trip_based.candidates.DefaultTripCandidate;
+import org.matsim.contribs.discrete_mode_choice.model.trip_based.candidates.TripCandidate;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+/**
+ * UtilityWriter is responsible for logging utility candidates and their selection status
+ * to a CSV file in a thread-safe manner.
+ */
+public class UtilityWriter {
+
+	private final static Logger logger = LogManager.getLogger(UtilityWriter.class);
+
+	private static final Object LOCK = new Object();
+	private static BufferedWriter writer = null;
+	private static final AtomicInteger selectionCounter = new AtomicInteger(0);
+	private static String csvFilePath = null;
+
+	/**
+	 * Initializes the writer by creating a BufferedWriter for the given file path.
+	 *
+	 * @param filePath the path to the output CSV file
+	 */
+	public static void init(String filePath) {
+		if (filePath == null) {
+			return;
+		}
+
+		synchronized (LOCK) {
+			if (filePath.equals(csvFilePath)) {return;} // if it is the same file, do nothing.
+			try {
+				Path path = Path.of(filePath);
+				writer = Files.newBufferedWriter(path);
+				logger.info("Writer initialized for file: " + path.toAbsolutePath());
+				writeHeader();
+				csvFilePath = filePath;
+			} catch (IOException e) {
+				throw new RuntimeException("Failed to initialize CSV writer", e);
+			}
+		}
+	}
+
+	public static boolean isWriterInitialized() {
+		return writer != null;
+	}
+
+	private static void writeHeader() throws IOException {
+		writer.write("person_id;trips_index;selection_id;candidate_mode;utilities;utility;selected\n");
+		writer.flush();
+		logger.info("Head is written");
+	}
+
+	/**
+	 * Writes a list of utility candidates to the CSV file, indicating which candidate was selected.
+	 *
+	 * @param personId     the ID of the person
+	 * @param tourTrips    the list of trips in the tour
+	 * @param candidates   the list of utility candidates
+	 * @param selectedIndex   the index of the selected candidate in the list of candidates
+	 */
+	public static void writeCandidate(Id<Person> personId, List<DiscreteModeChoiceTrip> tourTrips,
+									  List<UtilityCandidate> candidates, int selectedIndex) {
+		if (writer == null) return;
+
+		int selectionId = selectionCounter.incrementAndGet();
+		UtilityCandidate selectedCandidate = candidates.get(selectedIndex);
+
+		synchronized (LOCK) {
+			try {
+				String index = tourTrips.stream()
+					.map(t -> String.valueOf(t.getIndex()))
+					.collect(Collectors.joining(","));
+
+				for (UtilityCandidate candidate : candidates) {
+					String line = String.format("%s;%s;%d;%s;%s;%.4f;%b\n",
+						personId.toString(),
+						// startTime,
+						index,
+						selectionId,
+						getModes(candidate),
+						getUtilities(candidate),
+						candidate.getUtility(),
+						candidate.equals(selectedCandidate));
+					writer.write(line);
+				}
+				writer.flush(); // Consider buffering writes for large volumes
+			} catch (IOException e) {
+				logger.error("Failed to write to CSV: " + e.getMessage());
+			}
+		}
+	}
+
+	public static String getModes(UtilityCandidate candidate){
+		if (candidate instanceof DefaultTourCandidate){
+			List<String> modes = ((DefaultTourCandidate) candidate).getTripCandidates().stream()
+				.map(TripCandidate::getMode)
+				.collect(Collectors.toList());
+			return String.join(",", modes);
+		}
+		if (candidate instanceof DefaultTripCandidate){
+			return ((DefaultTripCandidate) candidate).getMode();
+		}
+		return "";
+	}
+
+	public static String getUtilities(UtilityCandidate candidate){
+		if (candidate instanceof DefaultTourCandidate){
+			return ((DefaultTourCandidate) candidate).getTripCandidates().stream()
+				.map(t -> String.format("%.4f", t.getUtility())) // Formats to 3 decimal places
+				.collect(Collectors.joining(","));
+		}
+		if (candidate instanceof DefaultTripCandidate){
+			return Double.toString(((DefaultTripCandidate) candidate).getUtility());
+		}
+		return "";
+	}
+
+	/**
+	 * Closes the writer, releasing any system resources.
+	 */
+	public static void close() {
+		synchronized (LOCK) {
+			if (writer != null) {
+				try {
+					writer.close();
+				} catch (IOException e) {
+					logger.error("Failed to close CSV writer: " + e.getMessage());
+				}
+			}
+		}
+	}
+}

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/SelectorModule.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/SelectorModule.java
@@ -17,7 +17,7 @@ import com.google.inject.Singleton;
 
 /**
  * Internal module that manages all built-in selectors.
- * 
+ *
  * @author sebhoerl
  *
  */
@@ -60,7 +60,7 @@ public class SelectorModule extends AbstractDiscreteModeChoiceExtension {
 			DiscreteModeChoiceConfigGroup dmcConfig) {
 		MultinomialLogitSelectorConfigGroup config = dmcConfig.getMultinomialLogitSelectorConfig();
 		return new MultinomialLogitSelector.Factory(config.getMinimumUtility(), config.getMaximumUtility(),
-				config.getConsiderMinimumUtility());
+				config.getConsiderMinimumUtility(), config.getWriteDetailedUtilities());
 	}
 
 	@Provides

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/config/MultinomialLogitSelectorConfigGroup.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/config/MultinomialLogitSelectorConfigGroup.java
@@ -34,7 +34,7 @@ public class MultinomialLogitSelectorConfigGroup extends ComponentConfigGroup {
 		comments.put(CONSIDER_MINIMUM_UTILITY,
 				"Defines whether candidates with a utility lower than the minimum utility should be filtered out.");
 		comments.put(WRITE_DETAILED_UTILITIES,
-			"If True, the selector writes the utilities of the tour candidates to a csv file called detailed config." );
+			"If True, the selector writes the utilities of the tour candidates to a csv file called detailed_utilities.csv." );
 		return comments;
 	}
 

--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/config/MultinomialLogitSelectorConfigGroup.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/modules/config/MultinomialLogitSelectorConfigGroup.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 /**
  * Config group for the MultinomialLogitSelector
- * 
+ *
  * @author sebhoerl
  *
  */
@@ -13,10 +13,12 @@ public class MultinomialLogitSelectorConfigGroup extends ComponentConfigGroup {
 	private double minimumUtility = -700.0;
 	private double maximumUtility = 700.0;
 	private boolean considerMinimumUtility = false;
+	private boolean writeDetailedUtilities = false;
 
 	public static final String MINIMUM_UTILITY = "minimumUtility";
 	public static final String MAXIMUM_UTILITY = "maximumUtility";
 	public static final String CONSIDER_MINIMUM_UTILITY = "considerMinimumUtility";
+	public static final String WRITE_DETAILED_UTILITIES = "writeDetailedUtilities";
 
 	public MultinomialLogitSelectorConfigGroup(String componentType, String componentName) {
 		super(componentType, componentName);
@@ -31,7 +33,8 @@ public class MultinomialLogitSelectorConfigGroup extends ComponentConfigGroup {
 		comments.put(MAXIMUM_UTILITY, "Candidates with a utility above that threshold will be cut off to this value.");
 		comments.put(CONSIDER_MINIMUM_UTILITY,
 				"Defines whether candidates with a utility lower than the minimum utility should be filtered out.");
-
+		comments.put(WRITE_DETAILED_UTILITIES,
+			"If True, the selector writes the utilities of the tour candidates to a csv file called detailed config." );
 		return comments;
 	}
 
@@ -63,5 +66,13 @@ public class MultinomialLogitSelectorConfigGroup extends ComponentConfigGroup {
 	@StringGetter(CONSIDER_MINIMUM_UTILITY)
 	public boolean getConsiderMinimumUtility() {
 		return considerMinimumUtility;
+	}
+
+	@StringSetter(WRITE_DETAILED_UTILITIES)
+	public void setWriteDetailedUtilities(boolean writeDetailedUtilities) {this.writeDetailedUtilities = writeDetailedUtilities;}
+
+	@StringGetter(WRITE_DETAILED_UTILITIES)
+	public boolean getWriteDetailedUtilities() {
+		return writeDetailedUtilities;
 	}
 }


### PR DESCRIPTION
**Summary**
Adds a new boolean config attribute `writeDetailedUtilities` (default: `false`).
When enabled, it writes a CSV with all considered mode options and their utilities for each considered tour, and which of the tours is finally selected for the agent plan.

**Purpose**

* Supports calibration of the discrete mode choice model
* Helps analyze and debug mode choice decisions

**Impact**

* No change to default behavior

**Config Example:**

```hocon
DiscreteModeChoice { 
     selector:MultinomialLogit {
          writeDetailedUtilities = true
                                 }
                    }
```
