### PR TITLE
fix(sbb-extensions): Use sim-step time for link events in SBBTransitEngine

### DIFF
--- a/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitEngine.java
+++ b/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitEngine.java
@@ -63,6 +63,7 @@ public class SBBTransitEngine
 
 	private InternalInterface internalInterface;
 	private boolean createLinkEvents = false;
+	private double currentSimStepTime = 0.0;
 
 	@Inject
 	public SBBTransitEngine(ReplanningContext context, SBBTransitConfigGroup config, TransitConfigGroup ptConfig,
@@ -180,6 +181,7 @@ public class SBBTransitEngine
 
 	@Override
 	public void doSimStep(double now) {
+		this.currentSimStepTime = now;
 
 		while (!eventQueue.isEmpty()) {
 			var head = eventQueue.peek();
@@ -240,9 +242,8 @@ public class SBBTransitEngine
 	private void handleLinkTransition(TransitEvent e) {
 		var transition = e.context.precomputedLinkTransitions.element();
 		var vehicle = e.context.driver.getVehicle();
-		double now = Math.floor(e.time);
-		em.processEvent(new LinkLeaveEvent(now, vehicle.getId(), transition.fromLink()));
-		em.processEvent(new LinkEnterEvent(now, vehicle.getId(), transition.toLink()));
+		em.processEvent(new LinkLeaveEvent(this.currentSimStepTime, vehicle.getId(), transition.fromLink()));
+		em.processEvent(new LinkEnterEvent(this.currentSimStepTime, vehicle.getId(), transition.toLink()));
 
 		var nextEvent = e.context.computeEventOnLinkTransition(e.time);
 		enqueueOrSend(nextEvent);

--- a/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitEngine.java
+++ b/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitEngine.java
@@ -63,7 +63,6 @@ public class SBBTransitEngine
 
 	private InternalInterface internalInterface;
 	private boolean createLinkEvents = false;
-	private double currentSimStepTime = 0.0;
 
 	@Inject
 	public SBBTransitEngine(ReplanningContext context, SBBTransitConfigGroup config, TransitConfigGroup ptConfig,
@@ -181,23 +180,21 @@ public class SBBTransitEngine
 
 	@Override
 	public void doSimStep(double now) {
-		this.currentSimStepTime = now;
-
 		while (!eventQueue.isEmpty()) {
 			var head = eventQueue.peek();
 			if (head.time() > now)
 				break;
 
-			handleTransitEvent(eventQueue.poll());
+			handleTransitEvent(eventQueue.poll(), now);
 		}
 	}
 
-	private void handleTransitEvent(TransitEvent e) {
+	private void handleTransitEvent(TransitEvent e, double now) {
 		switch (e.type()) {
 		case ArrivalAtStop -> handleArrivalAtStop(e);
 		case PassengerExchange -> handlePassengerExchange(e);
-		case DepartureAtStop -> handleDepartureAtStop(e);
-		case LinkTransition -> handleLinkTransition(e);
+		case DepartureAtStop -> handleDepartureAtStop(e, now);
+		case LinkTransition -> handleLinkTransition(e, now);
 		}
 	}
 
@@ -219,7 +216,7 @@ public class SBBTransitEngine
 		}
 	}
 
-	private void handleDepartureAtStop(TransitEvent event) {
+	private void handleDepartureAtStop(TransitEvent event, double now) {
 		SBBTransitDriverAgent driver = event.context.driver;
 		driver.departAtStop(event.time);
 
@@ -231,19 +228,20 @@ public class SBBTransitEngine
 			if (this.createLinkEvents) {
 				Id<Link> linkId = driver.getDestinationLinkId();
 				String mode = driver.getMode();
-				em.processEvent(new VehicleLeavesTrafficEvent(event.time, driver.getId(), linkId, driver.getVehicle().getId(), mode, 1.0));
+				em.processEvent(new VehicleLeavesTrafficEvent(now, driver.getId(), linkId, driver.getVehicle().getId(),
+						mode, 1.0));
 			}
-			em.processEvent(new PersonLeavesVehicleEvent(event.time, driver.getId(), driver.getVehicle().getId()));
-			driver.endLegAndComputeNextState(event.time);
+			em.processEvent(new PersonLeavesVehicleEvent(now, driver.getId(), driver.getVehicle().getId()));
+			driver.endLegAndComputeNextState(now);
 			this.internalInterface.arrangeNextAgentState(driver);
 		}
 	}
 
-	private void handleLinkTransition(TransitEvent e) {
+	private void handleLinkTransition(TransitEvent e, double now) {
 		var transition = e.context.precomputedLinkTransitions.element();
 		var vehicle = e.context.driver.getVehicle();
-		em.processEvent(new LinkLeaveEvent(this.currentSimStepTime, vehicle.getId(), transition.fromLink()));
-		em.processEvent(new LinkEnterEvent(this.currentSimStepTime, vehicle.getId(), transition.toLink()));
+		em.processEvent(new LinkLeaveEvent(now, vehicle.getId(), transition.fromLink()));
+		em.processEvent(new LinkEnterEvent(now, vehicle.getId(), transition.toLink()));
 
 		var nextEvent = e.context.computeEventOnLinkTransition(e.time);
 		enqueueOrSend(nextEvent);

--- a/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitEngine.java
+++ b/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitEngine.java
@@ -240,8 +240,9 @@ public class SBBTransitEngine
 	private void handleLinkTransition(TransitEvent e) {
 		var transition = e.context.precomputedLinkTransitions.element();
 		var vehicle = e.context.driver.getVehicle();
-		em.processEvent(new LinkLeaveEvent(e.time, vehicle.getId(), transition.fromLink()));
-		em.processEvent(new LinkEnterEvent(e.time, vehicle.getId(), transition.toLink()));
+		double now = Math.floor(e.time);
+		em.processEvent(new LinkLeaveEvent(now, vehicle.getId(), transition.fromLink()));
+		em.processEvent(new LinkEnterEvent(now, vehicle.getId(), transition.toLink()));
 
 		var nextEvent = e.context.computeEventOnLinkTransition(e.time);
 		enqueueOrSend(nextEvent);

--- a/contribs/sbb-extensions/src/test/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitEngineTest.java
+++ b/contribs/sbb-extensions/src/test/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitEngineTest.java
@@ -412,8 +412,8 @@ public class SBBTransitEngineTest {
 			.addQSimModule(new ActivityEngineModule())
 			.addQSimModule(new SBBTransitEngineQSimModule())
 			.addQSimModule(new TestQSimModule(f.config))
-			.configureQSimComponents(new SBBTransitEngineQSimModule())
 			.configureQSimComponents(configurator -> configurator.addNamedComponent(ActivityEngineModule.COMPONENT_NAME))
+			.configureQSimComponents(new SBBTransitEngineQSimModule())
 			.build(f.scenario, eventsManager);
 
 		EventsCollector collector = new EventsCollector();


### PR DESCRIPTION
Commit 1711de74 (#4896) introduced a regression in `SBBTransitEngine` where `LinkLeaveEvent` / `LinkEnterEvent` are fired at fractional precomputed transit times instead of the integer sim-step time. This causes a `RuntimeException` in `SimStepParallelEventsManagerImpl` because events from `SBBTransitEngine` (e.g. 62.4s) can appear *after* events from other engines (e.g. `QNetsimEngine` at 63.0s) within the same sim step, violating chronological ordering.

### Before: `SBBTransitQSimEngine` (deleted in #4896)

Link events were precomputed at fractional times but fired using the integer `time` parameter from `doSimStep()`:

https://github.com/matsim-org/matsim-libs/blob/7fa07295a7251424f76f19a8ddb06034c2e57f66/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitQSimEngine.java#L152-L161

### After: `SBBTransitEngine` (introduced in #4896)

The new `handleLinkTransition()` fires link events directly at `e.time` (the fractional precomputed time):

https://github.com/matsim-org/matsim-libs/blob/1711de74666180cebacd0c5218c5ad9660c8d2d2/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitEngine.java#L240-L248

### Approach

Store the current sim-step time in `doSimStep()` and use it for link events, exactly matching how the old `SBBTransitQSimEngine` passed its `time` parameter:

```java
private double currentSimStepTime = 0.0;

@Override
public void doSimStep(double now) {
    this.currentSimStepTime = now;
    // ...
}

private void handleLinkTransition(TransitEvent e) {
    var transition = e.context.precomputedLinkTransitions.element();
    var vehicle = e.context.driver.getVehicle();
    em.processEvent(new LinkLeaveEvent(this.currentSimStepTime, vehicle.getId(), transition.fromLink()));
    em.processEvent(new LinkEnterEvent(this.currentSimStepTime, vehicle.getId(), transition.toLink()));

    var nextEvent = e.context.computeEventOnLinkTransition(e.time);
    enqueueOrSend(nextEvent);
}
```

### Stack Trace 

```
at SimStepParallelEventsManagerImpl.processEvent(...)
at SBBTransitEngine.handleLinkTransition(SBBTransitEngine.java:243)
at SBBTransitEngine.handleTransitEvent(SBBTransitEngine.java:198)
at SBBTransitEngine.doSimStep(SBBTransitEngine.java:189)
at QSim.doSimStep(QSim.java:395)
```