### PR TITLE
fix(ev): activate charger writer

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/infrastructure/ChargingInfrastructureModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/infrastructure/ChargingInfrastructureModule.java
@@ -57,6 +57,8 @@ public final class ChargingInfrastructureModule extends AbstractModule {
 		bind(ChargingInfrastructureSpecification.class)
 				.toProvider(XmlChargingInfrasturcutreSpecificationProvider.class);
 
+		addControllerListenerBinding().to(ChargerWriterListener.class);
+
 		installQSimModule(new AbstractQSimModule() {
 			@Override
 			protected void configureQSim() {


### PR DESCRIPTION
Previously, the charger writer was present but didn't actually write out the chargers at the requested iterations / at the end of the simulation.