### PR TITLE
feat(ev): helper for loading a scenario with sevc

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/StrategicChargingUtils.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/StrategicChargingUtils.java
@@ -2,13 +2,17 @@ package org.matsim.contrib.ev.strategic;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.contrib.ev.EvConfigGroup;
 import org.matsim.contrib.ev.EvModule;
@@ -21,6 +25,8 @@ import org.matsim.contrib.ev.strategic.costs.TariffBasedChargingCostCalculator;
 import org.matsim.contrib.ev.strategic.infrastructure.FacilityChargerProvider;
 import org.matsim.contrib.ev.strategic.infrastructure.PersonChargerProvider;
 import org.matsim.contrib.ev.strategic.infrastructure.PublicChargerProvider;
+import org.matsim.contrib.ev.strategic.plan.ChargingPlans;
+import org.matsim.contrib.ev.strategic.plan.ChargingPlansConverter;
 import org.matsim.contrib.ev.strategic.replanning.StrategicChargingReplanningStrategy;
 import org.matsim.contrib.ev.strategic.replanning.innovator.RandomChargingPlanInnovator;
 import org.matsim.contrib.ev.strategic.reservation.StrategicChargingReservationEngine;
@@ -34,7 +40,9 @@ import org.matsim.core.config.Config;
 import org.matsim.core.config.groups.ReplanningConfigGroup.StrategySettings;
 import org.matsim.core.config.groups.ScoringConfigGroup.ActivityParams;
 import org.matsim.core.controler.Controler;
+import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.facilities.ActivityFacility;
+import org.matsim.utils.objectattributes.AttributeConverter;
 import org.matsim.utils.objectattributes.attributable.Attributable;
 import org.matsim.vehicles.Vehicle;
 
@@ -403,5 +411,45 @@ public class StrategicChargingUtils {
      */
     static public Double getReservationSlack(Person person) {
         return StrategicChargingReservationEngine.getReservationSlack(person);
+    }
+
+    /**
+     * Helper to obtain a map of attribute converters
+     */
+    static public Map<Class<?>, AttributeConverter<?>> getAttributeConverters() {
+        return Collections.singletonMap(ChargingPlans.class, new ChargingPlansConverter());
+    }
+
+    /**
+     * Helper that wraps around ScenarioUtils.loadScenario
+     */
+    static public Scenario loadScenario(Config config, Map<Class<?>, AttributeConverter<?>> converters) {
+        Map<Class<?>, AttributeConverter<?>> extendedConverters = new HashMap<>();
+        extendedConverters.putAll(getAttributeConverters());
+        extendedConverters.putAll(converters);
+
+        return ScenarioUtils.loadScenario(config, extendedConverters);
+    }
+
+    /**
+     * Helper that wraps around ScenarioUtils.loadScenario
+     */
+    static public Scenario loadScenario(Scenario scenario, Map<Class<?>, AttributeConverter<?>> converters) {
+        return ScenarioUtils.loadScenario(scenario.getConfig(),
+                Collections.singletonMap(ChargingPlans.class, new ChargingPlansConverter()));
+    }
+
+    /**
+     * Helper that wraps around ScenarioUtils.loadScenario
+     */
+    static public Scenario loadScenario(Config config) {
+        return loadScenario(config, Collections.emptyMap());
+    }
+
+    /**
+     * Helper that wraps around ScenarioUtils.loadScenario
+     */
+    static public Scenario loadScenario(Scenario scenario) {
+        return loadScenario(scenario, Collections.emptyMap());
     }
 }


### PR DESCRIPTION
This PR adds some helper functions. They are useful for loading a scenario in which a startegic ev charging simulation has already been run (i.e., restarting a simulation run based on output plans). The main issue is that the AttributeConverter for the charging plans needs to be communicated to the ScenarioLoader in that case.