### PR TITLE
refactor(core): Simplify take while

### DIFF
--- a/matsim/src/main/java/org/matsim/core/population/routes/RouteUtils.java
+++ b/matsim/src/main/java/org/matsim/core/population/routes/RouteUtils.java
@@ -269,7 +269,7 @@ public class RouteUtils {
 				// we need to include the last link id, so set the flag to false when we find it
 				// as takeWhile is exclusive
 				if (id.equals(exitLinkId)) {
-					continueTake.set(false);
+					return continueTake.getAndSet(false);
 				}
 				return continueTake.get();
 			})


### PR DESCRIPTION
I overengineered the `takeWhile` construct inside `calcDistance` with an inner class. Use a boolean flag and a lambda function instead.