### PR TITLE
refactor(ev/common): generify reservation manager

### DIFF
--- a/contribs/common/src/main/java/org/matsim/contrib/common/util/reservation/AbstractReservationManager.java
+++ b/contribs/common/src/main/java/org/matsim/contrib/common/util/reservation/AbstractReservationManager.java
@@ -1,0 +1,110 @@
+package org.matsim.contrib.common.util.reservation;
+
+import org.matsim.api.core.v01.IdMap;
+import org.matsim.api.core.v01.Identifiable;
+import org.matsim.core.controler.listener.IterationStartsListener;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ *
+ * @author Sebastian Hörl (sebhoerl), IRT SystemX
+ * @author nkuehnel refactored to abstract generic version
+ */
+public abstract class AbstractReservationManager<
+        R extends Identifiable<Id>,               // Resource type (must be identifiable, e.g. ChargerSpecification)
+        Id,                                     // Id type of the resource
+        C                                       // Consumer type (vehicle, person, etc.),
+        > implements ReservationManager<R, Id, C>, IterationStartsListener {
+
+    private final IdMap<Id, List<Reservation<R, Id, C>>> reservations;
+
+    public AbstractReservationManager(Class<Id> idClass) {
+        this.reservations = new IdMap<>(idClass);
+    }
+
+    public abstract int getCapacity(R resource);
+
+    @Override
+    public final boolean isAvailable(R resource, C consumer, double startTime, double endTime) {
+        int capacity = getCapacity(resource);
+        if (capacity == 0) {
+            return false;
+        }
+
+        if (!reservations.containsKey(resource.getId())) {
+            return true;
+        }
+
+        int remaining = capacity;
+        for (Reservation<R, Id, C> reservation : reservations.get(resource.getId())) {
+            if (reservation.consumer() != consumer && isOverlapping(reservation, startTime, endTime)) {
+                remaining--;
+            }
+        }
+
+        return remaining > 0;
+    }
+
+    @Override
+    public final Reservation<R, Id, C> addReservation(R resource, C consumer, double startTime, double endTime) {
+        if (isAvailable(resource, consumer, startTime, endTime)) {
+            List<Reservation<R, Id, C>> resourceReservations = reservations.get(resource.getId());
+
+            if (resourceReservations == null) {
+                resourceReservations = new LinkedList<>();
+                reservations.put(resource.getId(), resourceReservations);
+            }
+
+            Reservation<R, Id, C> reservation = new Reservation<>(resource, consumer, startTime, endTime);
+            resourceReservations.add(reservation);
+
+            return reservation;
+        }
+
+        return null;
+    }
+
+    @Override
+    public final boolean removeReservation(Reservation<R, Id, C> reservation) {
+        List<Reservation<R, Id, C>> resourceReservation = reservations.get(reservation.resource().getId());
+
+        if (resourceReservation != null) {
+            return resourceReservation.remove(reservation);
+        }
+
+        return false;
+    }
+
+    @Override
+    public final Reservation<R, Id, C> findReservation(R resource, C consumer, double now) {
+        List<Reservation<R, Id, C>> resourceReservations = reservations.get(resource.getId());
+
+        if (resourceReservations != null) {
+            for (Reservation<R, Id, C> reservation : resourceReservations) {
+                if (reservation.consumer() == consumer && now >= reservation.startTime() && now <= reservation.endTime()) {
+                    return reservation;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private boolean isOverlapping(Reservation<R, Id, C> reservation, double startTime, double endTime) {
+        if (startTime >= reservation.startTime() && startTime <= reservation.endTime()) {
+            return true; // start time within existing range
+        } else if (endTime >= reservation.startTime() && endTime <= reservation.endTime()) {
+            return true; // end time within existing range
+        } else if (startTime <= reservation.startTime() && endTime >= reservation.endTime()) {
+            return true; // new range covers existing range
+        } else {
+            return false;
+        }
+    }
+
+    protected void cleanReservations() {
+        reservations.clear();
+    }
+}

--- a/contribs/common/src/main/java/org/matsim/contrib/common/util/reservation/ReservationManager.java
+++ b/contribs/common/src/main/java/org/matsim/contrib/common/util/reservation/ReservationManager.java
@@ -1,0 +1,46 @@
+package org.matsim.contrib.common.util.reservation;
+
+import org.matsim.api.core.v01.Identifiable;
+
+/**
+ * A generic interface for managing reservations of limited-capacity resources.
+ *
+ * @param <R> Resource type (must be identifiable, e.g. ChargerSpecification)
+ * @param <Id> Id type of the resource (e.g. Charger in case of ChargerSpecification)
+ * @param <C> Consumer type (the entity making the reservation, e.g. Vehicle)
+ */
+public interface ReservationManager<
+        R extends Identifiable<Id>, Id, C> {
+
+    /**
+     * A reservation associates a consumer with a resource for a time interval.
+     */
+    record Reservation<R extends Identifiable<Id>, Id, C>(
+            R resource,
+            C consumer,
+            double startTime,
+            double endTime
+    ) {}
+
+    /**
+     * Check if a reservation is possible for the given consumer and resource
+     * in the specified time window.
+     */
+    boolean isAvailable(R resource, C consumer, double startTime, double endTime);
+
+    /**
+     * Add a reservation for the given consumer and resource in the specified time window.
+     * Returns the created reservation if successful, otherwise null.
+     */
+    Reservation<R, Id, C> addReservation(R resource, C consumer, double startTime, double endTime);
+
+    /**
+     * Remove a previously added reservation.
+     */
+    boolean removeReservation(Reservation<R, Id, C> reservation);
+
+    /**
+     * Find a reservation for the given consumer at the given resource at a specific time.
+     */
+    Reservation<R, Id, C> findReservation(R resource, C consumer, double now);
+}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/reservation/ChargerReservationManager.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/reservation/ChargerReservationManager.java
@@ -1,9 +1,6 @@
 package org.matsim.contrib.ev.reservation;
 
-import java.util.LinkedList;
-import java.util.List;
-
-import org.matsim.api.core.v01.IdMap;
+import org.matsim.contrib.common.util.reservation.AbstractReservationManager;
 import org.matsim.contrib.ev.fleet.ElectricVehicle;
 import org.matsim.contrib.ev.infrastructure.Charger;
 import org.matsim.contrib.ev.infrastructure.ChargerSpecification;
@@ -18,89 +15,19 @@ import org.matsim.core.controler.listener.IterationStartsListener;
  * 
  * @author Sebastian Hörl (sebhoerl), IRT SystemX
  */
-public class ChargerReservationManager implements IterationStartsListener {
-	private final IdMap<Charger, List<Reservation>> reservations = new IdMap<>(Charger.class);
+public class ChargerReservationManager extends AbstractReservationManager<ChargerSpecification, Charger, ElectricVehicle> implements IterationStartsListener {
 
-	public boolean isAvailable(ChargerSpecification charger, ElectricVehicle vehicle, double startTile,
-			double endTime) {
-		if (charger.getPlugCount() == 0) {
-			return false;
-		}
-
-		if (!reservations.containsKey(charger.getId())) {
-			return true;
-		}
-
-		int remaining = charger.getPlugCount();
-		for (Reservation reservation : reservations.get(charger.getId())) {
-			if (reservation.vehicle != vehicle && isOverlapping(reservation, startTile, endTime)) {
-				remaining--;
-			}
-		}
-
-		return remaining > 0;
+	public ChargerReservationManager() {
+		super(Charger.class);
 	}
 
-	private boolean isOverlapping(Reservation reservation, double startTime, double endTime) {
-		if (startTime >= reservation.startTime && startTime <= reservation.endTime) {
-			return true; // start time within existing range
-		} else if (endTime >= reservation.startTime && endTime <= reservation.endTime) {
-			return true; // end time within existing range
-		} else if (startTime <= reservation.startTime && endTime >= reservation.endTime) {
-			return true; // new range covers existing range
-		} else {
-			return false;
-		}
-	}
-
-	public Reservation addReservation(ChargerSpecification charger, ElectricVehicle vehicle, double startTime,
-			double endTime) {
-		if (isAvailable(charger, vehicle, startTime, endTime)) {
-			List<Reservation> chargerReservations = reservations.get(charger.getId());
-
-			if (chargerReservations == null) {
-				chargerReservations = new LinkedList<>();
-				reservations.put(charger.getId(), chargerReservations);
-			}
-
-			Reservation reservation = new Reservation(charger, vehicle, startTime, endTime);
-			chargerReservations.add(reservation);
-
-			return reservation;
-		}
-
-		return null;
-	}
-
-	public boolean removeReservation(Reservation reservation) {
-		List<Reservation> chargerReservations = reservations.get(reservation.charger.getId());
-
-		if (chargerReservations != null) {
-			return chargerReservations.remove(reservation);
-		}
-
-		return false;
-	}
-
-	public Reservation findReservation(ChargerSpecification charger, ElectricVehicle vehicle, double now) {
-		List<Reservation> chargerReservations = reservations.get(charger.getId());
-
-		if (chargerReservations != null) {
-			for (Reservation reservation : chargerReservations) {
-				if (reservation.vehicle == vehicle && now >= reservation.startTime && now <= reservation.endTime) {
-					return reservation;
-				}
-			}
-		}
-
-		return null;
-	}
-
-	public record Reservation(ChargerSpecification charger, ElectricVehicle vehicle, double startTime, double endTime) {
+	@Override
+	public int getCapacity(ChargerSpecification charger) {
+		return charger.getPlugCount();
 	}
 
 	@Override
 	public void notifyIterationStarts(IterationStartsEvent event) {
-		reservations.clear();
+		super.cleanReservations();
 	}
 }

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/reservation/ReservationBasedChargingPriority.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/reservation/ReservationBasedChargingPriority.java
@@ -2,8 +2,10 @@ package org.matsim.contrib.ev.reservation;
 
 import org.matsim.contrib.ev.charging.ChargingLogic.ChargingVehicle;
 import org.matsim.contrib.ev.charging.ChargingPriority;
+import org.matsim.contrib.ev.fleet.ElectricVehicle;
+import org.matsim.contrib.ev.infrastructure.Charger;
 import org.matsim.contrib.ev.infrastructure.ChargerSpecification;
-import org.matsim.contrib.ev.reservation.ChargerReservationManager.Reservation;
+import org.matsim.contrib.common.util.reservation.ReservationManager.Reservation;
 
 /**
  * This is an implementation of a charging priority which is backed by the
@@ -28,7 +30,7 @@ public class ReservationBasedChargingPriority implements ChargingPriority {
 
     @Override
     public boolean requestPlugNext(ChargingVehicle cv, double now) {
-        Reservation reservation = manager.findReservation(charger, cv.ev(), now);
+        Reservation<ChargerSpecification, Charger, ElectricVehicle> reservation = manager.findReservation(charger, cv.ev(), now);
 
         if (reservation != null) {
             // vehicle has a reservation, can be plugged right away, consume reservation


### PR DESCRIPTION
while working on https://github.com/matsim-org/matsim-libs/pull/4250 I realized today that @sebhoerl already implemented a very similar reservation logic for chargers.

To not re-invent the wheel, remove code duplication and improve maintainability I decided to generify the reservation manager so that it can be used for arbitrary reservation systems. If this is fine, I can update https://github.com/matsim-org/matsim-libs/pull/4250 so that operation facilities can make use of the same logic.