### PR TITLE
feat(simwrapper): add Plotly dataset filters

### DIFF
--- a/contribs/simwrapper/src/main/java/org/matsim/simwrapper/viz/Plotly.java
+++ b/contribs/simwrapper/src/main/java/org/matsim/simwrapper/viz/Plotly.java
@@ -352,6 +352,7 @@ public final class Plotly extends Viz {
 		private final String name;
 		private final String file;
 
+		private Map<String, Object> filter;
 		private Map<String, Object> pivot;
 		private Map<String, Object> constant;
 		private Map<String, Object> aggregate;
@@ -364,7 +365,8 @@ public final class Plotly extends Viz {
 		}
 
 		private Object toJSON() {
-			if (pivot == null &&
+			if (filter == null &&
+				pivot == null &&
 				constant == null &&
 				aggregate == null &&
 				normalize == null &&
@@ -380,6 +382,84 @@ public final class Plotly extends Viz {
 		public DataMapping mapping() {
 			return new DataMapping(name);
 		}
+
+		private static final Set<String> SUPPORTED_CONDITIONALS = Set.of("<", "<=", ">", ">=");
+
+		private Map<String, Object> ensureFilter() {
+			if (filter == null)
+				filter = new LinkedHashMap<>();
+			return filter;
+		}
+
+		/**
+		 * Exact match: filter: { column: value }
+		 */
+		public DataSet filter(String columnName, Object value) {
+			Objects.requireNonNull(columnName, "columnName can not be null");
+			ensureFilter().put(columnName, value);
+			return this;
+		}
+
+		/**
+		 * IN filter: filter: { column: [v1, v2, ...] }
+		 */
+		public DataSet filterIn(String columnName, Object... values) {
+			Objects.requireNonNull(columnName, "columnName can not be null");
+			if (values == null || values.length == 0)
+				throw new IllegalArgumentException("values can not be empty");
+
+			ensureFilter().put(columnName, Arrays.asList(values));
+			return this;
+		}
+
+		/**
+		 * Conditional filter: filter: { column: { conditional: \">=\", value: 0.1 } }
+		 */
+		public DataSet filterConditional(String columnName, String conditional, Number value) {
+			Objects.requireNonNull(columnName, "columnName can not be null");
+			Objects.requireNonNull(conditional, "conditional can not be null");
+			Objects.requireNonNull(value, "value can not be null");
+
+			if (!SUPPORTED_CONDITIONALS.contains(conditional))
+				throw new IllegalArgumentException("Unsupported conditional: " + conditional);
+
+			ensureFilter().put(columnName, Map.of(
+				"conditional", conditional,
+				"value", value
+			));
+			return this;
+		}
+
+		/**
+		 * Range filter: filter: { column: { range: true, values: [min, max] } }
+		 */
+		public DataSet filterRange(String columnName, Number min, Number max) {
+			Objects.requireNonNull(columnName, "columnName can not be null");
+			Objects.requireNonNull(min, "min can not be null");
+			Objects.requireNonNull(max, "max can not be null");
+
+			ensureFilter().put(columnName, Map.of(
+				"range", true,
+				"values", List.of(min, max)
+			));
+			return this;
+		}
+
+		/**
+		 * NOT filter: filter: { column: { invert: true, values: [...] } }
+		 */
+		public DataSet filterNotIn(String columnName, Object... values) {
+			Objects.requireNonNull(columnName, "columnName can not be null");
+			if (values == null || values.length == 0)
+				throw new IllegalArgumentException("values can not be empty");
+
+			ensureFilter().put(columnName, Map.of(
+				"invert", true,
+				"values", Arrays.asList(values)
+			));
+			return this;
+		}
+
 
 		/**
 		 * Indicates that each column beside the already mapped ones contain one data group. This is also known as 'wide-format'.

--- a/contribs/simwrapper/src/test/java/org/matsim/simwrapper/viz/PlotlyTest.java
+++ b/contribs/simwrapper/src/test/java/org/matsim/simwrapper/viz/PlotlyTest.java
@@ -3,6 +3,7 @@ package org.matsim.simwrapper.viz;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -25,6 +26,7 @@ import tech.tablesaw.plotly.traces.ScatterTrace;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 public class PlotlyTest {
 
@@ -142,6 +144,32 @@ public class PlotlyTest {
 		Assertions.assertThat(new File(utils.getClassInputDirectory(), "multiple.yaml"))
 				.hasContent(value);
 
+	}
+
+	@Test
+	void filter() throws IOException {
+
+		Plotly plotly = new Plotly();
+
+		plotly.addTrace(
+			BarTrace.builder(Plotly.OBJ_INPUT, Plotly.INPUT).build(),
+				plotly.addDataset("mode_share_personTraffic.csv")
+					.filter("subpopulation", "person")
+					.filterIn("main_mode", "car", "pt", "ride")
+					.filterConditional("share", ">=", 0.05)
+					.filterRange("distance", 0.05, 0.3)
+					.filterNotIn("dist_group", "20000+")
+					.mapping()
+					.x("dist_group")
+					.y("share")
+			);
+
+		String value = writer.writeValueAsString(plotly);
+		File expectedYaml = new File(utils.getClassInputDirectory(), "filter.yaml");
+		ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
+		JsonNode expected = yamlMapper.readTree(Files.readString(expectedYaml.toPath()));
+		JsonNode actual = yamlMapper.readTree(value);
+		Assertions.assertThat(actual).isEqualTo(expected);
 	}
 
 }

--- a/contribs/simwrapper/test/input/org/matsim/simwrapper/viz/PlotlyTest/filter.yaml
+++ b/contribs/simwrapper/test/input/org/matsim/simwrapper/viz/PlotlyTest/filter.yaml
@@ -1,0 +1,27 @@
+type: plotly
+datasets:
+  dataset:
+    file: mode_share_personTraffic.csv
+    filter:
+      subpopulation: person
+      main_mode:
+      - car
+      - pt
+      - ride
+      share:
+        conditional: ">="
+        value: 0.05
+      distance:
+        range: true
+        values:
+        - 0.05
+        - 0.3
+      dist_group:
+        invert: true
+        values:
+        - 20000+
+traces:
+- x: $dataset.dist_group
+  "y": $dataset.share
+  orientation: v
+  type: bar


### PR DESCRIPTION
**Description**
This PR adds dataset filter support to SimWrapper Plotly YAML generation and covers it with a test.