### PR TITLE
feat(router): network distance accumulation in CHLeastCostPathTree

### DIFF
--- a/matsim/src/main/java/org/matsim/core/router/speedy/CHBuilder.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/CHBuilder.java
@@ -2747,11 +2747,27 @@ public class CHBuilder {
             }
         }
 
+        // 7. Precompute per-edge accumulated network distance.
+        // For original edges: distance = link length.
+        // For shortcuts: distance = sum of the two lower edges' distances.
+        // customizeOrder visits lower edges before their parent shortcuts,
+        // so a single pass suffices.
+        double[] edgeDistance = new double[totalEdgeCount];
+        for (int i = 0; i < totalEdgeCount; i++) {
+            int e = customizeOrder[i];
+            int origLink = edgeOrigLink[e];
+            if (origLink >= 0) {
+                edgeDistance[e] = graph.getLink(origLink).getLength();
+            } else {
+                edgeDistance[e] = edgeDistance[edgeLower1[e]] + edgeDistance[edgeLower2[e]];
+            }
+        }
+
         return new CHGraph(graph, nodeCount,
                 totalUp, upOff, upCount, upEdges, upWeights,
                 totalDn, dnOff, dnCount, dnEdges, dnWeights,
                 totalEdgeCount, edgeOrigLink, edgeLower1, edgeLower2,
-                customizeOrder, nodeLevel);
+                edgeDistance, customizeOrder, nodeLevel);
     }
 
     // -------------------------------------------------------------------------

--- a/matsim/src/main/java/org/matsim/core/router/speedy/CHGraph.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/CHGraph.java
@@ -92,6 +92,7 @@ public class CHGraph {
     final int[]    edgeOrigLink;    // originalLinkIndex per global edge
     final int[]    edgeLower1;      // lowerEdge1 per global edge
     final int[]    edgeLower2;      // lowerEdge2 per global edge
+    final double[] edgeDistance;    // accumulated network distance per global edge (sum of original link lengths underneath)
 
     // Time-dependent TTF – bin-major flat contiguous array.
     // ttf[bin * totalEdgeCount + globalIdx] = travel time (seconds).
@@ -158,7 +159,7 @@ public class CHGraph {
                   int upEdgeCount, int[] upOff, int[] upLen, int[] upEdges, double[] upWeights,
                   int dnEdgeCount, int[] dnOff, int[] dnLen, int[] dnEdges, double[] dnWeights,
                   int totalEdgeCount, int[] edgeOrigLink, int[] edgeLower1, int[] edgeLower2,
-                  int[] customizeOrder, int[] nodeLevel) {
+                  double[] edgeDistance, int[] customizeOrder, int[] nodeLevel) {
         this.baseGraph      = baseGraph;
         this.nodeCount      = nodeCount;
         this.upEdgeCount    = upEdgeCount;
@@ -175,6 +176,7 @@ public class CHGraph {
         this.edgeOrigLink   = edgeOrigLink;
         this.edgeLower1     = edgeLower1;
         this.edgeLower2     = edgeLower2;
+        this.edgeDistance   = edgeDistance;
         this.customizeOrder = customizeOrder;
         this.nodeLevel      = nodeLevel;
         this.edgeWeights    = new double[totalEdgeCount];

--- a/matsim/src/main/java/org/matsim/core/router/speedy/CHLeastCostPathTree.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/CHLeastCostPathTree.java
@@ -97,6 +97,7 @@ public class CHLeastCostPathTree implements ShortestPathTree {
     private final double[] dnWeights;
     private final int[] sweepOrder;
     private final double[] ttf;
+    private final double[] edgeDistance;
     private final int totalEdgeCount;
 
     // Reverse CSR arrays for push-based Phase 2 sweep
@@ -129,6 +130,7 @@ public class CHLeastCostPathTree implements ShortestPathTree {
         this.dnWeights = chGraph.dnWeights;
         this.sweepOrder = chGraph.sweepOrder;
         this.ttf = chGraph.ttf;
+        this.edgeDistance = chGraph.edgeDistance;
         this.totalEdgeCount = chGraph.totalEdgeCount;
 
         // Reverse CSR for push-based Phase 2
@@ -208,6 +210,7 @@ public class CHLeastCostPathTree implements ShortestPathTree {
             // Iterate upward out-edges
             int uOff = upOff[v];
             int uEnd = uOff + upLen[v];
+            double vDist = getDistance(v);
             for (int slot = uOff; slot < uEnd; slot++) {
                 int eBase = slot * S;
                 int w = upEdges[eBase];
@@ -216,14 +219,15 @@ public class CHLeastCostPathTree implements ShortestPathTree {
                 double tTime = ttf[binOff + gIdx];
                 double newCost = cost + tTime;
                 double newArr = arr + tTime;
+                double newDist = vDist + edgeDistance[gIdx];
 
                 if (iterIds[w] == currentIteration) {
                     if (newCost < getCost(w)) {
-                        setNode(w, newCost, newArr, 0.0, v, gIdx);
+                        setNode(w, newCost, newArr, newDist, v, gIdx);
                         pq.decreaseKey(w, newCost);
                     }
                 } else {
-                    setNode(w, newCost, newArr, 0.0, v, gIdx);
+                    setNode(w, newCost, newArr, newDist, v, gIdx);
                     pq.insert(w, newCost);
                 }
             }
@@ -286,6 +290,7 @@ public class CHLeastCostPathTree implements ShortestPathTree {
             if (uCost >= maxCost) continue;
 
             double uArr = data[u * 3 + 1];      // getTimeRaw(u) inlined
+            double uDist = data[u * 3 + 2];     // getDistance(u) inlined
 
             // Push costs along u's outgoing downward edges (u→w, rank(w) < rank(u))
             int dOff = dnOutOff[u];
@@ -306,12 +311,13 @@ public class CHLeastCostPathTree implements ShortestPathTree {
                         ? data[wBase] : Double.POSITIVE_INFINITY;
 
                 if (newCost < wCost) {
+                    int gIdx = dnOutEdges[eBase + CHGraph.E_GIDX];
                     // setNode inlined for hot-path performance
                     data[wBase] = newCost;
                     data[wBase + 1] = uArr + tTime;
-                    data[wBase + 2] = 0.0;
+                    data[wBase + 2] = uDist + edgeDistance[gIdx];
                     comingFrom[w] = u;
-                    fromEdgeGIdx[w] = dnOutEdges[eBase + CHGraph.E_GIDX];
+                    fromEdgeGIdx[w] = gIdx;
                     iterIds[w] = iter;
                 }
             }
@@ -386,6 +392,7 @@ public class CHLeastCostPathTree implements ShortestPathTree {
 
             int dOff = dnOff[w];
             int dEnd = dOff + dnLen[w];
+            double wDist = getDistance(w);
             for (int slot = dOff; slot < dEnd; slot++) {
                 int eBase = slot * S;
                 int u = dnEdges[eBase];
@@ -393,16 +400,17 @@ public class CHLeastCostPathTree implements ShortestPathTree {
 
                 double edgeCost = chGraph.minTTF[gIdx];
                 double newCost = cost + edgeCost;
+                double newDist = wDist + edgeDistance[gIdx];
 
                 if (iterIds[u] == currentIteration) {
                     if (newCost < getCost(u)) {
                         double newTime = getTimeRaw(w) - edgeCost;
-                        setNode(u, newCost, newTime, 0.0, w, gIdx);
+                        setNode(u, newCost, newTime, newDist, w, gIdx);
                         pq.decreaseKey(u, newCost);
                     }
                 } else {
                     double newTime = getTimeRaw(w) - edgeCost;
-                    setNode(u, newCost, newTime, 0.0, w, gIdx);
+                    setNode(u, newCost, newTime, newDist, w, gIdx);
                     pq.insert(u, newCost);
                 }
             }
@@ -439,6 +447,7 @@ public class CHLeastCostPathTree implements ShortestPathTree {
             if (uCost >= maxCost) continue;      // cost-bounded pruning
 
             double uTime = data[u * 3 + 1];     // getTimeRaw(u) inlined
+            double uDist = data[u * 3 + 2];     // getDistance(u) inlined
 
             // Push cost from u back to lower-ranked w via incoming up-edges (w→u)
             int iOff = upInOff[u];
@@ -457,12 +466,13 @@ public class CHLeastCostPathTree implements ShortestPathTree {
                         ? data[wBase] : Double.POSITIVE_INFINITY;
 
                 if (newCost < wCost) {
+                    int gIdx = upInEdges[eBase + CHGraph.E_GIDX];
                     // setNode inlined
                     data[wBase] = newCost;
                     data[wBase + 1] = uTime - edgeCost;
-                    data[wBase + 2] = 0.0;
+                    data[wBase + 2] = uDist + edgeDistance[gIdx];
                     comingFrom[w] = u;
-                    fromEdgeGIdx[w] = upInEdges[eBase + CHGraph.E_GIDX];
+                    fromEdgeGIdx[w] = gIdx;
                     iterIds[w] = iter;
                 }
             }

--- a/matsim/src/test/java/org/matsim/core/router/speedy/CHLeastCostPathTreeTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/speedy/CHLeastCostPathTreeTest.java
@@ -1381,4 +1381,148 @@ public class CHLeastCostPathTreeTest {
                 Arrays.asList(Id.createLinkId("34"), Id.createLinkId("4T")));
         return network;
     }
+
+    // =========================================================================
+    // Distance accumulation tests
+    //
+    // CHLeastCostPathTree.getDistance(idx) must return the same network distance
+    // (sum of link lengths along the resolved shortest path) as plain
+    // LeastCostPathTree.  Distance is precomputed once per CH global edge
+    // (including shortcuts) at build time and accumulated during relaxation.
+    // =========================================================================
+
+    @Test
+    void testForwardDistanceMatchesDijkstra_grid() {
+        Network network = buildGridNetwork(10);
+        assertForwardDistanceMatchesDijkstra(network, 5);
+    }
+
+    @Test
+    void testBackwardDistanceMatchesDijkstra_grid() {
+        Network network = buildGridNetwork(10);
+        assertBackwardDistanceMatchesDijkstra(network, 5);
+    }
+
+    @Test
+    void testForwardDistanceMatchesDijkstra_equil() {
+        Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+        new MatsimNetworkReader(scenario.getNetwork()).readFile("test/scenarios/equil/network.xml");
+        assertForwardDistanceMatchesDijkstra(scenario.getNetwork(), 10);
+    }
+
+    @Test
+    void testBackwardDistanceMatchesDijkstra_equil() {
+        Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+        new MatsimNetworkReader(scenario.getNetwork()).readFile("test/scenarios/equil/network.xml");
+        assertBackwardDistanceMatchesDijkstra(scenario.getNetwork(), 10);
+    }
+
+    /**
+     * Forward distance with turn restrictions: the start link itself is not
+     * traversed (the tree is rooted at {@code startLink.getToNode()}); the
+     * legal path from node 1 is {@code 1->2->3->4->5->T} (5 links of length 1),
+     * not the forbidden {@code 1->T} (1 link).
+     */
+    @Test
+    void testForwardDistanceMatchesDijkstra_turnRestrictions() {
+        Network network = buildTurnRestrictionsTestNetwork();
+        FreespeedTravelTimeAndDisutility tc = new FreespeedTravelTimeAndDisutility(new ScoringConfigGroup());
+
+        SpeedyGraph baseGraph = SpeedyGraphBuilder.build(network);
+        InertialFlowCutter.NDOrderResult order = new InertialFlowCutter(baseGraph).computeOrderWithBatches();
+        CHGraph chGraph = new CHBuilder(baseGraph, tc).buildWithOrderParallel(order);
+        new CHTTFCustomizer().customize(chGraph, tc, tc);
+
+        CHLeastCostPathTree chTree = new CHLeastCostPathTree(chGraph, tc, tc);
+        LeastCostPathTree dijTree = new LeastCostPathTree(baseGraph, tc, tc);
+
+        Link startLink = network.getLinks().get(Id.createLinkId("S1"));
+        double depTime = 8.0 * 3600;
+        chTree.calculate(startLink, depTime, null, null);
+        dijTree.calculate(startLink, depTime, null, null);
+
+        int tIdx = network.getNodes().get(Id.createNodeId("T")).getId().index();
+        Assertions.assertEquals(5.0, dijTree.getDistance(tIdx), COST_TOLERANCE,
+                "test fixture broken: Dijkstra distance at T should be 5 (legal detour from node 1)");
+        Assertions.assertEquals(dijTree.getDistance(tIdx), chTree.getDistance(tIdx), COST_TOLERANCE,
+                "CH distance at T must match Dijkstra (legal 5-link detour from node 1)");
+    }
+
+    private static void assertForwardDistanceMatchesDijkstra(Network network, int numSources) {
+        FreespeedTravelTimeAndDisutility tc = new FreespeedTravelTimeAndDisutility(new ScoringConfigGroup());
+        SpeedyGraph baseGraph = SpeedyGraphBuilder.build(network);
+        InertialFlowCutter.NDOrderResult order = new InertialFlowCutter(baseGraph).computeOrderWithBatches();
+        CHGraph chGraph = new CHBuilder(baseGraph, tc).buildWithOrderParallel(order);
+        new CHTTFCustomizer().customize(chGraph, tc, tc);
+
+        CHLeastCostPathTree chTree = new CHLeastCostPathTree(chGraph, tc, tc);
+        LeastCostPathTree dijTree = new LeastCostPathTree(baseGraph, tc, tc);
+
+        List<Link> links = new ArrayList<>(network.getLinks().values());
+        Random rng = new Random(13);
+        int mismatches = 0;
+        int comparisons = 0;
+        double depTime = 8.0 * 3600;
+        for (int s = 0; s < numSources; s++) {
+            Link srcLink = links.get(rng.nextInt(links.size()));
+            chTree.calculate(srcLink, depTime, null, null);
+            dijTree.calculate(srcLink, depTime, null, null);
+
+            for (Node n : network.getNodes().values()) {
+                int idx = n.getId().index();
+                if (dijTree.getTime(idx).isUndefined()) continue;
+                comparisons++;
+                double chD = chTree.getDistance(idx);
+                double djD = dijTree.getDistance(idx);
+                if (Math.abs(chD - djD) > COST_TOLERANCE) {
+                    mismatches++;
+                    if (mismatches < 10) {
+                        System.err.printf("FWD-DIST MISMATCH src=%s node=%s: CH=%.6f Dijkstra=%.6f%n",
+                                srcLink.getId(), n.getId(), chD, djD);
+                    }
+                }
+            }
+        }
+        Assertions.assertEquals(0, mismatches,
+                mismatches + " forward-distance mismatches out of " + comparisons + " comparisons");
+    }
+
+    private static void assertBackwardDistanceMatchesDijkstra(Network network, int numArrivals) {
+        FreespeedTravelTimeAndDisutility tc = new FreespeedTravelTimeAndDisutility(new ScoringConfigGroup());
+        SpeedyGraph baseGraph = SpeedyGraphBuilder.build(network);
+        InertialFlowCutter.NDOrderResult order = new InertialFlowCutter(baseGraph).computeOrderWithBatches();
+        CHGraph chGraph = new CHBuilder(baseGraph, tc).buildWithOrderParallel(order);
+        new CHTTFCustomizer().customize(chGraph, tc, tc);
+
+        CHLeastCostPathTree chTree = new CHLeastCostPathTree(chGraph, tc, tc);
+        LeastCostPathTree dijTree = new LeastCostPathTree(baseGraph, tc, tc);
+
+        List<Link> links = new ArrayList<>(network.getLinks().values());
+        Random rng = new Random(17);
+        int mismatches = 0;
+        int comparisons = 0;
+        double arrTime = 8.0 * 3600;
+        for (int s = 0; s < numArrivals; s++) {
+            Link arrLink = links.get(rng.nextInt(links.size()));
+            chTree.calculateBackwards(arrLink, arrTime, null, null);
+            dijTree.calculateBackwards(arrLink, arrTime, null, null);
+
+            for (Node n : network.getNodes().values()) {
+                int idx = n.getId().index();
+                if (dijTree.getTime(idx).isUndefined()) continue;
+                comparisons++;
+                double chD = chTree.getDistance(idx);
+                double djD = dijTree.getDistance(idx);
+                if (Math.abs(chD - djD) > COST_TOLERANCE) {
+                    mismatches++;
+                    if (mismatches < 10) {
+                        System.err.printf("BWD-DIST MISMATCH arr=%s node=%s: CH=%.6f Dijkstra=%.6f%n",
+                                arrLink.getId(), n.getId(), chD, djD);
+                    }
+                }
+            }
+        }
+        Assertions.assertEquals(0, mismatches,
+                mismatches + " backward-distance mismatches out of " + comparisons + " comparisons");
+    }
 }


### PR DESCRIPTION
> -> Merge https://github.com/matsim-org/matsim-libs/pull/4986 before this one, this PR is stacked on it (the first commit).

`CHLeastCostPathTree.getDistance(idx)` returned `0.0` for every node because relaxations stored a constant `0.0` instead of accumulating link length.
This breaks any caller relying on the same `getDistance` contract as `LeastCostPathTree` (e.g. distance skim matrices).

### Changes
- precompute `double[] edgeDistance` once at CH build time: for original   edges = `link.getLength()`, for shortcuts = sum of the two lower edges' distances. Filled in `customizeOrder` so children precede parents   (single linear pass over `totalEdgeCount`).
- replace the `0.0` distance writes in `CHLeastCostPathTree` with `getDistance(predecessor) + edgeDistance[gIdx]` in all four relaxation sites (forward Dijkstra, forward sweep, backward Dijkstra, backward   sweep). Seeds remain at `0.0`.

### Tests
- five new cases in `CHLeastCostPathTreeTest` (forward/backward grid, forward/backward equil, turn-restricted detour). All five fail against the unfixed code; all 28 tests pass with the fix.