### PR TITLE
feat(ev): write vehicle trajectories

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/EvConfigGroup.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/EvConfigGroup.java
@@ -77,6 +77,10 @@
 	 @Comment("Number of individual time profiles to be created")
 	 @Positive
 	 private int numberOfIndividualTimeProfiles = 50;
+
+	 @Parameter
+	 @Comment("Interval at which detailed vehicle trajectories are written")
+	 private int writeVehicleTrajectoriesInterval = 0;
  
 	 public enum InitialSocBehavior {
 		 Keep, UpdateAfterIteration
@@ -150,5 +154,13 @@
 	 public void setInitialSocBehavior(InitialSocBehavior initialSocBehavior) {
 		 this.initialSocBehavior = initialSocBehavior;
 	 }	
+
+	 public int getWriteVehicleTrajectoriesInterval() {
+		return writeVehicleTrajectoriesInterval;
+	 }
+
+	 public void setWriteVehicleTrajectoriesInterval(int value) {
+		this.writeVehicleTrajectoriesInterval = value;
+	 }
  }
  

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/EvModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/EvModule.java
@@ -21,6 +21,8 @@ package org.matsim.contrib.ev;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+
+import org.matsim.contrib.ev.analysis.EvAnalysisModule;
 import org.matsim.contrib.ev.charging.VehicleChargingHandler;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
@@ -36,6 +38,7 @@ public class EvModule extends AbstractModule {
 	@Override
 	public void install() {
 		install( new EvBaseModule() );
+		install(new EvAnalysisModule());
 
 		// this is not for DynVehicles.  Does that mean that we cannot combine charging for normal vehicles with charging for eTaxis?  Can't say ...  kai, dec'22
 		installQSimModule(new AbstractQSimModule() {

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/analysis/EvAnalysisModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/analysis/EvAnalysisModule.java
@@ -1,0 +1,34 @@
+package org.matsim.contrib.ev.analysis;
+
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.ev.EvConfigGroup;
+import org.matsim.contrib.ev.fleet.ElectricFleetSpecification;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.controler.AbstractModule;
+import org.matsim.core.controler.OutputDirectoryHierarchy;
+
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+
+/**
+ * Module handling analysis for EV contrib.
+ * 
+ * TODO: The content from /stats should be cleaned up and added here.
+ * 
+ * @author sebhoerl, IRT SystemX
+ */
+public class EvAnalysisModule extends AbstractModule {
+    @Override
+    public void install() {
+        addControllerListenerBinding().to(VehicleTrajectoryListener.class);
+    }
+
+    @Provides
+    @Singleton
+    VehicleTrajectoryListener provideVehicleTrajectoryListener(EventsManager eventsManager, Network network,
+            ElectricFleetSpecification electricFleet, OutputDirectoryHierarchy outputHierarchy,
+            EvConfigGroup evConfig) {
+        return new VehicleTrajectoryListener(eventsManager, network, electricFleet, outputHierarchy,
+                evConfig.getWriteVehicleTrajectoriesInterval());
+    }
+}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/analysis/VehicleTrajectoryListener.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/analysis/VehicleTrajectoryListener.java
@@ -1,0 +1,158 @@
+package org.matsim.contrib.ev.analysis;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.IdMap;
+import org.matsim.api.core.v01.events.LinkLeaveEvent;
+import org.matsim.api.core.v01.events.VehicleLeavesTrafficEvent;
+import org.matsim.api.core.v01.events.handler.LinkLeaveEventHandler;
+import org.matsim.api.core.v01.events.handler.VehicleLeavesTrafficEventHandler;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.ev.EvUnits;
+import org.matsim.contrib.ev.charging.EnergyChargedEvent;
+import org.matsim.contrib.ev.charging.EnergyChargedEventHandler;
+import org.matsim.contrib.ev.discharging.DrivingEnergyConsumptionEvent;
+import org.matsim.contrib.ev.discharging.DrivingEnergyConsumptionEventHandler;
+import org.matsim.contrib.ev.discharging.IdlingEnergyConsumptionEvent;
+import org.matsim.contrib.ev.discharging.IdlingEnergyConsumptionEventHandler;
+import org.matsim.contrib.ev.fleet.ElectricFleetSpecification;
+import org.matsim.contrib.ev.fleet.ElectricVehicleSpecification;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.controler.OutputDirectoryHierarchy;
+import org.matsim.core.controler.events.IterationEndsEvent;
+import org.matsim.core.controler.events.IterationStartsEvent;
+import org.matsim.core.controler.listener.IterationEndsListener;
+import org.matsim.core.controler.listener.IterationStartsListener;
+import org.matsim.core.utils.io.IOUtils;
+import org.matsim.vehicles.Vehicle;
+
+public class VehicleTrajectoryListener implements LinkLeaveEventHandler,
+        VehicleLeavesTrafficEventHandler, EnergyChargedEventHandler,
+        IdlingEnergyConsumptionEventHandler, DrivingEnergyConsumptionEventHandler, IterationStartsListener,
+        IterationEndsListener {
+    static public final String OUTPUT_FILE = "ev_trajectories.csv.gz";
+
+    private final EventsManager eventsManager;
+    private final OutputDirectoryHierarchy outputHierarchy;
+
+    private final Network network;
+    private final ElectricFleetSpecification electricFleet;
+
+    private final IdMap<Vehicle, Double> energy = new IdMap<>(Vehicle.class);
+    private final IdMap<Vehicle, Double> capacity = new IdMap<>(Vehicle.class);
+
+    private BufferedWriter writer;
+    private final int interval;
+
+    public VehicleTrajectoryListener(EventsManager eventsManager, Network network,
+            ElectricFleetSpecification electricFleet,
+            OutputDirectoryHierarchy outputHierarchy, int interval) {
+        this.eventsManager = eventsManager;
+        this.network = network;
+        this.electricFleet = electricFleet;
+        this.interval = interval;
+        this.outputHierarchy = outputHierarchy;
+    }
+
+    @Override
+    public void notifyIterationStarts(IterationStartsEvent event) {
+        if (interval > 0 && (event.getIteration() % interval == 0 || event.isLastIteration())) {
+            energy.clear();
+            capacity.clear();
+
+            for (ElectricVehicleSpecification vehicle : electricFleet.getVehicleSpecifications().values()) {
+                energy.put(vehicle.getId(), vehicle.getInitialCharge());
+                capacity.put(vehicle.getId(), vehicle.getBatteryCapacity());
+            }
+
+            String outputPath = outputHierarchy.getIterationFilename(event.getIteration(), OUTPUT_FILE);
+
+            writer = IOUtils.getBufferedWriter(outputPath);
+
+            try {
+                writer.write(String.join(";", new String[] {
+                        "vehicle_id", //
+                        "time", //
+                        "link_id", //
+                        "x", //
+                        "y", //
+                        "charge_kWh", //
+                        "soc" //
+                }) + "\n");
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            eventsManager.addHandler(this);
+        }
+    }
+
+    @Override
+    public void notifyIterationEnds(IterationEndsEvent event) {
+        if (writer != null) {
+            try {
+                writer.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            writer = null;
+            eventsManager.removeHandler(this);
+        }
+    }
+
+    @Override
+    public void handleEvent(DrivingEnergyConsumptionEvent event) {
+        energy.compute(event.getVehicleId(), (id, value) -> {
+            return event.getEndCharge();
+        });
+    }
+
+    @Override
+    public void handleEvent(IdlingEnergyConsumptionEvent event) {
+        energy.compute(event.getVehicleId(), (id, value) -> {
+            return event.getEndCharge();
+        });
+    }
+
+    @Override
+    public void handleEvent(EnergyChargedEvent event) {
+        energy.compute(event.getVehicleId(), (id, value) -> {
+            return event.getEndCharge();
+        });
+    }
+
+    @Override
+    public void handleEvent(VehicleLeavesTrafficEvent event) {
+        pingVehicle(event.getTime(), event.getVehicleId(), event.getLinkId(), false);
+    }
+
+    @Override
+    public void handleEvent(LinkLeaveEvent event) {
+        pingVehicle(event.getTime(), event.getVehicleId(), event.getLinkId(), false);
+    }
+
+    private void pingVehicle(double time, Id<Vehicle> vehicleId, Id<Link> linkId, boolean useFromNode) {
+        Link link = network.getLinks().get(linkId);
+        Coord location = useFromNode ? link.getFromNode().getCoord() : link.getToNode().getCoord();
+
+        try {
+            writer.write(String.join(";", new String[] {
+                    vehicleId.toString(), //
+                    String.valueOf(time), //
+                    linkId.toString(), //
+                    String.valueOf(location.getX()), //
+                    String.valueOf(location.getY()), //
+                    String.valueOf(EvUnits.J_to_kWh(energy.getOrDefault(vehicleId, Double.NaN))), //
+                    String.valueOf(
+                            energy.getOrDefault(vehicleId, Double.NaN) / capacity.getOrDefault(vehicleId, Double.NaN)) //
+            }) + "\n");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/contribs/ev/src/test/java/org/matsim/contrib/ev/example/RunEvExampleTest.java
+++ b/contribs/ev/src/test/java/org/matsim/contrib/ev/example/RunEvExampleTest.java
@@ -1,5 +1,9 @@
 package org.matsim.contrib.ev.example;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -13,6 +17,8 @@ import org.matsim.core.population.routes.PopulationComparison;
 import org.matsim.testcases.MatsimTestUtils;
 import org.matsim.utils.eventsfilecomparison.ComparisonResult;
 
+import com.google.common.io.Files;
+
 public class RunEvExampleTest {
 
 	private static final Logger log = LogManager.getLogger(RunEvExample.class);
@@ -25,6 +31,7 @@ public class RunEvExampleTest {
 		try {
 			String[] args = {RunEvExample.DEFAULT_CONFIG_FILE,
 				"--config:controler.outputDirectory", utils.getOutputDirectory(),
+				"--config:ev.writeVehicleTrajectoriesInterval", "1"
 			};
 
 			new RunEvExample().run(args);
@@ -43,6 +50,9 @@ public class RunEvExampleTest {
 				String actual = utils.getOutputDirectory() + "/output_events.xml.gz";
 				ComparisonResult result = EventsUtils.compareEventsFiles(expected, actual);
 				Assertions.assertEquals(ComparisonResult.FILES_ARE_EQUAL, result);
+			}
+			{
+				assertTrue(new File(utils.getOutputDirectory() + "/ITERS/it.0/0.ev_trajectories.csv.gz").exists());
 			}
 
 		} catch (Exception ee) {


### PR DESCRIPTION
This PR adds the `writeVehicleTrajecotoriesInterval` to the `ev` contrib. It provides an output of the following shape, giving information on the location of every electric vehicle at any time during the simulation, together with the state of charge:

<img width="1696" height="746" alt="image" src="https://github.com/user-attachments/assets/35a1bdde-f2b9-4f27-ae27-cb3a1cfd133a" />

The output file is called `ITERS/it.X/X.ev_trajectories.csv.gz`.