### PR TITLE
chore(ev): some cleanup

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/EvConfigGroup.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/EvConfigGroup.java
@@ -17,11 +17,10 @@
  *                                                                         *
  * *********************************************************************** */
 
- package org.matsim.contrib.ev;
+package org.matsim.contrib.ev;
 
- import java.util.Collections;
- import java.util.Set;
-import java.util.function.Supplier;
+import java.util.Collections;
+import java.util.Set;
 
 import org.matsim.contrib.common.util.ReflectiveConfigGroupWithConfigurableParameterSets;
 import org.matsim.contrib.common.zones.ZoneSystemParams;
@@ -30,190 +29,187 @@ import org.matsim.contrib.common.zones.systems.grid.GISFileZoneSystemParams;
 import org.matsim.contrib.common.zones.systems.grid.h3.H3GridZoneSystemParams;
 import org.matsim.contrib.common.zones.systems.grid.square.SquareGridZoneSystemParams;
 import org.matsim.core.config.Config;
- import org.matsim.core.config.ReflectiveConfigGroup;
-import org.matsim.core.config.ReflectiveConfigGroup.Comment;
-import org.matsim.core.config.ReflectiveConfigGroup.Parameter;
 
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
- import jakarta.validation.constraints.Positive;
- 
- public final class EvConfigGroup extends ReflectiveConfigGroupWithConfigurableParameterSets {
-	 public static final String GROUP_NAME = "ev";
- 
-	 public EvConfigGroup() {
-		 super(GROUP_NAME);
-		 initSingletonParameterSets();
-	 }
- 
-	 public static EvConfigGroup get(Config config) {
-		 return (EvConfigGroup) config.getModules().get(GROUP_NAME);
-	 }
+import jakarta.validation.constraints.Positive;
 
-	 private void initSingletonParameterSets() {
-		addDefinition(SquareGridZoneSystemParams.SET_NAME, SquareGridZoneSystemParams::new,
-				() -> analysisZoneSystemParams,
-				params -> analysisZoneSystemParams = (SquareGridZoneSystemParams)params);
+public final class EvConfigGroup extends ReflectiveConfigGroupWithConfigurableParameterSets {
+    public static final String GROUP_NAME = "ev";
 
-		addDefinition(GISFileZoneSystemParams.SET_NAME, GISFileZoneSystemParams::new,
-				() -> analysisZoneSystemParams,
-				params -> analysisZoneSystemParams = (GISFileZoneSystemParams)params);
+    public EvConfigGroup() {
+        super(GROUP_NAME);
+        initSingletonParameterSets();
+    }
 
-		addDefinition(H3GridZoneSystemParams.SET_NAME, H3GridZoneSystemParams::new,
-				() -> analysisZoneSystemParams,
-				params -> analysisZoneSystemParams = (H3GridZoneSystemParams)params);
+    public static EvConfigGroup get(Config config) {
+        return (EvConfigGroup) config.getModules().get(GROUP_NAME);
+    }
 
-		addDefinition(GeometryFreeZoneSystemParams.SET_NAME, GeometryFreeZoneSystemParams::new,
-				() -> analysisZoneSystemParams,
-				params -> analysisZoneSystemParams = (GeometryFreeZoneSystemParams)params);
-	}
+    private void initSingletonParameterSets() {
+        addDefinition(SquareGridZoneSystemParams.SET_NAME, SquareGridZoneSystemParams::new,
+                () -> analysisZoneSystemParams,
+                params -> analysisZoneSystemParams = (SquareGridZoneSystemParams) params);
 
-	 @Nullable
-	 private ZoneSystemParams analysisZoneSystemParams;
+        addDefinition(GISFileZoneSystemParams.SET_NAME, GISFileZoneSystemParams::new,
+                () -> analysisZoneSystemParams,
+                params -> analysisZoneSystemParams = (GISFileZoneSystemParams) params);
 
-	public ZoneSystemParams addOrGetAnalysisZoneSystemParams() {
-		if (analysisZoneSystemParams == null) {
-			ZoneSystemParams params = new SquareGridZoneSystemParams();
-			this.addParameterSet(params);
-		}
+        addDefinition(H3GridZoneSystemParams.SET_NAME, H3GridZoneSystemParams::new,
+                () -> analysisZoneSystemParams,
+                params -> analysisZoneSystemParams = (H3GridZoneSystemParams) params);
 
-		return analysisZoneSystemParams;
-	}
- 
-	 @Parameter
-	 @Comment("charging will be simulated every 'chargeTimeStep'-th time step")
-	 // no need to simulate with 1-second time step
-	 @Positive
-	 private int chargeTimeStep = 15; // 15 s ==> 0.417% SOC when charging at 1C (i.e. full recharge in 1 hour)
- 
-	 @Parameter
-	 @Comment("AUX discharging will be simulated every 'auxDischargeTimeStep'-th time step")
-	 // only used if SeparateAuxDischargingHandler is used, otherwise ignored
-	 @Positive
-	 private int auxDischargeTimeStep = 60; // 1 min
- 
-	 @Parameter("minChargingTime")
-	 @Comment("Minimum activity duration for charging. Used in EvNetwork Routing.")
-	 private int minimumChargeTime = 1200;
- 
-	 @Parameter("enforceChargingInteractionDuration")
-	 @Comment("If true, prolongs the charging interaction for the amount of time waiting in the charger queue (plus 1 second), i.e." +
-		 "enforces that charging interactions are undertaken as long as initially planned (by EVNetworkRoutingModule). Default is false.")
-	 private boolean enforceChargingInteractionDuration = false;
- 
-	 @Parameter
-	 @Comment("Location of the chargers file")
-	 @NotNull
-	 private String chargersFile = null;
- 
-	 public enum EvAnalysisOutput {
-		 TimeProfiles
-	 }
- 
-	 @Parameter
-	 @Comment("Choose which outputs should be generated")
-	 private Set<EvAnalysisOutput> analysisOutputs = Collections.emptySet();
- 
-	 @Parameter
-	 @Comment("Number of individual time profiles to be created")
-	 @Positive
-	 private int numberOfIndividualTimeProfiles = 50;
+        addDefinition(GeometryFreeZoneSystemParams.SET_NAME, GeometryFreeZoneSystemParams::new,
+                () -> analysisZoneSystemParams,
+                params -> analysisZoneSystemParams = (GeometryFreeZoneSystemParams) params);
+    }
 
-	 @Parameter
-	 @Comment("Interval at which detailed vehicle trajectories are written")
-	 private int writeVehicleTrajectoriesInterval = 0;
- 
-	 @Parameter
-	 @Comment("Interval at which zonal energy demand information is written")
-	 private int writeZonalEnergyDemandInterval = 0;
+    @Nullable
+    private ZoneSystemParams analysisZoneSystemParams;
 
-	 public enum InitialSocBehavior {
-		 Keep, UpdateAfterIteration
-	 }
- 
-	 @Parameter
-	 @Comment("determines whether the resulting SoC at the end of the iteration X is set to be the initial SoC"
-			 + "in iteration X+1 for each EV.")
-	 public InitialSocBehavior initialSocBehavior = InitialSocBehavior.Keep;
- 
-	 public int getChargeTimeStep() {
-		 return chargeTimeStep;
-	 }
- 
-	 public void setChargeTimeStep(int chargeTimeStep) {
-		 this.chargeTimeStep = chargeTimeStep;
-	 }
- 
-	 public int getAuxDischargeTimeStep() {
-		 return auxDischargeTimeStep;
-	 }
- 
-	 public void setAuxDischargeTimeStep(int auxDischargeTimeStep) {
-		 this.auxDischargeTimeStep = auxDischargeTimeStep;
-	 }
- 
-	 public int getMinimumChargeTime() {
-		 return minimumChargeTime;
-	 }
- 
-	 public void setMinimumChargeTime(int minimumChargeTime) {
-		 this.minimumChargeTime = minimumChargeTime;
-	 }
- 
-	 public boolean isEnforceChargingInteractionDuration() {
-		 return enforceChargingInteractionDuration;
-	 }
- 
-	 public void setEnforceChargingInteractionDuration(boolean enforceChargingInteractionDuration) {
-		 this.enforceChargingInteractionDuration = enforceChargingInteractionDuration;
-	 }
- 
-	 public String getChargersFile() {
-		 return chargersFile;
-	 }
- 
-	 public void setChargersFile(String chargersFile) {
-		 this.chargersFile = chargersFile;
-	 }
- 
-	 public Set<EvAnalysisOutput> getAnalysisOutputs() {
-		 return analysisOutputs;
-	 }
- 
-	 public void setAnalysisOutputs(Set<EvAnalysisOutput> analysisOutputs) {
-		 this.analysisOutputs = analysisOutputs;
-	 }
- 
-	 public int getNumberOfIndividualTimeProfiles() {
-		 return numberOfIndividualTimeProfiles;
-	 }
- 
-	 public void setNumberOfIndividualTimeProfiles(int numberOfIndividualTimeProfiles) {
-		 this.numberOfIndividualTimeProfiles = numberOfIndividualTimeProfiles;
-	 }
- 
-	 public InitialSocBehavior getInitialSocBehavior() {
-		 return initialSocBehavior;
-	 }
- 
-	 public void setInitialSocBehavior(InitialSocBehavior initialSocBehavior) {
-		 this.initialSocBehavior = initialSocBehavior;
-	 }	
+    public ZoneSystemParams addOrGetAnalysisZoneSystemParams() {
+        if (analysisZoneSystemParams == null) {
+            ZoneSystemParams params = new SquareGridZoneSystemParams();
+            this.addParameterSet(params);
+        }
 
-	 public int getWriteVehicleTrajectoriesInterval() {
-		return writeVehicleTrajectoriesInterval;
-	 }
+        return analysisZoneSystemParams;
+    }
 
-	 public void setWriteVehicleTrajectoriesInterval(int value) {
-		this.writeVehicleTrajectoriesInterval = value;
-	 }
+    @Parameter
+    @Comment("charging will be simulated every 'chargeTimeStep'-th time step")
+    // no need to simulate with 1-second time step
+    @Positive
+    private int chargeTimeStep = 15; // 15 s ==> 0.417% SOC when charging at 1C (i.e. full recharge in 1 hour)
 
-	 public int getWriteZonalEnergyDemandInterval() {
-		return writeZonalEnergyDemandInterval;
-	 }
+    @Parameter
+    @Comment("AUX discharging will be simulated every 'auxDischargeTimeStep'-th time step")
+    // only used if SeparateAuxDischargingHandler is used, otherwise ignored
+    @Positive
+    private int auxDischargeTimeStep = 60; // 1 min
 
-	 public void setWriteZonalEnergyDemandInterval(int value) {
-		this.writeZonalEnergyDemandInterval = value;
-	 }
- }
- 
+    @Parameter("minChargingTime")
+    @Comment("Minimum activity duration for charging. Used in EvNetwork Routing.")
+    private int minimumChargeTime = 1200;
+
+    @Parameter("enforceChargingInteractionDuration")
+    @Comment("If true, prolongs the charging interaction for the amount of time waiting in the charger queue (plus 1 second), i.e."
+            +
+            "enforces that charging interactions are undertaken as long as initially planned (by EVNetworkRoutingModule). Default is false.")
+    private boolean enforceChargingInteractionDuration = false;
+
+    @Parameter
+    @Comment("Location of the chargers file")
+    @NotNull
+    private String chargersFile = null;
+
+    public enum EvAnalysisOutput {
+        TimeProfiles
+    }
+
+    @Parameter
+    @Comment("Choose which outputs should be generated")
+    private Set<EvAnalysisOutput> analysisOutputs = Collections.emptySet();
+
+    @Parameter
+    @Comment("Number of individual time profiles to be created")
+    @Positive
+    private int numberOfIndividualTimeProfiles = 50;
+
+    @Parameter
+    @Comment("Interval at which detailed vehicle trajectories are written")
+    private int writeVehicleTrajectoriesInterval = 0;
+
+    @Parameter
+    @Comment("Interval at which zonal energy demand information is written")
+    private int writeZonalEnergyDemandInterval = 0;
+
+    public enum InitialSocBehavior {
+        Keep, UpdateAfterIteration
+    }
+
+    @Parameter
+    @Comment("determines whether the resulting SoC at the end of the iteration X is set to be the initial SoC"
+            + "in iteration X+1 for each EV.")
+    public InitialSocBehavior initialSocBehavior = InitialSocBehavior.Keep;
+
+    public int getChargeTimeStep() {
+        return chargeTimeStep;
+    }
+
+    public void setChargeTimeStep(int chargeTimeStep) {
+        this.chargeTimeStep = chargeTimeStep;
+    }
+
+    public int getAuxDischargeTimeStep() {
+        return auxDischargeTimeStep;
+    }
+
+    public void setAuxDischargeTimeStep(int auxDischargeTimeStep) {
+        this.auxDischargeTimeStep = auxDischargeTimeStep;
+    }
+
+    public int getMinimumChargeTime() {
+        return minimumChargeTime;
+    }
+
+    public void setMinimumChargeTime(int minimumChargeTime) {
+        this.minimumChargeTime = minimumChargeTime;
+    }
+
+    public boolean isEnforceChargingInteractionDuration() {
+        return enforceChargingInteractionDuration;
+    }
+
+    public void setEnforceChargingInteractionDuration(boolean enforceChargingInteractionDuration) {
+        this.enforceChargingInteractionDuration = enforceChargingInteractionDuration;
+    }
+
+    public String getChargersFile() {
+        return chargersFile;
+    }
+
+    public void setChargersFile(String chargersFile) {
+        this.chargersFile = chargersFile;
+    }
+
+    public Set<EvAnalysisOutput> getAnalysisOutputs() {
+        return analysisOutputs;
+    }
+
+    public void setAnalysisOutputs(Set<EvAnalysisOutput> analysisOutputs) {
+        this.analysisOutputs = analysisOutputs;
+    }
+
+    public int getNumberOfIndividualTimeProfiles() {
+        return numberOfIndividualTimeProfiles;
+    }
+
+    public void setNumberOfIndividualTimeProfiles(int numberOfIndividualTimeProfiles) {
+        this.numberOfIndividualTimeProfiles = numberOfIndividualTimeProfiles;
+    }
+
+    public InitialSocBehavior getInitialSocBehavior() {
+        return initialSocBehavior;
+    }
+
+    public void setInitialSocBehavior(InitialSocBehavior initialSocBehavior) {
+        this.initialSocBehavior = initialSocBehavior;
+    }
+
+    public int getWriteVehicleTrajectoriesInterval() {
+        return writeVehicleTrajectoriesInterval;
+    }
+
+    public void setWriteVehicleTrajectoriesInterval(int value) {
+        this.writeVehicleTrajectoriesInterval = value;
+    }
+
+    public int getWriteZonalEnergyDemandInterval() {
+        return writeZonalEnergyDemandInterval;
+    }
+
+    public void setWriteZonalEnergyDemandInterval(int value) {
+        this.writeZonalEnergyDemandInterval = value;
+    }
+}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/infrastructure/ChargingInfrastructureModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/infrastructure/ChargingInfrastructureModule.java
@@ -31,6 +31,7 @@ import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
 import org.matsim.utils.objectattributes.AttributeConverter;
 
+import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import com.google.inject.Key;
 import com.google.inject.Provider;
@@ -64,6 +65,9 @@ public final class ChargingInfrastructureModule extends AbstractModule {
 			private Map<Class<?>,AttributeConverter<?>> attributeConverters = Collections.emptyMap();
 
 			public ChargingInfrastructureSpecification get() {
+				// do not replace this by @NotNull inside the config group as people tend to dynamically bind their custom infrastructure
+				Preconditions.checkNotNull(evCfg.getChargersFile(), "Need to specify a chargers file in the ev config group.");
+
 				ChargingInfrastructureSpecification chargingInfrastructureSpecification = new ChargingInfrastructureSpecificationDefaultImpl();
 				
 				ChargerReader reader = new ChargerReader(chargingInfrastructureSpecification);


### PR DESCRIPTION
Some cleanup in the `ev` contrib:
- Clean up indentation in the config group
- Allow `null` chargers path to avoid throwing errors when dynamically binding the infrastructure