### PR TITLE
fix(drt): Compute sharing metrics per DRT mode

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/sharingmetrics/SharingMetricsModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/sharingmetrics/SharingMetricsModule.java
@@ -19,7 +19,7 @@ public class SharingMetricsModule extends AbstractDvrpModeModule {
     @Override
     public void install() {
         bindModal(SharingMetricsTracker.class).toProvider(modalProvider(getter ->
-                new SharingMetricsTracker())).asEagerSingleton();
+                new SharingMetricsTracker(getMode()))).asEagerSingleton();
         addEventHandlerBinding().to(modalKey(SharingMetricsTracker.class));
         bindModal(SharingMetricsControllerListener.class).toProvider(modalProvider(getter ->
                 new SharingMetricsControllerListener(getConfig(), drtConfigGroup,

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/sharingmetrics/SharingMetricsTracker.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/sharingmetrics/SharingMetricsTracker.java
@@ -13,8 +13,6 @@ import org.matsim.contrib.dvrp.passenger.PassengerDroppedOffEventHandler;
 import org.matsim.contrib.dvrp.passenger.PassengerPickedUpEvent;
 import org.matsim.contrib.dvrp.passenger.PassengerPickedUpEventHandler;
 import org.matsim.core.gbl.Gbl;
-import org.matsim.core.mobsim.framework.events.MobsimBeforeCleanupEvent;
-import org.matsim.core.mobsim.framework.listeners.MobsimBeforeCleanupListener;
 
 import java.util.*;
 
@@ -29,6 +27,8 @@ public class SharingMetricsTracker implements DrtRequestSubmittedEventHandler, P
 	record Segment(double start, int occupancy) {
 	}
 
+	private final String mode;
+
 	private final Map<Id<DvrpVehicle>, List<Id<Request>>> occupancyByVehicle = new HashMap<>();
 
 	private final Map<Id<Request>, List<Segment>> segments = new HashMap<>();
@@ -39,16 +39,23 @@ public class SharingMetricsTracker implements DrtRequestSubmittedEventHandler, P
 	private final Map<Id<Request>, Boolean> poolingRate = new HashMap<>();
 
 
-	public SharingMetricsTracker() {
+	public SharingMetricsTracker(String mode) {
+		this.mode = mode;
 	}
 
 	@Override
 	public void handleEvent(DrtRequestSubmittedEvent event) {
+		if (!event.getMode().equals(mode)) {
+			return;
+		}
 		knownGroups.put(event.getRequestId(), new ArrayList<>(event.getPersonIds()));
 	}
 
 	@Override
 	public void handleEvent(PassengerDroppedOffEvent event) {
+		if (!event.getMode().equals(mode)) {
+			return;
+		}
 
 		List<Id<Person>> passengers = knownGroups.get(event.getRequestId());
 		Gbl.assertIf(passengers.contains(event.getPersonId()));
@@ -103,6 +110,9 @@ public class SharingMetricsTracker implements DrtRequestSubmittedEventHandler, P
 
 	@Override
 	public void handleEvent(PassengerPickedUpEvent event) {
+		if (!event.getMode().equals(mode)) {
+			return;
+		}
 		List<Id<Request>> occupancy = occupancyByVehicle.computeIfAbsent(event.getVehicleId(), vehicleId -> new ArrayList<>());
 		if (occupancy.contains(event.getRequestId())) {
 			if (knownGroups.get(event.getRequestId()).size() > 1) {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/sharingmetrics/SharingFactorTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/sharingmetrics/SharingFactorTest.java
@@ -31,7 +31,7 @@ public class SharingFactorTest {
 
 
 		ParallelEventsManager events = new ParallelEventsManager(false);
-		SharingMetricsTracker sharingFactorTracker = new SharingMetricsTracker();
+		SharingMetricsTracker sharingFactorTracker = new SharingMetricsTracker(mode);
 		events.addHandler(sharingFactorTracker);
 
 		events.initProcessing();
@@ -195,5 +195,72 @@ public class SharingFactorTest {
 			Assertions.assertFalse(sharingFactorTracker.getPoolingRates().get(requestId1));
 			Assertions.assertEquals(1., sharingFactorTracker.getSharingFactors().get(requestId1), MatsimTestUtils.EPSILON);
 		}
+	}
+
+	/**
+	 * Verifies that two trackers bound to different modes each process only their own
+	 * mode's events and produce independent, correct results.
+	 * <p>
+	 * mode_A has two pooled trips (sharing factor > 1); mode_B has a single solo trip
+	 * (sharing factor = 1). Before the fix both trackers would have seen all events and
+	 * produced identical, aggregated output.
+	 */
+	@Test
+	public void testSharingMetricsAreComputedPerMode() {
+		String modeA = "drt_A";
+		String modeB = "drt_B";
+
+		var vehicleA = Id.create("vA", DvrpVehicle.class);
+		var vehicleB = Id.create("vB", DvrpVehicle.class);
+
+		var person1 = Id.createPersonId("p1");
+		var person2 = Id.createPersonId("p2");
+		var person3 = Id.createPersonId("p3");
+
+		// Two requests in mode_A overlap completely -> both are pooled, sharing factor = 2
+		var requestA1 = Id.create("rA1", Request.class);
+		var requestA2 = Id.create("rA2", Request.class);
+
+		// One solo request in mode_B -> not pooled, sharing factor = 1
+		var requestB1 = Id.create("rB1", Request.class);
+
+		ParallelEventsManager events = new ParallelEventsManager(false);
+
+		SharingMetricsTracker trackerA = new SharingMetricsTracker(modeA);
+		SharingMetricsTracker trackerB = new SharingMetricsTracker(modeB);
+
+		events.addHandler(trackerA);
+		events.addHandler(trackerB);
+		events.initProcessing();
+
+		// mode_A: two requests picked up at the same time and dropped off at the same time
+		events.processEvent(new DrtRequestSubmittedEvent(0.0, modeA, requestA1, List.of(person1), null, null, 0, 0, 0, 0, 0, 0, null, null));
+		events.processEvent(new DrtRequestSubmittedEvent(0.0, modeA, requestA2, List.of(person2), null, null, 0, 0, 0, 0, 0, 0, null, null));
+		events.processEvent(new PassengerPickedUpEvent(100.0, modeA, requestA1, person1, vehicleA));
+		events.processEvent(new PassengerPickedUpEvent(100.0, modeA, requestA2, person2, vehicleA));
+		events.processEvent(new PassengerDroppedOffEvent(200.0, modeA, requestA1, person1, vehicleA));
+		events.processEvent(new PassengerDroppedOffEvent(200.0, modeA, requestA2, person2, vehicleA));
+
+		// mode_B: single solo trip
+		events.processEvent(new DrtRequestSubmittedEvent(0.0, modeB, requestB1, List.of(person3), null, null, 0, 0, 0, 0, 0, 0, null, null));
+		events.processEvent(new PassengerPickedUpEvent(100.0, modeB, requestB1, person3, vehicleB));
+		events.processEvent(new PassengerDroppedOffEvent(300.0, modeB, requestB1, person3, vehicleB));
+
+		events.flush();
+
+		// --- trackerA: must contain exactly the two mode_A requests ---
+		Assertions.assertEquals(2, trackerA.getSharingFactors().size(), "trackerA must track only mode_A requests");
+		Assertions.assertNull(trackerA.getSharingFactors().get(requestB1), "trackerA must not contain mode_B request");
+		Assertions.assertTrue(trackerA.getPoolingRates().get(requestA1), "requestA1 must be pooled");
+		Assertions.assertTrue(trackerA.getPoolingRates().get(requestA2), "requestA2 must be pooled");
+		Assertions.assertEquals(2., trackerA.getSharingFactors().get(requestA1), MatsimTestUtils.EPSILON);
+		Assertions.assertEquals(2., trackerA.getSharingFactors().get(requestA2), MatsimTestUtils.EPSILON);
+
+		// --- trackerB: must contain exactly the one mode_B request ---
+		Assertions.assertEquals(1, trackerB.getSharingFactors().size(), "trackerB must track only mode_B requests");
+		Assertions.assertNull(trackerB.getSharingFactors().get(requestA1), "trackerB must not contain mode_A request rA1");
+		Assertions.assertNull(trackerB.getSharingFactors().get(requestA2), "trackerB must not contain mode_A request rA2");
+		Assertions.assertFalse(trackerB.getPoolingRates().get(requestB1), "requestB1 must not be pooled");
+		Assertions.assertEquals(1., trackerB.getSharingFactors().get(requestB1), MatsimTestUtils.EPSILON);
 	}
 }


### PR DESCRIPTION
## Problem
When multiple DRT modes are configured, `SharingMetricsTracker` – although instantiated once per mode – performed no mode filtering on the events it received, so every tracker processed trips from all modes and produced identical output regardless of mode.

## Solution
`SharingMetricsTracker` now accepts a `mode` constructor argument and guards all three `handleEvent` methods with an `event.getMode().equals(mode)` check, following the same pattern used by `DrtEventSequenceCollector` and other modal handlers; `SharingMetricsModule` passes `getMode()` to the constructor.

A unit test is also added.

Tagging the original author @nkuehnel for review