### PR TITLE
fix(drt): calculate time detour using ride time in DrtAnalysisControl…

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/analysis/DrtAnalysisControlerListener.java
@@ -650,7 +650,9 @@ public class DrtAnalysisControlerListener implements IterationEndsListener, Shut
 			}
 
 			double distanceDetour = travelDistance / leg.unsharedDistanceEstimate_m;
-			double timeDetour = travelTime / leg.unsharedTimeEstimate;
+			double rideTime = leg.arrivalTime - leg.pickupTime;
+			double timeDetour = rideTime / leg.unsharedTimeEstimate;
+
 			detours.add(String.join(delimiter, leg.person + "",//
 					travelDistance + "",//
 					leg.unsharedDistanceEstimate_m + "",//


### PR DESCRIPTION
This pull request makes a targeted correction to the calculation of time detour in the DRT analysis code. Instead of using the total travel time, the code now uses the actual ride time (from pickup to arrival) for a more accurate detour calculation.

