### PR TITLE
fix(core): fix ConcurrentModificationException in EventsManagerImpl

### DIFF
--- a/matsim/src/main/java/org/matsim/core/events/EventsManagerImpl.java
+++ b/matsim/src/main/java/org/matsim/core/events/EventsManagerImpl.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
+import java.util.concurrent.CopyOnWriteArrayList;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -67,7 +67,7 @@ public final class EventsManagerImpl implements EventsManager {
 	static private class HandlerData {
 
 		protected Class<? extends Event> eventClass;
-		protected ArrayList<EventHandler> handlerList = new ArrayList<EventHandler>(5);
+		protected List<EventHandler> handlerList = new CopyOnWriteArrayList<>();
 		protected Method method;
 
 		protected HandlerData(final Class<? extends Event> eventClass, final Method method) {


### PR DESCRIPTION
## Problem

I got a `ConcurrentModificationException` when processing events:

```text
java.util.ConcurrentModificationException
    at java.util.ArrayList$Itr.checkForComodification(Unknown Source)
    at java.util.ArrayList$Itr.next(Unknown Source)
    at org.matsim.core.events.EventsManagerImpl.getHandlersForClass(EventsManagerImpl.java:235)
    at org.matsim.core.events.EventsManagerImpl.processEvent(EventsManagerImpl.java:118)
    at org.matsim.core.events.SimStepParallelEventsManagerImpl$ProcessEventsRunnable.run(SimStepParallelEventsManagerImpl.java:349)
    at java.lang.Thread.run(Unknown Source)
```

The issue seems to be: `EventsManagerImpl` stores registered handlers in a plain `ArrayList` inside each `HandlerData` object. `SimStepParallelEventsManagerImpl` runs one worker thread per configured thread count; each thread
holds a reference to one of the underlying `EventsManagerImpl` instances and calls `eventsManager.processEvent(event)` from within `ProcessEventsRunnable.run()`, which in turn iterates the `handlerList` in `getHandlersForClass()`.

`addHandler()` and `removeHandler()` on `SimStepParallelEventsManagerImpl` contain no synchronization and do not check `parallelMode`. They appear to directly mutate the `handlerList` of the underlying `EventsManagerImpl` instances at any time, including while worker threads are actively iterating the same list.

## Fix

I propose to replace `ArrayList<EventHandler>` with `CopyOnWriteArrayList<EventHandler>` in HandlerData.

On every write, CopyOnWriteArrayList atomically replaces its internal array with a fresh copy. Any iteration in progress always operates on the snapshot it started with and is never invalidated by a concurrent modification. Since reading is a _lot_ more common than writing on this list, the additional memory overhead should be negligible, and my initial tests with a 200k agent population show no significant performance decline.