### PR TITLE
fix(shared_mobility): set initialSoc on EV-typed dummy routing vehicles

### DIFF
--- a/contribs/shared_mobility/pom.xml
+++ b/contribs/shared_mobility/pom.xml
@@ -22,6 +22,11 @@
 			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.matsim.contrib</groupId>
+			<artifactId>ev</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>com.google.code.findbugs</groupId>
 			<artifactId>jsr305</artifactId>
 		</dependency>

--- a/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/SharingUtils.java
+++ b/contribs/shared_mobility/src/main/java/org/matsim/contrib/shared_mobility/service/SharingUtils.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.population.Activity;
+import org.matsim.contrib.ev.fleet.ElectricFleetUtils;
 import org.matsim.contrib.shared_mobility.run.SharingConfigGroup;
 import org.matsim.contrib.shared_mobility.run.SharingModes;
 import org.matsim.contrib.shared_mobility.run.SharingServiceConfigGroup;
@@ -133,6 +134,11 @@ public class SharingUtils {
 		} else {
 			VehicleType vehicleType = getOrCreateAndAddVehicleType(serviceConfig, vehicles);
 			routingVehicle = vehicles.getFactory().createVehicle(routingVehicleId, vehicleType);
+			// If the vehicle type is electric, set a default initialSoc so that
+			// GlobalElectricFleet can process this dummy vehicle without NPE.
+			if (ElectricFleetUtils.isElectricVehicleType(vehicleType)) {
+				ElectricFleetUtils.setInitialSoc(routingVehicle, 1.0);
+			}
 			vehicles.addVehicle(routingVehicle);
 		}
 		return routingVehicle;


### PR DESCRIPTION
When a sharing service uses an electric vehicle type (`HbefaTechnology="electricity"`), `getOrCreateAndAddDummyVehicle()` creates a routing-only dummy vehicle with that type but without setting the `initialSoc` attribute.

Since #4834, `GlobalElectricFleet` picks up **all** EV-typed vehicles from `scenario.getVehicles()` and wraps them via `ElectricVehicleSpecificationDefaultImpl`, whose constructor reads `initialSoc`. The missing attribute causes an NPE (null → double unboxing).

**Fix:** Use `ElectricFleetUtils.isElectricVehicleType()` and `setInitialSoc()` to set `initialSoc = 1.0` on the dummy vehicle when its type is electric. Adds ev contrib as a dependency of shared_mobility. The dummy is only used for replanning route calculations and never participates in the EV simulation, so the value has no functional impact.
