### PR TITLE
feat: add more information to PersonInitializedEvent

### DIFF
--- a/matsim/src/main/java/org/matsim/api/core/v01/events/PersonInitializedEvent.java
+++ b/matsim/src/main/java/org/matsim/api/core/v01/events/PersonInitializedEvent.java
@@ -20,30 +20,46 @@
 
 package org.matsim.api.core.v01.events;
 
+import java.util.Map;
+
 import org.matsim.api.core.v01.BasicLocation;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.population.Person;
+import org.matsim.facilities.ActivityFacility;
+
+import static org.matsim.core.utils.io.XmlUtils.writeEncodedAttributeKeyValue;
 
 /**
  * The idea of this event is to have a list of all Persons in the beginning of the events file
  * 
  * @author tkohl / senozon
+ * @author sebhoerl / IRT SystemX
  */
-public class PersonInitializedEvent extends Event implements HasPersonId, BasicLocation {
+public class PersonInitializedEvent extends Event implements HasPersonId, HasLinkId, HasFacilityId, BasicLocation {
 
 	public static final String EVENT_TYPE = "personInitialized";
+	public static final String ATTRIBUTE_ACTIVITY_TYPE = ActivityEndEvent.ATTRIBUTE_ACTTYPE;
 	
 	private final Id<Person> personId;
+	private final Id<Link> linkId;
+	private final Id<ActivityFacility> facilityId;
+	private final String activityType;
 	private final Coord coord;
 	
-	public PersonInitializedEvent(double time, Id<Person> personId) {
-		this(time, personId, null);
+	public PersonInitializedEvent(double time, Id<Person> personId, Id<Link> linkId, 
+		Id<ActivityFacility> facilityId, String activityType) {
+		this(time, personId, linkId, facilityId, activityType, null);
 	}
 	
-	public PersonInitializedEvent(double time, Id<Person> personId, Coord coord) {
+	public PersonInitializedEvent(double time, Id<Person> personId, Id<Link> linkId, 
+		Id<ActivityFacility> facilityId, String activityType, Coord coord) {
 		super(time);
 		this.personId = personId;
+		this.linkId = linkId;
+		this.facilityId = facilityId;
+		this.activityType = activityType;
 		this.coord = coord;
 	}
 
@@ -62,4 +78,29 @@ public class PersonInitializedEvent extends Event implements HasPersonId, BasicL
 		return this.coord;
 	}
 
+	public String getActivityType() {
+		return this.activityType;
+	}
+
+	@Override public Id<Link> getLinkId() {
+		return this.linkId;
+	}
+
+	@Override public Id<ActivityFacility> getFacilityId() {
+		return this.facilityId;
+	}
+
+	@Override
+	public Map<String, String> getAttributes() {
+		Map<String, String> attr = super.getAttributes();
+		attr.put(ATTRIBUTE_ACTIVITY_TYPE, this.activityType);
+		return attr;
+	}
+
+	@Override
+	public void writeAsXML(StringBuilder out) {
+		writeXMLStart(out);
+		writeEncodedAttributeKeyValue(out, ATTRIBUTE_ACTIVITY_TYPE, this.activityType);
+		writeXMLEnd(out);
+	}
 }

--- a/matsim/src/main/java/org/matsim/core/events/EventsReaderJson.java
+++ b/matsim/src/main/java/org/matsim/core/events/EventsReaderJson.java
@@ -323,7 +323,11 @@ public final class EventsReaderJson {
 				double yy = o.get(Event.ATTRIBUTE_Y).asDouble();
 				coord = new Coord(xx, yy);
 			}
-			this.events.processEvent(new PersonInitializedEvent(time, personId, coord));
+			this.events.processEvent(new PersonInitializedEvent(time, personId, 
+				o.has(HasLinkId.ATTRIBUTE_LINK) ? Id.create(o.get(HasLinkId.ATTRIBUTE_LINK).asText(), Link.class) : null,
+				o.has(HasFacilityId.ATTRIBUTE_FACILITY) ? Id.create(o.get(HasFacilityId.ATTRIBUTE_FACILITY).asText(), ActivityFacility.class) : null,
+				o.get(PersonInitializedEvent.ATTRIBUTE_ACTIVITY_TYPE).asText(),
+				coord));
 		} else {
 			GenericEvent event = new GenericEvent(eventType, time);
 

--- a/matsim/src/main/java/org/matsim/core/events/EventsReaderXMLv1.java
+++ b/matsim/src/main/java/org/matsim/core/events/EventsReaderXMLv1.java
@@ -270,7 +270,13 @@ public final class EventsReaderXMLv1 extends MatsimXmlEventsParser {
 				double yy = Double.parseDouble(atts.getValue(Event.ATTRIBUTE_Y));
 				coord = new Coord(xx, yy);
 			}
-			this.events.processEvent(new PersonInitializedEvent(time, personId, coord));
+			this.events.processEvent(new PersonInitializedEvent(time, personId, 
+				atts.getValue(HasLinkId.ATTRIBUTE_LINK) == null ? null : Id.create(atts.getValue(HasLinkId.ATTRIBUTE_LINK),
+					Link.class),
+				atts.getValue(HasFacilityId.ATTRIBUTE_FACILITY) == null ? null : Id.create(atts.getValue(HasFacilityId.ATTRIBUTE_FACILITY),
+					ActivityFacility.class),
+				atts.getValue(PersonInitializedEvent.ATTRIBUTE_ACTIVITY_TYPE),
+				coord));
 		} else {
 			GenericEvent event = new GenericEvent(eventType, time);
 			for (int ii = 0; ii < atts.getLength(); ii++) {

--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/agents/PopulationAgentSource.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/agents/PopulationAgentSource.java
@@ -101,8 +101,9 @@ public final class PopulationAgentSource implements AgentSource, DistributedAgen
 			qsim.insertAgentIntoMobsim(agent);
 			if (this.personHelloEventsSetting == PersonInitializedEventsSetting.all
 					|| (this.personHelloEventsSetting == PersonInitializedEventsSetting.singleActAgentsOnly && p.getSelectedPlan().getPlanElements().size() == 1)) {
-				Coord firstActCoord = ((Activity)p.getSelectedPlan().getPlanElements().get(0)).getCoord();
-				this.qsim.getEventsManager().processEvent(new PersonInitializedEvent(0, p.getId(), firstActCoord));
+				Activity firstActivity = (Activity)p.getSelectedPlan().getPlanElements().get(0);
+				this.qsim.getEventsManager().processEvent(new PersonInitializedEvent(0, p.getId(), firstActivity.getLinkId(), 
+					firstActivity.getFacilityId(), firstActivity.getType(), firstActivity.getCoord()));
 			}
 		}
 	}

--- a/matsim/src/test/java/org/matsim/core/events/PersonInitializedEventTest.java
+++ b/matsim/src/test/java/org/matsim/core/events/PersonInitializedEventTest.java
@@ -56,6 +56,7 @@ import org.matsim.core.controler.Controler;
 import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.population.routes.RouteUtils;
 import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.facilities.ActivityFacility;
 import org.matsim.pt.transitSchedule.api.Departure;
 import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
@@ -74,19 +75,25 @@ public class PersonInitializedEventTest {
 
 	@Test
 	void testWriteReadXml() {
-		final PersonInitializedEvent event1 = new PersonInitializedEvent(0, Id.createPersonId("testPerson"));
+		final PersonInitializedEvent event1 = new PersonInitializedEvent(0, Id.createPersonId("testPerson"), Id.createLinkId("testLink"), Id.create("testFacility", ActivityFacility.class), "testType", null);
 		final PersonInitializedEvent event2 = XmlEventsTester.testWriteReadXml(utils.getOutputDirectory() + "events.xml", event1);
 		assertEquals(event1.getTime(), event2.getTime(), MatsimTestUtils.EPSILON);
 		assertEquals(event1.getPersonId(), event2.getPersonId());
+		assertEquals(event1.getLinkId(), event2.getLinkId());
+		assertEquals(event1.getFacilityId(), event2.getFacilityId());
+		assertEquals(event1.getActivityType(), event2.getActivityType());
 		assertNull(event2.getCoord());
 	}
 	
 	@Test
 	void testWriteReadXmlWithCoord() {
-		final PersonInitializedEvent event1 = new PersonInitializedEvent(0, Id.createPersonId("testPerson"), new Coord(12345, 67890));
+		final PersonInitializedEvent event1 = new PersonInitializedEvent(0, Id.createPersonId("testPerson"), Id.createLinkId("testLink"), Id.create("testFacility", ActivityFacility.class), "testType", new Coord(12345, 67890));
 		final PersonInitializedEvent event2 = XmlEventsTester.testWriteReadXml(utils.getOutputDirectory() + "events.xml", event1);
 		assertEquals(event1.getTime(), event2.getTime(), MatsimTestUtils.EPSILON);
 		assertEquals(event1.getPersonId(), event2.getPersonId());
+		assertEquals(event1.getLinkId(), event2.getLinkId());
+		assertEquals(event1.getFacilityId(), event2.getFacilityId());
+		assertEquals(event1.getActivityType(), event2.getActivityType());
 		assertEquals(event1.getCoord(), event2.getCoord());
 	}
 	


### PR DESCRIPTION
This PR adds more information to the `PersonInitializedEvent` and makes it compatible with `ActivityEndEvent`. Especially this allows to derive from the events what kind of event the inactive agents performed during the day and the link / facility of that activity.