### PR TITLE
fix: unregister LegHistogramListener handler at iteration end to avoid cumulative counts (backport 2025.0)

### DIFF
--- a/matsim/src/main/java/org/matsim/analysis/LegHistogramListener.java
+++ b/matsim/src/main/java/org/matsim/analysis/LegHistogramListener.java
@@ -67,6 +67,7 @@ final class LegHistogramListener implements IterationEndsListener, IterationStar
 					LegHistogramChart.writeGraphic(this.histogram, controllerIO.getIterationFilename(event.getIteration(), "legHistogram_" + legMode + ".png"), legMode);
 				}
 			}
+			event.getServices().getEvents().removeHandler(this.histogram);
 		}
 	}
 


### PR DESCRIPTION
In the 2025.0 release, LegHistogramListener#notifyIterationEnds does not unregister the histogram event handler. As a result, the handler remains registered across iterations and counts accumulate, producing incorrect plots and leghistogram.txt files. Discovered when trying to analyse my own scenario built on the matsim example project which uses 2025.0

Joschka fixed this on the main branch at commit 8e358f47b0b1c0867166f8d21eebd6f4b8ae8c13 so the patch need not be applied on main, only on the 2025.0 release

Happy to learn how to deal with the release process so I can help with this kind of thing in future; tagging Paul and Janek as I see they have run the release gauntlet in the past, and to update Marcel as I have mentioned it to him in an email thread.