### PR TITLE
fix(ev): attribute list reading in sevc

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/StrategicChargingUtils.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/StrategicChargingUtils.java
@@ -306,7 +306,7 @@ public class StrategicChargingUtils {
         if (value == null) {
             return new HashSet<>();
         } else {
-            return new HashSet<>(Arrays.stream(attribute.split(",")).collect(Collectors.toSet()));
+            return new HashSet<>(Arrays.stream(value.split(",")).collect(Collectors.toSet()));
         }
     }
 


### PR DESCRIPTION
There was an error when reading lists of subscriptions for agents and tariffs for chargers in the strategic ev charging component.