### PR TITLE
maintenance: permit duplicates in the ZoneSystems of DvrpModule

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/StopWaypointFactoryImpl.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/StopWaypointFactoryImpl.java
@@ -14,6 +14,8 @@ public class StopWaypointFactoryImpl implements StopWaypointFactory {
     private final boolean scheduleWaitBeforeDrive;
 
     public StopWaypointFactoryImpl(DvrpLoadType loadType, boolean scheduleWaitBeforeDrive) {
+		// TODO Could you please document the meaning of parameter scheduleWaitBeforeDrive? Thanks, kai, may'26
+
         this.loadType = loadType;
         this.scheduleWaitBeforeDrive = scheduleWaitBeforeDrive;
     }

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/constraints/DrtRouteConstraints.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/optimizer/constraints/DrtRouteConstraints.java
@@ -32,6 +32,11 @@ public record DrtRouteConstraints(
 		boolean allowRejection
 ) {
 
+	// TODO could you please document that meanings of these variables?  In particular,
+	// * what is the difference between maxWaitDuration and maxPickupDelay; and
+	// * what is lateDiversionThreshold?
+	// Thanks.  kai, may'26
+
 	public final static DrtRouteConstraints UNDEFINED =
 			new DrtRouteConstraints(
 					Double.POSITIVE_INFINITY,

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/run/DvrpModule.java
@@ -77,7 +77,8 @@ public final class DvrpModule extends AbstractModule {
 
 		install(dvrpTravelTimeEstimationModule);
 
-		MapBinder.newMapBinder(binder(), String.class, ZoneSystem.class).addBinding(TT_MATRIX_ZONE_SYSTEM).toProvider(new com.google.inject.Provider<>() {
+		MapBinder.newMapBinder(binder(), String.class, ZoneSystem.class).permitDuplicates().addBinding(TT_MATRIX_ZONE_SYSTEM).toProvider(new com.google.inject.Provider<>() {
+			// yy I introduced "permitDuplicates" because I have some older code from Chengqi that otherwise I cannot get to run.  But it might not be the correct setting. kai, may'26
 
             @Inject
             private Network network;


### PR DESCRIPTION
I am having some legacy code that I currently cannot fix without this.  Do not know the possible side effects.
This should not break anything.  But it might have spurious side effects in future usages of this class.