### PR TITLE
feat: parsing cycleway tags with side attributes in OsmBicycleReader

### DIFF
--- a/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/OsmBicycleReader.java
+++ b/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/OsmBicycleReader.java
@@ -77,9 +77,26 @@ public final class OsmBicycleReader extends SupersonicOsmNetworkReader {
 	}
 
 	private static void setCycleWay(Link link, Map<String, String> tags) {
-		if (tags.containsKey(OsmTags.CYCLEWAY))
-			link.getAttributes().putAttribute(OsmTags.CYCLEWAY, tags.get(OsmTags.CYCLEWAY));
-	}
+        // Note: this logic assumes right-hand traffic.
+        // For forward links, the right side corresponds to the link direction.
+        // For reverse links, the left side corresponds to the link direction.
+        String cycleway = null;
+        String linkId = link.getId().toString();
+
+        if (tags.containsKey(OsmTags.CYCLEWAY)) {
+            cycleway = tags.get(OsmTags.CYCLEWAY);
+        } else if (tags.containsKey(OsmTags.CYCLEWAY_BOTH)) {
+            cycleway = tags.get(OsmTags.CYCLEWAY_BOTH);
+        } else if (linkId.endsWith("f") && tags.containsKey(OsmTags.CYCLEWAY_RIGHT)) {
+            cycleway = tags.get(OsmTags.CYCLEWAY_RIGHT);
+        } else if ((linkId.endsWith("r") || linkId.endsWith("_bike-reverse")) && tags.containsKey(OsmTags.CYCLEWAY_LEFT)) {
+            cycleway = tags.get(OsmTags.CYCLEWAY_LEFT);
+        }
+
+        if (cycleway != null) {
+            link.getAttributes().putAttribute(OsmTags.CYCLEWAY, cycleway);
+        }
+    }
 
 	private static void setRestrictions(Link link, Map<String, String> tags) {
 		if (tags.containsKey(OsmTags.BICYCLE))

--- a/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/OsmTags.java
+++ b/contribs/osm/src/main/java/org/matsim/contrib/osm/networkReader/OsmTags.java
@@ -17,6 +17,9 @@ public class OsmTags {
 	public static final String LIVING_STREET = "living_street";
 	public static final String TRACK = "track";
 	public static final String CYCLEWAY = "cycleway";
+    public static final String CYCLEWAY_BOTH = "cycleway:both";
+    public static final String CYCLEWAY_RIGHT = "cycleway:right";
+    public static final String CYCLEWAY_LEFT = "cycleway:left";
 	public static final String SERVICE = "service";
 	public static final String FOOTWAY = "footway";
 	public static final String PEDESTRIAN = "pedestrian";


### PR DESCRIPTION
Hi all,

I noticed (and this was also discussed in one issue a long time ago), that the OsmBicycleReader only reads tags called exactly 'cycleway' while the recommendation is to use this tag together with the side attribute, e.g., cycleway:left (https://wiki.openstreetmap.org/wiki/Key:cycleway).

In my scenario, for Brussels, from the links that had the cycleway tag (even though there were only few of them), only around one quarter were using 'cycleway', the rest were using the side attribute as well, and therefore these were ignored by the reader.

So I just thought this might be helpful for others as well. It needs to be noted, though, that the logic assumes right-side driving traffic.