### PR TITLE
fix(core): Make freespeed teleportation threadsafe

### DIFF
--- a/matsim/src/main/java/org/matsim/core/router/DefaultRoutingModules.java
+++ b/matsim/src/main/java/org/matsim/core/router/DefaultRoutingModules.java
@@ -24,6 +24,9 @@ import org.matsim.api.core.v01.population.PopulationFactory;
 import org.matsim.core.config.groups.RoutingConfigGroup;
 import org.matsim.core.config.groups.RoutingConfigGroup.TeleportedModeParams;
 import org.matsim.core.router.util.LeastCostPathCalculator;
+import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
+import org.matsim.core.router.util.TravelDisutility;
+import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.utils.timing.TimeInterpretation;
 
 import jakarta.annotation.Nullable;
@@ -39,13 +42,14 @@ public final class DefaultRoutingModules {
 
 	private DefaultRoutingModules(){} // do not instantiate
 
-	public static RoutingModule createPseudoTransitRouter( String mode, PopulationFactory popFac, Network net, LeastCostPathCalculator routeAlgo,
+	public static RoutingModule createPseudoTransitRouter( String mode, PopulationFactory popFac, Network net,
+			LeastCostPathCalculatorFactory calculatorFactory, TravelTime travelTime, TravelDisutility travelDisutility,
 			RoutingConfigGroup.TeleportedModeParams params ) {
 		return new FreespeedFactorRoutingModule(
 				mode,
 				popFac,
 				net,
-				routeAlgo,
+				calculatorFactory, travelTime, travelDisutility,
 				params) ;
 	}
 

--- a/matsim/src/main/java/org/matsim/core/router/FreespeedFactorRouting.java
+++ b/matsim/src/main/java/org/matsim/core/router/FreespeedFactorRouting.java
@@ -30,7 +30,6 @@ import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PopulationFactory;
 import org.matsim.core.config.groups.RoutingConfigGroup;
 import org.matsim.core.gbl.Gbl;
-import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
@@ -76,9 +75,8 @@ class FreespeedFactorRouting implements Provider<RoutingModule> {
 			}
 		} ;
 		Gbl.assertNotNull(leastCostPathCalculatorFactory);
-		LeastCostPathCalculator routeAlgoPtFreeFlow = leastCostPathCalculatorFactory.createPathCalculator(
-						network, travelDisutility, travelTime);
+		// Pass factory instead of creating algo instance - algo should be created per routing call for thread-safety
 		return DefaultRoutingModules.createPseudoTransitRouter(params.getMode(), populationFactory,
-				network, routeAlgoPtFreeFlow, params);
+				network, leastCostPathCalculatorFactory, travelTime, travelDisutility, params);
 	}
 }

--- a/matsim/src/main/java/org/matsim/core/router/FreespeedFactorRoutingModule.java
+++ b/matsim/src/main/java/org/matsim/core/router/FreespeedFactorRoutingModule.java
@@ -22,11 +22,13 @@ package org.matsim.core.router;
 
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
-import org.matsim.api.core.v01.network.Node;
 import org.matsim.api.core.v01.population.*;
 import org.matsim.core.config.groups.RoutingConfigGroup.TeleportedModeParams;
 import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.LeastCostPathCalculator.Path;
+import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
+import org.matsim.core.router.util.TravelDisutility;
+import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.utils.geometry.CoordUtils;
 import org.matsim.facilities.Facility;
 
@@ -39,17 +41,23 @@ public final class FreespeedFactorRoutingModule implements RoutingModule {
 	private final PopulationFactory populationFactory;
 
 	private final Network network;
-	private final LeastCostPathCalculator routeAlgo;
+	private final LeastCostPathCalculatorFactory calculatorFactory;
+	private final TravelTime travelTime;
+	private final TravelDisutility travelDisutility;
 	private final TeleportedModeParams params;
 
 	FreespeedFactorRoutingModule(
 			final String mode,
 			final PopulationFactory populationFactory,
             final Network network,
-			final LeastCostPathCalculator routeAlgo,
+			final LeastCostPathCalculatorFactory calculatorFactory,
+			final TravelTime travelTime,
+			final TravelDisutility travelDisutility,
 			TeleportedModeParams params ) {
 		this.network = network;
-		this.routeAlgo = routeAlgo;
+		this.calculatorFactory = calculatorFactory;
+		this.travelTime = travelTime;
+		this.travelDisutility = travelDisutility;
 		this.params = params;
 		this.mode = mode;
 		this.populationFactory = populationFactory;
@@ -91,7 +99,9 @@ public final class FreespeedFactorRoutingModule implements RoutingModule {
 		if (toLink == null) throw new RuntimeException("toLink missing.");
 		if (toLink != fromLink) {
 			// do not drive/walk around, if we stay on the same link
-			Path path = this.routeAlgo.calcLeastCostPath(fromLink, toLink, depTime, person, null);
+			// Create algo per-call for thread-safety
+			LeastCostPathCalculator routeAlgo = this.calculatorFactory.createPathCalculator(this.network, this.travelDisutility, this.travelTime);
+			Path path = routeAlgo.calcLeastCostPath(fromLink, toLink, depTime, person, null);
 			if (path == null) throw new RuntimeException("No route found from link " + fromLink.getId() + " to link " + toLink.getId() + ".");
 
 			// we're still missing the time on the final link, which the agent has to drive on in the java mobsim

--- a/matsim/src/test/java/org/matsim/core/router/PseudoTransitRoutingModuleTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/PseudoTransitRoutingModuleTest.java
@@ -49,6 +49,7 @@ import org.matsim.core.gbl.Gbl;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.router.costcalculators.FreespeedTravelTimeAndDisutility;
 import org.matsim.core.router.util.LeastCostPathCalculator;
+import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
 import org.matsim.core.scenario.ScenarioByInstanceModule;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.facilities.FacilitiesUtils;
@@ -60,6 +61,13 @@ public class PseudoTransitRoutingModuleTest {
 
 	@RegisterExtension
 	private MatsimTestUtils utils = new MatsimTestUtils();
+
+	/**
+	 * Helper method to create a factory that wraps a single calculator instance for testing.
+	 */
+	private static LeastCostPathCalculatorFactory createTestFactory(LeastCostPathCalculator calculator) {
+		return (network, travelDisutility, travelTime) -> calculator;
+	}
 
 	@Test
 	void testRouteLeg() {
@@ -80,10 +88,11 @@ public class PseudoTransitRoutingModuleTest {
 			params.setBeelineDistanceFactor(1.);
 			double tt = new FreespeedFactorRoutingModule(
 					"mode", f.s.getPopulation().getFactory(),
-					f.s.getNetwork(), routeAlgo, params).routeLeg(person, leg, fromAct, toAct, 7.0*3600);
+					f.s.getNetwork(),
+					createTestFactory(routeAlgo), freespeed, freespeed,
+					params).routeLeg(person, leg, fromAct, toAct, 7.0*3600);
 			Assertions.assertEquals(400.0, tt, 1e-8);
 			Assertions.assertEquals(400.0, leg.getTravelTime().seconds(), 1e-8);
-//			Assert.assertTrue(leg.getRoute() instanceof GenericRouteImpl);
 			Assertions.assertEquals(3000.0, leg.getRoute().getDistance(), 1e-8);
 		}{
 			TeleportedModeParams params = new TeleportedModeParams("mode") ;
@@ -91,7 +100,9 @@ public class PseudoTransitRoutingModuleTest {
 			params.setBeelineDistanceFactor(2.);
 			double tt = new FreespeedFactorRoutingModule(
 					"mode", f.s.getPopulation().getFactory(),
-					f.s.getNetwork(), routeAlgo, params).routeLeg(person, leg, fromAct, toAct, 7.0*3600);
+					f.s.getNetwork(),
+					createTestFactory(routeAlgo), freespeed, freespeed,
+					params).routeLeg(person, leg, fromAct, toAct, 7.0*3600);
 			Assertions.assertEquals(600.0, tt, 1e-8);
 			Assertions.assertEquals(600.0, leg.getTravelTime().seconds(), 1e-8);
 			Assertions.assertEquals(6000.0, leg.getRoute().getDistance(), 1e-8);
@@ -126,7 +137,6 @@ public class PseudoTransitRoutingModuleTest {
 			Leg newLeg = (Leg) result.get(0) ;
 
 			Assertions.assertEquals(800.0, newLeg.getTravelTime().seconds(), 1e-8);
-//			Assert.assertTrue(leg.getRoute() instanceof GenericRouteImpl);
 			Assertions.assertEquals(3000.0, newLeg.getRoute().getDistance(), 1e-8);
 		}
 	}


### PR DESCRIPTION
`LeastCostPathCalculator`s passed to `createPseudoTransitRouter()` are not guaranteed to be thread-safe (i.e. [`SpeedyALT`](https://github.com/matsim-org/matsim-libs/blob/main/matsim/src/main/java/org/matsim/core/router/speedy/SpeedyALT.java) or [`Dijkstra`](https://github.com/matsim-org/matsim-libs/blob/main/matsim/src/main/java/org/matsim/core/router/Dijkstra.java)), but are then called in a parallelised environment. By passing the factory + components, we can create an instance per routing call, and the operation becomes thread-safe.

I ran into a problem in a simulation with a _lot_ of freespeed teleportation, leading to `NoSuchElementExceptions` in [`DAryMinHeap@decreaseKey()`](https://github.com/matsim-org/matsim-libs/blob/ace48c04f2c6c4b8199fafee8133e775abcb3e75/matsim/src/main/java/org/matsim/core/router/speedy/DAryMinHeap.java#L60). However, looking at the rest of the default routing modules and how they are all just passed a non-thread-safe routing algorithm, I wonder why this isn't a problem there...

Additional automatic code formatting using Google Style + tabs + 150 char line length.