### PR TITLE
perf(raptor): improve raptor performance for pt skim matrices

### DIFF
--- a/contribs/sbb-extensions/src/test/java/ch/sbb/matsim/analysis/skims/PTSkimBenchmark.java
+++ b/contribs/sbb-extensions/src/test/java/ch/sbb/matsim/analysis/skims/PTSkimBenchmark.java
@@ -1,0 +1,158 @@
+package ch.sbb.matsim.analysis.skims;
+
+import ch.sbb.matsim.routing.pt.raptor.RaptorParameters;
+import ch.sbb.matsim.routing.pt.raptor.RaptorStaticConfig;
+import ch.sbb.matsim.routing.pt.raptor.RaptorUtils;
+import ch.sbb.matsim.routing.pt.raptor.SwissRailRaptorData;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.network.io.MatsimNetworkReader;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.core.utils.misc.Counter;
+import org.matsim.core.utils.misc.Time;
+import org.matsim.pt.transitSchedule.api.TransitScheduleReader;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Standalone benchmark for the PT skim matrix computation (Raptor one-to-all).
+ *
+ * <p>Configure paths via system properties:
+ * <pre>{@code
+ *   -Dnetwork.path=... -Dschedule.path=... -Dzone.coordinates.path=...
+ * }</pre>
+ * or relies on default paths relative to the workspace.
+ *
+ * <p>To keep runtime short, only a single 1-hour time window is computed and the zone
+ * set can be limited via {@code -DmaxZones=100}.
+ *
+ * <p>Example invocation:
+ * <pre>{@code
+ * cd matsim-libs && mvn -pl contribs/sbb-extensions exec:java \
+ *   -Dexec.mainClass=ch.sbb.matsim.analysis.skims.PTSkimBenchmark \
+ *   -Dexec.classpathScope=test \
+ *   -DmaxZones=100
+ * }</pre>
+ */
+public class PTSkimBenchmark {
+
+	private static final String DEFAULT_NETWORK = "network.xml.zst";
+	private static final String DEFAULT_SCHEDULE = "schedule.xml.zst";
+	private static final String DEFAULT_ZONE_COORDS = "zone_coordinates.csv";
+
+	public static void main(String[] args) throws IOException {
+		String networkPath = System.getProperty("network.path", DEFAULT_NETWORK);
+		String schedulePath = System.getProperty("schedule.path", DEFAULT_SCHEDULE);
+		String zoneCoordinatesPath = System.getProperty("zone.coordinates.path", DEFAULT_ZONE_COORDS);
+		int maxZones = Integer.parseInt(System.getProperty("maxZones", "100"));
+		int numberOfThreads = Integer.parseInt(System.getProperty("threads", String.valueOf(Runtime.getRuntime().availableProcessors())));
+
+		System.out.println("=== PT Skim Benchmark ===");
+		System.out.println("  network:     " + networkPath);
+		System.out.println("  schedule:    " + schedulePath);
+		System.out.println("  zones:       " + zoneCoordinatesPath);
+		System.out.println("  maxZones:    " + maxZones);
+		System.out.println("  threads:     " + numberOfThreads);
+		System.out.println();
+
+		// --- Load network + schedule ---
+		long t0 = System.currentTimeMillis();
+		Config config = ConfigUtils.createConfig();
+		Scenario scenario = ScenarioUtils.createScenario(config);
+		new MatsimNetworkReader(scenario.getNetwork()).readFile(networkPath);
+		new TransitScheduleReader(scenario).readFile(schedulePath);
+		long loadMs = System.currentTimeMillis() - t0;
+		System.out.println("Loaded network + schedule in " + loadMs + " ms");
+
+		// --- Prepare Raptor data ---
+		t0 = System.currentTimeMillis();
+		RaptorStaticConfig raptorConfig = RaptorUtils.createStaticConfig(config);
+		raptorConfig.setOptimization(RaptorStaticConfig.RaptorOptimization.OneToAllRouting);
+		SwissRailRaptorData raptorData = SwissRailRaptorData.create(
+				scenario.getTransitSchedule(), scenario.getTransitVehicles(),
+				raptorConfig, scenario.getNetwork(), null);
+		long prepMs = System.currentTimeMillis() - t0;
+		System.out.println("Raptor data preparation: " + prepMs + " ms");
+
+		// --- Load zone coordinates (subset) ---
+		t0 = System.currentTimeMillis();
+		Map<String, Coord[]> coordsPerZone = loadZoneCoordinates(zoneCoordinatesPath, maxZones);
+		long zoneMs = System.currentTimeMillis() - t0;
+		System.out.println("Loaded " + coordsPerZone.size() + " zones (" + countCoords(coordsPerZone) + " coords) in " + zoneMs + " ms");
+		System.out.println();
+
+		// --- Benchmark: single time window 12:00-13:00 ---
+		double startTime = Time.parseTime("12:00:00");
+		double endTime = Time.parseTime("13:00:00");
+		double stepSize = 120; // seconds between departure probes
+		RaptorParameters raptorParameters = RaptorUtils.createParameters(config);
+
+		System.out.println("Starting PT skim computation: " + Time.writeTime(startTime) + " - " + Time.writeTime(endTime)
+				+ ", step=" + (int) stepSize + "s, " + coordsPerZone.size() + " zones");
+
+		long benchStart = System.currentTimeMillis();
+		PTSkimMatrices.PtIndicators<String> result = PTSkimMatrices.calculateSkimMatrices(
+				raptorData, coordsPerZone, startTime, endTime, stepSize,
+				raptorParameters, numberOfThreads,
+				(line, route) -> "rail".equals(route.getTransportMode()),
+				new PTSkimMatrices.CoordAggregator() {});
+		long benchMs = System.currentTimeMillis() - benchStart;
+
+		// --- Report ---
+		int zones = coordsPerZone.size();
+		long odPairs = (long) zones * zones;
+		double odPerSec = odPairs / (benchMs / 1000.0);
+
+		System.out.println();
+		System.out.println("=== Results ===");
+		System.out.println("  Zones:       " + zones);
+		System.out.println("  OD pairs:    " + odPairs);
+		System.out.println("  Wall-clock:  " + benchMs + " ms (" + String.format("%.1f", benchMs / 1000.0) + " s)");
+		System.out.println("  Throughput:  " + String.format("%.0f", odPerSec) + " OD/s");
+		System.out.println("  Threads:     " + numberOfThreads);
+		System.out.println();
+
+		// prevent dead-code elimination
+		System.out.println("  (checksum: adaptionTime[0,0]=" + result.adaptionTimeMatrix.get(
+				coordsPerZone.keySet().iterator().next(), coordsPerZone.keySet().iterator().next()) + ")");
+	}
+
+	private static Map<String, Coord[]> loadZoneCoordinates(String filename, int maxZones) throws IOException {
+		Map<String, java.util.List<Coord>> tmp = new HashMap<>();
+		try (BufferedReader reader = Files.newBufferedReader(Path.of(filename))) {
+			String header = reader.readLine(); // skip header
+			String line;
+			while ((line = reader.readLine()) != null) {
+				String[] parts = line.split(";");
+				String zoneId = parts[0];
+				if (tmp.size() >= maxZones && !tmp.containsKey(zoneId)) {
+					continue; // limit zone count
+				}
+				double x = Double.parseDouble(parts[2]);
+				double y = Double.parseDouble(parts[3]);
+				tmp.computeIfAbsent(zoneId, k -> new java.util.ArrayList<>()).add(new Coord(x, y));
+			}
+		}
+		// convert to Coord[]
+		Map<String, Coord[]> result = new HashMap<>();
+		for (Map.Entry<String, java.util.List<Coord>> entry : tmp.entrySet()) {
+			result.put(entry.getKey(), entry.getValue().toArray(new Coord[0]));
+		}
+		return result;
+	}
+
+	private static int countCoords(Map<String, Coord[]> coordsPerZone) {
+		int count = 0;
+		for (Coord[] coords : coordsPerZone.values()) {
+			count += coords.length;
+		}
+		return count;
+	}
+}

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorCore.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorCore.java
@@ -597,11 +597,10 @@ public class SwissRailRaptorCore {
 
         // collect information for each stop
         Map<Id<TransitStopFacility>, TravelInfo> result = new HashMap<>();
-        for (Map.Entry<TransitStopFacility, Integer> e : this.data.stopFacilityIndices.entrySet()) {
-            TransitStopFacility stop = e.getKey();
-            int index = e.getValue();
+        for (int index = 0; index < this.data.countStops; index++) {
             PathElement destination = this.arrivalPathPerStop[index];
             if (destination != null) {
+                TransitStopFacility stop = this.data.stopFacilities[index];
                 TravelInfo ti = getTravelInfo(destination, parameters);
                 result.put(stop.getId(), ti);
             }

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorCore.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorCore.java
@@ -55,14 +55,15 @@ public class SwissRailRaptorCore {
     private final double[] egressCostsPerRouteStop;
     private final double[] leastArrivalCostAtRouteStop;
     private final double[] leastArrivalCostAtStop;
-    private final BitSet improvedRouteStopIndices;
-    private final BitSet reachedRouteStopIndices;
-    private final BitSet improvedStops;
-    private final BitSet destinationRouteStopIndices;
+    private final FixedBitSet improvedRouteStopIndices;
+    private final FixedBitSet improvedStops;
+    private final FixedBitSet destinationRouteStopIndices;
     private double bestArrivalCost = Double.POSITIVE_INFINITY;
     private final PathElement[] arrivalPathPerStop;
     private final PathElement[] tmpArrivalPathPerStop; // only used to ensure parallel update
-    private final BitSet tmpImprovedStops; // only used to ensure parallel update
+    private final FixedBitSet tmpImprovedStops; // only used to ensure parallel update
+    private final FixedBitSet scratchRouteStopBits;
+    private final FixedBitSet scratchStopBits;
     private final boolean useCapacityConstraints;
     private final boolean useAdaptiveTransferCalculation;
     private final RaptorInVehicleCostCalculator inVehicleCostCalculator;
@@ -77,13 +78,14 @@ public class SwissRailRaptorCore {
         this.egressCostsPerRouteStop = new double[data.countRouteStops];
         this.leastArrivalCostAtRouteStop = new double[data.countRouteStops];
         this.leastArrivalCostAtStop = new double[data.countStops];
-        this.improvedRouteStopIndices = new BitSet(this.data.countRouteStops);
-        this.reachedRouteStopIndices = new BitSet(this.data.countRouteStops);
-        this.destinationRouteStopIndices = new BitSet(this.data.countRouteStops);
-        this.improvedStops = new BitSet(this.data.countStops);
+        this.improvedRouteStopIndices = new FixedBitSet(this.data.countRouteStops);
+        this.destinationRouteStopIndices = new FixedBitSet(this.data.countRouteStops);
+        this.improvedStops = new FixedBitSet(this.data.countStops);
+        this.scratchRouteStopBits = new FixedBitSet(this.data.countRouteStops);
+        this.scratchStopBits = new FixedBitSet(this.data.countStops);
         this.arrivalPathPerStop = new PathElement[this.data.countStops];
         this.tmpArrivalPathPerStop = new PathElement[this.data.countStops];
-        this.tmpImprovedStops = new BitSet(this.data.countStops);
+        this.tmpImprovedStops = new FixedBitSet(this.data.countStops);
         this.useCapacityConstraints = this.data.config.isUseCapacityConstraints();
         this.useAdaptiveTransferCalculation = this.data.config.getTransferCalculation().equals(RaptorTransferCalculation.Adaptive);
         this.inVehicleCostCalculator = inVehicleCostCalculator;
@@ -99,8 +101,9 @@ public class SwissRailRaptorCore {
         Arrays.fill(this.leastArrivalCostAtStop, Double.POSITIVE_INFINITY);
         this.improvedStops.clear();
         this.improvedRouteStopIndices.clear();
-        this.reachedRouteStopIndices.clear();
         this.destinationRouteStopIndices.clear();
+        this.scratchRouteStopBits.clear();
+        this.scratchStopBits.clear();
         this.bestArrivalCost = Double.POSITIVE_INFINITY;
     }
 
@@ -237,11 +240,11 @@ public class SwissRailRaptorCore {
             // handleTransfers clears improvedRouteStopIndices, which is correct during rounds
             // but it loses the initial route stop indices directly after initialization.
             // so keep a copy and restore it
-            BitSet initialRouteStopIndices = new BitSet();
-            initialRouteStopIndices.or(this.improvedRouteStopIndices);
+            this.scratchRouteStopBits.copyFrom(this.improvedRouteStopIndices);
 
             handleTransfers(true, parameters, transferProvider);
-            this.improvedRouteStopIndices.or(initialRouteStopIndices);
+            this.improvedRouteStopIndices.or(this.scratchRouteStopBits);
+            this.scratchRouteStopBits.clear();
         }
 
         int allowedTransfersLeft = maxTransfersAfterFirstArrival;
@@ -503,8 +506,7 @@ public class SwissRailRaptorCore {
         reset();
 
         CachingTransferProvider transferProvider = this.data.new CachingTransferProvider();
-        BitSet initialRouteStopIndices = new BitSet();
-        BitSet initialStopIndices = new BitSet();
+        boolean hasInitialBits = true;
         for (InitialStop stop : startStops) {
             int[] routeStopIndices = this.data.routeStopsPerStopFacility.get(stop.stop);
             for (int routeStopIndex : routeStopIndices) {
@@ -536,8 +538,8 @@ public class SwissRailRaptorCore {
 								this.leastArrivalCostAtStop[toRouteStop.stopFacilityIndex] = arrivalCost;
 								this.improvedRouteStopIndices.set(routeStopIndex);
 								// this is special: make sure we can transfer even at the start stop
-								initialRouteStopIndices.set(routeStopIndex);
-								initialStopIndices.set(toRouteStop.stopFacilityIndex);
+								this.scratchRouteStopBits.set(routeStopIndex);
+								this.scratchStopBits.set(toRouteStop.stopFacilityIndex);
 							}
             }
         }
@@ -556,11 +558,12 @@ public class SwissRailRaptorCore {
                 break;
             }
 
-            if (initialRouteStopIndices != null) {
-                this.improvedRouteStopIndices.or(initialRouteStopIndices);
-                this.improvedStops.or(initialStopIndices);
-                initialRouteStopIndices = null;
-                initialStopIndices = null;
+            if (hasInitialBits) {
+                this.improvedRouteStopIndices.or(this.scratchRouteStopBits);
+                this.improvedStops.or(this.scratchStopBits);
+                this.scratchRouteStopBits.clear();
+                this.scratchStopBits.clear();
+                hasInitialBits = false;
             }
 
             if (transfers > maxTransfers) {
@@ -653,7 +656,6 @@ public class SwissRailRaptorCore {
 
     private void exploreRoutes(RaptorParameters parameters, Person person, CachingTransferProvider transferProvider) {
         this.improvedStops.clear();
-        this.reachedRouteStopIndices.clear();
 
         MutableInt routeIndex = new MutableInt(-1);
         for (int firstRouteStopIndex = this.improvedRouteStopIndices.nextSetBit(0); firstRouteStopIndex >= 0; firstRouteStopIndex = this.improvedRouteStopIndices.nextSetBit(firstRouteStopIndex+1)) {
@@ -1116,6 +1118,65 @@ public class SwissRailRaptorCore {
             this.depTime = depTime;
             this.costOffset = costOffset;
             this.accessStop = accessStop;
+        }
+    }
+
+    /**
+     * Lightweight replacement for {@link java.util.BitSet} that avoids the
+     * {@code expandTo}/{@code wordsInUse} bookkeeping overhead on every {@code set()} call.
+     * The backing {@code long[]} is pre-allocated to its full size and never grows.
+     */
+    private static final class FixedBitSet {
+        final long[] words;
+
+        FixedBitSet(int nbits) {
+            this.words = new long[Math.max(1, (nbits + 63) >>> 6)];
+        }
+
+        void set(int index) {
+            words[index >>> 6] |= 1L << index;
+        }
+
+        boolean get(int index) {
+            return (words[index >>> 6] & (1L << index)) != 0;
+        }
+
+        void clear(int index) {
+            words[index >>> 6] &= ~(1L << index);
+        }
+
+        void clear() {
+            Arrays.fill(words, 0L);
+        }
+
+        boolean isEmpty() {
+            for (long w : words) {
+                if (w != 0) return false;
+            }
+            return true;
+        }
+
+        int nextSetBit(int fromIndex) {
+            int u = fromIndex >>> 6;
+            if (u >= words.length) return -1;
+            long word = words[u] & (-1L << fromIndex);
+            while (true) {
+                if (word != 0) return (u << 6) + Long.numberOfTrailingZeros(word);
+                if (++u == words.length) return -1;
+                word = words[u];
+            }
+        }
+
+        void or(FixedBitSet other) {
+            long[] otherWords = other.words;
+            int len = Math.min(words.length, otherWords.length);
+            for (int i = 0; i < len; i++) {
+                words[i] |= otherWords[i];
+            }
+        }
+
+        void copyFrom(FixedBitSet other) {
+            System.arraycopy(other.words, 0, words, 0, Math.min(words.length, other.words.length));
         }
     }
 

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorCore.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorCore.java
@@ -30,6 +30,7 @@ import ch.sbb.matsim.routing.pt.raptor.SwissRailRaptorData.RRouteStop;
 import ch.sbb.matsim.routing.pt.raptor.SwissRailRaptorData.RTransfer;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.IdMap;
 import org.matsim.api.core.v01.TransportMode;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.facilities.Facility;
@@ -596,7 +597,7 @@ public class SwissRailRaptorCore {
 				}
 
         // collect information for each stop
-        Map<Id<TransitStopFacility>, TravelInfo> result = new HashMap<>();
+        Map<Id<TransitStopFacility>, TravelInfo> result = new IdMap<>(TransitStopFacility.class, this.data.countStops);
         for (int index = 0; index < this.data.countStops; index++) {
             PathElement destination = this.arrivalPathPerStop[index];
             if (destination != null) {

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorData.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorData.java
@@ -65,6 +65,7 @@ public class SwissRailRaptorData {
     final RTransfer[] transfers;
 	final Int2ObjectMap<RChained[]> chainedDepartures; // departure id to other departure ids
     final Map<TransitStopFacility, Integer> stopFacilityIndices;
+    final TransitStopFacility[] stopFacilities; // reverse lookup: index -> facility
     final Map<TransitStopFacility, int[]> routeStopsPerStopFacility;
     final QuadTree<TransitStopFacility> stopsQT;
     final Map<String, Map<String, QuadTree<TransitStopFacility>>> stopFilterAttribute2Value2StopsQT;
@@ -91,6 +92,10 @@ public class SwissRailRaptorData {
         this.transfers = transfers;
 		this.chainedDepartures = chainedDepartures;
         this.stopFacilityIndices = stopFacilityIndices;
+        this.stopFacilities = new TransitStopFacility[countStops];
+        for (Map.Entry<TransitStopFacility, Integer> entry : stopFacilityIndices.entrySet()) {
+            this.stopFacilities[entry.getValue()] = entry.getKey();
+        }
         this.routeStopsPerStopFacility = routeStopsPerStopFacility;
         this.stopsQT = stopsQT;
         this.stopFilterAttribute2Value2StopsQT = new HashMap<>();


### PR DESCRIPTION
This change reduces wall-clock time for one-to-all PT skim computation. It was tested with the attached benchmark class on a network with the following properties and resulted in a 20% speed-up:

| Resource | Count |
|---|---|
| Network nodes | 69,149 |
| Network links | 165,460 |
| Transit stop facilities | 41,820 |
| Transit routes | 12,924 |
| Transit lines | 1,378 |
| Benchmark zones | 100 (of the full set) |

**Commit `6fcb4a0`: Replace BitSet with FixedBitSet**
Introduces a lightweight `FixedBitSet` backed by pre-allocated `long[]`, eliminating the `expandTo`/`wordsInUse` bookkeeping that `java.util.BitSet` performs on every `set()` call after `clear()`. Also removes the unused `reachedRouteStopIndices` field and replaces per-call local `BitSet` allocations with reusable scratch fields.

**Commit `95c6c67`: Add reverse stop facility lookup array**
Adds a `TransitStopFacility[]` reverse-index array to `SwissRailRaptorData`, allowing `calcLeastCostTree` to iterate `arrivalPathPerStop` directly by index instead of iterating the `stopFacilityIndices` HashMap.

**Commit `0c9ccbb`: Replace HashMap with IdMap for result collection**
Changes the result map in `calcLeastCostTree` from `HashMap<Id<TransitStopFacility>, TravelInfo>` to `IdMap`, which uses `Id.index()` for O(1) array-backed put/get. This eliminates hash computation, bucket management, and dynamic resizing — previously 11% of CPU.

**Commit `5b9dc3a`: Add standalone PT skim benchmark**
Adds `PTSkimBenchmark` in sbb-extensions test sources for reproducible wall-clock and throughput measurement of the skim matrix computation.

@mrieser If you can spare the time, could you have a look and decide, whether these changes are worth the complexity they add?