### PR TITLE
feat(vsp): use SubpopulationDefaultNames for subpopulation attributes

### DIFF
--- a/contribs/application/pom.xml
+++ b/contribs/application/pom.xml
@@ -64,7 +64,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
-			<artifactId>vsp</artifactId>
+			<artifactId>common</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>

--- a/contribs/application/pom.xml
+++ b/contribs/application/pom.xml
@@ -64,6 +64,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
+			<artifactId>vsp</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.matsim.contrib</groupId>
 			<artifactId>emissions</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>

--- a/contribs/application/src/main/java/org/matsim/application/prepare/longDistanceFreightGER/tripExtraction/ExtractRelevantFreightTrips.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/longDistanceFreightGER/tripExtraction/ExtractRelevantFreightTrips.java
@@ -14,7 +14,7 @@ import org.matsim.api.core.v01.population.*;
 import org.matsim.application.MATSimAppCommand;
 import org.matsim.application.options.CrsOptions;
 import org.matsim.application.options.ShpOptions;
-import org.matsim.contrib.vsp.scenario.SubpopulationDefaultNames;
+import org.matsim.contrib.common.conventions.vsp.SubpopulationDefaultNames;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.router.costcalculators.RandomizingTimeDistanceTravelDisutilityFactory;

--- a/contribs/application/src/main/java/org/matsim/application/prepare/longDistanceFreightGER/tripExtraction/ExtractRelevantFreightTrips.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/longDistanceFreightGER/tripExtraction/ExtractRelevantFreightTrips.java
@@ -14,6 +14,7 @@ import org.matsim.api.core.v01.population.*;
 import org.matsim.application.MATSimAppCommand;
 import org.matsim.application.options.CrsOptions;
 import org.matsim.application.options.ShpOptions;
+import org.matsim.contrib.vsp.scenario.SubpopulationDefaultNames;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.router.costcalculators.RandomizingTimeDistanceTravelDisutilityFactory;
@@ -84,7 +85,7 @@ public class ExtractRelevantFreightTrips implements MATSimAppCommand {
 	@CommandLine.Option(names = "--legMode", description = "Set leg mode for long distance freight legs.", defaultValue = "car")
 	private String legMode;
 
-	@CommandLine.Option(names = "--subpopulation", description = "Set subpopulation for the extracted freight trips", defaultValue = "longDistanceFreight")
+	@CommandLine.Option(names = "--subpopulation", description = "Set subpopulation for the extracted freight trips", defaultValue = SubpopulationDefaultNames.SUBPOP_LONG_DISTANCE_FREIGHT)
 	private String subpopulation;
 
 	public static void main(String[] args) {

--- a/contribs/application/src/main/java/org/matsim/application/prepare/population/TrajectoryToPlans.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/population/TrajectoryToPlans.java
@@ -6,7 +6,7 @@ import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.population.*;
 import org.matsim.application.MATSimAppCommand;
 import org.matsim.application.options.CrsOptions;
-import org.matsim.contrib.vsp.scenario.SubpopulationDefaultNames;
+import org.matsim.contrib.common.conventions.vsp.SubpopulationDefaultNames;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.population.PopulationUtils;

--- a/contribs/application/src/main/java/org/matsim/application/prepare/population/TrajectoryToPlans.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/population/TrajectoryToPlans.java
@@ -6,6 +6,7 @@ import org.matsim.api.core.v01.Scenario;
 import org.matsim.api.core.v01.population.*;
 import org.matsim.application.MATSimAppCommand;
 import org.matsim.application.options.CrsOptions;
+import org.matsim.contrib.vsp.scenario.SubpopulationDefaultNames;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.population.PopulationUtils;
@@ -96,7 +97,7 @@ public class TrajectoryToPlans implements MATSimAppCommand {
 		scenario.getPopulation().getPersons().forEach((k, v) -> {
 
 			if (PopulationUtils.getSubpopulation(v) == null)
-				PopulationUtils.putSubpopulation(v, "person");
+				PopulationUtils.putSubpopulation(v, SubpopulationDefaultNames.SUBPOP_PERSON);
 		});
 		// (if a <person/> does not yet have a subpopulation attribute, tag it as a "person".  kai, feb'2024)
 

--- a/contribs/common/src/main/java/org/matsim/contrib/common/conventions/vsp/SubpopulationDefaultNames.java
+++ b/contribs/common/src/main/java/org/matsim/contrib/common/conventions/vsp/SubpopulationDefaultNames.java
@@ -1,4 +1,4 @@
-package org.matsim.contrib.vsp.scenario;
+package org.matsim.contrib.common.conventions.vsp;
 
 public class SubpopulationDefaultNames{
 	/**

--- a/contribs/perceived-safety/pom.xml
+++ b/contribs/perceived-safety/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>bicycle</artifactId>
-			<version>${version}</version>
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/contribs/small-scale-traffic-generation/pom.xml
+++ b/contribs/small-scale-traffic-generation/pom.xml
@@ -24,7 +24,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
-			<artifactId>vsp</artifactId>
+			<artifactId>common</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
 		<dependency>

--- a/contribs/small-scale-traffic-generation/pom.xml
+++ b/contribs/small-scale-traffic-generation/pom.xml
@@ -22,7 +22,11 @@
 			<artifactId>simwrapper</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
-
+		<dependency>
+			<groupId>org.matsim.contrib</groupId>
+			<artifactId>vsp</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>org.matsim.contrib</groupId>
 			<artifactId>freight</artifactId>

--- a/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/GenerateSmallScaleCommercialTrafficDemand.java
+++ b/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/GenerateSmallScaleCommercialTrafficDemand.java
@@ -40,6 +40,7 @@ import org.matsim.api.core.v01.population.Activity;
 import org.matsim.application.MATSimAppCommand;
 import org.matsim.application.options.ShpOptions.Index;
 import org.matsim.contrib.roadpricing.*;
+import org.matsim.contrib.vsp.scenario.SubpopulationDefaultNames;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.consistency.UnmaterializedConfigGroupChecker;
@@ -1201,9 +1202,11 @@ public class GenerateSmallScaleCommercialTrafficDemand implements MATSimAppComma
 													int fixedNumberOfVehiclePerTypeAndLocation) {
 
 		if (carrierAttributes.smallScaleCommercialTrafficType.equals(SmallScaleCommercialTrafficType.commercialPersonTraffic) && carrierAttributes.purpose == 3)
-			thisCarrier.getAttributes().putAttribute("subpopulation", carrierAttributes.smallScaleCommercialTrafficType + "_service");
+			thisCarrier.getAttributes().putAttribute("subpopulation", SubpopulationDefaultNames.SUBPOP_COM_PERSON_SERVICE);
+		else if (carrierAttributes.smallScaleCommercialTrafficType.equals(SmallScaleCommercialTrafficType.goodsTraffic) )
+			thisCarrier.getAttributes().putAttribute("subpopulation", SubpopulationDefaultNames.SUBPOP_GOODS);
 		else
-			thisCarrier.getAttributes().putAttribute("subpopulation", carrierAttributes.smallScaleCommercialTrafficType);
+			thisCarrier.getAttributes().putAttribute("subpopulation", SubpopulationDefaultNames.SUBPOP_COM_PERSON);
 
 		thisCarrier.getAttributes().putAttribute("purpose", carrierAttributes.purpose);
 		thisCarrier.getAttributes().putAttribute("tourStartArea", carrierAttributes.startZone);

--- a/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/GenerateSmallScaleCommercialTrafficDemand.java
+++ b/contribs/small-scale-traffic-generation/src/main/java/org/matsim/smallScaleCommercialTrafficGeneration/GenerateSmallScaleCommercialTrafficDemand.java
@@ -40,7 +40,7 @@ import org.matsim.api.core.v01.population.Activity;
 import org.matsim.application.MATSimAppCommand;
 import org.matsim.application.options.ShpOptions.Index;
 import org.matsim.contrib.roadpricing.*;
-import org.matsim.contrib.vsp.scenario.SubpopulationDefaultNames;
+import org.matsim.contrib.common.conventions.vsp.SubpopulationDefaultNames;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.consistency.UnmaterializedConfigGroupChecker;

--- a/contribs/vsp/src/main/java/org/matsim/contrib/vsp/scenario/SubpopulationDefaultNames.java
+++ b/contribs/vsp/src/main/java/org/matsim/contrib/vsp/scenario/SubpopulationDefaultNames.java
@@ -1,11 +1,23 @@
 package org.matsim.contrib.vsp.scenario;
 
 public class SubpopulationDefaultNames{
+	/**
+	 * Is used for the small-scale commercial person traffic trips.
+	 */
 	public static final String SUBPOP_COM_PERSON = "commercialPersonTraffic";
+	/**
+	 * Is used for the service trips of the small-scale commercial person traffic. The assumption is that for this subpopulation the usage of pt could be possible, because no material has to be carried.
+	 */
 	public static final String SUBPOP_COM_PERSON_SERVICE = "commercialPersonTraffic_service";
+	/**
+	 * Is used for the goods traffic trips of the small-scale commercial traffic.
+	 */
 	public static final String SUBPOP_GOODS = "goodsTraffic";
+	/**
+	 * Is used for the long-distance freight trips.
+	 */
+	public static final String SUBPOP_LONG_DISTANCE_FREIGHT = "longDistanceFreight";
 	public static final String SUBPOP_PERSON = "person";
-
 
 	/**
 	 * @deprecated -- this was used early, but should not be used in newer VSP matsim scenarios.  kai, apr/26, with input from RE and KMT


### PR DESCRIPTION
- adds longDistanceFreight subpopulation and uses the default names at first places
