### PR TITLE
fix(drt): make drt constrains relative again

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/ConfigurableCostCalculatorStrategy.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/ConfigurableCostCalculatorStrategy.java
@@ -25,7 +25,7 @@ public class ConfigurableCostCalculatorStrategy implements CostCalculationStrate
 
 	private boolean checkHardInsertion(DrtRequest request, DetourTimeInfo detourTimeInfo) {
 		return detourTimeInfo.pickupDetourInfo.requestPickupTime <= request.getLatestStartTime()
-				&& detourTimeInfo.dropoffDetourInfo.requestDropoffTime <= request.getConstraints().latestArrivalTime();
+				&& detourTimeInfo.dropoffDetourInfo.requestDropoffTime <= request.getLatestArrivalTime();
 	}
 
 	private double calculateSoftInsertionPenalty(DrtRequest request, DetourTimeInfo detourTimeInfo) {
@@ -36,7 +36,7 @@ public class ConfigurableCostCalculatorStrategy implements CostCalculationStrate
 					detourTimeInfo.pickupDetourInfo.requestPickupTime - request.getLatestStartTime());
 
 			double dropoffDelay = Math.max(0,
-					detourTimeInfo.dropoffDetourInfo.requestDropoffTime - request.getConstraints().latestArrivalTime());
+					detourTimeInfo.dropoffDetourInfo.requestDropoffTime - request.getLatestArrivalTime());
 
 			return softInsertionParams.pickupWeight * pickupDelay + softInsertionParams.dropoffWeight * dropoffDelay;
 		}

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/PromisedTimeWindowOfferAcceptor.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/insertion/PromisedTimeWindowOfferAcceptor.java
@@ -24,7 +24,7 @@ public class PromisedTimeWindowOfferAcceptor implements DrtOfferAcceptor {
 				request.getLatestStartTime());
 
 		double updatedDropoffTimeWindow = Math.min(arrivalTime + promisedDropoffTimeWindow,
-				request.getConstraints().latestArrivalTime());
+				request.getLatestArrivalTime());
 
 		return Optional
 				.of(AcceptedDrtRequest.newBuilder()

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preplanned/optimizer/PreplannedDrtOptimizer.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/preplanned/optimizer/PreplannedDrtOptimizer.java
@@ -217,7 +217,7 @@ public class PreplannedDrtOptimizer implements DrtOptimizer {
 	static PreplannedRequest createFromRequest(DrtRequest request) {
 		return new PreplannedRequest(new PreplannedRequestKey(Set.copyOf(request.getPassengerIds()), request.getFromLink().getId(),
 				request.getToLink().getId()), request.getEarliestStartTime(), request.getLatestStartTime(),
-				request.getConstraints().latestArrivalTime());
+				request.getLatestArrivalTime());
 	}
 
 	// sequence of preplanned tasks is the output from the external optimiser and the input to the drt simulation

--- a/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/insertion/spatialFilter/SpatIalRequestFleetFilterTest.java
+++ b/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/insertion/spatialFilter/SpatIalRequestFleetFilterTest.java
@@ -195,14 +195,14 @@ public class SpatIalRequestFleetFilterTest {
         return DrtRequest.newBuilder()
                 .id(Id.create(id, Request.class))
                 .passengerIds(List.of(Id.createPersonId(id)))
+                .earliestDepartureTime(submissionTime)
                 .constraints(
                         new DrtRouteConstraints(
-                                submissionTime,
-                                earliestStartTime,
-                                latestStartTime,
-                                latestArrivalTime,
+                                latestArrivalTime - earliestStartTime,
                                 Double.POSITIVE_INFINITY,
+                                latestStartTime - earliestStartTime,
                                 Double.POSITIVE_INFINITY,
+                                0.,
                                 false
                         )
                 )

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtRequestInsertionRetryQueue.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/DrtRequestInsertionRetryQueue.java
@@ -64,10 +64,9 @@ public class DrtRequestInsertionRetryQueue {
 			var oldRequest = entry.request;
 
 			DrtRouteConstraints updatedConstraints = new DrtRouteConstraints(
-					oldRequest.getEarliestStartTime(),
-					oldRequest.getConstraints().latestStartTime() + timeDelta,
-					oldRequest.getConstraints().latestArrivalTime() + timeDelta,
-					oldRequest.getConstraints().maxRideDuration(),
+					oldRequest.getConstraints().maxTravelDuration() + timeDelta,
+					oldRequest.getConstraints().maxRideDuration() ,
+					oldRequest.getConstraints().maxWaitDuration() + timeDelta,
 					oldRequest.getConstraints().maxPickupDelay(),
 					oldRequest.getConstraints().lateDiversionThreshold(),
 					oldRequest.getConstraints().allowRejection()
@@ -76,6 +75,7 @@ public class DrtRequestInsertionRetryQueue {
 			//XXX alternatively make both latest start/arrival times modifiable
 			var newRequest = DrtRequest.newBuilder(oldRequest)
 					.constraints(updatedConstraints)
+					.earliestDepartureTime(oldRequest.getEarliestStartTime())
 					.build();
 			requests.add(newRequest);
 		}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/constraints/DrtRouteConstraints.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/constraints/DrtRouteConstraints.java
@@ -19,18 +19,15 @@
 
 package org.matsim.contrib.drt.optimizer.constraints;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 /**
  * @author Sebastian Hörl, IRT SystemX
  * @author nkuehnel / MOIA
  */
 public record DrtRouteConstraints(
-		double earliestStartTime, //
-		double latestStartTime, //
-		double latestArrivalTime, //
-		double maxRideDuration, //
-		double maxPickupDelay, //
+		double maxTravelDuration,
+		double maxRideDuration,
+		double maxWaitDuration,
+		double maxPickupDelay,
 		double lateDiversionThreshold,
 		boolean allowRejection
 ) {
@@ -41,13 +38,7 @@ public record DrtRouteConstraints(
 					Double.POSITIVE_INFINITY,
 					Double.POSITIVE_INFINITY,
 					Double.POSITIVE_INFINITY,
-					Double.POSITIVE_INFINITY,
 					0,
 					false
 			);
-
-	@JsonIgnore
-	public double getMaxWaitTime() {
-		return latestStartTime - earliestStartTime;
-	}
 }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategy.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategy.java
@@ -54,7 +54,7 @@ public interface CostCalculationStrategy {
                                                              DetourTimeInfo detourTimeInfo) {
             double totalTimeLoss = detourTimeInfo.getTotalTimeLoss();
             if (detourTimeInfo.pickupDetourInfo.requestPickupTime > request.getLatestStartTime()
-                    || detourTimeInfo.dropoffDetourInfo.requestDropoffTime > request.getConstraints().latestArrivalTime()) {
+                    || detourTimeInfo.dropoffDetourInfo.requestDropoffTime > request.getLatestArrivalTime()) {
                 //no extra time is lost => do not check if the current slack time is long enough (can be even negative)
                 return InsertionCostCalculator.INFEASIBLE_SOLUTION_COST;
             }
@@ -104,7 +104,7 @@ public interface CostCalculationStrategy {
         double waitTimeViolation = Math.max(0, detourTimeInfo.pickupDetourInfo.requestPickupTime - request.getLatestStartTime());
         // (if drt vehicle picks up too late) (max wait time (often 600 sec) after submission)
 
-        double travelTimeViolation = Math.max(0, detourTimeInfo.dropoffDetourInfo.requestDropoffTime - request.getConstraints().latestArrivalTime());
+        double travelTimeViolation = Math.max(0, detourTimeInfo.dropoffDetourInfo.requestDropoffTime - request.getLatestArrivalTime());
         // (if drt vehicle drops off too late) (submission time + alpha * directTravelTime + beta)
 
         double detourViolation = Math.max(0,

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/extensive/MultiInsertionDetourPathCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/extensive/MultiInsertionDetourPathCalculator.java
@@ -122,7 +122,7 @@ class MultiInsertionDetourPathCalculator implements MobsimBeforeCleanupListener 
 
 	private Map<Link, PathData> calcPathsToDropoff(DrtRequest drtRequest, List<Insertion> filteredInsertions) {
 		// calc backward dijkstra from dropoff to ends of selected stops
-		double latestDropoffTime = drtRequest.getConstraints().latestArrivalTime(); // pessimistic
+		double latestDropoffTime = drtRequest.getLatestArrivalTime(); // pessimistic
 		Collection<Link> toLinks = getDetourLinks(filteredInsertions.stream()
 						.filter(insertion -> !(insertion.dropoff.previousWaypoint instanceof Waypoint.Pickup)),
 				insertion -> insertion.dropoff.previousWaypoint.getLink());
@@ -131,7 +131,7 @@ class MultiInsertionDetourPathCalculator implements MobsimBeforeCleanupListener 
 
 	private Map<Link, PathData> calcPathsFromDropoff(DrtRequest drtRequest, List<Insertion> filteredInsertions) {
 		// calc forward dijkstra from dropoff to beginnings of selected stops
-		double latestDropoffTime = drtRequest.getConstraints().latestArrivalTime(); // pessimistic
+		double latestDropoffTime = drtRequest.getLatestArrivalTime(); // pessimistic
 		Collection<Link> toLinks = getDetourLinks(filteredInsertions.stream()
 						.filter(insertion -> !(insertion.dropoff.nextWaypoint instanceof Waypoint.End)),
 				insertion -> insertion.dropoff.nextWaypoint.getLink());

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/selective/SingleInsertionDetourPathCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/insertion/selective/SingleInsertionDetourPathCalculator.java
@@ -86,7 +86,7 @@ public class SingleInsertionDetourPathCalculator implements MobsimBeforeCleanupL
 		Link dropoff = drtRequest.getToLink();
 
 		double earliestPickupTime = drtRequest.getEarliestStartTime(); // optimistic
-		double latestDropoffTime = drtRequest.getConstraints().latestArrivalTime(); // pessimistic
+		double latestDropoffTime = drtRequest.getLatestArrivalTime(); // pessimistic
 
 		// TODO use times from InsertionWithDetourData<Double> as approximate departure times for Dijkstra (will require
 		//  passing it as an argument, instead of Insertion)

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/AcceptedDrtRequest.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/AcceptedDrtRequest.java
@@ -39,7 +39,7 @@ public class AcceptedDrtRequest {
 				.request(request)
 				.earliestStartTime(request.getEarliestStartTime())
 				.latestStartTime(request.getLatestStartTime())
-				.latestArrivalTime(request.getConstraints().latestArrivalTime())
+				.latestArrivalTime(request.getLatestArrivalTime())
 				.maxRideDuration(request.getConstraints().maxRideDuration())
 				.dropoffDuration(dropoffDuration)
 				.build();

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DefaultOfferAcceptor.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/DefaultOfferAcceptor.java
@@ -32,7 +32,7 @@ public class DefaultOfferAcceptor implements DrtOfferAcceptor{
 			.request(request)
 			.earliestStartTime(request.getEarliestStartTime())
 			.maxRideDuration(request.getConstraints().maxRideDuration())
-			.latestArrivalTime(request.getConstraints().latestArrivalTime())
+			.latestArrivalTime(request.getLatestArrivalTime())
 			.latestStartTime(updatedLatestStartTime)
 			.dropoffDuration(dropoffDuration)
 			.plannedPickupTime(departureTime)

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/PromisedPickupTimeWindowDrtOfferAcceptor.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/passenger/PromisedPickupTimeWindowDrtOfferAcceptor.java
@@ -22,7 +22,7 @@ public final class PromisedPickupTimeWindowDrtOfferAcceptor implements DrtOfferA
 				.newBuilder()
 				.request(request)
 				.earliestStartTime(request.getEarliestStartTime())
-				.latestArrivalTime(request.getConstraints().latestArrivalTime())
+				.latestArrivalTime(request.getLatestArrivalTime())
 				.latestStartTime(updatedPickupTimeWindow)
 				.dropoffDuration(dropoffDuration).build());
 	}

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DefaultDrtRouteConstraintsCalculator.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DefaultDrtRouteConstraintsCalculator.java
@@ -47,10 +47,9 @@ public class DefaultDrtRouteConstraintsCalculator implements DrtRouteConstraints
 			double maxRideTime = unsharedRideTime + Math.min(defaultSet.getMaxAbsoluteDetour(), maxDetour);
 			double maxWaitTime = constraintsSet.getMaxWaitTime();
 			return new DrtRouteConstraints(
-					departureTime,
-					departureTime + maxWaitTime,
-					departureTime + maxTravelTime,
+					maxTravelTime,
 					maxRideTime,
+					maxWaitTime,
 					constraintsSet.getMaxAllowedPickupDelay(),
 					constraintsSet.getLateDiversionthreshold(),
 					constraintsSet.rejectRequestIfMaxWaitOrTravelTimeViolated

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRoute.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/DrtRoute.java
@@ -87,7 +87,7 @@ public class DrtRoute extends AbstractRoute {
 	public void setConstraints(DrtRouteConstraints constraints) {
 		//TODO: consolidate constraints / route description
 		this.routeDescription.setConstraints(constraints);
-		super.setTravelTime(constraints.latestArrivalTime() - constraints.earliestStartTime());
+		super.setTravelTime(constraints.maxTravelDuration());
 	}
 
 	private DvrpLoad load;

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategyTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/CostCalculationStrategyTest.java
@@ -58,12 +58,12 @@ public class CostCalculationStrategyTest {
 	private void assertRejectSoftConstraintViolations(double latestStartTime, double latestArrivalTime,
 			DetourTimeInfo detourTimeInfo, double expectedCost) {
 		var drtRequest = DrtRequest.newBuilder()
+				.earliestDepartureTime(0.)
 				.constraints(
 						new DrtRouteConstraints(
-								Double.POSITIVE_INFINITY,
-								latestStartTime,
 								latestArrivalTime,
 								Double.POSITIVE_INFINITY,
+								latestStartTime,
 								Double.POSITIVE_INFINITY,
 								Double.POSITIVE_INFINITY,
 								true
@@ -97,12 +97,12 @@ public class CostCalculationStrategyTest {
 	private void assertDiscourageSoftConstraintViolations(double latestStartTime, double latestArrivalTime,
 			DetourTimeInfo detourTimeInfo, double expectedCost) {
 		var drtRequest = DrtRequest.newBuilder()
+				.earliestDepartureTime(0.)
 				.constraints(
 						new DrtRouteConstraints(
-								Double.POSITIVE_INFINITY,
-								latestStartTime,
 								latestArrivalTime,
 								Double.POSITIVE_INFINITY,
+								latestStartTime,
 								Double.POSITIVE_INFINITY,
 								Double.POSITIVE_INFINITY,
 								false

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserterTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/DefaultUnplannedRequestInserterTest.java
@@ -157,17 +157,8 @@ public class DefaultUnplannedRequestInserterTest {
 		assertThat(retryQueue.getRequestsToRetryNow(now + retryInterval - 1)).isEmpty();
 		assertThat(retryQueue.getRequestsToRetryNow(now + retryInterval)).usingRecursiveFieldByFieldElementComparator()
 				.containsExactly(DrtRequest.newBuilder(request1)
-						.constraints(
-								new DrtRouteConstraints(
-										request1.getEarliestStartTime(),
-										request1.getLatestStartTime() + retryInterval,
-										request1.getConstraints().latestArrivalTime() + retryInterval,
-										Double.POSITIVE_INFINITY,
-										Double.POSITIVE_INFINITY,
-										0.,
-										false
-								)
-						)
+						.earliestDepartureTime(request1.getEarliestStartTime())
+						.constraints(request1.getConstraints())
 						.build());
 
 		//ensure rejection event is NOT emitted

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionCostCalculatorTest.java
@@ -52,11 +52,12 @@ import com.google.common.collect.ImmutableList;
 public class InsertionCostCalculatorTest {
 	private final Link fromLink = link("from");
 	private final Link toLink = link("to");
-	private final DrtRequest drtRequest = DrtRequest.newBuilder()
+
+		private final DrtRequest drtRequest = DrtRequest.newBuilder()
 			.fromLink(fromLink)
 			.toLink(toLink)
+			.earliestDepartureTime(0)
 			.constraints(new DrtRouteConstraints(
-					0,
 					Double.POSITIVE_INFINITY,
 					Double.POSITIVE_INFINITY,
 					Double.POSITIVE_INFINITY,
@@ -121,12 +122,12 @@ public class InsertionCostCalculatorTest {
 		DrtRequest drtRequest = builder
 				.fromLink(fromLink)
 				.toLink(toLink)
+				.earliestDepartureTime(Double.POSITIVE_INFINITY)
 				.constraints(
 						new DrtRouteConstraints(
-								Double.POSITIVE_INFINITY,
-								120,
 								300,
 								Double.POSITIVE_INFINITY,
+								120,
 								Double.POSITIVE_INFINITY,
 								180.,
 								true
@@ -148,12 +149,12 @@ public class InsertionCostCalculatorTest {
 		DrtRequest drtRequest2 = builder
 				.fromLink(fromLink)
 				.toLink(toLink)
+				.earliestDepartureTime(Double.POSITIVE_INFINITY)
 				.constraints(
 						new DrtRouteConstraints(
-								Double.POSITIVE_INFINITY,
-								120,
 								300,
 								Double.POSITIVE_INFINITY,
+								120,
 								Double.POSITIVE_INFINITY,
 								120.,
 								false
@@ -202,12 +203,12 @@ public class InsertionCostCalculatorTest {
 		DrtRequest drtRequest = builder
 				.fromLink(fromLink)
 				.toLink(toLink)
+				.earliestDepartureTime(Double.POSITIVE_INFINITY)
 				.constraints(
 						new DrtRouteConstraints(
-								Double.POSITIVE_INFINITY,
-								120,
 								300,
 								Double.POSITIVE_INFINITY,
+								120,
 								Double.POSITIVE_INFINITY,
 								300.,
 								true
@@ -225,12 +226,12 @@ public class InsertionCostCalculatorTest {
 		DrtRequest drtRequest2 = builder
 				.fromLink(fromLink)
 				.toLink(toLink)
+				.earliestDepartureTime(Double.POSITIVE_INFINITY)
 				.constraints(
 						new DrtRouteConstraints(
-								Double.POSITIVE_INFINITY,
-								120,
 								300,
 								Double.POSITIVE_INFINITY,
+								120,
 								Double.POSITIVE_INFINITY,
 								200.,
 								true

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorTest.java
@@ -72,7 +72,6 @@ public class InsertionGeneratorTest {
 	private static final double TIME_REPLACED_DRIVE = 100;
 
 	private static final DrtRouteConstraints DRT_ROUTE_CONSTRAINTS = new DrtRouteConstraints(
-			0,
 			Double.POSITIVE_INFINITY,
 			Double.POSITIVE_INFINITY,
 			Double.POSITIVE_INFINITY,
@@ -90,6 +89,7 @@ public class InsertionGeneratorTest {
 			.passengerIds(
 					List.of(Id.createPersonId("person"))
 			)
+			.earliestDepartureTime(0.)
 			.constraints(DRT_ROUTE_CONSTRAINTS)
 			.load(LOAD_TYPE.fromInt(1))
 			.build();
@@ -104,6 +104,7 @@ public class InsertionGeneratorTest {
 				)
 			)
 			.load(LOAD_TYPE.fromInt(2))
+			.earliestDepartureTime(0.)
 			.constraints(DRT_ROUTE_CONSTRAINTS)
 			.build();
 
@@ -120,17 +121,18 @@ public class InsertionGeneratorTest {
 				)
 			)
 			.load(LOAD_TYPE.fromInt(5))
+			.earliestDepartureTime(0.)
 			.constraints(DRT_ROUTE_CONSTRAINTS)
 			.build();
 
-	private final DrtRequest prebookedRequest = DrtRequest.newBuilder()
+		private final DrtRequest prebookedRequest = DrtRequest.newBuilder()
 			.fromLink(fromLink)
 			.toLink(toLink)
+			.earliestDepartureTime(100)
 			.constraints(
 					new DrtRouteConstraints(
-							100,
 							0,
-							0,
+							Double.POSITIVE_INFINITY,
 							Double.POSITIVE_INFINITY,
 							Double.POSITIVE_INFINITY,
 							0.,

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorWithChangingCapacitiesTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/InsertionGeneratorWithChangingCapacitiesTest.java
@@ -85,9 +85,10 @@ public class InsertionGeneratorWithChangingCapacitiesTest {
 			.toLink(toLink)
 			.passengerIds(List.of(Id.createPersonId("personA")))
 			.load(customLoadType.fromArray(1, 0))
+			.earliestDepartureTime(0)
 			.constraints(
 					new DrtRouteConstraints(
-							0, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY,
+							Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY,
 							Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, 0, false
 					)
 			)
@@ -97,9 +98,10 @@ public class InsertionGeneratorWithChangingCapacitiesTest {
 			.toLink(toLink)
 			.passengerIds(List.of(Id.createPersonId("personB")))
 			.load(customLoadType.fromArray(0, 1))
+			.earliestDepartureTime(0)
 			.constraints(
 					new DrtRouteConstraints(
-							0, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY,
+							Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY,
 							Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, 0, false
 					)
 			)

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/extensive/MultiInsertionDetourPathCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/extensive/MultiInsertionDetourPathCalculatorTest.java
@@ -64,12 +64,12 @@ public class MultiInsertionDetourPathCalculatorTest {
 	private final DrtRequest request = DrtRequest.newBuilder()
 			.fromLink(pickupLink)
 			.toLink(dropoffLink)
+			.earliestDepartureTime(100)
 			.constraints(
 					new DrtRouteConstraints(
-							100,
-							200,
-							500,
+							400,
 							Double.POSITIVE_INFINITY,
+							100,
 							Double.POSITIVE_INFINITY,
 							0.,
 							false
@@ -91,8 +91,8 @@ public class MultiInsertionDetourPathCalculatorTest {
 	void calculatePaths() {
 		var pathToPickup = mockCalcPathData(pickupLink, beforePickupLink, request.getEarliestStartTime(), false, 11);
 		var pathFromPickup = mockCalcPathData(pickupLink, afterPickupLink, request.getEarliestStartTime(), true, 22);
-		var pathToDropoff = mockCalcPathData(dropoffLink, beforeDropoffLink, request.getConstraints().latestArrivalTime(), false, 33);
-		var pathFromDropoff = mockCalcPathData(dropoffLink, afterDropoffLink, request.getConstraints().latestArrivalTime(), true, 44);
+		var pathToDropoff = mockCalcPathData(dropoffLink, beforeDropoffLink, request.getLatestArrivalTime(), false, 33);
+		var pathFromDropoff = mockCalcPathData(dropoffLink, afterDropoffLink, request.getLatestArrivalTime(), true, 44);
 
 		var pickup = insertionPoint(waypoint(beforePickupLink), waypoint(afterPickupLink));
 		var dropoff = insertionPoint(waypoint(beforeDropoffLink), waypoint(afterDropoffLink));
@@ -136,7 +136,7 @@ public class MultiInsertionDetourPathCalculatorTest {
 		when(pathSearch.calcPathDataMap(eq(pickupLink), eqSingleLinkCollection(pickupLink),
 				eq(request.getEarliestStartTime()), anyBoolean())).thenReturn(Map.of(pickupLink, PathData.EMPTY));
 		when(pathSearch.calcPathDataMap(eq(dropoffLink), eqSingleLinkCollection(dropoffLink),
-				eq(request.getConstraints().latestArrivalTime()), anyBoolean())).thenReturn(Map.of(dropoffLink, PathData.EMPTY));
+				eq(request.getLatestArrivalTime()), anyBoolean())).thenReturn(Map.of(dropoffLink, PathData.EMPTY));
 
 		var pickup = insertionPoint(waypoint(pickupLink), waypoint(pickupLink));
 		var dropoff = insertionPoint(waypoint(dropoffLink), waypoint(dropoffLink));

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/selective/SingleInsertionDetourPathCalculatorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/optimizer/insertion/selective/SingleInsertionDetourPathCalculatorTest.java
@@ -68,12 +68,12 @@ public class SingleInsertionDetourPathCalculatorTest {
 	private final DrtRequest request = DrtRequest.newBuilder()
 			.fromLink(pickupLink)
 			.toLink(dropoffLink)
+			.earliestDepartureTime(100)
 			.constraints(
 					new DrtRouteConstraints(
-							100,
-							200,
-							500,
+							400,
 							Double.POSITIVE_INFINITY,
+							100,
 							Double.POSITIVE_INFINITY,
 							0.,
 							false
@@ -94,8 +94,8 @@ public class SingleInsertionDetourPathCalculatorTest {
 	void calculatePaths() {
 		var pathToPickup = mockCalcLeastCostPath(beforePickupLink, pickupLink, request.getEarliestStartTime(), 11);
 		var pathFromPickup = mockCalcLeastCostPath(pickupLink, afterPickupLink, request.getEarliestStartTime(), 22);
-		var pathToDropoff = mockCalcLeastCostPath(beforeDropoffLink, dropoffLink, request.getConstraints().latestArrivalTime(), 33);
-		var pathFromDropoff = mockCalcLeastCostPath(dropoffLink, afterDropoffLink, request.getConstraints().latestArrivalTime(), 44);
+		var pathToDropoff = mockCalcLeastCostPath(beforeDropoffLink, dropoffLink, request.getLatestArrivalTime(), 33);
+		var pathFromDropoff = mockCalcLeastCostPath(dropoffLink, afterDropoffLink, request.getLatestArrivalTime(), 44);
 
 		var pickup = insertionPoint(waypoint(beforePickupLink), waypoint(afterPickupLink));
 		var dropoff = insertionPoint(waypoint(beforeDropoffLink), waypoint(afterDropoffLink));

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/prebooking/PrebookingConstraintsTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/prebooking/PrebookingConstraintsTest.java
@@ -1,0 +1,109 @@
+package org.matsim.contrib.drt.prebooking;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Plan;
+import org.matsim.contrib.drt.optimizer.constraints.DrtRouteConstraints;
+import org.matsim.contrib.drt.passenger.DrtRequest;
+import org.matsim.contrib.drt.passenger.DrtRequestCreator;
+import org.matsim.contrib.drt.routing.DrtRoute;
+import org.matsim.contrib.drt.routing.DrtRouteFactory;
+import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
+import org.matsim.contrib.dvrp.load.IntegerLoad;
+import org.matsim.contrib.dvrp.load.IntegerLoadType;
+import org.matsim.contrib.dvrp.optimizer.Request;
+import org.matsim.contrib.dvrp.optimizer.VrpOptimizer;
+import org.matsim.contrib.dvrp.passenger.DefaultPassengerRequestValidator;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.events.EventsManagerImpl;
+import org.matsim.core.mobsim.framework.MobsimTimer;
+import org.matsim.core.mobsim.framework.events.MobsimAfterSimStepEvent;
+import org.matsim.core.mobsim.qsim.agents.BasicPlanAgentImpl;
+import org.matsim.core.mobsim.qsim.agents.WithinDayAgentUtils;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.population.PopulationUtils;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.core.utils.timing.TimeInterpretation;
+import org.matsim.testcases.MatsimTestUtils;
+
+/**
+ * Tests that prebooking requests have the correct constraints. In particular, submission time and earliest start time
+ * should be different. Latest Arrival time should be relative to earliest start and not to submission time.
+ */
+public class PrebookingConstraintsTest {
+
+
+    @Test
+    public void test() {
+
+
+        EventsManagerImpl eventsManager = new EventsManagerImpl();
+        IntegerLoadType loadType = new IntegerLoadType("passengers");
+        DrtRequestCreator drtRequestCreator = new DrtRequestCreator("drt", eventsManager, loadType);
+
+        Network network = NetworkUtils.createNetwork();
+        Node node1 = NetworkUtils.createNode(Id.createNodeId("dummy1"));
+        network.addNode(node1);
+        Node node2 = NetworkUtils.createNode(Id.createNodeId("dummy2"));
+        network.addNode(node2);
+        Node node3 = NetworkUtils.createNode(Id.createNodeId("dummy3"));
+        network.addNode(node3);
+
+        network.addLink(NetworkUtils.createLink(Id.createLinkId("dummy1"), node1, node2, network, 0, 0, 0, 0));
+        network.addLink(NetworkUtils.createLink(Id.createLinkId("dummy2"), node2, node3, network, 0, 0, 0, 0));
+
+        MobsimTimer mobsimTimer = new MobsimTimer(1);
+
+        Plan plan = PopulationUtils.createPlan();
+        PopulationUtils.getFactory().createPerson(Id.createPersonId("dummy")).addPlan(plan);
+
+        plan.addActivity(PopulationUtils.getFactory().createActivityFromLinkId("dummy", Id.createLinkId("dummy")));
+        Leg leg = PopulationUtils.getFactory().createLeg("drt");
+        plan.addLeg(leg);
+
+        DrtRoute route = (DrtRoute) new DrtRouteFactory().createRoute(Id.createLinkId("dummy1"), Id.createLinkId("dummy2"));
+        route.setDistance(100);
+        route.setDirectRideTime(100);
+        DrtRouteConstraints drtRouteConstraints = new DrtRouteConstraints(
+                200,
+                50,
+                100,
+                10,
+                0,
+                true
+        );
+        route.setConstraints(drtRouteConstraints);
+        route.setLoad(IntegerLoad.fromValue(1), loadType);
+        leg.setRoute(route);
+
+        BasicPlanAgentImpl agent = new BasicPlanAgentImpl(plan, ScenarioUtils.createScenario(ConfigUtils.createConfig()),
+                eventsManager, mobsimTimer, TimeInterpretation.create(ConfigUtils.createConfig()));
+        plan.setPerson(agent.getPerson());
+
+        PrebookingManager prebookingManager = new PrebookingManager("drt", network, drtRequestCreator,
+                new VrpOptimizer() {
+                    @Override
+                    public void requestSubmitted(Request request) {
+                        DrtRequest drtRequest = (DrtRequest) request;
+                        Assertions.assertEquals(0, drtRequest.getSubmissionTime(), MatsimTestUtils.EPSILON);
+                        Assertions.assertEquals(50, drtRequest.getEarliestStartTime(), MatsimTestUtils.EPSILON);
+                        Assertions.assertEquals(150, drtRequest.getLatestStartTime(), MatsimTestUtils.EPSILON);
+                        Assertions.assertEquals(250, drtRequest.getLatestArrivalTime(), MatsimTestUtils.EPSILON);
+                        Assertions.assertEquals(drtRouteConstraints, drtRequest.getConstraints());
+                    }
+
+                    @Override
+                    public void nextTask(DvrpVehicle vehicle) {
+
+                    }
+                }, mobsimTimer, new DefaultPassengerRequestValidator(), eventsManager, null, false);
+
+        prebookingManager.prebook(agent, (Leg) WithinDayAgentUtils.getModifiablePlan(agent).getPlanElements().get(1), 50);
+        prebookingManager.notifyMobsimAfterSimStep(new MobsimAfterSimStepEvent(null, 51));
+
+    }
+}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/prebooking/VariableStopDurationTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/prebooking/VariableStopDurationTest.java
@@ -79,10 +79,9 @@ public class VariableStopDurationTest {
 												  double waitTimeConstraint
 		) {
 			data.put(personId, new DrtRouteConstraints(
-					departureTime,
-					departureTime + waitTimeConstraint,
-					departureTime + travelTimeConstraint,
+					travelTimeConstraint,
 					Double.POSITIVE_INFINITY,
+					waitTimeConstraint,
 					Double.POSITIVE_INFINITY,
 					0.0,
 					true

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/DrtRoutingModuleTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/DrtRoutingModuleTest.java
@@ -250,11 +250,10 @@ public class DrtRoutingModuleTest {
 					"{" +
 						"\"allowRejection\":\"true\"," +
 						"\"maxPickupDelay\":\"120\"," +
-						"\"latestStartTime\":\"4200\"," +
 						"\"maxRideDuration\":\"900\"," +
-						"\"earliestStartTime\":\"3600\"," +
-						"\"lateDiversionThreshold\":\"200\"," +
-						"\"latestArrivalTime\":\"7200\"" +
+						"\"maxTravelDuration\":\"3600\"," +
+						"\"maxWaitDuration\":\"600\"," +
+						"\"lateDiversionThreshold\":\"200\"" +
 					"}" +
 				"}";
 
@@ -267,11 +266,13 @@ public class DrtRoutingModuleTest {
 
 		DrtRoute drtRoute = new DrtRoute(h.getLinkId(), w.getLinkId());
 
+	//	String routeDescription = drtRoute.getRouteDescription();
+
 		drtRoute.setRouteDescription(newRouteFormatV3);
         Assertions.assertEquals(400, drtRoute.getDirectRideTime());
         Assertions.assertEquals(drtRoute.getUnsharedPath(), Arrays.asList("a", "b", "c"));
-        Assertions.assertEquals(600., drtRoute.getConstraints().latestStartTime() - drtRoute.getConstraints().earliestStartTime());
-        Assertions.assertEquals(7200, drtRoute.getConstraints().latestArrivalTime());
+        Assertions.assertEquals(600., drtRoute.getConstraints().maxWaitDuration());
+      //  Assertions.assertEquals(7200, drtRoute.getConstraints().latestArrivalTime());
         Assertions.assertEquals(200, drtRoute.getConstraints().lateDiversionThreshold());
         Assertions.assertEquals(120, drtRoute.getConstraints().maxPickupDelay());
 	}

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionSchedulerTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/scheduler/DefaultRequestInsertionSchedulerTest.java
@@ -234,12 +234,12 @@ public class DefaultRequestInsertionSchedulerTest {
                 .id(Id.create(id, Request.class))
                 .passengerIds(List.of(Id.createPersonId(id)))
                 .submissionTime(submissionTime)
+                .earliestDepartureTime(earliestStartTime)
                 .constraints(
                         new DrtRouteConstraints(
-                                earliestStartTime,
-                                latestStartTime,
-                                latestArrivalTime,
+                                latestArrivalTime - earliestStartTime,
                                 Double.POSITIVE_INFINITY,
+                                latestStartTime - earliestStartTime,
                                 Double.POSITIVE_INFINITY,
                                 0.,
                                 false


### PR DESCRIPTION
As per #4161 there's a bug for drt constraints in the case of prebooking. When the constraints were changed to absolute time stamps, the time stamps did not take into account the offset between submission time and earliest/planned departure, meaning that the time windows were too narrow for prebooked trips, causing more rejections.

The main reason was that the prebooking manager correctly passes the actual departure time to the request creator, which sets the earliest start time accordingly. However, the latest start time was already determined in the route creator and did not account for the offset between submission and earliest departure.

I changed it back such that the constraints object uses relative constraints again, but still kept re-using the constraints object for creating the requests.

Mea culpa, I added a test to ensure the behavior stays valid.