### PR TITLE
chore(ev): allow null for charger path

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/EvConfigGroup.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/EvConfigGroup.java
@@ -94,7 +94,6 @@ public final class EvConfigGroup extends ReflectiveConfigGroupWithConfigurablePa
 
     @Parameter
     @Comment("Location of the chargers file")
-    @NotNull
     private String chargersFile = null;
 
     public enum EvAnalysisOutput {


### PR DESCRIPTION
In case, someone provides the chargers via injection.