### PR TITLE
fix(deps): remove only occurrence of jboss logging in favor of log4j

### DIFF
--- a/matsim/pom.xml
+++ b/matsim/pom.xml
@@ -334,11 +334,6 @@
 			<artifactId>commons-io</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.jboss.logging</groupId>
-			<artifactId>jboss-logging</artifactId>
-			<version>3.6.1.Final</version>
-		</dependency>
-		<dependency>
 			<groupId>com.google.errorprone</groupId>
 			<artifactId>error_prone_annotations</artifactId>
 			<version>2.46.0</version>

--- a/matsim/src/main/java/org/matsim/core/replanning/conflicts/WorstPlanForRemovalSelectorWithConflicts.java
+++ b/matsim/src/main/java/org/matsim/core/replanning/conflicts/WorstPlanForRemovalSelectorWithConflicts.java
@@ -24,7 +24,8 @@ import java.util.Collections;
 import java.util.LinkedList;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.jboss.logging.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.population.HasPlansAndId;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Plan;
@@ -45,7 +46,7 @@ import com.google.inject.Inject;
 public class WorstPlanForRemovalSelectorWithConflicts implements PlanSelector<Plan, Person> {
 	public static final String SELECTOR_NAME = "WorstPlanForRemovalSelectorWithConflicts";
 
-	private final Logger logger = Logger.getLogger(WorstPlanForRemovalSelectorWithConflicts.class);
+	private final Logger logger = LogManager.getLogger(WorstPlanForRemovalSelectorWithConflicts.class);
 
 	private final ConflictManager conflictManager;
 


### PR DESCRIPTION
This change removes the only (presumably accidental) usage of jboss logging and replaces it with the usual log4j Logger. This reduces the dependency footprint of MATSim.