### PR TITLE
feat(application): Add createControler method

### DIFF
--- a/matsim/src/main/java/org/matsim/application/MATSimApplication.java
+++ b/matsim/src/main/java/org/matsim/application/MATSimApplication.java
@@ -24,9 +24,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * A helper class to define and execute MATSim scenarios, including a pipeline of prepare and analysis scripts.
- * This class provides a common scenario setup procedure and command line parsing.
- * Scenarios simply need to extend it and overwrite the *prepare methods if needed.
+ * A helper class to define and execute MATSim scenarios, including a pipeline of prepare and analysis scripts. This class provides a common scenario
+ * setup procedure and command line parsing. Scenarios simply need to extend it and overwrite the *prepare methods if needed.
  * <p>
  * To run your application use:
  * <code>
@@ -35,8 +34,8 @@ import java.util.concurrent.atomic.AtomicReference;
  * <p>
  * There are also other variants of this method, e.g. to run the scenario within code.
  * <p>
- * This class also automatically registers classes from the {@link Prepare} and {@link Analysis} annotations as subcommands.
- * These can be used to build a pipeline with command needed for preparation analysis.
+ * This class also automatically registers classes from the {@link Prepare} and {@link Analysis} annotations as subcommands. These can be used to
+ * build a pipeline with command needed for preparation analysis.
  *
  * @see #start(Class, String...)
  * @see #execute(Class, Config, String...)
@@ -142,10 +141,10 @@ public abstract class MATSimApplication implements Callable<Integer> {
 			// would, in my understanding, set the context separately from the config path name.
 			//  But I am not sure how this would execute in everything that follows.  kai, feb'26
 
-			String path = Objects.requireNonNull( configPath, "No config given; use --config=<path-to-config.xml>" );
+			String path = Objects.requireNonNull(configPath, "No config given; use --config=<path-to-config.xml>");
 
 			final Config config1 = ConfigUtils.loadConfig(IOUtils.resolveFileOrResource(path));
-			Config preparedConfig = prepareConfig( config1 );
+			Config preparedConfig = prepareConfig(config1);
 
 			config = preparedConfig != null ? preparedConfig : config1;
 			// (The above lines of code come from inlining so maybe it happened there: I cannot see how "preparedConfig" could
@@ -159,8 +158,8 @@ public abstract class MATSimApplication implements Callable<Integer> {
 
 		Objects.requireNonNull(config);
 
-		if ( yamlFilename != null)
-			ApplicationUtils.applyConfigUpdate(config, IOUtils.resolveFileOrResource( yamlFilename ) );
+		if (yamlFilename != null)
+			ApplicationUtils.applyConfigUpdate(config, IOUtils.resolveFileOrResource(yamlFilename));
 
 		if (remainingArgs != null) {
 			String[] args = remainingArgs.stream().map(s -> s.replace("-c:", "--config:")).toArray(String[]::new);
@@ -184,7 +183,7 @@ public abstract class MATSimApplication implements Callable<Integer> {
 
 			prepareScenario(scenario);
 
-			Controler controler = new Controler(scenario);
+			Controler controler = createControler(scenario);
 			prepareControler(controler);
 
 			// Check if simulation needs to be run
@@ -194,7 +193,8 @@ public abstract class MATSimApplication implements Callable<Integer> {
 
 		if (post != PostProcessOption.disabled) {
 
-			List<MATSimAppCommand> commands = preparePostProcessing(Path.of(config.controller().getOutputDirectory()), config.controller().getRunId());
+			List<MATSimAppCommand> commands = preparePostProcessing(Path.of(config.controller().getOutputDirectory()),
+				config.controller().getRunId());
 
 			for (MATSimAppCommand command : commands) {
 
@@ -207,7 +207,6 @@ public abstract class MATSimApplication implements Callable<Integer> {
 			}
 		}
 
-
 		return 0;
 	}
 
@@ -215,30 +214,30 @@ public abstract class MATSimApplication implements Callable<Integer> {
 		return configPath;
 	}
 
-//	/**
-//	 * Custom module configs that will be added to the {@link Config} object.
-//	 *
-//	 * @return {@link ConfigGroup} to add
-//	 */
-//	protected List<ConfigGroup> getCustomModules() {
-//		return Lists.newArrayList();
-//	}
+	//	/**
+	//	 * Custom module configs that will be added to the {@link Config} object.
+	//	 *
+	//	 * @return {@link ConfigGroup} to add
+	//	 */
+	//	protected List<ConfigGroup> getCustomModules() {
+	//		return Lists.newArrayList();
+	//	}
 	// (no longer used IMO.  kai, feb'26)
 	// (I think that this was meant to add "configurable modules".  However, modules are configurable via the sebhoerl
 	// command line syntax anyways.  I can't say if they possibly behave in a different way re non-default
 	// modules but am relatively sure that, because the corresponding
 	// command was commented out below, it would not have worked anyways with the current setup.)
 
-//	/**
-//	 * Modules that are configurable via command line arguments.
-//	 */
-//	protected List<ConfigGroup> getConfigurableModules() {
-//		return Lists.newArrayList(
-//			new ControllerConfigGroup(),
-//			new GlobalConfigGroup(),
-//			new QSimConfigGroup()
-//		);
-//	}
+	//	/**
+	//	 * Modules that are configurable via command line arguments.
+	//	 */
+	//	protected List<ConfigGroup> getConfigurableModules() {
+	//		return Lists.newArrayList(
+	//			new ControllerConfigGroup(),
+	//			new GlobalConfigGroup(),
+	//			new QSimConfigGroup()
+	//		);
+	//	}
 	// (never used IMO.  kai, feb'26)
 
 	/**
@@ -267,16 +266,22 @@ public abstract class MATSimApplication implements Callable<Integer> {
 	}
 
 	/**
-	 * Allows scenario creation with other loadScenario signatures
-	 * e.g. with AttributeConverter
+	 * Allows scenario creation with other loadScenario signatures e.g. with AttributeConverter
 	 */
 	protected Scenario createScenario(Config config) {
 		return ScenarioUtils.loadScenario(config);
 	}
 
 	/**
-	 * Preparation of {@link MATSimAppCommand} to run after the simulation has finished. The instances have to be fully constructed in this method
-	 * no further arguments are passed down to them.
+	 * Allows creating a controller other than the default. This is useful for distributed applications, for example.
+	 */
+	protected Controler createControler(Scenario scenario) {
+		return new Controler(scenario);
+	}
+
+	/**
+	 * Preparation of {@link MATSimAppCommand} to run after the simulation has finished. The instances have to be fully constructed in this method no
+	 * further arguments are passed down to them.
 	 *
 	 * @return list of commands to run.
 	 */
@@ -321,8 +326,7 @@ public abstract class MATSimApplication implements Callable<Integer> {
 	}
 
 	/**
-	 * Start the application class and terminates when done.
-	 * This should never be used in tests and only in main methods.
+	 * Start the application class and terminates when done. This should never be used in tests and only in main methods.
 	 */
 	public static void start(Class<? extends MATSimApplication> clazz, String... args) {
 		MATSimApplication app = newInstance(clazz, null);
@@ -376,7 +380,6 @@ public abstract class MATSimApplication implements Callable<Integer> {
 	/**
 	 * <p>Convenience method to run a scenario from code or automatically with gui when desktop application is detected.
 	 * This method may also be used to predefine some default arguments.</p>
-	 *
 	 * <p>With respect to args it looks like arguments are treated in the following sequence (programmed in the run method):
 	 * <ul>
 	 *         <li>ConfigUtils.loadConfig without args</li>
@@ -384,9 +387,7 @@ public abstract class MATSimApplication implements Callable<Integer> {
 	 *         <li>config options from some yaml file which can be provided as a command line option</li>
 	 *         <li>config options on command line </li>
 	 * </ul></p>
-	 *
 	 * <p>defaultArgs could be used to provide defaults when calling this method here; they would go in addition to what is coming in from "upstream" which is typically the command line.</p>
-	 *
 	 * <p>There are many execution paths that can be reached from this class, but a typical one for matsim-scenarios seems to be:<ul>
 	 * <li> This method runs MATSimApplication.start( TheScenarioClass.class , args ).</li>
 	 * <li> That run class will instantiate an instance of TheScenarioClass (*), then do some args consistenty checking, then call the piccoli execute method. </li>
@@ -465,7 +466,6 @@ public abstract class MATSimApplication implements Callable<Integer> {
 
 		CommandLine cli = prepare(app);
 
-
 		AtomicReference<Exception> exc = new AtomicReference<>();
 		cli.setExecutionExceptionHandler((ex, commandLine, parseResult) -> {
 			exc.set(ex);
@@ -496,8 +496,7 @@ public abstract class MATSimApplication implements Callable<Integer> {
 	}
 
 	/**
-	 * Prepare and return controller without running the scenario.
-	 * This allows to configure the controller after setup has been run.
+	 * Prepare and return controller without running the scenario. This allows to configure the controller after setup has been run.
 	 */
 	public static Controler prepare(MATSimApplication app, Config config, String... args) {
 		CommandLine cli = prepare(app);
@@ -515,7 +514,7 @@ public abstract class MATSimApplication implements Callable<Integer> {
 		config = tmp != null ? tmp : config;
 
 		if (app.yamlFilename != null) {
-			ApplicationUtils.applyConfigUpdate(config, IOUtils.resolveFileOrResource(app.yamlFilename ) );
+			ApplicationUtils.applyConfigUpdate(config, IOUtils.resolveFileOrResource(app.yamlFilename));
 		}
 
 		if (app.remainingArgs != null) {
@@ -533,9 +532,8 @@ public abstract class MATSimApplication implements Callable<Integer> {
 	}
 
 	/**
-	 * Prepare and return controller without running the scenario.
-	 * This allows to configure the controller after setup has been run.
-	 * This method tries to use one of the constructors of the given class automatically.
+	 * Prepare and return controller without running the scenario. This allows to configure the controller after setup has been run. This method tries
+	 * to use one of the constructors of the given class automatically.
 	 *
 	 * @see #prepare(MATSimApplication, Config, String...)
 	 */
@@ -595,7 +593,7 @@ public abstract class MATSimApplication implements Callable<Integer> {
 			try {
 				return clazz.getDeclaredConstructor(Config.class).newInstance(config);
 			} catch (NoSuchMethodException e) {
-				throw new RuntimeException( "Requested constructor not available", e );
+				throw new RuntimeException("Requested constructor not available", e);
 			} catch (ReflectiveOperationException e) {
 				throw new RuntimeException("Could not instantiate the application class", e);
 			}
@@ -614,8 +612,8 @@ public abstract class MATSimApplication implements Callable<Integer> {
 	private static CommandLine prepare(MATSimApplication app) {
 		CommandLine cli = new CommandLine(app);
 
-		if (cli.getCommandName().equals(DEFAULT_NAME)){
-			cli.setCommandName( app.getClass().getSimpleName() );
+		if (cli.getCommandName().equals(DEFAULT_NAME)) {
+			cli.setCommandName(app.getClass().getSimpleName());
 		}
 		// (commandName is what is displayed in the command line help text.  It seems that, with inheritance,
 		// piccoli sets this to the base class, but we want to have it set to the outermost class. kai,)
@@ -627,10 +625,9 @@ public abstract class MATSimApplication implements Callable<Integer> {
 		// (this extracts the "Prepare" and "Analysis" subcommands.  yy Note
 		// that additional subcommand namespaces need to be programmed here.)
 
-
-//		List<ConfigGroup> modules = Lists.newArrayList();
-//		modules.addAll(app.getConfigurableModules());
-//		modules.addAll(app.getCustomModules());
+		//		List<ConfigGroup> modules = Lists.newArrayList();
+		//		modules.addAll(app.getConfigurableModules());
+		//		modules.addAll(app.getCustomModules());
 		// I found the following with setupConfig( cli, modules ) commented out.  I am not touching the line to leave git annotate intact ...
 		// ... from here ...
 


### PR DESCRIPTION
Similar to `createScenario` user code can override the `createControler` method to supply its own `Controler`. This is necessary for distributed applications. where the `Controler` must be supplied with a `DistributedContext`.
