### PR TITLE
refactor(freight): move the carrier scoring function used in logistic to the carrier package and make it public

### DIFF
--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/usecases/CarrierScorerEventBasedInclToll.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/usecases/CarrierScorerEventBasedInclToll.java
@@ -1,25 +1,24 @@
 /*
- *********************************************************************** *
- * project: org.matsim.*
- *                                                                         *
- * *********************************************************************** *
- *                                                                         *
- * copyright       :  (C) 2024 by the members listed in the COPYING,       *
- *                   LICENSE and WARRANTY file.                            *
- * email           : info at matsim dot org                                *
- *                                                                         *
- * *********************************************************************** *
- *                                                                         *
- *   This program is free software; you can redistribute it and/or modify  *
- *   it under the terms of the GNU General Public License as published by  *
- *   the Free Software Foundation; either version 2 of the License, or     *
- *   (at your option) any later version.                                   *
- *   See also COPYING, LICENSE and WARRANTY file                           *
- *                                                                         *
- * ***********************************************************************
+ *   *********************************************************************** *
+ *   project: org.matsim.*													 *
+ *   *********************************************************************** *
+ *                                                                           *
+ *   copyright       : (C) 2025 by the members listed in the COPYING, 		 *
+ *                          LICENSE and WARRANTY file.  					 *
+ *   email           : info at matsim dot org   							 *
+ *                                                                         	 *
+ *   *********************************************************************** *
+ *                                                                        	 *
+ *     This program is free software; you can redistribute it and/or modify  *
+ *      it under the terms of the GNU General Public License as published by *
+ *     the Free Software Foundation; either version 2 of the License, or     *
+ *     (at your option) any later version.								     *
+ *     See also COPYING, LICENSE and WARRANTY file						 	 *
+ *                                                                           *
+ *   *********************************************************************** *
  */
 
-package org.matsim.freight.logistics.examples.multipleChains;
+package org.matsim.freight.carriers.usecases;
 
 import com.google.inject.Inject;
 import java.util.*;
@@ -52,12 +51,11 @@ import org.matsim.vehicles.VehicleUtils;
  *  - distance-dependent costs (using LinkEnterEvent)
  * 	- tolls (using PersonMoneyEvent)
  *
- * 	@todo Maybe move this up to the carrier package and make it public?
- * 	Can this be the new default scoring function for carriers?
+ * 	@todo 	Can this be the new default scoring function for carriers?
  * 	Discuss with RE/KN and write tests around it.
  *  @author Kai Martins-Turner (kturner)
  */
-class EventBasedCarrierScorer4MultipleChainsInclToll implements CarrierScoringFunctionFactory {
+public class CarrierScorerEventBasedInclToll implements CarrierScoringFunctionFactory {
 
 	@Inject private Scenario scenario;
 

--- a/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/logistics/examples/multipleChains/ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll.java
@@ -46,6 +46,7 @@ import org.matsim.freight.carriers.*;
 import org.matsim.freight.carriers.controller.CarrierControllerUtils;
 import org.matsim.freight.carriers.controller.CarrierScoringFunctionFactory;
 import org.matsim.freight.carriers.controller.CarrierStrategyManager;
+import org.matsim.freight.carriers.usecases.CarrierScorerEventBasedInclToll;
 import org.matsim.freight.logistics.*;
 import org.matsim.freight.logistics.examples.ExampleConstants;
 import org.matsim.freight.logistics.examples.MyLSPScorer;
@@ -359,7 +360,7 @@ final class ExampleTwoLspsGroceryDeliveryMultipleChainsWithToll {
 			new AbstractModule() {
 				@Override
 				public void install() {
-					bind(CarrierScoringFunctionFactory.class).toInstance(new EventBasedCarrierScorer4MultipleChainsInclToll());
+					bind(CarrierScoringFunctionFactory.class).toInstance(new CarrierScorerEventBasedInclToll());
 					bind(LSPScorerFactory.class).toInstance(MyLSPScorer::new);
 					bind(CarrierStrategyManager.class)
 						.toProvider(


### PR DESCRIPTION
While working on the `logistic` package, I wrote a new event-based `CarrierScoringFunction`.
This PR now moves (and renames) this into the `carriers` package and makes it public to be accessible from different places.
