### PR TITLE
feat(carriers): add splitter for VRPs

### DIFF
--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarriersUtils.java
@@ -61,6 +61,7 @@ import org.matsim.core.utils.misc.Time;
 import org.matsim.freight.carriers.analysis.CarriersAnalysis;
 import org.matsim.freight.carriers.consistency_checkers.CarrierConsistencyCheckers;
 import org.matsim.freight.carriers.jsprit.*;
+import org.matsim.freight.carriers.splitter.CarrierSplitter;
 import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.vehicles.Vehicle;
 import org.matsim.vehicles.VehicleType;
@@ -96,6 +97,21 @@ public class CarriersUtils {
 
 	public static Carrier createCarrier(Id<Carrier> id) {
 		return new CarrierImpl(id);
+	}
+
+	/**
+	 * Splits each carrier in the scenario into smaller carriers by clustering its shipments or services.
+	 * <p>
+	 * This is a convenience entry point; the actual split implementation lives in {@link CarrierSplitter}.
+	 *
+	 * @param scenario MATSim scenario containing the network and carriers to split.
+	 * @param clusterStrategy clustering strategy used to build the smaller carrier groups.
+	 * @param shipmentClusterLocation location representation for shipment clustering; required for carriers with shipments.
+	 * @param maxJobsPerCarrier target upper bound for jobs assigned to each new carrier.
+	 */
+	public static void splitCarriers(Scenario scenario, CarrierSplitter.ClusteringStrategy clusterStrategy,
+			CarrierSplitter.ShipmentClusteringLocation shipmentClusterLocation, int maxJobsPerCarrier) {
+		CarrierSplitter.splitCarriers(scenario, clusterStrategy, shipmentClusterLocation, maxJobsPerCarrier);
 	}
 
 	/**

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/splitter/CarrierSplitPlotWriter.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/splitter/CarrierSplitPlotWriter.java
@@ -1,0 +1,276 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C)  by the members listed in the COPYING,            *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.freight.carriers.splitter;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.freight.carriers.Carrier;
+import org.matsim.freight.carriers.CarrierShipment;
+import org.matsim.freight.carriers.CarriersUtils;
+import org.matsim.freight.carriers.FreightCarriersConfigGroup;
+import org.matsim.core.config.ConfigUtils;
+
+import javax.imageio.ImageIO;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+final class CarrierSplitPlotWriter {
+
+	private static final Logger log = LogManager.getLogger(CarrierSplitPlotWriter.class);
+	private static final int WIDTH = 1920;
+	private static final int HEIGHT = 1080;
+	private static final int MARGIN = 60;
+
+	private CarrierSplitPlotWriter() {
+	}
+
+	static void writeCarrierSplitPlot(Scenario scenario,
+			CarrierSplitter.ClusteringStrategy clusteringStrategy,
+			CarrierSplitter.ShipmentClusteringLocation shipmentClusteringLocation) {
+		List<PlotPoint> points = collectPoints(scenario, shipmentClusteringLocation);
+		if (points.isEmpty()) {
+			log.info("No carrier jobs available. Skipping carrier split plot.");
+			return;
+		}
+
+		Path outputFile = getOutputFile(scenario);
+		try {
+			Files.createDirectories(outputFile.getParent());
+			BufferedImage image = createImage(points, clusteringStrategy, shipmentClusteringLocation);
+			ImageIO.write(image, "png", outputFile.toFile());
+			log.info("Carrier split plot written to: {}", outputFile);
+		} catch (IOException e) {
+			throw new RuntimeException("Could not write carrier split plot to " + outputFile, e);
+		}
+	}
+
+	private static Path getOutputFile(Scenario scenario) {
+		String runId = scenario.getConfig().controller().getRunId();
+		String filename = runId == null ? "carrier_split.png" : runId + ".carrier_split.png";
+		FreightCarriersConfigGroup freightConfig = ConfigUtils.addOrGetModule(scenario.getConfig(), FreightCarriersConfigGroup.class);
+		if (freightConfig.getCarriersFile() != null && !freightConfig.getCarriersFile().isBlank()) {
+			Path carriersFile = Path.of(freightConfig.getCarriersFile());
+			Path carrierDirectory = carriersFile.getParent();
+			if (carrierDirectory != null) {
+				return carrierDirectory.resolve(filename);
+			}
+		}
+		return Path.of(scenario.getConfig().controller().getOutputDirectory()).resolve(filename);
+	}
+
+	private static List<PlotPoint> collectPoints(Scenario scenario,
+			CarrierSplitter.ShipmentClusteringLocation shipmentClusteringLocation) {
+		List<PlotPoint> points = new ArrayList<>();
+		List<Carrier> carriers = CarriersUtils.getCarriers(scenario).getCarriers().values().stream()
+				.sorted(Comparator.comparing(carrier -> carrier.getId().toString()))
+				.toList();
+
+		for (Carrier carrier : carriers) {
+			String carrierId = carrier.getId().toString();
+			carrier.getShipments().values().stream()
+					.sorted(Comparator.comparing(shipment -> shipment.getId().toString()))
+					.map(shipment -> new PlotPoint(getShipmentCoord(scenario, shipment, shipmentClusteringLocation),
+							carrierId, PointType.SHIPMENT))
+					.forEach(points::add);
+			carrier.getServices().values().stream()
+					.sorted(Comparator.comparing(service -> service.getId().toString()))
+					.map(service -> new PlotPoint(getLinkCoord(scenario, service.getServiceLinkId().toString()),
+							carrierId, PointType.SERVICE))
+					.forEach(points::add);
+			carrier.getCarrierCapabilities().getCarrierVehicles().values().stream()
+					.sorted(Comparator.comparing(vehicle -> vehicle.getId().toString()))
+					.map(vehicle -> new PlotPoint(getLinkCoord(scenario, vehicle.getLinkId().toString()),
+							carrierId, PointType.DEPOT))
+					.forEach(points::add);
+		}
+		return points;
+	}
+
+	private static Coord getShipmentCoord(Scenario scenario, CarrierShipment shipment,
+			CarrierSplitter.ShipmentClusteringLocation shipmentClusteringLocation) {
+		if (shipmentClusteringLocation == null) {
+			throw new IllegalArgumentException("shipmentClusteringLocation must be specified explicitly when shipments are present.");
+		}
+		Coord pickupCoord = getLinkCoord(scenario, shipment.getPickupLinkId().toString());
+		Coord deliveryCoord = getLinkCoord(scenario, shipment.getDeliveryLinkId().toString());
+		return switch (shipmentClusteringLocation) {
+			case PICKUP -> pickupCoord;
+			case DELIVERY -> deliveryCoord;
+			case MIDPOINT -> new Coord((pickupCoord.getX() + deliveryCoord.getX()) / 2,
+					(pickupCoord.getY() + deliveryCoord.getY()) / 2);
+		};
+	}
+
+	private static Coord getLinkCoord(Scenario scenario, String linkId) {
+		Link link = scenario.getNetwork().getLinks().get(Id.createLinkId(linkId));
+		if (link == null) {
+			throw new IllegalArgumentException("Link " + linkId + " is missing from the network.");
+		}
+		return link.getCoord();
+	}
+
+	private static BufferedImage createImage(List<PlotPoint> points,
+			CarrierSplitter.ClusteringStrategy clusteringStrategy,
+			CarrierSplitter.ShipmentClusteringLocation shipmentClusteringLocation) {
+		BufferedImage image = new BufferedImage(WIDTH, HEIGHT, BufferedImage.TYPE_INT_RGB);
+		Graphics2D graphics = image.createGraphics();
+		graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+		graphics.setColor(Color.WHITE);
+		graphics.fillRect(0, 0, WIDTH, HEIGHT);
+
+		Bounds bounds = Bounds.of(points);
+		Map<String, Color> colors = carrierColors(points);
+		drawTitle(graphics, points, clusteringStrategy, shipmentClusteringLocation);
+		for (PlotPoint point : points) {
+			drawPoint(graphics, point, bounds, colors.get(point.carrierId()));
+		}
+		drawLegend(graphics, points, shipmentClusteringLocation);
+		graphics.dispose();
+		return image;
+	}
+
+	private static void drawTitle(Graphics2D graphics, List<PlotPoint> points,
+			CarrierSplitter.ClusteringStrategy clusteringStrategy,
+			CarrierSplitter.ShipmentClusteringLocation shipmentClusteringLocation) {
+		graphics.setColor(Color.DARK_GRAY);
+		graphics.setFont(new Font(Font.SANS_SERIF, Font.PLAIN, 22));
+		long jobCount = points.stream().filter(point -> point.type() != PointType.DEPOT).count();
+		long carrierCount = points.stream().map(PlotPoint::carrierId).distinct().count();
+		String splitLocation = shipmentClusteringLocation == null ? "SERVICE" : shipmentClusteringLocation.name();
+		graphics.drawString("Carrier split: " + jobCount + " jobs, " + carrierCount + " carriers, algorithm "
+				+ clusteringStrategy.name() + ", split location " + splitLocation, MARGIN, 36);
+	}
+
+	private static void drawLegend(Graphics2D graphics, List<PlotPoint> points,
+			CarrierSplitter.ShipmentClusteringLocation shipmentClusteringLocation) {
+		int rowHeight = 26;
+		int legendWidth = 260;
+		int x = WIDTH - legendWidth - 60;
+		int y = 55;
+		boolean hasShipments = points.stream().anyMatch(point -> point.type() == PointType.SHIPMENT);
+		String jobLocationLabel = hasShipments ? switch (shipmentClusteringLocation) {
+			case PICKUP -> "pickups";
+			case DELIVERY -> "deliveries";
+			case MIDPOINT -> "midpoints";
+		} : "services";
+		int legendHeight = 52 + 2 * rowHeight;
+
+		graphics.setColor(new Color(255, 255, 255, 235));
+		graphics.fillRect(x, y, legendWidth, legendHeight);
+		graphics.setColor(Color.LIGHT_GRAY);
+		graphics.drawRect(x, y, legendWidth, legendHeight);
+
+		graphics.setColor(Color.DARK_GRAY);
+		graphics.setFont(new Font(Font.SANS_SERIF, Font.BOLD, 16));
+		graphics.drawString("Legend", x + 14, y + 24);
+
+		graphics.setFont(new Font(Font.SANS_SERIF, Font.PLAIN, 15));
+		drawDepotLegendEntry(graphics, x + 18, x + 42, y + 54);
+		drawJobLegendEntry(graphics, hasShipments, x + 18, x + 42, y + 54 + rowHeight, jobLocationLabel);
+	}
+
+	private static void drawJobLegendEntry(Graphics2D graphics, boolean hasShipments, int symbolX, int textX, int currentY, String label) {
+		graphics.setColor(Color.GRAY);
+		if (hasShipments)
+			graphics.fillOval(symbolX - 5, currentY - 10, 10, 10);
+		else
+			graphics.fillRect(symbolX - 5, currentY - 10, 10, 10);
+		graphics.setColor(Color.DARK_GRAY);
+		graphics.drawString(label + " (color = carrier)", textX, currentY);
+	}
+
+	private static void drawDepotLegendEntry(Graphics2D graphics, int symbolX, int textX, int currentY) {
+		graphics.setColor(Color.BLACK);
+		int[] depotX = {symbolX, symbolX - 8, symbolX + 8};
+		int[] depotY = {currentY - 13, currentY + 4, currentY + 4};
+		graphics.fillPolygon(depotX, depotY, 3);
+		graphics.setColor(Color.DARK_GRAY);
+		graphics.drawString("depot", textX, currentY);
+	}
+
+	private static void drawPoint(Graphics2D graphics, PlotPoint point, Bounds bounds, Color color) {
+		int x = scale(point.coord().getX(), bounds.minX(), bounds.maxX(), WIDTH - MARGIN);
+		int y = HEIGHT - scale(point.coord().getY(), bounds.minY(), bounds.maxY(), HEIGHT - MARGIN);
+		if (point.type() == PointType.DEPOT) {
+			graphics.setColor(Color.BLACK);
+			int[] xs = {x, x - 8, x + 8};
+			int[] ys = {y - 10, y + 7, y + 7};
+			graphics.fillPolygon(xs, ys, 3);
+			graphics.setColor(Color.WHITE);
+			graphics.setStroke(new BasicStroke(2f));
+			graphics.drawPolygon(xs, ys, 3);
+			return;
+		}
+		graphics.setColor(color);
+		if (point.type() == PointType.SERVICE)
+			graphics.fillRect(x - 5, y - 5, 10, 10);
+		else
+			graphics.fillOval(x - 5, y - 5, 10, 10);
+	}
+
+	private static int scale(double value, double min, double max, int upper) {
+		if (max == min) {
+			return (CarrierSplitPlotWriter.MARGIN + upper) / 2;
+		}
+		return (int) Math.round(CarrierSplitPlotWriter.MARGIN + (value - min) / (max - min) * (upper - CarrierSplitPlotWriter.MARGIN));
+	}
+
+	private static Map<String, Color> carrierColors(List<PlotPoint> points) {
+		Map<String, Color> colors = new HashMap<>();
+		List<String> carrierIds = points.stream().map(PlotPoint::carrierId).distinct().sorted().toList();
+		for (int i = 0; i < carrierIds.size(); i++) {
+			float hue = (float) i / carrierIds.size();
+			colors.put(carrierIds.get(i), Color.getHSBColor(hue, 0.7f, 0.8f));
+		}
+		return colors;
+	}
+
+	private enum PointType {
+		SHIPMENT, SERVICE, DEPOT
+	}
+
+	private record PlotPoint(Coord coord, String carrierId, PointType type) {
+	}
+
+	private record Bounds(double minX, double maxX, double minY, double maxY) {
+		static Bounds of(List<PlotPoint> points) {
+			double minX = points.stream().mapToDouble(point -> point.coord().getX()).min().orElse(0);
+			double maxX = points.stream().mapToDouble(point -> point.coord().getX()).max().orElse(1);
+			double minY = points.stream().mapToDouble(point -> point.coord().getY()).min().orElse(0);
+			double maxY = points.stream().mapToDouble(point -> point.coord().getY()).max().orElse(1);
+			return new Bounds(minX, maxX, minY, maxY);
+		}
+	}
+}

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/splitter/CarrierSplitter.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/splitter/CarrierSplitter.java
@@ -1,0 +1,612 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C)  by the members listed in the COPYING,            *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.freight.carriers.splitter;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.freight.carriers.*;
+import org.matsim.utils.objectattributes.attributable.AttributesUtils;
+import org.matsim.vehicles.Vehicle;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+/**
+ * Splits carriers into smaller carriers by spatially clustering their shipments or services.
+ * <p>
+ * This splitter currently supports carriers with infinite fleets only. Finite fleets need an explicit vehicle allocation
+ * policy and are therefore rejected until this behavior is implemented and tested.
+ */
+public final class CarrierSplitter {
+
+	private static final Logger log = LogManager.getLogger(CarrierSplitter.class);
+	//TODO vielelicht kann man die Jobs per Split carrier ja anhand des Widerstandes ermitteln
+	private CarrierSplitter() {
+	}
+
+	public enum ClusteringStrategy {
+		// TODO Add METIS clustering once the external solver dependency is injectable and covered by portable tests.
+		RANDOM, GREEDY, SINGLE_LINK, CENTROIDS
+	}
+
+	/**
+	 * This setting is intentionally mandatory for shipment clustering: {@link CarrierShipment}s have two spatially
+	 * relevant locations, pickup and delivery. Choosing the wrong one can fundamentally change the split result,
+	 * e.g. waste collection should usually be clustered by pickup locations, while distribution from one depot to many
+	 * customers often needs delivery locations. Use {@link #MIDPOINT} only when both ends of the shipment should
+	 * influence the spatial split.
+	 */
+	public enum ShipmentClusteringLocation {
+		/** Cluster shipments by their pickup link coordinate. */
+		PICKUP,
+		/** Cluster shipments by their delivery link coordinate. */
+		DELIVERY,
+		/** Cluster shipments by the midpoint between pickup and delivery link coordinates. */
+		MIDPOINT
+	}
+
+	private record Edge<T>(T a, T b, double distance) {
+	}
+
+	/**
+	 * Splits each carrier in the scenario into smaller carriers by clustering the carrier's jobs.
+	 * <p>
+	 * A carrier is expected to contain either shipments or services. Shipment carriers require an explicit
+	 * {@code shipmentClusterLocation}; service carriers ignore this setting because services have only one service
+	 * location.
+	 * <p>
+	 * The split is deterministic for identical inputs: carriers, vehicles and jobs are processed in ID order, and
+	 * distance ties are resolved by job IDs.
+	 *
+	 * @param scenario MATSim scenario containing the network and carriers to split.
+	 * @param clusterStrategy clustering strategy used to build the smaller carrier groups.
+	 * @param shipmentClusterLocation location representation for shipment clustering; required for carriers with shipments.
+	 * @param maxJobsPerCarrier target upper bound for jobs assigned to each new carrier.
+	 */
+	public static void splitCarriers(Scenario scenario, ClusteringStrategy clusterStrategy,
+			ShipmentClusteringLocation shipmentClusterLocation, int maxJobsPerCarrier) {
+		if (maxJobsPerCarrier <= 0) {
+			throw new IllegalArgumentException("maxJobsPerCarrier must be larger than zero.");
+		}
+
+		Network network = scenario.getNetwork();
+		Carriers carriers = CarriersUtils.getCarriers(scenario);
+		Carriers newCarriers = new Carriers();
+		boolean splitPerformed = false;
+
+		for (Carrier singleCarrier : sortedCarriers(carriers)) {
+			if (!singleCarrier.getPlans().isEmpty()) {
+				newCarriers.addCarrier(singleCarrier);
+				continue;
+			}
+
+			String carrierName = singleCarrier.getId().toString();
+			int jspritIterations = CarriersUtils.getJspritIterations(singleCarrier);
+			if (jspritIterations <= 0) {
+				throw new IllegalArgumentException("Carrier " + singleCarrier.getId() + " has invalid jsprit iterations: " + jspritIterations);
+			}
+
+			int numberOfCarriers = estimateNumberOfCarriers(maxJobsPerCarrier, singleCarrier);
+			if (numberOfCarriers <= 1) {
+				newCarriers.addCarrier(singleCarrier);
+				continue;
+			}
+			splitPerformed = true;
+			verifyInfiniteFleet(singleCarrier);
+
+			Function<CarrierShipment, Coord> shipmentCoordGetter = getCarrierShipmentCoordFunction(
+					shipmentClusterLocation, singleCarrier, network);
+			Function<CarrierService, Coord> serviceCoordGetter = service -> network.getLinks().get(service.getServiceLinkId()).getCoord();
+
+			List<List<CarrierShipment>> shipmentClusters;
+			List<List<CarrierService>> serviceClusters;
+			switch (clusterStrategy) {
+				case RANDOM -> {
+					shipmentClusters = findRandomClusters(singleCarrier.getShipments().values(), numberOfCarriers,
+							maxJobsPerCarrier, CarrierSplitter::shipmentId);
+					serviceClusters = findRandomClusters(singleCarrier.getServices().values(), numberOfCarriers,
+							maxJobsPerCarrier, CarrierSplitter::serviceId);
+				}
+				case GREEDY -> {
+					CarrierVehicle carrierVehicle = getGreedyDepotReferenceVehicle(singleCarrier);
+					shipmentClusters = findGreedyClusters(singleCarrier.getShipments().values(), network, numberOfCarriers,
+							carrierVehicle, maxJobsPerCarrier, shipmentCoordGetter,
+							CarrierSplitter::shipmentId, (shipment, seedName) -> shipment.getAttributes().putAttribute("seed", seedName));
+					serviceClusters = findGreedyClusters(singleCarrier.getServices().values(), network, numberOfCarriers,
+							carrierVehicle, maxJobsPerCarrier, serviceCoordGetter,
+							CarrierSplitter::serviceId, (service, seedName) -> service.getAttributes().putAttribute("seed", seedName));
+				}
+				case SINGLE_LINK -> {
+					shipmentClusters = findSingleLinkClusters(singleCarrier.getShipments().values(), numberOfCarriers,
+							maxJobsPerCarrier, shipmentCoordGetter, CarrierSplitter::shipmentId);
+					serviceClusters = findSingleLinkClusters(singleCarrier.getServices().values(), numberOfCarriers,
+							maxJobsPerCarrier, serviceCoordGetter, CarrierSplitter::serviceId);
+				}
+				case CENTROIDS -> {
+					shipmentClusters = findCentroidsClusters(singleCarrier.getShipments().values(), numberOfCarriers,
+							maxJobsPerCarrier, shipmentCoordGetter, CarrierSplitter::shipmentId);
+					serviceClusters = findCentroidsClusters(singleCarrier.getServices().values(), numberOfCarriers,
+							maxJobsPerCarrier, serviceCoordGetter, CarrierSplitter::serviceId);
+				}
+				default -> throw new IllegalArgumentException("Unsupported clustering strategy: " + clusterStrategy);
+			}
+
+			int numberOfSplitCarriers = Math.max(shipmentClusters.size(), serviceClusters.size());
+			ensureClusterCount(shipmentClusters, numberOfSplitCarriers);
+			ensureClusterCount(serviceClusters, numberOfSplitCarriers);
+
+			for (int i = 0; i < numberOfSplitCarriers; i++) {
+				if (shipmentClusters.get(i).isEmpty() && serviceClusters.get(i).isEmpty())
+					continue;
+				Carrier newCarrier = createSingleCarrier(singleCarrier, jspritIterations, i + 1);
+				newCarriers.addCarrier(newCarrier);
+
+				for (CarrierShipment shipment : shipmentClusters.get(i))
+					CarriersUtils.addShipment(newCarrier, shipment);
+				for (CarrierService service : serviceClusters.get(i))
+					CarriersUtils.addService(newCarrier, service);
+				log.info("New Carrier: {}: {} Shipments, {} Services", newCarrier.getId().toString(),
+						shipmentClusters.get(i).size(), serviceClusters.get(i).size());
+			}
+		}
+
+		carriers.getCarriers().clear();
+		for (Carrier singleCarrier : newCarriers.getCarriers().values()) {
+			carriers.addCarrier(singleCarrier);
+		}
+		if (splitPerformed) {
+			CarrierSplitPlotWriter.writeCarrierSplitPlot(scenario, clusterStrategy, shipmentClusterLocation);
+		}
+	}
+
+	/**
+	 * Verifies that the carrier uses an infinite fleet, which is the only fleet mode currently supported by this split.
+	 *
+	 * @param carrier carrier whose capabilities are checked.
+	 * @throws UnsupportedOperationException if the carrier uses a finite fleet.
+	 */
+	private static void verifyInfiniteFleet(Carrier carrier) {
+		if (carrier.getCarrierCapabilities().getFleetSize() == CarrierCapabilities.FleetSize.FINITE) {
+			throw new UnsupportedOperationException("Splitting carriers with finite fleets is not implemented or tested yet.");
+		}
+	}
+
+	private static List<Carrier> sortedCarriers(Carriers carriers) {
+		return carriers.getCarriers().values().stream()
+				.sorted(Comparator.comparing(carrier -> carrier.getId().toString()))
+				.toList();
+	}
+
+	/**
+	 * Returns the depot reference vehicle used by greedy clustering.
+	 * <p>
+	 * Greedy clustering starts its seed selection from one depot coordinate. If a carrier has multiple vehicles, this
+	 * coordinate is only well-defined when all vehicles share the same start link. After that validation, the vehicle
+	 * with the smallest ID is returned to keep the split deterministic.
+	 *
+	 * @param carrier carrier whose vehicles are checked.
+	 * @return vehicle with the smallest ID, used as depot reference for greedy clustering.
+	 * @throws IllegalArgumentException if the carrier has no vehicle or if its vehicles use different start links.
+	 */
+	private static CarrierVehicle getGreedyDepotReferenceVehicle(Carrier carrier) {
+		List<CarrierVehicle> vehicles = carrier.getCarrierCapabilities().getCarrierVehicles().values().stream()
+				.sorted(Comparator.comparing(vehicle -> vehicle.getId().toString()))
+				.toList();
+		if (vehicles.isEmpty()) {
+			throw new IllegalArgumentException("Carrier " + carrier.getId() + " has no carrier vehicle.");
+		}
+
+		Id<Link> startLinkId = vehicles.getFirst().getLinkId();
+		boolean hasDifferentStartLink = vehicles.stream()
+				.anyMatch(vehicle -> !Objects.equals(startLinkId, vehicle.getLinkId()));
+		if (hasDifferentStartLink) {
+			throw new IllegalArgumentException("Greedy clustering requires all vehicles of carrier " + carrier.getId()
+					+ " to have the same start link.");
+		}
+		return vehicles.getFirst();
+	}
+
+	private static String shipmentId(CarrierShipment shipment) {
+		return shipment.getId().toString();
+	}
+
+	private static String serviceId(CarrierService service) {
+		return service.getId().toString();
+	}
+
+	private static <T> List<T> sortedDemands(Collection<T> demands, Function<T, String> idGetter) {
+		return new ArrayList<>(demands.stream()
+				.sorted(Comparator.comparing(idGetter))
+				.toList());
+	}
+
+	private static <T> Comparator<Edge<T>> edgeComparator(Function<T, String> idGetter) {
+		return Comparator.<Edge<T>>comparingDouble(Edge::distance)
+				.thenComparing(edge -> idGetter.apply(edge.a()))
+				.thenComparing(edge -> idGetter.apply(edge.b()));
+	}
+
+	/**
+	 * Creates the shipment coordinate function for a carrier.
+	 *
+	 * @param shipmentClusterLocation chosen shipment location representation; must be non-null for shipment carriers.
+	 * @param singleCarrier carrier whose demand type is checked.
+	 * @param network network used to resolve shipment link coordinates.
+	 * @return coordinate lookup function for shipments of the carrier.
+	 */
+	private static Function<CarrierShipment, Coord> getCarrierShipmentCoordFunction(
+			ShipmentClusteringLocation shipmentClusterLocation, Carrier singleCarrier, Network network) {
+		boolean hasShipments = !singleCarrier.getShipments().isEmpty();
+
+		Function<CarrierShipment, Coord> shipmentCoordGetter = shipment -> {
+			throw new IllegalStateException("Shipment coordinates are only available for carriers with shipments.");
+		};
+		if (hasShipments) {
+			if (shipmentClusterLocation == null) {
+				throw new IllegalArgumentException("shipmentClusterLocation must be specified explicitly when shipments are present.");
+			}
+			shipmentCoordGetter = createShipmentCoordGetter(network, shipmentClusterLocation);
+		}
+		return shipmentCoordGetter;
+	}
+
+	/**
+	 * Builds the coordinate lookup used to represent each shipment during clustering.
+	 *
+	 * @param network network used to resolve pickup and delivery link coordinates.
+	 * @param shipmentClusterLocation shipment location representation selected by the caller.
+	 * @return coordinate lookup function for a shipment.
+	 */
+	private static Function<CarrierShipment, Coord> createShipmentCoordGetter(Network network,
+			ShipmentClusteringLocation shipmentClusterLocation) {
+		return switch (shipmentClusterLocation) {
+			case PICKUP -> shipment -> network.getLinks().get(shipment.getPickupLinkId()).getCoord();
+			case DELIVERY -> shipment -> network.getLinks().get(shipment.getDeliveryLinkId()).getCoord();
+			case MIDPOINT -> shipment -> {
+				Coord pickupCoord = network.getLinks().get(shipment.getPickupLinkId()).getCoord();
+				Coord deliveryCoord = network.getLinks().get(shipment.getDeliveryLinkId()).getCoord();
+				return new Coord((pickupCoord.getX() + deliveryCoord.getX()) / 2,
+						(pickupCoord.getY() + deliveryCoord.getY()) / 2);
+			};
+		};
+	}
+
+	/**
+	 * Randomly distributes demands over the requested number of clusters while respecting the max cluster size.
+	 *
+	 * @param demands shipment or service jobs to cluster.
+	 * @param numberOfCarriers number of clusters to create.
+	 * @param maxJobsPerCarrier maximum number of jobs per cluster.
+	 * @param <T> demand type, either {@link CarrierShipment} or {@link CarrierService}.
+	 * @return clustered demands.
+	 */
+	private static <T> List<List<T>> findRandomClusters(Collection<T> demands, int numberOfCarriers,
+			int maxJobsPerCarrier, Function<T, String> idGetter) {
+		List<List<T>> clusters = new ArrayList<>();
+		for (int i = 0; i < numberOfCarriers; i++) {
+			clusters.add(new ArrayList<>());
+		}
+		Random randomSeed = new Random(1);
+		for (T demand : sortedDemands(demands, idGetter)) {
+			boolean hasBeenAssigned = false;
+			while (!hasBeenAssigned) {
+				int coinFlip = randomSeed.nextInt(numberOfCarriers);
+				if (clusters.get(coinFlip).size() < maxJobsPerCarrier) {
+					clusters.get(coinFlip).add(demand);
+					hasBeenAssigned = true;
+				}
+			}
+		}
+		return clusters;
+	}
+
+	/**
+	 * Pads a cluster list with empty clusters until it matches the number of carrier slots.
+	 *
+	 * @param clusters clusters to pad.
+	 * @param numberOfCarriers required number of clusters.
+	 * @param <T> demand type stored in the clusters.
+	 */
+	private static <T> void ensureClusterCount(List<List<T>> clusters, int numberOfCarriers) {
+		while (clusters.size() < numberOfCarriers) {
+			clusters.add(new ArrayList<>());
+		}
+	}
+
+	/**
+	 * Builds spatial clusters by repeatedly choosing a seed far from existing seeds and assigning nearby demands.
+	 *
+	 * @param demands shipment or service jobs to cluster.
+	 * @param network network used to resolve the depot coordinate from the carrier vehicle.
+	 * @param numberOfCarriers number of clusters to create.
+	 * @param carrierVehicle vehicle whose start link is used as the depot reference.
+	 * @param maxJobsPerCarrier maximum number of jobs per cluster.
+	 * @param coordGetter coordinate representation for each demand.
+	 * @param seedMarker callback used to mark selected seeds for debug visualization.
+	 * @param <T> demand type, either {@link CarrierShipment} or {@link CarrierService}.
+	 * @return clustered demands.
+	 */
+	private static <T> List<List<T>> findGreedyClusters(Collection<T> demands, Network network, int numberOfCarriers,
+			CarrierVehicle carrierVehicle, int maxJobsPerCarrier, Function<T, Coord> coordGetter,
+			Function<T, String> idGetter, BiConsumer<T, String> seedMarker) {
+		List<List<T>> clusters = new ArrayList<>();
+		List<Coord> seedCoords = new ArrayList<>();
+		List<T> unassignedDemands = sortedDemands(demands, idGetter);
+
+		Map<T, Coord> coords = new HashMap<>();
+		for (T demand : unassignedDemands) {
+			coords.put(demand, coordGetter.apply(demand));
+		}
+
+		Coord depotCoord = network.getLinks().get(carrierVehicle.getLinkId()).getCoord();
+		for (int i = 0; i < numberOfCarriers; i++) {
+			clusters.add(new ArrayList<>());
+		}
+		for (int i = 0; i < numberOfCarriers && !unassignedDemands.isEmpty(); i++) {
+			double maxDistance = 0;
+			T seed = null;
+
+			for (T demand : unassignedDemands) {
+				double distance = 0;
+				if (seedCoords.isEmpty()) {
+					distance = NetworkUtils.getEuclideanDistance(depotCoord, coords.get(demand));
+				} else {
+					for (Coord coord : seedCoords) {
+						distance += NetworkUtils.getEuclideanDistance(coord, coords.get(demand));
+					}
+				}
+				if (distance > maxDistance) {
+					maxDistance = distance;
+					seed = demand;
+				}
+			}
+
+			Coord seedCoord = coords.get(seed);
+			log.info("Seed {} found at Coord {}", i + 1, seedCoord);
+			seedCoords.add(seedCoord);
+			seedMarker.accept(seed, "seed" + (i + 1));
+
+			List<Edge<T>> edges = new ArrayList<>();
+			for (T toDemand : unassignedDemands) {
+				double dist = NetworkUtils.getEuclideanDistance(seedCoord, coords.get(toDemand));
+				edges.add(new Edge<>(seed, toDemand, dist));
+			}
+			edges.sort(edgeComparator(idGetter));
+
+			int remainingDemands = unassignedDemands.size();
+			int clusterTargetSize = maxJobsPerCarrier;
+			if (remainingDemands < maxJobsPerCarrier * 1.3) {
+				clusterTargetSize = remainingDemands;
+			}
+			for (int counter = 0; clusters.get(i).size() < clusterTargetSize && counter < remainingDemands; counter++) {
+				T demandToBeClustered = edges.get(counter).b;
+				clusters.get(i).add(demandToBeClustered);
+				unassignedDemands.remove(demandToBeClustered);
+			}
+		}
+		return clusters;
+	}
+
+	/**
+	 * Builds agglomerative single-link clusters from pairwise Euclidean distances between demand coordinates.
+	 *
+	 * @param demands shipment or service jobs to cluster.
+	 * @param numberOfCarriers target number of clusters.
+	 * @param maxJobsPerCarrier maximum number of jobs per cluster.
+	 * @param coordGetter coordinate representation for each demand.
+	 * @param <T> demand type, either {@link CarrierShipment} or {@link CarrierService}.
+	 * @return clustered demands.
+	 */
+	private static <T> List<List<T>> findSingleLinkClusters(Collection<T> demands, int numberOfCarriers,
+			int maxJobsPerCarrier, Function<T, Coord> coordGetter, Function<T, String> idGetter) {
+		List<List<T>> clusters = new ArrayList<>();
+		List<T> demandList = sortedDemands(demands, idGetter);
+		int numberOfDemands = demandList.size();
+
+		Map<T, Coord> coords = new HashMap<>();
+		for (T demand : demandList) {
+			coords.put(demand, coordGetter.apply(demand));
+			clusters.add(new ArrayList<>(List.of(demand)));
+		}
+
+		List<Edge<T>> edges = new ArrayList<>();
+		for (int i = 0; i < numberOfDemands; i++) {
+			for (int j = i + 1; j < numberOfDemands; j++) {
+				T a = demandList.get(i);
+				T b = demandList.get(j);
+				double dist = NetworkUtils.getEuclideanDistance(coords.get(a), coords.get(b));
+				edges.add(new Edge<>(a, b, dist));
+			}
+		}
+		edges.sort(edgeComparator(idGetter));
+
+		for (Edge<T> edge : edges) {
+			T a = edge.a();
+			T b = edge.b();
+			int aIndex = getClusterIndex(a, clusters);
+			int bIndex = getClusterIndex(b, clusters);
+			if (clusters.get(aIndex).size() + clusters.get(bIndex).size() > maxJobsPerCarrier) {
+				if (clusters.size() > numberOfCarriers * 1.5) {
+					continue;
+				} else if (clusters.get(aIndex).size() + clusters.get(bIndex).size() > maxJobsPerCarrier * 1.3) {
+					continue;
+				}
+			}
+			if (aIndex != bIndex) {
+				if (aIndex < bIndex) {
+					clusters.get(aIndex).addAll(clusters.get(bIndex));
+					clusters.remove(bIndex);
+				} else {
+					clusters.get(bIndex).addAll(clusters.get(aIndex));
+					clusters.remove(aIndex);
+				}
+				boolean noSmallClusters = checkForSmallClusters(clusters, maxJobsPerCarrier);
+				if ((clusters.size() == numberOfCarriers) && noSmallClusters) {
+					break;
+				}
+			}
+		}
+
+		return clusters;
+	}
+
+	/**
+	 * Builds agglomerative clusters by repeatedly merging the two closest cluster centroids.
+	 *
+	 * @param demands shipment or service jobs to cluster.
+	 * @param numberOfCarriers target number of clusters.
+	 * @param maxJobsPerCarrier maximum number of jobs per cluster.
+	 * @param coordGetter coordinate representation for each demand.
+	 * @param <T> demand type, either {@link CarrierShipment} or {@link CarrierService}.
+	 * @return clustered demands.
+	 */
+	private static <T> List<List<T>> findCentroidsClusters(Collection<T> demands, int numberOfCarriers,
+			int maxJobsPerCarrier, Function<T, Coord> coordGetter, Function<T, String> idGetter) {
+		List<T> demandList = sortedDemands(demands, idGetter);
+		List<List<T>> clusters = new ArrayList<>();
+
+		Map<T, Coord> coords = new HashMap<>();
+		for (T demand : demandList) {
+			coords.put(demand, coordGetter.apply(demand));
+			clusters.add(new ArrayList<>(List.of(demand)));
+		}
+
+		while (clusters.size() > numberOfCarriers) {
+			double minDistance = Double.MAX_VALUE;
+			int aIndex = -1;
+			int bIndex = -1;
+
+			for (int i = 0; i < clusters.size(); i++) {
+				Coord centroidA = computeCentroid(coords, clusters.get(i));
+				for (int j = i + 1; j < clusters.size(); j++) {
+					if (clusters.get(i).size() + clusters.get(j).size() > maxJobsPerCarrier) {
+						continue;
+					}
+					Coord centroidB = computeCentroid(coords, clusters.get(j));
+					double distanceApart = NetworkUtils.getEuclideanDistance(centroidA, centroidB);
+					if (distanceApart < minDistance) {
+						minDistance = distanceApart;
+						aIndex = i;
+						bIndex = j;
+					}
+				}
+			}
+
+			if (aIndex < bIndex) {
+				clusters.get(aIndex).addAll(clusters.get(bIndex));
+				clusters.remove(bIndex);
+			} else if (aIndex > bIndex) {
+				clusters.get(bIndex).addAll(clusters.get(aIndex));
+				clusters.remove(aIndex);
+			} else {
+				log.info("No further merges found!");
+				break;
+			}
+		}
+
+		return clusters;
+	}
+
+	private static <T> boolean checkForSmallClusters(List<List<T>> clusters, int maxJobsPerCarrier) {
+		for (List<T> cluster : clusters) {
+			if (cluster.size() < maxJobsPerCarrier * 0.3) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static <T> int getClusterIndex(T a, List<List<T>> clusters) {
+		for (int i = 0; i < clusters.size(); i++) {
+			for (int j = 0; j < clusters.get(i).size(); j++) {
+				if (a == clusters.get(i).get(j)) {
+					return i;
+				}
+			}
+		}
+		return 0;
+	}
+
+	private static <T> Coord computeCentroid(Map<T, Coord> coords, List<T> cluster) {
+		double sumX = 0.0;
+		double sumY = 0.0;
+		for (T demand : cluster) {
+			Coord c = coords.get(demand);
+			sumX += c.getX();
+			sumY += c.getY();
+		}
+		int size = cluster.size();
+		return new Coord(sumX / size, sumY / size);
+	}
+
+	private static int estimateNumberOfCarriers(int maxJobsPerCarrier, Carrier carrier) {
+		int noOfJobs = carrier.getShipments().size() + carrier.getServices().size();
+		int noOfCarriers = (int) Math.ceil((double) noOfJobs / maxJobsPerCarrier);
+		if (noOfCarriers > 1) {
+			log.info("NO OF JOBS: {} / MAX JOBS PER CARRIER: {}", noOfJobs, maxJobsPerCarrier);
+			log.info("NO OF CARRIERS: {}", noOfCarriers);
+		}
+		return noOfCarriers;
+	}
+
+	private static Carrier createSingleCarrier(Carrier originalCarrier, int jspritIterations, int carrierNumber) {
+		String carrierName = originalCarrier.getId().toString();
+		Carrier newCarrier = CarriersUtils.createCarrier(Id.create(carrierName + "_split_" + carrierNumber, Carrier.class));
+		AttributesUtils.copyTo(originalCarrier.getAttributes(), newCarrier.getAttributes());
+		CarriersUtils.setJspritIterations(newCarrier, jspritIterations);
+		CarrierCapabilities.Builder capabilitiesBuilder = CarrierCapabilities.Builder.newInstance()
+				.setFleetSize(CarrierCapabilities.FleetSize.INFINITE);
+		List<CarrierVehicle> carrierVehicles = originalCarrier.getCarrierCapabilities().getCarrierVehicles().values().stream()
+				.sorted(Comparator.comparing(vehicle -> vehicle.getId().toString()))
+				.toList();
+		for (int vehicleIndex = 0; vehicleIndex < carrierVehicles.size(); vehicleIndex++) {
+			capabilitiesBuilder.addVehicle(createSplitCarrierVehicle(newCarrier.getId(), carrierVehicles.get(vehicleIndex),
+					vehicleIndex + 1));
+		}
+		CarrierCapabilities carrierCapabilities = capabilitiesBuilder.build();
+		newCarrier.setCarrierCapabilities(carrierCapabilities);
+		return newCarrier;
+	}
+
+	private static CarrierVehicle createSplitCarrierVehicle(Id<Carrier> splitCarrierId, CarrierVehicle originalVehicle,
+			int vehicleNumber) {
+		Id<Vehicle> splitVehicleId = Id.createVehicleId(splitCarrierId + "_" + vehicleNumber);
+		CarrierVehicle splitVehicle = CarrierVehicle.Builder.newInstance(splitVehicleId, originalVehicle.getLinkId(),
+						originalVehicle.getType())
+				.setEarliestStart(originalVehicle.getEarliestStartTime())
+				.setLatestEnd(originalVehicle.getLatestEndTime())
+				.build();
+		AttributesUtils.copyTo(originalVehicle.getAttributes(), splitVehicle.getAttributes());
+		return splitVehicle;
+	}
+}

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/splitter/CarrierSplitterTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/splitter/CarrierSplitterTest.java
@@ -1,0 +1,447 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C)  by the members listed in the COPYING,            *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.freight.carriers.splitter;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.core.utils.io.IOUtils;
+import org.matsim.examples.ExamplesUtils;
+import org.matsim.freight.carriers.*;
+import org.matsim.testcases.MatsimTestUtils;
+import org.matsim.vehicles.Vehicle;
+import org.matsim.vehicles.VehicleType;
+import org.matsim.vehicles.VehicleUtils;
+
+import java.util.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CarrierSplitterTest {
+
+	@RegisterExtension
+	private MatsimTestUtils utils = new MatsimTestUtils() ;
+
+
+	private static final String ORIGINAL_CARRIER_ATTRIBUTE = "originalCarrierAttribute";
+	private static final String ORIGINAL_CARRIER_ATTRIBUTE_VALUE = "copied-to-split-carriers";
+	private static final String ORIGINAL_VEHICLE_ATTRIBUTE = "originalVehicleAttribute";
+	private static final String ORIGINAL_VEHICLE_ATTRIBUTE_VALUE = "copied-to-split-vehicles";
+	private static final String DEPOT_LINK_ID = "j(0,1)R";
+	private static final String SECOND_DEPOT_LINK_ID = "j(9,7)";
+	private static final String[] CHESSBOARD_LINK_IDS = {
+			"j(0,1)R", "j(1,3)", "j(2,5)R", "j(3,7)", "j(4,2)R", "i(5,6)", "j(6,1)R", "i(7,7)R", "j(8,4)R", "j(9,2)"
+	};
+
+	@Test
+	void splitsShipmentCarrierWithRandomClustering() {
+		assertShipmentCarrierSplit(CarrierSplitter.ClusteringStrategy.RANDOM);
+	}
+
+	@Test
+	void splitsShipmentCarrierWithGreedyClustering() {
+		assertShipmentCarrierSplit(CarrierSplitter.ClusteringStrategy.GREEDY);
+	}
+
+	@Test
+	void splitsShipmentCarrierWithSingleLinkClustering() {
+		assertShipmentCarrierSplit(CarrierSplitter.ClusteringStrategy.SINGLE_LINK);
+	}
+
+	@Test
+	void splitsShipmentCarrierWithCentroidsClustering() {
+		assertShipmentCarrierSplit(CarrierSplitter.ClusteringStrategy.CENTROIDS);
+	}
+
+	@Test
+	void splitsServiceCarrierWithRandomClustering() {
+		assertServiceCarrierSplit(CarrierSplitter.ClusteringStrategy.RANDOM);
+	}
+
+	@Test
+	void splitsServiceCarrierWithGreedyClustering() {
+		assertServiceCarrierSplit(CarrierSplitter.ClusteringStrategy.GREEDY);
+	}
+
+	@Test
+	void splitsServiceCarrierWithSingleLinkClustering() {
+		assertServiceCarrierSplit(CarrierSplitter.ClusteringStrategy.SINGLE_LINK);
+	}
+
+	@Test
+	void splitsServiceCarrierWithCentroidsClustering() {
+		assertServiceCarrierSplit(CarrierSplitter.ClusteringStrategy.CENTROIDS);
+	}
+
+	@Test
+	void rejectsShipmentSplitWithoutExplicitShipmentLocation() {
+		Scenario scenario = createShipmentScenario();
+
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				() -> CarriersUtils.splitCarriers(scenario, CarrierSplitter.ClusteringStrategy.RANDOM, null, 2));
+
+		assertEquals("shipmentClusterLocation must be specified explicitly when shipments are present.", exception.getMessage());
+	}
+
+	@Test
+	void rejectsFiniteFleetCarriers() {
+		Scenario scenario = createShipmentScenario();
+		Carrier originalCarrier = CarriersUtils.getCarriers(scenario).getCarriers().values().iterator().next();
+		originalCarrier.getCarrierCapabilities().setFleetSize(CarrierCapabilities.FleetSize.FINITE);
+
+		UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+				() -> CarriersUtils.splitCarriers(
+						scenario,
+						CarrierSplitter.ClusteringStrategy.RANDOM,
+						CarrierSplitter.ShipmentClusteringLocation.DELIVERY,
+						2));
+
+		assertEquals("Splitting carriers with finite fleets is not implemented or tested yet.", exception.getMessage());
+	}
+
+	@Test
+	void rejectsGreedyClusteringWhenVehicleStartLinksDiffer() {
+		Scenario scenario = createShipmentScenario();
+		Carrier originalCarrier = CarriersUtils.getCarriers(scenario).getCarriers().values().iterator().next();
+		originalCarrier.setCarrierCapabilities(createCarrierCapabilities(
+				originalCarrier.getId().toString(),
+			SECOND_DEPOT_LINK_ID));
+
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				() -> CarriersUtils.splitCarriers(
+						scenario,
+						CarrierSplitter.ClusteringStrategy.GREEDY,
+						CarrierSplitter.ShipmentClusteringLocation.DELIVERY,
+						2));
+
+		assertEquals("Greedy clustering requires all vehicles of carrier shipmentCarrier to have the same start link.",
+				exception.getMessage());
+	}
+
+	@Test
+	void serviceCarrierDoesNotRequireShipmentLocation() {
+		Scenario scenario = createServiceScenario();
+
+		CarriersUtils.splitCarriers(scenario, CarrierSplitter.ClusteringStrategy.RANDOM, null, 10);
+
+		assertEquals(20, countServices(CarriersUtils.getCarriers(scenario)));
+	}
+
+	@Test
+	void writesCarrierSplitPlotToOutputDirectory() {
+		Scenario scenario = createShipmentScenario();
+		scenario.getConfig().controller().setOutputDirectory(utils.getOutputDirectory());
+
+		CarriersUtils.splitCarriers(
+				scenario,
+				CarrierSplitter.ClusteringStrategy.GREEDY,
+				CarrierSplitter.ShipmentClusteringLocation.PICKUP,
+				2);
+
+		Path outputFile = Path.of(utils.getOutputDirectory()).resolve("carrier_split.png");
+		assertTrue(Files.exists(outputFile), "splitCarriers should write a PNG plot to the output directory.");
+		assertTrue(outputFile.toFile().length() > 0, "The PNG plot should not be empty.");
+	}
+
+	@Test
+	void writesCarrierSplitPlotNextToConfiguredCarrierFile() throws Exception {
+		Scenario scenario = createShipmentScenario();
+		Path carrierDirectory = Path.of(utils.getOutputDirectory()).resolve("generatedInputData");
+		Files.createDirectories(carrierDirectory);
+		ConfigUtils.addOrGetModule(scenario.getConfig(), FreightCarriersConfigGroup.class)
+				.setCarriersFile(carrierDirectory.resolve("input_carriers.xml.gz").toString());
+
+		CarriersUtils.splitCarriers(
+				scenario,
+				CarrierSplitter.ClusteringStrategy.GREEDY,
+				CarrierSplitter.ShipmentClusteringLocation.PICKUP,
+				2);
+
+		Path outputFile = carrierDirectory.resolve("carrier_split.png");
+		assertTrue(Files.exists(outputFile), "splitCarriers should write the PNG plot next to the configured carrier file.");
+		assertTrue(outputFile.toFile().length() > 0, "The PNG plot should not be empty.");
+	}
+
+	@Test
+	void leavesCarrierUnchangedWhenSplitIsNotRequired() {
+		Scenario scenario = createShipmentScenario();
+		Carriers carriers = CarriersUtils.getCarriers(scenario);
+		Carrier originalCarrier = carriers.getCarriers().values().iterator().next();
+		Id<Carrier> originalCarrierId = originalCarrier.getId();
+		int originalShipmentCount = originalCarrier.getShipments().size();
+		int originalJspritIterations = CarriersUtils.getJspritIterations(originalCarrier);
+
+		CarriersUtils.splitCarriers(scenario, CarrierSplitter.ClusteringStrategy.RANDOM, null, 10);
+
+		Carriers splitCarriers = CarriersUtils.getCarriers(scenario);
+		assertEquals(1, splitCarriers.getCarriers().size(), "Carrier should not be split when the job limit is not exceeded.");
+		Carrier unchangedCarrier = splitCarriers.getCarriers().get(originalCarrierId);
+		assertNotNull(unchangedCarrier, "Original carrier id should be preserved when no split is required.");
+		assertEquals(originalShipmentCount, unchangedCarrier.getShipments().size(), "All shipments should stay on the original carrier.");
+		assertEquals(originalJspritIterations, CarriersUtils.getJspritIterations(unchangedCarrier), "Original jsprit iterations should remain unchanged.");
+		assertEquals(ORIGINAL_CARRIER_ATTRIBUTE_VALUE, unchangedCarrier.getAttributes().getAttribute(ORIGINAL_CARRIER_ATTRIBUTE));
+	}
+
+	@Test
+	void createsDeterministicServiceSplitsIndependentOfInputOrder() {
+		for (CarrierSplitter.ClusteringStrategy strategy : CarrierSplitter.ClusteringStrategy.values()) {
+			Scenario firstScenario = createServiceScenario(false);
+			Scenario secondScenario = createServiceScenario(true);
+
+			CarriersUtils.splitCarriers(firstScenario, strategy, null, 10);
+			CarriersUtils.splitCarriers(secondScenario, strategy, null, 10);
+
+			assertEquals(
+					splitSignature(CarriersUtils.getCarriers(firstScenario)),
+					splitSignature(CarriersUtils.getCarriers(secondScenario)),
+					"Split should be deterministic for " + strategy);
+		}
+	}
+
+	@Test
+	void greedySplitDoesNotCreateEmptyRemainderCarrier() {
+		Scenario scenario = createServiceScenario(62);
+
+		CarriersUtils.splitCarriers(scenario, CarrierSplitter.ClusteringStrategy.GREEDY, null, 10);
+
+		Carriers splitCarriers = CarriersUtils.getCarriers(scenario);
+		assertEquals(6, splitCarriers.getCarriers().size(), "62 services may be split into six non-empty carriers when the remainder is bundled.");
+		assertEquals(62, countServices(splitCarriers), "All services must remain assigned after splitting.");
+		for (Carrier splitCarrier : splitCarriers.getCarriers().values()) {
+			assertTrue(splitCarrier.getServices().size() <= 13, "Greedy remainder clusters should stay within the 1.3 tolerance.");
+			assertFalse(splitCarrier.getServices().isEmpty(), "Greedy split should not create empty remainder carriers.");
+		}
+	}
+
+	private void assertShipmentCarrierSplit(CarrierSplitter.ClusteringStrategy strategy) {
+		Scenario scenario = createShipmentScenario();
+		Carriers carriers = CarriersUtils.getCarriers(scenario);
+		Carrier originalCarrier = carriers.getCarriers().values().iterator().next();
+		int originalShipmentCount = originalCarrier.getShipments().size();
+		int originalJspritIterations = CarriersUtils.getJspritIterations(originalCarrier);
+
+		CarriersUtils.splitCarriers(
+				scenario,
+				strategy,
+				CarrierSplitter.ShipmentClusteringLocation.DELIVERY,
+				2);
+
+		Carriers splitCarriers = CarriersUtils.getCarriers(scenario);
+		assertEquals(3, splitCarriers.getCarriers().size(), "Five shipments with max two jobs should create three carriers.");
+		assertEquals(originalShipmentCount, countShipments(splitCarriers), "All original shipments must remain assigned after splitting.");
+		assertEquals(0, countServices(splitCarriers), "Shipment carrier split must not create services.");
+
+		for (Carrier splitCarrier : splitCarriers.getCarriers().values()) {
+			assertTrue(splitCarrier.getShipments().size() <= 2, "No split carrier should exceed maxJobsPerCarrier.");
+			assertEquals(originalJspritIterations, CarriersUtils.getJspritIterations(splitCarrier), "Split carriers must inherit jsprit iterations.");
+			assertEquals(ORIGINAL_CARRIER_ATTRIBUTE_VALUE, splitCarrier.getAttributes().getAttribute(ORIGINAL_CARRIER_ATTRIBUTE));
+			assertSplitVehicles(originalCarrier, splitCarrier);
+			assertEquals(CarrierCapabilities.FleetSize.INFINITE, splitCarrier.getCarrierCapabilities().getFleetSize());
+			assertTrue(splitCarrier.getServices().isEmpty(), "Shipment split carriers must not contain services.");
+		}
+		assertVehicleIdsAreUniqueAcrossCarriers(splitCarriers);
+	}
+
+	private void assertServiceCarrierSplit(CarrierSplitter.ClusteringStrategy strategy) {
+		Scenario scenario = createServiceScenario();
+		Carriers carriers = CarriersUtils.getCarriers(scenario);
+		int originalServiceCount = countServices(carriers);
+		Set<Integer> originalJspritIterations = new HashSet<>();
+		Carrier originalCarrier = carriers.getCarriers().values().iterator().next();
+		for (Carrier carrier : carriers.getCarriers().values()) {
+			originalJspritIterations.add(CarriersUtils.getJspritIterations(carrier));
+		}
+
+		CarriersUtils.splitCarriers(scenario, strategy, null, 10);
+
+		Carriers splitCarriers = CarriersUtils.getCarriers(scenario);
+		assertTrue(splitCarriers.getCarriers().size() >= 2, "The service carrier should be split into at least the estimated carriers.");
+		assertEquals(originalServiceCount, countServices(splitCarriers), "All original services must remain assigned after splitting.");
+		assertEquals(0, countShipments(splitCarriers), "Service carrier split must not create shipments.");
+
+		for (Carrier splitCarrier : splitCarriers.getCarriers().values()) {
+			assertTrue(splitCarrier.getServices().size() <= 13, "Service clusters should stay close to the requested size.");
+			assertTrue(originalJspritIterations.contains(CarriersUtils.getJspritIterations(splitCarrier)), "Split carriers must inherit jsprit iterations.");
+			assertEquals(ORIGINAL_CARRIER_ATTRIBUTE_VALUE, splitCarrier.getAttributes().getAttribute(ORIGINAL_CARRIER_ATTRIBUTE));
+			assertSplitVehicles(originalCarrier, splitCarrier);
+			assertEquals(CarrierCapabilities.FleetSize.INFINITE, splitCarrier.getCarrierCapabilities().getFleetSize());
+			assertTrue(splitCarrier.getShipments().isEmpty(), "Service split carriers must not contain shipments.");
+		}
+		assertVehicleIdsAreUniqueAcrossCarriers(splitCarriers);
+	}
+
+	private Scenario createShipmentScenario() {
+		Scenario scenario = createChessboardScenario();
+
+		Carriers carriers = CarriersUtils.addOrGetCarriers(scenario);
+		Carrier carrier = createCarrier("shipmentCarrier", 100);
+		for (int i = 0; i < 5; i++) {
+			String pickupLinkId = CHESSBOARD_LINK_IDS[i];
+			String deliveryLinkId = CHESSBOARD_LINK_IDS[i + 5];
+
+			CarrierShipment shipment = CarrierShipment.Builder.newInstance(
+					Id.create("shipment" + i, CarrierShipment.class),
+					Id.createLinkId(pickupLinkId),
+					Id.createLinkId(deliveryLinkId),
+					1).build();
+			CarriersUtils.addShipment(carrier, shipment);
+		}
+		carriers.addCarrier(carrier);
+		return scenario;
+	}
+
+	private Scenario createServiceScenario() {
+		return createServiceScenario(false);
+	}
+
+	private Scenario createServiceScenario(boolean reverseServiceInsertionOrder) {
+		return createServiceScenario(20, reverseServiceInsertionOrder);
+	}
+
+	private Scenario createServiceScenario(int numberOfServices) {
+		return createServiceScenario(numberOfServices, false);
+	}
+
+	private Scenario createServiceScenario(int numberOfServices, boolean reverseServiceInsertionOrder) {
+		Scenario scenario = createChessboardScenario();
+		Carriers carriers = CarriersUtils.addOrGetCarriers(scenario);
+		Carrier carrier = createCarrier("serviceCarrier", 75);
+		List<Integer> serviceIds = new ArrayList<>();
+		for (int i = 0; i < numberOfServices; i++) {
+			serviceIds.add(i);
+		}
+		if (reverseServiceInsertionOrder) {
+			Collections.reverse(serviceIds);
+		}
+		for (int i : serviceIds) {
+			String serviceLinkId = CHESSBOARD_LINK_IDS[i % CHESSBOARD_LINK_IDS.length];
+
+			CarrierService service = CarrierService.Builder.newInstance(
+							Id.create("service" + i, CarrierService.class),
+							Id.createLinkId(serviceLinkId),
+							1)
+					.setServiceDuration(60)
+					.build();
+			CarriersUtils.addService(carrier, service);
+		}
+		carriers.addCarrier(carrier);
+		return scenario;
+	}
+
+	private Scenario createChessboardScenario() {
+		var scenarioUrl = ExamplesUtils.getTestScenarioURL("freight-chessboard-9x9");
+		var config = ConfigUtils.createConfig();
+		config.controller().setOutputDirectory(utils.getOutputDirectory());
+		config.network().setInputFile(IOUtils.extendUrl(scenarioUrl, "grid9x9.xml").toString());
+		return ScenarioUtils.loadScenario(config);
+	}
+
+	private static Carrier createCarrier(String carrierId, int jspritIterations) {
+		Carrier carrier = CarriersUtils.createCarrier(Id.create(carrierId, Carrier.class));
+		carrier.getAttributes().putAttribute(ORIGINAL_CARRIER_ATTRIBUTE, ORIGINAL_CARRIER_ATTRIBUTE_VALUE);
+		carrier.setCarrierCapabilities(createCarrierCapabilities(carrierId, CarrierSplitterTest.DEPOT_LINK_ID));
+		CarriersUtils.setJspritIterations(carrier, jspritIterations);
+		return carrier;
+	}
+
+	private static CarrierCapabilities createCarrierCapabilities(String carrierId, String secondVehicleLinkId) {
+		VehicleType vehicleType = VehicleUtils.createDefaultVehicleType();
+		CarrierVehicle firstVehicle = CarrierVehicle.newInstance(
+				Id.create(carrierId + "_vehicle", Vehicle.class),
+				Id.createLinkId(CarrierSplitterTest.DEPOT_LINK_ID),
+				vehicleType);
+		firstVehicle.getAttributes().putAttribute(ORIGINAL_VEHICLE_ATTRIBUTE, ORIGINAL_VEHICLE_ATTRIBUTE_VALUE);
+		CarrierVehicle secondVehicle = CarrierVehicle.newInstance(
+				Id.create(carrierId + "_secondVehicle", Vehicle.class),
+				Id.createLinkId(secondVehicleLinkId),
+				vehicleType);
+		secondVehicle.getAttributes().putAttribute(ORIGINAL_VEHICLE_ATTRIBUTE, ORIGINAL_VEHICLE_ATTRIBUTE_VALUE);
+		return CarrierCapabilities.Builder.newInstance()
+				.addVehicle(firstVehicle)
+				.addVehicle(secondVehicle)
+				.setFleetSize(CarrierCapabilities.FleetSize.INFINITE)
+				.build();
+	}
+
+	private static int countShipments(Carriers carriers) {
+		return carriers.getCarriers().values().stream().mapToInt(carrier -> carrier.getShipments().size()).sum();
+	}
+
+	private static int countServices(Carriers carriers) {
+		return carriers.getCarriers().values().stream().mapToInt(carrier -> carrier.getServices().size()).sum();
+	}
+
+	private static void assertSplitVehicles(Carrier originalCarrier, Carrier splitCarrier) {
+		List<CarrierVehicle> originalVehicles = originalCarrier.getCarrierCapabilities().getCarrierVehicles().values().stream()
+				.sorted(Comparator.comparing(left -> left.getId().toString()))
+				.toList();
+		List<CarrierVehicle> splitVehicles = splitCarrier.getCarrierCapabilities().getCarrierVehicles().values().stream()
+				.sorted(Comparator.comparing(left -> left.getId().toString()))
+				.toList();
+		assertEquals(originalVehicles.size(), splitVehicles.size(), "Split carriers must inherit all vehicles from the original infinite fleet.");
+		for (int i = 0; i < originalVehicles.size(); i++) {
+			CarrierVehicle originalVehicle = originalVehicles.get(i);
+			CarrierVehicle splitVehicle = splitVehicles.get(i);
+			assertEquals(Id.createVehicleId(splitCarrier.getId() + "_" + (i + 1)),
+					splitVehicle.getId(), "Split vehicle id should use the split carrier id as prefix.");
+			assertEquals(originalVehicle.getLinkId(), splitVehicle.getLinkId(), "Split vehicle start link should match the original vehicle.");
+			assertEquals(originalVehicle.getType(), splitVehicle.getType(), "Split vehicle type should match the original vehicle.");
+			assertEquals(originalVehicle.getEarliestStartTime(), splitVehicle.getEarliestStartTime(), "Split vehicle earliest start should match the original vehicle.");
+			assertEquals(originalVehicle.getLatestEndTime(), splitVehicle.getLatestEndTime(), "Split vehicle latest end should match the original vehicle.");
+			assertEquals(ORIGINAL_VEHICLE_ATTRIBUTE_VALUE, splitVehicle.getAttributes().getAttribute(ORIGINAL_VEHICLE_ATTRIBUTE));
+		}
+	}
+
+	private static void assertVehicleIdsAreUniqueAcrossCarriers(Carriers carriers) {
+		List<Id<Vehicle>> vehicleIds = carriers.getCarriers().values().stream()
+				.flatMap(carrier -> carrier.getCarrierCapabilities().getCarrierVehicles().keySet().stream())
+				.toList();
+		Set<Id<Vehicle>> uniqueVehicleIds = new HashSet<>(vehicleIds);
+		assertEquals(vehicleIds.size(), uniqueVehicleIds.size(), "Vehicle IDs must be unique across all split carriers.");
+		Set<String> carrierIds = carriers.getCarriers().values().stream()
+				.map(carrier -> carrier.getId().toString())
+				.collect(Collectors.toSet());
+		assertTrue(vehicleIds.stream().map(Id::toString).noneMatch(carrierIds::contains), "Vehicle IDs must not be identical to carrier IDs.");
+	}
+
+	private static String splitSignature(Carriers carriers) {
+		StringBuilder signature = new StringBuilder();
+		carriers.getCarriers().values().stream()
+				.sorted(Comparator.comparing(left -> left.getId().toString()))
+				.forEach(carrier -> {
+					signature.append(carrier.getId()).append(":");
+					carrier.getShipments().values().stream()
+							.map(shipment -> shipment.getId().toString())
+							.sorted()
+							.forEach(id -> signature.append("shipment=").append(id).append(";"));
+					carrier.getServices().values().stream()
+							.map(service -> service.getId().toString())
+							.sorted()
+							.forEach(id -> signature.append("service=").append(id).append(";"));
+					signature.append("|");
+				});
+		return signature.toString();
+	}
+}


### PR DESCRIPTION
## Summary

- Add `CarrierSplitter` in the freight contrib and expose it via `CarriersUtils.splitCarriers(...)`.
- Support shipment and service splitting with `RANDOM`, `GREEDY`, `SINGLE_LINK`, and `CENTROIDS` clustering.
- Allow shipment clustering by pickup location, delivery location, or pickup/delivery midpoint.
- Preserve carrier attributes, jsprit iterations, and infinite fleet vehicle capabilities while assigning unique split vehicle IDs.
- Add scenario-based tests and PNG split plot output in the test output directory.

## Tests

- `mvn -q -pl contribs/freight "-Dtest=org.matsim.freight.carriers.splitter.CarrierSplitterTest" test`