### PR TITLE
feat(drt): relocation with preplanned/prebooked stops

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/EmptyVehicleRelocator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/scheduler/EmptyVehicleRelocator.java
@@ -19,67 +19,156 @@
 
 package org.matsim.contrib.drt.scheduler;
 
-import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.DRIVE;
-
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.contrib.drt.schedule.DrtStayTask;
-import org.matsim.contrib.drt.schedule.DrtTaskFactory;
-import org.matsim.contrib.drt.schedule.DrtTaskType;
+import org.matsim.contrib.drt.schedule.*;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.path.VrpPaths;
+import org.matsim.contrib.dvrp.schedule.DriveTask;
 import org.matsim.contrib.dvrp.schedule.Schedule;
+import org.matsim.contrib.dvrp.schedule.Task;
+import org.matsim.core.gbl.Gbl;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 import org.matsim.core.router.speedy.SpeedyALTFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
 
+import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.DRIVE;
+import static org.matsim.contrib.drt.schedule.DrtTaskBaseType.getBaseTypeOrElseThrow;
+
 /**
  * @author michalm
  */
 public class EmptyVehicleRelocator {
-	public static final DrtTaskType RELOCATE_VEHICLE_TASK_TYPE = new DrtTaskType("RELOCATE", DRIVE);
-	public static final DrtTaskType RELOCATE_VEHICLE_TO_DEPOT_TASK_TYPE = new DrtTaskType("RELOCATE_TO_DEPOT", DRIVE);
+    public static final DrtTaskType RELOCATE_VEHICLE_TASK_TYPE = new DrtTaskType("RELOCATE", DRIVE);
+    public static final DrtTaskType RELOCATE_VEHICLE_TO_DEPOT_TASK_TYPE = new DrtTaskType("RELOCATE_TO_DEPOT", DRIVE);
 
-	private final TravelTime travelTime;
-	private final MobsimTimer timer;
-	private final DrtTaskFactory taskFactory;
-	private final LeastCostPathCalculator router;
+    private final TravelTime travelTime;
+    private final MobsimTimer timer;
+    private final DrtTaskFactory taskFactory;
+    private final LeastCostPathCalculator router;
 
-	public EmptyVehicleRelocator(Network network, TravelTime travelTime, TravelDisutility travelDisutility,
-			MobsimTimer timer, DrtTaskFactory taskFactory) {
-		this.travelTime = travelTime;
-		this.timer = timer;
-		this.taskFactory = taskFactory;
-		router = new SpeedyALTFactory().createPathCalculator(network, travelDisutility, travelTime);
-	}
+    public EmptyVehicleRelocator(Network network, TravelTime travelTime, TravelDisutility travelDisutility,
+                                 MobsimTimer timer, DrtTaskFactory taskFactory) {
+        this.travelTime = travelTime;
+        this.timer = timer;
+        this.taskFactory = taskFactory;
+        router = new SpeedyALTFactory().createPathCalculator(network, travelDisutility, travelTime);
+    }
 
-	public void relocateVehicle(DvrpVehicle vehicle, Link link, DrtTaskType relocationTaskType) {
-		DrtStayTask currentTask = (DrtStayTask)vehicle.getSchedule().getCurrentTask();
-		Link currentLink = currentTask.getLink();
+    public void relocateVehicle(DvrpVehicle vehicle, Link link, DrtTaskType relocationTaskType) {
+        DrtStayTask currentTask = (DrtStayTask) vehicle.getSchedule().getCurrentTask();
+        Link currentLink = currentTask.getLink();
 
-		if (currentLink != link) {
-			VrpPathWithTravelData path = VrpPaths.calcAndCreatePath(currentLink, link, timer.getTimeOfDay(), router,
-					travelTime);
-			if (path.getArrivalTime() < vehicle.getServiceEndTime()) {
-				relocateVehicleImpl(vehicle, path, relocationTaskType);
-			}
-		}
-	}
+        if (currentLink != link) {
+            VrpPathWithTravelData relocationPath = VrpPaths.calcAndCreatePath(
+                    currentLink, link, timer.getTimeOfDay(), router, travelTime);
 
-	private void relocateVehicleImpl(DvrpVehicle vehicle, VrpPathWithTravelData vrpPath, DrtTaskType relocationTaskType) {
-		Schedule schedule = vehicle.getSchedule();
-		DrtStayTask stayTask = (DrtStayTask)schedule.getCurrentTask();
-		if (stayTask.getTaskIdx() != schedule.getTaskCount() - 1) {
-			throw new IllegalStateException("The current STAY task is not last. Not possible without prebooking");
-		}
+            if (relocationPath.getArrivalTime() < vehicle.getServiceEndTime()) {
 
-		stayTask.setEndTime(vrpPath.getDepartureTime()); // finish STAY
-		schedule.addTask(taskFactory.createDriveTask(vehicle, vrpPath, relocationTaskType)); // add RELOCATE
-		// append STAY
-		schedule.addTask(taskFactory.createStayTask(vehicle, vrpPath.getArrivalTime(), vehicle.getServiceEndTime(),
-				vrpPath.getToLink()));
-	}
+                Schedule schedule = vehicle.getSchedule();
+                int nextIdx = currentTask.getTaskIdx() + 1;
+
+                // follow up tasks
+                if (schedule.getTaskCount() > nextIdx) {
+                    Task nextTask = schedule.getTasks().get(nextIdx);
+
+                    Link nextLink;
+                    double nextFixedTime;
+
+                    switch (getBaseTypeOrElseThrow(nextTask)) {
+                        case DRIVE -> {
+                            nextLink = ((DriveTask) nextTask).getPath().getToLink();
+                            nextFixedTime = nextTask.getEndTime();
+                        }
+                        case STOP -> {
+                            nextLink = ((DrtStopTask) nextTask).getLink();
+                            Gbl.assertIf(nextLink == currentLink);
+                            nextFixedTime = nextTask.getBeginTime();
+                        }
+                        case STAY -> throw new IllegalStateException("Did not expect two consecutive STAY tasks");
+                        default -> throw new IllegalStateException("Unexpected base type");
+                    }
+
+                    if(relocationPath.getArrivalTime() > nextFixedTime) {
+                        return;
+                    }
+
+                    double followUpArrivalTime = relocationPath.getArrivalTime();
+
+                    if (nextLink != relocationPath.getToLink()) {
+                        VrpPathWithTravelData followUpPath = VrpPaths.calcAndCreatePath(
+                                relocationPath.getToLink(), nextLink, relocationPath.getArrivalTime(), router, travelTime);
+                        followUpArrivalTime += followUpPath.getTravelTime();
+
+                        if (followUpArrivalTime > nextFixedTime) {
+                            // relocation would make us late for next fixed task
+                            return;
+                        }
+
+                        if(nextTask instanceof DriveTask) {
+                            // remove replaced drive
+                            schedule.removeTask(nextTask);
+                        }
+
+                        double slack = nextFixedTime - followUpArrivalTime;
+                        relocateVehicleSubtourImpl(nextIdx, vehicle, relocationPath, slack, relocationTaskType, followUpPath);
+                    } else {
+                        // relocation destination already matches next target
+                        if(nextTask instanceof DriveTask) {
+                            // remove replaced drive
+                            schedule.removeTask(nextTask);
+                        }
+                        double slack = nextFixedTime - followUpArrivalTime;
+                        relocateVehicleSubtourImpl(nextIdx, vehicle, relocationPath, slack, relocationTaskType, null);
+                    }
+
+                } else {
+                    // last task → simple relocation to target
+                    relocateVehicleSimpleImpl(vehicle, relocationPath, relocationTaskType);
+                }
+            }
+        }
+    }
+
+    private void relocateVehicleSubtourImpl(int index, DvrpVehicle vehicle,
+                                            VrpPathWithTravelData relocatePath, double slack,
+                                            DrtTaskType relocationTaskType,
+                                            VrpPathWithTravelData followUpPathOrNull) {
+        Schedule schedule = vehicle.getSchedule();
+        DrtStayTask stayTask = (DrtStayTask) schedule.getCurrentTask();
+
+        // finish current STAY
+        stayTask.setEndTime(relocatePath.getDepartureTime());
+
+        // insert RELOCATE drive
+        schedule.addTask(index, taskFactory.createDriveTask(vehicle, relocatePath, relocationTaskType));
+
+        // insert STAY during slack at relocation destination
+        double followUpDepartureTime = relocatePath.getArrivalTime() + slack;
+        schedule.addTask(index + 1, taskFactory.createStayTask(
+                vehicle, relocatePath.getArrivalTime(), followUpDepartureTime, relocatePath.getToLink()));
+
+        // optional drive back to original plan target, AFTER the slack STAY
+        if (followUpPathOrNull != null) {
+            VrpPathWithTravelData followUpPath = followUpPathOrNull.withDepartureTime(followUpDepartureTime);
+            schedule.addTask(index + 2, taskFactory.createDriveTask(vehicle, followUpPath, DrtDriveTask.TYPE));
+        }
+    }
+
+    private void relocateVehicleSimpleImpl(DvrpVehicle vehicle, VrpPathWithTravelData vrpPath, DrtTaskType relocationTaskType) {
+        Schedule schedule = vehicle.getSchedule();
+        DrtStayTask stayTask = (DrtStayTask)schedule.getCurrentTask();
+        if (stayTask.getTaskIdx() != schedule.getTaskCount() - 1) {
+            throw new IllegalStateException("The current STAY task is not last. Not possible without prebooking");
+        }
+
+        stayTask.setEndTime(vrpPath.getDepartureTime()); // finish STAY
+        schedule.addTask(taskFactory.createDriveTask(vehicle, vrpPath, relocationTaskType)); // add RELOCATE
+        // append STAY
+        schedule.addTask(taskFactory.createStayTask(vehicle, vrpPath.getArrivalTime(), vehicle.getServiceEndTime(),
+                vrpPath.getToLink()));
+    }
 }

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/EmptyVehicleRelocatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/EmptyVehicleRelocatorTest.java
@@ -1,0 +1,581 @@
+package org.matsim.contrib.drt.optimizer.rebalancing;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.contrib.drt.schedule.*;
+import org.matsim.contrib.drt.scheduler.EmptyVehicleRelocator;
+import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
+import org.matsim.contrib.dvrp.fleet.DvrpVehicleImpl;
+import org.matsim.contrib.dvrp.fleet.ImmutableDvrpVehicleSpecification;
+import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
+import org.matsim.contrib.dvrp.path.VrpPaths;
+import org.matsim.contrib.dvrp.schedule.Schedule;
+import org.matsim.contrib.dvrp.schedule.Task;
+import org.matsim.core.config.groups.ScoringConfigGroup;
+import org.matsim.core.mobsim.framework.MobsimTimer;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.router.costcalculators.FreespeedTravelTimeAndDisutility;
+import org.matsim.core.router.speedy.SpeedyALTFactory;
+import org.matsim.core.router.util.LeastCostPathCalculator;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * @author nkuehnel / MOIA
+ */
+public class EmptyVehicleRelocatorTest {
+
+    @Test
+    void relocatesAndReturnsBeforeFixedStopAtDifferentLink_whenSlackIsSufficient() {
+        NetworkAndLinks networkAndLinks = getNetworkAndLinks();
+
+        FreespeedTravelTimeAndDisutility freespeedTravelTimeAndDisutility = new FreespeedTravelTimeAndDisutility(new ScoringConfigGroup());
+
+        // --- Mobsim time "now" = 1000s
+        MobsimTimer timer = Mockito.mock(MobsimTimer.class);
+        when(timer.getTimeOfDay()).thenReturn(1000.);
+
+        // --- Vehicle & schedule
+        double serviceBegin = 0.0;
+        double serviceEnd = 10_000.0;
+
+        ImmutableDvrpVehicleSpecification spec = getImmutableDvrpVehicleSpecification(networkAndLinks, serviceBegin, serviceEnd);
+
+        DvrpVehicle veh = new DvrpVehicleImpl(spec, networkAndLinks.lAB());
+        Schedule schedule = veh.getSchedule();
+        DrtTaskFactory taskFactory = new DrtTaskFactoryImpl();
+
+        // Current STAY at AB
+        DrtStayTask currentStay = taskFactory.createStayTask(veh, 1000.0, 2400, networkAndLinks.lAB());
+        schedule.addTask(currentStay);
+
+        // DRIVE to existing fixed/prebooked stop at BC
+        LeastCostPathCalculator lcpc = new SpeedyALTFactory().createPathCalculator(networkAndLinks.net(), freespeedTravelTimeAndDisutility, freespeedTravelTimeAndDisutility);
+        VrpPathWithTravelData path = VrpPaths.calcAndCreatePath(networkAndLinks.lAB(), networkAndLinks.lBC(), currentStay.getEndTime(), lcpc, freespeedTravelTimeAndDisutility);
+        DrtDriveTask driveTask = taskFactory.createDriveTask(veh, path, DrtDriveTask.TYPE);
+        schedule.addTask(driveTask);
+
+        // Upcoming fixed STOP at BC
+        DrtStopTask fixedStop = taskFactory.createStopTask(veh, path.getArrivalTime(), path.getArrivalTime() + 10, networkAndLinks.lBC());
+        schedule.addTask(fixedStop);
+
+        // final STAY at BC
+        DrtStayTask finalStay = taskFactory.createStayTask(veh, fixedStop.getEndTime(), veh.getServiceEndTime(), networkAndLinks.lBC());
+        schedule.addTask(finalStay);
+
+        //trigger start of schedule
+        schedule.nextTask();
+
+        // Sanity preconditions
+        Assertions.assertThat(schedule.getTaskCount()).isEqualTo(4);
+        Assertions.assertThat(schedule.getCurrentTask()).isSameAs(currentStay);
+        Assertions.assertThat(schedule.getTasks().get(2)).isSameAs(fixedStop);
+        Assertions.assertThat(verifyTaskContinuity(schedule));
+
+
+        EmptyVehicleRelocator relocator = new EmptyVehicleRelocator(networkAndLinks.net(), freespeedTravelTimeAndDisutility, freespeedTravelTimeAndDisutility, timer, taskFactory);
+
+        // Try to relocate to CD
+        relocator.relocateVehicle(veh, networkAndLinks.lCD(), EmptyVehicleRelocator.RELOCATE_VEHICLE_TASK_TYPE);
+
+        // --- Verify schedule shape:
+        // After relocation we expect:
+        // 0: STAY(AB) shortened to depart at 1000 (relocate departure)
+        // 1: DRIVE(RELOCATE) AB->CD, arr 1201
+        // 2: STAY(CD) for slack (should be 999s): 1201..2200
+        // 3: DRIVE(CD-> BC) depart 2200
+        // 4: STOP(BC) begin 2501 end 2511 (unchanged begin)
+        // 5: STAY(BC) begin 2511 end 10000
+
+        Assertions.assertThat(schedule.getTaskCount()).isEqualTo(6);
+        Assertions.assertThat(verifyTaskContinuity(schedule));
+
+
+        // 0: current STAY truncated
+        Task t0 = schedule.getTasks().get(0);
+        Assertions.assertThat(t0).isInstanceOf(DrtStayTask.class);
+        Assertions.assertThat(t0.getBeginTime()).isEqualTo(1000.0);
+        Assertions.assertThat(t0.getEndTime()).isEqualTo(1000.0); // finished at relocate departure
+
+        // 1: relocate DRIVE to CD
+        Task t1 = schedule.getTasks().get(1);
+        Assertions.assertThat(t1).isInstanceOf(DrtDriveTask.class);
+        Assertions.assertThat(((DrtDriveTask) t1).getPath().getFromLink()).isSameAs(networkAndLinks.lAB()); // A
+        Assertions.assertThat(((DrtDriveTask) t1).getPath().getToLink()).isSameAs(networkAndLinks.lCD()); // B
+        Assertions.assertThat(t1.getBeginTime()).isEqualTo(1000);
+        Assertions.assertThat(t1.getEndTime()).isEqualTo(1201);
+
+        // 2: STAY at CD for slack
+        Task t2 = schedule.getTasks().get(2);
+        Assertions.assertThat(t2).isInstanceOf(DrtStayTask.class);
+        Assertions.assertThat(t2.getBeginTime()).isEqualTo(1201);
+        Assertions.assertThat(t2.getEndTime()).isEqualTo(2200);
+        Assertions.assertThat(((DrtStayTask)t2).getLink()).isSameAs(networkAndLinks.lCD());
+
+        // 3: follow-up DRIVE B->C
+        Task t3 = schedule.getTasks().get(3);
+        Assertions.assertThat(t3).isInstanceOf(DrtDriveTask.class);
+        Assertions.assertThat(((DrtDriveTask) t3).getPath().getFromLink()).isSameAs(networkAndLinks.lCD()); // B node
+        Assertions.assertThat(((DrtDriveTask) t3).getPath().getToLink()).isSameAs(networkAndLinks.lBC()); // to C
+        Assertions.assertThat(t3.getBeginTime()).isEqualTo(2200);
+        Assertions.assertThat(t3.getEndTime()).isEqualTo(2501);
+
+        // 4: original STOP at BC
+        Task t4 = schedule.getTasks().get(4);
+        Assertions.assertThat(t4).isSameAs(fixedStop);
+        Assertions.assertThat(t4.getBeginTime()).isEqualTo(2501);
+        Assertions.assertThat(t4.getEndTime()).isEqualTo(2511);
+        Assertions.assertThat(((DrtStopTask)t4).getLink()).isSameAs(networkAndLinks.lBC());
+
+
+        // 5: final STAY at BC
+        Task t5 = schedule.getTasks().get(5);
+        Assertions.assertThat(t5).isSameAs(finalStay);
+        Assertions.assertThat(t5.getBeginTime()).isEqualTo(2511);
+        Assertions.assertThat(t5.getEndTime()).isEqualTo(veh.getServiceEndTime());
+        Assertions.assertThat(((DrtStayTask)t5).getLink()).isSameAs(networkAndLinks.lBC());
+    }
+
+
+    @Test
+    void relocatesAndReturnsBeforeFixedStopAtSameLink_whenSlackIsSufficient() {
+        NetworkAndLinks networkAndLinks = getNetworkAndLinks();
+
+        FreespeedTravelTimeAndDisutility freespeedTravelTimeAndDisutility = new FreespeedTravelTimeAndDisutility(new ScoringConfigGroup());
+
+        // --- Mobsim time "now" = 1000s
+        MobsimTimer timer = Mockito.mock(MobsimTimer.class);
+        when(timer.getTimeOfDay()).thenReturn(1000.);
+
+        // --- Vehicle & schedule
+        double serviceBegin = 0.0;
+        double serviceEnd = 10_000.0;
+
+        ImmutableDvrpVehicleSpecification spec = getImmutableDvrpVehicleSpecification(networkAndLinks, serviceBegin, serviceEnd);
+
+        DvrpVehicle veh = new DvrpVehicleImpl(spec, networkAndLinks.lAB());
+        Schedule schedule = veh.getSchedule();
+        DrtTaskFactory taskFactory = new DrtTaskFactoryImpl();
+
+        // Current STAY at AB
+        DrtStayTask currentStay = taskFactory.createStayTask(veh, 1000.0, 2400, networkAndLinks.lAB());
+        schedule.addTask(currentStay);
+
+        // Upcoming fixed STOP at AB
+        DrtStopTask fixedStop = taskFactory.createStopTask(veh, 2400, 2410, networkAndLinks.lAB());
+        schedule.addTask(fixedStop);
+
+        // final STAY at AB
+        DrtStayTask finalStay = taskFactory.createStayTask(veh, fixedStop.getEndTime(), veh.getServiceEndTime(), networkAndLinks.lAB());
+        schedule.addTask(finalStay);
+
+        //trigger start of schedule
+        schedule.nextTask();
+
+        // Sanity preconditions
+        Assertions.assertThat(schedule.getTaskCount()).isEqualTo(3);
+        Assertions.assertThat(schedule.getCurrentTask()).isSameAs(currentStay);
+        Assertions.assertThat(schedule.getTasks().get(1)).isSameAs(fixedStop);
+        Assertions.assertThat(verifyTaskContinuity(schedule));
+
+        EmptyVehicleRelocator relocator = new EmptyVehicleRelocator(networkAndLinks.net(), freespeedTravelTimeAndDisutility, freespeedTravelTimeAndDisutility, timer, taskFactory);
+
+        // Try to relocate to CD
+        relocator.relocateVehicle(veh, networkAndLinks.lCD(), EmptyVehicleRelocator.RELOCATE_VEHICLE_TASK_TYPE);
+
+        // --- Verify schedule shape:
+        // After relocation we expect:
+        // 0: STAY(AB) shortened to depart at 1000 (relocate departure)
+        // 1: DRIVE(RELOCATE) AB-> CD, arr 1201
+        // 2: STAY(CD) for slack (should be 999s): 1201..2200
+        // 3: DRIVE(CD->AB) depart 2200
+        // 4: STOP(AB) begin 2501 end 2511 (unchanged begin)
+
+        Assertions.assertThat(schedule.getTaskCount()).isEqualTo(6);
+        Assertions.assertThat(verifyTaskContinuity(schedule));
+
+
+        // 0: current STAY truncated
+        Task t0 = schedule.getTasks().get(0);
+        Assertions.assertThat(t0).isInstanceOf(DrtStayTask.class);
+        Assertions.assertThat(t0.getBeginTime()).isEqualTo(1000.0);
+        Assertions.assertThat(t0.getEndTime()).isEqualTo(1000.0); // finished at relocate departure
+
+        // 1: relocate DRIVE to CD
+        Task t1 = schedule.getTasks().get(1);
+        Assertions.assertThat(t1).isInstanceOf(DrtDriveTask.class);
+        Assertions.assertThat(((DrtDriveTask) t1).getPath().getFromLink()).isSameAs(networkAndLinks.lAB()); // A
+        Assertions.assertThat(((DrtDriveTask) t1).getPath().getToLink()).isSameAs(networkAndLinks.lCD()); // B
+        Assertions.assertThat(t1.getBeginTime()).isEqualTo(1000);
+        Assertions.assertThat(t1.getEndTime()).isEqualTo(1201);
+
+        // 2: STAY at CD for slack
+        Task t2 = schedule.getTasks().get(2);
+        Assertions.assertThat(t2).isInstanceOf(DrtStayTask.class);
+        Assertions.assertThat(t2.getBeginTime()).isEqualTo(1201);
+        Assertions.assertThat(t2.getEndTime()).isEqualTo(1999);
+        Assertions.assertThat(((DrtStayTask)t2).getLink()).isSameAs(networkAndLinks.lCD());
+
+
+        // 3: follow-up DRIVE CD->AB
+        Task t3 = schedule.getTasks().get(3);
+        Assertions.assertThat(t3).isInstanceOf(DrtDriveTask.class);
+        Assertions.assertThat(((DrtDriveTask) t3).getPath().getFromLink()).isSameAs(networkAndLinks.lCD()); // B node
+        Assertions.assertThat(((DrtDriveTask) t3).getPath().getToLink()).isSameAs(networkAndLinks.lAB()); // to C
+        Assertions.assertThat(t3.getBeginTime()).isEqualTo(1999);
+        Assertions.assertThat(t3.getEndTime()).isEqualTo(2400);
+
+        // 4: original STOP at BC
+        Task t4 = schedule.getTasks().get(4);
+        Assertions.assertThat(t4).isSameAs(fixedStop);
+        Assertions.assertThat(t4.getBeginTime()).isEqualTo(2400);
+        Assertions.assertThat(t4.getEndTime()).isEqualTo(2410);
+        Assertions.assertThat(((DrtStopTask)t4).getLink()).isSameAs(networkAndLinks.lBC());
+
+
+        // 5: final STAY at BC
+        Task t5 = schedule.getTasks().get(5);
+        Assertions.assertThat(t5).isSameAs(finalStay);
+        Assertions.assertThat(t5.getBeginTime()).isEqualTo(2410);
+        Assertions.assertThat(t5.getEndTime()).isEqualTo(veh.getServiceEndTime());
+        Assertions.assertThat(((DrtStayTask)t5).getLink()).isSameAs(networkAndLinks.lBC());
+
+    }
+
+    @Test
+    void relocatesToFixedStopAtSameLink_whenSlackIsSufficient() {
+        NetworkAndLinks networkAndLinks = getNetworkAndLinks();
+
+        FreespeedTravelTimeAndDisutility freespeedTravelTimeAndDisutility = new FreespeedTravelTimeAndDisutility(new ScoringConfigGroup());
+
+        // --- Mobsim time "now" = 1000s
+        MobsimTimer timer = Mockito.mock(MobsimTimer.class);
+        when(timer.getTimeOfDay()).thenReturn(1000.);
+
+        // --- Vehicle & schedule
+        double serviceBegin = 0.0;
+        double serviceEnd = 10_000.0;
+
+        ImmutableDvrpVehicleSpecification spec = getImmutableDvrpVehicleSpecification(networkAndLinks, serviceBegin, serviceEnd);
+
+        DvrpVehicle veh = new DvrpVehicleImpl(spec, networkAndLinks.lAB());
+        Schedule schedule = veh.getSchedule();
+        DrtTaskFactory taskFactory = new DrtTaskFactoryImpl();
+
+        // Current STAY at AB
+        DrtStayTask currentStay = taskFactory.createStayTask(veh, 1000.0, 2400, networkAndLinks.lAB());
+        schedule.addTask(currentStay);
+
+        // DRIVE to existing fixed/prebooked stop at CD
+        LeastCostPathCalculator lcpc = new SpeedyALTFactory().createPathCalculator(networkAndLinks.net(), freespeedTravelTimeAndDisutility, freespeedTravelTimeAndDisutility);
+        VrpPathWithTravelData path = VrpPaths.calcAndCreatePath(networkAndLinks.lAB(), networkAndLinks.lCD(), currentStay.getEndTime(), lcpc, freespeedTravelTimeAndDisutility);
+        DrtDriveTask driveTask = taskFactory.createDriveTask(veh, path, DrtDriveTask.TYPE);
+        schedule.addTask(driveTask);
+
+        // Upcoming fixed STOP at CD
+        DrtStopTask fixedStop = taskFactory.createStopTask(veh, path.getArrivalTime(), path.getArrivalTime() + 10, networkAndLinks.lCD());
+        schedule.addTask(fixedStop);
+
+        // final STAY at CD
+        DrtStayTask finalStay = taskFactory.createStayTask(veh, fixedStop.getEndTime(), veh.getServiceEndTime(), networkAndLinks.lCD());
+        schedule.addTask(finalStay);
+
+        //trigger start of schedule
+        schedule.nextTask();
+
+        // Sanity preconditions
+        Assertions.assertThat(schedule.getTaskCount()).isEqualTo(4);
+        Assertions.assertThat(schedule.getCurrentTask()).isSameAs(currentStay);
+        Assertions.assertThat(schedule.getTasks().get(2)).isSameAs(fixedStop);
+        Assertions.assertThat(verifyTaskContinuity(schedule));
+
+        EmptyVehicleRelocator relocator = new EmptyVehicleRelocator(networkAndLinks.net(), freespeedTravelTimeAndDisutility, freespeedTravelTimeAndDisutility, timer, taskFactory);
+
+        // Try to relocate to CD
+        relocator.relocateVehicle(veh, networkAndLinks.lCD(), EmptyVehicleRelocator.RELOCATE_VEHICLE_TASK_TYPE);
+
+        // --- Verify schedule shape:
+        // After relocation we expect:
+        // 0: STAY(AB) shortened to depart at 1000 (relocate departure)
+        // 1: DRIVE(RELOCATE) AB->CD, arr 1201
+        // 2: STAY(CD) for slack (should be 999s): 1201..2200
+        // 3: STOP(CD) begin 2501 end 2511 (unchanged begin)
+        // 4: STAY(CD) begin 2511 end 10000
+
+        Assertions.assertThat(schedule.getTaskCount()).isEqualTo(5);
+        Assertions.assertThat(verifyTaskContinuity(schedule));
+
+        // 0: current STAY truncated
+        Task t0 = schedule.getTasks().get(0);
+        Assertions.assertThat(t0).isInstanceOf(DrtStayTask.class);
+        Assertions.assertThat(t0.getBeginTime()).isEqualTo(1000.0);
+        Assertions.assertThat(t0.getEndTime()).isEqualTo(1000.0); // finished at relocate departure
+
+        // 1: relocate DRIVE to CD
+        Task t1 = schedule.getTasks().get(1);
+        Assertions.assertThat(t1).isInstanceOf(DrtDriveTask.class);
+        Assertions.assertThat(((DrtDriveTask) t1).getPath().getFromLink()).isSameAs(networkAndLinks.lAB()); // A
+        Assertions.assertThat(((DrtDriveTask) t1).getPath().getToLink()).isSameAs(networkAndLinks.lCD()); // B
+        Assertions.assertThat(t1.getBeginTime()).isEqualTo(1000);
+        Assertions.assertThat(t1.getEndTime()).isEqualTo(1201);
+
+        // 2: STAY at CD for slack
+        Task t2 = schedule.getTasks().get(2);
+        Assertions.assertThat(t2).isInstanceOf(DrtStayTask.class);
+        Assertions.assertThat(t2.getBeginTime()).isEqualTo(1201);
+        Assertions.assertThat(t2.getEndTime()).isEqualTo(2601);
+        Assertions.assertThat(((DrtStayTask)t2).getLink()).isSameAs(networkAndLinks.lCD());
+
+
+        // 3: original STOP at CD
+        Task t3 = schedule.getTasks().get(3);
+        Assertions.assertThat(t3).isSameAs(fixedStop);
+        Assertions.assertThat(t3.getBeginTime()).isEqualTo(2601);
+        Assertions.assertThat(t3.getEndTime()).isEqualTo(2611);
+        Assertions.assertThat(((DrtStopTask)t3).getLink()).isSameAs(networkAndLinks.lCD());
+
+
+        // 4: final STAY at CD
+        Task t4 = schedule.getTasks().get(4);
+        Assertions.assertThat(t4).isSameAs(finalStay);
+        Assertions.assertThat(t4.getBeginTime()).isEqualTo(2611);
+        Assertions.assertThat(t4.getEndTime()).isEqualTo(veh.getServiceEndTime());
+        Assertions.assertThat(((DrtStayTask)t4).getLink()).isSameAs(networkAndLinks.lCD());
+    }
+
+    @Test
+    void relocatesAndReturnsBeforeFixedStopAtDifferentLink_whenSlackIsInSufficientForReturn() {
+        NetworkAndLinks networkAndLinks = getNetworkAndLinks();
+
+        FreespeedTravelTimeAndDisutility freespeedTravelTimeAndDisutility = new FreespeedTravelTimeAndDisutility(new ScoringConfigGroup());
+
+        // --- Mobsim time "now" = 1000s
+        MobsimTimer timer = Mockito.mock(MobsimTimer.class);
+        when(timer.getTimeOfDay()).thenReturn(1000.);
+
+        // --- Vehicle & schedule
+        double serviceBegin = 0.0;
+        double serviceEnd = 10_000.0;
+
+        ImmutableDvrpVehicleSpecification spec = getImmutableDvrpVehicleSpecification(networkAndLinks, serviceBegin, serviceEnd);
+
+        DvrpVehicle veh = new DvrpVehicleImpl(spec, networkAndLinks.lAB());
+        Schedule schedule = veh.getSchedule();
+        DrtTaskFactory taskFactory = new DrtTaskFactoryImpl();
+
+        // Current STAY at AB, short slack
+        DrtStayTask currentStay = taskFactory.createStayTask(veh, 1000.0, 1200, networkAndLinks.lAB());
+        schedule.addTask(currentStay);
+
+        // DRIVE to existing fixed/prebooked stop at BC
+        LeastCostPathCalculator lcpc = new SpeedyALTFactory().createPathCalculator(networkAndLinks.net(), freespeedTravelTimeAndDisutility, freespeedTravelTimeAndDisutility);
+        VrpPathWithTravelData path = VrpPaths.calcAndCreatePath(networkAndLinks.lAB(), networkAndLinks.lBC(), currentStay.getEndTime(), lcpc, freespeedTravelTimeAndDisutility);
+        DrtDriveTask driveTask = taskFactory.createDriveTask(veh, path, DrtDriveTask.TYPE);
+        schedule.addTask(driveTask);
+
+        // Upcoming fixed STOP at BC
+        DrtStopTask fixedStop = taskFactory.createStopTask(veh, path.getArrivalTime(), path.getArrivalTime() + 10, networkAndLinks.lBC());
+        schedule.addTask(fixedStop);
+
+        // final STAY at BC
+        DrtStayTask finalStay = taskFactory.createStayTask(veh, fixedStop.getEndTime(), veh.getServiceEndTime(), networkAndLinks.lBC());
+        schedule.addTask(finalStay);
+
+        //trigger start of schedule
+        schedule.nextTask();
+
+        // Sanity preconditions
+        Assertions.assertThat(schedule.getTaskCount()).isEqualTo(4);
+        Assertions.assertThat(schedule.getCurrentTask()).isSameAs(currentStay);
+        Assertions.assertThat(schedule.getTasks().get(2)).isSameAs(fixedStop);
+        Assertions.assertThat(verifyTaskContinuity(schedule));
+
+
+        EmptyVehicleRelocator relocator = new EmptyVehicleRelocator(networkAndLinks.net(), freespeedTravelTimeAndDisutility, freespeedTravelTimeAndDisutility, timer, taskFactory);
+
+        // Try to relocate to CD
+        relocator.relocateVehicle(veh, networkAndLinks.lCD(), EmptyVehicleRelocator.RELOCATE_VEHICLE_TASK_TYPE);
+
+        // --- Verify schedule shape:
+        // After failed relocation we expect (unchanged):
+        // 0: STAY(AB)
+        // 1: DRIVE AB->BC
+        // 2: STOP(BC)
+        // 3: STAY(BC)
+
+        Assertions.assertThat(schedule.getTaskCount()).isEqualTo(4);
+        Assertions.assertThat(verifyTaskContinuity(schedule));
+
+
+        // 0: current STAY left as before
+        Task t0 = schedule.getTasks().get(0);
+        Assertions.assertThat(t0).isInstanceOf(DrtStayTask.class);
+        Assertions.assertThat(t0.getBeginTime()).isEqualTo(1000.0);
+        Assertions.assertThat(t0.getEndTime()).isEqualTo(1200); // finished at relocate departure
+
+        // 1: DRIVE AB->BC
+        Task t1 = schedule.getTasks().get(1);
+        Assertions.assertThat(t1).isInstanceOf(DrtDriveTask.class);
+        Assertions.assertThat(((DrtDriveTask) t1).getPath().getFromLink()).isSameAs(networkAndLinks.lAB()); // B node
+        Assertions.assertThat(((DrtDriveTask) t1).getPath().getToLink()).isSameAs(networkAndLinks.lBC()); // to C
+        Assertions.assertThat(t1.getBeginTime()).isEqualTo(1200);
+        Assertions.assertThat(t1.getEndTime()).isEqualTo(1301);
+
+        // 2: original STOP at BC
+        Task t2 = schedule.getTasks().get(2);
+        Assertions.assertThat(t2).isSameAs(fixedStop);
+        Assertions.assertThat(t2.getBeginTime()).isEqualTo(1301);
+        Assertions.assertThat(t2.getEndTime()).isEqualTo(1311);
+        Assertions.assertThat(((DrtStopTask)t2).getLink()).isSameAs(networkAndLinks.lBC());
+
+
+        // 3: final STAY at BC
+        Task t3 = schedule.getTasks().get(3);
+        Assertions.assertThat(t3).isSameAs(finalStay);
+        Assertions.assertThat(t3.getBeginTime()).isEqualTo(1311);
+        Assertions.assertThat(t3.getEndTime()).isEqualTo(veh.getServiceEndTime());
+        Assertions.assertThat(((DrtStayTask)t3).getLink()).isSameAs(networkAndLinks.lBC());
+    }
+
+    @Test
+    void relocatesAndReturnsBeforeFixedStopAtDifferentLink_whenSlackIsInSufficientForRelocation() {
+        NetworkAndLinks networkAndLinks = getNetworkAndLinks();
+
+        FreespeedTravelTimeAndDisutility freespeedTravelTimeAndDisutility = new FreespeedTravelTimeAndDisutility(new ScoringConfigGroup());
+
+        // --- Mobsim time "now" = 1000s
+        MobsimTimer timer = Mockito.mock(MobsimTimer.class);
+        when(timer.getTimeOfDay()).thenReturn(1000.);
+
+        // --- Vehicle & schedule
+        double serviceBegin = 0.0;
+        double serviceEnd = 10_000.0;
+
+        ImmutableDvrpVehicleSpecification spec = getImmutableDvrpVehicleSpecification(networkAndLinks, serviceBegin, serviceEnd);
+
+        DvrpVehicle veh = new DvrpVehicleImpl(spec, networkAndLinks.lAB());
+        Schedule schedule = veh.getSchedule();
+        DrtTaskFactory taskFactory = new DrtTaskFactoryImpl();
+
+        // Current STAY at AB, short slack
+        DrtStayTask currentStay = taskFactory.createStayTask(veh, 1000.0, 1100, networkAndLinks.lAB());
+        schedule.addTask(currentStay);
+
+        // DRIVE to existing fixed/prebooked stop at BC
+        LeastCostPathCalculator lcpc = new SpeedyALTFactory().createPathCalculator(networkAndLinks.net(), freespeedTravelTimeAndDisutility, freespeedTravelTimeAndDisutility);
+        VrpPathWithTravelData path = VrpPaths.calcAndCreatePath(networkAndLinks.lAB(), networkAndLinks.lBC(), currentStay.getEndTime(), lcpc, freespeedTravelTimeAndDisutility);
+        DrtDriveTask driveTask = taskFactory.createDriveTask(veh, path, DrtDriveTask.TYPE);
+        schedule.addTask(driveTask);
+
+        // Upcoming fixed STOP at BC
+        DrtStopTask fixedStop = taskFactory.createStopTask(veh, path.getArrivalTime(), path.getArrivalTime() + 10, networkAndLinks.lBC());
+        schedule.addTask(fixedStop);
+
+        // final STAY at BC
+        DrtStayTask finalStay = taskFactory.createStayTask(veh, fixedStop.getEndTime(), veh.getServiceEndTime(), networkAndLinks.lBC());
+        schedule.addTask(finalStay);
+
+        //trigger start of schedule
+        schedule.nextTask();
+
+        // Sanity preconditions
+        Assertions.assertThat(schedule.getTaskCount()).isEqualTo(4);
+        Assertions.assertThat(schedule.getCurrentTask()).isSameAs(currentStay);
+        Assertions.assertThat(schedule.getTasks().get(2)).isSameAs(fixedStop);
+        Assertions.assertThat(verifyTaskContinuity(schedule));
+
+
+        EmptyVehicleRelocator relocator = new EmptyVehicleRelocator(networkAndLinks.net(), freespeedTravelTimeAndDisutility, freespeedTravelTimeAndDisutility, timer, taskFactory);
+
+        // Try to relocate to CD
+        relocator.relocateVehicle(veh, networkAndLinks.lCD(), EmptyVehicleRelocator.RELOCATE_VEHICLE_TASK_TYPE);
+
+        // --- Verify schedule shape:
+        // After failed relocation we expect (unchanged):
+        // 0: STAY(AB)
+        // 1: DRIVE AB->BC
+        // 2: STOP(BC)
+        // 3: STAY(BC)
+
+        Assertions.assertThat(schedule.getTaskCount()).isEqualTo(4);
+        Assertions.assertThat(verifyTaskContinuity(schedule));
+
+
+        // 0: current STAY left as before
+        Task t0 = schedule.getTasks().get(0);
+        Assertions.assertThat(t0).isInstanceOf(DrtStayTask.class);
+        Assertions.assertThat(t0.getBeginTime()).isEqualTo(1000.0);
+        Assertions.assertThat(t0.getEndTime()).isEqualTo(1100); // finished at relocate departure
+
+        // 1: DRIVE AB->BC
+        Task t1 = schedule.getTasks().get(1);
+        Assertions.assertThat(t1).isInstanceOf(DrtDriveTask.class);
+        Assertions.assertThat(((DrtDriveTask) t1).getPath().getFromLink()).isSameAs(networkAndLinks.lAB()); // B node
+        Assertions.assertThat(((DrtDriveTask) t1).getPath().getToLink()).isSameAs(networkAndLinks.lBC()); // to C
+        Assertions.assertThat(t1.getBeginTime()).isEqualTo(1100);
+        Assertions.assertThat(t1.getEndTime()).isEqualTo(1201);
+
+        // 2: original STOP at BC
+        Task t2 = schedule.getTasks().get(2);
+        Assertions.assertThat(t2).isSameAs(fixedStop);
+        Assertions.assertThat(t2.getBeginTime()).isEqualTo(1201);
+        Assertions.assertThat(t2.getEndTime()).isEqualTo(1211);
+        Assertions.assertThat(((DrtStopTask)t2).getLink()).isSameAs(networkAndLinks.lBC());
+
+
+        // 3: final STAY at BC
+        Task t3 = schedule.getTasks().get(3);
+        Assertions.assertThat(t3).isSameAs(finalStay);
+        Assertions.assertThat(t3.getBeginTime()).isEqualTo(1211);
+        Assertions.assertThat(t3.getEndTime()).isEqualTo(veh.getServiceEndTime());
+        Assertions.assertThat(((DrtStayTask)t3).getLink()).isSameAs(networkAndLinks.lBC());
+    }
+
+
+    private static ImmutableDvrpVehicleSpecification getImmutableDvrpVehicleSpecification(NetworkAndLinks networkAndLinks, double serviceBegin, double serviceEnd) {
+        ImmutableDvrpVehicleSpecification spec = ImmutableDvrpVehicleSpecification.newBuilder()
+                .id(Id.create(1, DvrpVehicle.class))
+                .startLinkId(networkAndLinks.lAB().getId())
+                .serviceBeginTime(serviceBegin)
+                .serviceEndTime(serviceEnd)
+                .capacity(4)
+                .build();
+        return spec;
+    }
+
+    private static NetworkAndLinks getNetworkAndLinks() {
+        Network net = NetworkUtils.createNetwork();
+        Node nA = NetworkUtils.createAndAddNode(net, Id.createNodeId("A"), new Coord(0, 0));
+        Node nB = NetworkUtils.createAndAddNode(net, Id.createNodeId("B"), new Coord(1000, 0));
+        Node nC = NetworkUtils.createAndAddNode(net, Id.createNodeId("C"), new Coord(2000, 0));
+        Node nD = NetworkUtils.createAndAddNode(net, Id.createNodeId("D"), new Coord(3000, 0));
+        Link lAB = NetworkUtils.createAndAddLink(net, Id.createLinkId("A-B"), nA, nB, 1000, 10.0, 9999, 1);
+        Link lBA = NetworkUtils.createAndAddLink(net, Id.createLinkId("B-A"), nB, nA, 1000, 10.0, 9999, 1);
+        Link lBC = NetworkUtils.createAndAddLink(net, Id.createLinkId("B-C"), nB, nC, 1000, 10.0, 9999, 1);
+        Link lCB = NetworkUtils.createAndAddLink(net, Id.createLinkId("C-B"), nC, nB, 1000, 10.0, 9999, 1);
+        Link lCD = NetworkUtils.createAndAddLink(net, Id.createLinkId("C-D"), nC, nD, 1000, 10.0, 9999, 1);
+        Link lDC = NetworkUtils.createAndAddLink(net, Id.createLinkId("D-C"), nD, nC, 1000, 10.0, 9999, 1);
+        NetworkAndLinks networkAndLinks = new NetworkAndLinks(net, lAB, lBC, lCD);
+        return networkAndLinks;
+    }
+
+    private record NetworkAndLinks(Network net, Link lAB, Link lBC, Link lCD) {
+    }
+
+    private boolean verifyTaskContinuity(Schedule schedule) {
+        for (int i = 1; i < schedule.getTaskCount(); i++) {
+            Task first = schedule.getTasks().get(i - 1);
+            Task second = schedule.getTasks().get(i);
+            if(first.getEndTime() != second.getBeginTime()) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/EmptyVehicleRelocatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/rebalancing/EmptyVehicleRelocatorTest.java
@@ -87,11 +87,11 @@ public class EmptyVehicleRelocatorTest {
         // --- Verify schedule shape:
         // After relocation we expect:
         // 0: STAY(AB) shortened to depart at 1000 (relocate departure)
-        // 1: DRIVE(RELOCATE) AB->CD, arr 1201
-        // 2: STAY(CD) for slack (should be 999s): 1201..2200
-        // 3: DRIVE(CD-> BC) depart 2200
-        // 4: STOP(BC) begin 2501 end 2511 (unchanged begin)
-        // 5: STAY(BC) begin 2511 end 10000
+        // 1: DRIVE(RELOCATE)
+        // 2: STAY(CD)
+        // 3: DRIVE(CD-> BC)
+        // 4: STOP(BC)
+        // 5: STAY(BC)
 
         Assertions.assertThat(schedule.getTaskCount()).isEqualTo(6);
         Assertions.assertThat(verifyTaskContinuity(schedule));
@@ -101,13 +101,13 @@ public class EmptyVehicleRelocatorTest {
         Task t0 = schedule.getTasks().get(0);
         Assertions.assertThat(t0).isInstanceOf(DrtStayTask.class);
         Assertions.assertThat(t0.getBeginTime()).isEqualTo(1000.0);
-        Assertions.assertThat(t0.getEndTime()).isEqualTo(1000.0); // finished at relocate departure
+        Assertions.assertThat(t0.getEndTime()).isEqualTo(1000.0);
 
         // 1: relocate DRIVE to CD
         Task t1 = schedule.getTasks().get(1);
         Assertions.assertThat(t1).isInstanceOf(DrtDriveTask.class);
-        Assertions.assertThat(((DrtDriveTask) t1).getPath().getFromLink()).isSameAs(networkAndLinks.lAB()); // A
-        Assertions.assertThat(((DrtDriveTask) t1).getPath().getToLink()).isSameAs(networkAndLinks.lCD()); // B
+        Assertions.assertThat(((DrtDriveTask) t1).getPath().getFromLink()).isSameAs(networkAndLinks.lAB());
+        Assertions.assertThat(((DrtDriveTask) t1).getPath().getToLink()).isSameAs(networkAndLinks.lCD());
         Assertions.assertThat(t1.getBeginTime()).isEqualTo(1000);
         Assertions.assertThat(t1.getEndTime()).isEqualTo(1201);
 
@@ -121,8 +121,8 @@ public class EmptyVehicleRelocatorTest {
         // 3: follow-up DRIVE B->C
         Task t3 = schedule.getTasks().get(3);
         Assertions.assertThat(t3).isInstanceOf(DrtDriveTask.class);
-        Assertions.assertThat(((DrtDriveTask) t3).getPath().getFromLink()).isSameAs(networkAndLinks.lCD()); // B node
-        Assertions.assertThat(((DrtDriveTask) t3).getPath().getToLink()).isSameAs(networkAndLinks.lBC()); // to C
+        Assertions.assertThat(((DrtDriveTask) t3).getPath().getFromLink()).isSameAs(networkAndLinks.lCD());
+        Assertions.assertThat(((DrtDriveTask) t3).getPath().getToLink()).isSameAs(networkAndLinks.lBC());
         Assertions.assertThat(t3.getBeginTime()).isEqualTo(2200);
         Assertions.assertThat(t3.getEndTime()).isEqualTo(2501);
 
@@ -153,7 +153,6 @@ public class EmptyVehicleRelocatorTest {
         MobsimTimer timer = Mockito.mock(MobsimTimer.class);
         when(timer.getTimeOfDay()).thenReturn(1000.);
 
-        // --- Vehicle & schedule
         double serviceBegin = 0.0;
         double serviceEnd = 10_000.0;
 
@@ -191,11 +190,11 @@ public class EmptyVehicleRelocatorTest {
 
         // --- Verify schedule shape:
         // After relocation we expect:
-        // 0: STAY(AB) shortened to depart at 1000 (relocate departure)
-        // 1: DRIVE(RELOCATE) AB-> CD, arr 1201
-        // 2: STAY(CD) for slack (should be 999s): 1201..2200
-        // 3: DRIVE(CD->AB) depart 2200
-        // 4: STOP(AB) begin 2501 end 2511 (unchanged begin)
+        // 0: STAY(AB) shortened to depart at 1000
+        // 1: DRIVE(RELOCATE) AB-> CD
+        // 2: STAY(CD)
+        // 3: DRIVE(CD->AB)
+        // 4: STOP(AB) (unchanged begin)
 
         Assertions.assertThat(schedule.getTaskCount()).isEqualTo(6);
         Assertions.assertThat(verifyTaskContinuity(schedule));
@@ -205,13 +204,13 @@ public class EmptyVehicleRelocatorTest {
         Task t0 = schedule.getTasks().get(0);
         Assertions.assertThat(t0).isInstanceOf(DrtStayTask.class);
         Assertions.assertThat(t0.getBeginTime()).isEqualTo(1000.0);
-        Assertions.assertThat(t0.getEndTime()).isEqualTo(1000.0); // finished at relocate departure
+        Assertions.assertThat(t0.getEndTime()).isEqualTo(1000.0);
 
         // 1: relocate DRIVE to CD
         Task t1 = schedule.getTasks().get(1);
         Assertions.assertThat(t1).isInstanceOf(DrtDriveTask.class);
-        Assertions.assertThat(((DrtDriveTask) t1).getPath().getFromLink()).isSameAs(networkAndLinks.lAB()); // A
-        Assertions.assertThat(((DrtDriveTask) t1).getPath().getToLink()).isSameAs(networkAndLinks.lCD()); // B
+        Assertions.assertThat(((DrtDriveTask) t1).getPath().getFromLink()).isSameAs(networkAndLinks.lAB());
+        Assertions.assertThat(((DrtDriveTask) t1).getPath().getToLink()).isSameAs(networkAndLinks.lCD());
         Assertions.assertThat(t1.getBeginTime()).isEqualTo(1000);
         Assertions.assertThat(t1.getEndTime()).isEqualTo(1201);
 
@@ -226,25 +225,25 @@ public class EmptyVehicleRelocatorTest {
         // 3: follow-up DRIVE CD->AB
         Task t3 = schedule.getTasks().get(3);
         Assertions.assertThat(t3).isInstanceOf(DrtDriveTask.class);
-        Assertions.assertThat(((DrtDriveTask) t3).getPath().getFromLink()).isSameAs(networkAndLinks.lCD()); // B node
-        Assertions.assertThat(((DrtDriveTask) t3).getPath().getToLink()).isSameAs(networkAndLinks.lAB()); // to C
+        Assertions.assertThat(((DrtDriveTask) t3).getPath().getFromLink()).isSameAs(networkAndLinks.lCD());
+        Assertions.assertThat(((DrtDriveTask) t3).getPath().getToLink()).isSameAs(networkAndLinks.lAB());
         Assertions.assertThat(t3.getBeginTime()).isEqualTo(1999);
         Assertions.assertThat(t3.getEndTime()).isEqualTo(2400);
 
-        // 4: original STOP at BC
+        // 4: original STOP at AB
         Task t4 = schedule.getTasks().get(4);
         Assertions.assertThat(t4).isSameAs(fixedStop);
         Assertions.assertThat(t4.getBeginTime()).isEqualTo(2400);
         Assertions.assertThat(t4.getEndTime()).isEqualTo(2410);
-        Assertions.assertThat(((DrtStopTask)t4).getLink()).isSameAs(networkAndLinks.lBC());
+        Assertions.assertThat(((DrtStopTask)t4).getLink()).isSameAs(networkAndLinks.lAB());
 
 
-        // 5: final STAY at BC
+        // 5: final STAY at AB
         Task t5 = schedule.getTasks().get(5);
         Assertions.assertThat(t5).isSameAs(finalStay);
         Assertions.assertThat(t5.getBeginTime()).isEqualTo(2410);
         Assertions.assertThat(t5.getEndTime()).isEqualTo(veh.getServiceEndTime());
-        Assertions.assertThat(((DrtStayTask)t5).getLink()).isSameAs(networkAndLinks.lBC());
+        Assertions.assertThat(((DrtStayTask)t5).getLink()).isSameAs(networkAndLinks.lAB());
 
     }
 
@@ -303,10 +302,10 @@ public class EmptyVehicleRelocatorTest {
         // --- Verify schedule shape:
         // After relocation we expect:
         // 0: STAY(AB) shortened to depart at 1000 (relocate departure)
-        // 1: DRIVE(RELOCATE) AB->CD, arr 1201
-        // 2: STAY(CD) for slack (should be 999s): 1201..2200
-        // 3: STOP(CD) begin 2501 end 2511 (unchanged begin)
-        // 4: STAY(CD) begin 2511 end 10000
+        // 1: DRIVE(RELOCATE) AB->CD
+        // 2: STAY(CD)
+        // 3: STOP(CD)
+        // 4: STAY(CD)
 
         Assertions.assertThat(schedule.getTaskCount()).isEqualTo(5);
         Assertions.assertThat(verifyTaskContinuity(schedule));
@@ -315,13 +314,13 @@ public class EmptyVehicleRelocatorTest {
         Task t0 = schedule.getTasks().get(0);
         Assertions.assertThat(t0).isInstanceOf(DrtStayTask.class);
         Assertions.assertThat(t0.getBeginTime()).isEqualTo(1000.0);
-        Assertions.assertThat(t0.getEndTime()).isEqualTo(1000.0); // finished at relocate departure
+        Assertions.assertThat(t0.getEndTime()).isEqualTo(1000.0);
 
         // 1: relocate DRIVE to CD
         Task t1 = schedule.getTasks().get(1);
         Assertions.assertThat(t1).isInstanceOf(DrtDriveTask.class);
-        Assertions.assertThat(((DrtDriveTask) t1).getPath().getFromLink()).isSameAs(networkAndLinks.lAB()); // A
-        Assertions.assertThat(((DrtDriveTask) t1).getPath().getToLink()).isSameAs(networkAndLinks.lCD()); // B
+        Assertions.assertThat(((DrtDriveTask) t1).getPath().getFromLink()).isSameAs(networkAndLinks.lAB());
+        Assertions.assertThat(((DrtDriveTask) t1).getPath().getToLink()).isSameAs(networkAndLinks.lCD());
         Assertions.assertThat(t1.getBeginTime()).isEqualTo(1000);
         Assertions.assertThat(t1.getEndTime()).isEqualTo(1201);
 
@@ -417,13 +416,13 @@ public class EmptyVehicleRelocatorTest {
         Task t0 = schedule.getTasks().get(0);
         Assertions.assertThat(t0).isInstanceOf(DrtStayTask.class);
         Assertions.assertThat(t0.getBeginTime()).isEqualTo(1000.0);
-        Assertions.assertThat(t0.getEndTime()).isEqualTo(1200); // finished at relocate departure
+        Assertions.assertThat(t0.getEndTime()).isEqualTo(1200);
 
         // 1: DRIVE AB->BC
         Task t1 = schedule.getTasks().get(1);
         Assertions.assertThat(t1).isInstanceOf(DrtDriveTask.class);
-        Assertions.assertThat(((DrtDriveTask) t1).getPath().getFromLink()).isSameAs(networkAndLinks.lAB()); // B node
-        Assertions.assertThat(((DrtDriveTask) t1).getPath().getToLink()).isSameAs(networkAndLinks.lBC()); // to C
+        Assertions.assertThat(((DrtDriveTask) t1).getPath().getFromLink()).isSameAs(networkAndLinks.lAB());
+        Assertions.assertThat(((DrtDriveTask) t1).getPath().getToLink()).isSameAs(networkAndLinks.lBC());
         Assertions.assertThat(t1.getBeginTime()).isEqualTo(1200);
         Assertions.assertThat(t1.getEndTime()).isEqualTo(1301);
 
@@ -511,13 +510,13 @@ public class EmptyVehicleRelocatorTest {
         Task t0 = schedule.getTasks().get(0);
         Assertions.assertThat(t0).isInstanceOf(DrtStayTask.class);
         Assertions.assertThat(t0.getBeginTime()).isEqualTo(1000.0);
-        Assertions.assertThat(t0.getEndTime()).isEqualTo(1100); // finished at relocate departure
+        Assertions.assertThat(t0.getEndTime()).isEqualTo(1100);
 
         // 1: DRIVE AB->BC
         Task t1 = schedule.getTasks().get(1);
         Assertions.assertThat(t1).isInstanceOf(DrtDriveTask.class);
-        Assertions.assertThat(((DrtDriveTask) t1).getPath().getFromLink()).isSameAs(networkAndLinks.lAB()); // B node
-        Assertions.assertThat(((DrtDriveTask) t1).getPath().getToLink()).isSameAs(networkAndLinks.lBC()); // to C
+        Assertions.assertThat(((DrtDriveTask) t1).getPath().getFromLink()).isSameAs(networkAndLinks.lAB());
+        Assertions.assertThat(((DrtDriveTask) t1).getPath().getToLink()).isSameAs(networkAndLinks.lBC());
         Assertions.assertThat(t1.getBeginTime()).isEqualTo(1100);
         Assertions.assertThat(t1.getEndTime()).isEqualTo(1201);
 


### PR DESCRIPTION
Adds the possibility to relocate a vehicle that is idle, but still has other tasks in the (distant) future.
The relocation takes care of driving to the target relocation link but also ensures that the vehicle drives back to the next fixed stop in time. If the vehicle cannot make it to the next stop in time, the relocation is not performed.

Includes a few test that should cover most of the important scenarios, including when the relocation target equals the link of the next fixed stop, when there is not enough idle time to include the relocation + driving back.

Why is this important?
- currently no relocation of vehicles that a have prebooked stop in the future, even if it is hours away
- allows to plan shift breaks and changeovers at the beginning of a shift without losing the possibility of relocation
