### PR TITLE
fix: BicycleParamsDefaultImpl.java -- infrastructure factor for highway cycleway

### DIFF
--- a/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/BicycleParamsDefaultImpl.java
+++ b/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/BicycleParamsDefaultImpl.java
@@ -48,6 +48,7 @@ public class BicycleParamsDefaultImpl implements BicycleParams {
 		// janek may '23
 
 		if (type == null) return 0.85;
+		if (type.equals("cycleway")) return 1.0;
 		if (hasNoCycleway(cyclewaytype)) {
 			return switch (type) {
 				case "trunk" -> 0.05;


### PR DESCRIPTION
Hey hey, 

I believe that that the tag highway=cycleway is actually not usually used together with the cycleway tag, since the cycleway tag specifies a cycle path that is part of a road, whereas highway=cycleway means that it is already a completely separate cycle path. https://wiki.openstreetmap.org/wiki/Tag:highway%3Dcycleway

Hence, highway=cycleway will fall into the hasNoCycleway if branch and will be assigned 0.95 by default, while it should have the best possible infrastructure factor of 1. 

In my network (Brussels), I only ever saw type=cycleway and cycleway not being set or type=anything else and cycleway being set.