### PR TITLE
fix(drt): fix adaptive prebooking logic

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/prebooking/logic/AdaptivePrebookingLogic.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/prebooking/logic/AdaptivePrebookingLogic.java
@@ -10,6 +10,7 @@ import org.matsim.contrib.drt.prebooking.PrebookingManager;
 import org.matsim.contrib.drt.prebooking.logic.helpers.PrebookingQueue;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.dvrp.run.AbstractDvrpModeQSimModule;
+import org.matsim.contrib.dynagent.DynAgent;
 import org.matsim.core.controler.Controler;
 import org.matsim.core.events.MobsimScopeEventHandler;
 import org.matsim.core.mobsim.framework.MobsimAgent;
@@ -26,7 +27,7 @@ import com.google.common.base.Preconditions;
  * whether there is a DRT leg coming up before the next main (non-stage)
  * activity. If so, the upcoming leg is prebooked in advance with the
  * submissionSlack parameter defining how much in advance.
- * 
+ *
  * @author Sebastian Hörl (sebhoerl), IRT SystemX
  */
 public class AdaptivePrebookingLogic implements PrebookingLogic, ActivityStartEventHandler, MobsimScopeEventHandler {
@@ -40,7 +41,7 @@ public class AdaptivePrebookingLogic implements PrebookingLogic, ActivityStartEv
 	private final double submissionSlack;
 
 	private AdaptivePrebookingLogic(String mode, QSim qsim, PrebookingManager prebookingManager,
-			PrebookingQueue prebookingQueue, TimeInterpretation timeInterpretation, double submissionSlack) {
+									PrebookingQueue prebookingQueue, TimeInterpretation timeInterpretation, double submissionSlack) {
 		this.prebookingManager = prebookingManager;
 		this.prebookingQueue = prebookingQueue;
 		this.qsim = qsim;
@@ -52,6 +53,9 @@ public class AdaptivePrebookingLogic implements PrebookingLogic, ActivityStartEv
 	@Override
 	public void handleEvent(ActivityStartEvent event) {
 		MobsimAgent agent = qsim.getAgents().get(event.getPersonId());
+		if(agent instanceof DynAgent) {
+			return;
+		}
 
 		Plan plan = WithinDayAgentUtils.getModifiablePlan(agent);
 		int planElementIndex = WithinDayAgentUtils.getCurrentPlanElementIndex(agent);


### PR DESCRIPTION
Skip DynAgents (ie drt driver agents) in adaptive prebooking logic, as they should not be touched and the simulation crashes with

Caused by: java.lang.RuntimeException: Sorry, agent is from type class org.matsim.contrib.dynagent.DynAgent which does not support getModifiablePlan(...). Aborting!
	at org.matsim.core.mobsim.qsim.agents.WithinDayAgentUtils.getModifiablePlan(WithinDayAgentUtils.java:162)
	at org.matsim.contrib.drt.prebooking.logic.AdaptivePrebookingLogic.handleEvent(AdaptivePrebookingLogic.java:60)
	at org.matsim.core.events.EventsManagerImpl.callHandlerFast(EventsManagerImpl.java:272)
	at org.matsim.core.events.EventsManagerImpl.processEvent(EventsManagerImpl.java:120)

@sebhoerl I'm afraid the adaptive logic does not seem to work when the first trip is a drt trip, because the first activity in a plan doesn't throw an activity start event and thus the prebooking is never applied :/ 

I'm not sure how this would be fixed best
