### PR TITLE
fix: bind ChargingInfrastructureSpecification as singelton

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/infrastructure/ChargingInfrastructureModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/infrastructure/ChargingInfrastructureModule.java
@@ -55,7 +55,7 @@ public final class ChargingInfrastructureModule extends AbstractModule {
 		bind(Network.class).annotatedWith(Names.named(CHARGERS)).to(networkKey).asEagerSingleton();
 
 		bind(ChargingInfrastructureSpecification.class)
-				.toProvider(XmlChargingInfrasturcutreSpecificationProvider.class);
+				.toProvider(XmlChargingInfrasturcutreSpecificationProvider.class).asEagerSingleton();
 
 		addControllerListenerBinding().to(ChargerWriterListener.class);
 


### PR DESCRIPTION
This PR binds the ChargingInfrastructureSpecification again as a singelton, like it was before #4432 