### PR TITLE
feat(ev): add specific parameters for innovation startegy in sevc

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/StrategicChargingConfigGroup.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/StrategicChargingConfigGroup.java
@@ -5,6 +5,8 @@ import org.matsim.contrib.ev.strategic.costs.AttributeBasedChargingCostsParamete
 import org.matsim.contrib.ev.strategic.costs.ChargingCostsParameters;
 import org.matsim.contrib.ev.strategic.costs.DefaultChargingCostsParameters;
 import org.matsim.contrib.ev.strategic.costs.TariffBasedChargingCostsParameters;
+import org.matsim.contrib.ev.strategic.replanning.innovator.ChargingInnovationParameters;
+import org.matsim.contrib.ev.strategic.replanning.innovator.RandomChargingPlanInnovator;
 import org.matsim.contrib.ev.strategic.scoring.ChargingPlanScoringParameters;
 import org.matsim.core.config.Config;
 
@@ -57,10 +59,18 @@ public class StrategicChargingConfigGroup extends ReflectiveConfigGroupWithConfi
 				c -> {
 					costs = (TariffBasedChargingCostsParameters) c;
 				});
+
+		addDefinition(RandomChargingPlanInnovator.Parameters.SET_NAME, //
+				RandomChargingPlanInnovator.Parameters::new, //
+				() -> (RandomChargingPlanInnovator.Parameters) innovation, //
+				i -> {
+					innovation = (RandomChargingPlanInnovator.Parameters) i;
+				});
 	}
 
 	private ChargingPlanScoringParameters scoring;
 	private ChargingCostsParameters costs;
+	private ChargingInnovationParameters innovation;
 
 	@Parameter
 	@Comment("Minimum duration of the activity-based charging slots")
@@ -162,6 +172,10 @@ public class StrategicChargingConfigGroup extends ReflectiveConfigGroupWithConfi
 
 	public ChargingCostsParameters getCostParameters() {
 		return costs;
+	}
+
+	public ChargingInnovationParameters getInnovationParameters() {
+		return innovation;
 	}
 
 	public double getMinimumActivityChargingDuration() {

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/replanning/innovator/ChargingInnovationParameters.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/replanning/innovator/ChargingInnovationParameters.java
@@ -1,0 +1,5 @@
+package org.matsim.contrib.ev.strategic.replanning.innovator;
+
+public interface ChargingInnovationParameters {
+	// just a tag interface
+}

--- a/contribs/ev/src/test/java/org/matsim/contrib/ev/strategic/StrategicChargingTest.java
+++ b/contribs/ev/src/test/java/org/matsim/contrib/ev/strategic/StrategicChargingTest.java
@@ -10,6 +10,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.contrib.ev.strategic.plan.ChargingPlans;
 import org.matsim.contrib.ev.strategic.plan.ChargingPlansConverter;
+import org.matsim.contrib.ev.strategic.replanning.innovator.RandomChargingPlanInnovator;
 import org.matsim.contrib.ev.strategic.utils.TestScenarioBuilder;
 import org.matsim.contrib.ev.strategic.utils.TestScenarioBuilder.TestScenario;
 import org.matsim.contrib.ev.withinday.WithinDayEvConfigGroup;
@@ -39,6 +40,7 @@ public class StrategicChargingTest {
         StrategicChargingConfigGroup config = StrategicChargingConfigGroup.get(scenario.config());
         config.setScoreTrackingInterval(1);
         config.getScoringParameters().setZeroSoc(-1000.0); // incentivize agent to charge at work
+        ((RandomChargingPlanInnovator.Parameters) config.getInnovationParameters()).setActivityInclusionProbability(1.0);
 
         // motivate agent to charge at activity
         config.setMinimumEnrouteDriveTime(Double.POSITIVE_INFINITY);
@@ -78,7 +80,7 @@ public class StrategicChargingTest {
     @Test
     public void testChargingEnroute() {
         TestScenario scenario = new TestScenarioBuilder(utils) //
-                .enableStrategicCharging(3) //
+                .enableStrategicCharging(1) //
                 .addPublicCharger("charger", 6, 6, 1, 1.0, "default") //
                 .setElectricVehicleRange(10000.0) //
                 .addPerson("person", 0.5) // SoC goes to zero after leaving from work
@@ -89,6 +91,7 @@ public class StrategicChargingTest {
 
         StrategicChargingConfigGroup config = StrategicChargingConfigGroup.get(scenario.config());
         config.getScoringParameters().setZeroSoc(-1000.0); // incentivize agent to charge
+        ((RandomChargingPlanInnovator.Parameters) config.getInnovationParameters()).setLegInclusionProbability(1.0);
 
         // motivate agent to charge enroute
         config.setMaximumActivityChargingDuration(0.0);

--- a/contribs/ev/src/test/java/org/matsim/contrib/ev/strategic/utils/TestScenarioBuilder.java
+++ b/contribs/ev/src/test/java/org/matsim/contrib/ev/strategic/utils/TestScenarioBuilder.java
@@ -5,7 +5,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
-import org.matsim.api.core.v01.*;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.IdMap;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.events.ActivityEndEvent;
 import org.matsim.api.core.v01.events.ActivityStartEvent;
 import org.matsim.api.core.v01.events.PersonDepartureEvent;
@@ -50,6 +54,7 @@ import org.matsim.contrib.ev.strategic.infrastructure.FacilityChargerProvider;
 import org.matsim.contrib.ev.strategic.infrastructure.PersonChargerProvider;
 import org.matsim.contrib.ev.strategic.infrastructure.PublicChargerProvider;
 import org.matsim.contrib.ev.strategic.replanning.StrategicChargingReplanningStrategy;
+import org.matsim.contrib.ev.strategic.replanning.innovator.RandomChargingPlanInnovator;
 import org.matsim.contrib.ev.strategic.scoring.ChargingPlanScoringParameters;
 import org.matsim.contrib.ev.withinday.WithinDayEvConfigGroup;
 import org.matsim.contrib.ev.withinday.WithinDayEvEngine;
@@ -468,6 +473,9 @@ public class TestScenarioBuilder {
 			ChargingPlanScoringParameters scoringParameters = new ChargingPlanScoringParameters();
 			strategicConfig.addParameterSet(scoringParameters);
 
+			RandomChargingPlanInnovator.Parameters innovationParameters = new RandomChargingPlanInnovator.Parameters();
+			strategicConfig.addParameterSet(innovationParameters);
+
 			// only strategic charging
 			StrategySettings chargingStrategy = new StrategySettings();
 			chargingStrategy.setStrategyName(StrategicChargingReplanningStrategy.STRATEGY);
@@ -573,7 +581,8 @@ public class TestScenarioBuilder {
 
 		@Override
 		synchronized public void handleEvent(ActivityStartEvent event) {
-			if (!TripStructureUtils.isStageActivityType(event.getActType()) || WithinDayEvEngine.isManagedActivityType(event.getActType())) {
+			if (!TripStructureUtils.isStageActivityType(event.getActType())
+					|| WithinDayEvEngine.isManagedActivityType(event.getActType())) {
 				activityStartEvents.add(event);
 
 				if (event.getActType().equals(WithinDayEvEngine.PLUG_ACTIVITY_TYPE)) {


### PR DESCRIPTION
- This PR adds the infrastructure to add dedicated parameter sets for different innovation strategies in strategic electric vehicle charging (sevc). 
- For the random innovation strategy, one can now define the inclusion probabilities for activities and legs.
- BREAKING CHANGE: In order to activate innovation, an innovation parameter set now needs to be added to the SEVC config group. For now, only the `RandomChargingPlanInnovator.Parameters` is available.