### PR TITLE
fix(DSim): Clear node singleton listeners before next iteration

### DIFF
--- a/contribs/distributed-simulation/src/test/java/org/matsim/dsim/simulation/SimProviderTest.java
+++ b/contribs/distributed-simulation/src/test/java/org/matsim/dsim/simulation/SimProviderTest.java
@@ -1,0 +1,165 @@
+package org.matsim.dsim.simulation;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.matsim.contrib.drt.routing.DrtRoute;
+import org.matsim.contrib.drt.routing.DrtRouteFactory;
+import org.matsim.contrib.drt.run.DrtConfigs;
+import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
+import org.matsim.contrib.drt.run.MultiModeDrtModule;
+import org.matsim.contrib.dvrp.run.DvrpConfigGroup;
+import org.matsim.contrib.dvrp.run.DvrpModule;
+import org.matsim.contrib.dvrp.run.DvrpQSimComponents;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.config.groups.ControllerConfigGroup;
+import org.matsim.core.config.groups.RoutingConfigGroup;
+import org.matsim.core.controler.Controler;
+import org.matsim.core.controler.OutputDirectoryHierarchy;
+import org.matsim.core.mobsim.dsim.NodeSingleton;
+import org.matsim.core.mobsim.dsim.NodeSingletons;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.core.utils.io.IOUtils;
+import org.matsim.dsim.Activities;
+import org.matsim.dsim.DSimConfigGroup;
+import org.matsim.dsim.LocalContext;
+import org.matsim.examples.ExamplesUtils;
+import org.matsim.testcases.MatsimTestUtils;
+
+import java.util.HashSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class SimProviderTest {
+
+	// ── Fixture types for NodeSingletonDetector tests ────────────────────────
+
+	@NodeSingleton
+	static class DirectlyAnnotated {
+	}
+
+	@NodeSingleton
+	interface AnnotatedIface {
+	}
+
+	static class ImplementsAnnotatedIface implements AnnotatedIface {
+	}
+
+	@NodeSingleton
+	static class AnnotatedBase {
+	}
+
+	static class ExtendsAnnotatedBase extends AnnotatedBase {
+	}
+
+	// deep: ParentIface extends AnnotatedIface, LeafClass implements ParentIface
+	interface ParentIface extends AnnotatedIface {
+	}
+
+	static class ImplementsParentIface implements ParentIface {
+	}
+
+	static class PlainClass {
+	}
+
+	interface PlainIface {
+	}
+
+	static class ImplementsPlainIface implements PlainIface {
+	}
+
+	// ── Group 1: NodeSingletonDetector ───────────────────────────────────────
+
+	@Test
+	void detectsDirectAnnotation() {
+		assertThat(NodeSingletons.isNodeSingleton(new DirectlyAnnotated())).isTrue();
+	}
+
+	@Test
+	void detectsAnnotatedInterface() {
+		// This is the DrtOptimizer pattern: interface is @NodeSingleton, implementing class is not
+		assertThat(NodeSingletons.isNodeSingleton(new ImplementsAnnotatedIface())).isTrue();
+	}
+
+	@Test
+	void detectsAnnotatedSuperclass() {
+		assertThat(NodeSingletons.isNodeSingleton(new ExtendsAnnotatedBase())).isTrue();
+	}
+
+	@Test
+	void detectsDeepInterfaceHierarchy() {
+		// Class → PlainIface → AnnotatedIface: annotation must be found transitively
+		assertThat(NodeSingletons.isNodeSingleton(new ImplementsParentIface())).isTrue();
+	}
+
+	@Test
+	void rejectsPlainClass() {
+		assertThat(NodeSingletons.isNodeSingleton(new PlainClass())).isFalse();
+	}
+
+	@Test
+	void rejectsUnannotatedInterface() {
+		assertThat(NodeSingletons.isNodeSingleton(new ImplementsPlainIface())).isFalse();
+	}
+
+	// ── Integration: multi-iteration regression ──────────────────────────────
+
+	@RegisterExtension
+	MatsimTestUtils utils = new MatsimTestUtils();
+
+	/**
+	 * Regression test for the SimProvider.listeners accumulation bug.
+	 * <p>
+	 * Before the fix, {@code SimProvider.listeners} was never cleared between iterations. NodeSingleton listeners (e.g. {@code MoiaEDrtOptimizer} via
+	 * the {@code @NodeSingleton} {@code DrtOptimizer} interface) accumulated across iterations. In iteration 2, both the stale iteration-1 instance
+	 * (with a shut-down ForkJoinPool) and the fresh iteration-2 instance were fired, causing a {@code RejectedExecutionException}.
+	 */
+	@Test
+	void nodeSingletonListenersNotAccumulatedAcrossIterations() {
+		var kelheim = IOUtils.extendUrl(ExamplesUtils.getTestScenarioURL("kelheim"), "config-with-drt.xml");
+		Config config = ConfigUtils.loadConfig(kelheim);
+
+		config.controller().setOutputDirectory(utils.getOutputDirectory());
+		config.controller().setOverwriteFileSetting(OutputDirectoryHierarchy.OverwriteFileSetting.overwriteExistingFiles);
+		config.controller().setLastIteration(1);
+		config.controller().setWriteEventsInterval(1);
+		config.controller().setMobsim(ControllerConfigGroup.MobsimType.dsim.name());
+		config.dsim().setThreads(1);
+		config.routing().setRoutingRandomness(0);
+		config.routing().setAccessEgressType(RoutingConfigGroup.AccessEgressType.accessEgressModeToLink);
+
+		config.dsim().setLinkDynamics(config.qsim().getLinkDynamics());
+		config.dsim().setTrafficDynamics(config.qsim().getTrafficDynamics());
+		config.dsim().setStuckTime(config.qsim().getStuckTime());
+		config.dsim().setNetworkModes(new HashSet<>(config.qsim().getMainModes()));
+		config.dsim().setStartTime(config.qsim().getStartTime().orElse(0));
+		config.dsim().setEndTime(config.qsim().getEndTime().orElse(86400));
+		config.dsim().setVehicleBehavior(config.qsim().getVehicleBehavior());
+		config.dsim().setPartitioning(DSimConfigGroup.Partitioning.bisect);
+
+		Activities.addScoringParams(config);
+
+		MultiModeDrtConfigGroup multiModeDrtConfig = ConfigUtils.addOrGetModule(config, MultiModeDrtConfigGroup.class);
+		ConfigUtils.addOrGetModule(config, DvrpConfigGroup.class);
+		DrtConfigs.adjustMultiModeDrtConfig(multiModeDrtConfig, config.scoring(), config.routing());
+
+		var scenario = ScenarioUtils.loadScenario(config);
+
+		scenario.getNetwork().getLinks().values().parallelStream()
+			.filter(l -> l.getAllowedModes().contains("car"))
+			.forEach(l -> l.setAllowedModes(Stream.concat(l.getAllowedModes().stream(), Stream.of("freight")).collect(Collectors.toSet())));
+
+		scenario.getPopulation().getFactory().getRouteFactories()
+			.setRouteFactory(DrtRoute.class, new DrtRouteFactory());
+
+		Controler controler = new Controler(scenario, LocalContext.create(scenario.getConfig()));
+		controler.addOverridingModule(new DvrpModule());
+		controler.addOverridingModule(new MultiModeDrtModule());
+		controler.configureQSimComponents(DvrpQSimComponents.activateAllModes(multiModeDrtConfig));
+
+		assertThatCode(controler::run).doesNotThrowAnyException();
+	}
+}

--- a/contribs/ev/src/test/java/org/matsim/contrib/ev/dsim/EvDSimTestFixture.java
+++ b/contribs/ev/src/test/java/org/matsim/contrib/ev/dsim/EvDSimTestFixture.java
@@ -25,6 +25,7 @@ import org.matsim.core.config.groups.RoutingConfigGroup;
 import org.matsim.core.config.groups.ScoringConfigGroup;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.Controler;
+import org.matsim.core.controler.OutputDirectoryHierarchy;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.population.routes.RouteUtils;
 import org.matsim.core.scenario.ScenarioUtils;
@@ -38,16 +39,14 @@ import java.util.List;
 /**
  * Shared test fixture for EV + DSim integration tests.
  * <p>
- * Uses the same three-link network topology as {@code ThreeLinkTestFixture} in
- * the distributed-simulation contrib, adapted for EV: car mode on all links,
- * an electric vehicle type, and a simple home → car → work plan that crosses
- * all three partition boundaries.
+ * Uses the same three-link network topology as {@code ThreeLinkTestFixture} in the distributed-simulation contrib, adapted for EV: car mode on all
+ * links, an electric vehicle type, and a simple home → car → work plan that crosses all three partition boundaries.
  */
 public final class EvDSimTestFixture {
 
 	/**
-	 * Vehicle range in metres with a 1 J/m drive consumption model.
-	 * Equals the energy capacity in Joules. Must exceed the total route length (1200 m).
+	 * Vehicle range in metres with a 1 J/m drive consumption model. Equals the energy capacity in Joules. Must exceed the total route length (1200
+	 * m).
 	 */
 	static final double BATTERY_CAPACITY = 10_000.0;
 
@@ -61,7 +60,8 @@ public final class EvDSimTestFixture {
 	static final String PERSON_ID = "ev-test-person";
 	static final String EV_ID = PERSON_ID + "-ev";
 
-	private EvDSimTestFixture() {}
+	private EvDSimTestFixture() {
+	}
 
 	// -------------------------------------------------------------------------
 	// Network
@@ -121,8 +121,10 @@ public final class EvDSimTestFixture {
 			l3.getAttributes().putAttribute(NetworkDecomposition.PARTITION_ATTR_KEY, 2);
 		}
 
-		for (var n : List.of(n1, n2, n3, n4)) network.addNode(n);
-		for (var l : List.of(l1, l2, l3)) network.addLink(l);
+		for (var n : List.of(n1, n2, n3, n4))
+			network.addNode(n);
+		for (var l : List.of(l1, l2, l3))
+			network.addLink(l);
 
 		return network;
 	}
@@ -148,8 +150,7 @@ public final class EvDSimTestFixture {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Creates one EV person with a simple home → car → work plan traversing the
-	 * full three-link network (l1 → l2 → l3).  No access/egress walk legs —
+	 * Creates one EV person with a simple home → car → work plan traversing the full three-link network (l1 → l2 → l3).  No access/egress walk legs —
 	 * use {@link RoutingConfigGroup.AccessEgressType#none} in the config.
 	 */
 	public static Person createPerson(PopulationFactory factory, Vehicles vehicles, VehicleType evType) {
@@ -196,7 +197,7 @@ public final class EvDSimTestFixture {
 		config.controller().setOutputDirectory(outputDir);
 		config.controller().setLastIteration(0);
 		config.controller().setOverwriteFileSetting(
-			org.matsim.core.controler.OutputDirectoryHierarchy.OverwriteFileSetting.deleteDirectoryIfExists);
+			OutputDirectoryHierarchy.OverwriteFileSetting.overwriteExistingFiles);
 		config.controller().setCompressionType(ControllerConfigGroup.CompressionType.none);
 
 		// No access/egress routing — plans are pre-built with explicit routes.
@@ -263,8 +264,7 @@ public final class EvDSimTestFixture {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Adds the EV modules and bindings required by all integration tests in this
-	 * package.  Provides an empty charging infrastructure (no chargers).
+	 * Adds the EV modules and bindings required by all integration tests in this package.  Provides an empty charging infrastructure (no chargers).
 	 */
 	public static void installEvModules(Controler controller) {
 		controller.addOverridingModule(new EvModule());

--- a/matsim/src/main/java/org/matsim/core/mobsim/dsim/NodeSingletons.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/dsim/NodeSingletons.java
@@ -1,0 +1,37 @@
+package org.matsim.core.mobsim.dsim;
+
+/**
+ * Utility for detecting whether an object's class (or any class or interface in its hierarchy) is annotated with {@link NodeSingleton}.
+ * <p>
+ * The check intentionally walks the full hierarchy so that classes implementing an annotated interface (e.g. {@code DrtOptimizer}) are detected as
+ * node singletons even when the implementing class itself carries no annotation.
+ */
+public final class NodeSingletons {
+
+	private NodeSingletons() {
+	}
+
+	public static boolean isNodeSingleton(Object o) {
+		var clazz = o.getClass();
+		while (clazz != null) {
+			if (clazz.isAnnotationPresent(NodeSingleton.class))
+				return true;
+			for (var iface : clazz.getInterfaces()) {
+				if (isNodeSingletonInterface(iface))
+					return true;
+			}
+			clazz = clazz.getSuperclass();
+		}
+		return false;
+	}
+
+	private static boolean isNodeSingletonInterface(Class<?> iface) {
+		if (iface.isAnnotationPresent(NodeSingleton.class))
+			return true;
+		for (Class<?> parent : iface.getInterfaces()) {
+			if (isNodeSingletonInterface(parent))
+				return true;
+		}
+		return false;
+	}
+}

--- a/matsim/src/main/java/org/matsim/dsim/DSim.java
+++ b/matsim/src/main/java/org/matsim/dsim/DSim.java
@@ -41,25 +41,15 @@ import java.util.concurrent.TimeUnit;
 
 import static com.google.inject.Key.get;
 
-
 public final class DSim implements Mobsim {
 
 	private static final Logger log = LogManager.getLogger(DSim.class);
 
 	private final Injector injector;
-	private final Communicator comm;
-	private final MessageBroker broker;
-	private final Set<LPProvider> lps;
-	private final MobsimTimer timer;
 
 	@Inject
 	public DSim(Injector injector) {
 		this.injector = injector;
-		this.comm = injector.getInstance(Communicator.class);
-		this.broker = injector.getInstance(MessageBroker.class);
-		this.lps = injector.getInstance(get(new TypeLiteral<>() {
-		}));
-		this.timer = new MobsimTimer();
 	}
 
 	private static double round(double v) {
@@ -72,10 +62,15 @@ public final class DSim implements Mobsim {
 	@Override
 	public void run() {
 
+		Communicator comm = injector.getInstance(Communicator.class);
+		MessageBroker broker = injector.getInstance(MessageBroker.class);
+		Set<LPProvider> lps = injector.getInstance(get(new TypeLiteral<>() {
+		}));
 		ComputeNode computeNode = injector.getInstance(ComputeNode.class);
 		Topology topology = injector.getInstance(Topology.class);
 		Config config = injector.getInstance(Config.class);
 		DSimConfigGroup dsimConfig = ConfigUtils.addOrGetModule(config, DSimConfigGroup.class);
+		var timer = new MobsimTimer();
 
 		LPExecutor executor = injector.getInstance(LPExecutor.class);
 		DistributedEventsManager manager = (DistributedEventsManager) injector.getInstance(EventsManager.class);
@@ -161,7 +156,7 @@ public final class DSim implements Mobsim {
 			try {
 				executor.doSimStep(time);
 			} catch (Throwable e) {
-				log.error("Error in simulation step: %.2fs".formatted(time), e);
+				log.error(() -> "Error in simulation step: %.2fs".formatted(timer.getTimeOfDay()), e);
 				throw e;
 			}
 
@@ -238,7 +233,7 @@ public final class DSim implements Mobsim {
 	}
 
 	private void writeRuntimes(ComputeNode node, Histogram simulation, Histogram broker, Histogram sizes, LPExecutor executor,
-							   long overallRuntime, long beforeListener, long afterListener, long syncStep) {
+		long overallRuntime, long beforeListener, long afterListener, long syncStep) {
 
 		OutputDirectoryHierarchy io = injector.getInstance(OutputDirectoryHierarchy.class);
 

--- a/matsim/src/main/java/org/matsim/dsim/simulation/SimProvider.java
+++ b/matsim/src/main/java/org/matsim/dsim/simulation/SimProvider.java
@@ -15,6 +15,7 @@ import org.matsim.core.config.Config;
 import org.matsim.core.controler.IterationCounter;
 import org.matsim.core.mobsim.dsim.DistributedAgentSource;
 import org.matsim.core.mobsim.dsim.NodeSingleton;
+import org.matsim.core.mobsim.dsim.NodeSingletons;
 import org.matsim.core.mobsim.framework.listeners.MobsimListener;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
 import org.matsim.core.mobsim.qsim.components.QSimComponent;
@@ -149,7 +150,7 @@ public class SimProvider implements LPProvider {
 				QSimComponent qSimComponent = provider.get();
 
 				// Skip component that is a node singleton, but this process is not the first
-				if (!isFirstPartition(partition) && isNodeSingleton(qSimComponent)) {
+				if (!isFirstPartition(partition) && NodeSingletons.isNodeSingleton(qSimComponent)) {
 					continue;
 				}
 
@@ -187,7 +188,7 @@ public class SimProvider implements LPProvider {
 	 * {@link org.matsim.dsim.DSim}.
 	 */
 	private void addMobsimListener(NetworkPartition partition, MobsimListener l, Collection<MobsimListener> listeners, SimProcess simProcess) {
-		if (isFirstPartition(partition) && isNodeSingleton(l)) {
+		if (isFirstPartition(partition) && NodeSingletons.isNodeSingleton(l)) {
 			listeners.add(l);
 		} else {
 			simProcess.addQueueSimulationListeners(l);
@@ -196,36 +197,6 @@ public class SimProvider implements LPProvider {
 
 	private boolean isFirstPartition(NetworkPartition partition) {
 		return node.isFirstPartition(partition.getIndex());
-	}
-
-	/**
-	 * Helper that tests whether the given object is annotated with {@link NodeSingleton} or any interface or superclass in the hierarchy.
-	 */
-	private static boolean isNodeSingleton(Object o) {
-		var clazz = o.getClass();
-		while (clazz != null) {
-			if (clazz.isAnnotationPresent(NodeSingleton.class))
-				return true;
-			for (var iface : clazz.getInterfaces()) {
-				if (isNodeSingletonInterface(iface))
-					return true;
-			}
-			clazz = clazz.getSuperclass();
-		}
-		return false;
-	}
-
-	/**
-	 * Helper that tests whether any interface in the hierarchy is annotated with {@link NodeSingleton}.
-	 */
-	private static boolean isNodeSingletonInterface(Class<?> iface) {
-		if (iface.isAnnotationPresent(NodeSingleton.class))
-			return true;
-		for (Class<?> parent : iface.getInterfaces()) {
-			if (isNodeSingletonInterface(parent))
-				return true;
-		}
-		return false;
 	}
 
 	/**

--- a/matsim/src/main/java/org/matsim/dsim/simulation/SimProvider.java
+++ b/matsim/src/main/java/org/matsim/dsim/simulation/SimProvider.java
@@ -15,6 +15,7 @@ import org.matsim.core.config.Config;
 import org.matsim.core.controler.IterationCounter;
 import org.matsim.core.mobsim.dsim.DistributedAgentSource;
 import org.matsim.core.mobsim.dsim.NodeSingleton;
+import org.matsim.core.mobsim.dsim.NodeSingletons;
 import org.matsim.core.mobsim.framework.listeners.MobsimListener;
 import org.matsim.core.mobsim.qsim.AbstractQSimModule;
 import org.matsim.core.mobsim.qsim.components.QSimComponent;
@@ -198,34 +199,8 @@ public class SimProvider implements LPProvider {
 		return node.isFirstPartition(partition.getIndex());
 	}
 
-	/**
-	 * Helper that tests whether the given object is annotated with {@link NodeSingleton} or any interface or superclass in the hierarchy.
-	 */
 	private static boolean isNodeSingleton(Object o) {
-		var clazz = o.getClass();
-		while (clazz != null) {
-			if (clazz.isAnnotationPresent(NodeSingleton.class))
-				return true;
-			for (var iface : clazz.getInterfaces()) {
-				if (isNodeSingletonInterface(iface))
-					return true;
-			}
-			clazz = clazz.getSuperclass();
-		}
-		return false;
-	}
-
-	/**
-	 * Helper that tests whether any interface in the hierarchy is annotated with {@link NodeSingleton}.
-	 */
-	private static boolean isNodeSingletonInterface(Class<?> iface) {
-		if (iface.isAnnotationPresent(NodeSingleton.class))
-			return true;
-		for (Class<?> parent : iface.getInterfaces()) {
-			if (isNodeSingletonInterface(parent))
-				return true;
-		}
-		return false;
+		return NodeSingletons.isNodeSingleton(o);
 	}
 
 	/**

--- a/matsim/src/main/java/org/matsim/dsim/simulation/SimProvider.java
+++ b/matsim/src/main/java/org/matsim/dsim/simulation/SimProvider.java
@@ -59,8 +59,8 @@ public class SimProvider implements LPProvider {
 
 	@Inject
 	SimProvider(Injector injector, Collection<AbstractQSimModule> modules,
-	            @Named("overrides") List<AbstractQSimModule> overridingModules,
-	            @Named("overridesFromAbstractModule") Set<AbstractQSimModule> overridingModulesFromAbstractModule) {
+		@Named("overrides") List<AbstractQSimModule> overridingModules,
+		@Named("overridesFromAbstractModule") Set<AbstractQSimModule> overridingModulesFromAbstractModule) {
 		this.injector = injector;
 		this.modules = new ArrayList<>(modules);
 		// (these are the implementations)
@@ -123,9 +123,13 @@ public class SimProvider implements LPProvider {
 			}
 		};
 
-		// Partitions other than the first one re-use the injector from the first partition for node singletons. See the end of this
-		// method where the node singleton injector is assigend when this method is called for the first partition.
-		if (!isFirstPartition(partition)) {
+		if (isFirstPartition(partition)) {
+			// we need to clear listeners between iterations. The first partition handles node-singleton listeners. Therefore, the first
+			// partition must clear the listeners.
+			listeners.clear();
+		} else {
+			// Partitions other than the first one re-use the injector from the first partition for node singletons. See the end of this
+			// method where the node singleton injector is assigned when this method is called for the first partition.
 			Objects.requireNonNull(nodeSingletonInjector, "Node singleton injector must be present for non-first partitions");
 			module = Modules.override(module).with(new NodeSingletonModule(nodeSingletonInjector));
 		}
@@ -162,7 +166,8 @@ public class SimProvider implements LPProvider {
 		}
 
 		// Retrieve all mobsim listeners that are not mobsim components
-		Set<MobsimListener> mobsimListeners = dsimInjector.getInstance(Key.get(new TypeLiteral<>() {}));
+		Set<MobsimListener> mobsimListeners = dsimInjector.getInstance(Key.get(new TypeLiteral<>() {
+		}));
 		for (var l : mobsimListeners) {
 			addMobsimListener(partition, l, listeners, simProcess);
 		}
@@ -199,9 +204,11 @@ public class SimProvider implements LPProvider {
 	private static boolean isNodeSingleton(Object o) {
 		var clazz = o.getClass();
 		while (clazz != null) {
-			if (clazz.isAnnotationPresent(NodeSingleton.class)) return true;
+			if (clazz.isAnnotationPresent(NodeSingleton.class))
+				return true;
 			for (var iface : clazz.getInterfaces()) {
-				if (isNodeSingletonInterface(iface)) return true;
+				if (isNodeSingletonInterface(iface))
+					return true;
 			}
 			clazz = clazz.getSuperclass();
 		}
@@ -212,9 +219,11 @@ public class SimProvider implements LPProvider {
 	 * Helper that tests whether any interface in the hierarchy is annotated with {@link NodeSingleton}.
 	 */
 	private static boolean isNodeSingletonInterface(Class<?> iface) {
-		if (iface.isAnnotationPresent(NodeSingleton.class)) return true;
+		if (iface.isAnnotationPresent(NodeSingleton.class))
+			return true;
 		for (Class<?> parent : iface.getInterfaces()) {
-			if (isNodeSingletonInterface(parent)) return true;
+			if (isNodeSingletonInterface(parent))
+				return true;
 		}
 		return false;
 	}
@@ -222,7 +231,8 @@ public class SimProvider implements LPProvider {
 	/**
 	 * Helper that wraps the getInstance call to injector with a try-catch block.
 	 */
-	private static @Nonnull Collection<Provider<QSimComponent>> getComponentProviders(Key<Collection<Provider<QSimComponent>>> activeComponentKey, Object activeComponent, Injector dsimInjector) {
+	private static @Nonnull Collection<Provider<QSimComponent>> getComponentProviders(Key<Collection<Provider<QSimComponent>>> activeComponentKey,
+		Object activeComponent, Injector dsimInjector) {
 		try {
 			return dsimInjector.getInstance(activeComponentKey);
 		} catch (ProvisionException | ConfigurationException e) {


### PR DESCRIPTION
We maintain a list of node singleton mobsim listeners. This list must be cleared between iterations, as those listeners are re created each iteration. 
