### PR TITLE
fix(drt): clarify reference/column name in od.csv (DrtAnalysisPostProcessing)

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/dashboards/DrtAnalysisPostProcessing.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/dashboards/DrtAnalysisPostProcessing.java
@@ -296,7 +296,7 @@ public final class DrtAnalysisPostProcessing implements MATSimAppCommand {
 
 		try (CSVPrinter csv = new CSVPrinter(Files.newBufferedWriter(path), CSVFormat.DEFAULT)) {
 
-			csv.printRecord("from_stop", "to_stop", "trips");
+			csv.printRecord("from_linkId", "to_linkId", "trips");
 
 			for (Object2IntMap.Entry<OD> e : entries) {
 				OD od = e.getKey();

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/dashboards/DrtDashboard.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/dashboards/DrtDashboard.java
@@ -146,7 +146,7 @@ public class DrtDashboard implements Dashboard {
 		;
 
 //		This plot is not absolutely necesarry given the hex plots
-//		if (drtConfigGroup.operationalScheme == DrtConfigGroup.OperationalScheme.stopbased)
+//		if (drtConfigGroup.getOperationalScheme() == DrtConfigGroup.OperationalScheme.stopbased)
 //			layout.row("od").el(AggregateOD.class, (viz, data) -> {
 //
 //				viz.shpFile = postProcess(data, "stops.shp");


### PR DESCRIPTION

column names in `analysis/drt/od.csv` were misleading: in fact, this is a link-based analysis and not stop-based.