### PR TITLE
fix(drt): Avoid prebooking of stuck agents

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/prebooking/logic/helpers/PrebookingQueue.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/prebooking/logic/helpers/PrebookingQueue.java
@@ -47,6 +47,11 @@ public class PrebookingQueue implements MobsimBeforeSimStepListener {
 		Map<Id<PassengerGroupIdentifier.PassengerGroup>, List<ScheduledSubmission>> groups = new LinkedHashMap<>();
 		while (!queue.isEmpty() && queue.peek().submissionTime <= time) {
 			var item = queue.poll();
+
+			if(item.agent.getState().equals(MobsimAgent.State.ABORT)) {
+				continue;
+			}
+
 			Optional<Id<PassengerGroupIdentifier.PassengerGroup>> groupId = groupIdentifier.getGroupId((MobsimPassengerAgent) item.agent);
 			if(groupId.isEmpty()) {
 				prebookingManager.prebook(item.agent(), item.leg(), item.departureTime());


### PR DESCRIPTION
I have a use case where agents can have multiple DRT legs in the plan, sometimes even two DRT legs in an intermodal chain.  And not all DRT requests are necessarily prebooked.

Some simulations were crashing at this line of the `PrebookingManager`
```java
Preconditions.checkState(!personLeg.agent().getState().equals(State.ABORT), "Cannot prebook aborted agent");
```

This class manages rejections and agents getting stucked only related to requests that have already been prebooked and not agents stuck for other reasons. 

In this PR, I propose to just check that the agent is not stuck while processing the `PrebookingQueue`. 

**Note**: There is an implication on group requests. If a member of the group is stuck, the rest will carry on normally. 

@sebhoerl , @nkuehnel, what do you think ? 
