### PR TITLE
refactor(Dsim): Scan class graph only once

### DIFF
--- a/contribs/distributed-simulation/src/test/java/org/matsim/dsim/DefaultEventHandlerTaskTest.java
+++ b/contribs/distributed-simulation/src/test/java/org/matsim/dsim/DefaultEventHandlerTaskTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.when;
 
 class DefaultEventHandlerTaskTest {
 
-	private static final SerializationProvider serializer = new SerializationProvider();
+	private static final SerializationProvider serializer = SerializationProvider.getInstance();
 
 	@Test
 	public void syncTimeStep() {

--- a/contribs/distributed-simulation/src/test/java/org/matsim/dsim/DistributedEventsManagerTest.java
+++ b/contribs/distributed-simulation/src/test/java/org/matsim/dsim/DistributedEventsManagerTest.java
@@ -32,7 +32,7 @@ class DistributedEventsManagerTest {
 	@Test
 	public void globalHandler() {
 		MessageBroker broker = mock(MessageBroker.class);
-		var provider = new SerializationProvider();
+		var provider = SerializationProvider.getInstance();
 		LPExecutor executor = new SingleExecutor(provider);
 		var computeNode = ComputeNode.builder()
 			.rank(0)
@@ -58,7 +58,7 @@ class DistributedEventsManagerTest {
 	@Test
 	public void globalHandlerNotHeadNode() {
 		MessageBroker broker = mock(MessageBroker.class);
-		var provider = new SerializationProvider();
+		var provider = SerializationProvider.getInstance();
 		LPExecutor executor = new SingleExecutor(provider);
 		var computeNode = ComputeNode.builder()
 			.rank(1)
@@ -82,7 +82,7 @@ class DistributedEventsManagerTest {
 	@Test
 	public void nodeHandler() {
 		MessageBroker broker = mock(MessageBroker.class);
-		var provider = new SerializationProvider();
+		var provider = SerializationProvider.getInstance();
 		LPExecutor executor = new SingleExecutor(provider);
 		var computeNode = ComputeNode.builder()
 			.rank(0)
@@ -108,7 +108,7 @@ class DistributedEventsManagerTest {
 	@Test
 	public void nodeConcurrentHandler() {
 		MessageBroker broker = mock(MessageBroker.class);
-		var provider = new SerializationProvider();
+		var provider = SerializationProvider.getInstance();
 		LPExecutor executor = new SingleExecutor(provider);
 		var computeNode = ComputeNode.builder()
 			.rank(0)
@@ -137,7 +137,7 @@ class DistributedEventsManagerTest {
 	@Test
 	public void nodeConcurrentHandlerDirect() {
 		MessageBroker broker = mock(MessageBroker.class);
-		var provider = new SerializationProvider();
+		var provider = SerializationProvider.getInstance();
 		LPExecutor executor = new SingleExecutor(provider);
 		var computeNode = ComputeNode.builder()
 			.rank(0)
@@ -164,7 +164,7 @@ class DistributedEventsManagerTest {
 	@Test
 	public void partitionHandler() {
 		MessageBroker broker = mock(MessageBroker.class);
-		var serializationProvider = new SerializationProvider();
+		var serializationProvider = SerializationProvider.getInstance();
 		LPExecutor executor = new SingleExecutor(serializationProvider);
 		var computeNode = ComputeNode.builder()
 			.rank(0)
@@ -196,7 +196,7 @@ class DistributedEventsManagerTest {
 	public void partitionHandlerParticularPart() {
 
 		MessageBroker broker = mock(MessageBroker.class);
-		var serializationProvider = new SerializationProvider();
+		var serializationProvider = SerializationProvider.getInstance();
 		LPExecutor executor = new SingleExecutor(serializationProvider);
 		var computeNode = ComputeNode.builder()
 			.rank(0)
@@ -222,7 +222,7 @@ class DistributedEventsManagerTest {
 	public void eventClassHierachy() {
 
 		MessageBroker broker = mock(MessageBroker.class);
-		var serializationProvider = new SerializationProvider();
+		var serializationProvider = SerializationProvider.getInstance();
 		LPExecutor executor = new SingleExecutor(serializationProvider);
 		var computeNode = ComputeNode.builder()
 			.rank(0)
@@ -273,7 +273,7 @@ class DistributedEventsManagerTest {
 	@Test
 	public void globalHandlerReceivesRemoteEvent() throws Exception {
 		var communicators = LocalCommunicator.create(2);
-		var provider = new SerializationProvider();
+		var provider = SerializationProvider.getInstance();
 
 		var node0 = ComputeNode.builder().rank(0).parts(IntList.of(0)).build();
 		var node1 = ComputeNode.builder().rank(1).parts(IntList.of(1)).build();

--- a/contribs/distributed-simulation/src/test/java/org/matsim/dsim/MessageBrokerTest.java
+++ b/contribs/distributed-simulation/src/test/java/org/matsim/dsim/MessageBrokerTest.java
@@ -29,7 +29,7 @@ public class MessageBrokerTest {
 
 	// Topology: rank 0 → partitions [0,1], rank 1 → partitions [2,3], rank 2 → partitions [4,5]
 	private static final Topology TOPOLOGY = buildTopology();
-	private static final SerializationProvider serializer = new SerializationProvider();
+	private static final SerializationProvider serializer = SerializationProvider.getInstance();
 
 	private static Topology buildTopology() {
 		var node0 = ComputeNode.builder().distributed(true).rank(0).parts(IntList.of(0, 1)).cores(1).hostname("localhost").build();
@@ -42,16 +42,16 @@ public class MessageBrokerTest {
 			.build();
 	}
 
-	private static Communicator mockComm(int rank) {
+	private static Communicator mockComm() {
 		var comm = mock(Communicator.class);
-		when(comm.getRank()).thenReturn(rank);
+		when(comm.getRank()).thenReturn(0);
 		when(comm.getSize()).thenReturn(TOPOLOGY.getNodesCount());
 		return comm;
 	}
 
 	@Test
 	void waitForRank() throws IOException {
-		var comm = mockComm(0);
+		var comm = mockComm();
 		var broker = new MessageBroker(comm, TOPOLOGY, serializer);
 
 		// register rank to wait for
@@ -69,7 +69,7 @@ public class MessageBrokerTest {
 
 	@Test
 	void dontWaitForOwnRank() {
-		var comm = mockComm(0);
+		var comm = mockComm();
 		var broker = new MessageBroker(comm, TOPOLOGY, serializer);
 
 		broker.syncFromRank(broker.getRank());
@@ -78,7 +78,7 @@ public class MessageBrokerTest {
 
 	@Test
 	void sendEmptyMessageToOtherRank() {
-		var comm = mockComm(0);
+		var comm = mockComm();
 		var broker = new MessageBroker(comm, TOPOLOGY, serializer);
 
 		broker.beforeSimStep(0);
@@ -90,7 +90,7 @@ public class MessageBrokerTest {
 
 	@Test
 	void sendOneEmptyMessageToRemotePart() {
-		var comm = mockComm(0);
+		var comm = mockComm();
 		var broker = new MessageBroker(comm, TOPOLOGY, serializer);
 
 		broker.beforeSimStep(0);
@@ -106,7 +106,7 @@ public class MessageBrokerTest {
 
 	@Test
 	void sendNoEmptyMessageToOwnRank() {
-		var comm = mockComm(0);
+		var comm = mockComm();
 		var broker = new MessageBroker(comm, TOPOLOGY, serializer);
 
 		broker.beforeSimStep(0);
@@ -122,7 +122,7 @@ public class MessageBrokerTest {
 		var otherRank = 1;
 		var time = 43;
 		var receivedBytes = msgBytes(otherRank, 0, MessageBroker.ANY_PARTITION, EmptyMessage.INSTANCE, MessageBroker.seqFrom(time));
-		var comm = mockComm(0);
+		var comm = mockComm();
 		doAnswer(i -> {
 			MessageReceiver expectsNext = i.getArgument(0);
 			MessageConsumer msgConsumer = i.getArgument(1);
@@ -163,7 +163,7 @@ public class MessageBrokerTest {
 		var otherRank = 1;
 		var receivedBytes = msgBytes(otherRank, 0, MessageBroker.ANY_PARTITION, EmptyMessage.INSTANCE, seq(0));
 
-		var comm = mockComm(0);
+		var comm = mockComm();
 		doAnswer(i -> {
 			MessageReceiver expectsNext = i.getArgument(0);
 			MessageConsumer msgConsumer = i.getArgument(1);
@@ -197,8 +197,8 @@ public class MessageBrokerTest {
 	}
 
 	@Test
-	void sendMultipleRanks() throws Exception {
-		var comm = mockComm(0);
+	void sendMultipleRanks() {
+		var comm = mockComm();
 		var broker = new MessageBroker(comm, TOPOLOGY, serializer);
 
 		var receiverTask = mock(LPTask.class);
@@ -234,10 +234,10 @@ public class MessageBrokerTest {
 		var msgArgs = msgCaptor.getAllValues();
 		assertEquals(2, msgArgs.size());
 
-		MessageA msg1 = verifyMsg(seq(0), 0, 1, 2, msgToPart2.getType(), msgArgs.get(iRank1).asByteBuffer());
+		MessageA msg1 = verifyMsg(seq(0), 1, 2, msgToPart2.getType(), msgArgs.get(iRank1).asByteBuffer());
 		assertEquals(msgToPart2.payload(), msg1.payload());
 
-		EmptyMessage msg2 = verifyMsg(seq(0), 0, 2, MessageBroker.ANY_PARTITION, EmptyMessage.INSTANCE.getType(), msgArgs.get(iRank2).asByteBuffer());
+		EmptyMessage msg2 = verifyMsg(seq(0), 2, MessageBroker.ANY_PARTITION, EmptyMessage.INSTANCE.getType(), msgArgs.get(iRank2).asByteBuffer());
 		assertNotNull(msg2);
 	}
 
@@ -248,7 +248,7 @@ public class MessageBrokerTest {
 		var bytesRank1 = msgBytes(1, 0, 0, msgFromRank1, seq(0));
 		var bytesRank2 = msgBytes(2, 0, 1, msgFromRank2, seq(0));
 
-		var comm = mockComm(0);
+		var comm = mockComm();
 		doAnswer(i -> {
 			MessageReceiver expectsNext = i.getArgument(0);
 			MessageConsumer msgConsumer = i.getArgument(1);
@@ -301,8 +301,8 @@ public class MessageBrokerTest {
 	}
 
 	@Test
-	public void sendBroadcast() throws IOException {
-		var comm = mockComm(0);
+	public void sendBroadcast() {
+		var comm = mockComm();
 		var broker = new MessageBroker(comm, TOPOLOGY, serializer);
 
 		var msgA = new MessageA("broadcast payload");
@@ -315,7 +315,7 @@ public class MessageBrokerTest {
 		verify(comm, times(1)).send(eq(Communicator.BROADCAST_TO_ALL), msgCaptor.capture(), anyLong(), anyLong());
 
 		var type = serializer.getType(MessageA.class);
-		MessageA received = verifyMsg(seq(0), 0, Communicator.BROADCAST_TO_ALL, Communicator.BROADCAST_TO_ALL, type,
+		MessageA received = verifyMsg(seq(0), Communicator.BROADCAST_TO_ALL, Communicator.BROADCAST_TO_ALL, type,
 			msgCaptor.getValue().asByteBuffer());
 		assertEquals(msgA.payload(), received.payload());
 	}
@@ -329,7 +329,7 @@ public class MessageBrokerTest {
 		var msgFromRank2 = new MessageA("incoming broadcast from rank 2");
 		var bytesFromRank2 = msgBytes(2, Communicator.BROADCAST_TO_ALL, Communicator.BROADCAST_TO_ALL, msgFromRank2, seq(0));
 
-		var comm = mockComm(0);
+		var comm = mockComm();
 		doAnswer(i -> {
 			MessageReceiver expectsNext = i.getArgument(0);
 			MessageConsumer msgConsumer = i.getArgument(1);
@@ -378,7 +378,7 @@ public class MessageBrokerTest {
 
 	@Test
 	public void sendBroadcastMessageAndEmptyMessage() {
-		var comm = mockComm(0);
+		var comm = mockComm();
 		var broker = new MessageBroker(comm, TOPOLOGY, serializer);
 
 		var msgA = new MessageA("broadcast with empty");
@@ -411,7 +411,7 @@ public class MessageBrokerTest {
 		var msgBFromRank2 = new MessageB("message B from rank 2");
 		var msgBBytes = msgBytes(2, 0, 1, msgBFromRank2, seq(0));
 
-		var comm = mockComm(0);
+		var comm = mockComm();
 		doAnswer(i -> {
 
 			MessageReceiver expectsNext = i.getArgument(0);
@@ -472,7 +472,7 @@ public class MessageBrokerTest {
 		var inSequenceMessage = new MessageA("in sequence message");
 		var inSequenceBytes = msgBytes(1, 0, 0, inSequenceMessage, seq(time));
 
-		var comm = mockComm(0);
+		var comm = mockComm();
 		doAnswer(i -> {
 			MessageReceiver expectsNext = i.getArgument(0);
 			MessageConsumer msgConsumer = i.getArgument(1);
@@ -538,7 +538,7 @@ public class MessageBrokerTest {
 		var inSequenceMessage = new MessageA("in sequence message");
 		var inSequenceBytes = msgBytes(syncRank, 0, 0, inSequenceMessage, seq(time));
 
-		var comm = mockComm(0);
+		var comm = mockComm();
 		doAnswer(i -> {
 			MessageReceiver expectsNext = i.getArgument(0);
 			MessageConsumer msgConsumer = i.getArgument(1);
@@ -586,7 +586,7 @@ public class MessageBrokerTest {
 		var pastMessageFromSyncedRank = new MessageA("illegal past message");
 		var pastBytesFromSyncRank = msgBytes(syncRank, 0, 0, pastMessageFromSyncedRank, seq(pastTime));
 
-		var comm = mockComm(0);
+		var comm = mockComm();
 		doAnswer(i -> {
 			MessageReceiver expectsNext = i.getArgument(0);
 			MessageConsumer msgConsumer = i.getArgument(1);
@@ -608,13 +608,13 @@ public class MessageBrokerTest {
 	}
 
 	@SuppressWarnings("unchecked")
-	private <T extends Message> T verifyMsg(int expectedTag, int expectedSender, int expectedReceiver, int expectedPartition, int expectedType, ByteBuffer actualBytes) {
+	private <T extends Message> T verifyMsg(int expectedTag, int expectedReceiver, int expectedPartition, int expectedType, ByteBuffer actualBytes) {
 		actualBytes.order(ByteOrder.LITTLE_ENDIAN);
 		var memBuf = MemoryBuffer.fromByteBuffer(actualBytes);
 
 		// verify rank header
 		assertEquals(expectedTag, memBuf.readInt32());
-		assertEquals(expectedSender, memBuf.readInt32());
+		assertEquals(0, memBuf.readInt32());
 		assertEquals(expectedReceiver, memBuf.readInt32());
 
 		// verify part header

--- a/matsim/src/main/java/org/matsim/core/serialization/SerializationProvider.java
+++ b/matsim/src/main/java/org/matsim/core/serialization/SerializationProvider.java
@@ -105,10 +105,6 @@ public class SerializationProvider {
 		}
 	}
 
-	public static void main() throws ClassNotFoundException {
-		System.out.println(SerializationProvider.getInstance());
-	}
-
 	/**
 	 * Serialize message object and return byte array.
 	 */

--- a/matsim/src/main/java/org/matsim/core/serialization/SerializationProvider.java
+++ b/matsim/src/main/java/org/matsim/core/serialization/SerializationProvider.java
@@ -30,12 +30,18 @@ import java.nio.ByteBuffer;
  */
 public class SerializationProvider {
 
+	private static final SerializationProvider INSTANCE = new SerializationProvider();
+
+	public static SerializationProvider getInstance() {
+		return INSTANCE;
+	}
+
 	private final Int2ObjectMap<Class<? extends Message>> type2Class = new Int2ObjectOpenHashMap<>(128);
 	private final Object2IntMap<Class<? extends Message>> class2Type = new Object2IntOpenHashMap<>();
 
 	private final ThreadSafeFory fory;
 
-	public SerializationProvider() {
+	private SerializationProvider() {
 
 		// Fory uses its own verbose logging. Disable this manually here, so users don't see the internals of how Fory compiles classes into
 		// wire formats.
@@ -100,14 +106,7 @@ public class SerializationProvider {
 	}
 
 	public static void main() throws ClassNotFoundException {
-		System.out.println(new SerializationProvider());
-	}
-
-	/**
-	 * Return whether the given type is an event.
-	 */
-	public boolean isEvent(int type) {
-		return type2Class.containsKey(type) && Event.class.isAssignableFrom(type2Class.get(type));
+		System.out.println(SerializationProvider.getInstance());
 	}
 
 	/**
@@ -157,10 +156,6 @@ public class SerializationProvider {
 	 */
 	public boolean hasType(int type) {
 		return type == Event.ANY_TYPE || type2Class.containsKey(type);
-	}
-
-	public boolean hasType(Class<?> msgClass) {
-		return msgClass == Event.class || class2Type.containsKey(msgClass);
 	}
 
 	/**

--- a/matsim/src/main/java/org/matsim/dsim/DistributedContext.java
+++ b/matsim/src/main/java/org/matsim/dsim/DistributedContext.java
@@ -60,7 +60,7 @@ public final class DistributedContext implements ExecutionContext {
 			throw new RuntimeException("Local communication problem", e);
 		}
 
-		SerializationProvider serializer = new SerializationProvider();
+		SerializationProvider serializer = SerializationProvider.getInstance();
 
 		log.info("Local topology has {} partitions.", topology.getTotalPartitions());
 
@@ -88,7 +88,7 @@ public final class DistributedContext implements ExecutionContext {
 
 		log.info("All nodes connected");
 
-		SerializationProvider serializer = new SerializationProvider();
+		SerializationProvider serializer = SerializationProvider.getInstance();
 
 		// This may be relevant if we want to partition the network or other lps
 		Topology topology = createTopology(comm, threads, serializer);

--- a/matsim/src/test/java/org/matsim/core/serialization/SerializationProviderTest.java
+++ b/matsim/src/test/java/org/matsim/core/serialization/SerializationProviderTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 class SerializationProviderTest {
 
-	private final SerializationProvider provider = new SerializationProvider();
+	private final SerializationProvider provider = SerializationProvider.getInstance();
 
 	@Test
 	void serializeEvents() {


### PR DESCRIPTION
`SerializationProvider` scans the classgraph to generate wire types for `Message` and `Event` types (and some others). The simulation created mutliple instances of this provider on startup, which resulted in multiple (slow) traversals of the class graph. Since there is only ever one instance of this class, it is switched to a singleton.