### PR TITLE
refactor: generalize mobsim dependencies

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/BackpackDrtRoute.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/routing/BackpackDrtRoute.java
@@ -1,7 +1,5 @@
 package org.matsim.contrib.drt.routing;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Message;
 import org.matsim.api.core.v01.events.*;
@@ -20,7 +18,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 class BackpackDrtRoute implements BackpackRoute {
-	private static final Logger log = LogManager.getLogger(BackpackDrtRoute.class);
 
 	private final Data data;
 	private final Network network;
@@ -36,7 +33,6 @@ class BackpackDrtRoute implements BackpackRoute {
 
 	@Override
 	public void handleEvent(Event e) {
-		log.info(e);
 		if (e instanceof PersonDepartureEvent pde) {
 			data.startTime = pde.getTime();
 			data.links.add(pde.getLinkId());

--- a/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DriveDischargingHandler.java
+++ b/contribs/ev/src/main/java/org/matsim/contrib/ev/discharging/DriveDischargingHandler.java
@@ -41,8 +41,8 @@ import org.matsim.contrib.ev.fleet.ElectricVehicle;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.events.MobsimScopeEventHandler;
 import org.matsim.core.mobsim.qsim.InternalInterface;
-import org.matsim.core.mobsim.qsim.QSim;
 import org.matsim.core.mobsim.qsim.interfaces.MobsimEngine;
+import org.matsim.core.mobsim.qsim.interfaces.Netsim;
 import org.matsim.vehicles.Vehicle;
 
 import com.google.inject.Inject;
@@ -75,16 +75,16 @@ public class DriveDischargingHandler
 	private final EventsManager eventsManager;
 	private final Map<Id<Vehicle>, ? extends ElectricVehicle> eVehicles;
 	private final Map<Id<Vehicle>, EvDrive> evDrives;
-	
+
 	private final Queue<VehicleEntersTrafficEvent> trafficEnterEvents = new ConcurrentLinkedQueue<>();
 	private final Queue<LinkLeaveEvent> linkLeaveEvents = new ConcurrentLinkedQueue<>();
 	private final Queue<VehicleLeavesTrafficEvent> trafficLeaveEvents = new ConcurrentLinkedQueue<>();
-	
-	private final QSim qsim;
+
+	private final Netsim netsim;
 
 	@Inject
-	DriveDischargingHandler(QSim qsim, ElectricFleet data, Network network, EventsManager eventsManager) {
-		this.qsim = qsim;
+	DriveDischargingHandler(Netsim netsim, ElectricFleet data, Network network, EventsManager eventsManager) {
+		this.netsim = netsim;
 		this.network = network;
 		this.eventsManager = eventsManager;
 		eVehicles = data.getElectricVehicles();
@@ -120,13 +120,9 @@ public class DriveDischargingHandler
 	}
 
 	@Override
-	public void onPrepareSim() {
-	}
-
-	@Override
 	public void afterSim() {
 		// process remaining events
-		doSimStep(this.qsim.getSimTimer().getTimeOfDay());
+		doSimStep(this.netsim.getSimTimer().getTimeOfDay());
 	}
 
 	@Override
@@ -184,7 +180,7 @@ public class DriveDischargingHandler
 			//===============================================================
 			//Added to handle cases when the negative energy discharged would surpass the battery capacity
 			//The new resulting energy should mean that the battery stays at the battery capacity when the energy is negative
-			if(ev.getBattery().getCharge() - energy > ev.getBattery().getCapacity()){
+			if (ev.getBattery().getCharge() - energy > ev.getBattery().getCapacity()) {
 				energy = ev.getBattery().getCharge() - ev.getBattery().getCapacity();
 			}
 			//===================================================================

--- a/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitQSimEngine.java
+++ b/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitQSimEngine.java
@@ -33,7 +33,7 @@ import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.mobsim.framework.MobsimAgent;
 import org.matsim.core.mobsim.framework.PassengerAgent;
 import org.matsim.core.mobsim.qsim.InternalInterface;
-import org.matsim.core.mobsim.qsim.QSim;
+import org.matsim.core.mobsim.qsim.interfaces.Netsim;
 import org.matsim.core.mobsim.qsim.pt.*;
 import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.replanning.ReplanningContext;
@@ -58,50 +58,53 @@ public class SBBTransitQSimEngine extends TransitQSimEngine /*implements Departu
 
 	private static final Logger log = LogManager.getLogger(SBBTransitQSimEngine.class);
 
-    private final SBBTransitConfigGroup config;
-    private final TransitConfigGroup ptConfig;
-    private final QSim qSim;
-    private final ReplanningContext context;
-    private final TransitStopAgentTracker agentTracker;
-    private final TransitSchedule schedule;
-    private final PriorityQueue<TransitEvent> eventQueue = new PriorityQueue<>();
-    private final Map<TransitRoute, List<Link[]>> linksCache;
-    private final PriorityQueue<LinkEvent> linkEventQueue;
-    private InternalInterface internalInterface;
-    private TransitDriverAgentFactory deterministicDriverFactory;
-    private TransitDriverAgentFactory networkDriverFactory;
-    @Inject private TransitStopHandlerFactory stopHandlerFactory = new SimpleTransitStopHandlerFactory();
-    private boolean createLinkEvents = false;
+	private final SBBTransitConfigGroup config;
+	private final TransitConfigGroup ptConfig;
+	private final Netsim netsim;
+	private final ReplanningContext context;
+	private final TransitStopAgentTracker agentTracker;
+	private final TransitSchedule schedule;
+	private final PriorityQueue<TransitEvent> eventQueue = new PriorityQueue<>();
+	private final Map<TransitRoute, List<Link[]>> linksCache;
+	private final PriorityQueue<LinkEvent> linkEventQueue;
+	private InternalInterface internalInterface;
+	private TransitDriverAgentFactory deterministicDriverFactory;
+	private TransitDriverAgentFactory networkDriverFactory;
+	@Inject
+	private TransitStopHandlerFactory stopHandlerFactory = new SimpleTransitStopHandlerFactory();
+	private boolean createLinkEvents = false;
 
-    @Inject
-    SBBTransitQSimEngine(QSim qSim, ReplanningContext context, TransitStopAgentTracker agentTracker, TimeInterpretation timeInterpretation, TransitDriverAgentFactory networkDriverFactory) {
-        // ( https://github.com/google/guice/wiki/KeepConstructorsHidden )
+	@Inject
+	SBBTransitQSimEngine(Netsim netsim, ReplanningContext context, TransitStopAgentTracker agentTracker, TimeInterpretation timeInterpretation, TransitDriverAgentFactory networkDriverFactory) {
+		// ( https://github.com/google/guice/wiki/KeepConstructorsHidden )
 
-        super(qSim, new SimpleTransitStopHandlerFactory(), new ReconstructingUmlaufBuilder(qSim.getScenario()), agentTracker, timeInterpretation, networkDriverFactory);
-        // (it feels a bit odd to inject TransitStopHandlerFactory, but to put the simple version here as an argument.  kai, feb '25)
+		super(netsim, new SimpleTransitStopHandlerFactory(), new ReconstructingUmlaufBuilder(netsim.getScenario()), agentTracker, timeInterpretation, networkDriverFactory);
+		// (it feels a bit odd to inject TransitStopHandlerFactory, but to put the simple version here as an argument.  kai, feb '25)
 
-        this.qSim = qSim;
-        this.context = context;
-        this.config = ConfigUtils.addOrGetModule(qSim.getScenario().getConfig(), SBBTransitConfigGroup.GROUP_NAME, SBBTransitConfigGroup.class);
-        this.ptConfig = qSim.getScenario().getConfig().transit();
-        this.schedule = qSim.getScenario().getTransitSchedule();
-        this.agentTracker = agentTracker;
-        if (this.config.getCreateLinkEventsInterval() > 0) {
-            this.linkEventQueue = new PriorityQueue<>();
-            this.linksCache = new ConcurrentHashMap<>();
-        } else {
-            this.linkEventQueue = null;
-            this.linksCache = null;
-        }
-        checkSettings();
-    }
+		this.netsim = netsim;
+		this.context = context;
+		this.config = ConfigUtils.addOrGetModule(netsim.getScenario().getConfig(), SBBTransitConfigGroup.GROUP_NAME, SBBTransitConfigGroup.class);
+		this.ptConfig = netsim.getScenario().getConfig().transit();
+		this.schedule = netsim.getScenario().getTransitSchedule();
+		this.agentTracker = agentTracker;
+		if (this.config.getCreateLinkEventsInterval() > 0) {
+			this.linkEventQueue = new PriorityQueue<>();
+			this.linksCache = new ConcurrentHashMap<>();
+		} else {
+			this.linkEventQueue = null;
+			this.linksCache = null;
+		}
+		checkSettings();
+	}
 
 	/**
 	 * Tha agent id for an umlauf.
 	 */
 	static String createId(TransitLine line, TransitRoute route, Departure departure) {
 		return line.getId().toString() + "_" + route.getId().toString() + "_" + departure.getId().toString();
-	}private void checkSettings() {
+	}
+
+	private void checkSettings() {
 		if (this.config.getDeterministicServiceModes().isEmpty()) {
 			log.warn("There are no modes registered for the deterministic transit simulation, so no transit vehicle will be handled by this engine.");
 		}
@@ -151,8 +154,8 @@ public class SBBTransitQSimEngine extends TransitQSimEngine /*implements Departu
 			LinkEvent linkEvent = this.linkEventQueue.peek();
 			while (linkEvent != null && linkEvent.time <= time) {
 				this.linkEventQueue.poll();
-				this.qSim.getEventsManager().processEvent(new LinkLeaveEvent(time, linkEvent.vehicleId, linkEvent.fromLinkId));
-				this.qSim.getEventsManager().processEvent(new LinkEnterEvent(time, linkEvent.vehicleId, linkEvent.toLinkId));
+				this.netsim.getEventsManager().processEvent(new LinkLeaveEvent(time, linkEvent.vehicleId, linkEvent.fromLinkId));
+				this.netsim.getEventsManager().processEvent(new LinkEnterEvent(time, linkEvent.vehicleId, linkEvent.toLinkId));
 				linkEvent = this.linkEventQueue.peek();
 			}
 		}
@@ -167,13 +170,13 @@ public class SBBTransitQSimEngine extends TransitQSimEngine /*implements Departu
 	@Override
 	public void afterSim() {
 		// check that all agents have arrived, generate stuck events otherwise
-		double now = this.qSim.getSimTimer().getTimeOfDay();
+		double now = this.netsim.getSimTimer().getTimeOfDay();
 		for (Map.Entry<Id<TransitStopFacility>, List<PTPassengerAgent>> agentsAtStop : this.agentTracker.getAgentsAtStop().entrySet()) {
 			TransitStopFacility stop = this.schedule.getFacilities().get(agentsAtStop.getKey());
 			for (PTPassengerAgent agent : agentsAtStop.getValue()) {
-				this.qSim.getEventsManager().processEvent(new PersonStuckEvent(now, agent.getId(), stop.getLinkId(), agent.getMode()));
-				this.qSim.getAgentCounter().decLiving();
-				this.qSim.getAgentCounter().incLost();
+				this.netsim.getEventsManager().processEvent(new PersonStuckEvent(now, agent.getId(), stop.getLinkId(), agent.getMode()));
+				this.netsim.getAgentCounter().decLiving();
+				this.netsim.getAgentCounter().incLost();
 			}
 		}
 
@@ -182,15 +185,15 @@ public class SBBTransitQSimEngine extends TransitQSimEngine /*implements Departu
 		while ((event = this.eventQueue.poll()) != null) {
 			Id<Link> nextStopLinkId = event.context.nextStop.getStopFacility().getLinkId();
 			for (PassengerAgent agent : event.context.driver.getVehicle().getPassengers()) {
-				this.qSim.getEventsManager().processEvent(new PersonStuckEvent(now, agent.getId(), nextStopLinkId, agent.getMode()));
-				this.qSim.getAgentCounter().decLiving();
-				this.qSim.getAgentCounter().incLost();
+				this.netsim.getEventsManager().processEvent(new PersonStuckEvent(now, agent.getId(), nextStopLinkId, agent.getMode()));
+				this.netsim.getAgentCounter().decLiving();
+				this.netsim.getAgentCounter().incLost();
 			}
 		}
 	}
 
 	private void createVehiclesAndDrivers() {
-		Scenario scenario = this.qSim.getScenario();
+		Scenario scenario = this.netsim.getScenario();
 		TransitSchedule schedule = scenario.getTransitSchedule();
 		Vehicles vehicles = scenario.getTransitVehicles();
 		Set<String> deterministicModes = this.config.getDeterministicServiceModes();
@@ -201,7 +204,7 @@ public class SBBTransitQSimEngine extends TransitQSimEngine /*implements Departu
 			throw new RuntimeException(
 				"There are modes configured to be pt passenger modes as well as deterministic service modes. This will not work! common modes = " + CollectionUtils.setToString(commonModes));
 		}
-		Set<String> mainModes = new HashSet<>(this.qSim.getScenario().getConfig().qsim().getMainModes());
+		Set<String> mainModes = new HashSet<>(this.netsim.getScenario().getConfig().qsim().getMainModes());
 		mainModes.retainAll(deterministicModes);
 		if (!mainModes.isEmpty()) {
 			throw new RuntimeException(
@@ -236,9 +239,9 @@ public class SBBTransitQSimEngine extends TransitQSimEngine /*implements Departu
 		Leg firstLeg = (Leg) driver.getNextPlanElement();
 		if (!isDeterministic) {
 			Id<Link> startLinkId = firstLeg.getRoute().getStartLinkId();
-			this.qSim.addParkedVehicle(qVeh, startLinkId);
+			this.netsim.addParkedVehicle(qVeh, startLinkId);
 		}
-		this.qSim.insertAgentIntoMobsim(driver);
+		this.netsim.insertAgentIntoMobsim(driver);
 	}
 
 	private Umlauf createUmlauf(TransitLine line, TransitRoute route, Departure departure) {
@@ -257,13 +260,13 @@ public class SBBTransitQSimEngine extends TransitQSimEngine /*implements Departu
 			// looks like this agent has a bad transit route, likely no
 			// route could be calculated for it
 			log.error("pt-agent doesn't know to what transit stop to go to. Removing agent from simulation. Agent " + passenger.getId().toString());
-			this.qSim.getAgentCounter().decLiving();
-			this.qSim.getAgentCounter().incLost();
+			this.netsim.getAgentCounter().decLiving();
+			this.netsim.getAgentCounter().incLost();
 			return;
 		}
 		TransitStopFacility stop = this.schedule.getFacilities().get(accessStopId);
 		if (stop.getLinkId() == null || stop.getLinkId().equals(linkId)) {
-			double now = this.qSim.getSimTimer().getTimeOfDay();
+			double now = this.netsim.getSimTimer().getTimeOfDay();
 			this.agentTracker.addAgentToStop(now, passenger, stop.getId());
 			this.internalInterface.registerAdditionalAgentOnLink(agent);
 		} else {
@@ -274,13 +277,13 @@ public class SBBTransitQSimEngine extends TransitQSimEngine /*implements Departu
 	private void handleDeterministicDriverDeparture(MobsimAgent agent, double now) {
 		SBBTransitDriverAgent driver = (SBBTransitDriverAgent) agent;
 		TransitRoute trRoute = driver.getTransitRoute();
-		List<Link[]> links = this.createLinkEvents ? this.linksCache.computeIfAbsent(trRoute, r -> getLinksPerStopAlongRoute(r, this.qSim.getScenario().getNetwork())) : null;
+		List<Link[]> links = this.createLinkEvents ? this.linksCache.computeIfAbsent(trRoute, r -> getLinksPerStopAlongRoute(r, this.netsim.getScenario().getNetwork())) : null;
 		TransitContext context = new TransitContext(driver, links);
-		this.qSim.getEventsManager().processEvent(new PersonEntersVehicleEvent(now, driver.getId(), driver.getVehicle().getId()));
+		this.netsim.getEventsManager().processEvent(new PersonEntersVehicleEvent(now, driver.getId(), driver.getVehicle().getId()));
 		if (this.createLinkEvents) {
 			Id<Link> linkId = driver.getCurrentLinkId();
 			String mode = driver.getMode();
-			this.qSim.getEventsManager().processEvent(new VehicleEntersTrafficEvent(now, driver.getId(), linkId, driver.getVehicle().getId(), mode, 1.0));
+			this.netsim.getEventsManager().processEvent(new VehicleEntersTrafficEvent(now, driver.getId(), linkId, driver.getVehicle().getId(), mode, 1.0));
 		}
 		TransitEvent event = new TransitEvent(now, TransitEventType.ArrivalAtStop, context);
 		this.eventQueue.add(event);
@@ -344,9 +347,9 @@ public class SBBTransitQSimEngine extends TransitQSimEngine /*implements Departu
 			if (this.createLinkEvents) {
 				Id<Link> linkId = driver.getDestinationLinkId();
 				String mode = driver.getMode();
-				this.qSim.getEventsManager().processEvent(new VehicleLeavesTrafficEvent(event.time, driver.getId(), linkId, driver.getVehicle().getId(), mode, 1.0));
+				this.netsim.getEventsManager().processEvent(new VehicleLeavesTrafficEvent(event.time, driver.getId(), linkId, driver.getVehicle().getId(), mode, 1.0));
 			}
-			this.qSim.getEventsManager().processEvent(new PersonLeavesVehicleEvent(event.time, driver.getId(), driver.getVehicle().getId()));
+			this.netsim.getEventsManager().processEvent(new PersonLeavesVehicleEvent(event.time, driver.getId(), driver.getVehicle().getId()));
 			driver.endLegAndComputeNextState(event.time);
 			this.internalInterface.arrangeNextAgentState(driver);
 		}
@@ -374,8 +377,8 @@ public class SBBTransitQSimEngine extends TransitQSimEngine /*implements Departu
 					double time = depTime + travelledLength * secondsPerMeter;
 					if (travelTime == 0) {
 						// create the events right now, so they stay in correct order before next arrival
-						this.qSim.getEventsManager().processEvent(new LinkLeaveEvent(time, vehicle.getId(), fromLink.getId()));
-						this.qSim.getEventsManager().processEvent(new LinkEnterEvent(time, vehicle.getId(), toLink.getId()));
+						this.netsim.getEventsManager().processEvent(new LinkLeaveEvent(time, vehicle.getId(), fromLink.getId()));
+						this.netsim.getEventsManager().processEvent(new LinkEnterEvent(time, vehicle.getId(), toLink.getId()));
 					} else {
 						this.linkEventQueue.add(new LinkEvent(time, fromLink.getId(), toLink.getId(), vehicle.getId()));
 					}


### PR DESCRIPTION
Use the more general `Netsim` interface for injected dependencies to allow alternative `Netsim` implementations such as `SimProcess` 
