### PR TITLE
fix(deps): remove version definition for jackson-annotations

### DIFF
--- a/contribs/drt-extensions/pom.xml
+++ b/contribs/drt-extensions/pom.xml
@@ -162,7 +162,6 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.20</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/contribs/simwrapper/pom.xml
+++ b/contribs/simwrapper/pom.xml
@@ -119,7 +119,6 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.20</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
This should be controlled by the jackson-bom definition in the contribs pom.xml