### PR TITLE
fix(longHaulFreight): Fix cases with activity on boundery links

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/prepare/longDistanceFreightGER/tripExtraction/ExtractRelevantFreightTrips.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/longDistanceFreightGER/tripExtraction/ExtractRelevantFreightTrips.java
@@ -163,8 +163,8 @@ public class ExtractRelevantFreightTrips implements MATSimAppCommand {
 			Coord endCoord = endActivity.getCoord();
 			double departureTime = startActivity.getEndTime().orElse(0);
 
-			boolean originIsInside = relevantArea.contains(MGC.coord2Point(sct.transform(startCoord)));
-			boolean destinationIsInside = relevantArea.contains(MGC.coord2Point(sct.transform(endCoord)));
+			boolean originIsInside = relevantArea.contains(MGC.coord2Point(sct.transform(startCoord))) || linksOnTheBoundary.contains(startLink);
+			boolean destinationIsInside = relevantArea.contains(MGC.coord2Point(sct.transform(endCoord))) || linksOnTheBoundary.contains(endLink);
 
 			Activity act0 = populationFactory.createActivityFromCoord("freight_start", null);
 			Leg leg = populationFactory.createLeg(legMode);


### PR DESCRIPTION
- Changes the default subpopulation to longDistanceFreight and mode to car
- fixes a bug if an activity is on a boundary link and the coord of the link is outside the polygon
