### PR TITLE
fix(conventional-commits): fix title spec

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -19,17 +19,18 @@ jobs:
       pull-requests: read
     steps:
       - uses: amannn/action-semantic-pull-request@v6
-        types: |
-          feat
-          fix
-          docs
-          chore
-          refactor
-          test
-          ci
-          perf
-          build
-          revert
-          maintenance
+        with:
+          types: |
+            feat
+            fix
+            docs
+            chore
+            refactor
+            test
+            ci
+            perf
+            build
+            revert
+            maintenance
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
According to https://github.com/amannn/action-semantic-pull-request, the config needs to be adapted, otherwise this workflow fails