### PR TITLE
fix(ev): ignore icvs in trajectory analysis

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/analysis/VehicleTrajectoryListener.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/analysis/VehicleTrajectoryListener.java
@@ -158,6 +158,10 @@ public class VehicleTrajectoryListener implements LinkLeaveEventHandler,
     }
 
     private void pingVehicle(double time, Id<Vehicle> vehicleId, Id<Link> linkId, boolean useFromNode) {
+        if (!electricFleet.getVehicleSpecifications().containsKey(vehicleId)) {
+            return;
+        }
+
         Link link = network.getLinks().get(linkId);
         Coord location = useFromNode ? link.getFromNode().getCoord() : link.getToNode().getCoord();
 


### PR DESCRIPTION
This fix stops writing out the energy trajectory of non-electric vehicles (which were filled with useless NaN values).