### PR TITLE
fix(deps): remove version from jaxb-core dependency

### DIFF
--- a/contribs/vsp/pom.xml
+++ b/contribs/vsp/pom.xml
@@ -315,7 +315,6 @@
 		<dependency>
 			<groupId>com.sun.xml.bind</groupId>
 			<artifactId>jaxb-core</artifactId>
-			<version>4.0.6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>


### PR DESCRIPTION
Removed version specification for jaxb-core dependency because we have the BOM in the dependency management section.