### PR TITLE
fix(shared_mobility): fix loading of configs with SharingServiceConfigGroup

### DIFF
--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/run/SharingConfigGroup.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/run/SharingConfigGroup.java
@@ -40,6 +40,29 @@ public class SharingConfigGroup extends ReflectiveConfigGroup {
 	}
 
 	@Override
+	public ConfigGroup createParameterSet(final String type) {
+		switch (type) {
+			case SharingServiceConfigGroup.GROUP_NAME:
+				return new SharingServiceConfigGroup();
+			default:
+				throw new IllegalArgumentException(type);
+		}
+	}
+
+	@Override
+	protected void checkParameterSet(final ConfigGroup module) {
+		switch (module.getName()) {
+			case SharingServiceConfigGroup.GROUP_NAME:
+				if (!(module instanceof SharingServiceConfigGroup)) {
+					throw new RuntimeException("unexpected class for module " + module);
+				}
+				break;
+			default:
+				throw new IllegalArgumentException(module.getName());
+		}
+	}
+
+	@Override
 	protected void checkConsistency(Config config) {
 		super.checkConsistency(config);
 		new BeanValidationConfigConsistencyChecker().checkConsistency(config);


### PR DESCRIPTION
This change ensures, that the `SharingServiceConfigGroup` contained by `SharingConfigGroup`can be loaded as `SharingServiceConfigGroup` and not just as generic `ConfigGroup`.