### PR TITLE
build(deps): bump io.aeron:aeron-all from 1.47.7 to 1.48.10

### DIFF
--- a/contribs/distributed-simulation/pom.xml
+++ b/contribs/distributed-simulation/pom.xml
@@ -15,7 +15,7 @@
 	<description>Provides communication implementations for distributed simulations on multiple jvms.</description>
 
 	<properties>
-		<aeron.version>1.47.7</aeron.version>
+		<aeron.version>1.48.10</aeron.version>
 		<hazelcast.version>5.6.0</hazelcast.version>
 
 		<!-- Use -DskipShaded=false to build a executable jar. -->


### PR DESCRIPTION
stacked on [build(deps): bump io.aeron:aeron-all from 1.46.9 to 1.47.7 (#4508)](https://github.com/matsim-org/matsim-libs/pull/4508)

It seems, there were no changes required to accomodate the breaking changes in the [Aeron 1.48.x Changelog](https://github.com/aeron-io/aeron/wiki/Change-Log#1480-2025-06-03) and the [Agrona 2.3.0 Changelog](https://github.com/aeron-io/agrona/releases/tag/2.3.0)

