### PR TITLE
fix(pt): Catch when there is no chained departure (during umlauf)

### DIFF
--- a/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitDriverAgent.java
+++ b/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitDriverAgent.java
@@ -78,7 +78,8 @@ public class SBBTransitDriverAgent extends TransitDriverAgentImpl {
 	protected void handleEndRoute(double now) {
 
 		// Delegates call to the correct access egress
-		accessEgress.relocatePassengers( this, getDeparture().getChainedDepartures(), now);
+		if (getDeparture() != null)
+			accessEgress.relocatePassengers( this, getDeparture().getChainedDepartures(), now);
 
 	}
 

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/pt/TransitDriverAgentImpl.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/pt/TransitDriverAgentImpl.java
@@ -173,7 +173,8 @@ public class TransitDriverAgentImpl extends AbstractTransitDriverAgent {
 	 */
 	protected void handleEndRoute(double now) {
 
-		accessEgress.relocatePassengers( this, departure.getChainedDepartures(), now);
+		if (departure != null)
+			accessEgress.relocatePassengers( this, departure.getChainedDepartures(), now);
 
 	}
 


### PR DESCRIPTION
Additional change to #4220, to catch situation when no departure is defined. This happens during umlauf between serving two transit routes.