### PR TITLE
feat(dsim): remove Hazelcast CP Subsystem usage during startup

### DIFF
--- a/contribs/distributed-simulation/src/main/java/org/matsim/core/communication/HazelcastCommunicator.java
+++ b/contribs/distributed-simulation/src/main/java/org/matsim/core/communication/HazelcastCommunicator.java
@@ -1,13 +1,15 @@
 package org.matsim.core.communication;
 
+import com.hazelcast.collection.ISet;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MulticastConfig;
 import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.map.IMap;
 import com.hazelcast.topic.ITopic;
+
+import org.agrona.concurrent.BackoffIdleStrategy;
 import org.agrona.concurrent.BusySpinIdleStrategy;
 import org.agrona.concurrent.IdleStrategy;
 import org.agrona.concurrent.ManyToOneConcurrentLinkedQueue;
@@ -86,19 +88,20 @@ public class HazelcastCommunicator implements Communicator {
 
 	@Override
 	public void connect() throws Exception {
-		IMap<Integer, Boolean> startupMap = hz.getMap("startup");
+		ISet<Integer> startupSet = hz.getSet("startup");
 
 		topics.get(rank).addMessageListener(this::onMessage);
 
-		startupMap.put(rank, true);
+		startupSet.add(rank);
 
 		// Wait for all nodes to register
+		IdleStrategy idleStrategy = new BackoffIdleStrategy();
 		long deadline = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(10);
-		while (startupMap.size() < size) {
+		while (startupSet.size() < size) {
 			if (System.currentTimeMillis() > deadline) {
 				throw new RuntimeException("Timeout waiting for all nodes to connect");
 			}
-			Thread.sleep(100);
+			idleStrategy.idle();
 		}
 	}
 


### PR DESCRIPTION
We were using the [Hazelcast CP Subsystem](https://docs.hazelcast.com/hazelcast/5.6/cp-subsystem/cp-subsystem
) for waiting for the nodes to start up. However, a paid license is required to use that feature (https://github.com/hazelcast/hazelcast/issues/26483) so this change replaces the usage of the CP Subsystem with a simple IMap.