### PR TITLE
fix(core): Support VehicleType.networkMode == null in VehiclesWriter

### DIFF
--- a/matsim/src/main/java/org/matsim/vehicles/VehicleWriterV2.java
+++ b/matsim/src/main/java/org/matsim/vehicles/VehicleWriterV2.java
@@ -203,7 +203,7 @@ final class VehicleWriterV2 extends MatsimXmlWriter {
 			}
 
 			//Write networkMode, if present
-			if (vt.getNetworkMode() != null) {
+			if (vt.hasNetworkMode()) {
 				atts.clear();
 				atts.add(this.createTuple(VehicleSchemaV2Names.NETWORKMODE, vt.getNetworkMode()));
 				this.writeStartTag(VehicleSchemaV2Names.NETWORKMODE, atts, true);


### PR DESCRIPTION
VehiclesWriter did not support VehicleType.networkMode == null, despite trying to do so

vt.getNetowrkMode() throws an exception when the network mode is null, so the check getNetworkMode() != null was pointless
