### PR TITLE
fix: add check for correct bicycleMode before calculating additional score

### DIFF
--- a/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/AdditionalBicycleLinkScore.java
+++ b/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/AdditionalBicycleLinkScore.java
@@ -1,7 +1,9 @@
 package org.matsim.contrib.bicycle;
 
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
+import org.matsim.vehicles.Vehicle;
 
 public interface AdditionalBicycleLinkScore{
-	double computeLinkBasedScore( Link link );
+	double computeLinkBasedScore(Link link, Id<Vehicle> vehicleId, String bicycleMode );
 }

--- a/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/AdditionalBicycleLinkScoreDefaultImpl.java
+++ b/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/AdditionalBicycleLinkScoreDefaultImpl.java
@@ -1,10 +1,15 @@
 package org.matsim.contrib.bicycle;
 
 import com.google.inject.Inject;
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.network.NetworkUtils;
+import org.matsim.vehicles.Vehicle;
+import org.matsim.vehicles.Vehicles;
+
+import java.util.Objects;
 
 public final class AdditionalBicycleLinkScoreDefaultImpl implements AdditionalBicycleLinkScore {
 
@@ -13,14 +18,22 @@ public final class AdditionalBicycleLinkScoreDefaultImpl implements AdditionalBi
 	private final double marginalUtilityOfInfrastructure_m;
 	private final double marginalUtilityOfComfort_m;
 	private final double marginalUtilityOfGradient_pct_m;
+	private final Vehicles vehicles;
+
 	@Inject AdditionalBicycleLinkScoreDefaultImpl( Scenario scenario ) {
 		BicycleConfigGroup bicycleConfigGroup = ConfigUtils.addOrGetModule( scenario.getConfig(), BicycleConfigGroup.class );
 		this.marginalUtilityOfInfrastructure_m = bicycleConfigGroup.getMarginalUtilityOfInfrastructure_m();
 		this.marginalUtilityOfComfort_m = bicycleConfigGroup.getMarginalUtilityOfComfort_m();
 		this.marginalUtilityOfGradient_pct_m = bicycleConfigGroup.getMarginalUtilityOfGradient_pct_m();
-
+		this.vehicles = scenario.getVehicles();
 	}
-	@Override public double computeLinkBasedScore( Link link ){
+	@Override public double computeLinkBasedScore( Link link, Id<Vehicle> vehicleId, String bicycleMode ){
+
+//		if we do not check for the correct bicycleMode here, every network mode is scored with bicycleScores! -sm0825
+		if (!Objects.equals(vehicles.getVehicles().get(vehicleId).getType().getNetworkMode(), bicycleMode)) {
+			return Double.NaN;
+		}
+
 		String surface = BicycleUtils.getSurface(link);
 		String type = NetworkUtils.getType( link );
 		String cyclewaytype = BicycleUtils.getCyclewaytype( link );

--- a/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/BicycleScoreEventsCreator.java
+++ b/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/BicycleScoreEventsCreator.java
@@ -112,20 +112,24 @@ class BicycleScoreEventsCreator implements
 		}
 
 		if ( vehicle2driver.getDriverOfVehicle( event.getVehicleId() ) != null ){
-			double amount = additionalBicycleLinkScore.computeLinkBasedScore( network.getLinks().get( event.getLinkId() ) );
+			double amount = additionalBicycleLinkScore.computeLinkBasedScore( network.getLinks().get( event.getLinkId() ),
+				event.getVehicleId(), this.bicycleMode );
 
-			if ( this.bicycleConfig.isMotorizedInteraction() ) {
-				// yyyy this is the place where instead a data structure would need to be build that counts interaction with every car
-				// that entered the link after the bicycle, and left it before.  kai, jul'23
-				var carCounts = this.numberOfVehiclesOnLinkByMode.get( TransportMode.car );
-				if ( carCounts != null ){
-					amount -= 0.004 * carCounts.getOrDefault( event.getLinkId(), 0. );
+			// only throw PersonScoreEvent if amount != NaN = mode of vehicle equals bicycleMode. -sm0825
+			if (!Double.isNaN(amount)) {
+				if ( this.bicycleConfig.isMotorizedInteraction() ) {
+					// yyyy this is the place where instead a data structure would need to be build that counts interaction with every car
+					// that entered the link after the bicycle, and left it before.  kai, jul'23
+					var carCounts = this.numberOfVehiclesOnLinkByMode.get( TransportMode.car );
+					if ( carCounts != null ){
+						amount -= 0.004 * carCounts.getOrDefault( event.getLinkId(), 0. );
+					}
 				}
-			}
 
-			final Id<Person> driverOfVehicle = vehicle2driver.getDriverOfVehicle( event.getVehicleId() );
-			Gbl.assertNotNull( driverOfVehicle );
-			this.eventsManager.processEvent( new PersonScoreEvent( event.getTime(), driverOfVehicle, amount, "bicycleAdditionalLinkScore" ) );
+				final Id<Person> driverOfVehicle = vehicle2driver.getDriverOfVehicle( event.getVehicleId() );
+				Gbl.assertNotNull( driverOfVehicle );
+				this.eventsManager.processEvent( new PersonScoreEvent( event.getTime(), driverOfVehicle, amount, "bicycleAdditionalLinkScore" ) );
+			}
 		} else {
 			log.warn( "no driver found for vehicleId=" + event.getVehicleId() + "; not clear why this could happen");
 		}
@@ -147,11 +151,15 @@ class BicycleScoreEventsCreator implements
 
 //				TODO: I am pretty sure that here the last link is scored twice. It is already scored for LinkLeaveEvent, so why are we doing it again here? -sm0325
 
-				double amount = additionalBicycleLinkScore.computeLinkBasedScore( network.getLinks().get( event.getLinkId() ) );
+				double amount = additionalBicycleLinkScore.computeLinkBasedScore( network.getLinks().get( event.getLinkId() ),
+					event.getVehicleId(), this.bicycleMode);
 
-				final Id<Person> driverOfVehicle = vehicle2driver.getDriverOfVehicle( event.getVehicleId() );
-				Gbl.assertNotNull( driverOfVehicle );
-				this.eventsManager.processEvent( new PersonScoreEvent( event.getTime(), driverOfVehicle, amount, "bicycleAdditionalLinkScore" ) );
+				// only throw PersonScoreEvent if amount != NaN = mode of vehicle equals bicycleMode. -sm0825
+				if (!Double.isNaN(amount)) {
+					final Id<Person> driverOfVehicle = vehicle2driver.getDriverOfVehicle( event.getVehicleId() );
+					Gbl.assertNotNull( driverOfVehicle );
+					this.eventsManager.processEvent( new PersonScoreEvent( event.getTime(), driverOfVehicle, amount, "bicycleAdditionalLinkScore" ) );
+				}
 			}
 		} else {
 			log.warn( "no driver found for vehicleId=" + event.getVehicleId() + "; not clear why this could happen" );

--- a/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/run/RunBicycleExample.java
+++ b/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/run/RunBicycleExample.java
@@ -37,6 +37,7 @@ import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.Controler;
 import org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting;
 import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
 import org.matsim.vehicles.VehicleUtils;
 import org.matsim.vehicles.VehiclesFactory;
@@ -170,10 +171,10 @@ public class RunBicycleExample {
 
 		@Inject private AdditionalBicycleLinkScoreDefaultImpl delegate;
 
-		@Override public double computeLinkBasedScore( Link link ){
+		@Override public double computeLinkBasedScore(Link link, Id<Vehicle> vehicleId, String bicycleMode ){
 			double result = (double) link.getAttributes().getAttribute( "carFreeStatus" );  // from zero to one
 
-			double amount = delegate.computeLinkBasedScore( link );
+			double amount = delegate.computeLinkBasedScore( link, vehicleId, bicycleMode );
 
 			return amount + result ;  // or some other way to augment the score
 


### PR DESCRIPTION
We are using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), so that we are able to auto generate a changelog. The format is described below:

#### Title
`<type>[optional scope]: <description>` e.g.: fix(QSim): Correctly calculate travel times on links

Available types:
 - feat: A new feature
 - fix: A bug fix
 - docs: Documentation only changes
 - style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
 - refactor: A code change that neither fixes a bug nor adds a feature
 - perf: A code change that improves performance
 - test: Adding missing tests or correcting existing tests
 - build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
 - ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
 - chore: Other changes that don't modify src or test files
 - revert: Reverts a previous commit

#### Body
Optionally, describe the change in more detail.

If the PR introduces a breaking change write: BREAKING CHANGE at the bottom of the message
