### PR TITLE
ci: allow >maintenance< as commit title

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -19,5 +19,17 @@ jobs:
       pull-requests: read
     steps:
       - uses: amannn/action-semantic-pull-request@v6
+        types: |
+          feat
+          fix
+          docs
+          chore
+          refactor
+          test
+          ci
+          perf
+          build
+          revert
+          maintenance
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I would like to allow "maintenance: ..." as allowed commit type.  

Reason: I quite often have smallish changes related to code cleanup, clearing up modelling details, changing defaults, etc.  These are clearly code changes, and NOT refactorings.  They are also not "features", and not bug "fixes". 

It is also not "chore" since it does modify sources.

Anybody against this?

---

We are using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), so that we are able to auto generate a changelog. The format is described below:

#### Title
`<type>[optional scope]: <description>` e.g.: fix(QSim): Correctly calculate travel times on links

Available types:
 - feat: A new feature
 - fix: A bug fix
 - docs: Documentation only changes
 - style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
 - refactor: A code change that neither fixes a bug nor adds a feature
 - perf: A code change that improves performance
 - test: Adding missing tests or correcting existing tests
 - build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
 - ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
 - chore: Other changes that don't modify src or test files
 - revert: Reverts a previous commit

#### Body
Optionally, describe the change in more detail.

If the PR introduces a breaking change write: BREAKING CHANGE at the bottom of the message
