### PR TITLE
refactor: simplify MATSimApplication class and add test for null config

### DIFF
--- a/contribs/application/src/test/java/org/matsim/application/MATSimApplicationTest.java
+++ b/contribs/application/src/test/java/org/matsim/application/MATSimApplicationTest.java
@@ -1,5 +1,6 @@
 package org.matsim.application;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -180,6 +181,11 @@ public class MATSimApplicationTest {
 
 	}
 
+	@Test
+	void run_noConfig() {
+		Assertions.assertThrows(NullPointerException.class, () -> MATSimApplication.execute(TestScenario.class));
+	}
+
 	@MATSimApplication.Prepare({
 		TrajectoryToPlans.class, GenerateShortDistanceTrips.class, ExtractRelevantFreightTrips.class, MergePopulations.class
 	})
@@ -192,7 +198,6 @@ public class MATSimApplicationTest {
 			super(config);
 		}
 
-		// Public constructor is required to run the class
 		public TestScenario() {
 		}
 

--- a/matsim/src/main/java/org/matsim/application/ShowGUI.java
+++ b/matsim/src/main/java/org/matsim/application/ShowGUI.java
@@ -28,10 +28,6 @@ class ShowGUI implements Callable<Integer> {
 
 		File configFile = null;
 
-		// Try to load default config file
-		if (parent.getConfigFilename() != null && new File(parent.getConfigFilename()).exists())
-			configFile = new File(parent.getConfigFilename());
-
 		// override the default if present
 		if (parent.getConfigPath() != null)
 			configFile = new File(parent.getConfigPath());


### PR DESCRIPTION
Removes the default config path in MATSim Application. This forces the user to pass a path to a config if MATSim is started with MATSim application. 

The reason is that we want the user to be explicit about the config that should be used. This should in particular minimize the risk that users e.g. start without passing a reference to a 10pct (default) config with the corresponding ASCs and pass "--1pct" (if sample options defined in the scenario). In this case, they might expect to get the calibrated 1pct scenario, but in fact they get the 1pct population and network downsampled to 1pct -- but the 10pct ASCs.   