### PR TITLE
fix(DSim): Correctly register global event handlers in distributed setup

### DIFF
--- a/contribs/distributed-simulation/src/test/java/org/matsim/dsim/DistributedEventsManagerTest.java
+++ b/contribs/distributed-simulation/src/test/java/org/matsim/dsim/DistributedEventsManagerTest.java
@@ -4,12 +4,14 @@ import com.google.inject.Provider;
 import it.unimi.dsi.fastutil.ints.IntList;
 import org.junit.jupiter.api.Test;
 import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Topology;
 import org.matsim.api.core.v01.events.Event;
 import org.matsim.api.core.v01.events.LinkEnterEvent;
 import org.matsim.api.core.v01.events.handler.DistributedEventHandler;
 import org.matsim.api.core.v01.events.handler.DistributedMode;
 import org.matsim.api.core.v01.events.handler.ProcessingMode;
 import org.matsim.api.core.v01.messages.ComputeNode;
+import org.matsim.core.communication.LocalCommunicator;
 import org.matsim.core.events.handler.BasicEventHandler;
 import org.matsim.core.events.handler.EventHandler;
 import org.matsim.core.serialization.SerializationProvider;
@@ -18,6 +20,8 @@ import org.matsim.dsim.executors.SingleExecutor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -264,6 +268,56 @@ class DistributedEventsManagerTest {
 		assertEquals(1, subclassedTestEventHandler.counter.get());
 		assertEquals(2, testEventHandler.counter.get());
 		assertEquals(3, basicEventHandler.counter.get());
+	}
+	
+	@Test
+	public void globalHandlerReceivesRemoteEvent() throws Exception {
+		var communicators = LocalCommunicator.create(2);
+		var provider = new SerializationProvider();
+
+		var node0 = ComputeNode.builder().rank(0).parts(IntList.of(0)).build();
+		var node1 = ComputeNode.builder().rank(1).parts(IntList.of(1)).build();
+		var topology = Topology.builder()
+			.totalPartitions(2)
+			.computeNodes(List.of(node0, node1))
+			.build();
+
+		var executor0 = new SingleExecutor(provider);
+		var broker0 = new MessageBroker(communicators.getFirst(), topology, provider);
+		var manager0 = new DistributedEventsManager(broker0, node0, executor0, provider);
+
+		var executor1 = new SingleExecutor(provider);
+		var broker1 = new MessageBroker(communicators.getLast(), topology, provider);
+		var manager1 = new DistributedEventsManager(broker1, node1, executor1, provider);
+
+		// Register global handler on both nodes. It should only be registered with manager0
+		var globalHandler = new GlobalTestHandler();
+		manager0.addHandler(globalHandler);
+		manager1.addHandler(globalHandler);
+
+		// syncEventRegistry is a collective barrier: run both nodes concurrently
+		runConcurrently(
+			() -> manager0.syncEventRegistry(communicators.getFirst()),
+			() -> manager1.syncEventRegistry(communicators.getLast())
+		);
+
+		// Fire an event on node 1 — the global handler on node 0 must receive it
+		manager1.setContext(1);
+		manager1.processEvent(new TestEvent(0.0, "from-node1"));
+
+		// finishProcessing flushes queued remote events, syncs across nodes, and runs handlers
+		runConcurrently(manager0::finishProcessing, manager1::finishProcessing);
+
+		assertEquals(1, globalHandler.counter.get());
+	}
+
+	private static void runConcurrently(Runnable r0, Runnable r1) throws Exception {
+		try (ExecutorService exec = Executors.newFixedThreadPool(2)) {
+			var f0 = exec.submit(r0);
+			var f1 = exec.submit(r1);
+			f0.get();
+			f1.get();
+		}
 	}
 
 	@DistributedEventHandler(value = DistributedMode.GLOBAL)

--- a/matsim/src/main/java/org/matsim/core/events/handler/EventHandler.java
+++ b/matsim/src/main/java/org/matsim/core/events/handler/EventHandler.java
@@ -55,8 +55,13 @@ public interface EventHandler extends MatsimExtensionPoint, MessageProcessor {
 		return 900;
 	}
 
+	/**
+	 * By default, this is the same as {@link #getProcessInterval()}. This is necessary for global event handlers that
+	 * rely on the correct order of events. Distributed handlers may have varying intervals as for them processing is
+	 * independent of syncing.
+	 */
 	default double getSyncInterval() {
-		return 900;
+		return getProcessInterval();
 	}
 
 	/**

--- a/matsim/src/main/java/org/matsim/dsim/DistributedEventsManager.java
+++ b/matsim/src/main/java/org/matsim/dsim/DistributedEventsManager.java
@@ -115,9 +115,7 @@ public final class DistributedEventsManager implements EventsManager {
 
 		var distMode = getDistributedMode(handler);
 		switch (distMode) {
-			case GLOBAL -> {
-				if (computeNode.isHeadNode()) addAsNodeSingleton(handler);
-			}
+			case GLOBAL -> addAsGlobalHandler(handler);
 			case NODE -> addAsNodeSingleton(handler);
 			case NODE_CONCURRENT -> addAsConcurrentNodeSingleton(handler);
 			case PARTITION -> throw new IllegalArgumentException("Adding instance of PartitionEventHandler without provider. " +
@@ -147,6 +145,23 @@ public final class DistributedEventsManager implements EventsManager {
 		var part = computeNode.getParts().getInt(0);
 		EventHandlerTask task = executor.register(handler, this, part, 1, null);
 		addTaskForEachPart(task, part);
+	}
+
+	/**
+	 * Registers a GLOBAL event handler. The handler is registered similar to a node handler. It is also registered
+	 * as a global listener. The globalListener collection is used to tell other partitions that the handler is
+	 * interested in events from other compute nodes.
+	 */
+	private void addAsGlobalHandler(EventHandler handler) {
+		// only the head node registers global handlers all others send events to the head node
+		if (!computeNode.isHeadNode()) return;
+
+		var part = computeNode.getParts().getInt(0);
+		EventHandlerTask task = executor.register(handler, this, part, 1, null);
+		addTaskForEachPart(task, part);
+		for (int type : task.getSupportedMessages()) {
+			globalListener.computeIfAbsent(type, _ -> new ArrayList<>()).add(task);
+		}
 	}
 
 	public void addAsConcurrentNodeSingleton(EventHandler handler) {
@@ -325,6 +340,8 @@ public final class DistributedEventsManager implements EventsManager {
 
 	@Override
 	public void processEvent(Event e) {
+
+		log.info("#{}: {}", this.broker.getRank(), e);
 
 		if (eventsDisabled) {
 			return;

--- a/matsim/src/main/java/org/matsim/dsim/DistributedEventsManager.java
+++ b/matsim/src/main/java/org/matsim/dsim/DistributedEventsManager.java
@@ -75,7 +75,7 @@ public final class DistributedEventsManager implements EventsManager {
 
 	private final boolean eventsDisabled;
 	/**
-	 * The remote sync step for events, which is the minimum of all handlers.
+	 * Sync intervall for global event handlers. This value should be the minimum of all global event handlers.
 	 */
 	private double remoteSyncStep = Double.POSITIVE_INFINITY;
 	/**
@@ -162,6 +162,7 @@ public final class DistributedEventsManager implements EventsManager {
 		for (int type : task.getSupportedMessages()) {
 			globalListener.computeIfAbsent(type, _ -> new ArrayList<>()).add(task);
 		}
+		remoteSyncStep = Math.min(remoteSyncStep, handler.getSyncInterval());
 	}
 
 	public void addAsConcurrentNodeSingleton(EventHandler handler) {
@@ -410,6 +411,9 @@ public final class DistributedEventsManager implements EventsManager {
 	@Override
 	public void afterSimStep(double time) {
 
+		// this works because lastSync is initially set to -1. Therefore we send events one timestep before the processing intervall.
+		// I.e. if processing/sync intervall is 900 this will trigger a send at 899. The event handlers will process the received events
+		// at 900
 		if (lastSync + remoteSyncStep <= time) {
 
 			for (Int2ObjectMap.Entry<ManyToOneConcurrentLinkedQueue<Event>> kv : remoteEvents.int2ObjectEntrySet()) {

--- a/matsim/src/main/java/org/matsim/dsim/DistributedEventsManager.java
+++ b/matsim/src/main/java/org/matsim/dsim/DistributedEventsManager.java
@@ -341,8 +341,6 @@ public final class DistributedEventsManager implements EventsManager {
 	@Override
 	public void processEvent(Event e) {
 
-		log.info("#{}: {}", this.broker.getRank(), e);
-
 		if (eventsDisabled) {
 			return;
 		}


### PR DESCRIPTION
Global event handlers were not correctly registered in distributed setups. 

The `DistributedEventsManager` now correctly registers global handlers and subscribes to events for this handler at other compute nodes. 

This PR also adds a test for this aspect.