### PR TITLE
feat(router): add isWalkOnly flag to TravelInfo and update PTSkimMatrices logic

### DIFF
--- a/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/analysis/skims/PTSkimMatrices.java
+++ b/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/analysis/skims/PTSkimMatrices.java
@@ -316,7 +316,7 @@ public class PTSkimMatrices {
                     Id<TransitStopFacility> egressStopId = egressEntry.getKey();
                     Double egressTime = egressEntry.getValue();
                     TravelInfo info = tree.get(egressStopId);
-                    if (info != null && !info.isWalkOnly()) {
+                    if (info != null && !info.isWalkOnly) {
                         Double accessTime = accessTimes.get(info.departureStop);
                         ODConnection connection = new ODConnection(info.ptDepartureTime, info.ptTravelTime, accessTime, egressTime, info.transferCount, info);
                         connections.add(connection);

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorCore.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorCore.java
@@ -1141,6 +1141,8 @@ public class SwissRailRaptorCore {
         /** the costs an agent accumulates due to waiting at the first stop until the first pt vehicle departs. */
         public final double waitingCost;
 
+        public final boolean isWalkOnly;
+
         private final PathElement destinationPath;
 
         TravelInfo(Id<TransitStopFacility> departureStop, double departureTime, double arrivalTime, double travelCost, double accessTime, double accessCost, int transferCount, double waitingTime, double waitingCost, PathElement destinationPath) {
@@ -1155,6 +1157,7 @@ public class SwissRailRaptorCore {
             this.waitingTime = waitingTime;
             this.waitingCost = waitingCost;
             this.destinationPath = destinationPath;
+            this.isWalkOnly = computeWalkOnly(destinationPath);
         }
 
         public RaptorRoute getRaptorRoute() {
@@ -1168,11 +1171,11 @@ public class SwissRailRaptorCore {
             return createRaptorRoute(fromFacility, toFacility, this.destinationPath, firstPath.arrivalTime);
         }
 
-        public boolean isWalkOnly() {
-            if (this.destinationPath.comingFrom == null) {
+        private static boolean computeWalkOnly(PathElement destinationPath) {
+            if (destinationPath.comingFrom == null) {
                 return true;
             }
-            PathElement pe = this.destinationPath;
+            PathElement pe = destinationPath;
             while (pe != null) {
                 if (!pe.isTransfer) {
                     return false;


### PR DESCRIPTION
This change computes the `isWalkOnly` property once in the constructor of the `TravelInfo` object. 

Before, it was computed multiple times again in `PTSkimMatrices` resulting in a performance bottleneck.