### PR TITLE
build(deps): bump burnett01/rsync-deployments from 8.0.2 to v8 in the github-actions group

### DIFF
--- a/.github/workflows/deploy-dtds.yaml
+++ b/.github/workflows/deploy-dtds.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: rsync dtds
-        uses: burnett01/rsync-deployments@8.0.2
+        uses: burnett01/rsync-deployments@v8
         with:
           switches: -avz
           path: matsim/src/main/resources/dtd/


### PR DESCRIPTION
https://github.com/Burnett01/rsync-deployments/releases/tag/v8