### PR TITLE
fix(router): turn-restriction support in CHLeastCostPathTree

### DIFF
--- a/matsim/src/main/java/org/matsim/core/router/speedy/CHLeastCostPathTree.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/CHLeastCostPathTree.java
@@ -22,6 +22,7 @@ package org.matsim.core.router.speedy;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.api.core.v01.population.Person;
+import org.matsim.core.network.turnRestrictions.TurnRestrictionsContext;
 import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.utils.misc.OptionalTime;
@@ -29,6 +30,7 @@ import org.matsim.vehicles.Vehicle;
 
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 
 /**
@@ -154,6 +156,16 @@ public class CHLeastCostPathTree implements ShortestPathTree {
                           LeastCostPathTree.StopCriterion stopCriterion) {
         lastForwardSearch = true;
         int startNode = baseGraph.getNodeIndex(startLink.getToNode());
+        // If the base graph contains turn restrictions, the start link may have been
+        // replaced by a colored copy.  Use that colored to-node so the CH search
+        // starts from the topologically correct (restriction-aware) entry node.
+        if (baseGraph.getTurnRestrictions().isPresent()) {
+            TurnRestrictionsContext context = baseGraph.getTurnRestrictions().get();
+            TurnRestrictionsContext.ColoredLink replaced = context.replacedLinks.get(startLink.getId());
+            if (replaced != null && replaced.toColoredNode != null) {
+                startNode = baseGraph.getInternalIndex(replaced.toColoredNode.index());
+            }
+        }
         calculateForward(startNode, startTime, stopCriterion);
     }
 
@@ -225,6 +237,15 @@ public class CHLeastCostPathTree implements ShortestPathTree {
         //   - Cost-bounded pruning skips nodes/edges beyond earlyTermCost
         //   - Sequential memory access on sweepOrder (cache-friendly)
         forwardSweepLinear(S, earlyTermCost);
+
+        // When turn restrictions are present, the base graph contains colored copies
+        // of real nodes; only the colored copy may have been reached.  Mirror each
+        // best colored label onto the corresponding real-node slot so that callers
+        // querying getCost/getTime/getDistance on the real node observe the correct
+        // result.  Mirrors org.matsim.core.router.speedy.LeastCostPathTree.
+        if (baseGraph.getTurnRestrictions().isPresent()) {
+            consolidateColoredNodes();
+        }
     }
 
     /**
@@ -310,11 +331,12 @@ public class CHLeastCostPathTree implements ShortestPathTree {
                                    LeastCostPathTree.StopCriterion stopCriterion) {
         lastForwardSearch = false;
         int arrivalNode = baseGraph.getNodeIndex(arrivalLink.getFromNode());
-        calculateBackwardImpl(arrivalNode, arrivalTime, stopCriterion);
+        calculateBackwardImpl(arrivalNode, arrivalTime, stopCriterion, arrivalLink);
     }
 
     private void calculateBackwardImpl(int targetNode, double arrivalTime,
-                                        LeastCostPathTree.StopCriterion stopCriterion) {
+                                        LeastCostPathTree.StopCriterion stopCriterion,
+                                        Link arrivalLink) {
         advanceIteration();
 
         final int S = CHGraph.E_STRIDE;
@@ -323,6 +345,31 @@ public class CHLeastCostPathTree implements ShortestPathTree {
         setNode(targetNode, 0.0, arrivalTime, 0.0, -1, -1);
         pq.clear();
         pq.insert(targetNode, 0.0);
+
+        // When turn restrictions are present, the real arrival node may be unreachable;
+        // only colored copies sitting "in front of" the arrival link may be reachable.
+        // Seed every such colored arrival node, mirroring LeastCostPathTree.
+        if (arrivalLink != null && baseGraph.getTurnRestrictions().isPresent()) {
+            TurnRestrictionsContext ctx = baseGraph.getTurnRestrictions().get();
+            for (Link inLink : arrivalLink.getFromNode().getInLinks().values()) {
+                TurnRestrictionsContext.ColoredLink replaced = ctx.replacedLinks.get(inLink.getId());
+                if (replaced != null && replaced.toColoredNode != null) {
+                    int coloredArrival = baseGraph.getInternalIndex(replaced.toColoredNode.index());
+                    setNode(coloredArrival, 0.0, arrivalTime, 0.0, -1, -1);
+                    pq.insert(coloredArrival, 0.0);
+                }
+                List<TurnRestrictionsContext.ColoredLink> coloredLinks = ctx.coloredLinksPerLinkMap.get(inLink.getId());
+                if (coloredLinks != null) {
+                    for (TurnRestrictionsContext.ColoredLink coloredLink : coloredLinks) {
+                        if (coloredLink.toColoredNode != null) {
+                            int coloredArrival = baseGraph.getInternalIndex(coloredLink.toColoredNode.index());
+                            setNode(coloredArrival, 0.0, arrivalTime, 0.0, -1, -1);
+                            pq.insert(coloredArrival, 0.0);
+                        }
+                    }
+                }
+            }
+        }
 
         // Track the cost at which Phase 1 terminates (for sweep pruning).
         double earlyTermCost = Double.POSITIVE_INFINITY;
@@ -363,6 +410,11 @@ public class CHLeastCostPathTree implements ShortestPathTree {
 
         // Phase 2: Cost-bounded linear push sweep.
         backwardSweepLinear(S, earlyTermCost);
+
+        // Consolidate colored copies onto real nodes (see calculateForward).
+        if (baseGraph.getTurnRestrictions().isPresent()) {
+            consolidateColoredNodes();
+        }
     }
 
     /**
@@ -483,6 +535,47 @@ public class CHLeastCostPathTree implements ShortestPathTree {
         comingFrom[nodeIndex] = from;
         fromEdgeGIdx[nodeIndex] = edgeGIdx;
         iterIds[nodeIndex] = currentIteration;
+    }
+
+    /**
+     * When the base graph carries turn restrictions, real nodes may have been
+     * replaced by one or more colored copies during graph construction.  The CH
+     * search settles labels on those colored copies; this method propagates the
+     * best label of each colored copy onto its corresponding real-node slot, so
+     * that {@link #getCost(int)}, {@link #getTime(int)} and {@link #getDistance(int)}
+     * return meaningful results when queried by real-node index.
+     *
+     * <p>Mirrors {@link LeastCostPathTree#consolidateColoredNodes()}.
+     */
+    private void consolidateColoredNodes() {
+        for (int i = 0; i < nodeCount; i++) {
+            Node uncoloredNode = baseGraph.getNode(i);
+            if (uncoloredNode == null) continue;
+
+            // If the node at internal index i resolves to a different internal
+            // index, then i is a colored copy of a real node.
+            int uncoloredIndex = baseGraph.getNodeIndex(uncoloredNode);
+            if (uncoloredIndex == i) continue;
+
+            // Skip colored copies that were not visited in this iteration.
+            if (iterIds[i] != currentIteration) continue;
+
+            double coloredCost = data[i * 3];
+            double uncoloredCost = (iterIds[uncoloredIndex] == currentIteration)
+                    ? data[uncoloredIndex * 3]
+                    : Double.POSITIVE_INFINITY;
+
+            if (coloredCost < uncoloredCost) {
+                int uBase = uncoloredIndex * 3;
+                int cBase = i * 3;
+                data[uBase]     = data[cBase];
+                data[uBase + 1] = data[cBase + 1];
+                data[uBase + 2] = data[cBase + 2];
+                comingFrom[uncoloredIndex]   = comingFrom[i];
+                fromEdgeGIdx[uncoloredIndex] = fromEdgeGIdx[i];
+                iterIds[uncoloredIndex]      = currentIteration;
+            }
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/matsim/src/test/java/org/matsim/core/router/speedy/CHLeastCostPathTreeTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/speedy/CHLeastCostPathTreeTest.java
@@ -25,18 +25,21 @@ import org.junit.jupiter.api.Test;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.NetworkFactory;
 import org.matsim.api.core.v01.network.Node;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.groups.ScoringConfigGroup;
+import org.matsim.core.network.NetworkUtils;
 import org.matsim.core.network.io.MatsimNetworkReader;
 import org.matsim.core.router.costcalculators.FreespeedTravelTimeAndDisutility;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.utils.misc.OptionalTime;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
@@ -1066,5 +1069,316 @@ public class CHLeastCostPathTreeTest {
 
         Assertions.assertEquals(0, disconnectedPaths,
                 disconnectedPaths + " disconnected backward paths out of " + totalPaths);
+    }
+
+    // =========================================================================
+    // Turn-restriction tests
+    //
+    // These cover the case where the base graph carries DisallowedNextLinks.
+    // SpeedyGraphBuilder responds by inserting "colored" copies of nodes and
+    // links so the shortest path respects forbidden manoeuvres.  The CH built
+    // on top inherits those colored copies, but only some are reached during
+    // the search.  The test verifies that:
+    //   (a) forward and backward searches still settle every node that plain
+    //       Dijkstra (LeastCostPathTree) settles,
+    //   (b) the cost on the real (uncolored) node index matches plain
+    //       Dijkstra, i.e. consolidateColoredNodes() has run, and
+    //   (c) for a hand-crafted network with a forbidden direct path, the CH
+    //       result is the expected long detour rather than the forbidden short
+    //       direct route.
+    // =========================================================================
+
+    /**
+     * Hand-crafted network from {@link org.matsim.core.router.AbstractLeastCostPathCalculatorTestWithTurnRestrictions}:
+     * {@code S -> 1 -> T} is the direct two-link path but is forbidden by a
+     * turn restriction on link {@code S1}.  The only legal way is the
+     * six-link detour {@code S -> 1 -> 2 -> 3 -> 4 -> 5 -> T}.
+     */
+    @Test
+    void testForwardSearchTurnRestrictions_handcrafted() {
+        Network network = buildTurnRestrictionsTestNetwork();
+        FreespeedTravelTimeAndDisutility tc = new FreespeedTravelTimeAndDisutility(new ScoringConfigGroup());
+
+        SpeedyGraph baseGraph = SpeedyGraphBuilder.build(network);
+        InertialFlowCutter.NDOrderResult order = new InertialFlowCutter(baseGraph).computeOrderWithBatches();
+        CHGraph chGraph = new CHBuilder(baseGraph, tc).buildWithOrderParallel(order);
+        new CHTTFCustomizer().customize(chGraph, tc, tc);
+
+        CHLeastCostPathTree chTree = new CHLeastCostPathTree(chGraph, tc, tc);
+        LeastCostPathTree dijTree = new LeastCostPathTree(baseGraph, tc, tc);
+
+        Link startLink = network.getLinks().get(Id.createLinkId("S1"));
+        double depTime = 8.0 * 3600;
+        chTree.calculate(startLink, depTime, null, null);
+        dijTree.calculate(startLink, depTime, null, null);
+
+        Node nodeT = network.getNodes().get(Id.createNodeId("T"));
+        int tIdx = nodeT.getId().index();
+
+        OptionalTime chT = chTree.getTime(tIdx);
+        OptionalTime dijT = dijTree.getTime(tIdx);
+        Assertions.assertTrue(dijT.isDefined(),
+                "test fixture broken: Dijkstra should reach T via the legal detour");
+        Assertions.assertTrue(chT.isDefined(),
+                "CH must reach T via the legal detour (forbidden direct turn must be respected)");
+        Assertions.assertEquals(dijT.seconds(), chT.seconds(), COST_TOLERANCE,
+                "CH arrival time at T must match Dijkstra (legal 6-link detour)");
+
+        // Cross-check every reachable node: CH must agree with Dijkstra wherever
+        // Dijkstra has a defined time.  This catches the case where CH leaves a
+        // colored copy populated but the real node slot empty.
+        int mismatches = 0;
+        for (Node n : network.getNodes().values()) {
+            int idx = n.getId().index();
+            OptionalTime cht = chTree.getTime(idx);
+            OptionalTime djt = dijTree.getTime(idx);
+            if (djt.isDefined()) {
+                if (cht.isUndefined()) {
+                    mismatches++;
+                    System.err.printf("FORWARD-TR MISMATCH node=%s: CH=unreachable Dijkstra=%.3f%n",
+                            n.getId(), djt.seconds());
+                } else if (Math.abs(cht.seconds() - djt.seconds()) > COST_TOLERANCE) {
+                    mismatches++;
+                    System.err.printf("FORWARD-TR MISMATCH node=%s: CH=%.6f Dijkstra=%.6f%n",
+                            n.getId(), cht.seconds(), djt.seconds());
+                }
+            }
+        }
+        Assertions.assertEquals(0, mismatches, mismatches + " forward TR mismatches");
+    }
+
+    /**
+     * Same hand-crafted network as
+     * {@link #testForwardSearchTurnRestrictions_handcrafted()} but with a
+     * backward search from {@code T}.  Every node reachable by plain Dijkstra
+     * must also be reachable by CH with the same cost.
+     */
+    @Test
+    void testBackwardSearchTurnRestrictions_handcrafted() {
+        Network network = buildTurnRestrictionsTestNetwork();
+        FreespeedTravelTimeAndDisutility tc = new FreespeedTravelTimeAndDisutility(new ScoringConfigGroup());
+
+        SpeedyGraph baseGraph = SpeedyGraphBuilder.build(network);
+        InertialFlowCutter.NDOrderResult order = new InertialFlowCutter(baseGraph).computeOrderWithBatches();
+        CHGraph chGraph = new CHBuilder(baseGraph, tc).buildWithOrderParallel(order);
+        new CHTTFCustomizer().customize(chGraph, tc, tc);
+
+        CHLeastCostPathTree chTree = new CHLeastCostPathTree(chGraph, tc, tc);
+        LeastCostPathTree dijTree = new LeastCostPathTree(baseGraph, tc, tc);
+
+        Link arrivalLink = network.getLinks().get(Id.createLinkId("5T"));
+        double arrTime = 8.0 * 3600;
+        chTree.calculateBackwards(arrivalLink, arrTime, null, null);
+        dijTree.calculateBackwards(arrivalLink, arrTime, null, null);
+
+        Node nodeS = network.getNodes().get(Id.createNodeId("S"));
+        int sIdx = nodeS.getId().index();
+        OptionalTime chS = chTree.getTime(sIdx);
+        OptionalTime djS = dijTree.getTime(sIdx);
+        Assertions.assertTrue(djS.isDefined(),
+                "test fixture broken: Dijkstra backwards should reach S");
+        Assertions.assertTrue(chS.isDefined(),
+                "CH backwards must reach S via the legal detour");
+        Assertions.assertEquals(djS.seconds(), chS.seconds(), COST_TOLERANCE,
+                "CH backwards departure time at S must match Dijkstra");
+
+        int mismatches = 0;
+        for (Node n : network.getNodes().values()) {
+            int idx = n.getId().index();
+            OptionalTime cht = chTree.getTime(idx);
+            OptionalTime djt = dijTree.getTime(idx);
+            if (djt.isDefined()) {
+                if (cht.isUndefined()) {
+                    mismatches++;
+                    System.err.printf("BACKWARD-TR MISMATCH node=%s: CH=unreachable Dijkstra=%.3f%n",
+                            n.getId(), djt.seconds());
+                } else if (Math.abs(cht.seconds() - djt.seconds()) > COST_TOLERANCE) {
+                    mismatches++;
+                    System.err.printf("BACKWARD-TR MISMATCH node=%s: CH=%.6f Dijkstra=%.6f%n",
+                            n.getId(), cht.seconds(), djt.seconds());
+                }
+            }
+        }
+        Assertions.assertEquals(0, mismatches, mismatches + " backward TR mismatches");
+    }
+
+    /**
+     * Realistic-scale coverage check: load the equil scenario, mark a handful
+     * of disallowed turns, and confirm that for many random sources the CH
+     * tree reaches the same set of nodes as plain Dijkstra with the same
+     * costs.  This is the regression test for the production failure where
+     * CH workers threw {@code "Undefined Time"} for destinations that plain
+     * Dijkstra reached because colored copies were never consolidated.
+     */
+    @Test
+    void testForwardSearchTurnRestrictions_equilCoverage() {
+        Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+        new MatsimNetworkReader(scenario.getNetwork()).readFile("test/scenarios/equil/network.xml");
+        Network network = scenario.getNetwork();
+
+        // Add a few disallowed turns spread across the network so multiple
+        // colored copies are inserted.  We pick links by iteration order so
+        // the test is reproducible without depending on exact equil link IDs.
+        List<Link> links = new ArrayList<>(network.getLinks().values());
+        int restrictionsAdded = 0;
+        for (int i = 0; i < links.size() && restrictionsAdded < 3; i++) {
+            Link from = links.get(i);
+            // Find an outgoing link of from.getToNode() to forbid.
+            for (Link out : from.getToNode().getOutLinks().values()) {
+                if (out.getToNode() != from.getFromNode()) { // skip U-turn (often already disallowed)
+                    NetworkUtils.addDisallowedNextLinks(from, TransportMode.car,
+                            Arrays.asList(out.getId()));
+                    restrictionsAdded++;
+                    break;
+                }
+            }
+        }
+        Assertions.assertTrue(restrictionsAdded >= 1,
+                "expected to add at least one disallowed-turn restriction");
+
+        FreespeedTravelTimeAndDisutility tc = new FreespeedTravelTimeAndDisutility(new ScoringConfigGroup());
+
+        SpeedyGraph baseGraph = SpeedyGraphBuilder.build(network);
+        InertialFlowCutter.NDOrderResult order = new InertialFlowCutter(baseGraph).computeOrderWithBatches();
+        CHGraph chGraph = new CHBuilder(baseGraph, tc).buildWithOrderParallel(order);
+        new CHTTFCustomizer().customize(chGraph, tc, tc);
+
+        CHLeastCostPathTree chTree = new CHLeastCostPathTree(chGraph, tc, tc);
+        LeastCostPathTree dijTree = new LeastCostPathTree(baseGraph, tc, tc);
+
+        Random rng = new Random(7);
+        int mismatches = 0;
+        int comparisons = 0;
+        double depTime = 8.0 * 3600;
+        for (int s = 0; s < 10; s++) {
+            Link startLink = links.get(rng.nextInt(links.size()));
+            chTree.calculate(startLink, depTime, null, null);
+            dijTree.calculate(startLink, depTime, null, null);
+
+            for (Node n : network.getNodes().values()) {
+                int idx = n.getId().index();
+                OptionalTime cht = chTree.getTime(idx);
+                OptionalTime djt = dijTree.getTime(idx);
+                if (djt.isUndefined()) continue;
+                comparisons++;
+                if (cht.isUndefined()) {
+                    mismatches++;
+                    if (mismatches < 10) {
+                        System.err.printf("EQUIL-TR MISMATCH src=%s node=%s: CH=unreachable Dijkstra=%.3f%n",
+                                startLink.getId(), n.getId(), djt.seconds());
+                    }
+                } else if (Math.abs(cht.seconds() - djt.seconds()) > COST_TOLERANCE) {
+                    mismatches++;
+                    if (mismatches < 10) {
+                        System.err.printf("EQUIL-TR MISMATCH src=%s node=%s: CH=%.6f Dijkstra=%.6f%n",
+                                startLink.getId(), n.getId(), cht.seconds(), djt.seconds());
+                    }
+                }
+            }
+        }
+        Assertions.assertEquals(0, mismatches,
+                mismatches + " TR coverage mismatches out of " + comparisons + " comparisons");
+    }
+
+    /**
+     * Backward equivalent of {@link #testForwardSearchTurnRestrictions_equilCoverage()}.
+     * Loads the equil scenario with the same disallowed turns and confirms
+     * backward CH matches backward Dijkstra everywhere the latter is defined.
+     * This exercises the colored-arrival seeding in {@code calculateBackwardImpl}.
+     */
+    @Test
+    void testBackwardSearchTurnRestrictions_equilCoverage() {
+        Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+        new MatsimNetworkReader(scenario.getNetwork()).readFile("test/scenarios/equil/network.xml");
+        Network network = scenario.getNetwork();
+
+        List<Link> links = new ArrayList<>(network.getLinks().values());
+        int restrictionsAdded = 0;
+        for (int i = 0; i < links.size() && restrictionsAdded < 3; i++) {
+            Link from = links.get(i);
+            for (Link out : from.getToNode().getOutLinks().values()) {
+                if (out.getToNode() != from.getFromNode()) {
+                    NetworkUtils.addDisallowedNextLinks(from, TransportMode.car,
+                            Arrays.asList(out.getId()));
+                    restrictionsAdded++;
+                    break;
+                }
+            }
+        }
+        Assertions.assertTrue(restrictionsAdded >= 1,
+                "expected to add at least one disallowed-turn restriction");
+
+        FreespeedTravelTimeAndDisutility tc = new FreespeedTravelTimeAndDisutility(new ScoringConfigGroup());
+
+        SpeedyGraph baseGraph = SpeedyGraphBuilder.build(network);
+        InertialFlowCutter.NDOrderResult order = new InertialFlowCutter(baseGraph).computeOrderWithBatches();
+        CHGraph chGraph = new CHBuilder(baseGraph, tc).buildWithOrderParallel(order);
+        new CHTTFCustomizer().customize(chGraph, tc, tc);
+
+        CHLeastCostPathTree chTree = new CHLeastCostPathTree(chGraph, tc, tc);
+        LeastCostPathTree dijTree = new LeastCostPathTree(baseGraph, tc, tc);
+
+        Random rng = new Random(11);
+        int mismatches = 0;
+        int comparisons = 0;
+        double arrTime = 8.0 * 3600;
+        for (int s = 0; s < 10; s++) {
+            Link arrivalLink = links.get(rng.nextInt(links.size()));
+            chTree.calculateBackwards(arrivalLink, arrTime, null, null);
+            dijTree.calculateBackwards(arrivalLink, arrTime, null, null);
+
+            for (Node n : network.getNodes().values()) {
+                int idx = n.getId().index();
+                OptionalTime cht = chTree.getTime(idx);
+                OptionalTime djt = dijTree.getTime(idx);
+                if (djt.isUndefined()) continue;
+                comparisons++;
+                if (cht.isUndefined()) {
+                    mismatches++;
+                    if (mismatches < 10) {
+                        System.err.printf("EQUIL-TR-BWD MISMATCH arr=%s node=%s: CH=unreachable Dijkstra=%.3f%n",
+                                arrivalLink.getId(), n.getId(), djt.seconds());
+                    }
+                } else if (Math.abs(cht.seconds() - djt.seconds()) > COST_TOLERANCE) {
+                    mismatches++;
+                    if (mismatches < 10) {
+                        System.err.printf("EQUIL-TR-BWD MISMATCH arr=%s node=%s: CH=%.6f Dijkstra=%.6f%n",
+                                arrivalLink.getId(), n.getId(), cht.seconds(), djt.seconds());
+                    }
+                }
+            }
+        }
+        Assertions.assertEquals(0, mismatches,
+                mismatches + " backward TR coverage mismatches out of " + comparisons + " comparisons");
+    }
+
+    /**
+     * {@link org.matsim.core.router.AbstractLeastCostPathCalculatorTestWithTurnRestrictions}
+     * with forbidden turns {@code S1->1T} and {@code 23->34}, {@code 23->4T}.
+     */
+    private static Network buildTurnRestrictionsTestNetwork() {
+        Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+        Network network = scenario.getNetwork();
+        Node nodeS = NetworkUtils.createAndAddNode(network, Id.createNodeId("S"), new Coord(1, 2));
+        Node node1 = NetworkUtils.createAndAddNode(network, Id.createNodeId("1"), new Coord(1, 1));
+        Node node2 = NetworkUtils.createAndAddNode(network, Id.createNodeId("2"), new Coord(0, 1));
+        Node node3 = NetworkUtils.createAndAddNode(network, Id.createNodeId("3"), new Coord(0, 0));
+        Node node4 = NetworkUtils.createAndAddNode(network, Id.createNodeId("4"), new Coord(1, 0));
+        Node node5 = NetworkUtils.createAndAddNode(network, Id.createNodeId("5"), new Coord(2, 0));
+        Node nodeT = NetworkUtils.createAndAddNode(network, Id.createNodeId("T"), new Coord(2, 0));
+
+        Link linkS1 = NetworkUtils.createAndAddLink(network, Id.createLinkId("S1"), nodeS, node1, 1, 1, 1, 1);
+        NetworkUtils.createAndAddLink(network, Id.createLinkId("12"), node1, node2, 1, 1, 1, 1);
+        NetworkUtils.createAndAddLink(network, Id.createLinkId("1T"), node1, nodeT, 1, 1, 1, 1);
+        Link link23 = NetworkUtils.createAndAddLink(network, Id.createLinkId("23"), node2, node3, 1, 1, 1, 1);
+        NetworkUtils.createAndAddLink(network, Id.createLinkId("34"), node3, node4, 1, 1, 1, 1);
+        NetworkUtils.createAndAddLink(network, Id.createLinkId("4T"), node4, nodeT, 1, 1, 1, 1);
+        NetworkUtils.createAndAddLink(network, Id.createLinkId("45"), node4, node5, 1, 1, 1, 1);
+        NetworkUtils.createAndAddLink(network, Id.createLinkId("5T"), node5, nodeT, 1, 1, 1, 1);
+
+        NetworkUtils.addDisallowedNextLinks(linkS1, TransportMode.car, Arrays.asList(Id.createLinkId("1T")));
+        NetworkUtils.addDisallowedNextLinks(link23, TransportMode.car,
+                Arrays.asList(Id.createLinkId("34"), Id.createLinkId("4T")));
+        return network;
     }
 }


### PR DESCRIPTION
This enables `CHLeastCostPathTree` to consider turn restrictions correctly. Both forward and backward paths are tested now.