### PR TITLE
fix(drt): unify name pattern for output stops file and ...

### DIFF
--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/dashboards/DrtAnalysisPostProcessing.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/dashboards/DrtAnalysisPostProcessing.java
@@ -34,6 +34,7 @@ import org.matsim.core.utils.geometry.CoordinateTransformation;
 import org.matsim.core.utils.geometry.transformations.TransformationFactory;
 import org.matsim.core.utils.gis.GeoFileReader;
 import org.matsim.core.utils.gis.GeoFileWriter;
+import org.matsim.core.utils.io.IOUtils;
 import org.matsim.pt.transitSchedule.api.TransitScheduleReader;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 import picocli.CommandLine;
@@ -76,8 +77,9 @@ public final class DrtAnalysisPostProcessing implements MATSimAppCommand {
 	@CommandLine.Option(names = "--drt-mode", required = true, description = "Name of the drt mode to analyze.")
 	private String drtMode;
 
-	@CommandLine.Option(names = "--stops-file", description = "URL to drt stops file")
-	private URL stopsFile;
+	@CommandLine.Option(names = "--with-stops", defaultValue = "false",
+		description = "read stops file from matsim output directory")
+	private boolean readStops;
 
 	@CommandLine.Option(names = "--area-file", description = "URL to drt service area file")
 	private URL areaFile;
@@ -180,8 +182,8 @@ public final class DrtAnalysisPostProcessing implements MATSimAppCommand {
 			.separator(';').build());
 
 		Table tableSupplyKPI = Table.create("supplyKPI");
-		if (stopsFile != null) {
-			List<TransitStopFacility> stops = readTransitStops(stopsFile);
+		if (readStops) {
+			List<TransitStopFacility> stops = readTransitStops();
 			writeStopsShp(stops, output.getPath("stops.shp"));
 
 			Map<String, TransitStopFacility> byLink = stops.stream().collect(Collectors.toMap(s -> s.getLinkId().toString(), Function.identity(),
@@ -307,11 +309,11 @@ public final class DrtAnalysisPostProcessing implements MATSimAppCommand {
 		}
 	}
 
-	private List<TransitStopFacility> readTransitStops(URL stopFile) {
-
+	private List<TransitStopFacility> readTransitStops() {
+		URL stopFile = IOUtils.resolveFileOrResource(ApplicationUtils.matchInput("output_drt_stops_" + drtMode + ".xml",
+			input.getRunDirectory()).toAbsolutePath().toString());
 		Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
 		new TransitScheduleReader(scenario).readURL(stopFile);
-
 
 		return new ArrayList<>(scenario.getTransitSchedule().getFacilities().values());
 	}

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/dashboards/DrtDashboard.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/dashboards/DrtDashboard.java
@@ -51,7 +51,7 @@ public class DrtDashboard implements Dashboard {
 		switch (drtConfigGroup.getOperationalScheme()) {
 			case stopbased ->
 //				drtConfigGroup.transitStopFile can not be null, otherwise simulation crashed, earlier
-				args.addAll(List.of("--with-stops", ConfigGroup.getInputFileURL(matsimConfigContext, drtConfigGroup.getTransitStopFile()).toString()));
+				args.addAll(List.of("--with-stops", "true"));
 			case door2door -> {
 				//TODO potentially show the entire drt network (all drt links have stops)
 			}

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/dashboards/DrtDashboard.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/dashboards/DrtDashboard.java
@@ -51,7 +51,7 @@ public class DrtDashboard implements Dashboard {
 		switch (drtConfigGroup.getOperationalScheme()) {
 			case stopbased ->
 //				drtConfigGroup.transitStopFile can not be null, otherwise simulation crashed, earlier
-				args.addAll(List.of("--stops-file", ConfigGroup.getInputFileURL(matsimConfigContext, drtConfigGroup.getTransitStopFile()).toString()));
+				args.addAll(List.of("--with-stops", ConfigGroup.getInputFileURL(matsimConfigContext, drtConfigGroup.getTransitStopFile()).toString()));
 			case door2door -> {
 				//TODO potentially show the entire drt network (all drt links have stops)
 			}

--- a/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/dashboards/DrtDashboard.java
+++ b/contribs/drt-extensions/src/main/java/org/matsim/contrib/drt/extension/dashboards/DrtDashboard.java
@@ -51,7 +51,7 @@ public class DrtDashboard implements Dashboard {
 		switch (drtConfigGroup.getOperationalScheme()) {
 			case stopbased ->
 //				drtConfigGroup.transitStopFile can not be null, otherwise simulation crashed, earlier
-				args.addAll(List.of("--with-stops", "true"));
+				args.addAll(List.of("--with-stops"));
 			case door2door -> {
 				//TODO potentially show the entire drt network (all drt links have stops)
 			}

--- a/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/dashboards/DashboardTests.java
+++ b/contribs/drt-extensions/src/test/java/org/matsim/contrib/drt/extension/dashboards/DashboardTests.java
@@ -23,9 +23,9 @@ public class DashboardTests {
 	private void run() {
 
 		Config config = DrtTestScenario.loadConfig(utils);
-		config.controller().setLastIteration(4);
-		config.controller().setWritePlansInterval(4);
-		config.controller().setWriteEventsInterval(4);
+		config.controller().setLastIteration(2);
+		config.controller().setWritePlansInterval(2);
+		config.controller().setWriteEventsInterval(2);
 
 		SimWrapperConfigGroup group = ConfigUtils.addOrGetModule(config, SimWrapperConfigGroup.class);
 //		group.setSampleSize(0.001);

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeRoutingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeRoutingModule.java
@@ -111,6 +111,7 @@ public class DrtModeRoutingModule extends AbstractDvrpModeModule {
 		if(drtCfg.getOperationalScheme() == DrtConfigGroup.OperationalScheme.stopbased) {
 			bindModal(DumpDrtStopsAtEnd.class).toProvider(modalProvider(
 					getter -> new DumpDrtStopsAtEnd(
+							this.getMode(),
 							getter.getModal(DrtStopNetwork.class),
 							getter.get(OutputDirectoryHierarchy.class)
 					))

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/util/DumpDrtStopsAtEnd.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/util/DumpDrtStopsAtEnd.java
@@ -19,8 +19,10 @@ public final class DumpDrtStopsAtEnd implements ShutdownListener {
 	private final DrtStopNetwork drtStopNetwork;
 
 	private final OutputDirectoryHierarchy outputDirectoryHierarchy;
+	private final String mode;
 
-	public DumpDrtStopsAtEnd(DrtStopNetwork drtStopNetwork, OutputDirectoryHierarchy outputDirectoryHierarchy) {
+	public DumpDrtStopsAtEnd(String mode, DrtStopNetwork drtStopNetwork, OutputDirectoryHierarchy outputDirectoryHierarchy) {
+		this.mode = mode;
 		this.drtStopNetwork = drtStopNetwork;
 		this.outputDirectoryHierarchy = outputDirectoryHierarchy;
 	}
@@ -37,7 +39,8 @@ public final class DumpDrtStopsAtEnd implements ShutdownListener {
 		try {
 			if (this.drtStopNetwork != null) {
 				TransitSchedule transitSchedule = DrtStopNetwork.toTransitSchedule(this.drtStopNetwork);
-				new TransitScheduleWriter(transitSchedule).writeFile(this.outputDirectoryHierarchy.getOutputFilename("output_drt_Stops.xml.gz"));
+				new TransitScheduleWriter(transitSchedule).writeFile(this.outputDirectoryHierarchy
+					.getOutputFilename("output_drt_stops_" + this.mode + ".xml.gz"));
 			}
 		} catch (Exception ee) {
 			log.error("Exception writing drt stops.", ee);


### PR DESCRIPTION
... read drt stops from output instead of from input when creating SimWrapper dashboard for drt
