### PR TITLE
build: Update to Java 25

### DIFF
--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 25
           distribution: 'zulu'
           cache: 'maven'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 25
           distribution: 'zulu'
           cache: 'maven'
 

--- a/.github/workflows/deploy-on-pr-merge.yaml
+++ b/.github/workflows/deploy-on-pr-merge.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 25
           distribution: 'zulu'
           cache: 'maven'
           server-id: 'matsim-releases'

--- a/.github/workflows/deploy-on-release-created.yaml
+++ b/.github/workflows/deploy-on-release-created.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 25
           distribution: 'zulu'
           cache: 'maven'
           server-id: matsim-releases

--- a/.github/workflows/deploy-weekly.yaml
+++ b/.github/workflows/deploy-weekly.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 25
           distribution: 'zulu'
           cache: 'maven'
           server-id: 'matsim-releases'

--- a/.github/workflows/full-integration.yaml
+++ b/.github/workflows/full-integration.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 25
           distribution: 'zulu'
           cache: 'maven'
 

--- a/.github/workflows/verify-push.yaml
+++ b/.github/workflows/verify-push.yaml
@@ -87,7 +87,7 @@ jobs:
         if: ${{matrix.module != 'matsim' || steps.detect-changes.outputs.outside-contribs == 'true'}}
         uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 25
           distribution: 'zulu'
           cache: 'maven'
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.release>25</maven.compiler.release>
         <argLine />
 
         <log4j.version>2.25.1</log4j.version>
@@ -403,8 +403,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.0</version>
 				<configuration>
-					<source>21</source>
-					<target>21</target>
+					<source>25</source>
+					<target>25</target>
 				</configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This PR updates MATSim to Java 25. No changes to the code have been necesarry, only the version numbers in CI and Maven has been increased.

Java 25 is an LTS Release with support for at least 5 years. 
Since Java 21 (MATSim's current version) a lot of new features have been added.  Some of these (e.g the new Foreign Function Interface) are particually relevant for DSim (#1453) which currently needs a newer version to run.

I would like to encourage everyone to install java 25 on their machines already so that we can upgrade MATSim rather soonish if there are no objections.