### PR TITLE
fix(Config): validation of countsScaleFactor in globalConfigGroup

### DIFF
--- a/contribs/simwrapper/src/test/java/org/matsim/simwrapper/dashboard/TrafficCountsDashboardTest.java
+++ b/contribs/simwrapper/src/test/java/org/matsim/simwrapper/dashboard/TrafficCountsDashboardTest.java
@@ -106,7 +106,8 @@ public class TrafficCountsDashboardTest {
 			String absolutPath = Path.of(utils.getPackageInputDirectory()).normalize().toAbsolutePath() + "/dummy_counts.xml";
 
 			config.counts().setInputFile(absolutPath);
-			config.counts().setCountsScaleFactor( config.qsim().getFlowCapFactor() );
+			// due to implementation in CountsComparisonAlgorithm this needs to be the inverse of flowCapFactor
+			config.counts().setCountsScaleFactor( 1. / config.qsim().getFlowCapFactor());
 			new CountsWriter(counts).write(absolutPath);
 		} catch (IOException e) {
 			e.printStackTrace();

--- a/matsim/src/main/java/org/matsim/core/config/groups/GlobalConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/GlobalConfigGroup.java
@@ -161,7 +161,8 @@ public final class GlobalConfigGroup extends ReflectiveConfigGroup {
 										   + ". (The old approach of setting the stor cap fact larger than the flow cap fact is no longer needed since the qsim became a lot more deterministic.)  Relative tolerance can be set in the global config group." );
 		}
 		if ( config.counts().getCountsFileName()!=null && !config.counts().getCountsFileName().isEmpty() ){
-			if( !Precision.equalsWithRelativeTolerance( flowCapFactor, config.counts().getCountsScaleFactor(), relativeTolerance ) ){
+			// CountsComparisonAlgorithm multiplies the count-value from sim with the countsScaleFactor, i.e. we need the inverse of the flowCapFactor here
+			if( !Precision.equalsWithRelativeTolerance( flowCapFactor, 1. / config.counts().getCountsScaleFactor(), relativeTolerance ) ){
 				throw new RuntimeException(
 					"your countsScaleFactor=" + config.counts().getCountsScaleFactor() + " is more than the relativeTolerance=" + relativeTolerance + " different from the flowCapFactor=" + flowCapFactor
 				+ ". Relative tolerance can be set in the global config group.");


### PR DESCRIPTION
The validation currently checks if countsScaleFactor and flowCap are equal, but countsScaleFactor needs to be the inverse of flowCap, because [CountsComparisonAlgorithm](https://github.com/matsim-org/matsim-libs/blob/8fbe12b6ebb9816d271e4e1fc18fc134ec7707dc/matsim/src/main/java/org/matsim/counts/algorithms/CountsComparisonAlgorithm.java#L138) multiplies the count-value from sim with the countsScaleFactor.

close #4892 