### PR TITLE
feat(freigh): Add usable range for range constraint freight

### DIFF
--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/FreightCarriersConfigGroup.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/FreightCarriersConfigGroup.java
@@ -57,6 +57,11 @@ public class FreightCarriersConfigGroup extends ReflectiveConfigGroup {
     private UseDistanceConstraintForTourPlanning useDistanceConstraintForTourPlanning = UseDistanceConstraintForTourPlanning.noDistanceConstraint;
     private static final String USE_DISTANCE_CONSTRAINT_DESC = "Use distance constraint within the tour planning phase. This does NOT ensure that the tours in MATSim will respect this limitation";
 
+	static final String DISTANCE_CONSTRAINT_USABLE_RANGE = "distanceConstraintUsableRange";
+	private static final String DISTANCE_CONSTRAINT_USABLE_RANGE_DESC = "Usable vehicle range in percent for tour planning in Jsprit. "
+		+ "For example, a value of 90 limits the usable range to 90 percent of the vehicle range. Default value is 100 percent.";
+	private double distanceConstraintUsableRange = 100.;
+
     public FreightCarriersConfigGroup() {
         super(GROUPNAME);
     }
@@ -176,6 +181,22 @@ public class FreightCarriersConfigGroup extends ReflectiveConfigGroup {
 		this.useDistanceConstraintForTourPlanning = useDistanceConstraintForTourPlanning;
 	}
 
+	/**
+	 * @return distanceConstraintUsableRange -- {@value #DISTANCE_CONSTRAINT_USABLE_RANGE_DESC}
+	 */
+	@StringGetter(DISTANCE_CONSTRAINT_USABLE_RANGE)
+	public double getDistanceConstraintUsableRange() {
+		return distanceConstraintUsableRange;
+	}
+
+	/**
+	 * @param distanceConstraintUsableRange {@value #DISTANCE_CONSTRAINT_USABLE_RANGE_DESC}
+	 */
+	@StringSetter(DISTANCE_CONSTRAINT_USABLE_RANGE)
+	public void setDistanceConstraintUsableRange(double distanceConstraintUsableRange) {
+		this.distanceConstraintUsableRange = distanceConstraintUsableRange;
+	}
+
 	//---
 	//---
 	@Override
@@ -186,6 +207,7 @@ public class FreightCarriersConfigGroup extends ReflectiveConfigGroup {
         map.put(VEHICLE_ROUTING_ALGORITHM, VEHICLE_ROUTING_ALGORITHM_DESC);
         map.put(TRAVEL_TIME_SLICE_WIDTH, TRAVEL_TIME_SLICE_WIDTH_DESC);
         map.put(USE_DISTANCE_CONSTRAINT, USE_DISTANCE_CONSTRAINT_DESC);
+        map.put(DISTANCE_CONSTRAINT_USABLE_RANGE, DISTANCE_CONSTRAINT_USABLE_RANGE_DESC);
         return map;
     }
 

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/DistanceConstraint.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/DistanceConstraint.java
@@ -51,7 +51,9 @@ import org.matsim.vehicles.VehicleUtils;
  */
 /* package-private */ class DistanceConstraint implements HardActivityConstraint {
 
-	@SuppressWarnings("unused")
+	// Recalculating every candidate route is expensive, so only do it close to the usable range limit.
+	private static final double FULL_ROUTE_RECALCULATION_THRESHOLD = 0.9;
+
 	private static final Logger log = LogManager.getLogger(DistanceConstraint.class);
 
 	private final CarrierVehicleTypes vehicleTypes;
@@ -146,7 +148,20 @@ import org.matsim.vehicles.VehicleUtils;
 			additionalConsumptionOfPickup = additionalDistanceOfPickup * (consumptionPerMeter);
 		}
 
-		if (currentRouteConsumption + additionalConsumption + additionalConsumptionOfPickup > energyCapacityInKWhOrLiters)
+		double estimatedConsumption = currentRouteConsumption + additionalConsumption + additionalConsumptionOfPickup;
+		if (estimatedConsumption < energyCapacityInKWhOrLiters * FULL_ROUTE_RECALCULATION_THRESHOLD)
+			return ConstraintsStatus.FULFILLED;
+
+		// Static routing cannot change the distance of subsequent legs. During pickup evaluation, jsprit has also not
+		// selected the delivery position yet; the complete shipment is recalculated with its delivery candidate.
+		// recalculation is only done if the network is time-dependent
+		if (!netBasedCosts.usesTimeDependentRouting() || newAct instanceof PickupShipment)
+			return estimatedConsumption > energyCapacityInKWhOrLiters
+				? ConstraintsStatus.NOT_FULFILLED
+				: ConstraintsStatus.FULFILLED;
+
+		double recalculatedConsumption = calculateRouteDistanceWithInsertion(context, newAct, newVehicle) * consumptionPerMeter;
+		if (recalculatedConsumption > energyCapacityInKWhOrLiters)
 			return ConstraintsStatus.NOT_FULFILLED;
 
 		return ConstraintsStatus.FULFILLED;
@@ -174,6 +189,64 @@ import org.matsim.vehicles.VehicleUtils;
 		realRouteDistance = realRouteDistance + getDistance(
 				context.getRoute().getTourActivities().getActivities().get(n), context.getRoute().getEnd(), newVehicle, from.getEndTime());
 		return realRouteDistance;
+	}
+
+	/**
+	 * Recalculates the complete candidate route while propagating its departure times. Thus, an insertion can also
+	 * change the time-dependent distance of all subsequent legs.
+	 */
+	private double calculateRouteDistanceWithInsertion(JobInsertionContext context, TourActivity newAct, Vehicle vehicle) {
+		List<TourActivity> activities = createActivitySequenceWithInsertion(context, newAct);
+		Location previousLocation = vehicle.getStartLocation();
+		double departureTime = context.getNewDepTime();
+		double distance = 0.;
+
+		for (TourActivity activity : activities) {
+			distance += getDistance(previousLocation, activity.getLocation(), vehicle, departureTime);
+			double arrivalTime = departureTime + netBasedCosts.getTransportTime(
+				previousLocation, activity.getLocation(), departureTime, context.getNewDriver(), vehicle);
+			double operationStartTime = Math.max(arrivalTime, activity.getTheoreticalEarliestOperationStartTime());
+			departureTime = operationStartTime + activity.getOperationTime(); // + activityCosts.getActivityDuration(activity, arrivalTime, context.getNewDriver(), vehicle);
+			previousLocation = activity.getLocation();
+		}
+
+		if (vehicle.isReturnToDepot()) {
+			distance += getDistance(previousLocation, vehicle.getEndLocation(), vehicle, departureTime);
+		}
+		return distance;
+	}
+
+	/**
+	 * Creates the complete activity sequence represented by the current insertion context. Shipment pickup and
+	 * delivery indices both refer to positions in the original route.
+	 */
+	private List<TourActivity> createActivitySequenceWithInsertion(JobInsertionContext context, TourActivity newAct) {
+		List<TourActivity> currentActivities = context.getRoute().getActivities();
+		List<TourActivity> activitiesWithInsertion = new ArrayList<>(currentActivities.size() + 2);
+		int insertionIndex = context.getActivityContext().getInsertionIndex();
+
+		if (newAct instanceof DeliverShipment) {
+			int pickupInsertionIndex = context.getRelatedActivityContext().getInsertionIndex();
+			TourActivity pickup = context.getAssociatedActivities().getFirst();
+			for (int index = 0; index <= currentActivities.size(); index++) {
+				if (index == pickupInsertionIndex) activitiesWithInsertion.add(pickup);
+				if (index == insertionIndex) activitiesWithInsertion.add(newAct);
+				if (index < currentActivities.size()) activitiesWithInsertion.add(currentActivities.get(index));
+			}
+		} else {
+			activitiesWithInsertion.addAll(currentActivities.subList(0, insertionIndex));
+			activitiesWithInsertion.add(newAct);
+			activitiesWithInsertion.addAll(currentActivities.subList(insertionIndex, currentActivities.size()));
+		}
+		return activitiesWithInsertion;
+	}
+
+	private double calculateDepartureTimeAtNewActivity(JobInsertionContext context, TourActivity prevAct,
+			TourActivity newAct, Vehicle vehicle, double prevActDepTime) {
+			double arrivalTime = prevActDepTime + netBasedCosts.getTransportTime(
+			prevAct.getLocation(), newAct.getLocation(), prevActDepTime, context.getNewDriver(), vehicle);
+		double operationStartTime = Math.max(arrivalTime, newAct.getTheoreticalEarliestOperationStartTime());
+		return operationStartTime + newAct.getOperationTime(); //.activityCosts.getActivityDuration(newAct, arrivalTime, context.getNewDriver(), vehicle);
 	}
 
 	private double getDistance(TourActivity from, TourActivity to, Vehicle vehicle, double departureTime) {

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/DistanceConstraint.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/DistanceConstraint.java
@@ -21,6 +21,7 @@
 
 package org.matsim.freight.carriers.jsprit;
 
+import com.graphhopper.jsprit.core.problem.Location;
 import com.graphhopper.jsprit.core.problem.constraint.HardActivityConstraint;
 import com.graphhopper.jsprit.core.problem.misc.JobInsertionContext;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.*;
@@ -108,10 +109,12 @@ import org.matsim.vehicles.VehicleUtils;
 
 		double currentDistance = calculateRouteDistance(context, newVehicle);
 		double currentRouteConsumption = currentDistance * (consumptionPerMeter);
-		if (currentRouteConsumption > energyCapacityInKWhOrLiters) return ConstraintsStatus.NOT_FULFILLED_BREAK;
+		if (currentRouteConsumption > energyCapacityInKWhOrLiters && newAct instanceof PickupShipment)
+			return ConstraintsStatus.NOT_FULFILLED_BREAK;
 
 		double distancePrevAct2NewAct = getDistance(prevAct, newAct, newVehicle, prevActDepTime);
-		double distanceNewAct2nextAct = getDistance(newAct, nextAct, newVehicle, prevActDepTime);
+		double newActDepTime = calculateDepartureTimeAtNewActivity(context, prevAct, newAct, newVehicle, prevActDepTime);
+		double distanceNewAct2nextAct = getDistance(newAct, nextAct, newVehicle, newActDepTime);
 		double distancePrevAct2NextAct = getDistance(prevAct, nextAct, newVehicle, prevActDepTime);
 		if (prevAct instanceof Start && nextAct instanceof End) distancePrevAct2NextAct = 0;
 		if (nextAct instanceof End && !context.getNewVehicle().isReturnToDepot()) {
@@ -120,25 +123,30 @@ import org.matsim.vehicles.VehicleUtils;
 		}
 		double additionalDistance = distancePrevAct2NewAct + distanceNewAct2nextAct - distancePrevAct2NextAct;
 		double additionalConsumption = additionalDistance * (consumptionPerMeter);
-		if (currentRouteConsumption + additionalConsumption > energyCapacityInKWhOrLiters) return ConstraintsStatus.NOT_FULFILLED;
-
 
 		double additionalDistanceOfPickup;
 		double additionalConsumptionOfPickup = 0;
 		if (newAct instanceof DeliverShipment) {
 			int iIndexOfPickup = context.getRelatedActivityContext().getInsertionIndex();
 			TourActivity pickup = context.getAssociatedActivities().getFirst();
-			TourActivity actBeforePickup;
-			if (iIndexOfPickup > 0) actBeforePickup = context.getRoute().getActivities().get(iIndexOfPickup - 1);
-			else actBeforePickup = new Start(context.getNewVehicle().getStartLocation(), 0, Double.MAX_VALUE);
+			Location beforePickupLocation;
+			double beforePickupDepTime;
+			if (iIndexOfPickup > 0) {
+				TourActivity actBeforePickup = context.getRoute().getActivities().get(iIndexOfPickup - 1);
+				beforePickupLocation = actBeforePickup.getLocation();
+				beforePickupDepTime = actBeforePickup.getEndTime();
+			} else {
+				beforePickupLocation = context.getNewVehicle().getStartLocation();
+				beforePickupDepTime = context.getNewDepTime();
+			}
 			TourActivity actAfterPickup;
 			if (iIndexOfPickup < context.getRoute().getActivities().size())
 				actAfterPickup = context.getRoute().getActivities().get(iIndexOfPickup);
 			else
 				actAfterPickup = nextAct;
-			double distanceActBeforePickup2Pickup = getDistance(actBeforePickup, pickup, newVehicle, actBeforePickup.getEndTime());
+			double distanceActBeforePickup2Pickup = getDistance(beforePickupLocation, pickup.getLocation(), newVehicle, beforePickupDepTime);
 			double distancePickup2ActAfterPickup = getDistance(pickup, actAfterPickup, newVehicle, context.getRelatedActivityContext().getEndTime());
-			double distanceBeforePickup2AfterPickup = getDistance(actBeforePickup, actAfterPickup,newVehicle, actBeforePickup.getEndTime());
+			double distanceBeforePickup2AfterPickup = getDistance(beforePickupLocation, actAfterPickup.getLocation(), newVehicle, beforePickupDepTime);
 			if (context.getRoute().isEmpty()) distanceBeforePickup2AfterPickup = 0;
 			if (actAfterPickup instanceof End && !context.getNewVehicle().isReturnToDepot()) {
 				distancePickup2ActAfterPickup = 0;
@@ -169,7 +177,8 @@ import org.matsim.vehicles.VehicleUtils;
 	}
 
 	/**
-	 * Calculates the distance based on the route-based distances between every tour activity.
+	 * Calculates the distance of the current route using its stored activity end times. This is the cheap baseline
+	 * for the local insertion estimate.
 	 */
 	private double calculateRouteDistance(JobInsertionContext context, Vehicle newVehicle) {
 		double realRouteDistance = 0;
@@ -250,8 +259,11 @@ import org.matsim.vehicles.VehicleUtils;
 	}
 
 	private double getDistance(TourActivity from, TourActivity to, Vehicle vehicle, double departureTime) {
-		double distance = netBasedCosts.getDistance(from.getLocation(), to.getLocation(), departureTime,
-				vehicle);
+		return getDistance(from.getLocation(), to.getLocation(), vehicle, departureTime);
+	}
+
+	private double getDistance(Location from, Location to, Vehicle vehicle, double departureTime) {
+		double distance = netBasedCosts.getDistance(from, to, departureTime, vehicle);
 		if (!(distance >= 0.))
 			throw new AssertionError("Distance must not be negative! From, to" + from + ", " + to
 					+ " distance " + distance);

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/DistanceConstraint.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/DistanceConstraint.java
@@ -25,6 +25,10 @@ import com.graphhopper.jsprit.core.problem.constraint.HardActivityConstraint;
 import com.graphhopper.jsprit.core.problem.misc.JobInsertionContext;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.*;
 import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Id;
@@ -54,10 +58,20 @@ import org.matsim.vehicles.VehicleUtils;
 
 	private final NetworkBasedTransportCosts netBasedCosts;
 
-	public DistanceConstraint(CarrierVehicleTypes vehicleTypes,
-							  NetworkBasedTransportCosts netBasedCosts) {
+	private final double usableEnergyCapacityFactor;
+
+	private final Set<Id<VehicleType>> loggedVehicleTypes = ConcurrentHashMap.newKeySet();
+
+	public DistanceConstraint(CarrierVehicleTypes vehicleTypes, NetworkBasedTransportCosts netBasedCosts,
+			double usableRangeInPercent) {
+		if (!Double.isFinite(usableRangeInPercent) || usableRangeInPercent <= 0. || usableRangeInPercent > 100.) {
+			throw new IllegalArgumentException("Distance constraint usable range must be in the range (0, 100].");
+		}
 		this.vehicleTypes = vehicleTypes;
 		this.netBasedCosts = netBasedCosts;
+		this.usableEnergyCapacityFactor = usableRangeInPercent / 100.;
+		log.info("Distance constraint initialized with a usable range of {} percent of the vehicle range during tour planning.",
+				usableRangeInPercent);
 	}
 
 	/**
@@ -72,12 +86,17 @@ import org.matsim.vehicles.VehicleUtils;
 //		double additionalDistance;
 
 		Vehicle newVehicle = context.getNewVehicle();
+		Id<VehicleType> vehicleTypeId = Id.create(newVehicle.getType().getTypeId(), VehicleType.class);
 		VehicleType vehicleTypeOfNewVehicle = vehicleTypes.getVehicleTypes()
-				.get(Id.create(newVehicle.getType().getTypeId(), VehicleType.class));
-		if (VehicleUtils.getEnergyCapacity(vehicleTypeOfNewVehicle.getEngineInformation()) == null)  return ConstraintsStatus.FULFILLED;
+				.get(vehicleTypeId);
+		Double vehicleEnergyCapacity = VehicleUtils.getEnergyCapacity(vehicleTypeOfNewVehicle.getEngineInformation());
+		if (vehicleEnergyCapacity == null)  return ConstraintsStatus.FULFILLED;
 
-		Double energyCapacityInKWhOrLiters = VehicleUtils
-			.getEnergyCapacity(vehicleTypeOfNewVehicle.getEngineInformation());
+		double energyCapacityInKWhOrLiters = vehicleEnergyCapacity * usableEnergyCapacityFactor;
+		if (loggedVehicleTypes.add(vehicleTypeId)) {
+			log.info("Distance constraint checks vehicle type {} with energy capacity {} and usable energy capacity {} ({} percent usable range).",
+				vehicleTypeId, vehicleEnergyCapacity, energyCapacityInKWhOrLiters, (usableEnergyCapacityFactor * 100.));
+		}
 		Double consumptionPerMeter;
 		if (VehicleUtils.getHbefaTechnology(vehicleTypeOfNewVehicle.getEngineInformation()).equals("electricity"))
 			consumptionPerMeter = VehicleUtils

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/DistanceConstraint.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/DistanceConstraint.java
@@ -82,11 +82,9 @@ import org.matsim.vehicles.VehicleUtils;
 	 * If a delivery is added, it also accounts for the necessary consumption if the pickup is added at the given position of the tour. This is also important for the fulfilled decision of this
 	 * function. In the end, the conditions check if the consumption of the tour including the additional shipment is possible with the possible energyCapacity.
 	 */
-	//TODO add the time dependencies of the distance calculation because the route choice can be different for different times
 	@Override
 	public ConstraintsStatus fulfilled(JobInsertionContext context, TourActivity prevAct, TourActivity newAct,
 			TourActivity nextAct, double prevActDepTime) {
-//		double additionalDistance;
 
 		Vehicle newVehicle = context.getNewVehicle();
 		Id<VehicleType> vehicleTypeId = Id.create(newVehicle.getType().getTypeId(), VehicleType.class);

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/MatsimJspritFactory.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/MatsimJspritFactory.java
@@ -674,7 +674,8 @@ public final class MatsimJspritFactory {
 					StateManager stateManager = new StateManager(problem);
 					stateManager.addStateUpdater(new DistanceUpdater(stateManager.createStateId("distance"), stateManager, netBasedCosts));
 					ConstraintManager constraintManager = new ConstraintManager(problem, stateManager);
-					constraintManager.addConstraint(new DistanceConstraint(CarriersUtils.getOrAddCarrierVehicleTypes(scenario), netBasedCosts), ConstraintManager.Priority.CRITICAL);
+					constraintManager.addConstraint(new DistanceConstraint(CarriersUtils.getOrAddCarrierVehicleTypes(scenario), netBasedCosts,
+						freightConfig.getDistanceConstraintUsableRange()), ConstraintManager.Priority.CRITICAL);
 					AlgorithmConfig algorithmConfig = new AlgorithmConfig();
 					AlgorithmConfigXmlReader xmlReader = new AlgorithmConfigXmlReader(algorithmConfig);
 					xmlReader.read(vraURL);
@@ -693,7 +694,8 @@ public final class MatsimJspritFactory {
 					StateManager stateManager = new StateManager(problem);
 					stateManager.addStateUpdater(new DistanceUpdater(stateManager.createStateId("distance"), stateManager, netBasedCosts));
 					ConstraintManager constraintManager = new ConstraintManager(problem, stateManager);
-					constraintManager.addConstraint(new DistanceConstraint(CarriersUtils.getOrAddCarrierVehicleTypes(scenario), netBasedCosts), ConstraintManager.Priority.CRITICAL);
+					constraintManager.addConstraint(new DistanceConstraint(CarriersUtils.getOrAddCarrierVehicleTypes(scenario), netBasedCosts,
+						freightConfig.getDistanceConstraintUsableRange()), ConstraintManager.Priority.CRITICAL);
 					//by default of Jsprit the fixed costs are not considered in the algorithm. Adding this property takes this into account.
 					algorithm = Jsprit.Builder.newInstance(problem).setProperty(Jsprit.Parameter.FIXED_COST_PARAM, "0.5").setStateAndConstraintManager(stateManager, constraintManager).buildAlgorithm();
 				}

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/NetworkBasedTransportCosts.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/jsprit/NetworkBasedTransportCosts.java
@@ -45,7 +45,6 @@ import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
 import org.matsim.core.utils.misc.Counter;
 import org.matsim.freight.carriers.CarrierVehicle;
-import org.matsim.freight.carriers.CarriersUtils;
 import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.utils.objectattributes.attributable.AttributesImpl;
 import org.matsim.vehicles.VehicleType;
@@ -826,6 +825,13 @@ public class NetworkBasedTransportCosts implements VRPTransportCosts {
 
 	private int getTimeSlice(double time) {
 		return (int) (time / timeSliceWidth);
+	}
+
+	/**
+	 * @return true if routing distinguishes between different departure-time slices
+	 */
+	public boolean usesTimeDependentRouting() {
+		return timeSliceWidth != Integer.MAX_VALUE;
 	}
 
 	/**

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/FreightCarriersConfigGroupTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/FreightCarriersConfigGroupTest.java
@@ -47,6 +47,8 @@ public class FreightCarriersConfigGroupTest {
 		Assertions.assertTrue(params.containsKey(FreightCarriersConfigGroup.VEHICLE_ROUTING_ALGORITHM));
 		Assertions.assertTrue(params.containsKey(FreightCarriersConfigGroup.TRAVEL_TIME_SLICE_WIDTH));
 		Assertions.assertTrue(params.containsKey(FreightCarriersConfigGroup.USE_DISTANCE_CONSTRAINT));
+		Assertions.assertTrue(params.containsKey(FreightCarriersConfigGroup.DISTANCE_CONSTRAINT_USABLE_RANGE));
+		Assertions.assertEquals(100., freight.getDistanceConstraintUsableRange());
 	}
 
 	@Test
@@ -64,6 +66,7 @@ public class FreightCarriersConfigGroupTest {
 			    <param name="vehicleRoutingAlgorithmFile" value="/path/to/carriersRoutingAlgorithm.xml" />
 			    <param name="travelTimeSliceWidth" value="3600" />
 			    <param name="useDistanceConstraintForTourPlanning" value="basedOnEnergyConsumption" />
+			    <param name="distanceConstraintUsableRange" value="75" />
 			  </module>
 			</config>""";
 
@@ -76,6 +79,7 @@ public class FreightCarriersConfigGroupTest {
 		Assertions.assertEquals("/path/to/carriersRoutingAlgorithm.xml", freight.getVehicleRoutingAlgorithmFile());
 		Assertions.assertEquals(3600.0, freight.getTravelTimeSliceWidth(), 1e-8);
 		Assertions.assertEquals(UseDistanceConstraintForTourPlanning.basedOnEnergyConsumption, freight.getUseDistanceConstraintForTourPlanning());
+		Assertions.assertEquals(75., freight.getDistanceConstraintUsableRange());
 	}
 
 }

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/DistanceConstraintTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/DistanceConstraintTest.java
@@ -149,6 +149,72 @@ public class DistanceConstraintTest {
 	}
 
 	/**
+	 * Checks that the configurable distance-constraint usable range reduces the vehicle range during tour planning.
+	 * With a 75 percent usable range, the combined tour with 24 km is no longer feasible for vehicles with a nominal range of
+	 * 30 km, so the carrier needs two separate tours.
+	 */
+	@Test
+	final void distanceConstraintUsableRangeAffectsTourPlanning() throws ExecutionException, InterruptedException {
+		Config config = ConfigUtils.createConfig();
+		config.controller().setOutputDirectory(testUtils.getOutputDirectory());
+		prepareConfig(config);
+		ConfigUtils.addOrGetModule(config, FreightCarriersConfigGroup.class).setDistanceConstraintUsableRange(75.);
+
+		Scenario scenario = ScenarioUtils.loadScenario(config);
+
+		Carriers carriers = new Carriers();
+		CarrierVehicleTypes vehicleTypes = new CarrierVehicleTypes();
+		FleetSize fleetSize = FleetSize.INFINITE;
+
+		Carrier carrier = CarriersUtils.createCarrier(Id.create("Carrier_UsableRange", Carrier.class));
+		VehicleType vehicleTypeLarge = VehicleUtils.createVehicleType(Id.create("LargeBattery_UsableRange", VehicleType.class));
+		vehicleTypeLarge.getCostInformation().setCostsPerMeter(0.00055).setCostsPerSecond(0.008).setFixedCost(100.);
+		VehicleUtils.setHbefaTechnology(vehicleTypeLarge.getEngineInformation(), "electricity");
+		VehicleUtils.setEnergyCapacity(vehicleTypeLarge.getEngineInformation(), 450.);
+		VehicleUtils.setEnergyConsumptionKWhPerMeter(vehicleTypeLarge.getEngineInformation(), 0.015);
+		vehicleTypeLarge.setDescription("Carrier_UsableRange");
+		vehicleTypeLarge.getCapacity().setOther(80.);
+
+		VehicleType vehicleTypeSmall = VehicleUtils.createVehicleType(Id.create("SmallBattery_UsableRange", VehicleType.class));
+		vehicleTypeSmall.getCostInformation().setCostsPerMeter(0.00055).setCostsPerSecond(0.008).setFixedCost(70.);
+		VehicleUtils.setHbefaTechnology(vehicleTypeSmall.getEngineInformation(), "electricity");
+		VehicleUtils.setEnergyCapacity(vehicleTypeSmall.getEngineInformation(), 300.);
+		VehicleUtils.setEnergyConsumptionKWhPerMeter(vehicleTypeSmall.getEngineInformation(), 0.01);
+		vehicleTypeSmall.setDescription("Carrier_UsableRange");
+		vehicleTypeSmall.getCapacity().setOther(80.);
+
+		vehicleTypes.getVehicleTypes().put(vehicleTypeLarge.getId(), vehicleTypeLarge);
+		vehicleTypes.getVehicleTypes().put(vehicleTypeSmall.getId(), vehicleTypeSmall);
+
+		carriers.addCarrier(addTwoServicesToCarrier(carrier));
+		createCarrier(fleetSize, carrier, vehicleTypes);
+
+		scenario.addScenarioElement("carrierVehicleTypes", vehicleTypes);
+		scenario.addScenarioElement("carriers", carriers);
+		CarriersUtils.setJspritIterations(carrier, 25);
+
+		CarriersUtils.runJsprit(scenario);
+
+		Assertions.assertEquals(2, carrier.getSelectedPlan().getScheduledTours().size(),
+			"The usable range should make the combined 24 km tour infeasible.");
+
+		List<Double> distancesOfTours = new ArrayList<>();
+		for (ScheduledTour scheduledTour : carrier.getSelectedPlan().getScheduledTours()) {
+			Assertions.assertEquals(vehicleTypeSmall.getId(), scheduledTour.getVehicle().getType().getId());
+			double distanceTour = 0.0;
+			for (Tour.TourElement element : scheduledTour.getTour().getTourElements()) {
+				if (element instanceof Tour.Leg legElement && legElement.getRoute().getDistance() != 0) {
+					distanceTour += RouteUtils.calcDistance((NetworkRoute) legElement.getRoute(), 0, 0,
+						scenario.getNetwork());
+				}
+			}
+			distancesOfTours.add(distanceTour);
+		}
+
+		Assertions.assertTrue(distancesOfTours.contains(12000.0), "The scheduled tour has a non expected distance");
+		Assertions.assertTrue(distancesOfTours.contains(20000.0), "The scheduled tour has a non expected distance");
+	}
+	/**
 	 * Option 2: Tour is not possible with the vehicle with the small battery.
 	 * That's why one vehicle with a large battery is used.
 	 */

--- a/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/NetworkBasedTransportCostsTest.java
+++ b/contribs/freight/src/test/java/org/matsim/freight/carriers/jsprit/NetworkBasedTransportCostsTest.java
@@ -60,6 +60,17 @@ public class NetworkBasedTransportCostsTest {
 	public final MatsimTestUtils utils = new MatsimTestUtils();
 
 	@Test
+	void usesTimeDependentRoutingOnlyWithFiniteTimeSlices() {
+		Network network = ScenarioUtils.createScenario(ConfigUtils.createConfig()).getNetwork();
+
+		Assertions.assertFalse(NetworkBasedTransportCosts.Builder.newInstance(network).build().usesTimeDependentRouting());
+		Assertions.assertTrue(NetworkBasedTransportCosts.Builder.newInstance(network)
+			.setTimeSliceWidth(1800)
+			.build()
+			.usesTimeDependentRouting());
+	}
+
+	@Test
 	void test_whenAddingTwoDifferentVehicleTypes_itMustAccountForThem(){
 		Config config = ConfigUtils.createConfig();
 		Scenario scenario = ScenarioUtils.createScenario(config);


### PR DESCRIPTION
- adds a usable range of the energy capacity of a vehicle for the VRP solving with Jsprit
- The usable range in percent can be set via freightCarriersCaonfigGroup
- Increases the performance of the distance constraint if a time-dependent network is used.
