### PR TITLE
feat(ev): a basic charger placement algorithm

### DIFF
--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/extensions/placement/ChargerPlacement.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/extensions/placement/ChargerPlacement.java
@@ -1,0 +1,19 @@
+package org.matsim.contrib.ev.extensions.placement;
+
+import org.matsim.contrib.ev.infrastructure.ChargerSpecification;
+
+public class ChargerPlacement {
+    static public final String REMOVABLE_ATTRIBUTE = "chargerPlacement:isRemovable";
+
+    private ChargerPlacement() {
+    }
+
+    static public void setRemovable(ChargerSpecification charger, boolean isRemovable) {
+        charger.getAttributes().putAttribute(REMOVABLE_ATTRIBUTE, isRemovable);
+    }
+
+    static public boolean isRemovable(ChargerSpecification charger) {
+        Boolean isRemovable = (Boolean) charger.getAttributes().getAttribute(REMOVABLE_ATTRIBUTE);
+        return isRemovable != null && isRemovable;
+    }
+}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/extensions/placement/ChargerPlacementAccess.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/extensions/placement/ChargerPlacementAccess.java
@@ -1,0 +1,37 @@
+package org.matsim.contrib.ev.extensions.placement;
+
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.contrib.ev.infrastructure.Charger;
+import org.matsim.contrib.ev.infrastructure.ChargerSpecification;
+import org.matsim.contrib.ev.strategic.access.ChargerAccess;
+
+/**
+ * Wraps around the base ChargerAccess to forbid access to blacklisted chargers
+ */
+public class ChargerPlacementAccess implements ChargerAccess {
+    private final ChargerPlacementManager manager;
+    private final ChargerAccess delegate;
+
+    public ChargerPlacementAccess(ChargerPlacementManager manager, ChargerAccess delegate) {
+        this.manager = manager;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean hasAccess(Person person, Charger charger) {
+        if (manager.isBlacklisted(charger.getId())) {
+            return false;
+        }
+
+        return delegate.hasAccess(person, charger);
+    }
+
+    @Override
+    public boolean hasAccess(Person person, ChargerSpecification charger) {
+        if (manager.isBlacklisted(charger.getId())) {
+            return false;
+        }
+
+        return delegate.hasAccess(person, charger);
+    }
+}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/extensions/placement/ChargerPlacementCollector.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/extensions/placement/ChargerPlacementCollector.java
@@ -1,0 +1,58 @@
+package org.matsim.contrib.ev.extensions.placement;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.IdMap;
+import org.matsim.api.core.v01.IdSet;
+import org.matsim.api.core.v01.events.PersonMoneyEvent;
+import org.matsim.api.core.v01.events.handler.PersonMoneyEventHandler;
+import org.matsim.contrib.ev.charging.EnergyChargedEvent;
+import org.matsim.contrib.ev.charging.EnergyChargedEventHandler;
+import org.matsim.contrib.ev.infrastructure.Charger;
+import org.matsim.contrib.ev.strategic.scoring.ChargingPlanScoring;
+
+/**
+ * Collects information on the chargers that will be used for placement
+ */
+public class ChargerPlacementCollector implements EnergyChargedEventHandler, PersonMoneyEventHandler {
+    private final IdMap<Charger, Double> energy = new IdMap<>(Charger.class);
+    private final IdMap<Charger, Double> revenue = new IdMap<>(Charger.class);
+    private final IdSet<Charger> used = new IdSet<>(Charger.class);
+
+    @Override
+    public void handleEvent(EnergyChargedEvent event) {
+        energy.compute(event.getChargerId(), (id, val) -> {
+            return (val == null ? 0.0 : val) + event.getEnergy();
+        });
+
+        used.add(event.getChargerId());
+    }
+
+    @Override
+    public void handleEvent(PersonMoneyEvent event) {
+        if (event.getPurpose().equals(ChargingPlanScoring.MONEY_EVENT_PURPOSE)) {
+            Id<Charger> chargerId = Id.create(event.getTransactionPartner(), Charger.class);
+
+            revenue.compute(chargerId, (id, val) -> {
+                return (val == null ? 0.0 : val) + event.getAmount();
+            });
+        }
+    }
+
+    public double getEnergy(Id<Charger> chargerId) {
+        return energy.getOrDefault(chargerId, 0.0);
+    }
+
+    public double getRevenue(Id<Charger> chargerId) {
+        return revenue.getOrDefault(chargerId, 0.0);
+    }
+
+    public boolean isUsed(Id<Charger> chargerId) {
+        return used.contains(chargerId);
+    }
+
+    public void clear() {
+        energy.clear();
+        revenue.clear();
+        used.clear();
+    }
+}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/extensions/placement/ChargerPlacementConfigGroup.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/extensions/placement/ChargerPlacementConfigGroup.java
@@ -1,0 +1,82 @@
+package org.matsim.contrib.ev.extensions.placement;
+
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ReflectiveConfigGroup;
+
+public class ChargerPlacementConfigGroup extends ReflectiveConfigGroup {
+    static public final String CONFIG_GROUP = "ev:charger_placement";
+
+    public ChargerPlacementConfigGroup() {
+        super(CONFIG_GROUP);
+    }
+
+    @Parameter
+    private double blacklistPenalty = -1e3;
+
+    @Parameter
+    private int removalInterval = 10;
+
+    @Parameter
+    private double removalQuantile = 0.01;
+
+    @Parameter
+    private boolean removeUnused = true;
+
+    public enum ChargerPlacementObjective {
+        Revenue, Energy
+    }
+
+    private ChargerPlacementObjective objective = ChargerPlacementObjective.Energy;
+
+    public double getBlacklistPenalty() {
+        return blacklistPenalty;
+    }
+
+    public void setBlacklistPenalty(double blacklistPenalty) {
+        this.blacklistPenalty = blacklistPenalty;
+    }
+
+    public int getRemovalInterval() {
+        return removalInterval;
+    }
+
+    public void setRemovalInterval(int removalInterval) {
+        this.removalInterval = removalInterval;
+    }
+
+    public double getRemovalQuantile() {
+        return removalQuantile;
+    }
+
+    public void setRemovalQuantile(double removalQuantile) {
+        this.removalQuantile = removalQuantile;
+    }
+
+    public boolean getRemoveUnused() {
+        return removeUnused;
+    }
+
+    public void setRemoveUnused(boolean removeUnused) {
+        this.removeUnused = removeUnused;
+    }
+
+    public ChargerPlacementObjective getObjective() {
+        return objective;
+    }
+
+    public void setObjective(ChargerPlacementObjective objective) {
+        this.objective = objective;
+    }
+
+    static public ChargerPlacementConfigGroup get(Config config, boolean create) {
+        ChargerPlacementConfigGroup placementConfig = (ChargerPlacementConfigGroup) config.getModules()
+                .get(CONFIG_GROUP);
+
+        if (placementConfig == null && create) {
+            placementConfig = new ChargerPlacementConfigGroup();
+            config.addModule(placementConfig);
+        }
+
+        return placementConfig;
+    }
+}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/extensions/placement/ChargerPlacementListener.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/extensions/placement/ChargerPlacementListener.java
@@ -1,0 +1,99 @@
+package org.matsim.contrib.ev.extensions.placement;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+
+import org.matsim.contrib.ev.charging.ChargingStartEvent;
+import org.matsim.contrib.ev.charging.ChargingStartEventHandler;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.controler.OutputDirectoryHierarchy;
+import org.matsim.core.controler.events.IterationEndsEvent;
+import org.matsim.core.controler.events.IterationStartsEvent;
+import org.matsim.core.controler.events.ShutdownEvent;
+import org.matsim.core.controler.events.StartupEvent;
+import org.matsim.core.controler.listener.IterationEndsListener;
+import org.matsim.core.controler.listener.IterationStartsListener;
+import org.matsim.core.controler.listener.ShutdownListener;
+import org.matsim.core.controler.listener.StartupListener;
+import org.matsim.core.utils.io.IOUtils;
+
+/**
+ * Information on charger placement
+ */
+public class ChargerPlacementListener implements StartupListener, ShutdownListener, IterationStartsListener,
+        IterationEndsListener, ChargingStartEventHandler {
+    private static final String OUTPUT_FILE = "ev_charger_placement_status.csv";
+
+    private final OutputDirectoryHierarchy outputDirectoryHierarchy;
+    private final EventsManager eventsManager;
+    private final ChargerPlacementManager chargerManager;
+
+    public ChargerPlacementListener(ChargerPlacementManager chargerManager, EventsManager eventsManager,
+            OutputDirectoryHierarchy outputDirectoryHierarchy) {
+        this.chargerManager = chargerManager;
+        this.eventsManager = eventsManager;
+        this.outputDirectoryHierarchy = outputDirectoryHierarchy;
+    }
+
+    private BufferedWriter writer;
+
+    @Override
+    public void notifyStartup(StartupEvent event) {
+        try {
+            String path = outputDirectoryHierarchy.getOutputFilename(OUTPUT_FILE);
+            writer = IOUtils.getBufferedWriter(path);
+
+            writer.write(String.join(";", new String[] {
+                    "iteration", "charging_events", "blacklisted_events", "chargers", "blacklisted_chargers"
+            }) + "\n");
+
+            writer.flush();
+        } catch (IOException e) {
+        }
+    }
+
+    private int chargingEvents = 0;
+    private int blacklistedEvents = 0;
+
+    @Override
+    public void notifyIterationStarts(IterationStartsEvent event) {
+        eventsManager.addHandler(this);
+
+        chargingEvents = 0;
+        blacklistedEvents = 0;
+    }
+
+    @Override
+    public void handleEvent(ChargingStartEvent event) {
+        chargingEvents++;
+
+        if (chargerManager.isBlacklisted(event.getChargerId())) {
+            blacklistedEvents++;
+        }
+    }
+
+    @Override
+    public void notifyIterationEnds(IterationEndsEvent event) {
+        eventsManager.removeHandler(this);
+
+        try {
+            writer.write(String.join(";", new String[] {
+                    String.valueOf(event.getIteration()), String.valueOf(chargingEvents),
+                    String.valueOf(blacklistedEvents),
+                    String.valueOf(chargerManager.getChargers().size()),
+                    String.valueOf(chargerManager.getBlacklist().size())
+            }) + "\n");
+
+            writer.flush();
+        } catch (IOException e) {
+        }
+    }
+
+    @Override
+    public void notifyShutdown(ShutdownEvent event) {
+        try {
+            writer.close();
+        } catch (IOException e) {
+        }
+    }
+}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/extensions/placement/ChargerPlacementManager.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/extensions/placement/ChargerPlacementManager.java
@@ -1,0 +1,179 @@
+package org.matsim.contrib.ev.extensions.placement;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.ev.extensions.placement.ChargerPlacementConfigGroup.ChargerPlacementObjective;
+import org.matsim.contrib.ev.infrastructure.Charger;
+import org.matsim.contrib.ev.infrastructure.ChargerSpecification;
+import org.matsim.contrib.ev.infrastructure.ChargingInfrastructureSpecification;
+import org.matsim.core.controler.OutputDirectoryHierarchy;
+import org.matsim.core.controler.events.IterationStartsEvent;
+import org.matsim.core.controler.listener.IterationStartsListener;
+import org.matsim.core.utils.io.IOUtils;
+
+public class ChargerPlacementManager implements IterationStartsListener {
+    private static final String OUTPUT_FILE = "ev_charger_placement.csv.gz";
+    private static final String OBJECTIVE_OUTPUT_FILE = "ev_charger_placement_objectives.csv.gz";
+
+    private final List<ChargerSpecification> chargers = new LinkedList<>();
+    private final Map<Id<Charger>, Integer> blacklist = new HashMap<>();
+
+    private final OutputDirectoryHierarchy outputDirectoryHierarchy;
+    private final Network network;
+
+    private final ChargerPlacementCollector collector;
+
+    private final int interval;
+    private final double removalQuantile;
+    private final boolean removeUnused;
+    private final ChargerPlacementObjective objective;
+
+    public ChargerPlacementManager(ChargingInfrastructureSpecification infrastructure,
+            OutputDirectoryHierarchy outputDirectoryHierarchy, ChargerPlacementCollector collector, Network network,
+            int interval,
+            double removalQuantile, boolean removeUnused, ChargerPlacementObjective objective) {
+        this.outputDirectoryHierarchy = outputDirectoryHierarchy;
+        this.network = network;
+        this.collector = collector;
+        this.interval = interval;
+        this.removalQuantile = removalQuantile;
+        this.removeUnused = removeUnused;
+        this.objective = objective;
+
+        for (ChargerSpecification charger : infrastructure.getChargerSpecifications().values()) {
+            if (ChargerPlacement.isRemovable(charger)) {
+                this.chargers.add(charger);
+            }
+        }
+    }
+
+    public boolean isBlacklisted(Id<Charger> chargerId) {
+        return blacklist.containsKey(chargerId);
+    }
+
+    public Set<Id<Charger>> getBlacklist() {
+        return blacklist.keySet();
+    }
+
+    @Override
+    public void notifyIterationStarts(IterationStartsEvent event) {
+        writeObjectives(event.getIteration());
+
+        if (event.getIteration() > 0 && event.getIteration() % interval == 0) {
+            List<ChargerRecord> sorted = switch (objective) {
+                case Revenue -> collect(collector::getRevenue);
+                case Energy -> collect(collector::getEnergy);
+            };
+
+            if (removeUnused) {
+                Iterator<ChargerRecord> iterator = sorted.iterator();
+
+                while (iterator.hasNext()) {
+                    ChargerRecord record = iterator.next();
+
+                    if (!collector.isUsed(record.chargerId)) {
+                        iterator.remove();
+                        blacklist.put(record.chargerId, event.getIteration());
+                    }
+                }
+            }
+
+            if (sorted.size() > 0) {
+                int remove = Math.max(1, (int) Math.floor(removalQuantile * sorted.size()));
+
+                for (int k = 0; k < remove; k++) {
+                    blacklist.put(sorted.get(k).chargerId(), event.getIteration());
+                }
+            }
+
+            writeChargers(event.getIteration());
+            collector.clear();
+        }
+    }
+
+    private void writeChargers(int iteration) {
+        try {
+            String outputPath = outputDirectoryHierarchy.getOutputFilename(OUTPUT_FILE);
+
+            BufferedWriter writer = IOUtils.getBufferedWriter(outputPath);
+
+            writer.write(String.join(";", new String[] {
+                    "charger_id", "link_id", "x", "y", "blacklisted", "iteration"
+            }) + "\n");
+
+            for (ChargerSpecification charger : chargers) {
+                Link link = network.getLinks().get(charger.getLinkId());
+
+                writer.write(String.join(";", new String[] {
+                        charger.getId().toString(), //
+                        link.getId().toString(), //
+                        String.valueOf(link.getCoord().getX()), //
+                        String.valueOf(link.getCoord().getY()), //
+                        String.valueOf(blacklist.containsKey(charger.getId())), //
+                        String.valueOf(blacklist.getOrDefault(charger.getId(), 0)) //
+                }) + "\n");
+            }
+
+            writer.close();
+        } catch (IOException e) {
+        }
+    }
+
+    private void writeObjectives(int iteration) {
+        try {
+            String outputPath = outputDirectoryHierarchy.getIterationFilename(iteration, OBJECTIVE_OUTPUT_FILE);
+
+            BufferedWriter writer = IOUtils.getBufferedWriter(outputPath);
+
+            writer.write(String.join(";", new String[] {
+                    "charger_id", "used", "revenue", "energy"
+            }) + "\n");
+
+            for (ChargerSpecification charger : chargers) {
+                writer.write(String.join(";", new String[] {
+                        charger.getId().toString(), //
+                        String.valueOf(collector.isUsed(charger.getId())), //
+                        String.valueOf(collector.getRevenue(charger.getId())), //
+                        String.valueOf(collector.getEnergy(charger.getId())) //
+                }) + "\n");
+            }
+
+            writer.close();
+        } catch (IOException e) {
+        }
+    }
+
+    private record ChargerRecord(Id<Charger> chargerId, double objective) {
+    }
+
+    private List<ChargerRecord> collect(Function<Id<Charger>, Double> objectiveFunction) {
+        List<ChargerRecord> records = new LinkedList<>();
+
+        for (ChargerSpecification charger : chargers) {
+            if (!blacklist.containsKey(charger.getId())) {
+                records.add(new ChargerRecord(charger.getId(), objectiveFunction.apply(charger.getId())));
+            }
+        }
+
+        Collections.sort(records, Comparator.comparing(ChargerRecord::objective));
+
+        return records;
+    }
+
+    public List<ChargerSpecification> getChargers() {
+        return chargers;
+    }
+}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/extensions/placement/ChargerPlacementModule.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/extensions/placement/ChargerPlacementModule.java
@@ -1,0 +1,79 @@
+package org.matsim.contrib.ev.extensions.placement;
+
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.contrib.ev.infrastructure.ChargingInfrastructureSpecification;
+import org.matsim.contrib.ev.strategic.access.AttributeBasedChargerAccess;
+import org.matsim.contrib.ev.strategic.access.ChargerAccess;
+import org.matsim.contrib.ev.strategic.access.SubscriptionRegistry;
+import org.matsim.contrib.ev.strategic.scoring.ChargingPlanScoring;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.controler.AbstractModule;
+import org.matsim.core.controler.OutputDirectoryHierarchy;
+import org.matsim.core.mobsim.qsim.AbstractQSimModule;
+
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+
+/**
+ * Enables charger placement
+ */
+public class ChargerPlacementModule extends AbstractModule {
+    @Override
+    public void install() {
+        ChargerPlacementConfigGroup placementConfig = ChargerPlacementConfigGroup.get(getConfig(), false);
+
+        if (placementConfig != null) {
+            addControllerListenerBinding().to(ChargerPlacementManager.class);
+            addControllerListenerBinding().to(ChargerPlacementListener.class);
+            addEventHandlerBinding().to(ChargerPlacementCollector.class);
+
+            bind(ChargerAccess.class).to(ChargerPlacementAccess.class);
+
+            installOverridingQSimModule(new AbstractQSimModule() {
+                @Override
+                protected void configureQSim() {
+                    addMobsimScopeEventHandlerBinding().to(ChargerPlacementScorer.class);
+                }
+
+                @Provides
+                @Singleton
+                ChargerPlacementScorer provideChargerPlacementScorer(ChargerPlacementManager manager,
+                        ChargingPlanScoring scoring) {
+                    return new ChargerPlacementScorer(manager, scoring, placementConfig.getBlacklistPenalty());
+                }
+            });
+        }
+    }
+
+    @Provides
+    @Singleton
+    ChargerPlacementAccess provideChargerPlacementAccess(ChargerPlacementManager manager,
+            SubscriptionRegistry subscriptionRegistry) {
+        ChargerAccess delegate = new AttributeBasedChargerAccess(subscriptionRegistry);
+        return new ChargerPlacementAccess(manager, delegate);
+    }
+
+    @Provides
+    @Singleton
+    ChargerPlacementCollector provideChargerPlacementCollector() {
+        return new ChargerPlacementCollector();
+    }
+
+    @Provides
+    @Singleton
+    ChargerPlacementListener provideChargerPlacementListener(ChargerPlacementManager chargerManager,
+            EventsManager eventsManager, OutputDirectoryHierarchy outputDirectoryHierarchy) {
+        return new ChargerPlacementListener(chargerManager, eventsManager, outputDirectoryHierarchy);
+    }
+
+    @Provides
+    @Singleton
+    ChargerPlacementManager provideChargerPlacementManager(ChargingInfrastructureSpecification infrastructure,
+            OutputDirectoryHierarchy outputDirectoryHierarchy, ChargerPlacementCollector collector, Network network,
+            ChargerPlacementConfigGroup placementConfig) {
+        return new ChargerPlacementManager(infrastructure, outputDirectoryHierarchy, collector, network,
+                placementConfig.getRemovalInterval(),
+                placementConfig.getRemovalQuantile(), placementConfig.getRemoveUnused(),
+                placementConfig.getObjective());
+    }
+}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/extensions/placement/ChargerPlacementScorer.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/extensions/placement/ChargerPlacementScorer.java
@@ -1,0 +1,30 @@
+package org.matsim.contrib.ev.extensions.placement;
+
+import org.matsim.contrib.ev.charging.ChargingStartEvent;
+import org.matsim.contrib.ev.charging.ChargingStartEventHandler;
+import org.matsim.contrib.ev.strategic.scoring.ChargingPlanScoring;
+import org.matsim.core.events.MobsimScopeEventHandler;
+
+/**
+ * Outscoring blacklisted chargers
+ */
+public class ChargerPlacementScorer implements ChargingStartEventHandler, MobsimScopeEventHandler {
+    private final ChargerPlacementManager manager;
+    private final ChargingPlanScoring scoring;
+
+    private final double penalty;
+
+    public ChargerPlacementScorer(ChargerPlacementManager manager, ChargingPlanScoring scoring, double penalty) {
+        this.manager = manager;
+        this.scoring = scoring;
+        this.penalty = penalty;
+    }
+
+    @Override
+    public void handleEvent(ChargingStartEvent event) {
+        if (manager.isBlacklisted(event.getChargerId())) {
+            scoring.addScoreForVehicle(event.getVehicleId(), penalty);
+            scoring.trackScoreForVehicle(event.getTime(), event.getVehicleId(), "placement", penalty, penalty);
+        }
+    }
+}

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/scoring/ChargingPlanScoring.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/strategic/scoring/ChargingPlanScoring.java
@@ -170,7 +170,7 @@ public class ChargingPlanScoring implements IterationStartsListener, ScoringList
 		eventsManager.addHandler(this);
 	}
 
-	private void addScoreForPerson(Id<Person> personId, double score) {
+	public void addScoreForPerson(Id<Person> personId, double score) {
 		if (score != 0.0) {
 			AtomicDouble item = scores.get(personId);
 
@@ -186,7 +186,7 @@ public class ChargingPlanScoring implements IterationStartsListener, ScoringList
 		}
 	}
 
-	private void addScoreForVehicle(Id<Vehicle> vehicleId, double score) {
+	public void addScoreForVehicle(Id<Vehicle> vehicleId, double score) {
 		Id<Person> personId = getPerson(vehicleId);
 
 		if (personId != null) {


### PR DESCRIPTION
This PR introduces a simple charger placement algorithm. The idea is to define a large initial set of chargers and then gradually remove them. 

The process (in which iterations to remove, how many by quantile to remove, which objective between revenue and energy) is activated by adding the `ChargerPlacementConfigGroup` and then the `ChargerPlacementModule` to the controller.

Removable chargers need to be tagged by using `ChargerPlacement.setRemovable(chargerSpecification, true)`.