### PR TITLE
feat(router): reduce memory for static CH routing

### DIFF
--- a/matsim/src/main/java/org/matsim/core/router/speedy/CHBuilder.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/CHBuilder.java
@@ -116,6 +116,13 @@ public class CHBuilder {
     private final TravelDisutility td;
     private final int nodeCount;
 
+    /**
+     * Whether the produced {@link CHGraph} should carry time-of-day TTF storage.
+     * Set via {@link #withTimeDependence(boolean)} before calling {@code build*}.
+     * Defaults to {@code true} for backward compatibility.
+     */
+    private boolean timeDependent = true;
+
     // Build-time edge storage (grows dynamically)
     private final AtomicInteger buildEdgeCounter = new AtomicInteger(0);
     private volatile int[] buildEdgeData;
@@ -408,6 +415,29 @@ public class CHBuilder {
 
         // Guard against duplicate neighbor processing in reestimateCellNeighborsParallel
         this.nbrRemovedGen = new int[nodeCount];
+    }
+
+    /**
+     * Configures whether the produced {@link CHGraph} should allocate
+     * time-of-day TTF storage ({@code ttf}, {@code minTTF}, {@code ttfHash}).
+     *
+     * <p>Pass {@code false} when the resulting CH will only be used with the
+     * static {@link CHRouter} (which reads {@code edgeWeights[]} alone). This
+     * skips a {@code NUM_BINS x totalEdgeCount} double[] allocation \u2014 several
+     * tens of GB on large multi-mode networks \u2014 and avoids running
+     * {@link CHTTFCustomizer} entirely.
+     *
+     * <p>When {@code false}, consumers requiring per-bin travel times \u2014
+     * {@link CHTTFCustomizer}, {@link CHRouterTimeDep},
+     * {@link CHLeastCostPathTree} \u2014 will throw {@link IllegalStateException}.
+     *
+     * <p>Defaults to {@code true} (backward compatible).
+     *
+     * @return this builder, for fluent chaining
+     */
+    public CHBuilder withTimeDependence(boolean timeDependent) {
+        this.timeDependent = timeDependent;
+        return this;
     }
 
     /** Runs the full CH build pipeline and returns the ready-to-customize graph. */
@@ -2767,7 +2797,8 @@ public class CHBuilder {
                 totalUp, upOff, upCount, upEdges, upWeights,
                 totalDn, dnOff, dnCount, dnEdges, dnWeights,
                 totalEdgeCount, edgeOrigLink, edgeLower1, edgeLower2,
-                edgeDistance, customizeOrder, nodeLevel);
+                edgeDistance, customizeOrder, nodeLevel,
+                this.timeDependent);
     }
 
     // -------------------------------------------------------------------------

--- a/matsim/src/main/java/org/matsim/core/router/speedy/CHGraph.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/CHGraph.java
@@ -98,12 +98,35 @@ public class CHGraph {
     // ttf[bin * totalEdgeCount + globalIdx] = travel time (seconds).
     // Bin-major layout gives sequential access when iterating a node's edges
     // (constant bin, contiguous globalIdx values).
+    // Null when {@link #timeDependent} is {@code false} (graph built for the
+    // static {@link CHRouter} path only, e.g. by
+    // {@code StaticCHRouterFactory} — saves NUM_BINS x totalEdgeCount doubles
+    // of heap and skips the full-graph CHTTFCustomizer pass).
     double[] ttf;
     double[] minTTF;
 
     // Change detection for incremental TTF customization.
     // ttfHash[globalIdx] = sum of TTF bins; NaN until first customization.
+    // Null when {@link #timeDependent} is {@code false}.
     double[] ttfHash;
+
+    /**
+     * Whether this CH overlay was built with time-of-day TTF storage.
+     *
+     * <p>When {@code false}, the {@code ttf}, {@code minTTF} and {@code ttfHash}
+     * arrays are not allocated and the graph can only be used with the static
+     * {@link CHRouter} (which reads {@code edgeWeights[]} only). Consumers that
+     * require per-bin travel times — namely {@link CHTTFCustomizer},
+     * {@link CHRouterTimeDep} and {@link CHLeastCostPathTree} — must reject
+     * a static graph by throwing {@link IllegalStateException} in their
+     * constructor / entry point.
+     */
+    private final boolean timeDependent;
+
+    /** Whether this CH overlay carries per-bin time-of-day TTF storage. */
+    public boolean isTimeDependent() {
+        return timeDependent;
+    }
 
     // Topological processing order for customization.
     // Ensures lower (component) edges are processed before their parent shortcuts.
@@ -159,7 +182,8 @@ public class CHGraph {
                   int upEdgeCount, int[] upOff, int[] upLen, int[] upEdges, double[] upWeights,
                   int dnEdgeCount, int[] dnOff, int[] dnLen, int[] dnEdges, double[] dnWeights,
                   int totalEdgeCount, int[] edgeOrigLink, int[] edgeLower1, int[] edgeLower2,
-                  double[] edgeDistance, int[] customizeOrder, int[] nodeLevel) {
+                  double[] edgeDistance, int[] customizeOrder, int[] nodeLevel,
+                  boolean timeDependent) {
         this.baseGraph      = baseGraph;
         this.nodeCount      = nodeCount;
         this.upEdgeCount    = upEdgeCount;
@@ -179,6 +203,7 @@ public class CHGraph {
         this.edgeDistance   = edgeDistance;
         this.customizeOrder = customizeOrder;
         this.nodeLevel      = nodeLevel;
+        this.timeDependent  = timeDependent;
         this.edgeWeights    = new double[totalEdgeCount];
 
         // Precompute sweep order: nodes sorted by decreasing level
@@ -194,11 +219,34 @@ public class CHGraph {
             sweepOrder[i] = invLevel[nodeCount - 1 - i];
         }
 
-        // Pre-allocate bin-major flat TTF arrays.
-        this.ttf    = new double[CHTTFCustomizer.NUM_BINS * totalEdgeCount];
-        this.minTTF = new double[totalEdgeCount];
-        this.ttfHash = new double[totalEdgeCount];
-        java.util.Arrays.fill(this.ttfHash, Double.NaN);
+        // Pre-allocate bin-major flat TTF arrays (only when this graph will be
+        // used with a time-dependent router/tree). Static-only graphs skip the
+        // NUM_BINS x totalEdgeCount allocation entirely — it can run into many
+        // tens of GB and also overflows int sizing on large networks.
+        if (timeDependent) {
+            // Guard against int overflow before the JVM throws an opaque
+            // NegativeArraySizeException. Math.multiplyExact would do, but we want
+            // the message to name the dimensions so callers can act on it.
+            long ttfSize = (long) CHTTFCustomizer.NUM_BINS * (long) totalEdgeCount;
+            if (ttfSize > Integer.MAX_VALUE - 8L) {
+                throw new IllegalStateException(
+                        "CH time-dependent TTF array size exceeds Integer.MAX_VALUE: "
+                        + "NUM_BINS=" + CHTTFCustomizer.NUM_BINS
+                        + ", totalEdgeCount=" + totalEdgeCount
+                        + " (would need " + ttfSize + " doubles, ~"
+                        + (ttfSize * 8L / (1024L * 1024L * 1024L)) + " GB). "
+                        + "Either build the CH graph in static mode "
+                        + "(timeDependent=false) or split the network.");
+            }
+            this.ttf    = new double[(int) ttfSize];
+            this.minTTF = new double[totalEdgeCount];
+            this.ttfHash = new double[totalEdgeCount];
+            java.util.Arrays.fill(this.ttfHash, Double.NaN);
+        } else {
+            this.ttf     = null;
+            this.minTTF  = null;
+            this.ttfHash = null;
+        }
 
         // Build reverse CSR: dnOutEdges (reverse of dnEdges).
         // dnEdges[w] stores incoming edges u→w.  dnOutEdges[u] stores outgoing edges u→w.

--- a/matsim/src/main/java/org/matsim/core/router/speedy/CHLeastCostPathTree.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/CHLeastCostPathTree.java
@@ -108,6 +108,14 @@ public class CHLeastCostPathTree implements ShortestPathTree {
     private final int nodeCount;
 
     public CHLeastCostPathTree(CHGraph chGraph, TravelTime tt, TravelDisutility td) {
+		if (!chGraph.isTimeDependent()) {
+			// Refuse to wrap a static graph rather than NPE in the hot loop on the null
+			// ttf/minTTF arrays.
+			throw new IllegalStateException(
+					"CHLeastCostPathTree currently requires a time-dependent "
+							+ "CHGraph; the supplied graph was built with "
+							+ "timeDependent=false.");
+		}
         this.chGraph = chGraph;
         this.baseGraph = chGraph.getBaseGraph();
         this.tt = tt;

--- a/matsim/src/main/java/org/matsim/core/router/speedy/CHLeastCostPathTree.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/CHLeastCostPathTree.java
@@ -96,7 +96,10 @@ public class CHLeastCostPathTree implements ShortestPathTree {
     private final int[] dnOff, dnLen, dnEdges;
     private final double[] dnWeights;
     private final int[] sweepOrder;
-    private final double[] ttf;
+    private final double[] ttf;            // null in static mode
+    private final double[] minTTF;         // null in static mode
+    private final double[] edgeWeights;    // populated in both modes
+    private final boolean staticGraph;     // !chGraph.isTimeDependent()
     private final double[] edgeDistance;
     private final int totalEdgeCount;
 
@@ -108,18 +111,11 @@ public class CHLeastCostPathTree implements ShortestPathTree {
     private final int nodeCount;
 
     public CHLeastCostPathTree(CHGraph chGraph, TravelTime tt, TravelDisutility td) {
-		if (!chGraph.isTimeDependent()) {
-			// Refuse to wrap a static graph rather than NPE in the hot loop on the null
-			// ttf/minTTF arrays.
-			throw new IllegalStateException(
-					"CHLeastCostPathTree currently requires a time-dependent "
-							+ "CHGraph; the supplied graph was built with "
-							+ "timeDependent=false.");
-		}
         this.chGraph = chGraph;
         this.baseGraph = chGraph.getBaseGraph();
         this.tt = tt;
         this.td = td;
+        this.staticGraph = !chGraph.isTimeDependent();
 
         int n = chGraph.nodeCount;
         this.data = new double[n * 3];
@@ -138,6 +134,8 @@ public class CHLeastCostPathTree implements ShortestPathTree {
         this.dnWeights = chGraph.dnWeights;
         this.sweepOrder = chGraph.sweepOrder;
         this.ttf = chGraph.ttf;
+        this.minTTF = chGraph.minTTF;
+        this.edgeWeights = chGraph.edgeWeights;
         this.edgeDistance = chGraph.edgeDistance;
         this.totalEdgeCount = chGraph.totalEdgeCount;
 
@@ -184,8 +182,6 @@ public class CHLeastCostPathTree implements ShortestPathTree {
         advanceIteration();
 
         final int S = CHGraph.E_STRIDE;
-        final int NUM_BINS = CHTTFCustomizer.NUM_BINS;
-        final double INV_BIN = CHTTFCustomizer.INV_BIN_SIZE;
 
         // Phase 1: Upward Dijkstra from source
         // Uses time-dependent TTF for travel time; cost = travel time (consistent
@@ -195,8 +191,42 @@ public class CHLeastCostPathTree implements ShortestPathTree {
         pq.insert(startNode, 0.0);
 
         // Track the cost at which Phase 1 terminates.  All unsettled nodes
-        // have cost ≥ this value (Dijkstra monotonicity), so the sweep only
+        // have cost >= this value (Dijkstra monotonicity), so the sweep only
         // needs to propagate from nodes with cost < earlyTermCost.
+        // Branch hoisted out of the hot loop: static graphs use scalar
+        // edgeWeights[gIdx]; time-dependent graphs use ttf[bin * totalEdgeCount + gIdx].
+        double earlyTermCost = staticGraph
+                ? forwardPhase1Static(startTime, stopCriterion, S)
+                : forwardPhase1TimeDep(startTime, stopCriterion, S);
+
+        // Phase 2: Downward propagation.
+        // Always use the linear push-based sweep with cost-bounded pruning.
+        // The linear scan of sweepOrder (decreasing rank) with push semantics
+        // is both simpler and faster than the heap-based lazy approach:
+        //   - No heap overhead (O(1) per node instead of O(log n))
+        //   - Cost-bounded pruning skips nodes/edges beyond earlyTermCost
+        //   - Sequential memory access on sweepOrder (cache-friendly)
+        forwardSweepLinear(S, earlyTermCost);
+
+        // When turn restrictions are present, the base graph contains colored copies
+        // of real nodes; only the colored copy may have been reached.  Mirror each
+        // best colored label onto the corresponding real-node slot so that callers
+        // querying getCost/getTime/getDistance on the real node observe the correct
+        // result.  Mirrors org.matsim.core.router.speedy.LeastCostPathTree.
+        if (baseGraph.getTurnRestrictions().isPresent()) {
+            consolidateColoredNodes();
+        }
+    }
+
+    /**
+     * Forward Phase-1 Dijkstra in time-dependent mode: edge cost is read from
+     * the bin-major TTF array using the current node's arrival time to pick a bin.
+     */
+    private double forwardPhase1TimeDep(double startTime,
+                                        LeastCostPathTree.StopCriterion stopCriterion,
+                                        int S) {
+        final int NUM_BINS = CHTTFCustomizer.NUM_BINS;
+        final double INV_BIN = CHTTFCustomizer.INV_BIN_SIZE;
         double earlyTermCost = Double.POSITIVE_INFINITY;
 
         while (!pq.isEmpty()) {
@@ -240,24 +270,58 @@ public class CHLeastCostPathTree implements ShortestPathTree {
                 }
             }
         }
+        return earlyTermCost;
+    }
 
-        // Phase 2: Downward propagation.
-        // Always use the linear push-based sweep with cost-bounded pruning.
-        // The linear scan of sweepOrder (decreasing rank) with push semantics
-        // is both simpler and faster than the heap-based lazy approach:
-        //   - No heap overhead (O(1) per node instead of O(log n))
-        //   - Cost-bounded pruning skips nodes/edges beyond earlyTermCost
-        //   - Sequential memory access on sweepOrder (cache-friendly)
-        forwardSweepLinear(S, earlyTermCost);
+    /**
+     * Forward Phase-1 Dijkstra in static (time-independent) mode: edge cost is
+     * the scalar {@code edgeWeights[gIdx]}; the arrival-time field is advanced
+     * by the same scalar (which equals travel time when the supplied
+     * {@link TravelDisutility} returns travel time, e.g. for time-only
+     * disutilities used by {@code NetworkLinkStripper}).
+     */
+    private double forwardPhase1Static(double startTime,
+                                       LeastCostPathTree.StopCriterion stopCriterion,
+                                       int S) {
+        double earlyTermCost = Double.POSITIVE_INFINITY;
+        final double[] ew = edgeWeights;
 
-        // When turn restrictions are present, the base graph contains colored copies
-        // of real nodes; only the colored copy may have been reached.  Mirror each
-        // best colored label onto the corresponding real-node slot so that callers
-        // querying getCost/getTime/getDistance on the real node observe the correct
-        // result.  Mirrors org.matsim.core.router.speedy.LeastCostPathTree.
-        if (baseGraph.getTurnRestrictions().isPresent()) {
-            consolidateColoredNodes();
+        while (!pq.isEmpty()) {
+            int v = pq.poll();
+            double cost = getCost(v);
+            double arr = getTimeRaw(v);
+
+            if (stopCriterion.stop(baseGraph.getNode(v).getId().index(),
+                    arr, cost, getDistance(v), startTime)) {
+                earlyTermCost = cost;
+                break;
+            }
+
+            int uOff = upOff[v];
+            int uEnd = uOff + upLen[v];
+            double vDist = getDistance(v);
+            for (int slot = uOff; slot < uEnd; slot++) {
+                int eBase = slot * S;
+                int w = upEdges[eBase];
+                int gIdx = upEdges[eBase + CHGraph.E_GIDX];
+
+                double tTime = ew[gIdx];
+                double newCost = cost + tTime;
+                double newArr = arr + tTime;
+                double newDist = vDist + edgeDistance[gIdx];
+
+                if (iterIds[w] == currentIteration) {
+                    if (newCost < getCost(w)) {
+                        setNode(w, newCost, newArr, newDist, v, gIdx);
+                        pq.decreaseKey(w, newCost);
+                    }
+                } else {
+                    setNode(w, newCost, newArr, newDist, v, gIdx);
+                    pq.insert(w, newCost);
+                }
+            }
         }
+        return earlyTermCost;
     }
 
     /**
@@ -386,6 +450,11 @@ public class CHLeastCostPathTree implements ShortestPathTree {
         }
 
         // Track the cost at which Phase 1 terminates (for sweep pruning).
+        // Branch hoisted out of the hot loop: static graphs use scalar
+        // edgeWeights[gIdx]; time-dependent graphs use minTTF[gIdx] (the lower
+        // bound over all time bins, which is correct since CHLeastCostPathTree's
+        // cost metric is travel-time-lower-bound on the contracted graph).
+        double[] edgeCostArr = staticGraph ? edgeWeights : minTTF;
         double earlyTermCost = Double.POSITIVE_INFINITY;
 
         while (!pq.isEmpty()) {
@@ -406,7 +475,7 @@ public class CHLeastCostPathTree implements ShortestPathTree {
                 int u = dnEdges[eBase];
                 int gIdx = dnEdges[eBase + CHGraph.E_GIDX];
 
-                double edgeCost = chGraph.minTTF[gIdx];
+                double edgeCost = edgeCostArr[gIdx];
                 double newCost = cost + edgeCost;
                 double newDist = wDist + edgeDistance[gIdx];
 

--- a/matsim/src/main/java/org/matsim/core/router/speedy/CHRouterTimeDep.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/CHRouterTimeDep.java
@@ -105,6 +105,12 @@ public class CHRouterTimeDep implements LeastCostPathCalculator {
     public long getChQueryCount()    { return chQueryCount; }
 
     public CHRouterTimeDep(CHGraph chGraph, TravelTime tt, TravelDisutility td) {
+        if (!chGraph.isTimeDependent()) {
+            throw new IllegalStateException(
+                    "CHRouterTimeDep requires a time-dependent CHGraph; "
+                    + "the supplied graph was built with timeDependent=false. "
+                    + "Use the static CHRouter instead.");
+        }
         this.chGraph   = chGraph;
         this.baseGraph = chGraph.getBaseGraph();
         this.tt        = tt;

--- a/matsim/src/main/java/org/matsim/core/router/speedy/CHTTFCustomizer.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/CHTTFCustomizer.java
@@ -78,6 +78,13 @@ public class CHTTFCustomizer {
     private static final int PARALLEL_REAL_EDGE_THRESHOLD = 200;
 
     public void customize(CHGraph chGraph, TravelTime tt, TravelDisutility td) {
+        if (!chGraph.isTimeDependent()) {
+            throw new IllegalStateException(
+                    "CHTTFCustomizer.customize requires a time-dependent CHGraph; "
+                    + "the supplied graph was built with timeDependent=false "
+                    + "(no ttf/minTTF/ttfHash storage). Use CHCustomizer for "
+                    + "static-only CH graphs.");
+        }
         // Quick-check: sample a few original edges to detect if travel times
         // changed since the last customization.  This avoids the expensive full
         // scan (~20M getLinkTravelTime calls for a 200k-link network) when nothing

--- a/matsim/src/main/java/org/matsim/core/router/speedy/StaticCHRouterFactory.java
+++ b/matsim/src/main/java/org/matsim/core/router/speedy/StaticCHRouterFactory.java
@@ -1,0 +1,141 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * StaticCHRouterFactory.java
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2026 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+package org.matsim.core.router.speedy;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.core.config.groups.GlobalConfigGroup;
+import org.matsim.core.router.util.LeastCostPathCalculator;
+import org.matsim.core.router.util.LeastCostPathCalculatorFactory;
+import org.matsim.core.router.util.TravelDisutility;
+import org.matsim.core.router.util.TravelTime;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Factory for the time-independent {@link CHRouter}, for use cases without
+ * time-of-day travel-time variation (skims, accessibility, link strippers,
+ * freespeed-only routing, etc.).
+ *
+ * <p>Compared with {@link CHRouterFactory} (which always emits
+ * {@link CHRouterTimeDep}), this factory:
+ * <ul>
+ *   <li>builds the {@link CHGraph} via
+ *       {@link CHBuilder#withTimeDependence(boolean) CHBuilder.withTimeDependence(false)},
+ *       skipping the {@code NUM_BINS x totalEdgeCount} TTF allocation entirely
+ *       (tens of GB on large multi-mode networks);</li>
+ *   <li>customises via {@link CHCustomizer} (one
+ *       {@link TravelDisutility#getLinkMinimumTravelDisutility(Link)} lookup per
+ *       real edge) instead of {@link CHTTFCustomizer}'s
+ *       {@code NUM_BINS x edgeCount} {@link TravelTime#getLinkTravelTime} pass;</li>
+ *   <li>returns {@link CHRouter}, whose inner loop reads {@code edgeWeights[]}
+ *       directly and skips the per-edge time-bin computation present in
+ *       {@code CHRouterTimeDep}.</li>
+ * </ul>
+ *
+ * <h3>Disutility contract</h3>
+ * <p>The supplied {@link TravelDisutility} must return the actual per-link cost
+ * from {@link TravelDisutility#getLinkMinimumTravelDisutility(Link)
+ * getLinkMinimumTravelDisutility}, because {@link CHCustomizer} writes that
+ * value directly into the CH edge weights. Implementations that return
+ * {@code 0} (the upstream default for several MATSim disutilities) will
+ * degenerate the search to "any path". The supplied {@link TravelTime} is
+ * forwarded to {@link CHRouter} but never queried by the search itself.
+ *
+ * <p>Note: on a static {@link CHGraph}, the inner Dijkstra advances its
+ * arrival-time field by the same scalar {@code edgeWeights[]} value it uses as
+ * cost. As a result, {@code getTime()} on any resulting path (or on a
+ * {@link CHLeastCostPathTree} backed by a static graph) is only meaningful when
+ * the supplied {@link TravelDisutility} returns travel time in seconds;
+ * otherwise only {@code getCost()} and {@code getDistance()} carry meaning.
+ *
+ * <h3>Thread safety</h3>
+ * <p>This class is {@link Singleton} and thread-safe: every call returns a new,
+ * independent {@link CHRouter} instance. The underlying {@link CHGraph} is
+ * cached per {@link Network} (the expensive contraction runs only once); the
+ * cheap {@link CHCustomizer} pass runs on every call to reflect the current
+ * {@link TravelDisutility}.
+ */
+@Singleton
+public class StaticCHRouterFactory implements LeastCostPathCalculatorFactory {
+
+    private static final Logger LOG = LogManager.getLogger(StaticCHRouterFactory.class);
+
+    private final Map<Network, SpeedyGraph> baseGraphs = new ConcurrentHashMap<>();
+    private final Map<SpeedyGraph, CHGraph> chGraphCache = new ConcurrentHashMap<>();
+
+    private final int nThreads;
+
+    /**
+     * No-arg constructor that defaults to {@link GlobalConfigGroup}'s default
+     * thread count. Useful when no Guice context is available.
+     */
+    public StaticCHRouterFactory() {
+        this(new GlobalConfigGroup());
+    }
+
+    @Inject
+    public StaticCHRouterFactory(GlobalConfigGroup globalConfig) {
+        this.nThreads = Math.max(1, globalConfig.getNumberOfThreads());
+    }
+
+    @Override
+    public LeastCostPathCalculator createPathCalculator(
+            Network network, TravelDisutility travelCosts, TravelTime travelTimes) {
+
+        SpeedyGraph baseGraph = baseGraphs.computeIfAbsent(network, SpeedyGraphBuilder::buildWithSpatialOrdering);
+
+        CHGraph chGraph = chGraphCache.computeIfAbsent(baseGraph, key -> {
+            LOG.info("[CH-static] Preparing contraction hierarchy for {} nodes, {} links ({} threads)",
+                    fmt(key.nodeCount), fmt(key.linkCount), nThreads);
+            long t0 = System.nanoTime();
+            InertialFlowCutter.NDOrderResult ndOrder =
+                    new InertialFlowCutter(key).computeOrderWithBatches();
+            CHGraph result = new CHBuilder(key, travelCosts)
+                    .withTimeDependence(false)
+                    .buildWithOrderParallel(ndOrder, nThreads);
+            double totalSecs = (System.nanoTime() - t0) / 1_000_000_000.0;
+            LOG.info("[CH-static] CH preprocessing complete: {}s total",
+                    String.format(Locale.US, "%.1f", totalSecs));
+            return result;
+        });
+
+        // Customise on every call to reflect the current disutility. This is an
+        // O(edges) pass with one getLinkMinimumTravelDisutility lookup per real
+        // edge — far cheaper than CHTTFCustomizer's NUM_BINS x edges pass.
+        synchronized (chGraph) {
+            new CHCustomizer().customize(chGraph, travelCosts);
+        }
+
+        return new CHRouter(chGraph, travelTimes, travelCosts);
+    }
+
+    /** Formats an integer with thousands separators (e.g. 195,246). */
+    private static String fmt(int n) {
+        return String.format(Locale.US, "%,d", n);
+    }
+
+}

--- a/matsim/src/test/java/org/matsim/core/router/speedy/CHLeastCostPathTreeTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/speedy/CHLeastCostPathTreeTest.java
@@ -1525,4 +1525,168 @@ public class CHLeastCostPathTreeTest {
         Assertions.assertEquals(0, mismatches,
                 mismatches + " backward-distance mismatches out of " + comparisons + " comparisons");
     }
+
+    // ---- static (time-independent) CHLeastCostPathTree correctness ----
+    //
+    // Mirrors runForward/Backward CorrectnessTest but builds the CH with
+    // withTimeDependence(false) and customizes with CHCustomizer instead of
+    // CHTTFCustomizer.  Exercises the static branches added in
+    // CHLeastCostPathTree (forwardPhase1Static + edgeWeights[] in backward
+    // phase 1).  Since FreespeedTravelTimeAndDisutility is time-independent,
+    // the static tree must match the time-dependent reference Dijkstra exactly.
+
+    @Test
+    void testForwardSearchSmallGridStatic() {
+        runForwardStaticCorrectnessTest(buildGridNetwork(5));
+    }
+
+    @Test
+    void testForwardSearchEquilNetworkStatic() {
+        Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+        new MatsimNetworkReader(scenario.getNetwork()).readFile("test/scenarios/equil/network.xml");
+        runForwardStaticCorrectnessTest(scenario.getNetwork());
+    }
+
+    @Test
+    void testBackwardSearchSmallGridStatic() {
+        runBackwardStaticCorrectnessTest(buildGridNetwork(5));
+    }
+
+    @Test
+    void testBackwardSearchEquilNetworkStatic() {
+        Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+        new MatsimNetworkReader(scenario.getNetwork()).readFile("test/scenarios/equil/network.xml");
+        runBackwardStaticCorrectnessTest(scenario.getNetwork());
+    }
+
+    private void runForwardStaticCorrectnessTest(Network network) {
+        FreespeedTravelTimeAndDisutility tc = new FreespeedTravelTimeAndDisutility(
+                new ScoringConfigGroup());
+
+        SpeedyGraph baseGraph = SpeedyGraphBuilder.build(network);
+
+        InertialFlowCutter.NDOrderResult orderResult =
+                new InertialFlowCutter(baseGraph).computeOrderWithBatches();
+        CHGraph chGraph = new CHBuilder(baseGraph, tc)
+                .withTimeDependence(false)
+                .buildWithOrderParallel(orderResult);
+        new CHCustomizer().customize(chGraph, tc);
+        Assertions.assertFalse(chGraph.isTimeDependent(),
+                "CHGraph must be marked time-independent in static mode.");
+
+        CHLeastCostPathTree chTree = new CHLeastCostPathTree(chGraph, tc, tc);
+        LeastCostPathTree dijkstraTree = new LeastCostPathTree(baseGraph, tc, tc);
+
+        List<Link> linkList = new ArrayList<>(network.getLinks().values());
+        int n = linkList.size();
+        if (n < 2) return;
+
+        Random rng = new Random(42);
+        int mismatches = 0;
+        int comparisons = 0;
+
+        for (int s = 0; s < NUM_SOURCE_NODES; s++) {
+            Link srcLink = linkList.get(rng.nextInt(n));
+            double startTime = 8.0 * 3600;
+
+            chTree.calculate(srcLink, startTime, null, null);
+            dijkstraTree.calculate(srcLink, startTime, null, null);
+
+            for (int t = 0; t < NUM_TARGET_NODES; t++) {
+                Link tgtLink = linkList.get(rng.nextInt(n));
+                int tgtNodeIdx = tgtLink.getFromNode().getId().index();
+
+                // Compare cost (= sum of edge disutilities). In static mode
+                // the "time" field is not meaningful because edgeWeights[]
+                // holds disutility, not travel time.
+                double chCost = chTree.getCost(tgtNodeIdx);
+                double dijCost = dijkstraTree.getCost(tgtNodeIdx);
+
+                boolean chUnreach = Double.isInfinite(chCost) || Double.isNaN(chCost);
+                boolean dijUnreach = Double.isInfinite(dijCost) || Double.isNaN(dijCost);
+                if (chUnreach && dijUnreach) {
+                    comparisons++;
+                    continue;
+                }
+                if (chUnreach || dijUnreach) {
+                    if (!dijUnreach && chUnreach) mismatches++;
+                    comparisons++;
+                    continue;
+                }
+
+                comparisons++;
+                if (Math.abs(chCost - dijCost) > COST_TOLERANCE) {
+                    mismatches++;
+                    System.err.printf("STATIC FORWARD MISMATCH src=%s tgt=%s: CH=%.6f  Dijkstra=%.6f%n",
+                            srcLink.getId(), tgtLink.getId(), chCost, dijCost);
+                }
+            }
+        }
+
+        Assertions.assertEquals(0, mismatches,
+                mismatches + " static-forward cost mismatches out of " + comparisons + " comparisons.");
+    }
+
+    private void runBackwardStaticCorrectnessTest(Network network) {
+        FreespeedTravelTimeAndDisutility tc = new FreespeedTravelTimeAndDisutility(
+                new ScoringConfigGroup());
+
+        SpeedyGraph baseGraph = SpeedyGraphBuilder.build(network);
+
+        InertialFlowCutter.NDOrderResult orderResult =
+                new InertialFlowCutter(baseGraph).computeOrderWithBatches();
+        CHGraph chGraph = new CHBuilder(baseGraph, tc)
+                .withTimeDependence(false)
+                .buildWithOrderParallel(orderResult);
+        new CHCustomizer().customize(chGraph, tc);
+
+        CHLeastCostPathTree chTree = new CHLeastCostPathTree(chGraph, tc, tc);
+        LeastCostPathTree dijkstraTree = new LeastCostPathTree(baseGraph, tc, tc);
+
+        List<Link> linkList = new ArrayList<>(network.getLinks().values());
+        int n = linkList.size();
+        if (n < 2) return;
+
+        Random rng = new Random(42);
+        int mismatches = 0;
+        int comparisons = 0;
+
+        for (int s = 0; s < NUM_SOURCE_NODES; s++) {
+            Link arrLink = linkList.get(rng.nextInt(n));
+            double arrivalTime = 8.0 * 3600;
+
+            chTree.calculateBackwards(arrLink, arrivalTime, null, null);
+            dijkstraTree.calculateBackwards(arrLink, arrivalTime, null, null);
+
+            for (int t = 0; t < NUM_TARGET_NODES; t++) {
+                Link srcLink = linkList.get(rng.nextInt(n));
+                int srcNodeIdx = srcLink.getToNode().getId().index();
+
+                double chCost = chTree.getCost(srcNodeIdx);
+                double dijCost = dijkstraTree.getCost(srcNodeIdx);
+
+                boolean chUnreach = Double.isInfinite(chCost) || Double.isNaN(chCost);
+                boolean dijUnreach = Double.isInfinite(dijCost) || Double.isNaN(dijCost);
+                if (chUnreach && dijUnreach) {
+                    comparisons++;
+                    continue;
+                }
+                if (chUnreach || dijUnreach) {
+                    if (!dijUnreach && chUnreach) mismatches++;
+                    comparisons++;
+                    continue;
+                }
+
+                comparisons++;
+                if (Math.abs(chCost - dijCost) > COST_TOLERANCE) {
+                    mismatches++;
+                    System.err.printf("STATIC BACKWARD MISMATCH src=%s arr=%s: CH=%.6f  Dijkstra=%.6f%n",
+                            srcLink.getId(), arrLink.getId(), chCost, dijCost);
+                }
+            }
+        }
+
+        Assertions.assertEquals(0, mismatches,
+                mismatches + " static-backward cost mismatches out of " + comparisons + " comparisons.");
+    }
 }

--- a/matsim/src/test/java/org/matsim/core/router/speedy/StaticCHRouterFactoryTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/speedy/StaticCHRouterFactoryTest.java
@@ -1,0 +1,41 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * StaticCHRouterFactoryTest.java
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2026 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+package org.matsim.core.router.speedy;
+
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.core.config.groups.ScoringConfigGroup;
+import org.matsim.core.router.AbstractCHLeastCostPathCalculatorTest;
+import org.matsim.core.router.costcalculators.FreespeedTravelTimeAndDisutility;
+import org.matsim.core.router.util.LeastCostPathCalculator;
+
+/**
+ * Standard test suite for {@link StaticCHRouterFactory}. Inherits the full
+ * {@link AbstractCHLeastCostPathCalculatorTest} suite (basic routing + turn
+ * restrictions) and exercises the factory exactly the way external callers
+ * would: a single {@code createPathCalculator} call per scenario, using
+ * {@link FreespeedTravelTimeAndDisutility} for static travel costs.
+ */
+public class StaticCHRouterFactoryTest extends AbstractCHLeastCostPathCalculatorTest {
+	@Override
+	protected LeastCostPathCalculator getLeastCostPathCalculator(final Network network) {
+		FreespeedTravelTimeAndDisutility tc = new FreespeedTravelTimeAndDisutility(new ScoringConfigGroup());
+		return new StaticCHRouterFactory().createPathCalculator(network, tc, tc);
+	}
+}


### PR DESCRIPTION
Adds a static-only mode to the CH overlay so that callers without time-of-day travel-time variation (skims, accessibility, link strippers, freespeed routers, pt2matsim's schedule mapping, …) can avoid the `NUM_BINS × totalEdgeCount` TTF allocation (tens of GB on large multi-mode networks) and the corresponding `CHTTFCustomizer` pass. Together with the static-graph support in `CHLeastCostPathTree`, this unblocks downstream consumers like `pt2matsim` (see https://github.com/matsim-org/pt2matsim/pull/417), which routes on time-independent disutilities and currently pays the full time-dependent CH cost for no benefit.

**Commit 1: `feat(router): add time-dependence configuration to CHGraph`**
Adds `CHBuilder.withTimeDependence(boolean)` and a matching `CHGraph.isTimeDependent()` flag; when `false`, the `ttf`/`minTTF`/`ttfHash` arrays are skipped entirely. Adds an overflow guard around the TTF allocation (previously a `96 × edgeCount` int overflow silently produced `NegativeArraySizeException`) and rejects static graphs in `CHTTFCustomizer`, `CHRouterTimeDep`, and `CHLeastCostPathTree`.

**Commit 2: `feat(router): enhance CHLeastCostPathTree for static graph support and add corresponding tests`**
Lifts the temporary rejection in `CHLeastCostPathTree` and adds a static branch that reads `edgeWeights[]` directly (no per-edge bin lookup); branch is hoisted out of the Phase-1 hot loop. Adds 4 randomized correctness tests on small-grid and equil networks for both forward and backward search.

**Commit 3: `feat(router): add StaticCHRouterFactory for time-independent CH routing`**
Adds `StaticCHRouterFactory`, a Guice-`@Singleton` `LeastCostPathCalculatorFactory` mirroring `CHRouterFactory`'s caching pattern but using `withTimeDependence(false)` + `CHCustomizer` + `CHRouter`. Inherits the full `AbstractCHLeastCostPathCalculatorTest` suite (basic routing + turn restrictions, 8 tests).