### PR TITLE
fix(drt): handle several stops on the same link in DrtAnalysisPostProcessing

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/dashboards/DrtAnalysisPostProcessing.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/dashboards/DrtAnalysisPostProcessing.java
@@ -183,7 +183,10 @@ public final class DrtAnalysisPostProcessing implements MATSimAppCommand {
 		if (stopsFile != null) {
 			List<TransitStopFacility> stops = readTransitStops(stopsFile);
 			writeStopsShp(stops, output.getPath("stops.shp"));
-			Map<String, TransitStopFacility> byLink = stops.stream().collect(Collectors.toMap(s -> s.getLinkId().toString(), Function.identity()));
+
+			Map<String, TransitStopFacility> byLink = stops.stream().collect(Collectors.toMap(s -> s.getLinkId().toString(), Function.identity(),
+				//when several stops have the same link id, only one is kept. the resulting map will be used for link-based analysis only, anyways.
+				(s, a) -> s));
 
 			//needs to be a DoubleColumn because transposing later forces us to have the same column type for all (new) value columns
 			tableSupplyKPI.addColumns(DoubleColumn.create("Number of stops", new Integer[]{stops.size()}));


### PR DESCRIPTION
Several stops in the same link led to an IllegalArgumentException during analysis.

This is fixed by this PR:
As the line of code inducing this exception is only preparing link-based analysis, anyway, we can just store one random stop out of the set of stops on the given link