### PR TITLE
feat(fiss): add trip statistics logging

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISS.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISS.java
@@ -95,6 +95,9 @@ public class FISS implements NetworkModeDepartureHandler, DistributedDepartureHa
 
 	private InternalInterface internalInterface;
 
+	private long teleportedTrips = 0;
+	private long simulatedTrips = 0;
+
 	@Inject
 	FISS(MatsimServices matsimServices, Scenario scenario, FISSConfigGroup fissConfigGroup, Network network, TeleportationEngine teleport,
 		 @Named(TransportMode.car) TravelTime travelTime,
@@ -117,12 +120,15 @@ public class FISS implements NetworkModeDepartureHandler, DistributedDepartureHa
 		if (!this.qsimConfig.getMainModes().contains(agent.getMode())) {
 			return false;
 		} else if (agent instanceof DynAgent) {
+			simulatedTrips++;
 			return delegate.handleDeparture(now, agent, linkId);
 		} else if (!this.fissConfigGroup.getSampledModes().contains(agent.getMode())) {
+			simulatedTrips++;
 			return delegate.handleDeparture(now, agent, linkId); // not covered by test
 			// (the earlier design would have such agents fall through, in which case they would be treated by the standard network mode
 			// dp handler)
 		} else if (random.nextDouble() < fissConfigGroup.getSampleFactor() || agent instanceof TransitDriverAgent || this.switchOffFISS()) {
+			simulatedTrips++;
 			return delegate.handleDeparture(now, agent, linkId);
 		}
 
@@ -160,6 +166,7 @@ public class FISS implements NetworkModeDepartureHandler, DistributedDepartureHa
 						internalInterface.getMobsim().getEventsManager().processEvent(
 								new VehicleTeleportationDepartureEvent(now, driverAgent.getId(), vehicleId, linkId,
 										agent.getMode()));
+						teleportedTrips++;
 						boolean result = teleport.handleDeparture(now, agent, linkId);
 						Gbl.assertIf(result);
 						return result;
@@ -178,13 +185,15 @@ public class FISS implements NetworkModeDepartureHandler, DistributedDepartureHa
 						// silently lost.
 						deferredDepartures.computeIfAbsent(vehicleId, k -> new ArrayDeque<>())
 								.addLast(new DeferredDeparture(now, agent, linkId));
+						teleportedTrips++;
 						return true;
 					}
 				}
 				// Vehicle not in FISS queue -- delegate to QSim.
-				LOG.info(
+				LOG.debug(
 						"Vehicle {} not found on link {} for agent {} at time {}. Falling back to standard departure.",
 						vehicleId, linkId, driverAgent.getId(), now);
+				simulatedTrips++;
 				return delegate.handleDeparture(now, agent, linkId);
 			}
 			addVehicleArrival(now + newTravelTime, removedVehicle, destinationLinkId);
@@ -197,6 +206,7 @@ public class FISS implements NetworkModeDepartureHandler, DistributedDepartureHa
 							agent.getMode()));
 		}
 
+		teleportedTrips++;
 		boolean result = teleport.handleDeparture(now, agent, linkId);
 		Gbl.assertIf(result); // otherwise we are now confused
 
@@ -343,6 +353,15 @@ public class FISS implements NetworkModeDepartureHandler, DistributedDepartureHa
 			}
 		}
 		teleport.afterMobsim();
+
+		long total = teleportedTrips + simulatedTrips;
+		double teleportedShare = total > 0 ? (double) teleportedTrips / total : 0.0;
+		LOG.info("FISS stats: total={}, simulated={}, teleported={}, teleportedShare={}, configuredSampleFactor={}",
+				total, simulatedTrips, teleportedTrips,
+				String.format("%.4f", teleportedShare),
+				fissConfigGroup.getSampleFactor());
+		teleportedTrips = 0;
+		simulatedTrips = 0;
 	}
 
 	private boolean switchOffFISS() {

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISS.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/fiss/FISS.java
@@ -96,7 +96,9 @@ public class FISS implements NetworkModeDepartureHandler, DistributedDepartureHa
 	private InternalInterface internalInterface;
 
 	private long teleportedTrips = 0;
+	private long teleportedDeferredTrips = 0;
 	private long simulatedTrips = 0;
+	private long simulatedQsimFallbackTrips = 0;
 
 	@Inject
 	FISS(MatsimServices matsimServices, Scenario scenario, FISSConfigGroup fissConfigGroup, Network network, TeleportationEngine teleport,
@@ -186,6 +188,7 @@ public class FISS implements NetworkModeDepartureHandler, DistributedDepartureHa
 						deferredDepartures.computeIfAbsent(vehicleId, k -> new ArrayDeque<>())
 								.addLast(new DeferredDeparture(now, agent, linkId));
 						teleportedTrips++;
+						teleportedDeferredTrips++;
 						return true;
 					}
 				}
@@ -194,6 +197,7 @@ public class FISS implements NetworkModeDepartureHandler, DistributedDepartureHa
 						"Vehicle {} not found on link {} for agent {} at time {}. Falling back to standard departure.",
 						vehicleId, linkId, driverAgent.getId(), now);
 				simulatedTrips++;
+				simulatedQsimFallbackTrips++;
 				return delegate.handleDeparture(now, agent, linkId);
 			}
 			addVehicleArrival(now + newTravelTime, removedVehicle, destinationLinkId);
@@ -356,12 +360,23 @@ public class FISS implements NetworkModeDepartureHandler, DistributedDepartureHa
 
 		long total = teleportedTrips + simulatedTrips;
 		double teleportedShare = total > 0 ? (double) teleportedTrips / total : 0.0;
-		LOG.info("FISS stats: total={}, simulated={}, teleported={}, teleportedShare={}, configuredSampleFactor={}",
-				total, simulatedTrips, teleportedTrips,
-				String.format("%.4f", teleportedShare),
-				fissConfigGroup.getSampleFactor());
+		double fallbackShare = total > 0 ? (double) simulatedQsimFallbackTrips / total : 0.0;
+		LOG.info("FISS stats (sampleFactor={}):" +
+				"\n\ttotal departures: {}" +
+				"\n\t  teleported:     {} (share={})" +
+				"\n\t    of which deferred: {}" +
+				"\n\t  simulated:      {}" +
+				"\n\t    of which qsim fallback: {} (share={})",
+				fissConfigGroup.getSampleFactor(),
+				total,
+				teleportedTrips, String.format("%.4f", teleportedShare),
+				teleportedDeferredTrips,
+				simulatedTrips,
+				simulatedQsimFallbackTrips, String.format("%.4f", fallbackShare));
 		teleportedTrips = 0;
+		teleportedDeferredTrips = 0;
 		simulatedTrips = 0;
+		simulatedQsimFallbackTrips = 0;
 	}
 
 	private boolean switchOffFISS() {


### PR DESCRIPTION
Add per-iteration logging of FISS trip counters to `afterMobsim()`:

- **teleported** vs **simulated** trips (with teleported share)
- **deferred** teleportations (vehicle in transit, departure queued)
- **qsim fallback** trips (vehicle unavailable, delegated to QSim)

Counters use a naming convention that reflects the subset hierarchy (`teleportedDeferredTrips` ⊂ `teleportedTrips`, `simulatedQsimFallbackTrips` ⊂ `simulatedTrips`).

Example output:
```
FISS stats (sampleFactor=0.1):
	total departures: 50000
	  teleported:     45000 (share=0.9000)
	    of which deferred: 120
	  simulated:      5000
	    of which qsim fallback: 30 (share=0.0006)
```