### PR TITLE
build(deps): bump io.aeron:aeron-all from 1.48.10 to 1.49.1

### DIFF
--- a/contribs/distributed-simulation/pom.xml
+++ b/contribs/distributed-simulation/pom.xml
@@ -15,7 +15,7 @@
 	<description>Provides communication implementations for distributed simulations on multiple jvms.</description>
 
 	<properties>
-		<aeron.version>1.48.10</aeron.version>
+		<aeron.version>1.49.1</aeron.version>
 		<hazelcast.version>5.6.0</hazelcast.version>
 
 		<!-- Use -DskipShaded=false to build a executable jar. -->


### PR DESCRIPTION
stacked on [build(deps): bump io.aeron:aeron-all from 1.47.7 to 1.48.10 #4509](https://github.com/matsim-org/matsim-libs/pull/4509)