### PR TITLE
refactor(shared_mobility): use Parameter annotation in SharingServiceConfigGroup

### DIFF
--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/examples/RunCarsharing.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/examples/RunCarsharing.java
@@ -4,10 +4,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.matsim.api.core.v01.Id;
 import org.matsim.contrib.shared_mobility.run.SharingConfigGroup;
 import org.matsim.contrib.shared_mobility.run.SharingModule;
 import org.matsim.contrib.shared_mobility.run.SharingServiceConfigGroup;
 import org.matsim.contrib.shared_mobility.run.SharingServiceConfigGroup.ServiceScheme;
+import org.matsim.contrib.shared_mobility.service.SharingService;
 import org.matsim.contrib.shared_mobility.service.SharingUtils;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.CommandLine.ConfigurationException;
@@ -39,7 +41,7 @@ public class RunCarsharing {
 		sharingConfig.addService(serviceConfig);
 
 		// ... with a service id. The respective mode will be "sharing:velib".
-		serviceConfig.id = "mobility";
+		serviceConfig.setIdFromString("mobility");
 
 		// ... with freefloating characteristics
 		serviceConfig.maximumAccessEgressDistance = 100000;

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/examples/RunParisVelib.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/examples/RunParisVelib.java
@@ -4,10 +4,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.matsim.api.core.v01.Id;
 import org.matsim.contrib.shared_mobility.run.SharingConfigGroup;
 import org.matsim.contrib.shared_mobility.run.SharingModule;
 import org.matsim.contrib.shared_mobility.run.SharingServiceConfigGroup;
 import org.matsim.contrib.shared_mobility.run.SharingServiceConfigGroup.ServiceScheme;
+import org.matsim.contrib.shared_mobility.service.SharingService;
 import org.matsim.contrib.shared_mobility.service.SharingUtils;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.CommandLine.ConfigurationException;
@@ -34,7 +36,7 @@ public class RunParisVelib {
 		sharingConfig.addService(serviceConfig);
 
 		// ... with a service id. The respective mode will be "sharing:velib".
-		serviceConfig.id = "velib";
+		serviceConfig.setIdFromString("velib");
 
 		// ... with freefloating characteristics
 		serviceConfig.maximumAccessEgressDistance = 100000;

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/examples/RunTeleportationBikesharing.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/examples/RunTeleportationBikesharing.java
@@ -4,10 +4,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.matsim.api.core.v01.Id;
 import org.matsim.contrib.shared_mobility.run.SharingConfigGroup;
 import org.matsim.contrib.shared_mobility.run.SharingModule;
 import org.matsim.contrib.shared_mobility.run.SharingServiceConfigGroup;
 import org.matsim.contrib.shared_mobility.run.SharingServiceConfigGroup.ServiceScheme;
+import org.matsim.contrib.shared_mobility.service.SharingService;
 import org.matsim.contrib.shared_mobility.service.SharingUtils;
 import org.matsim.core.config.CommandLine;
 import org.matsim.core.config.CommandLine.ConfigurationException;
@@ -56,7 +58,7 @@ public class RunTeleportationBikesharing {
 		sharingConfig.addService(serviceConfig);
 
 		// ... with a service id. The respective mode will be "sharing:velib".
-		serviceConfig.id = "velib";
+		serviceConfig.setIdFromString("velib");
 
 		// ... with freefloating characteristics
 		serviceConfig.maximumAccessEgressDistance = 100000;

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/run/SharingConfigGroup.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/run/SharingConfigGroup.java
@@ -9,7 +9,9 @@ import java.util.Set;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.matsim.api.core.v01.Id;
 import org.matsim.contrib.shared_mobility.run.SharingServiceConfigGroup.ServiceScheme;
+import org.matsim.contrib.shared_mobility.service.SharingService;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigGroup;
 import org.matsim.core.config.ReflectiveConfigGroup;
@@ -42,22 +44,23 @@ public class SharingConfigGroup extends ReflectiveConfigGroup {
 		super.checkConsistency(config);
 		new BeanValidationConfigConsistencyChecker().checkConsistency(config);
 
-		Set<String> serviceIds = new HashSet<>();
+		Set<Id<SharingService>> serviceIds = new HashSet<>();
 
 		for (SharingServiceConfigGroup serviceConfig : getServices()) {
 			// Avoid duplicate IDs
 
-			if (serviceIds.contains(serviceConfig.id)) {
-				throw new IllegalStateException("Duplicate sharing service: " + serviceConfig.id);
+			if (serviceIds.contains(serviceConfig.getId())) {
+				throw new IllegalStateException("Duplicate sharing service: " + serviceConfig.getId());
 			}
 
-			serviceIds.add(serviceConfig.id);
+			serviceIds.add(serviceConfig.getId());
 
 			// Some warnings
 
 			if (serviceConfig.serviceScheme.equals(ServiceScheme.StationBased)
 					&& serviceConfig.serviceAreaShapeFile != null) {
-				logger.warn("Service " + serviceConfig.id + " is station-based, so service area file will not be used!");
+				logger.warn("Service " + serviceConfig.getId()
+						+ " is station-based, so service area file will not be used!");
 			}
 		}
 	}

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/run/SharingQSimServiceModule.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/run/SharingQSimServiceModule.java
@@ -56,8 +56,8 @@ public class SharingQSimServiceModule extends AbstractModalQSimModule<SharingMod
 			Network network = getter.get(Network.class);
 			SharingServiceSpecification specification = getter.getModal(SharingServiceSpecification.class);
 
-			return new FreefloatingService(Id.create(serviceConfig.id, SharingService.class),
-					specification.getVehicles(), network, serviceConfig.maximumAccessEgressDistance);
+			return new FreefloatingService(serviceConfig.getId(), specification.getVehicles(), network,
+							serviceConfig.maximumAccessEgressDistance);
 		})).in(Singleton.class);
 
 
@@ -74,8 +74,8 @@ public class SharingQSimServiceModule extends AbstractModalQSimModule<SharingMod
 			Network network = getter.get(Network.class);
 			SharingServiceSpecification specification = getter.getModal(SharingServiceSpecification.class);
 
-			return new StationBasedService(Id.create(serviceConfig.id, SharingService.class), specification,
-					network, serviceConfig.maximumAccessEgressDistance);
+			return new StationBasedService(serviceConfig.getId(), specification, network,
+							serviceConfig.maximumAccessEgressDistance);
 		})).in(Singleton.class);
 
 		switch (serviceConfig.serviceScheme) {

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/run/SharingServiceConfigGroup.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/run/SharingServiceConfigGroup.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 import javax.annotation.Nonnegative;
 
+import org.matsim.api.core.v01.Id;
+import org.matsim.contrib.shared_mobility.service.SharingService;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ReflectiveConfigGroup;
 import org.matsim.core.config.consistency.BeanValidationConfigConsistencyChecker;
@@ -16,6 +18,9 @@ public class SharingServiceConfigGroup extends ReflectiveConfigGroup {
 
 	public static final String GROUP_NAME = "mode";
 
+	public static final String ID = "id";
+	public static final String SERVICE_SCHEME = "serviceScheme";
+	public static final String ID_COMMENT = "The id of the sharing service";
 	public static final String SERVICE_SCHEME_COMMENT = "One of: " + String.join(", ",
 			Arrays.asList(ServiceScheme.values()).stream().map(String::valueOf).toList());
 
@@ -32,10 +37,8 @@ public class SharingServiceConfigGroup extends ReflectiveConfigGroup {
 	@NotNull
 	public String serviceInputFile;
 
-	@Parameter
-	@Comment("The id of the sharing service")
 	@NotNull
-	public String id;
+	private Id<SharingService> id;
 
 	@Parameter
 	@NotNull
@@ -81,10 +84,29 @@ public class SharingServiceConfigGroup extends ReflectiveConfigGroup {
 		new BeanValidationConfigConsistencyChecker().checkConsistency(config);
 	}
 
+	public Id<SharingService> getId() {
+		return id;
+	}
+
+	public void setId(Id<SharingService> serviceId) {
+		id = serviceId;
+	}
+
+	@StringGetter(ID)
+	public String getIdAsString() {
+		return id != null ? id.toString() : "";
+	}
+
+	@StringSetter(ID)
+	public void setIdFromString(String idString) {
+		this.id = (idString != null && !idString.isBlank()) ? Id.create(idString, SharingService.class) : null;
+	}
+
 	@Override
 	public Map<String, String> getComments() {
 		Map<String, String> map = super.getComments();
-		map.put("serviceScheme", SERVICE_SCHEME_COMMENT);
+		map.put(ID, ID_COMMENT);
+		map.put(SERVICE_SCHEME, SERVICE_SCHEME_COMMENT);
 		return map;
 	}
 

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/run/SharingServiceModule.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/run/SharingServiceModule.java
@@ -61,7 +61,7 @@ public class SharingServiceModule extends AbstractModalModule<SharingMode> {
 			TimeInterpretation timeInterpretation = getter.get(TimeInterpretation.class);
 
 			return new SharingRoutingModule(scenario, accessEgressRoutingModule, mainModeRoutingModule,
-					interactionFinder, Id.create(serviceConfig.id, SharingService.class), timeInterpretation);
+					interactionFinder, serviceConfig.getId(), timeInterpretation);
 		}));
 
 		addRoutingModuleBinding(getMode()).to(modalKey(SharingRoutingModule.class));
@@ -83,26 +83,24 @@ public class SharingServiceModule extends AbstractModalModule<SharingMode> {
 			SharingServiceSpecification specification = getter.getModal(SharingServiceSpecification.class);
 			OutputDirectoryHierarchy outputHierarchy = getter.get(OutputDirectoryHierarchy.class);
 
-			return new OutputWriter(Id.create(serviceConfig.id, SharingService.class), specification,
-					outputHierarchy);
+			return new OutputWriter(serviceConfig.getId(), specification, outputHierarchy);
 		})).in(Singleton.class);
 
 		addControllerListenerBinding().to(modalKey(OutputWriter.class));
 
 		bindModal(FreefloatingServiceValidator.class).toProvider(modalProvider(getter -> {
-			return new FreefloatingServiceValidator(Id.create(serviceConfig.id, SharingService.class));
+			return new FreefloatingServiceValidator(serviceConfig.getId());
 		})).in(Singleton.class);
 
 		bindModal(StationBasedServiceValidator.class).toProvider(modalProvider(getter -> {
-			return new StationBasedServiceValidator(Id.create(serviceConfig.id, SharingService.class));
+			return new StationBasedServiceValidator(serviceConfig.getId());
 		})).in(Singleton.class);
 
 		bindModal(ValidationListener.class).toProvider(modalProvider(getter -> {
 			SharingServiceSpecification specification = getter.getModal(SharingServiceSpecification.class);
 			SharingServiceValidator validator = getter.getModal(SharingServiceValidator.class);
 
-			return new ValidationListener(Id.create(serviceConfig.id, SharingService.class), validator,
-					specification);
+			return new ValidationListener(serviceConfig.getId(), validator, specification);
 		}));
 
 		addControllerListenerBinding().to(modalKey(ValidationListener.class));

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/SharingNetworkRentalsHandler.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/SharingNetworkRentalsHandler.java
@@ -42,7 +42,7 @@ public class SharingNetworkRentalsHandler implements SharingPickupEventHandler, 
 	@Override
 	public void handleEvent(SharingPickupEvent event) {
 
-		if (event.getServiceId().toString().equals(serviceParams.id)) {
+		if (event.getServiceId().equals(serviceParams.getId())) {
 			pickups.put(event.getPersonId(), event);
 		}
 	}
@@ -57,7 +57,7 @@ public class SharingNetworkRentalsHandler implements SharingPickupEventHandler, 
 	@Override
 	public void handleEvent(SharingDropoffEvent event) {
 
-		if (event.getServiceId().toString().equals(serviceParams.id)) {
+		if (event.getServiceId().equals(serviceParams.getId())) {
 			Verify.verify(this.distance.containsKey(event.getPersonId()));
 			// distance fare
 			double sharedDistanceFare = this.distance.get(event.getPersonId()) * this.serviceParams.distanceFare;

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/SharingTeleportedRentalsHandler.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/SharingTeleportedRentalsHandler.java
@@ -34,7 +34,7 @@ public class SharingTeleportedRentalsHandler
 	@Override
 	public void handleEvent(SharingPickupEvent event) {
 
-		if (event.getServiceId().toString().equals(serviceParams.id)) {
+		if (event.getServiceId().equals(serviceParams.getId())) {
 			pickups.put(event.getPersonId(), event);
 		}
 	}
@@ -50,7 +50,7 @@ public class SharingTeleportedRentalsHandler
 	@Override
 	public void handleEvent(SharingDropoffEvent event) {
 
-		if (event.getServiceId().toString().equals(serviceParams.id)) {
+		if (event.getServiceId().equals(serviceParams.getId())) {
 			Verify.verify(this.distance.containsKey(event.getPersonId()));
 			// distance fare
 			double sharedDistanceFare = this.distance.get(event.getPersonId()) * this.serviceParams.distanceFare;

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/SharingUtils.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/SharingUtils.java
@@ -62,7 +62,7 @@ public class SharingUtils {
 	}
 
 	static public String getServiceMode(SharingServiceConfigGroup serviceConfig) {
-		return getServiceMode(Id.create(serviceConfig.id, SharingService.class));
+		return getServiceMode(serviceConfig.getId());
 	}
 
 	public static QSimComponentsConfigurator configureQSim(SharingConfigGroup sharingConfig) {

--- a/contribs/shared_mobility/src/test/java/org/matsim/contrib/shared_mobility/RunIT.java
+++ b/contribs/shared_mobility/src/test/java/org/matsim/contrib/shared_mobility/RunIT.java
@@ -11,11 +11,13 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.events.handler.PersonDepartureEventHandler;
 import org.matsim.contrib.shared_mobility.run.SharingConfigGroup;
 import org.matsim.contrib.shared_mobility.run.SharingModule;
 import org.matsim.contrib.shared_mobility.run.SharingServiceConfigGroup;
 import org.matsim.contrib.shared_mobility.run.SharingServiceConfigGroup.ServiceScheme;
+import org.matsim.contrib.shared_mobility.service.SharingService;
 import org.matsim.contrib.shared_mobility.service.SharingUtils;
 import org.matsim.contrib.shared_mobility.service.events.SharingDropoffEventHandler;
 import org.matsim.contrib.shared_mobility.service.events.SharingFailedDropoffEventHandler;
@@ -55,7 +57,7 @@ public class RunIT {
 		sharingConfig.addService(serviceConfig);
 
 		// ... with a service id. The respective mode will be "sharing:velib".
-		serviceConfig.id = "mobility";
+		serviceConfig.setIdFromString("mobility");
 
 		// ... with freefloating characteristics
 		serviceConfig.maximumAccessEgressDistance = 100000;
@@ -79,7 +81,7 @@ public class RunIT {
 		sharingConfig.addService(serviceConfigBike);
 
 		// ... with a service id. The respective mode will be "sharing:velib".
-		serviceConfigBike.id = "velib";
+		serviceConfigBike.setIdFromString("velib");
 
 		// ... with freefloating characteristics
 		serviceConfigBike.maximumAccessEgressDistance = 100000;
@@ -103,7 +105,7 @@ public class RunIT {
 		sharingConfig.addService(serviceConfigBikeFF);
 
 		// ... with a service id. The respective mode will be "sharing:velib".
-		serviceConfigBikeFF.id = "wheels";
+		serviceConfigBikeFF.setIdFromString("wheels");
 
 		// ... with freefloating characteristics
 		serviceConfigBikeFF.maximumAccessEgressDistance = 100000;


### PR DESCRIPTION
This change 
* changes the `SharingServiceConfigGroup` over to the current Parameter annotation from `ReflectiveConfigGroup` and
* changes the `id` parameter's type from `String` to `Id<SharingService>` to avoid having to create an `Id` object from it at every usage thus reducing the risk of bugs from comparing objects of different types at some point.
