### PR TITLE
fix(deps): remove duplicate version info for aws contrib

### DIFF
--- a/contribs/aws/pom.xml
+++ b/contribs/aws/pom.xml
@@ -37,22 +37,18 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>regions</artifactId>
-            <version>2.33.2</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>aws-core</artifactId>
-            <version>2.33.2</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>auth</artifactId>
-            <version>2.33.2</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sdk-core</artifactId>
-            <version>2.33.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>


### PR DESCRIPTION
This will reduce the number of open dependabot PRs e.g., #4350 #4352 #4354 #4355. This slipped through in #4345.