### PR TITLE
feat(discrete-mode-choice): caching trip candidate by trip and depart…

### DIFF
--- a/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/estimation/CachedTripEstimator.java
+++ b/contribs/discrete_mode_choice/src/main/java/org/matsim/contribs/discrete_mode_choice/model/estimation/CachedTripEstimator.java
@@ -19,7 +19,7 @@ import org.matsim.contribs.discrete_mode_choice.model.trip_based.candidates.Trip
  * @author sebhoerl
  */
 public class CachedTripEstimator implements TripEstimator {
-	final private Map<String, Map<DiscreteModeChoiceTrip, Map<Double, TripCandidate>>> cache = new HashMap<>();
+	final private Map<String, Map<DiscreteModeChoiceTrip, Map<Long, TripCandidate>>> cache = new HashMap<>();
 	final private TripEstimator delegate;
 
 	public CachedTripEstimator(TripEstimator delegate, Collection<String> cachedModes) {
@@ -33,14 +33,15 @@ public class CachedTripEstimator implements TripEstimator {
 	@Override
 	public TripCandidate estimateTrip(Person person, String mode, DiscreteModeChoiceTrip trip,
 			List<TripCandidate> preceedingTrips) {
-		Map<DiscreteModeChoiceTrip, Map<Double, TripCandidate>> modeCache = cache.get(mode);
+		Map<DiscreteModeChoiceTrip, Map<Long, TripCandidate>> modeCache = cache.get(mode);
 
 		if (modeCache != null) {
-			TripCandidate candidate = modeCache.computeIfAbsent(trip, t -> new HashMap<>()).get(trip.getDepartureTime());
+			Long departureTime = Double.valueOf(Math.ceil(trip.getDepartureTime())).longValue();
+			TripCandidate candidate = modeCache.computeIfAbsent(trip, t -> new HashMap<>()).get(departureTime);
 
 			if (candidate == null) {
 				candidate = delegate.estimateTrip(person, mode, trip, preceedingTrips);
-				modeCache.get(trip).put(trip.getDepartureTime(), candidate);
+				modeCache.get(trip).put(departureTime, candidate);
 			}
 
 			return candidate;


### PR DESCRIPTION
See initial feature request at https://github.com/eqasim-org/eqasim-java/issues/126
Also linked to: https://github.com/eqasim-org/eqasim-java/issues/156

It seems to me that it's not needed to explicitly pass the departure time into the estimator, we can just retrieve it from the `DiscreteModeChoice` object that contains the right value when evaluated by the estimator.  In the cache, `DiscreteModeChoice` are hashed using the person index and trip index. 