### PR TITLE
refactor(core): Reduce logging on simulation start

### DIFF
--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/MobsimListenerManager.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/MobsimListenerManager.java
@@ -20,8 +20,6 @@
 
 package org.matsim.core.mobsim.qsim;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.matsim.core.api.internal.MatsimManager;
 import org.matsim.core.mobsim.framework.Mobsim;
 import org.matsim.core.mobsim.framework.events.MobsimAfterSimStepEvent;
@@ -35,23 +33,19 @@ import javax.swing.event.EventListenerList;
 
 public final class MobsimListenerManager implements MatsimManager {
 
-	private final static Logger log = LogManager.getLogger(MobsimListenerManager.class);
-
 	private final Mobsim sim;
 
 	private final EventListenerList listenerList = new EventListenerList();
 
-	public MobsimListenerManager(Mobsim sim){
+	public MobsimListenerManager(Mobsim sim) {
 		this.sim = sim;
 	}
 
 	@SuppressWarnings("unchecked")
 	public void addQueueSimulationListener(final MobsimListener l) {
-		log.info("calling addQueueSimulationListener");
 		for (Class interfaceClass : ClassUtils.getAllTypes(l.getClass())) {
 			if (MobsimListener.class.isAssignableFrom(interfaceClass)) {
 				this.listenerList.add(interfaceClass, l);
-				log.info("  assigned class " + MobsimListener.class.getName() + " to interface " + interfaceClass.getName());
 			}
 		}
 	}
@@ -71,9 +65,9 @@ public final class MobsimListenerManager implements MatsimManager {
 	public void fireQueueSimulationInitializedEvent() {
 		MobsimInitializedEvent<Mobsim> event = new MobsimInitializedEvent<>(sim);
 		MobsimInitializedListener[] listener = this.listenerList.getListeners(MobsimInitializedListener.class);
-        for (MobsimInitializedListener aListener : listener) {
-            aListener.notifyMobsimInitialized(event);
-        }
+		for (MobsimInitializedListener aListener : listener) {
+			aListener.notifyMobsimInitialized(event);
+		}
 	}
 
 	/**
@@ -84,28 +78,28 @@ public final class MobsimListenerManager implements MatsimManager {
 	public void fireQueueSimulationAfterSimStepEvent(final double simTime) {
 		MobsimAfterSimStepEvent<Mobsim> event = new MobsimAfterSimStepEvent<>(sim, simTime);
 		MobsimAfterSimStepListener[] listener = this.listenerList.getListeners(MobsimAfterSimStepListener.class);
-        for (MobsimAfterSimStepListener aListener : listener) {
-            aListener.notifyMobsimAfterSimStep(event);
-        }
+		for (MobsimAfterSimStepListener aListener : listener) {
+			aListener.notifyMobsimAfterSimStep(event);
+		}
 	}
 
 	/**
 	 * Creates the event and notifies all listeners
 	 */
-	public void fireQueueSimulationBeforeCleanupEvent(){
+	public void fireQueueSimulationBeforeCleanupEvent() {
 		MobsimBeforeCleanupEvent<Mobsim> event = new MobsimBeforeCleanupEvent<>(this.sim);
 		MobsimBeforeCleanupListener[] listener = this.listenerList.getListeners(MobsimBeforeCleanupListener.class);
-        for (MobsimBeforeCleanupListener aListener : listener) {
-            aListener.notifyMobsimBeforeCleanup(event);
-        }
+		for (MobsimBeforeCleanupListener aListener : listener) {
+			aListener.notifyMobsimBeforeCleanup(event);
+		}
 	}
 
 	public void fireQueueSimulationBeforeSimStepEvent(double time) {
 		MobsimBeforeSimStepEvent<Mobsim> event = new MobsimBeforeSimStepEvent<>(sim, time);
 		MobsimBeforeSimStepListener[] listener = this.listenerList.getListeners(MobsimBeforeSimStepListener.class);
-        for (MobsimBeforeSimStepListener aListener : listener) {
-            aListener.notifyMobsimBeforeSimStep(event);
-        }
+		for (MobsimBeforeSimStepListener aListener : listener) {
+			aListener.notifyMobsimBeforeSimStep(event);
+		}
 	}
 
 }

--- a/matsim/src/main/java/org/matsim/pt/ReconstructingUmlaufBuilder.java
+++ b/matsim/src/main/java/org/matsim/pt/ReconstructingUmlaufBuilder.java
@@ -20,8 +20,6 @@
 package org.matsim.pt;
 
 import com.google.inject.Inject;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
 import org.matsim.core.gbl.Gbl;
@@ -46,7 +44,6 @@ import java.util.Map;
  * @author (of documentation) kai
  */
 public final class ReconstructingUmlaufBuilder implements UmlaufBuilder {
-	private static final Logger log = LogManager.getLogger(ReconstructingUmlaufBuilder.class);
 
 	private static final Comparator<UmlaufStueck> departureTimeComparator = Comparator.comparingDouble(o -> o.getDeparture().getDepartureTime());
 
@@ -77,7 +74,7 @@ public final class ReconstructingUmlaufBuilder implements UmlaufBuilder {
 	}
 
 	/**
-	 * (connect multiple umlautStuecke to one umlauf.  will do anything interesting only if same vehicle is shared across multiple departures.  vehicle
+	 * (connect multiple umlautStuecke to one umlauf.  will do anything interesting only if same vehicle is shared across multiple departures. vehicle
 	 * id can be set for departures in transit schedule.  but usually isn't)
 	 */
 	private void createUmlaeufe() {
@@ -120,7 +117,6 @@ public final class ReconstructingUmlaufBuilder implements UmlaufBuilder {
 	 */
 	private void createUmlaufStuecke() {
 		this.umlaufStuecke = new ArrayList<>();
-		log.info("Generating rotation segments");
 		for (TransitLine line : transitLines) {
 			for (TransitRoute route : line.getRoutes().values()) {
 				Gbl.assertNotNull(route.getRoute()); // will fail much later if this is null.  kai, may'17
@@ -130,7 +126,6 @@ public final class ReconstructingUmlaufBuilder implements UmlaufBuilder {
 				}
 			}
 		}
-		log.info("Finished generating rotation segments");
 		this.umlaufStuecke.sort(departureTimeComparator);
 	}
 }


### PR DESCRIPTION
Removes logging in `MobsimListenerManager` and `Umlaufbuilder`. Both are triggered multiple times per simulation process which causes a lot of logging. Also, I don't think the `Umlaufbuilder` logging was particularly interesting.
