### PR TITLE
feat(ev): simplify registration of custom charging infrastructure

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/EvUtils.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/EvUtils.java
@@ -1,0 +1,15 @@
+package org.matsim.contrib.ev;
+
+import org.matsim.contrib.ev.infrastructure.ChargingInfrastructureSpecification;
+import org.matsim.contrib.ev.infrastructure.CustomCharingInfrastructureModule;
+import org.matsim.core.controler.Controler;
+
+public class EvUtils {
+    private EvUtils() {
+    }
+
+    static public void registerInfrastructure(Controler controller,
+            ChargingInfrastructureSpecification infrastructureSpecification) {
+        controller.addOverridingModule(new CustomCharingInfrastructureModule(infrastructureSpecification));
+    }
+}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/infrastructure/CustomCharingInfrastructureModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/infrastructure/CustomCharingInfrastructureModule.java
@@ -1,0 +1,16 @@
+package org.matsim.contrib.ev.infrastructure;
+
+import org.matsim.core.controler.AbstractModule;
+
+public class CustomCharingInfrastructureModule extends AbstractModule {
+    private final ChargingInfrastructureSpecification infrastructureSpecification;
+
+    public CustomCharingInfrastructureModule(ChargingInfrastructureSpecification infrastructureSpecification) {
+        this.infrastructureSpecification = infrastructureSpecification;
+    }
+
+    @Override
+    public void install() {
+        bind(ChargingInfrastructureSpecification.class).toInstance(infrastructureSpecification);
+    }
+}


### PR DESCRIPTION
This is a small PR that adds the helper `EvUtils.registerInfrastructure` that allows registering a custom charging infrastructure that is created on-the-fly with the controller.