### PR TITLE
refactor(shared_mobility): use both Parameter annotation and Getter/Setter in SharingServiceConfigGroup

### DIFF
--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/examples/RunCarsharing.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/examples/RunCarsharing.java
@@ -18,6 +18,7 @@ import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.groups.ScoringConfigGroup.ActivityParams;
 import org.matsim.core.config.groups.ScoringConfigGroup.ModeParams;
 import org.matsim.core.controler.Controler;
+
 /**
  *
  * This is an example of a station-based oneway car-sharing service
@@ -44,15 +45,15 @@ public class RunCarsharing {
 		serviceConfig.setIdFromString("mobility");
 
 		// ... with freefloating characteristics
-		serviceConfig.maximumAccessEgressDistance = 100000;
-		serviceConfig.serviceScheme = ServiceScheme.StationBased;
-		serviceConfig.serviceAreaShapeFile = null;
+		serviceConfig.setMaximumAccessEgressDistance(100000);
+		serviceConfig.setServiceScheme(ServiceScheme.StationBased);
+		serviceConfig.setServiceAreaShapeFile(null);
 
 		// ... with a number of available vehicles and their initial locations
-		serviceConfig.serviceInputFile = "shared_taxi_vehicles_stations.xml";
+		serviceConfig.setServiceInputFile("shared_taxi_vehicles_stations.xml");
 
 		// ... and, we need to define the underlying mode, here "car".
-		serviceConfig.mode = "car";
+		serviceConfig.setMode("car");
 
 		// Finally, we need to make sure that the service mode (sharing:velib) is
 		// considered in mode choice.

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/examples/RunParisVelib.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/examples/RunParisVelib.java
@@ -39,15 +39,15 @@ public class RunParisVelib {
 		serviceConfig.setIdFromString("velib");
 
 		// ... with freefloating characteristics
-		serviceConfig.maximumAccessEgressDistance = 100000;
-		serviceConfig.serviceScheme = ServiceScheme.StationBased;
-		serviceConfig.serviceAreaShapeFile = null;
+		serviceConfig.setMaximumAccessEgressDistance(100000);
+		serviceConfig.setServiceScheme(ServiceScheme.StationBased);
+		serviceConfig.setServiceAreaShapeFile(null);
 
 		// ... with a number of available vehicles and their initial locations
-		serviceConfig.serviceInputFile = "velib_service.xml.gz";
+		serviceConfig.setServiceInputFile("velib_service.xml.gz");
 
 		// ... and, we need to define the underlying mode, here "bike".
-		serviceConfig.mode = "bike";
+		serviceConfig.setMode("bike");
 
 		// Finally, we need to make sure that the service mode (sharing:velib) is
 		// considered in mode choice.

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/examples/RunTeleportationBikesharing.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/examples/RunTeleportationBikesharing.java
@@ -61,16 +61,17 @@ public class RunTeleportationBikesharing {
 		serviceConfig.setIdFromString("velib");
 
 		// ... with freefloating characteristics
-		serviceConfig.maximumAccessEgressDistance = 100000;
-		serviceConfig.serviceScheme = ServiceScheme.StationBased;
-		serviceConfig.serviceAreaShapeFile = null;
+		serviceConfig.setMaximumAccessEgressDistance(100000);
+		serviceConfig.setServiceScheme(ServiceScheme.StationBased);
+		serviceConfig.setServiceAreaShapeFile(null);
 
 		// ... with a number of available vehicles and their initial locations
-		// the following file is an example and it works with the siouxfalls-2014 scenario
-		serviceConfig.serviceInputFile = "shared_taxi_vehicles_stations.xml";
+		// the following file is an example and it works with the siouxfalls-2014
+		// scenario
+		serviceConfig.setServiceInputFile("shared_taxi_vehicles_stations.xml");
 
 		// ... and, we need to define the underlying mode, here "bike".
-		serviceConfig.mode = "bike";
+		serviceConfig.setMode("bike");
 
 		// Finally, we need to make sure that the service mode (sharing:velib) is
 		// considered in mode choice.

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/run/SharingConfigGroup.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/run/SharingConfigGroup.java
@@ -57,8 +57,8 @@ public class SharingConfigGroup extends ReflectiveConfigGroup {
 
 			// Some warnings
 
-			if (serviceConfig.serviceScheme.equals(ServiceScheme.StationBased)
-					&& serviceConfig.serviceAreaShapeFile != null) {
+			if (serviceConfig.getServiceScheme().equals(ServiceScheme.StationBased)
+					&& serviceConfig.getServiceAreaShapeFile() != null) {
 				logger.warn("Service " + serviceConfig.getId()
 						+ " is station-based, so service area file will not be used!");
 			}

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/run/SharingQSimServiceModule.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/run/SharingQSimServiceModule.java
@@ -46,7 +46,7 @@ public class SharingQSimServiceModule extends AbstractModalQSimModule<SharingMod
 			SharingService service = getter.getModal(SharingService.class);
 
 			RoutingModule accessEgressRoutingModule = getter.getNamed(RoutingModule.class, TransportMode.walk);
-			RoutingModule mainModeRoutingModule = getter.getNamed(RoutingModule.class, serviceConfig.mode);
+			RoutingModule mainModeRoutingModule = getter.getNamed(RoutingModule.class, serviceConfig.getMode());
 
 			return new SharingLogic(service, accessEgressRoutingModule, mainModeRoutingModule, scenario, eventsManager,
 					timeInterpretation);
@@ -57,9 +57,8 @@ public class SharingQSimServiceModule extends AbstractModalQSimModule<SharingMod
 			SharingServiceSpecification specification = getter.getModal(SharingServiceSpecification.class);
 
 			return new FreefloatingService(serviceConfig.getId(), specification.getVehicles(), network,
-							serviceConfig.maximumAccessEgressDistance);
+					serviceConfig.getMaximumAccessEgressDistance());
 		})).in(Singleton.class);
-
 
 		addModalComponent(AgentSource.class, modalProvider(getter -> {
 
@@ -75,18 +74,18 @@ public class SharingQSimServiceModule extends AbstractModalQSimModule<SharingMod
 			SharingServiceSpecification specification = getter.getModal(SharingServiceSpecification.class);
 
 			return new StationBasedService(serviceConfig.getId(), specification, network,
-							serviceConfig.maximumAccessEgressDistance);
+					serviceConfig.getMaximumAccessEgressDistance());
 		})).in(Singleton.class);
 
-		switch (serviceConfig.serviceScheme) {
-		case Freefloating:
-			bindModal(SharingService.class).to(modalKey(FreefloatingService.class));
-			break;
-		case StationBased:
-			bindModal(SharingService.class).to(modalKey(StationBasedService.class));
-			break;
-		default:
-			throw new IllegalStateException();
+		switch (serviceConfig.getServiceScheme()) {
+			case Freefloating:
+				bindModal(SharingService.class).to(modalKey(FreefloatingService.class));
+				break;
+			case StationBased:
+				bindModal(SharingService.class).to(modalKey(StationBasedService.class));
+				break;
+			default:
+				throw new IllegalStateException();
 		}
 	}
 }

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/run/SharingServiceConfigGroup.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/run/SharingServiceConfigGroup.java
@@ -35,53 +35,61 @@ public class SharingServiceConfigGroup extends ReflectiveConfigGroup {
 	@Parameter
 	@Comment("Input file defining vehicles and stations")
 	@NotNull
-	public String serviceInputFile;
+	private String serviceInputFile;
 
 	@NotNull
 	private Id<SharingService> id;
 
 	@Parameter
 	@NotNull
-	public ServiceScheme serviceScheme;
+	private ServiceScheme serviceScheme;
 
 	@Parameter
 	@Comment("Shape file defining the service area")
-	public String serviceAreaShapeFile;
+	private String serviceAreaShapeFile;
 
 	@Parameter
 	@Comment("Defines the underlying mode of the service")
 	@NotNull
-	public String mode;
+	private String mode;
 
 	@Parameter
 	@Comment("Maximum distance to a bike or station")
 	@Positive
-	public double maximumAccessEgressDistance = 1000;
+	private double maximumAccessEgressDistance = 1000;
 
 	@Parameter
 	@Comment("Time [second] fare")
 	@Nonnegative
-	public double timeFare = 0.0;
+	private double timeFare = 0.0;
 
 	@Parameter
 	@Comment("Distance [meter] fare")
 	@Nonnegative
-	public double distanceFare = 0.0;
+	private double distanceFare = 0.0;
 
 	@Parameter
 	@Comment("Base fare")
 	@Nonnegative
-	public double baseFare = 0.0;
+	private double baseFare = 0.0;
 
 	@Parameter
 	@Comment("Minimum fare per rental")
 	@Nonnegative
-	public double minimumFare = 0.0;
+	private double minimumFare = 0.0;
 
 	@Override
 	protected void checkConsistency(Config config) {
 		super.checkConsistency(config);
 		new BeanValidationConfigConsistencyChecker().checkConsistency(config);
+	}
+
+	public String getServiceInputFile() {
+		return serviceInputFile;
+	}
+
+	public void setServiceInputFile(String serviceInputFile) {
+		this.serviceInputFile = serviceInputFile;
 	}
 
 	public Id<SharingService> getId() {
@@ -90,6 +98,70 @@ public class SharingServiceConfigGroup extends ReflectiveConfigGroup {
 
 	public void setId(Id<SharingService> serviceId) {
 		id = serviceId;
+	}
+
+	public ServiceScheme getServiceScheme() {
+		return serviceScheme;
+	}
+
+	public void setServiceScheme(ServiceScheme serviceScheme) {
+		this.serviceScheme = serviceScheme;
+	}
+
+	public String getServiceAreaShapeFile() {
+		return serviceAreaShapeFile;
+	}
+
+	public void setServiceAreaShapeFile(String serviceAreaShapeFile) {
+		this.serviceAreaShapeFile = serviceAreaShapeFile;
+	}
+
+	public String getMode() {
+		return mode;
+	}
+
+	public void setMode(String mode) {
+		this.mode = mode;
+	}
+
+	public double getMaximumAccessEgressDistance() {
+		return maximumAccessEgressDistance;
+	}
+
+	public void setMaximumAccessEgressDistance(double maximumAccessEgressDistance) {
+		this.maximumAccessEgressDistance = maximumAccessEgressDistance;
+	}
+
+	public double getTimeFare() {
+		return timeFare;
+	}
+
+	public void setTimeFare(double timeFare) {
+		this.timeFare = timeFare;
+	}
+
+	public double getDistanceFare() {
+		return distanceFare;
+	}
+
+	public void setDistanceFare(double distanceFare) {
+		this.distanceFare = distanceFare;
+	}
+
+	public double getBaseFare() {
+		return baseFare;
+	}
+
+	public void setBaseFare(double baseFare) {
+		this.baseFare = baseFare;
+	}
+
+	public double getMinimumFare() {
+		return minimumFare;
+	}
+
+	public void setMinimumFare(double minimumFare) {
+		this.minimumFare = minimumFare;
 	}
 
 	@StringGetter(ID)

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/SharingNetworkRentalsHandler.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/SharingNetworkRentalsHandler.java
@@ -60,21 +60,22 @@ public class SharingNetworkRentalsHandler implements SharingPickupEventHandler, 
 		if (event.getServiceId().equals(serviceParams.getId())) {
 			Verify.verify(this.distance.containsKey(event.getPersonId()));
 			// distance fare
-			double sharedDistanceFare = this.distance.get(event.getPersonId()) * this.serviceParams.distanceFare;
+			double sharedDistanceFare = this.distance.get(event.getPersonId()) * this.serviceParams.getDistanceFare();
 
 			// base fare
-			double sharedBaseFare = this.serviceParams.baseFare;
+			double sharedBaseFare = this.serviceParams.getBaseFare();
 
 			// time fare
 			double pickuptime = this.pickups.get(event.getPersonId()).getTime();
 			double rentalTime = event.getTime() - pickuptime;
-			double sharedTimeFare = rentalTime * serviceParams.timeFare;
+			double sharedTimeFare = rentalTime * serviceParams.getTimeFare();
 
 			// minimum fare
-			double minimumFare = serviceParams.minimumFare;
+			double minimumFare = serviceParams.getMinimumFare();
 
 			double sharedFare = Math.max(minimumFare, sharedBaseFare + sharedDistanceFare + sharedTimeFare);
-			eventsManager.processEvent(new PersonMoneyEvent(event.getTime(), event.getPersonId(), -sharedFare, PERSON_MONEY_EVENT_PURPOSE_SHARING_FARE, event.getServiceId().toString(), null));
+			eventsManager.processEvent(new PersonMoneyEvent(event.getTime(), event.getPersonId(), -sharedFare,
+					PERSON_MONEY_EVENT_PURPOSE_SHARING_FARE, event.getServiceId().toString(), null));
 			this.distance.remove(event.getPersonId());
 			this.pickups.remove(event.getPersonId());
 		}

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/SharingTeleportedRentalsHandler.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/SharingTeleportedRentalsHandler.java
@@ -53,21 +53,22 @@ public class SharingTeleportedRentalsHandler
 		if (event.getServiceId().equals(serviceParams.getId())) {
 			Verify.verify(this.distance.containsKey(event.getPersonId()));
 			// distance fare
-			double sharedDistanceFare = this.distance.get(event.getPersonId()) * this.serviceParams.distanceFare;
+			double sharedDistanceFare = this.distance.get(event.getPersonId()) * this.serviceParams.getDistanceFare();
 
 			// base fare
-			double sharedBaseFare = this.serviceParams.baseFare;
+			double sharedBaseFare = this.serviceParams.getBaseFare();
 
 			// time fare
 			double pickuptime = this.pickups.get(event.getPersonId()).getTime();
 			double rentalTime = event.getTime() - pickuptime;
-			double sharedTimeFare = rentalTime * serviceParams.timeFare;
+			double sharedTimeFare = rentalTime * serviceParams.getTimeFare();
 
 			// minimum fare
-			double minimumFare = serviceParams.minimumFare;
+			double minimumFare = serviceParams.getMinimumFare();
 
 			double sharedFare = Math.max(minimumFare, sharedBaseFare + sharedDistanceFare + sharedTimeFare);
-			eventsManager.processEvent(new PersonMoneyEvent(event.getTime(), event.getPersonId(), -sharedFare, PERSON_MONEY_EVENT_PURPOSE_SHARING_FARE, event.getServiceId().toString(), null));
+			eventsManager.processEvent(new PersonMoneyEvent(event.getTime(), event.getPersonId(), -sharedFare,
+					PERSON_MONEY_EVENT_PURPOSE_SHARING_FARE, event.getServiceId().toString(), null));
 
 			this.distance.remove(event.getPersonId());
 			this.pickups.remove(event.getPersonId());

--- a/contribs/shared_mobility/src/test/java/org/matsim/contrib/shared_mobility/RunIT.java
+++ b/contribs/shared_mobility/src/test/java/org/matsim/contrib/shared_mobility/RunIT.java
@@ -11,13 +11,11 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.events.handler.PersonDepartureEventHandler;
 import org.matsim.contrib.shared_mobility.run.SharingConfigGroup;
 import org.matsim.contrib.shared_mobility.run.SharingModule;
 import org.matsim.contrib.shared_mobility.run.SharingServiceConfigGroup;
 import org.matsim.contrib.shared_mobility.run.SharingServiceConfigGroup.ServiceScheme;
-import org.matsim.contrib.shared_mobility.service.SharingService;
 import org.matsim.contrib.shared_mobility.service.SharingUtils;
 import org.matsim.contrib.shared_mobility.service.events.SharingDropoffEventHandler;
 import org.matsim.contrib.shared_mobility.service.events.SharingFailedDropoffEventHandler;
@@ -43,7 +41,6 @@ public class RunIT {
 	final void test() throws UncheckedIOException, ConfigurationException, URISyntaxException {
 		URL scenarioUrl = ExamplesUtils.getTestScenarioURL("siouxfalls-2014");
 
-
 		Config config = ConfigUtils.loadConfig(ConfigGroup.getInputFileURL(scenarioUrl, "config_default.xml"));
 		config.controller().setLastIteration(2);
 
@@ -60,16 +57,16 @@ public class RunIT {
 		serviceConfig.setIdFromString("mobility");
 
 		// ... with freefloating characteristics
-		serviceConfig.maximumAccessEgressDistance = 100000;
-		serviceConfig.serviceScheme = ServiceScheme.StationBased;
-		serviceConfig.serviceAreaShapeFile = null;
+		serviceConfig.setMaximumAccessEgressDistance(100000);
+		serviceConfig.setServiceScheme(ServiceScheme.StationBased);
+		serviceConfig.setServiceAreaShapeFile(null);
 
 		// ... with a number of available vehicles and their initial locations
 		URL vehiclesUrl_mobility = RunIT.class.getResource("shared_vehicles_mobility.xml");
-		serviceConfig.serviceInputFile = vehiclesUrl_mobility.toURI().getPath();
+		serviceConfig.setServiceInputFile(vehiclesUrl_mobility.toURI().getPath());
 
 		// ... and, we need to define the underlying mode, here "car".
-		serviceConfig.mode = "car";
+		serviceConfig.setMode("car");
 
 		// Finally, we need to make sure that the service mode (sharing:velib) is
 		// considered in mode choice.
@@ -84,16 +81,16 @@ public class RunIT {
 		serviceConfigBike.setIdFromString("velib");
 
 		// ... with freefloating characteristics
-		serviceConfigBike.maximumAccessEgressDistance = 100000;
-		serviceConfigBike.serviceScheme = ServiceScheme.StationBased;
-		serviceConfigBike.serviceAreaShapeFile = null;
+		serviceConfigBike.setMaximumAccessEgressDistance(100000);
+		serviceConfigBike.setServiceScheme(ServiceScheme.StationBased);
+		serviceConfigBike.setServiceAreaShapeFile(null);
 
 		// ... with a number of available vehicles and their initial locations
 		URL vehiclesUrl_velib = RunIT.class.getResource("shared_vehicles_velib.xml");
-		serviceConfigBike.serviceInputFile = vehiclesUrl_velib.toURI().getPath();
+		serviceConfigBike.setServiceInputFile(vehiclesUrl_velib.toURI().getPath());
 
 		// ... and, we need to define the underlying mode, here "car".
-		serviceConfigBike.mode = "bike";
+		serviceConfigBike.setMode("bike");
 
 		// Finally, we need to make sure that the service mode (sharing:velib) is
 		// considered in mode choice.
@@ -108,16 +105,16 @@ public class RunIT {
 		serviceConfigBikeFF.setIdFromString("wheels");
 
 		// ... with freefloating characteristics
-		serviceConfigBikeFF.maximumAccessEgressDistance = 100000;
-		serviceConfigBikeFF.serviceScheme = ServiceScheme.Freefloating;
-		serviceConfigBikeFF.serviceAreaShapeFile = null;
+		serviceConfigBikeFF.setMaximumAccessEgressDistance(100000);
+		serviceConfigBikeFF.setServiceScheme(ServiceScheme.Freefloating);
+		serviceConfigBikeFF.setServiceAreaShapeFile(null);
 
 		// ... with a number of available vehicles and their initial locations
 		URL vehiclesUrl_wheels = RunIT.class.getResource("shared_vehicles_wheels.xml");
-		serviceConfigBikeFF.serviceInputFile = vehiclesUrl_wheels.toURI().getPath();
+		serviceConfigBikeFF.setServiceInputFile(vehiclesUrl_wheels.toURI().getPath());
 
 		// ... and, we need to define the underlying mode, here "car".
-		serviceConfigBikeFF.mode = "bike";
+		serviceConfigBikeFF.setMode("bike");
 
 		// Finally, we need to make sure that the service mode (sharing:velib) is
 		// considered in mode choice.
@@ -172,9 +169,9 @@ public class RunIT {
 		Assertions.assertEquals(0, (long) data.dropoffCounts.getOrDefault("mobility", 0L));
 		Assertions.assertEquals(10, (long) data.dropoffCounts.get("velib"));
 
-		Assertions.assertEquals(0, (long) data.failedPickupCounts.getOrDefault("wheels",0L));
-		Assertions.assertEquals(0, (long) data.failedPickupCounts.getOrDefault("mobility",0L));
-		Assertions.assertEquals(0, (long) data.failedPickupCounts.getOrDefault("velib",0L));
+		Assertions.assertEquals(0, (long) data.failedPickupCounts.getOrDefault("wheels", 0L));
+		Assertions.assertEquals(0, (long) data.failedPickupCounts.getOrDefault("mobility", 0L));
+		Assertions.assertEquals(0, (long) data.failedPickupCounts.getOrDefault("velib", 0L));
 
 		Assertions.assertEquals(0, (long) data.failedDropoffCounts.getOrDefault("wheels", 0L));
 		Assertions.assertEquals(0, (long) data.failedDropoffCounts.getOrDefault("mobility", 0L));


### PR DESCRIPTION
Fix for https://github.com/matsim-org/matsim-libs/pull/4385 to keep the boilerplate getter/setters as discussed in the last code sprint.