### PR TITLE
feat(router): add maxCost-bounded search to Speedy and CH routers

### DIFF
--- a/matsim/src/main/java/org/matsim/core/router/speedy/CHRouter.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/CHRouter.java
@@ -126,7 +126,7 @@ public class CHRouter implements LeastCostPathCalculator {
                                   double startTime, Person person, Vehicle vehicle) {
         int startIdx = baseGraph.getNodeIndex(startNode);
         int endIdx   = baseGraph.getNodeIndex(endNode);
-        Path path    = calcLeastCostPathImpl(startIdx, endIdx, startTime, person, vehicle);
+        Path path    = calcLeastCostPathImpl(startIdx, endIdx, startTime, person, vehicle, Double.POSITIVE_INFINITY);
         if (path == null) logNoRoute("node " + startNode.getId(), "node " + endNode.getId());
         return path;
     }
@@ -134,6 +134,12 @@ public class CHRouter implements LeastCostPathCalculator {
     @Override
     public Path calcLeastCostPath(Link fromLink, Link toLink,
                                   double startTime, Person person, Vehicle vehicle) {
+        return calcLeastCostPath(fromLink, toLink, startTime, person, vehicle, Double.POSITIVE_INFINITY);
+    }
+
+    @Override
+    public Path calcLeastCostPath(Link fromLink, Link toLink,
+                                  double startTime, Person person, Vehicle vehicle, double maxCost) {
         int startIdx = baseGraph.getNodeIndex(fromLink.getToNode());
         int endIdx   = baseGraph.getNodeIndex(toLink.getFromNode());
 
@@ -144,13 +150,13 @@ public class CHRouter implements LeastCostPathCalculator {
             }
         }
 
-        Path path = calcLeastCostPathImpl(startIdx, endIdx, startTime, person, vehicle);
+        Path path = calcLeastCostPathImpl(startIdx, endIdx, startTime, person, vehicle, maxCost);
         if (path == null) logNoRoute("link " + fromLink.getId(), "link " + toLink.getId());
         return path;
     }
 
     private Path calcLeastCostPathImpl(int startIdx, int endIdx,
-                                       double startTime, Person person, Vehicle vehicle) {
+                                       double startTime, Person person, Vehicle vehicle, double maxCost) {
         advanceIteration();
 
         if (startIdx == endIdx) {
@@ -198,6 +204,12 @@ public class CHRouter implements LeastCostPathCalculator {
             double fMin = fwdPQ.isEmpty() ? Double.POSITIVE_INFINITY : fwdCost[fwdPQ.peek()];
             double bMin = bwdPQ.isEmpty() ? Double.POSITIVE_INFINITY : bwdCost[bwdPQ.peek()];
             if (fMin >= bestCost && bMin >= bestCost) break;
+            // Bounded-search early termination: once both queue minima exceed maxCost,
+            // no further meeting node can yield a complete path with cost <= maxCost,
+            // because fwdCost and bwdCost are both monotone-nondecreasing in the order
+            // their respective searches settle nodes, and any meeting cost is
+            // fwdCost[m] + bwdCost[m] >= max(fMin, bMin) > maxCost.
+            if (fMin > maxCost && bMin > maxCost) break;
 
             boolean expandForward = !fwdPQ.isEmpty()
                     && (bwdPQ.isEmpty() || fMin <= bMin);
@@ -321,6 +333,10 @@ public class CHRouter implements LeastCostPathCalculator {
         }
 
         if (meetingNode < 0) return null;
+        // Bounded-search guard: a meeting node found before the early-termination check
+        // fired may still have total cost above maxCost (the early-termination is
+        // monotone but not a per-iteration check on bestCost itself).
+        if (bestCost > maxCost) return null;
         return constructPath(startIdx, meetingNode, startTime, person, vehicle);
     }
 

--- a/matsim/src/main/java/org/matsim/core/router/speedy/CHRouterTimeDep.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/CHRouterTimeDep.java
@@ -148,7 +148,7 @@ public class CHRouterTimeDep implements LeastCostPathCalculator {
                                   double startTime, Person person, Vehicle vehicle) {
         int startIdx = baseGraph.getNodeIndex(startNode);
         int endIdx   = baseGraph.getNodeIndex(endNode);
-        Path path    = calcLeastCostPathImpl(startIdx, endIdx, startTime, person, vehicle);
+        Path path    = calcLeastCostPathImpl(startIdx, endIdx, startTime, person, vehicle, Double.POSITIVE_INFINITY);
         if (path == null) logNoRoute("node " + startNode.getId(), "node " + endNode.getId());
         return path;
     }
@@ -156,6 +156,12 @@ public class CHRouterTimeDep implements LeastCostPathCalculator {
     @Override
     public Path calcLeastCostPath(Link fromLink, Link toLink,
                                   double startTime, Person person, Vehicle vehicle) {
+        return calcLeastCostPath(fromLink, toLink, startTime, person, vehicle, Double.POSITIVE_INFINITY);
+    }
+
+    @Override
+    public Path calcLeastCostPath(Link fromLink, Link toLink,
+                                  double startTime, Person person, Vehicle vehicle, double maxCost) {
         int startIdx = baseGraph.getNodeIndex(fromLink.getToNode());
         int endIdx   = baseGraph.getNodeIndex(toLink.getFromNode());
 
@@ -166,7 +172,7 @@ public class CHRouterTimeDep implements LeastCostPathCalculator {
             }
         }
 
-        Path path = calcLeastCostPathImpl(startIdx, endIdx, startTime, person, vehicle);
+        Path path = calcLeastCostPathImpl(startIdx, endIdx, startTime, person, vehicle, maxCost);
         if (path == null) logNoRoute("link " + fromLink.getId(), "link " + toLink.getId());
         return path;
     }
@@ -176,7 +182,7 @@ public class CHRouterTimeDep implements LeastCostPathCalculator {
     // -------------------------------------------------------------------------
 
     private Path calcLeastCostPathImpl(int startIdx, int endIdx,
-                                       double startTime, Person person, Vehicle vehicle) {
+                                       double startTime, Person person, Vehicle vehicle, double maxCost) {
         advanceIteration();
 
         if (startIdx == endIdx) {
@@ -234,6 +240,17 @@ public class CHRouterTimeDep implements LeastCostPathCalculator {
             double fMin = fwdPQ.isEmpty() ? Double.POSITIVE_INFINITY : fwdCost[fwdPQ.peek()];
             double bMin = bwdPQ.isEmpty() ? Double.POSITIVE_INFINITY : bwdLB[bwdPQ.peek()];
             if (fMin >= bestBound && bMin >= bestBound) break;
+            // NOTE: no loop-level early termination on maxCost is applied here.
+            // CHRouterTimeDep's internal search optimises *travel time* (required for the
+            // CATCHUp/TCH time-dependent CH invariant), while {@code maxCost} is expressed
+            // in the same units as {@link Path#travelCost} — i.e. travel *disutility* as
+            // reconstructed in {@link #constructPath}. Comparing the time-valued queue
+            // minima against a disutility-valued maxCost would be unsound. The bounded
+            // contract is enforced via a final guard on the reconstructed path cost
+            // below, which is correct but provides no in-loop speedup. A proper fast-path
+            // would require either pushing the disutility into the search metric or
+            // bounding via a time-unit cap derived from maxCost, both of which require
+            // changes beyond this method.
 
             boolean expandForward = !fwdPQ.isEmpty()
                     && (bwdPQ.isEmpty() || fMin <= bMin);
@@ -376,7 +393,13 @@ public class CHRouterTimeDep implements LeastCostPathCalculator {
         chQueryCount++;
 
         if (meetingNode < 0) return null;
-        return constructPath(startIdx, meetingNode, startTime, person, vehicle);
+        // Bounded-search final guard. bestBound is a lower bound on the actual cost,
+        // so a meeting found before the early-termination check fired may still
+        // reconstruct to a path with actualCost > maxCost. We must reconstruct first
+        // and then drop the result if its actual cost exceeds the bound.
+        Path path = constructPath(startIdx, meetingNode, startTime, person, vehicle);
+        if (path != null && path.travelCost > maxCost) return null;
+        return path;
     }
 
     // -------------------------------------------------------------------------

--- a/matsim/src/main/java/org/matsim/core/router/speedy/DAryMinHeap.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/DAryMinHeap.java
@@ -110,6 +110,18 @@ class DAryMinHeap {
 		return this.heap[0];
 	}
 
+	/**
+	 * Returns the cost (priority key) of the element at the root of the heap
+	 * without removing it. Used by bounded shortest-path searches to abort
+	 * exploration as soon as the next-best candidate cost exceeds a cutoff.
+	 */
+	double peekCost() {
+		if (this.size == 0) {
+			throw new NoSuchElementException("heap is empty");
+		}
+		return this.cost[0];
+	}
+
 	public boolean remove(int node) {
 		int i = this.pos[node];
 		if (i < 0) {

--- a/matsim/src/main/java/org/matsim/core/router/speedy/SpeedyALT.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/SpeedyALT.java
@@ -98,6 +98,11 @@ public class SpeedyALT implements LeastCostPathCalculator {
 	}
 
 	public Path calcLeastCostPath(Link fromLink, Link toLink, double starttime, final Person person, final Vehicle vehicle) {
+		return calcLeastCostPath(fromLink, toLink, starttime, person, vehicle, Double.POSITIVE_INFINITY);
+	}
+
+	@Override
+	public Path calcLeastCostPath(Link fromLink, Link toLink, double starttime, final Person person, final Vehicle vehicle, double maxCost) {
 
 		int startNodeIndex = this.graph.getNodeIndex(fromLink.getToNode());
 		int endNodeIndex = this.graph.getNodeIndex(toLink.getFromNode());
@@ -109,8 +114,9 @@ public class SpeedyALT implements LeastCostPathCalculator {
 			}
 		}
 
-		Path path = calcLeastCostPathImpl(startNodeIndex, endNodeIndex, starttime, person, vehicle);
-		if(path == null) {
+		Path path = calcLeastCostPathImpl(startNodeIndex, endNodeIndex, starttime, person, vehicle, maxCost);
+		// Do not warn on cutoff-driven aborts: a bounded null is an intentional caller hint, not a config issue.
+		if(path == null && Double.isInfinite(maxCost)) {
 			LOG.warn("No route was found from link " + fromLink.getId() + " to link " + toLink.getId() + ". Some possible reasons:");
 		  LOG.warn("  * Network is not connected.  Run NetworkUtils.cleanNetwork(Network network, Set<String> modes).") ;
 			LOG.warn("  * Network for considered mode does not even exist.  Modes need to be entered for each link in network.xml.");
@@ -122,7 +128,7 @@ public class SpeedyALT implements LeastCostPathCalculator {
 
 	@Override
 	public Path calcLeastCostPath(Node startNode, Node endNode, double startTime, Person person, Vehicle vehicle) {
-		Path path = calcLeastCostPathImpl(this.graph.getNodeIndex(startNode), this.graph.getNodeIndex(endNode), startTime, person, vehicle);
+		Path path = calcLeastCostPathImpl(this.graph.getNodeIndex(startNode), this.graph.getNodeIndex(endNode), startTime, person, vehicle, Double.POSITIVE_INFINITY);
 		if(path == null) {
       LOG.warn("No route was found from node " + startNode.getId() + " to node " + endNode.getId() + ". Some possible reasons:");
 		  LOG.warn("  * Network is not connected.  Run NetworkUtils.cleanNetwork(Network network, Set<String> modes).") ;
@@ -133,7 +139,7 @@ public class SpeedyALT implements LeastCostPathCalculator {
 		return path;
 	}
 
-	private Path calcLeastCostPathImpl(int startNodeIndex, int endNodeIndex, double startTime, Person person, Vehicle vehicle) {
+	private Path calcLeastCostPathImpl(int startNodeIndex, int endNodeIndex, double startTime, Person person, Vehicle vehicle, double maxCost) {
 		this.currentIteration++;
 		if (this.currentIteration == Integer.MAX_VALUE) {
 			// reset iteration as we overflow
@@ -154,6 +160,32 @@ public class SpeedyALT implements LeastCostPathCalculator {
 		boolean foundEndNode = false;
 
 		while (!this.pq.isEmpty()) {
+			// Bounded-search early termination.
+			//
+			// The heap key is f = g + h, where h is the landmark lower bound
+			//     h(n) = max_L max(d(n,L) - d(t,L), d(L,t) - d(L,n)).
+			// Standard ALT admissibility: by the triangle inequality each individual landmark
+			// estimate is a lower bound on d(n, t), so h(n) <= d(n, t).
+			//
+			// The +infinity case is admissible too and is actually load-bearing for the
+			// disconnected-subgraph use case:
+			//   - If d(n, L) = +inf and d(t, L) finite, the triangle inequality
+			//     d(n, t) + d(t, L) >= d(n, L) forces d(n, t) = +inf (n cannot reach t).
+			//   - Symmetric for d(L, t) = +inf with d(L, n) finite.
+			// So a node only gets h = +inf when it genuinely cannot reach t, and returning null
+			// from such a search is correct.
+			//
+			// The NaN case (both d(n, L) and d(t, L) are +inf, similarly for the other pair)
+			// represents a landmark isolated from both endpoints. Math.max propagates NaN, the
+			// heap key becomes NaN, and `peek > maxCost` evaluates to false, so the cutoff is
+			// silently skipped (a missed optimisation, not a correctness issue).
+			//
+			// Nodes that cannot reach t but are pushed during exploration get key = g + (+inf)
+			// = +inf and sink to the bottom of the heap; they do not affect peek, which always
+			// reflects the best finite-keyed reachable candidate.
+			if (this.pq.peekCost() > maxCost) {
+				return null;
+			}
 			final int nodeIdx = this.pq.poll();
 			if (!hasTurnRestrictions && nodeIdx == endNodeIndex) {
 				foundEndNode = true;
@@ -209,6 +241,14 @@ public class SpeedyALT implements LeastCostPathCalculator {
 					double oldCost = getCost(toNode);
 					if (newCost < oldCost) {
 						estimation = estimateMinTravelcostToDestination(toNode, endNodeIndex);
+						// Bounded-search edge-level pruning: skip if the admissible f-value
+						// exceeds maxCost. Since h(toNode) <= true remaining cost to target,
+						// f = g + h <= true cost through toNode, so f > maxCost implies the
+						// path through toNode cannot satisfy the cutoff. Mirrors the
+						// cost-bounded pruning in CHLeastCostPathTree.
+						if (newCost + estimation > maxCost) {
+							continue;
+						}
 						this.pq.decreaseKey(toNode, newCost + estimation);
 						setData(toNode, newCost, newTime, currDistance + link.getLength());
 						this.comingFrom[toNode] = nodeIdx;
@@ -216,6 +256,10 @@ public class SpeedyALT implements LeastCostPathCalculator {
 					}
 				} else {
 					estimation = estimateMinTravelcostToDestination(toNode, endNodeIndex);
+					// Bounded-search edge-level pruning (see comment above).
+					if (newCost + estimation > maxCost) {
+						continue;
+					}
 					setData(toNode, newCost, newTime, currDistance + link.getLength());
 					this.pq.insert(toNode, newCost + estimation);
 					this.comingFrom[toNode] = nodeIdx;

--- a/matsim/src/main/java/org/matsim/core/router/speedy/SpeedyDijkstra.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/SpeedyDijkstra.java
@@ -71,7 +71,7 @@ public class SpeedyDijkstra implements LeastCostPathCalculator {
 	public Path calcLeastCostPath(Node startNode, Node endNode, double startTime, Person person, Vehicle vehicle) {
 		int startNodeIndex = this.graph.getNodeIndex(startNode);
 		int endNodeIndex = this.graph.getNodeIndex(endNode);
-		Path path = calcLeastCostPathImpl(startNodeIndex, endNodeIndex, startTime, person, vehicle);
+		Path path = calcLeastCostPathImpl(startNodeIndex, endNodeIndex, startTime, person, vehicle, Double.POSITIVE_INFINITY);
 
 		if(path == null) {
 			LOG.warn("No route was found from node " + startNode.getId() + " to node " + endNode.getId() + ". Some possible reasons:");
@@ -85,6 +85,11 @@ public class SpeedyDijkstra implements LeastCostPathCalculator {
 
 
 	public Path calcLeastCostPath(Link fromLink, Link toLink, double starttime, final Person person, final Vehicle vehicle) {
+		return calcLeastCostPath(fromLink, toLink, starttime, person, vehicle, Double.POSITIVE_INFINITY);
+	}
+
+	@Override
+	public Path calcLeastCostPath(Link fromLink, Link toLink, double starttime, final Person person, final Vehicle vehicle, double maxCost) {
 
 		int startNodeIndex = this.graph.getNodeIndex(fromLink.getToNode());
 		int endNodeIndex = this.graph.getNodeIndex(toLink.getFromNode());
@@ -96,8 +101,9 @@ public class SpeedyDijkstra implements LeastCostPathCalculator {
 			}
 		}
 
-		Path path = calcLeastCostPathImpl(startNodeIndex, endNodeIndex, starttime, person, vehicle);
-		if(path == null) {
+		Path path = calcLeastCostPathImpl(startNodeIndex, endNodeIndex, starttime, person, vehicle, maxCost);
+		// Do not warn on cutoff-driven aborts: a bounded null is an intentional caller hint, not a config issue.
+		if(path == null && Double.isInfinite(maxCost)) {
 			LOG.warn("No route was found from link " + fromLink.getId() + " to link " + toLink.getId() + ". Some possible reasons:");
 			LOG.warn("  * Network is not connected.  Run NetworkCleaner().");
 			LOG.warn("  * Network for considered mode does not even exist.  Modes need to be entered for each link in network.xml.");
@@ -107,7 +113,7 @@ public class SpeedyDijkstra implements LeastCostPathCalculator {
 		return path;
 	}
 
-	private Path calcLeastCostPathImpl(int startNodeIndex, int endNodeIndex, double startTime, Person person, Vehicle vehicle) {
+	private Path calcLeastCostPathImpl(int startNodeIndex, int endNodeIndex, double startTime, Person person, Vehicle vehicle, double maxCost) {
 		this.currentIteration++;
 		if (this.currentIteration == Integer.MAX_VALUE) {
 			// reset iteration as we overflow
@@ -124,6 +130,12 @@ public class SpeedyDijkstra implements LeastCostPathCalculator {
 		boolean foundEndNode = false;
 
 		while (!this.pq.isEmpty()) {
+			// Bounded-search early termination: once the smallest priority key in the heap
+			// exceeds maxCost, no remaining path through any queued node can be <= maxCost,
+			// because Dijkstra's heap key is the proven shortest cost from the start.
+			if (this.pq.peekCost() > maxCost) {
+				return null;
+			}
 			final int nodeIdx = this.pq.poll();
 			if (nodeIdx == endNodeIndex) {
 				foundEndNode = true;
@@ -152,6 +164,14 @@ public class SpeedyDijkstra implements LeastCostPathCalculator {
 				double travelTime = this.tt.getLinkTravelTime(link, currTime, person, vehicle);
 				double newTime = currTime + travelTime;
 				double newCost = currCost + this.td.getLinkTravelDisutility(link, currTime, person, vehicle);
+
+				// Bounded-search edge-level pruning: skip the successor entirely if its proven
+				// cost already exceeds maxCost. This mirrors the cost-bounded pruning in
+				// CHLeastCostPathTree and reduces heap pressure (fewer inserts and
+				// decreaseKey calls) near the cutoff boundary.
+				if (newCost > maxCost) {
+					continue;
+				}
 
 				if (this.iterationIds[toNode] == this.currentIteration) {
 					// this node was already visited in this route-query

--- a/matsim/src/main/java/org/matsim/core/router/util/LeastCostPathCalculator.java
+++ b/matsim/src/main/java/org/matsim/core/router/util/LeastCostPathCalculator.java
@@ -44,6 +44,26 @@ public interface LeastCostPathCalculator {
 		return calcLeastCostPath(fromLink.getToNode(), toLink.getFromNode(), startTime, person, vehicle);
 	}
 
+	/**
+	 * Bounded variant of {@link #calcLeastCostPath(Link, Link, double, Person, Vehicle)}.
+	 *
+	 * <p>Implementations that support a search cutoff may return {@code null} as soon as it is
+	 * provable that no path with cost {@code <= maxCost} exists, instead of exploring the
+	 * remaining reachable subgraph. This is useful for callers that would discard any path
+	 * above a known threshold anyway (e.g. mapping algorithms that fall back to artificial
+	 * links beyond a maximum travel-cost factor).</p>
+	 *
+	 * <p>The default implementation ignores {@code maxCost} and delegates to the unbounded
+	 * overload, preserving behaviour for implementations that do not support a cutoff.</p>
+	 *
+	 * @param maxCost maximum allowed path cost; pass {@link Double#POSITIVE_INFINITY} to
+	 *                disable the cutoff. Must be {@code >= 0}.
+	 * @return the least-cost path, or {@code null} if no path with cost {@code <= maxCost} exists.
+	 */
+	default Path calcLeastCostPath(Link fromLink, Link toLink, double startTime, final Person person, final Vehicle vehicle, double maxCost) {
+		return calcLeastCostPath(fromLink, toLink, startTime, person, vehicle);
+	}
+
 	class Path {
 		public List<Node> nodes;
 		public final List<Link> links;

--- a/matsim/src/test/java/org/matsim/core/router/speedy/CHBoundedSearchTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/speedy/CHBoundedSearchTest.java
@@ -1,0 +1,218 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2026 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.core.router.speedy;
+
+import org.junit.jupiter.api.Test;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.config.groups.ScoringConfigGroup;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.router.costcalculators.FreespeedTravelTimeAndDisutility;
+import org.matsim.core.router.util.LeastCostPathCalculator;
+import org.matsim.core.router.util.LeastCostPathCalculator.Path;
+import org.matsim.core.scenario.ScenarioUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Tests for the bounded-search ({@code maxCost}) overload of
+ * {@link LeastCostPathCalculator#calcLeastCostPath(Link, Link, double, org.matsim.api.core.v01.population.Person, org.matsim.vehicles.Vehicle, double)}
+ * on the CH routers: {@link CHRouter} (static) and {@link CHRouterTimeDep} (time-dependent).
+ *
+ * <p>Contract under test (identical to {@link SpeedyBoundedSearchTest}):
+ * <ul>
+ *   <li>Cutoff above the optimal cost: returns the same path as the unbounded call.</li>
+ *   <li>Cutoff below the optimal cost: returns {@code null}.</li>
+ *   <li>{@code Double.POSITIVE_INFINITY}: equivalent to the unbounded call.</li>
+ *   <li>Disconnected target: returns {@code null} under any finite cutoff.</li>
+ * </ul>
+ */
+public class CHBoundedSearchTest {
+
+	/** 4-node chain identical to {@link SpeedyBoundedSearchTest#buildChainNetwork()}. */
+	private static Network buildChainNetwork() {
+		Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+		Network network = scenario.getNetwork();
+
+		Node a = NetworkUtils.createAndAddNode(network, Id.createNodeId("A"), new Coord(0, 0));
+		Node b = NetworkUtils.createAndAddNode(network, Id.createNodeId("B"), new Coord(1000, 0));
+		Node c = NetworkUtils.createAndAddNode(network, Id.createNodeId("C"), new Coord(2000, 0));
+		Node d = NetworkUtils.createAndAddNode(network, Id.createNodeId("D"), new Coord(3000, 0));
+
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("AB"), a, b, 1000.0, 10.0, 1000.0, 1.0);
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("BC"), b, c, 1000.0, 10.0, 1000.0, 1.0);
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("CD"), c, d, 1000.0, 10.0, 1000.0, 1.0);
+
+		return network;
+	}
+
+	/** Disconnected network: ABC component plus DEF island. */
+	private static Network buildDisconnectedNetwork() {
+		Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+		Network network = scenario.getNetwork();
+
+		Node a = NetworkUtils.createAndAddNode(network, Id.createNodeId("A"), new Coord(0, 0));
+		Node b = NetworkUtils.createAndAddNode(network, Id.createNodeId("B"), new Coord(1000, 0));
+		Node c = NetworkUtils.createAndAddNode(network, Id.createNodeId("C"), new Coord(2000, 0));
+		Node d = NetworkUtils.createAndAddNode(network, Id.createNodeId("D"), new Coord(5000, 0));
+		Node e = NetworkUtils.createAndAddNode(network, Id.createNodeId("E"), new Coord(6000, 0));
+		Node f = NetworkUtils.createAndAddNode(network, Id.createNodeId("F"), new Coord(7000, 0));
+
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("AB"), a, b, 1000.0, 10.0, 1000.0, 1.0);
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("BC"), b, c, 1000.0, 10.0, 1000.0, 1.0);
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("DE"), d, e, 1000.0, 10.0, 1000.0, 1.0);
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("EF"), e, f, 1000.0, 10.0, 1000.0, 1.0);
+
+		return network;
+	}
+
+	private static CHRouter buildChRouter(Network network) {
+		FreespeedTravelTimeAndDisutility td = new FreespeedTravelTimeAndDisutility(new ScoringConfigGroup());
+		SpeedyGraph graph = SpeedyGraphBuilder.buildWithSpatialOrdering(network);
+		CHGraph chGraph = new CHBuilder(graph, td).build();
+		new CHCustomizer().customize(chGraph, td);
+		return new CHRouter(chGraph, td, td);
+	}
+
+	private static CHRouterTimeDep buildChRouterTimeDep(Network network) {
+		FreespeedTravelTimeAndDisutility td = new FreespeedTravelTimeAndDisutility(new ScoringConfigGroup());
+		SpeedyGraph graph = SpeedyGraphBuilder.buildWithSpatialOrdering(network);
+		CHGraph chGraph = new CHBuilder(graph, td).build();
+		new CHTTFCustomizer().customize(chGraph, td, td);
+		return new CHRouterTimeDep(chGraph, td, td);
+	}
+
+	// ------------------------------------------------------------------
+	// CHRouter (static)
+	// ------------------------------------------------------------------
+
+	@Test
+	void chRouter_cutoffAboveOptimal_returnsSamePath() {
+		Network network = buildChainNetwork();
+		Link linkAB = network.getLinks().get(Id.createLinkId("AB"));
+		Link linkCD = network.getLinks().get(Id.createLinkId("CD"));
+
+		CHRouter router = buildChRouter(network);
+		Path unbounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null);
+		Path bounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null, unbounded.travelCost + 1.0);
+
+		assertNotNull(bounded);
+		assertEquals(unbounded.travelCost, bounded.travelCost, 1e-9);
+		assertEquals(unbounded.links.size(), bounded.links.size());
+	}
+
+	@Test
+	void chRouter_cutoffBelowOptimal_returnsNull() {
+		Network network = buildChainNetwork();
+		Link linkAB = network.getLinks().get(Id.createLinkId("AB"));
+		Link linkCD = network.getLinks().get(Id.createLinkId("CD"));
+
+		CHRouter router = buildChRouter(network);
+		Path unbounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null);
+		assertNotNull(unbounded);
+		Path bounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null, unbounded.travelCost - 1e-6);
+		assertNull(bounded);
+	}
+
+	@Test
+	void chRouter_positiveInfinityCutoff_equalsUnbounded() {
+		Network network = buildChainNetwork();
+		Link linkAB = network.getLinks().get(Id.createLinkId("AB"));
+		Link linkCD = network.getLinks().get(Id.createLinkId("CD"));
+
+		CHRouter router = buildChRouter(network);
+		Path unbounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null);
+		Path bounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null, Double.POSITIVE_INFINITY);
+		assertEquals(unbounded.travelCost, bounded.travelCost, 1e-9);
+	}
+
+	@Test
+	void chRouter_disconnectedTarget_returnsNullUnderCutoff() {
+		Network network = buildDisconnectedNetwork();
+		Link linkAB = network.getLinks().get(Id.createLinkId("AB"));
+		Link linkEF = network.getLinks().get(Id.createLinkId("EF"));
+
+		CHRouter router = buildChRouter(network);
+		Path bounded = router.calcLeastCostPath(linkAB, linkEF, 0, null, null, 1000.0);
+		assertNull(bounded);
+	}
+
+	// ------------------------------------------------------------------
+	// CHRouterTimeDep
+	// ------------------------------------------------------------------
+
+	@Test
+	void chRouterTimeDep_cutoffAboveOptimal_returnsSamePath() {
+		Network network = buildChainNetwork();
+		Link linkAB = network.getLinks().get(Id.createLinkId("AB"));
+		Link linkCD = network.getLinks().get(Id.createLinkId("CD"));
+
+		CHRouterTimeDep router = buildChRouterTimeDep(network);
+		Path unbounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null);
+		Path bounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null, unbounded.travelCost + 1.0);
+
+		assertNotNull(bounded);
+		assertEquals(unbounded.travelCost, bounded.travelCost, 1e-9);
+		assertEquals(unbounded.links.size(), bounded.links.size());
+	}
+
+	@Test
+	void chRouterTimeDep_cutoffBelowOptimal_returnsNull() {
+		Network network = buildChainNetwork();
+		Link linkAB = network.getLinks().get(Id.createLinkId("AB"));
+		Link linkCD = network.getLinks().get(Id.createLinkId("CD"));
+
+		CHRouterTimeDep router = buildChRouterTimeDep(network);
+		Path unbounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null);
+		assertNotNull(unbounded);
+		Path bounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null, unbounded.travelCost - 1e-6);
+		assertNull(bounded);
+	}
+
+	@Test
+	void chRouterTimeDep_positiveInfinityCutoff_equalsUnbounded() {
+		Network network = buildChainNetwork();
+		Link linkAB = network.getLinks().get(Id.createLinkId("AB"));
+		Link linkCD = network.getLinks().get(Id.createLinkId("CD"));
+
+		CHRouterTimeDep router = buildChRouterTimeDep(network);
+		Path unbounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null);
+		Path bounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null, Double.POSITIVE_INFINITY);
+		assertEquals(unbounded.travelCost, bounded.travelCost, 1e-9);
+	}
+
+	@Test
+	void chRouterTimeDep_disconnectedTarget_returnsNullUnderCutoff() {
+		Network network = buildDisconnectedNetwork();
+		Link linkAB = network.getLinks().get(Id.createLinkId("AB"));
+		Link linkEF = network.getLinks().get(Id.createLinkId("EF"));
+
+		CHRouterTimeDep router = buildChRouterTimeDep(network);
+		Path bounded = router.calcLeastCostPath(linkAB, linkEF, 0, null, null, 1000.0);
+		assertNull(bounded);
+	}
+}

--- a/matsim/src/test/java/org/matsim/core/router/speedy/SpeedyBoundedSearchBenchmark.java
+++ b/matsim/src/test/java/org/matsim/core/router/speedy/SpeedyBoundedSearchBenchmark.java
@@ -19,6 +19,9 @@
 
 package org.matsim.core.router.speedy;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.matsim.api.core.v01.Coord;
@@ -31,219 +34,562 @@ import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.groups.ScoringConfigGroup;
 import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.router.costcalculators.FreespeedTravelTimeAndDisutility;
+import org.matsim.core.router.util.LeastCostPathCalculator;
 import org.matsim.core.router.util.LeastCostPathCalculator.Path;
 import org.matsim.core.scenario.ScenarioUtils;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
 /**
- * Benchmark demonstrating the speedup of the bounded-search (maxCost) overload
- * on the speedy routers vs. the unbounded variant.
+ * Benchmark for the bounded-search ({@code maxCost}) overload of the speedy routers.
  *
- * <p>Disabled by default; enable with {@code -Dmatsim.benchmark=true}, e.g.
+ * <p>Disabled by default; enable with {@code -Dmatsim.benchmark=true}:
  * <pre>{@code
  *   mvn test -pl matsim -Dtest=SpeedyBoundedSearchBenchmark -Dmatsim.benchmark=true
  * }</pre>
  *
- * <p>Two scenarios are measured:
- * <ol>
- *   <li><b>Disconnected target</b>: a large NxN grid (reachable from source) plus
- *       a tiny separate component (where the target lives). The unbounded search
- *       must exhaust the full reachable component before returning {@code null};
- *       the bounded search returns {@code null} after exploring only the local
- *       ball of cost {@code maxCost}.</li>
- *   <li><b>Connected with cutoff below optimal</b>: source and target are both
- *       in the same NxN grid but at far corners; {@code maxCost} is set well
- *       below the optimal cost (the realistic pt2matsim case where a candidate
- *       pair exceeds {@code maxAllowedTravelCost}). The unbounded search
- *       explores up to the optimal cost before returning; the bounded search
- *       stops once {@code peek > maxCost}.</li>
- * </ol>
+ * <h2>Measurement methodology</h2>
+ * <ul>
+ *   <li><b>Realistic graph size</b>: a {@value #GRID_N}x{@value #GRID_N} grid
+ *       (~{@code GRID_N*GRID_N} nodes, ~{@code 4*GRID_N*(GRID_N-1)} links). Large
+ *       enough that CH preprocessing and queries do non-trivial work, while still
+ *       deterministic and self-contained (no test resources).</li>
+ *   <li><b>Randomized queries</b>: {@value #NUM_QUERIES} random (source, target)
+ *       link pairs generated with a fixed seed. Iterations cycle through this set
+ *       round-robin, preventing the JIT from over-specializing on a single
+ *       (src, tgt) pair and giving realistic branch/cache behavior.</li>
+ *   <li><b>Per-query cutoff</b>: each query's {@code maxCost} is set to
+ *       {@value #CUTOFF_FRACTION} times its <em>own</em> unbounded optimal cost
+ *       (precomputed once at setup). A single global cutoff would be meaningless
+ *       across queries of different lengths.</li>
+ *   <li><b>Shared setup</b>: networks and routers are lazy-initialised once per
+ *       JVM and shared across all benchmark methods. CH preprocessing in
+ *       particular is amortized across the suite.</li>
+ *   <li><b>Iteration counts vary by scenario</b>: scenarios where every
+ *       unbounded call has to exhaust the full reachable component
+ *       ({@link SpeedyDijkstra}/{@link SpeedyALT} against a disconnected
+ *       target) take tens of milliseconds per call on the 200x200 grid, so
+ *       they use {@value #WARMUP_ITERATIONS_SLOW}/{@value #MEASURE_ITERATIONS_SLOW}
+ *       iterations; CH variants and all cutoff-below-optimal scenarios use
+ *       {@value #WARMUP_ITERATIONS_FAST}/{@value #MEASURE_ITERATIONS_FAST}.</li>
+ *   <li><b>Dead-code prevention</b>: returned paths are accumulated into a
+ *       checksum that is printed, preventing JIT from eliminating the call.</li>
+ * </ul>
  *
- * <p>Each measurement runs {@code WARMUP_ITERATIONS} warmup calls + {@code MEASURE_ITERATIONS}
- * measured calls and reports mean time per call and the bounded/unbounded speedup factor.
- * No assertions are made on timing (results are environment-dependent); failures here
- * indicate a correctness regression, not a perf regression.
+ * <h2>Scenarios</h2>
+ * <ul>
+ *   <li><b>Disconnected target</b>: source in the main grid, target on a tiny
+ *       disconnected "island". Unbounded must exhaust the reachable component
+ *       before returning {@code null}; bounded should bail after a small ball.</li>
+ *   <li><b>Cutoff below optimal</b>: both endpoints in the grid;
+ *       {@code maxCost = CUTOFF_FRACTION * optimal}. Unbounded runs to completion;
+ *       bounded bails as soon as the queue minimum exceeds the cutoff.</li>
+ * </ul>
+ *
+ * <p>No assertions are made on timing (results are environment-dependent).
+ * Correctness assertions check that the bounded/unbounded calls agree on
+ * null-ness as required by the scenario contract.
+ *
+ * <p><b>Note on {@link CHRouterTimeDep}</b>: its internal search optimises
+ * travel <em>time</em> (required for the CATCHUp/TCH time-dependent CH
+ * invariant), while {@code maxCost} is in disutility units (matching
+ * {@link Path#travelCost} reconstructed by {@code constructPath}). In-loop
+ * pruning on {@code maxCost} would be unit-unsound, so the contract is enforced
+ * only by a final guard on the reconstructed path cost. The benchmarks below
+ * therefore expect a speedup of ~1.0x for {@code CHRouterTimeDep} and exist to
+ * (a) document this fact, and (b) detect future regressions or improvements.
  */
 @EnabledIfSystemProperty(named = "matsim.benchmark", matches = "true")
 public class SpeedyBoundedSearchBenchmark {
 
-	private static final int GRID_N = 80; // 80x80 = 6400 nodes in the main component
+	private static final int GRID_N = 200;
 	private static final double LINK_LENGTH = 100.0;
 	private static final double LINK_FREESPEED = 10.0;
-	private static final int WARMUP_ITERATIONS = 200;
-	private static final int MEASURE_ITERATIONS = 1000;
+	private static final int NUM_QUERIES = 200;
+	private static final long QUERY_SEED = 4242L;
+
+	// Iteration counts are scenario-dependent: scenarios where every unbounded call
+	// has to exhaust the full reachable component (SpeedyDijkstra/SpeedyALT against a
+	// disconnected target) take ~50-100 ms per call on the 200x200 grid, so 5000
+	// iterations would push runtime past 10 min for one benchmark alone. CH variants
+	// terminate in microseconds either way.
+	private static final int WARMUP_ITERATIONS_FAST = 500;
+	private static final int MEASURE_ITERATIONS_FAST = 5000;
+	private static final int WARMUP_ITERATIONS_SLOW = 50;
+	private static final int MEASURE_ITERATIONS_SLOW = 500;
+
+	/** True iff the router/scenario combination requires a full-component scan per unbounded call. */
+	private static boolean isSlow(LeastCostPathCalculator router, boolean disconnected) {
+		return disconnected && (router instanceof SpeedyDijkstra || router instanceof SpeedyALT);
+	}
 
 	/**
-	 * Bounded {@code maxCost} expressed as a fraction of the unbounded optimal cost.
-	 * 0.1 means "set the cutoff at 10% of the true optimum" so bounded should bail
-	 * after exploring only a small fraction of the reachable component.
+	 * {@code maxCost = CUTOFF_FRACTION * unbounded_optimal_cost} per query. 0.1 means
+	 * "cut at 10% of the true optimum" so the bounded search should bail after a
+	 * small fraction of the work.
 	 */
 	private static final double CUTOFF_FRACTION = 0.1;
 
-	@Test
-	void disconnectedTarget_dijkstra() {
-		Network network = buildGridPlusDisconnectedIsland(GRID_N);
-		Link sourceLink = network.getLinks().get(Id.createLinkId("g_0_0_E"));
-		Link reachableFarLink = network.getLinks().get(Id.createLinkId("g_" + (GRID_N - 2) + "_" + (GRID_N - 1) + "_E"));
-		Link targetLink = network.getLinks().get(Id.createLinkId("island_AB"));
+	// -------- shared, lazily built state --------
 
-		SpeedyDijkstra router = buildDijkstra(network);
-		// Sample a representative cost (diameter of the reachable component) and cut at a fraction of it.
-		Path reference = router.calcLeastCostPath(sourceLink, reachableFarLink, 0, null, null);
-		double maxCost = reference.travelCost * CUTOFF_FRACTION;
-		runBenchmark("SpeedyDijkstra / disconnected target / grid " + GRID_N + "x" + GRID_N
-				+ " / cutoff=" + String.format("%.1f", maxCost),
-				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null),
-				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null, maxCost),
-				true);
-	}
+	private static volatile Network gridNetworkShared;
+	private static volatile Network gridPlusIslandNetworkShared;
+	private static volatile QueryPlan[] connectedQueriesShared;
+	private static volatile QueryPlan[] disconnectedQueriesShared;
 
-	@Test
-	void disconnectedTarget_alt() {
-		Network network = buildGridPlusDisconnectedIsland(GRID_N);
-		Link sourceLink = network.getLinks().get(Id.createLinkId("g_0_0_E"));
-		Link reachableFarLink = network.getLinks().get(Id.createLinkId("g_" + (GRID_N - 2) + "_" + (GRID_N - 1) + "_E"));
-		Link targetLink = network.getLinks().get(Id.createLinkId("island_AB"));
-
-		SpeedyALT router = buildAlt(network);
-		Path reference = router.calcLeastCostPath(sourceLink, reachableFarLink, 0, null, null);
-		double maxCost = reference.travelCost * CUTOFF_FRACTION;
-		runBenchmark("SpeedyALT      / disconnected target / grid " + GRID_N + "x" + GRID_N
-				+ " / cutoff=" + String.format("%.1f", maxCost),
-				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null),
-				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null, maxCost),
-				true);
-	}
-
-	@Test
-	void cutoffBelowOptimal_dijkstra() {
-		Network network = buildGrid(GRID_N);
-		Link sourceLink = network.getLinks().get(Id.createLinkId("g_0_0_E"));
-		// Target on far side of grid.
-		Link targetLink = network.getLinks().get(Id.createLinkId("g_" + (GRID_N - 2) + "_" + (GRID_N - 1) + "_E"));
-
-		SpeedyDijkstra router = buildDijkstra(network);
-		Path reference = router.calcLeastCostPath(sourceLink, targetLink, 0, null, null);
-		double maxCost = reference.travelCost * CUTOFF_FRACTION;
-		runBenchmark("SpeedyDijkstra / cutoff below optimal / grid " + GRID_N + "x" + GRID_N
-				+ " / cutoff=" + String.format("%.1f", maxCost) + " (optimal=" + String.format("%.1f", reference.travelCost) + ")",
-				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null),
-				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null, maxCost),
-				false);
-	}
-
-	@Test
-	void cutoffBelowOptimal_alt() {
-		Network network = buildGrid(GRID_N);
-		Link sourceLink = network.getLinks().get(Id.createLinkId("g_0_0_E"));
-		Link targetLink = network.getLinks().get(Id.createLinkId("g_" + (GRID_N - 2) + "_" + (GRID_N - 1) + "_E"));
-
-		SpeedyALT router = buildAlt(network);
-		Path reference = router.calcLeastCostPath(sourceLink, targetLink, 0, null, null);
-		double maxCost = reference.travelCost * CUTOFF_FRACTION;
-		runBenchmark("SpeedyALT      / cutoff below optimal / grid " + GRID_N + "x" + GRID_N
-				+ " / cutoff=" + String.format("%.1f", maxCost) + " (optimal=" + String.format("%.1f", reference.travelCost) + ")",
-				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null),
-				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null, maxCost),
-				false);
-	}
+	// Router instances: built lazily, one per (router-kind x network-kind).
+	// They are stateless after build (no per-query mutable state visible to the API).
+	private static volatile SpeedyDijkstra dijkstraGrid;
+	private static volatile SpeedyDijkstra dijkstraIsland;
+	private static volatile SpeedyALT altGrid;
+	private static volatile SpeedyALT altIsland;
+	private static volatile CHRouter chRouterGrid;
+	private static volatile CHRouter chRouterIsland;
+	private static volatile CHRouterTimeDep chRouterTimeDepGrid;
+	private static volatile CHRouterTimeDep chRouterTimeDepIsland;
 
 	/**
-	 * Tight-cutoff scenario: cutoff is set at 95% of the optimal cost. Both the unbounded
-	 * search and the bounded search end up exploring most of the relevant graph, so the
-	 * dominant cost is the inner loop. This is the regime where edge-level pruning
-	 * (skipping the heap insert when {@code newCost + h > maxCost}) is most visible.
+	 * One precomputed query: source link, target link, unbounded optimal cost
+	 * (used only for setup/diagnostics), and per-query {@code maxCost}.
 	 */
-	@Test
-	void tightCutoff_dijkstra() {
-		Network network = buildGrid(GRID_N);
-		Link sourceLink = network.getLinks().get(Id.createLinkId("g_0_0_E"));
-		Link targetLink = network.getLinks().get(Id.createLinkId("g_" + (GRID_N - 2) + "_" + (GRID_N - 1) + "_E"));
+	private record QueryPlan(Link srcLink, Link tgtLink, double optimalCost, double maxCost) {}
 
-		SpeedyDijkstra router = buildDijkstra(network);
-		Path reference = router.calcLeastCostPath(sourceLink, targetLink, 0, null, null);
-		// 95% of optimal: bounded will explore most of the graph but still bail just short of the target.
-		double maxCost = reference.travelCost * 0.95;
-		runBenchmark("SpeedyDijkstra / tight cutoff (95%)    / grid " + GRID_N + "x" + GRID_N
-				+ " / cutoff=" + String.format("%.2f", maxCost) + " (optimal=" + String.format("%.2f", reference.travelCost) + ")",
-				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null),
-				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null, maxCost),
-				false);
-	}
-
-	@Test
-	void tightCutoff_alt() {
-		Network network = buildGrid(GRID_N);
-		Link sourceLink = network.getLinks().get(Id.createLinkId("g_0_0_E"));
-		Link targetLink = network.getLinks().get(Id.createLinkId("g_" + (GRID_N - 2) + "_" + (GRID_N - 1) + "_E"));
-
-		SpeedyALT router = buildAlt(network);
-		Path reference = router.calcLeastCostPath(sourceLink, targetLink, 0, null, null);
-		double maxCost = reference.travelCost * 0.95;
-		runBenchmark("SpeedyALT      / tight cutoff (95%)    / grid " + GRID_N + "x" + GRID_N
-				+ " / cutoff=" + String.format("%.2f", maxCost) + " (optimal=" + String.format("%.2f", reference.travelCost) + ")",
-				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null),
-				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null, maxCost),
-				false);
+	/**
+	 * Silence the "No route was found" warnings emitted by every router on a null
+	 * return. With {@value #NUM_QUERIES} disconnected queries x {@value #MEASURE_ITERATIONS}
+	 * iterations x 4 routers, this would otherwise produce hundreds of thousands of
+	 * log lines per run and dominate the wall-clock time of the benchmark.
+	 */
+	@BeforeAll
+	static void silenceRouterWarnings() {
+		Configurator.setLevel(CHRouter.class.getName(), Level.ERROR);
+		Configurator.setLevel(CHRouterTimeDep.class.getName(), Level.ERROR);
+		Configurator.setLevel(SpeedyDijkstra.class.getName(), Level.ERROR);
+		Configurator.setLevel(SpeedyALT.class.getName(), Level.ERROR);
 	}
 
 	// ------------------------------------------------------------------
-	// helpers
+	// All scenarios run in one @Test method
 	// ------------------------------------------------------------------
+	//
+	// NOTE: This benchmark intentionally collapses all 8 scenarios into a
+	// single test method. Matsim registers {@code AutoResetIdCaches} as a
+	// JUnit 5 {@code TestWatcher} (see META-INF/services), which calls
+	// {@code Id.resetCaches()} after every successful test. Because we share
+	// {@link Network} singletons across scenarios to amortise CH preprocessing,
+	// a mid-suite Id cache reset invalidates the cached {@code Id.index()}
+	// values stored inside our shared Node/Link references and triggers
+	// {@code ArrayIndexOutOfBoundsException} the next time a graph is built.
+	// Running everything inside one test keeps Id state stable for the entire
+	// run.
 
-	private static void runBenchmark(String label, java.util.function.Supplier<Path> unbounded,
-			java.util.function.Supplier<Path> bounded, boolean expectNull) {
-		// Warmup
-		for (int i = 0; i < WARMUP_ITERATIONS; i++) {
-			unbounded.get();
-			bounded.get();
+	@Test
+	void runAllScenarios() {
+		runBenchmark("SpeedyDijkstra / disconnected target",
+				dijkstraIsland(), disconnectedQueries(), true);
+		runBenchmark("SpeedyDijkstra / cutoff below optimal (" + pct(CUTOFF_FRACTION) + " of optimal)",
+				dijkstraGrid(), connectedQueries(), false);
+
+		runBenchmark("SpeedyALT      / disconnected target",
+				altIsland(), disconnectedQueries(), true);
+		runBenchmark("SpeedyALT      / cutoff below optimal (" + pct(CUTOFF_FRACTION) + " of optimal)",
+				altGrid(), connectedQueries(), false);
+
+		runBenchmark("CHRouter       / disconnected target",
+				chRouterIsland(), disconnectedQueries(), true);
+		runBenchmark("CHRouter       / cutoff below optimal (" + pct(CUTOFF_FRACTION) + " of optimal)",
+				chRouterGrid(), connectedQueries(), false);
+
+		runBenchmark("CHRouterTimeDep/ disconnected target (no in-loop pruning, ~1.0x expected)",
+				chRouterTimeDepIsland(), disconnectedQueries(), true);
+		runBenchmark("CHRouterTimeDep/ cutoff below optimal (" + pct(CUTOFF_FRACTION) + " of optimal, no in-loop pruning, ~1.0x expected)",
+				chRouterTimeDepGrid(), connectedQueries(), false);
+	}
+
+	// ==================================================================
+	// Benchmark core
+	// ==================================================================
+
+	private static void runBenchmark(String label, LeastCostPathCalculator router,
+			QueryPlan[] queries, boolean expectNull) {
+		boolean slow = isSlow(router, expectNull);
+		int warmupIterations = slow ? WARMUP_ITERATIONS_SLOW : WARMUP_ITERATIONS_FAST;
+		int measureIterations = slow ? MEASURE_ITERATIONS_SLOW : MEASURE_ITERATIONS_FAST;
+
+		System.out.printf("%n[bench] %s — starting (%d warmup + %d measure)%n", label, warmupIterations, measureIterations);
+		System.out.flush();
+
+		// Warmup: alternate unbounded and bounded so both JIT paths heat up.
+		long warmupChecksum = 0;
+		for (int i = 0; i < warmupIterations; i++) {
+			QueryPlan q = queries[i % queries.length];
+			Path pu = router.calcLeastCostPath(q.srcLink, q.tgtLink, 0, null, null);
+			Path pb = router.calcLeastCostPath(q.srcLink, q.tgtLink, 0, null, null, q.maxCost);
+			if (pu != null) warmupChecksum += pu.links.size();
+			if (pb != null) warmupChecksum += pb.links.size();
 		}
 
-		// Measure unbounded
+		// Measure unbounded.
+		long unboundedChecksum = 0;
+		long nullCountUnbounded = 0;
 		long t0 = System.nanoTime();
-		Path lastUnbounded = null;
-		for (int i = 0; i < MEASURE_ITERATIONS; i++) {
-			lastUnbounded = unbounded.get();
+		for (int i = 0; i < measureIterations; i++) {
+			QueryPlan q = queries[i % queries.length];
+			Path p = router.calcLeastCostPath(q.srcLink, q.tgtLink, 0, null, null);
+			if (p == null) {
+				nullCountUnbounded++;
+			} else {
+				unboundedChecksum += p.links.size();
+			}
 		}
 		long unboundedNanos = System.nanoTime() - t0;
 
-		// Measure bounded
+		// Measure bounded.
+		long boundedChecksum = 0;
+		long nullCountBounded = 0;
 		long t1 = System.nanoTime();
-		Path lastBounded = null;
-		for (int i = 0; i < MEASURE_ITERATIONS; i++) {
-			lastBounded = bounded.get();
+		for (int i = 0; i < measureIterations; i++) {
+			QueryPlan q = queries[i % queries.length];
+			Path p = router.calcLeastCostPath(q.srcLink, q.tgtLink, 0, null, null, q.maxCost);
+			if (p == null) {
+				nullCountBounded++;
+			} else {
+				boundedChecksum += p.links.size();
+			}
 		}
 		long boundedNanos = System.nanoTime() - t1;
 
-		double unboundedMsPerCall = unboundedNanos / 1e6 / MEASURE_ITERATIONS;
-		double boundedMsPerCall = boundedNanos / 1e6 / MEASURE_ITERATIONS;
+		double unboundedUsPerCall = unboundedNanos / 1e3 / measureIterations;
+		double boundedUsPerCall = boundedNanos / 1e3 / measureIterations;
 		double speedup = (double) unboundedNanos / boundedNanos;
 
 		System.out.println();
-		System.out.println("====================================================================");
+		System.out.println("=====================================================================");
 		System.out.println(label);
-		System.out.println("--------------------------------------------------------------------");
-		System.out.printf("  unbounded: %8.3f ms/call (returned %s)%n",
-				unboundedMsPerCall, lastUnbounded == null ? "null" : "path");
-		System.out.printf("  bounded:   %8.3f ms/call (returned %s)%n",
-				boundedMsPerCall, lastBounded == null ? "null" : "path");
-		System.out.printf("  speedup:   %8.1fx%n", speedup);
-		System.out.println("====================================================================");
+		System.out.println("---------------------------------------------------------------------");
+		System.out.printf("  iterations:  %d warmup + %d measure (cycling %d queries)%n",
+				warmupIterations, measureIterations, queries.length);
+		System.out.printf("  unbounded:   %9.2f us/call  (%d/%d nulls)%n",
+				unboundedUsPerCall, nullCountUnbounded, measureIterations);
+		System.out.printf("  bounded:     %9.2f us/call  (%d/%d nulls)%n",
+				boundedUsPerCall, nullCountBounded, measureIterations);
+		System.out.printf("  speedup:     %9.2fx%n", speedup);
+		System.out.printf("  checksum:    warmup=%d  unbounded=%d  bounded=%d%n",
+				warmupChecksum, unboundedChecksum, boundedChecksum);
+		System.out.println("=====================================================================");
+		System.out.flush();
 
-		// Correctness check: both must agree on null-ness in the disconnected case;
-		// in the cutoff-below-optimal case bounded must be null and unbounded must be non-null.
+		// Correctness contracts.
 		if (expectNull) {
-			if (lastUnbounded != null || lastBounded != null) {
-				throw new AssertionError("disconnected target must produce null on both calls");
+			if (nullCountUnbounded != measureIterations || nullCountBounded != measureIterations) {
+				throw new AssertionError("disconnected scenario must return null for every call (got "
+						+ nullCountUnbounded + " / " + nullCountBounded + " nulls)");
 			}
 		} else {
-			if (lastUnbounded == null) {
-				throw new AssertionError("unbounded must find the path");
+			if (nullCountUnbounded != 0) {
+				throw new AssertionError("unbounded must find a path for every query (got "
+						+ nullCountUnbounded + " nulls)");
 			}
-			if (lastBounded != null) {
-				throw new AssertionError("bounded must return null when cutoff is below optimal");
+			if (nullCountBounded != measureIterations) {
+				throw new AssertionError("bounded must return null for every query when cutoff is below optimal (got "
+						+ nullCountBounded + " nulls / " + measureIterations + " calls)");
 			}
 		}
 	}
+
+	private static String pct(double fraction) {
+		return String.format("%.0f%%", fraction * 100.0);
+	}
+
+	// ==================================================================
+	// Lazy singletons: networks
+	// ==================================================================
+
+	private static Network gridNetwork() {
+		Network local = gridNetworkShared;
+		if (local == null) {
+			synchronized (SpeedyBoundedSearchBenchmark.class) {
+				local = gridNetworkShared;
+				if (local == null) {
+					long t0 = System.nanoTime();
+					local = buildGrid(GRID_N);
+					gridNetworkShared = local;
+					System.out.printf("[setup] built %dx%d grid (%d nodes, %d links) in %.2f s%n",
+							GRID_N, GRID_N, local.getNodes().size(), local.getLinks().size(),
+							(System.nanoTime() - t0) / 1e9);
+				}
+			}
+		}
+		return local;
+	}
+
+	private static Network gridPlusIslandNetwork() {
+		Network local = gridPlusIslandNetworkShared;
+		if (local == null) {
+			synchronized (SpeedyBoundedSearchBenchmark.class) {
+				local = gridPlusIslandNetworkShared;
+				if (local == null) {
+					long t0 = System.nanoTime();
+					local = buildGridPlusDisconnectedIsland(GRID_N);
+					gridPlusIslandNetworkShared = local;
+					System.out.printf("[setup] built %dx%d grid + island (%d nodes, %d links) in %.2f s%n",
+							GRID_N, GRID_N, local.getNodes().size(), local.getLinks().size(),
+							(System.nanoTime() - t0) / 1e9);
+				}
+			}
+		}
+		return local;
+	}
+
+	// ==================================================================
+	// Lazy singletons: routers
+	// ==================================================================
+
+	private static SpeedyDijkstra dijkstraGrid() {
+		SpeedyDijkstra local = dijkstraGrid;
+		if (local == null) {
+			synchronized (SpeedyBoundedSearchBenchmark.class) {
+				local = dijkstraGrid;
+				if (local == null) {
+					local = buildDijkstra(gridNetwork());
+					dijkstraGrid = local;
+				}
+			}
+		}
+		return local;
+	}
+
+	private static SpeedyDijkstra dijkstraIsland() {
+		SpeedyDijkstra local = dijkstraIsland;
+		if (local == null) {
+			synchronized (SpeedyBoundedSearchBenchmark.class) {
+				local = dijkstraIsland;
+				if (local == null) {
+					local = buildDijkstra(gridPlusIslandNetwork());
+					dijkstraIsland = local;
+				}
+			}
+		}
+		return local;
+	}
+
+	private static SpeedyALT altGrid() {
+		SpeedyALT local = altGrid;
+		if (local == null) {
+			synchronized (SpeedyBoundedSearchBenchmark.class) {
+				local = altGrid;
+				if (local == null) {
+					long t0 = System.nanoTime();
+					local = buildAlt(gridNetwork());
+					altGrid = local;
+					System.out.printf("[setup] built SpeedyALT (landmarks) for grid in %.2f s%n",
+							(System.nanoTime() - t0) / 1e9);
+				}
+			}
+		}
+		return local;
+	}
+
+	private static SpeedyALT altIsland() {
+		SpeedyALT local = altIsland;
+		if (local == null) {
+			synchronized (SpeedyBoundedSearchBenchmark.class) {
+				local = altIsland;
+				if (local == null) {
+					long t0 = System.nanoTime();
+					local = buildAlt(gridPlusIslandNetwork());
+					altIsland = local;
+					System.out.printf("[setup] built SpeedyALT (landmarks) for grid+island in %.2f s%n",
+							(System.nanoTime() - t0) / 1e9);
+				}
+			}
+		}
+		return local;
+	}
+
+	private static CHRouter chRouterGrid() {
+		CHRouter local = chRouterGrid;
+		if (local == null) {
+			synchronized (SpeedyBoundedSearchBenchmark.class) {
+				local = chRouterGrid;
+				if (local == null) {
+					long t0 = System.nanoTime();
+					local = buildChRouter(gridNetwork());
+					chRouterGrid = local;
+					System.out.printf("[setup] built CHRouter for grid in %.2f s%n",
+							(System.nanoTime() - t0) / 1e9);
+				}
+			}
+		}
+		return local;
+	}
+
+	private static CHRouter chRouterIsland() {
+		CHRouter local = chRouterIsland;
+		if (local == null) {
+			synchronized (SpeedyBoundedSearchBenchmark.class) {
+				local = chRouterIsland;
+				if (local == null) {
+					long t0 = System.nanoTime();
+					local = buildChRouter(gridPlusIslandNetwork());
+					chRouterIsland = local;
+					System.out.printf("[setup] built CHRouter for grid+island in %.2f s%n",
+							(System.nanoTime() - t0) / 1e9);
+				}
+			}
+		}
+		return local;
+	}
+
+	private static CHRouterTimeDep chRouterTimeDepGrid() {
+		CHRouterTimeDep local = chRouterTimeDepGrid;
+		if (local == null) {
+			synchronized (SpeedyBoundedSearchBenchmark.class) {
+				local = chRouterTimeDepGrid;
+				if (local == null) {
+					long t0 = System.nanoTime();
+					local = buildChRouterTimeDep(gridNetwork());
+					chRouterTimeDepGrid = local;
+					System.out.printf("[setup] built CHRouterTimeDep for grid in %.2f s%n",
+							(System.nanoTime() - t0) / 1e9);
+				}
+			}
+		}
+		return local;
+	}
+
+	private static CHRouterTimeDep chRouterTimeDepIsland() {
+		CHRouterTimeDep local = chRouterTimeDepIsland;
+		if (local == null) {
+			synchronized (SpeedyBoundedSearchBenchmark.class) {
+				local = chRouterTimeDepIsland;
+				if (local == null) {
+					long t0 = System.nanoTime();
+					local = buildChRouterTimeDep(gridPlusIslandNetwork());
+					chRouterTimeDepIsland = local;
+					System.out.printf("[setup] built CHRouterTimeDep for grid+island in %.2f s%n",
+							(System.nanoTime() - t0) / 1e9);
+				}
+			}
+		}
+		return local;
+	}
+
+	// ==================================================================
+	// Lazy singletons: query plans
+	// ==================================================================
+
+	/**
+	 * Generates {@value #NUM_QUERIES} random (source, target) link pairs within the
+	 * connected grid. For each pair, the unbounded optimal cost is computed once
+	 * (via the reference Dijkstra router) and {@code maxCost} is set to
+	 * {@value #CUTOFF_FRACTION} times that optimal.
+	 */
+	private static QueryPlan[] connectedQueries() {
+		QueryPlan[] local = connectedQueriesShared;
+		if (local == null) {
+			synchronized (SpeedyBoundedSearchBenchmark.class) {
+				local = connectedQueriesShared;
+				if (local == null) {
+					long t0 = System.nanoTime();
+					local = generateConnectedQueries(gridNetwork(), dijkstraGrid());
+					connectedQueriesShared = local;
+					double meanOpt = Arrays.stream(local).mapToDouble(QueryPlan::optimalCost).average().orElse(0);
+					double meanCut = Arrays.stream(local).mapToDouble(QueryPlan::maxCost).average().orElse(0);
+					System.out.printf("[setup] generated %d connected queries in %.2f s (mean optimal=%.2f, mean cutoff=%.3f)%n",
+							local.length, (System.nanoTime() - t0) / 1e9, meanOpt, meanCut);
+				}
+			}
+		}
+		return local;
+	}
+
+	/**
+	 * Generates {@value #NUM_QUERIES} random sources in the main grid, each paired
+	 * with the (unreachable) island target link. {@code maxCost} is set to
+	 * {@value #CUTOFF_FRACTION} times the grid diameter cost so the bounded search
+	 * has a meaningful, non-trivial ball to explore before bailing.
+	 */
+	private static QueryPlan[] disconnectedQueries() {
+		QueryPlan[] local = disconnectedQueriesShared;
+		if (local == null) {
+			synchronized (SpeedyBoundedSearchBenchmark.class) {
+				local = disconnectedQueriesShared;
+				if (local == null) {
+					long t0 = System.nanoTime();
+					local = generateDisconnectedQueries(gridPlusIslandNetwork(), dijkstraIsland());
+					disconnectedQueriesShared = local;
+					double meanCut = Arrays.stream(local).mapToDouble(QueryPlan::maxCost).average().orElse(0);
+					System.out.printf("[setup] generated %d disconnected queries in %.2f s (cutoff=%.3f)%n",
+							local.length, (System.nanoTime() - t0) / 1e9, meanCut);
+				}
+			}
+		}
+		return local;
+	}
+
+	private static QueryPlan[] generateConnectedQueries(Network network, LeastCostPathCalculator reference) {
+		Random rng = new Random(QUERY_SEED);
+		List<Link> linkPool = new ArrayList<>(network.getLinks().values());
+		QueryPlan[] plans = new QueryPlan[NUM_QUERIES];
+		int found = 0;
+		int attempts = 0;
+		int maxAttempts = NUM_QUERIES * 50;
+		while (found < NUM_QUERIES && attempts < maxAttempts) {
+			attempts++;
+			Link src = linkPool.get(rng.nextInt(linkPool.size()));
+			Link tgt = linkPool.get(rng.nextInt(linkPool.size()));
+			if (src == tgt) continue;
+			if (src.getId().toString().startsWith("island_")) continue;
+			if (tgt.getId().toString().startsWith("island_")) continue;
+			Path p = reference.calcLeastCostPath(src, tgt, 0, null, null);
+			if (p == null || p.travelCost <= 0 || p.links.size() < 2) continue;
+			plans[found++] = new QueryPlan(src, tgt, p.travelCost, p.travelCost * CUTOFF_FRACTION);
+		}
+		if (found < NUM_QUERIES) {
+			throw new IllegalStateException("could not generate " + NUM_QUERIES + " connected queries in "
+					+ maxAttempts + " attempts (got " + found + ")");
+		}
+		return plans;
+	}
+
+	private static QueryPlan[] generateDisconnectedQueries(Network network, LeastCostPathCalculator reference) {
+		// Use the grid diameter (corner-to-corner) cost as a representative scale,
+		// then set the cutoff to a fraction of it.
+		Link diameterSrc = network.getLinks().get(Id.createLinkId("g_0_0_E"));
+		Link diameterTgt = network.getLinks().get(Id.createLinkId("g_" + (GRID_N - 2) + "_" + (GRID_N - 1) + "_E"));
+		Path diameter = reference.calcLeastCostPath(diameterSrc, diameterTgt, 0, null, null);
+		if (diameter == null) {
+			throw new IllegalStateException("grid corner-to-corner diameter query returned null");
+		}
+		double cutoff = diameter.travelCost * CUTOFF_FRACTION;
+
+		Link islandTarget = network.getLinks().get(Id.createLinkId("island_AB"));
+		if (islandTarget == null) {
+			throw new IllegalStateException("island_AB link not present in network");
+		}
+
+		Random rng = new Random(QUERY_SEED + 1);
+		List<Link> gridLinks = new ArrayList<>(network.getLinks().size());
+		for (Link link : network.getLinks().values()) {
+			if (!link.getId().toString().startsWith("island_")) {
+				gridLinks.add(link);
+			}
+		}
+		QueryPlan[] plans = new QueryPlan[NUM_QUERIES];
+		for (int i = 0; i < NUM_QUERIES; i++) {
+			Link src = gridLinks.get(rng.nextInt(gridLinks.size()));
+			plans[i] = new QueryPlan(src, islandTarget, Double.POSITIVE_INFINITY, cutoff);
+		}
+		return plans;
+	}
+
+	// ==================================================================
+	// Router builders
+	// ==================================================================
 
 	private static SpeedyDijkstra buildDijkstra(Network network) {
 		FreespeedTravelTimeAndDisutility td = new FreespeedTravelTimeAndDisutility(new ScoringConfigGroup());
@@ -257,6 +603,26 @@ public class SpeedyBoundedSearchBenchmark {
 		SpeedyALTData altData = new SpeedyALTData(graph, 8, td, 4);
 		return new SpeedyALT(altData, td, td);
 	}
+
+	private static CHRouter buildChRouter(Network network) {
+		FreespeedTravelTimeAndDisutility td = new FreespeedTravelTimeAndDisutility(new ScoringConfigGroup());
+		SpeedyGraph graph = SpeedyGraphBuilder.buildWithSpatialOrdering(network);
+		CHGraph chGraph = new CHBuilder(graph, td).build();
+		new CHCustomizer().customize(chGraph, td);
+		return new CHRouter(chGraph, td, td);
+	}
+
+	private static CHRouterTimeDep buildChRouterTimeDep(Network network) {
+		FreespeedTravelTimeAndDisutility td = new FreespeedTravelTimeAndDisutility(new ScoringConfigGroup());
+		SpeedyGraph graph = SpeedyGraphBuilder.buildWithSpatialOrdering(network);
+		CHGraph chGraph = new CHBuilder(graph, td).build();
+		new CHTTFCustomizer().customize(chGraph, td, td);
+		return new CHRouterTimeDep(chGraph, td, td);
+	}
+
+	// ==================================================================
+	// Network builders
+	// ==================================================================
 
 	/**
 	 * Builds an NxN grid graph. Each interior node has 4 outgoing links (N/S/E/W). All
@@ -299,7 +665,7 @@ public class SpeedyBoundedSearchBenchmark {
 
 	/**
 	 * Grid as in {@link #buildGrid(int)} plus a tiny disconnected 2-node "island" component
-	 * with link id {@code island_AB}. The grid is fully reachable from {@code g_0_0}; the
+	 * with link id {@code island_AB}. The grid is fully reachable from any grid node; the
 	 * island is unreachable from the grid (and vice versa).
 	 */
 	private static Network buildGridPlusDisconnectedIsland(int n) {

--- a/matsim/src/test/java/org/matsim/core/router/speedy/SpeedyBoundedSearchBenchmark.java
+++ b/matsim/src/test/java/org/matsim/core/router/speedy/SpeedyBoundedSearchBenchmark.java
@@ -1,0 +1,315 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2026 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.core.router.speedy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.config.groups.ScoringConfigGroup;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.router.costcalculators.FreespeedTravelTimeAndDisutility;
+import org.matsim.core.router.util.LeastCostPathCalculator.Path;
+import org.matsim.core.scenario.ScenarioUtils;
+
+/**
+ * Benchmark demonstrating the speedup of the bounded-search (maxCost) overload
+ * on the speedy routers vs. the unbounded variant.
+ *
+ * <p>Disabled by default; enable with {@code -Dmatsim.benchmark=true}, e.g.
+ * <pre>{@code
+ *   mvn test -pl matsim -Dtest=SpeedyBoundedSearchBenchmark -Dmatsim.benchmark=true
+ * }</pre>
+ *
+ * <p>Two scenarios are measured:
+ * <ol>
+ *   <li><b>Disconnected target</b>: a large NxN grid (reachable from source) plus
+ *       a tiny separate component (where the target lives). The unbounded search
+ *       must exhaust the full reachable component before returning {@code null};
+ *       the bounded search returns {@code null} after exploring only the local
+ *       ball of cost {@code maxCost}.</li>
+ *   <li><b>Connected with cutoff below optimal</b>: source and target are both
+ *       in the same NxN grid but at far corners; {@code maxCost} is set well
+ *       below the optimal cost (the realistic pt2matsim case where a candidate
+ *       pair exceeds {@code maxAllowedTravelCost}). The unbounded search
+ *       explores up to the optimal cost before returning; the bounded search
+ *       stops once {@code peek > maxCost}.</li>
+ * </ol>
+ *
+ * <p>Each measurement runs {@code WARMUP_ITERATIONS} warmup calls + {@code MEASURE_ITERATIONS}
+ * measured calls and reports mean time per call and the bounded/unbounded speedup factor.
+ * No assertions are made on timing (results are environment-dependent); failures here
+ * indicate a correctness regression, not a perf regression.
+ */
+@EnabledIfSystemProperty(named = "matsim.benchmark", matches = "true")
+public class SpeedyBoundedSearchBenchmark {
+
+	private static final int GRID_N = 80; // 80x80 = 6400 nodes in the main component
+	private static final double LINK_LENGTH = 100.0;
+	private static final double LINK_FREESPEED = 10.0;
+	private static final int WARMUP_ITERATIONS = 200;
+	private static final int MEASURE_ITERATIONS = 1000;
+
+	/**
+	 * Bounded {@code maxCost} expressed as a fraction of the unbounded optimal cost.
+	 * 0.1 means "set the cutoff at 10% of the true optimum" so bounded should bail
+	 * after exploring only a small fraction of the reachable component.
+	 */
+	private static final double CUTOFF_FRACTION = 0.1;
+
+	@Test
+	void disconnectedTarget_dijkstra() {
+		Network network = buildGridPlusDisconnectedIsland(GRID_N);
+		Link sourceLink = network.getLinks().get(Id.createLinkId("g_0_0_E"));
+		Link reachableFarLink = network.getLinks().get(Id.createLinkId("g_" + (GRID_N - 2) + "_" + (GRID_N - 1) + "_E"));
+		Link targetLink = network.getLinks().get(Id.createLinkId("island_AB"));
+
+		SpeedyDijkstra router = buildDijkstra(network);
+		// Sample a representative cost (diameter of the reachable component) and cut at a fraction of it.
+		Path reference = router.calcLeastCostPath(sourceLink, reachableFarLink, 0, null, null);
+		double maxCost = reference.travelCost * CUTOFF_FRACTION;
+		runBenchmark("SpeedyDijkstra / disconnected target / grid " + GRID_N + "x" + GRID_N
+				+ " / cutoff=" + String.format("%.1f", maxCost),
+				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null),
+				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null, maxCost),
+				true);
+	}
+
+	@Test
+	void disconnectedTarget_alt() {
+		Network network = buildGridPlusDisconnectedIsland(GRID_N);
+		Link sourceLink = network.getLinks().get(Id.createLinkId("g_0_0_E"));
+		Link reachableFarLink = network.getLinks().get(Id.createLinkId("g_" + (GRID_N - 2) + "_" + (GRID_N - 1) + "_E"));
+		Link targetLink = network.getLinks().get(Id.createLinkId("island_AB"));
+
+		SpeedyALT router = buildAlt(network);
+		Path reference = router.calcLeastCostPath(sourceLink, reachableFarLink, 0, null, null);
+		double maxCost = reference.travelCost * CUTOFF_FRACTION;
+		runBenchmark("SpeedyALT      / disconnected target / grid " + GRID_N + "x" + GRID_N
+				+ " / cutoff=" + String.format("%.1f", maxCost),
+				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null),
+				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null, maxCost),
+				true);
+	}
+
+	@Test
+	void cutoffBelowOptimal_dijkstra() {
+		Network network = buildGrid(GRID_N);
+		Link sourceLink = network.getLinks().get(Id.createLinkId("g_0_0_E"));
+		// Target on far side of grid.
+		Link targetLink = network.getLinks().get(Id.createLinkId("g_" + (GRID_N - 2) + "_" + (GRID_N - 1) + "_E"));
+
+		SpeedyDijkstra router = buildDijkstra(network);
+		Path reference = router.calcLeastCostPath(sourceLink, targetLink, 0, null, null);
+		double maxCost = reference.travelCost * CUTOFF_FRACTION;
+		runBenchmark("SpeedyDijkstra / cutoff below optimal / grid " + GRID_N + "x" + GRID_N
+				+ " / cutoff=" + String.format("%.1f", maxCost) + " (optimal=" + String.format("%.1f", reference.travelCost) + ")",
+				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null),
+				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null, maxCost),
+				false);
+	}
+
+	@Test
+	void cutoffBelowOptimal_alt() {
+		Network network = buildGrid(GRID_N);
+		Link sourceLink = network.getLinks().get(Id.createLinkId("g_0_0_E"));
+		Link targetLink = network.getLinks().get(Id.createLinkId("g_" + (GRID_N - 2) + "_" + (GRID_N - 1) + "_E"));
+
+		SpeedyALT router = buildAlt(network);
+		Path reference = router.calcLeastCostPath(sourceLink, targetLink, 0, null, null);
+		double maxCost = reference.travelCost * CUTOFF_FRACTION;
+		runBenchmark("SpeedyALT      / cutoff below optimal / grid " + GRID_N + "x" + GRID_N
+				+ " / cutoff=" + String.format("%.1f", maxCost) + " (optimal=" + String.format("%.1f", reference.travelCost) + ")",
+				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null),
+				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null, maxCost),
+				false);
+	}
+
+	/**
+	 * Tight-cutoff scenario: cutoff is set at 95% of the optimal cost. Both the unbounded
+	 * search and the bounded search end up exploring most of the relevant graph, so the
+	 * dominant cost is the inner loop. This is the regime where edge-level pruning
+	 * (skipping the heap insert when {@code newCost + h > maxCost}) is most visible.
+	 */
+	@Test
+	void tightCutoff_dijkstra() {
+		Network network = buildGrid(GRID_N);
+		Link sourceLink = network.getLinks().get(Id.createLinkId("g_0_0_E"));
+		Link targetLink = network.getLinks().get(Id.createLinkId("g_" + (GRID_N - 2) + "_" + (GRID_N - 1) + "_E"));
+
+		SpeedyDijkstra router = buildDijkstra(network);
+		Path reference = router.calcLeastCostPath(sourceLink, targetLink, 0, null, null);
+		// 95% of optimal: bounded will explore most of the graph but still bail just short of the target.
+		double maxCost = reference.travelCost * 0.95;
+		runBenchmark("SpeedyDijkstra / tight cutoff (95%)    / grid " + GRID_N + "x" + GRID_N
+				+ " / cutoff=" + String.format("%.2f", maxCost) + " (optimal=" + String.format("%.2f", reference.travelCost) + ")",
+				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null),
+				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null, maxCost),
+				false);
+	}
+
+	@Test
+	void tightCutoff_alt() {
+		Network network = buildGrid(GRID_N);
+		Link sourceLink = network.getLinks().get(Id.createLinkId("g_0_0_E"));
+		Link targetLink = network.getLinks().get(Id.createLinkId("g_" + (GRID_N - 2) + "_" + (GRID_N - 1) + "_E"));
+
+		SpeedyALT router = buildAlt(network);
+		Path reference = router.calcLeastCostPath(sourceLink, targetLink, 0, null, null);
+		double maxCost = reference.travelCost * 0.95;
+		runBenchmark("SpeedyALT      / tight cutoff (95%)    / grid " + GRID_N + "x" + GRID_N
+				+ " / cutoff=" + String.format("%.2f", maxCost) + " (optimal=" + String.format("%.2f", reference.travelCost) + ")",
+				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null),
+				() -> router.calcLeastCostPath(sourceLink, targetLink, 0, null, null, maxCost),
+				false);
+	}
+
+	// ------------------------------------------------------------------
+	// helpers
+	// ------------------------------------------------------------------
+
+	private static void runBenchmark(String label, java.util.function.Supplier<Path> unbounded,
+			java.util.function.Supplier<Path> bounded, boolean expectNull) {
+		// Warmup
+		for (int i = 0; i < WARMUP_ITERATIONS; i++) {
+			unbounded.get();
+			bounded.get();
+		}
+
+		// Measure unbounded
+		long t0 = System.nanoTime();
+		Path lastUnbounded = null;
+		for (int i = 0; i < MEASURE_ITERATIONS; i++) {
+			lastUnbounded = unbounded.get();
+		}
+		long unboundedNanos = System.nanoTime() - t0;
+
+		// Measure bounded
+		long t1 = System.nanoTime();
+		Path lastBounded = null;
+		for (int i = 0; i < MEASURE_ITERATIONS; i++) {
+			lastBounded = bounded.get();
+		}
+		long boundedNanos = System.nanoTime() - t1;
+
+		double unboundedMsPerCall = unboundedNanos / 1e6 / MEASURE_ITERATIONS;
+		double boundedMsPerCall = boundedNanos / 1e6 / MEASURE_ITERATIONS;
+		double speedup = (double) unboundedNanos / boundedNanos;
+
+		System.out.println();
+		System.out.println("====================================================================");
+		System.out.println(label);
+		System.out.println("--------------------------------------------------------------------");
+		System.out.printf("  unbounded: %8.3f ms/call (returned %s)%n",
+				unboundedMsPerCall, lastUnbounded == null ? "null" : "path");
+		System.out.printf("  bounded:   %8.3f ms/call (returned %s)%n",
+				boundedMsPerCall, lastBounded == null ? "null" : "path");
+		System.out.printf("  speedup:   %8.1fx%n", speedup);
+		System.out.println("====================================================================");
+
+		// Correctness check: both must agree on null-ness in the disconnected case;
+		// in the cutoff-below-optimal case bounded must be null and unbounded must be non-null.
+		if (expectNull) {
+			if (lastUnbounded != null || lastBounded != null) {
+				throw new AssertionError("disconnected target must produce null on both calls");
+			}
+		} else {
+			if (lastUnbounded == null) {
+				throw new AssertionError("unbounded must find the path");
+			}
+			if (lastBounded != null) {
+				throw new AssertionError("bounded must return null when cutoff is below optimal");
+			}
+		}
+	}
+
+	private static SpeedyDijkstra buildDijkstra(Network network) {
+		FreespeedTravelTimeAndDisutility td = new FreespeedTravelTimeAndDisutility(new ScoringConfigGroup());
+		SpeedyGraph graph = SpeedyGraphBuilder.build(network);
+		return new SpeedyDijkstra(graph, td, td);
+	}
+
+	private static SpeedyALT buildAlt(Network network) {
+		FreespeedTravelTimeAndDisutility td = new FreespeedTravelTimeAndDisutility(new ScoringConfigGroup());
+		SpeedyGraph graph = SpeedyGraphBuilder.build(network);
+		SpeedyALTData altData = new SpeedyALTData(graph, 8, td, 4);
+		return new SpeedyALT(altData, td, td);
+	}
+
+	/**
+	 * Builds an NxN grid graph. Each interior node has 4 outgoing links (N/S/E/W). All
+	 * links have {@link #LINK_LENGTH}m length and {@link #LINK_FREESPEED}m/s freespeed,
+	 * so each link costs 10s of travel time under {@link FreespeedTravelTimeAndDisutility}.
+	 * <p>
+	 * Node ids: {@code "g_<x>_<y>"}. Eastbound link ids: {@code "g_<x>_<y>_E"}; westbound
+	 * {@code _W}; northbound {@code _N}; southbound {@code _S}.
+	 */
+	private static Network buildGrid(int n) {
+		Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+		Network network = scenario.getNetwork();
+		for (int x = 0; x < n; x++) {
+			for (int y = 0; y < n; y++) {
+				NetworkUtils.createAndAddNode(network, Id.createNodeId("g_" + x + "_" + y),
+						new Coord(x * LINK_LENGTH, y * LINK_LENGTH));
+			}
+		}
+		for (int x = 0; x < n; x++) {
+			for (int y = 0; y < n; y++) {
+				Node here = network.getNodes().get(Id.createNodeId("g_" + x + "_" + y));
+				if (x + 1 < n) {
+					Node east = network.getNodes().get(Id.createNodeId("g_" + (x + 1) + "_" + y));
+					NetworkUtils.createAndAddLink(network, Id.createLinkId("g_" + x + "_" + y + "_E"),
+							here, east, LINK_LENGTH, LINK_FREESPEED, 1000.0, 1.0);
+					NetworkUtils.createAndAddLink(network, Id.createLinkId("g_" + (x + 1) + "_" + y + "_W"),
+							east, here, LINK_LENGTH, LINK_FREESPEED, 1000.0, 1.0);
+				}
+				if (y + 1 < n) {
+					Node north = network.getNodes().get(Id.createNodeId("g_" + x + "_" + (y + 1)));
+					NetworkUtils.createAndAddLink(network, Id.createLinkId("g_" + x + "_" + y + "_N"),
+							here, north, LINK_LENGTH, LINK_FREESPEED, 1000.0, 1.0);
+					NetworkUtils.createAndAddLink(network, Id.createLinkId("g_" + x + "_" + (y + 1) + "_S"),
+							north, here, LINK_LENGTH, LINK_FREESPEED, 1000.0, 1.0);
+				}
+			}
+		}
+		return network;
+	}
+
+	/**
+	 * Grid as in {@link #buildGrid(int)} plus a tiny disconnected 2-node "island" component
+	 * with link id {@code island_AB}. The grid is fully reachable from {@code g_0_0}; the
+	 * island is unreachable from the grid (and vice versa).
+	 */
+	private static Network buildGridPlusDisconnectedIsland(int n) {
+		Network network = buildGrid(n);
+		Node islandA = NetworkUtils.createAndAddNode(network, Id.createNodeId("island_A"),
+				new Coord(-10000.0, -10000.0));
+		Node islandB = NetworkUtils.createAndAddNode(network, Id.createNodeId("island_B"),
+				new Coord(-10000.0 + LINK_LENGTH, -10000.0));
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("island_AB"),
+				islandA, islandB, LINK_LENGTH, LINK_FREESPEED, 1000.0, 1.0);
+		return network;
+	}
+}

--- a/matsim/src/test/java/org/matsim/core/router/speedy/SpeedyBoundedSearchTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/speedy/SpeedyBoundedSearchTest.java
@@ -1,0 +1,382 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2026 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.core.router.speedy;
+
+import org.junit.jupiter.api.Test;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.config.groups.ScoringConfigGroup;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.router.costcalculators.FreespeedTravelTimeAndDisutility;
+import org.matsim.core.router.util.LeastCostPathCalculator;
+import org.matsim.core.router.util.LeastCostPathCalculator.Path;
+import org.matsim.core.scenario.ScenarioUtils;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the bounded-search ({@code maxCost}) overload of
+ * {@link LeastCostPathCalculator#calcLeastCostPath(Link, Link, double, org.matsim.api.core.v01.population.Person, org.matsim.vehicles.Vehicle, double)}
+ * on the speedy implementations.
+ *
+ * <p>The contract under test:
+ * <ul>
+ *   <li>Cutoff above the optimal cost: returns the same path as the unbounded call.</li>
+ *   <li>Cutoff below the optimal cost: returns {@code null}.</li>
+ *   <li>Cutoff at exactly the optimal cost: returns the optimal path (cutoff is inclusive).</li>
+ *   <li>{@code Double.POSITIVE_INFINITY}: equivalent to the unbounded call.</li>
+ *   <li>Turn restrictions: cutoff behaviour is independent of turn-restriction expansion;
+ *       optimal path through restrictions is found when cutoff is high enough, and
+ *       {@code null} is returned when the cutoff is below that path's cost.</li>
+ * </ul>
+ */
+public class SpeedyBoundedSearchTest {
+
+	/**
+	 * Builds a simple 4-node chain network:
+	 * <pre>
+	 *   A --(linkAB, 1000m)--> B --(linkBC, 1000m)--> C --(linkCD, 1000m)--> D
+	 * </pre>
+	 * All links have freespeed 10 m/s, so each link costs 100s of travel time
+	 * under {@link FreespeedTravelTimeAndDisutility}. The optimal A->D cost is 300s.
+	 * <p>
+	 * Note that the link-based router queries from {@code linkAB.toNode = B} to
+	 * {@code linkCD.fromNode = C}, exercising the path B->C of cost 100s.
+	 */
+	private static Network buildChainNetwork() {
+		Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+		Network network = scenario.getNetwork();
+
+		Node a = NetworkUtils.createAndAddNode(network, Id.createNodeId("A"), new Coord(0, 0));
+		Node b = NetworkUtils.createAndAddNode(network, Id.createNodeId("B"), new Coord(1000, 0));
+		Node c = NetworkUtils.createAndAddNode(network, Id.createNodeId("C"), new Coord(2000, 0));
+		Node d = NetworkUtils.createAndAddNode(network, Id.createNodeId("D"), new Coord(3000, 0));
+
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("AB"), a, b, 1000.0, 10.0, 1000.0, 1.0);
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("BC"), b, c, 1000.0, 10.0, 1000.0, 1.0);
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("CD"), c, d, 1000.0, 10.0, 1000.0, 1.0);
+
+		return network;
+	}
+
+	private static SpeedyDijkstra buildDijkstra(Network network) {
+		FreespeedTravelTimeAndDisutility td = new FreespeedTravelTimeAndDisutility(new ScoringConfigGroup());
+		SpeedyGraph graph = SpeedyGraphBuilder.build(network);
+		return new SpeedyDijkstra(graph, td, td);
+	}
+
+	private static SpeedyALT buildAlt(Network network) {
+		FreespeedTravelTimeAndDisutility td = new FreespeedTravelTimeAndDisutility(new ScoringConfigGroup());
+		SpeedyGraph graph = SpeedyGraphBuilder.build(network);
+		SpeedyALTData altData = new SpeedyALTData(graph, 4, td, 4);
+		return new SpeedyALT(altData, td, td);
+	}
+
+	// ------------------------------------------------------------------
+	// SpeedyDijkstra
+	// ------------------------------------------------------------------
+
+	@Test
+	void dijkstra_cutoffAboveOptimal_returnsSamePath() {
+		Network network = buildChainNetwork();
+		Link linkAB = network.getLinks().get(Id.createLinkId("AB"));
+		Link linkCD = network.getLinks().get(Id.createLinkId("CD"));
+
+		SpeedyDijkstra router = buildDijkstra(network);
+		Path unbounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null);
+		Path bounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null, unbounded.travelCost + 1.0);
+
+		assertNotNull(bounded, "cutoff above optimal must return a path");
+		assertEquals(unbounded.travelCost, bounded.travelCost, 1e-9);
+		assertEquals(unbounded.travelTime, bounded.travelTime, 1e-9);
+		assertEquals(unbounded.links.size(), bounded.links.size());
+		for (int i = 0; i < unbounded.links.size(); i++) {
+			assertEquals(unbounded.links.get(i).getId(), bounded.links.get(i).getId(),
+					"link " + i + " differs");
+		}
+	}
+
+	@Test
+	void dijkstra_cutoffBelowOptimal_returnsNull() {
+		Network network = buildChainNetwork();
+		Link linkAB = network.getLinks().get(Id.createLinkId("AB"));
+		Link linkCD = network.getLinks().get(Id.createLinkId("CD"));
+
+		SpeedyDijkstra router = buildDijkstra(network);
+		Path unbounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null);
+		assertNotNull(unbounded);
+		assertTrue(unbounded.travelCost > 0, "optimal cost must be > 0 for this test");
+
+		Path bounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null, unbounded.travelCost - 1e-6);
+		assertNull(bounded, "cutoff strictly below optimal must return null");
+	}
+
+	@Test
+	void dijkstra_cutoffAtExactlyOptimal_returnsPath() {
+		Network network = buildChainNetwork();
+		Link linkAB = network.getLinks().get(Id.createLinkId("AB"));
+		Link linkCD = network.getLinks().get(Id.createLinkId("CD"));
+
+		SpeedyDijkstra router = buildDijkstra(network);
+		Path unbounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null);
+		Path bounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null, unbounded.travelCost);
+		assertNotNull(bounded, "cutoff == optimal must return the path (cutoff is inclusive)");
+		assertEquals(unbounded.travelCost, bounded.travelCost, 1e-9);
+	}
+
+	@Test
+	void dijkstra_positiveInfinityCutoff_equalsUnbounded() {
+		Network network = buildChainNetwork();
+		Link linkAB = network.getLinks().get(Id.createLinkId("AB"));
+		Link linkCD = network.getLinks().get(Id.createLinkId("CD"));
+
+		SpeedyDijkstra router = buildDijkstra(network);
+		Path unbounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null);
+		Path bounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null, Double.POSITIVE_INFINITY);
+		assertEquals(unbounded.travelCost, bounded.travelCost, 1e-9);
+		assertEquals(unbounded.links.size(), bounded.links.size());
+	}
+
+	// ------------------------------------------------------------------
+	// SpeedyALT
+	// ------------------------------------------------------------------
+
+	@Test
+	void alt_cutoffAboveOptimal_returnsSamePath() {
+		Network network = buildChainNetwork();
+		Link linkAB = network.getLinks().get(Id.createLinkId("AB"));
+		Link linkCD = network.getLinks().get(Id.createLinkId("CD"));
+
+		SpeedyALT router = buildAlt(network);
+		Path unbounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null);
+		Path bounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null, unbounded.travelCost + 1.0);
+
+		assertNotNull(bounded);
+		assertEquals(unbounded.travelCost, bounded.travelCost, 1e-9);
+		assertEquals(unbounded.links.size(), bounded.links.size());
+		for (int i = 0; i < unbounded.links.size(); i++) {
+			assertEquals(unbounded.links.get(i).getId(), bounded.links.get(i).getId());
+		}
+	}
+
+	@Test
+	void alt_cutoffBelowOptimal_returnsNull() {
+		Network network = buildChainNetwork();
+		Link linkAB = network.getLinks().get(Id.createLinkId("AB"));
+		Link linkCD = network.getLinks().get(Id.createLinkId("CD"));
+
+		SpeedyALT router = buildAlt(network);
+		Path unbounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null);
+		assertNotNull(unbounded);
+
+		Path bounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null, unbounded.travelCost - 1e-6);
+		assertNull(bounded);
+	}
+
+	@Test
+	void alt_cutoffAtExactlyOptimal_returnsPath() {
+		// ALT compares f = g + h against maxCost. Because the heuristic is admissible
+		// (h <= remaining true cost), f at the target equals the true optimal cost, so
+		// maxCost == optimalCost must still return the path (cutoff is inclusive).
+		Network network = buildChainNetwork();
+		Link linkAB = network.getLinks().get(Id.createLinkId("AB"));
+		Link linkCD = network.getLinks().get(Id.createLinkId("CD"));
+
+		SpeedyALT router = buildAlt(network);
+		Path unbounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null);
+		Path bounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null, unbounded.travelCost);
+		assertNotNull(bounded, "cutoff == optimal must return the path (cutoff is inclusive)");
+		assertEquals(unbounded.travelCost, bounded.travelCost, 1e-9);
+		assertEquals(unbounded.links.size(), bounded.links.size());
+	}
+
+	@Test
+	void alt_positiveInfinityCutoff_equalsUnbounded() {
+		Network network = buildChainNetwork();
+		Link linkAB = network.getLinks().get(Id.createLinkId("AB"));
+		Link linkCD = network.getLinks().get(Id.createLinkId("CD"));
+
+		SpeedyALT router = buildAlt(network);
+		Path unbounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null);
+		Path bounded = router.calcLeastCostPath(linkAB, linkCD, 0, null, null, Double.POSITIVE_INFINITY);
+		assertEquals(unbounded.travelCost, bounded.travelCost, 1e-9);
+		assertEquals(unbounded.links.size(), bounded.links.size());
+	}
+
+	// ------------------------------------------------------------------
+	// Turn restrictions: cutoff is orthogonal to turn-restriction expansion.
+	// We use the same network shape as AbstractLeastCostPathCalculatorTestWithTurnRestrictions
+	// so we know the unique S->T path under the restrictions is S-1-2-3-4-5-T (6 links).
+	// ------------------------------------------------------------------
+
+	private static Network buildTurnRestrictionsNetwork() {
+		Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+		Network network = scenario.getNetwork();
+
+		Node nodeS = NetworkUtils.createAndAddNode(network, Id.createNodeId("S"), new Coord(1, 2));
+		Node node1 = NetworkUtils.createAndAddNode(network, Id.createNodeId("1"), new Coord(1, 1));
+		Node node2 = NetworkUtils.createAndAddNode(network, Id.createNodeId("2"), new Coord(0, 1));
+		Node node3 = NetworkUtils.createAndAddNode(network, Id.createNodeId("3"), new Coord(0, 0));
+		Node node4 = NetworkUtils.createAndAddNode(network, Id.createNodeId("4"), new Coord(1, 0));
+		Node node5 = NetworkUtils.createAndAddNode(network, Id.createNodeId("5"), new Coord(2, 0));
+		Node nodeT = NetworkUtils.createAndAddNode(network, Id.createNodeId("T"), new Coord(2, 0));
+
+		Link linkS1 = NetworkUtils.createAndAddLink(network, Id.createLinkId("S1"), nodeS, node1, 1, 1, 1, 1);
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("12"), node1, node2, 1, 1, 1, 1);
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("1T"), node1, nodeT, 1, 1, 1, 1);
+		Link link23 = NetworkUtils.createAndAddLink(network, Id.createLinkId("23"), node2, node3, 1, 1, 1, 1);
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("34"), node3, node4, 1, 1, 1, 1);
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("4T"), node4, nodeT, 1, 1, 1, 1);
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("45"), node4, node5, 1, 1, 1, 1);
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("5T"), node5, nodeT, 1, 1, 1, 1);
+
+		NetworkUtils.addDisallowedNextLinks(linkS1, TransportMode.car, Arrays.asList(Id.createLinkId("1T")));
+		NetworkUtils.addDisallowedNextLinks(link23, TransportMode.car, Arrays.asList(Id.createLinkId("34"), Id.createLinkId("4T")));
+
+		return network;
+	}
+
+	@Test
+	void dijkstra_turnRestrictions_cutoffAboveOptimal_findsRoutedPath() {
+		Network network = buildTurnRestrictionsNetwork();
+		Link linkS1 = network.getLinks().get(Id.createLinkId("S1"));
+		Link link5T = network.getLinks().get(Id.createLinkId("5T"));
+
+		SpeedyDijkstra router = buildDijkstra(network);
+		Path unbounded = router.calcLeastCostPath(linkS1, link5T, 0, null, null);
+		assertNotNull(unbounded, "the turn-restriction-aware path must exist");
+		Path bounded = router.calcLeastCostPath(linkS1, link5T, 0, null, null, unbounded.travelCost + 1.0);
+		assertNotNull(bounded);
+		assertEquals(unbounded.travelCost, bounded.travelCost, 1e-9);
+		assertEquals(unbounded.links.size(), bounded.links.size());
+	}
+
+	@Test
+	void dijkstra_turnRestrictions_cutoffBelowOptimal_returnsNull() {
+		Network network = buildTurnRestrictionsNetwork();
+		Link linkS1 = network.getLinks().get(Id.createLinkId("S1"));
+		Link link5T = network.getLinks().get(Id.createLinkId("5T"));
+
+		SpeedyDijkstra router = buildDijkstra(network);
+		Path unbounded = router.calcLeastCostPath(linkS1, link5T, 0, null, null);
+		assertNotNull(unbounded);
+
+		Path bounded = router.calcLeastCostPath(linkS1, link5T, 0, null, null, unbounded.travelCost - 1e-6);
+		assertNull(bounded, "cutoff strictly below the routed path's cost must return null");
+	}
+
+	@Test
+	void alt_turnRestrictions_cutoffAboveOptimal_findsRoutedPath() {
+		Network network = buildTurnRestrictionsNetwork();
+		Link linkS1 = network.getLinks().get(Id.createLinkId("S1"));
+		Link link5T = network.getLinks().get(Id.createLinkId("5T"));
+
+		SpeedyALT router = buildAlt(network);
+		Path unbounded = router.calcLeastCostPath(linkS1, link5T, 0, null, null);
+		assertNotNull(unbounded);
+		Path bounded = router.calcLeastCostPath(linkS1, link5T, 0, null, null, unbounded.travelCost + 1.0);
+		assertNotNull(bounded);
+		assertEquals(unbounded.travelCost, bounded.travelCost, 1e-9);
+	}
+
+	@Test
+	void alt_turnRestrictions_cutoffBelowOptimal_returnsNull() {
+		Network network = buildTurnRestrictionsNetwork();
+		Link linkS1 = network.getLinks().get(Id.createLinkId("S1"));
+		Link link5T = network.getLinks().get(Id.createLinkId("5T"));
+
+		SpeedyALT router = buildAlt(network);
+		Path unbounded = router.calcLeastCostPath(linkS1, link5T, 0, null, null);
+		assertNotNull(unbounded);
+
+		Path bounded = router.calcLeastCostPath(linkS1, link5T, 0, null, null, unbounded.travelCost - 1e-6);
+		assertNull(bounded);
+	}
+
+	// ------------------------------------------------------------------
+	// Disconnected target: the source can never reach the target.
+	// This is the pt2matsim long-tail use case (a transit-route stop pair lands on a
+	// disconnected component of the mode-specific subgraph). Bounded search must return
+	// {@code null} for both routers, and it must do so quickly without exhausting the
+	// full reachable component.
+	// ------------------------------------------------------------------
+
+	/**
+	 * Builds two disconnected chain components.
+	 * <pre>
+	 *   A --(AB)--> B --(BC)--> C        (reachable component from A)
+	 *   D --(DE)--> E --(EF)--> F        (separate component, unreachable from A)
+	 * </pre>
+	 */
+	private static Network buildDisconnectedNetwork() {
+		Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+		Network network = scenario.getNetwork();
+
+		Node a = NetworkUtils.createAndAddNode(network, Id.createNodeId("A"), new Coord(0, 0));
+		Node b = NetworkUtils.createAndAddNode(network, Id.createNodeId("B"), new Coord(1000, 0));
+		Node c = NetworkUtils.createAndAddNode(network, Id.createNodeId("C"), new Coord(2000, 0));
+		Node d = NetworkUtils.createAndAddNode(network, Id.createNodeId("D"), new Coord(5000, 0));
+		Node e = NetworkUtils.createAndAddNode(network, Id.createNodeId("E"), new Coord(6000, 0));
+		Node f = NetworkUtils.createAndAddNode(network, Id.createNodeId("F"), new Coord(7000, 0));
+
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("AB"), a, b, 1000.0, 10.0, 1000.0, 1.0);
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("BC"), b, c, 1000.0, 10.0, 1000.0, 1.0);
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("DE"), d, e, 1000.0, 10.0, 1000.0, 1.0);
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("EF"), e, f, 1000.0, 10.0, 1000.0, 1.0);
+
+		return network;
+	}
+
+	@Test
+	void dijkstra_disconnectedTarget_returnsNullUnderCutoff() {
+		Network network = buildDisconnectedNetwork();
+		Link linkAB = network.getLinks().get(Id.createLinkId("AB"));
+		Link linkEF = network.getLinks().get(Id.createLinkId("EF"));
+
+		SpeedyDijkstra router = buildDijkstra(network);
+		Path bounded = router.calcLeastCostPath(linkAB, linkEF, 0, null, null, 1000.0);
+		assertNull(bounded, "target on disconnected component must return null under a finite cutoff");
+	}
+
+	@Test
+	void alt_disconnectedTarget_returnsNullUnderCutoff() {
+		Network network = buildDisconnectedNetwork();
+		Link linkAB = network.getLinks().get(Id.createLinkId("AB"));
+		Link linkEF = network.getLinks().get(Id.createLinkId("EF"));
+
+		SpeedyALT router = buildAlt(network);
+		// On the disconnected component, h(start) is +infinity (the triangle inequality with any
+		// landmark reachable from t but not from start). The bounded cutoff must therefore fire on
+		// the very first peek and return null without exploring the full reachable component.
+		Path bounded = router.calcLeastCostPath(linkAB, linkEF, 0, null, null, 1000.0);
+		assertNull(bounded, "target on disconnected component must return null under a finite cutoff");
+	}
+}


### PR DESCRIPTION
Adds an optional `maxCost` upper bound to `LeastCostPathCalculator.calcLeastCostPath(...)` and implements it in all Speedy routers. When the best feasible path exceeds the bound, the routers return `null` quickly instead of exhausting the reachable component. Default overload (`maxCost = Double.POSITIVE_INFINITY`) preserves existing behavior.

### Motivation

PT2MATSim performs many short routings with a max bound, but currently, the graphs are fully explored in all its routers. This change would enable a massive performance improvement for its use case, see: https://github.com/matsim-org/pt2matsim/pull/415

### What's changed

- `LeastCostPathCalculator`: new 6-arg overload with `maxCost` (defaults to `+∞`).
- `SpeedyDijkstra`, `SpeedyALT`: edge-level pruning using the admissible cost lower bound (Dijkstra: `g`; ALT: `g + h`). Adds `DAryMinHeap.peekCost()`.
- `CHRouter`: in-loop early termination on actual path cost (best forward + best backward + shortcut).
- `CHRouterTimeDep`: final-guard only. In-loop pruning is unit-unsound here because `minTTF` stores travel time while `maxCost` is disutility.

### Tests

- `SpeedyBoundedSearchTest` (14 tests) and `CHBoundedSearchTest` (8 tests).
- `SpeedyBoundedSearchBenchmark` (gated by `-Dmatsim.benchmark=true`) measures unbounded vs bounded on a 200×200 grid + disconnected island with 200 randomized queries:

| Router            | Scenario                          | Unbounded   | Bounded     | Speedup |
| ----------------- | --------------------------------- | ----------- | ----------- | ------- |
| `SpeedyDijkstra`  | disconnected target               |  7 237 µs  |    419 µs  | 17 ×    |
| `SpeedyDijkstra`  | cutoff = 10 % of optimal          |  3 245 µs  |   53.8 µs  | 60 ×    |
| `SpeedyALT`       | disconnected target               | 77 561 µs  |   0.26 µs  | 293 000 × |
| `SpeedyALT`       | cutoff = 10 % of optimal          |    549 µs  |   0.09 µs  | 6 100 × |
| `CHRouter`        | disconnected target               |    118 µs  |   33.9 µs  | 3.5 ×   |
| `CHRouter`        | cutoff = 10 % of optimal          |    194 µs  |   19.4 µs  | 10 ×    |
| `CHRouterTimeDep` | both scenarios                    |    ≈190 µs |   ≈190 µs  | 1.0 × *(final-guard only)* |