### PR TITLE
perf(io): unsynchronized FastBufferedWriter for MATSim file writing

### DIFF
--- a/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/qgis/QGisFileWriter.java
+++ b/contribs/analysis/src/main/java/org/matsim/contrib/analysis/vsp/qgis/QGisFileWriter.java
@@ -1,7 +1,7 @@
 package org.matsim.contrib.analysis.vsp.qgis;
 
-import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.Writer;
 import java.nio.file.Paths;
 
 /**
@@ -19,20 +19,20 @@ public class QGisFileWriter {
 		this.writer = writer;
 	}
 	
-	public void writeHeaderAndStartElement(BufferedWriter out) throws IOException{
+	public void writeHeaderAndStartElement(Writer out) throws IOException{
 		
 		out.write("<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>\n");
 		out.write("<qgis projectname=\"" + this.writer.getProjectname() + "\" version=\"" + QGisConstants.currentVersion + "\">\n");
 		
 	}
 	
-	public void writeTitle(BufferedWriter out) throws IOException{
+	public void writeTitle(Writer out) throws IOException{
 		
 		out.write("\t<title>" + this.writer.getTitle() + "</title>\n");
 		
 	}
 	
-	public void writeLayerTreeGroup(BufferedWriter out) throws IOException{
+	public void writeLayerTreeGroup(Writer out) throws IOException{
 		
 		out.write("\t<layer-tree-group expanded=\"1\" checked=\"Qt::Checked\" name=\"\">\n");
 		
@@ -48,7 +48,7 @@ public class QGisFileWriter {
 		
 	}
 	
-	private void writeLayerTreeLayer(BufferedWriter out, QGisLayer layer) throws IOException{
+	private void writeLayerTreeLayer(Writer out, QGisLayer layer) throws IOException{
 		
 		out.write("\t\t<layer-tree-layer expanded=\"1\" checked=\"Qt::Checked\" id=\"" + layer.getId().toString() + "\" name=\"" + layer.getName() + "\">\n");
 		out.write("\t\t\t<customproperties/>\n");
@@ -56,7 +56,7 @@ public class QGisFileWriter {
 		
 	}
 	
-	public void writeMapCanvas(BufferedWriter out) throws IOException{
+	public void writeMapCanvas(Writer out) throws IOException{
 		
 		out.write("\t<mapcanvas>\n");
 		
@@ -77,7 +77,7 @@ public class QGisFileWriter {
 		
 	}
 	
-	private void writeDestinationSrs(BufferedWriter out) throws IOException{
+	private void writeDestinationSrs(Writer out) throws IOException{
 		
 		out.write("\t\t<destinationsrs>\n");
 		
@@ -98,7 +98,7 @@ public class QGisFileWriter {
 		
 	}
 	
-	public void writeLayerTreeCanvas(BufferedWriter out) throws IOException{
+	public void writeLayerTreeCanvas(Writer out) throws IOException{
 		
 		out.write("\t<layer-tree-canvas>\n");
 		
@@ -116,13 +116,13 @@ public class QGisFileWriter {
 		
 	}
 	
-	private void writeItem(BufferedWriter out, QGisLayer layer) throws IOException{
+	private void writeItem(Writer out, QGisLayer layer) throws IOException{
 		
 		out.write("\t\t\t<item>" + layer.getId().toString() + "</item>\n");
 		
 	}
 	
-	public void writeProjectLayers(BufferedWriter out) throws IOException{
+	public void writeProjectLayers(Writer out) throws IOException{
 		
 		out.write("\t<projectlayers layercount=\"" + this.writer.getLayers().size() + "\">\n");
 		
@@ -136,7 +136,7 @@ public class QGisFileWriter {
 		
 	}
 	
-	private void writeMapLayer(BufferedWriter out, QGisLayer layer) throws IOException{
+	private void writeMapLayer(Writer out, QGisLayer layer) throws IOException{
 		
 		if(layer.getType().equals(QGisConstants.layerType.vector)){
 			
@@ -154,7 +154,7 @@ public class QGisFileWriter {
 		
 	}
 	
-	private void writeVectorLayer(BufferedWriter out, QGisLayer layer) throws IOException {
+	private void writeVectorLayer(Writer out, QGisLayer layer) throws IOException {
 		
 		VectorLayer vlayer = (VectorLayer) layer;
 		
@@ -283,7 +283,7 @@ public class QGisFileWriter {
 	
 	}
 
-	private void writeRasterLayer(BufferedWriter out, QGisLayer layer)throws IOException {
+	private void writeRasterLayer(Writer out, QGisLayer layer)throws IOException {
 		
 		RasterLayer rlayer = (RasterLayer) layer;
 		
@@ -352,7 +352,7 @@ public class QGisFileWriter {
 		
 	}
 	
-	private void writeGeometryLayer(BufferedWriter out, VectorLayer layer) throws IOException {
+	private void writeGeometryLayer(Writer out, VectorLayer layer) throws IOException {
 	
 		QGisRenderer qRenderer = layer.getRenderer();
 		
@@ -453,7 +453,7 @@ public class QGisFileWriter {
 		
 	}
 
-	private void writePointLayer(BufferedWriter out, QGisLayer layer, int idx) throws IOException {
+	private void writePointLayer(Writer out, QGisLayer layer, int idx) throws IOException {
 
 		QGisPointSymbolLayer psl = (QGisPointSymbolLayer)layer.getRenderer().getSymbolLayers().get(idx);
 		
@@ -499,7 +499,7 @@ public class QGisFileWriter {
 			
 	}
 
-	private void writeLineLayer(BufferedWriter out, QGisLayer layer, int idx) throws IOException {
+	private void writeLineLayer(Writer out, QGisLayer layer, int idx) throws IOException {
 		
 		QGisLineSymbolLayer lsl = (QGisLineSymbolLayer)layer.getRenderer().getSymbolLayers().get(0);
 		
@@ -534,7 +534,7 @@ public class QGisFileWriter {
 			
 	}
 
-	private void writePolygonLayer(BufferedWriter out, QGisLayer layer, int idx) throws IOException {
+	private void writePolygonLayer(Writer out, QGisLayer layer, int idx) throws IOException {
 
 		QGisPolygonSymbolLayer psl = (QGisPolygonSymbolLayer)layer.getRenderer().getSymbolLayers().get(idx);
 
@@ -574,7 +574,7 @@ public class QGisFileWriter {
 
 	}
 
-	public void writeProperties(BufferedWriter out) throws IOException{
+	public void writeProperties(Writer out) throws IOException{
 		
 		out.write("\t<properties>\n");
 		
@@ -605,7 +605,7 @@ public class QGisFileWriter {
 		
 	}
 
-	public void endFile(BufferedWriter out) throws IOException{
+	public void endFile(Writer out) throws IOException{
 		
 		out.write("</qgis>");
 		

--- a/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlWriterV2_1.java
+++ b/contribs/freight/src/main/java/org/matsim/freight/carriers/CarrierPlanXmlWriterV2_1.java
@@ -24,9 +24,9 @@ package org.matsim.freight.carriers;
 import static org.matsim.freight.carriers.CarrierConstants.*;
 
 import com.google.inject.Inject;
-import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -111,7 +111,7 @@ import org.matsim.vehicles.VehicleType;
 		this.writeStartTag(CARRIERS, atts);
 	}
 
-	private void startCarrier(Carrier carrier, BufferedWriter writer) {
+	private void startCarrier(Carrier carrier, Writer writer) {
 		this.writeStartTag(CARRIER, List.of(
 				createTuple(ID, carrier.getId().toString())), false, true
 		);
@@ -140,7 +140,7 @@ import org.matsim.vehicles.VehicleType;
 		this.writeEndTag(CAPABILITIES);
 	}
 
-	private void writeShipments(Carrier carrier, BufferedWriter writer) {
+	private void writeShipments(Carrier carrier, Writer writer) {
 		if(carrier.getShipments().isEmpty()) return;
 		this.writeStartTag(SHIPMENTS, null);
 		for (CarrierShipment s : carrier.getShipments().values()) {
@@ -171,7 +171,7 @@ import org.matsim.vehicles.VehicleType;
 		);
 	}
 
-	private void writeServices(Carrier carrier, BufferedWriter writer) {
+	private void writeServices(Carrier carrier, Writer writer) {
 		if(carrier.getServices().isEmpty()) return;
 		this.writeStartTag(SERVICES, null);
 		for (CarrierService s : carrier.getServices().values()) {
@@ -202,7 +202,7 @@ import org.matsim.vehicles.VehicleType;
 		return Time.writeTime(time);
 	}
 
-	private void writePlans(Carrier carrier, BufferedWriter writer)
+	private void writePlans(Carrier carrier, Writer writer)
 			throws IOException {
 		if (carrier.getSelectedPlan() == null) {
 			return;

--- a/contribs/freightreceiver/src/main/java/org/matsim/freight/receiver/ReceiversWriterHandler.java
+++ b/contribs/freightreceiver/src/main/java/org/matsim/freight/receiver/ReceiversWriterHandler.java
@@ -21,7 +21,7 @@
 package org.matsim.freight.receiver;
 
 import org.matsim.freight.carriers.TimeWindow;
-import java.io.BufferedWriter;
+import java.io.Writer;
 import java.io.IOException;
 
 /**
@@ -31,48 +31,48 @@ import java.io.IOException;
  interface ReceiversWriterHandler {
 
 	/* <freightReceivers> ... </freightReceivers> */
-	void startReceivers(final Receivers receivers, final BufferedWriter out) throws IOException;
-	void endReceivers(final BufferedWriter out) throws IOException;
+	void startReceivers(final Receivers receivers, final Writer out) throws IOException;
+	void endReceivers(final Writer out) throws IOException;
 
 	/* <products> ... </products> */
-	void startProducts(final BufferedWriter out) throws IOException;
-	void endProducts(final BufferedWriter out) throws IOException;
+	void startProducts(final Writer out) throws IOException;
+	void endProducts(final Writer out) throws IOException;
 
 	/* <product> ... </product> */
-	void startProduct(final ProductType product, final BufferedWriter out) throws IOException;
-	void endProduct(final BufferedWriter out) throws IOException;
+	void startProduct(final ProductType product, final Writer out) throws IOException;
+	void endProduct(final Writer out) throws IOException;
 
 	/* <receiver> ... </receiver> */
-	void startReceiver(final Receiver receiver, final BufferedWriter out) throws IOException;
-	void endReceiver(final BufferedWriter out) throws IOException;
+	void startReceiver(final Receiver receiver, final Writer out) throws IOException;
+	void endReceiver(final Writer out) throws IOException;
 
 	/* <timeWindow> ... </timeWindow> */
-	void startTimeWindow(final TimeWindow window, final BufferedWriter out) throws IOException;
-	void endTimeWindow(final BufferedWriter out) throws IOException;
+	void startTimeWindow(final TimeWindow window, final Writer out) throws IOException;
+	void endTimeWindow(final Writer out) throws IOException;
 
 	/* <product> ... </product> */
-	void startReceiverProduct(final ReceiverProduct product, final BufferedWriter out) throws IOException;
-	void endReceiverProduct(final BufferedWriter out) throws IOException;
+	void startReceiverProduct(final ReceiverProduct product, final Writer out) throws IOException;
+	void endReceiverProduct(final Writer out) throws IOException;
 
 	/* <reorderPolicy> ... </reorderPolicy> */
-	void startReorderPolicy(final ReorderPolicy policy, final BufferedWriter out) throws IOException;
-	void endReorderPolicy(final BufferedWriter out) throws IOException;
+	void startReorderPolicy(final ReorderPolicy policy, final Writer out) throws IOException;
+	void endReorderPolicy(final Writer out) throws IOException;
 
 	/* <plan> ... </plan> */
-	void startPlan(final ReceiverPlan plan, final BufferedWriter out) throws IOException;
-	void endPlan(final BufferedWriter out) throws IOException;
+	void startPlan(final ReceiverPlan plan, final Writer out) throws IOException;
+	void endPlan(final Writer out) throws IOException;
 
 	/* <order> ... </order> */
-	void startOrder(final ReceiverOrder order, final BufferedWriter out) throws IOException;
-	void endOrder(final BufferedWriter out) throws IOException;
+	void startOrder(final ReceiverOrder order, final Writer out) throws IOException;
+	void endOrder(final Writer out) throws IOException;
 
 	/* <item> ... </item> */
-	void startItem(final Order item, final BufferedWriter out) throws IOException;
-	void endItem(final BufferedWriter out) throws IOException;
+	void startItem(final Order item, final Writer out) throws IOException;
+	void endItem(final Writer out) throws IOException;
 
 	/*TODO <route ... > */
 
-	void writeSeparator(final BufferedWriter out) throws IOException;
-	void writeGap(final BufferedWriter out) throws IOException;
+	void writeSeparator(final Writer out) throws IOException;
+	void writeGap(final Writer out) throws IOException;
 
 }

--- a/contribs/freightreceiver/src/main/java/org/matsim/freight/receiver/ReceiversWriterHandlerImplV1.java
+++ b/contribs/freightreceiver/src/main/java/org/matsim/freight/receiver/ReceiversWriterHandlerImplV1.java
@@ -25,7 +25,7 @@ import org.matsim.core.utils.misc.Time;
 import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.utils.objectattributes.attributable.AttributesXmlWriterDelegate;
 
-import java.io.BufferedWriter;
+import java.io.Writer;
 import java.io.IOException;
 import java.util.Locale;
 
@@ -38,7 +38,7 @@ import java.util.Locale;
 	private final AttributesXmlWriterDelegate attributesWriter = new AttributesXmlWriterDelegate();
 
 	@Override
-	public void startReceivers(Receivers receivers, BufferedWriter out) throws IOException {
+	public void startReceivers(Receivers receivers, Writer out) throws IOException {
 		out.write("\n<freightReceivers");
 		if(!receivers.getDescription().equalsIgnoreCase("")) {
 			out.write(" desc=\"");
@@ -51,12 +51,12 @@ import java.util.Locale;
 	}
 
 	@Override
-	public void endReceivers(BufferedWriter out) throws IOException {
+	public void endReceivers(Writer out) throws IOException {
 		out.write("\n</freightReceivers>\n");
 	}
 
 	@Override
-	public void startReceiver(Receiver receiver, BufferedWriter out) throws IOException {
+	public void startReceiver(Receiver receiver, Writer out) throws IOException {
 		out.write("\n\t<receiver id=\"");
 		out.write(receiver.getId().toString());
 		out.write("\"");
@@ -74,22 +74,22 @@ import java.util.Locale;
 	}
 
 	@Override
-	public void endReceiver(BufferedWriter out) throws IOException {
+	public void endReceiver(Writer out) throws IOException {
 		out.write("\t</receiver>\n");
 	}
 
 	@Override
-	public void writeSeparator(BufferedWriter out) throws IOException {
+	public void writeSeparator(Writer out) throws IOException {
 		out.write("\n\t<!-- =========================================================================================== -->\n");
 	}
 
 	@Override
-	public void writeGap(BufferedWriter out) throws IOException {
+	public void writeGap(Writer out) throws IOException {
 		out.write("\n");
 	}
 
 	@Override
-	public void startReceiverProduct(ReceiverProduct product, BufferedWriter out) throws IOException {
+	public void startReceiverProduct(ReceiverProduct product, Writer out) throws IOException {
 		out.write("\t\t<product id=\"");
 		out.write(product.getProductType().getId().toString());
 		out.write("\" onHand=\"");
@@ -98,13 +98,13 @@ import java.util.Locale;
 	}
 
 	@Override
-	public void endReceiverProduct(BufferedWriter out) throws IOException {
+	public void endReceiverProduct(Writer out) throws IOException {
 		out.write("\t\t</product>\n");
 
 	}
 
 	@Override
-	public void startReorderPolicy(ReorderPolicy policy, BufferedWriter out) throws IOException {
+	public void startReorderPolicy(ReorderPolicy policy, Writer out) throws IOException {
 		out.write("\t\t\t<reorderPolicy name=\"");
 		out.write(policy.getPolicyName());
 		out.write("\">\n");
@@ -114,12 +114,12 @@ import java.util.Locale;
 	}
 
 	@Override
-	public void endReorderPolicy(BufferedWriter out) throws IOException {
+	public void endReorderPolicy(Writer out) throws IOException {
 		out.write("\t\t\t</reorderPolicy>\n");
 	}
 
 	@Override
-	public void startPlan(ReceiverPlan plan, BufferedWriter out) throws IOException {
+	public void startPlan(ReceiverPlan plan, Writer out) throws IOException {
 		Double score = plan.getScore();
 		String selected = plan.isSelected() ? "yes" : "no";
 
@@ -131,24 +131,24 @@ import java.util.Locale;
 	}
 
 	@Override
-	public void endPlan(BufferedWriter out) throws IOException {
+	public void endPlan(Writer out) throws IOException {
 		out.write("\t\t</plan>\n");
 	}
 
 	@Override
-	public void endOrder(BufferedWriter out) throws IOException {
+	public void endOrder(Writer out) throws IOException {
 		out.write("\t\t\t</order>\n");
 	}
 
 	@Override
-	public void startOrder(ReceiverOrder order, BufferedWriter out) throws IOException {
+	public void startOrder(ReceiverOrder order, Writer out) throws IOException {
 		out.write("\t\t\t<order carrierId=\"");
 		out.write(order.getCarrierId().toString());
 		out.write("\">\n");
 	}
 
 	@Override
-	public void startItem(Order item, BufferedWriter out) throws IOException {
+	public void startItem(Order item, Writer out) throws IOException {
 		out.write("\t\t\t\t<item id=\"");
 		out.write(item.getId().toString());
 		out.write("\" productId=\"");
@@ -162,22 +162,22 @@ import java.util.Locale;
 	}
 
 	@Override
-	public void endItem(BufferedWriter out) throws IOException {
+	public void endItem(Writer out) throws IOException {
 		out.write("/>\n");
 	}
 
 	@Override
-	public void startProducts(BufferedWriter out) throws IOException {
+	public void startProducts(Writer out) throws IOException {
 		out.write("\t<productTypes>\n");
 	}
 
 	@Override
-	public void endProducts(BufferedWriter out) throws IOException {
+	public void endProducts(Writer out) throws IOException {
 		out.write("\t</productTypes>\n");
 	}
 
 	@Override
-	public void startProduct(ProductType productType, BufferedWriter out) throws IOException {
+	public void startProduct(ProductType productType, Writer out) throws IOException {
 		out.write("\t\t<productType id=\"");
 		out.write(productType.getId().toString());
 		out.write("\" descr=\"");
@@ -189,13 +189,13 @@ import java.util.Locale;
 	}
 
 	@Override
-	public void endProduct(BufferedWriter out) throws IOException {
+	public void endProduct(Writer out) throws IOException {
 		out.write("/>\n");
 	}
 
 
 	@Override
-	public void startTimeWindow(TimeWindow window, BufferedWriter out) throws IOException {
+	public void startTimeWindow(TimeWindow window, Writer out) throws IOException {
 		out.write("\t\t\t<timeWindow start=\"");
 		out.write(Time.writeTime(window.getStart(), Time.TIMEFORMAT_HHMMSS));
 		out.write("\" end=\"");
@@ -204,7 +204,7 @@ import java.util.Locale;
 	}
 
 	@Override
-	public void endTimeWindow(BufferedWriter out) throws IOException {
+	public void endTimeWindow(Writer out) throws IOException {
 		out.write("/>\n");
 	}
 

--- a/contribs/freightreceiver/src/main/java/org/matsim/freight/receiver/ReceiversWriterHandlerImplV2.java
+++ b/contribs/freightreceiver/src/main/java/org/matsim/freight/receiver/ReceiversWriterHandlerImplV2.java
@@ -25,7 +25,7 @@ import org.matsim.core.utils.misc.Time;
 import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.utils.objectattributes.attributable.AttributesXmlWriterDelegate;
 
-import java.io.BufferedWriter;
+import java.io.Writer;
 import java.io.IOException;
 import java.util.Locale;
 
@@ -39,7 +39,7 @@ import java.util.Locale;
 	private final AttributesXmlWriterDelegate attributesWriter = new AttributesXmlWriterDelegate();
 
 	@Override
-	public void startReceivers(Receivers receivers, BufferedWriter out) throws IOException {
+	public void startReceivers(Receivers receivers, Writer out) throws IOException {
 		out.write("\n<freightReceivers");
 		if(!receivers.getDescription().equalsIgnoreCase("")) {
 			out.write(" desc=\"");
@@ -52,12 +52,12 @@ import java.util.Locale;
 	}
 
 	@Override
-	public void endReceivers(BufferedWriter out) throws IOException {
+	public void endReceivers(Writer out) throws IOException {
 		out.write("\n</freightReceivers>\n");
 	}
 
 	@Override
-	public void startReceiver(Receiver receiver, BufferedWriter out) throws IOException {
+	public void startReceiver(Receiver receiver, Writer out) throws IOException {
 		out.write("\n\t<receiver id=\"");
 		out.write(receiver.getId().toString());
 		out.write("\"");
@@ -75,22 +75,22 @@ import java.util.Locale;
 	}
 
 	@Override
-	public void endReceiver(BufferedWriter out) throws IOException {
+	public void endReceiver(Writer out) throws IOException {
 		out.write("\t</receiver>\n");
 	}
 
 	@Override
-	public void writeSeparator(BufferedWriter out) throws IOException {
+	public void writeSeparator(Writer out) throws IOException {
 		out.write("\n\t<!-- =========================================================================================== -->\n");
 	}
 
 	@Override
-	public void writeGap(BufferedWriter out) throws IOException {
+	public void writeGap(Writer out) throws IOException {
 		out.write("\n");
 	}
 
 	@Override
-	public void startReceiverProduct(ReceiverProduct product, BufferedWriter out) throws IOException {
+	public void startReceiverProduct(ReceiverProduct product, Writer out) throws IOException {
 		out.write("\t\t<product id=\"");
 		out.write(product.getProductType().getId().toString());
 		out.write("\" onHand=\"");
@@ -99,13 +99,13 @@ import java.util.Locale;
 	}
 
 	@Override
-	public void endReceiverProduct(BufferedWriter out) throws IOException {
+	public void endReceiverProduct(Writer out) throws IOException {
 		out.write("\t\t</product>\n");
 
 	}
 
 	@Override
-	public void startReorderPolicy(ReorderPolicy policy, BufferedWriter out) throws IOException {
+	public void startReorderPolicy(ReorderPolicy policy, Writer out) throws IOException {
 		out.write("\t\t\t<reorderPolicy name=\"");
 		out.write(policy.getPolicyName());
 		out.write("\">\n");
@@ -115,12 +115,12 @@ import java.util.Locale;
 	}
 
 	@Override
-	public void endReorderPolicy(BufferedWriter out) throws IOException {
+	public void endReorderPolicy(Writer out) throws IOException {
 		out.write("\t\t\t</reorderPolicy>\n");
 	}
 
 	@Override
-	public void startPlan(ReceiverPlan plan, BufferedWriter out) throws IOException {
+	public void startPlan(ReceiverPlan plan, Writer out) throws IOException {
 		Double score = plan.getScore();
 		String selected = plan.isSelected() ? "yes" : "no";
 
@@ -132,24 +132,24 @@ import java.util.Locale;
 	}
 
 	@Override
-	public void endPlan(BufferedWriter out) throws IOException {
+	public void endPlan(Writer out) throws IOException {
 		out.write("\t\t</plan>\n");
 	}
 
 	@Override
-	public void endOrder(BufferedWriter out) throws IOException {
+	public void endOrder(Writer out) throws IOException {
 		out.write("\t\t\t</order>\n");
 	}
 
 	@Override
-	public void startOrder(ReceiverOrder order, BufferedWriter out) throws IOException {
+	public void startOrder(ReceiverOrder order, Writer out) throws IOException {
 		out.write("\t\t\t<order carrierId=\"");
 		out.write(order.getCarrierId().toString());
 		out.write("\">\n");
 	}
 
 	@Override
-	public void startItem(Order item, BufferedWriter out) throws IOException {
+	public void startItem(Order item, Writer out) throws IOException {
 		out.write("\t\t\t\t<item id=\"");
 		out.write(item.getId().toString());
 		out.write("\" productId=\"");
@@ -163,22 +163,22 @@ import java.util.Locale;
 	}
 
 	@Override
-	public void endItem(BufferedWriter out) throws IOException {
+	public void endItem(Writer out) throws IOException {
 		out.write("/>\n");
 	}
 
 	@Override
-	public void startProducts(BufferedWriter out) throws IOException {
+	public void startProducts(Writer out) throws IOException {
 		out.write("\t<productTypes>\n");
 	}
 
 	@Override
-	public void endProducts(BufferedWriter out) throws IOException {
+	public void endProducts(Writer out) throws IOException {
 		out.write("\t</productTypes>\n");
 	}
 
 	@Override
-	public void startProduct(ProductType productType, BufferedWriter out) throws IOException {
+	public void startProduct(ProductType productType, Writer out) throws IOException {
 		out.write("\t\t<productType id=\"");
 		out.write(productType.getId().toString());
 		out.write("\" originLinkId=\"");
@@ -192,13 +192,13 @@ import java.util.Locale;
 	}
 
 	@Override
-	public void endProduct(BufferedWriter out) throws IOException {
+	public void endProduct(Writer out) throws IOException {
 		out.write("/>\n");
 	}
 
 
 	@Override
-	public void startTimeWindow(TimeWindow window, BufferedWriter out) throws IOException {
+	public void startTimeWindow(TimeWindow window, Writer out) throws IOException {
 		out.write("\t\t\t<timeWindow start=\"");
 		out.write(Time.writeTime(window.getStart(), Time.TIMEFORMAT_HHMMSS));
 		out.write("\" end=\"");
@@ -207,7 +207,7 @@ import java.util.Locale;
 	}
 
 	@Override
-	public void endTimeWindow(BufferedWriter out) throws IOException {
+	public void endTimeWindow(Writer out) throws IOException {
 		out.write("/>\n");
 	}
 

--- a/contribs/signals/src/main/java/org/matsim/contrib/signals/data/conflicts/io/ConflictingDirectionsWriterHandler.java
+++ b/contribs/signals/src/main/java/org/matsim/contrib/signals/data/conflicts/io/ConflictingDirectionsWriterHandler.java
@@ -20,8 +20,8 @@
  */
 package org.matsim.contrib.signals.data.conflicts.io;
 
-import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.Writer;
 
 import org.matsim.contrib.signals.data.conflicts.ConflictData;
 import org.matsim.contrib.signals.data.conflicts.Direction;
@@ -31,28 +31,28 @@ import org.matsim.contrib.signals.data.conflicts.Direction;
  */
 public interface ConflictingDirectionsWriterHandler {
 	
-	public void writeHeaderAndStartElement(final BufferedWriter out) throws IOException;
+	public void writeHeaderAndStartElement(final Writer out) throws IOException;
 
 	//////////////////////////////////////////////////////////////////////
 	// <conflictData ... > ... </conflictData>
 	//////////////////////////////////////////////////////////////////////
-	public void startConflictData(final BufferedWriter out) throws IOException;	
+	public void startConflictData(final Writer out) throws IOException;	
 	
-	public void endConflictData(final BufferedWriter out) throws IOException;
+	public void endConflictData(final Writer out) throws IOException;
 
 	//////////////////////////////////////////////////////////////////////
 	// <signalSystem ... > ... </signalSystem>
 	//////////////////////////////////////////////////////////////////////
 
-	public void writeIntersections(final ConflictData conflictData, final BufferedWriter out) throws IOException;
+	public void writeIntersections(final ConflictData conflictData, final Writer out) throws IOException;
 
 	//////////////////////////////////////////////////////////////////////
 	// <direction ... > ... </direction>
 	//////////////////////////////////////////////////////////////////////
 
-	public void writeDirection(final Direction direction, final BufferedWriter out) throws IOException;
+	public void writeDirection(final Direction direction, final Writer out) throws IOException;
 	
 	
-	public void writeSeparator(final BufferedWriter out) throws IOException;
+	public void writeSeparator(final Writer out) throws IOException;
 	
 }

--- a/contribs/signals/src/main/java/org/matsim/contrib/signals/data/conflicts/io/ConflictingDirectionsWriterHandlerImpl.java
+++ b/contribs/signals/src/main/java/org/matsim/contrib/signals/data/conflicts/io/ConflictingDirectionsWriterHandlerImpl.java
@@ -20,8 +20,8 @@
  */
 package org.matsim.contrib.signals.data.conflicts.io;
 
-import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.Writer;
 import java.util.List;
 
 import org.matsim.api.core.v01.Id;
@@ -37,23 +37,23 @@ import org.matsim.contrib.signals.model.SignalSystem;
 final class ConflictingDirectionsWriterHandlerImpl implements ConflictingDirectionsWriterHandler {
 
 	@Override
-	public void writeHeaderAndStartElement(BufferedWriter out) throws IOException {
+	public void writeHeaderAndStartElement(Writer out) throws IOException {
 		out.write("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n");
 //		out.write("<!DOCTYPE conflictData SYSTEM \"" + MatsimXmlWriter.DEFAULT_DTD_LOCATION + "conflictData.dtd\">\n\n");
 	}
 
 	@Override
-	public void startConflictData(BufferedWriter out) throws IOException {
+	public void startConflictData(Writer out) throws IOException {
 		out.write("<conflictData>\n\n");
 	}
 
 	@Override
-	public void endConflictData(BufferedWriter out) throws IOException {
+	public void endConflictData(Writer out) throws IOException {
 		out.write("</conflictData>\n");
 	}
 
 	@Override
-	public void writeIntersections(ConflictData conflictData, BufferedWriter out) throws IOException {
+	public void writeIntersections(ConflictData conflictData, Writer out) throws IOException {
 		for (IntersectionDirections conflictingDirections : conflictData.getConflictsPerSignalSystem().values()) {
 			this.startIntersection(conflictingDirections.getNodeId(), conflictingDirections.getSignalSystemId(), out);
 			for (Direction direction : conflictingDirections.getDirections().values()) {
@@ -63,21 +63,21 @@ final class ConflictingDirectionsWriterHandlerImpl implements ConflictingDirecti
 		}
 	}
 
-	private void startIntersection(Id<Node> nodeId, Id<SignalSystem> systemId, BufferedWriter out) throws IOException {
+	private void startIntersection(Id<Node> nodeId, Id<SignalSystem> systemId, Writer out) throws IOException {
 		out.write("\t<intersection");
 		out.write(" nodeId=\"" + nodeId + "\"");
 		out.write(" signalSystemId=\"" + systemId + "\"");
 		out.write(" >\n");
 	}
 
-	private void endIntersection(BufferedWriter out) throws IOException {
+	private void endIntersection(Writer out) throws IOException {
 		out.write("\t</intersection>\n");
 		this.writeSeparator(out);
 		out.flush();
 	}
 
 	@Override
-	public void writeDirection(Direction direction, BufferedWriter out) throws IOException {
+	public void writeDirection(Direction direction, Writer out) throws IOException {
 		this.startDirection(direction, out);
 		
 		this.startTag(ConflictingDirectionsReader.CONFLICTING_DIRECTIONS, out);
@@ -99,7 +99,7 @@ final class ConflictingDirectionsWriterHandlerImpl implements ConflictingDirecti
 		this.endDirection(out);
 	}
 
-	private void startDirection(Direction direction, BufferedWriter out) throws IOException {
+	private void startDirection(Direction direction, Writer out) throws IOException {
 		out.write("\t\t<direction");
 		out.write(" id=\"" + direction.getId() + "\"");
 		out.write(" fromLinkId=\"" + direction.getFromLink() + "\"");
@@ -107,26 +107,26 @@ final class ConflictingDirectionsWriterHandlerImpl implements ConflictingDirecti
 		out.write(" >\n");
 	}
 
-	private void endDirection(BufferedWriter out) throws IOException {
+	private void endDirection(Writer out) throws IOException {
 		out.write("\t\t</direction>\n\n");
 	}
 	
-	private void startTag(String tagName, BufferedWriter out) throws IOException {
+	private void startTag(String tagName, Writer out) throws IOException {
 		out.write("\t\t\t<"+tagName+">");
 	}
 	
-	private void endTag(String tagName, BufferedWriter out) throws IOException {
+	private void endTag(String tagName, Writer out) throws IOException {
 		out.write(" </"+tagName+">\n");
 	}
 	
-	private void writeListOfDirections(List<Id<Direction>> directionList, BufferedWriter out) throws IOException {
+	private void writeListOfDirections(List<Id<Direction>> directionList, Writer out) throws IOException {
 		for (Id<Direction> directionId : directionList) {
 			out.write(" " + directionId);
 		}
 	}
 
 	@Override
-	public void writeSeparator(BufferedWriter out) throws IOException {
+	public void writeSeparator(Writer out) throws IOException {
 		out.write("<!-- ====================================================================== -->\n\n");
 	}
 

--- a/contribs/vsp/src/main/java/playground/vsp/analysis/modules/networkAnalysis/utils/QGisProjectFileWriter.java
+++ b/contribs/vsp/src/main/java/playground/vsp/analysis/modules/networkAnalysis/utils/QGisProjectFileWriter.java
@@ -1,7 +1,7 @@
 package playground.vsp.analysis.modules.networkAnalysis.utils;
 
-import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.Writer;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
@@ -133,15 +133,15 @@ public class QGisProjectFileWriter extends MatsimXmlWriter implements MatsimWrit
 		private SimpleDateFormat df = new SimpleDateFormat("yyyyMMdd");
 		private Date now = new Date();
 		
-		public void endDocument(BufferedWriter out) throws IOException{
+		public void endDocument(Writer out) throws IOException{
 			out.write("</qgis>");
 		}
 		
-		public void startLegend(final BufferedWriter out) throws IOException{
+		public void startLegend(final Writer out) throws IOException{
 			out.write("\t<legend updateDrawingOrder=\"true\">\n");
 		}
 		
-		public void writeLegendLayer(BufferedWriter out, String key) throws IOException {
+		public void writeLegendLayer(Writer out, String key) throws IOException {
 			String id = key+this.df.format(this.now);
 			out.write("\t\t<legendlayer drawingOrder=\"-1\" open=\"false\" checked=\"Qt::Checked\" name=\""+key+"\" showFeatureCount=\"0\">\n");
 			out.write("\t\t\t<filegroup open=\"true\" hidden=\"false\">\n");
@@ -150,15 +150,15 @@ public class QGisProjectFileWriter extends MatsimXmlWriter implements MatsimWrit
 			out.write("\t\t</legendlayer>\n");
 		}
 
-		public void endLegend(final BufferedWriter out) throws IOException{
+		public void endLegend(final Writer out) throws IOException{
 			out.write("\t</legend>\n");
 		}
 		
-		public void startProjectLayers(final BufferedWriter out, int size) throws IOException{
+		public void startProjectLayers(final Writer out, int size) throws IOException{
 			out.write("\t<projectlayers layercount=\""+size+"\">\n");
 		}
 		
-		public void writeProjectLayer(final BufferedWriter out, String key, String geometry, String clazz, String type) throws IOException{
+		public void writeProjectLayer(final Writer out, String key, String geometry, String clazz, String type) throws IOException{
 			
 			String id = key+this.df.format(this.now);
 			
@@ -206,7 +206,7 @@ public class QGisProjectFileWriter extends MatsimXmlWriter implements MatsimWrit
 			}
 		}
 		
-		private void writePolygonLayer(BufferedWriter out, String key,
+		private void writePolygonLayer(Writer out, String key,
 				String geometry, String clazz, String type, String id) throws IOException {
 			
 			out.write("\t\t<maplayer minimumScale=\"0\" maximumScale=\"1e+08\" geometry=\""+geometry+"\" type=\"vector\"" +
@@ -245,7 +245,7 @@ public class QGisProjectFileWriter extends MatsimXmlWriter implements MatsimWrit
 			
 		}
 
-		private void writeNodeTypesLayer(BufferedWriter out, String key, String geometry, String clazz, String type, String id) throws IOException {
+		private void writeNodeTypesLayer(Writer out, String key, String geometry, String clazz, String type, String id) throws IOException {
 			
 			out.write("\t\t<maplayer minimumScale=\"0\" maximumScale=\"1e+08\" geometry=\""+geometry+"\" type =\"vector\"" +
 					" hasScaleBasedVisibilityFlag=\"0\">\n");
@@ -313,11 +313,11 @@ public class QGisProjectFileWriter extends MatsimXmlWriter implements MatsimWrit
 			out.write("\t\t</maplayer>\n");
 		}
 
-		public void endProjectLayers(BufferedWriter out) throws IOException{
+		public void endProjectLayers(Writer out) throws IOException{
 			out.write("\t</projectlayers>\n");
 		}
 		
-		public void writeProperties(BufferedWriter out) throws IOException{
+		public void writeProperties(Writer out) throws IOException{
 			out.write("\t<properties>\n");
 			out.write("\t\t<Paths>\n");
 			out.write("\t\t\t<Absolute type=\"bool\">false</Absolute>\n");

--- a/matsim/src/main/java/org/matsim/core/config/ConfigWriterHandler.java
+++ b/matsim/src/main/java/org/matsim/core/config/ConfigWriterHandler.java
@@ -20,17 +20,17 @@
 
 package org.matsim.core.config;
 
-import java.io.BufferedWriter;
+import java.io.Writer;
 
 /*package*/ abstract class ConfigWriterHandler {
 
-	abstract void startConfig(final Config config, final BufferedWriter out);
+	abstract void startConfig(final Config config, final Writer out);
 	
-	abstract void endConfig(final BufferedWriter out);
+	abstract void endConfig(final Writer out);
 	
-	abstract void writeModule(final ConfigGroup module, final BufferedWriter out);
+	abstract void writeModule(final ConfigGroup module, final Writer out);
 	
-	abstract void writeSeparator(final BufferedWriter out);
+	abstract void writeSeparator(final Writer out);
 	
 	/**
 	 * Sets the string to be used as newline separator.

--- a/matsim/src/main/java/org/matsim/core/config/ConfigWriterHandlerImplV1.java
+++ b/matsim/src/main/java/org/matsim/core/config/ConfigWriterHandlerImplV1.java
@@ -20,7 +20,7 @@
 
 package org.matsim.core.config;
 
-import java.io.BufferedWriter;
+import java.io.Writer;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Map;
@@ -41,7 +41,7 @@ import java.util.Map;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	 void startConfig(final Config config, final BufferedWriter out) throws UncheckedIOException {
+	 void startConfig(final Config config, final Writer out) throws UncheckedIOException {
 		try {
 			out.write("<config>");
 			out.write(this.newline);
@@ -52,7 +52,7 @@ import java.util.Map;
 	}
 
 	@Override
-	 void endConfig(final BufferedWriter out) throws UncheckedIOException {
+	 void endConfig(final Writer out) throws UncheckedIOException {
 		try {
 			out.write("</config>");
 			out.write(this.newline);
@@ -66,7 +66,7 @@ import java.util.Map;
 //////////////////////////////////////////////////////////////////////
 
 	@Override
-	 void writeModule(final ConfigGroup module, final BufferedWriter out) throws UncheckedIOException {
+	 void writeModule(final ConfigGroup module, final Writer out) throws UncheckedIOException {
 		Map<String, String> params = module.getParams();
 		Map<String, String> comments = module.getComments();
 
@@ -105,7 +105,7 @@ import java.util.Map;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	 void writeSeparator(final BufferedWriter out) throws UncheckedIOException {
+	 void writeSeparator(final Writer out) throws UncheckedIOException {
 		try {
 			out.write("<!-- ====================================================================== -->");
 			out.write(this.newline);

--- a/matsim/src/main/java/org/matsim/core/config/ConfigWriterHandlerImplV2.java
+++ b/matsim/src/main/java/org/matsim/core/config/ConfigWriterHandlerImplV2.java
@@ -28,7 +28,7 @@ import org.matsim.core.config.groups.ScoringConfigGroup.ScoringParameterSet;
 import org.matsim.core.config.groups.RoutingConfigGroup;
 import org.matsim.core.config.groups.ReplanningConfigGroup.StrategySettings;
 
-import java.io.BufferedWriter;
+import java.io.Writer;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
@@ -69,7 +69,7 @@ class ConfigWriterHandlerImplV2 extends ConfigWriterHandler {
 	}
 
 	private void writeModule(
-			final BufferedWriter writer,
+			final Writer writer,
 			final String indent,
 			final String moduleTag,
 			final String moduleNameAtt,
@@ -103,7 +103,7 @@ class ConfigWriterHandlerImplV2 extends ConfigWriterHandler {
 		}
 	}
 
-	private Boolean processParameterSets(BufferedWriter writer, String indent, String moduleTag, String moduleNameAtt, String moduleName,
+	private Boolean processParameterSets(Writer writer, String indent, String moduleTag, String moduleNameAtt, String moduleName,
 							 ConfigGroup module, ConfigGroup comparisonModule, Boolean headerHasBeenWritten) throws IOException {
 		for ( Entry<String, ? extends Collection<? extends ConfigGroup>> entry : module.getParameterSets().entrySet() ) {
 			Collection<? extends ConfigGroup> comparisonSets = new ArrayList<>() ;
@@ -161,7 +161,7 @@ class ConfigWriterHandlerImplV2 extends ConfigWriterHandler {
 		return headerHasBeenWritten;
 	}
 
-	private Boolean writeRegularEntries(BufferedWriter writer, String indent, String moduleTag, String moduleNameAtt,
+	private Boolean writeRegularEntries(Writer writer, String indent, String moduleTag, String moduleNameAtt,
 							String moduleName, ConfigGroup comparisonModule, Map<String, String> params,
 							Map<String, String> comments) throws IOException {
 		boolean headerHasBeenWritten = false ;
@@ -221,7 +221,7 @@ class ConfigWriterHandlerImplV2 extends ConfigWriterHandler {
 		return headerHasBeenWritten;
 	}
 
-	private static void writeHeader(BufferedWriter writer, String indent, String moduleTag, String moduleNameAtt, String moduleName, String newline) throws IOException {
+	private static void writeHeader(Writer writer, String indent, String moduleTag, String moduleNameAtt, String moduleName, String newline) throws IOException {
 		//			writer.write( this.newline );
 		writer.write( indent );
 		writer.write("\t<"+moduleTag);
@@ -262,7 +262,7 @@ class ConfigWriterHandlerImplV2 extends ConfigWriterHandler {
 	@Override
 	 void startConfig(
 			final Config config,
-			final BufferedWriter out) {
+			final Writer out) {
 		try {
 			out.write("<"+CONFIG+">");
 			out.write( this.newline );
@@ -274,7 +274,7 @@ class ConfigWriterHandlerImplV2 extends ConfigWriterHandler {
 
 	@Override
 	 void endConfig(
-			final BufferedWriter out) {
+			final Writer out) {
 		try {
 			out.write( this.newline );
 			out.write("</"+CONFIG+">");
@@ -287,7 +287,7 @@ class ConfigWriterHandlerImplV2 extends ConfigWriterHandler {
 	@Override
 	 void writeModule(
 			final ConfigGroup module,
-			final BufferedWriter out) {
+			final Writer out) {
 			ConfigGroup comparisonConfig = null ;
 			switch( verbosity ) {
 				case all -> {
@@ -311,7 +311,7 @@ class ConfigWriterHandlerImplV2 extends ConfigWriterHandler {
 	}
 
 	@Override
-	 void writeSeparator(final BufferedWriter out) {
+	 void writeSeparator(final Writer out) {
 //		try {
 ////			out.write( this.newline );
 //			out.write("<!-- ====================================================================== -->");

--- a/matsim/src/main/java/org/matsim/core/network/io/NetworkWriterHandler.java
+++ b/matsim/src/main/java/org/matsim/core/network/io/NetworkWriterHandler.java
@@ -24,7 +24,7 @@ import org.matsim.api.core.v01.network.Link;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.api.core.v01.network.Node;
 
-import java.io.BufferedWriter;
+import java.io.Writer;
 import java.io.IOException;
 
 interface NetworkWriterHandler {
@@ -33,41 +33,41 @@ interface NetworkWriterHandler {
 	// <network ... > ... </network>
 	//////////////////////////////////////////////////////////////////////
 
-	public void startNetwork(final Network network, final BufferedWriter out) throws IOException;
+	public void startNetwork(final Network network, final Writer out) throws IOException;
 
-	public void endNetwork(final BufferedWriter out) throws IOException;
+	public void endNetwork(final Writer out) throws IOException;
 
 	//////////////////////////////////////////////////////////////////////
 	// <nodes ... > ... </nodes>
 	//////////////////////////////////////////////////////////////////////
 
-	public void startNodes(final Network network, final BufferedWriter out) throws IOException;
+	public void startNodes(final Network network, final Writer out) throws IOException;
 
-	public void endNodes(final BufferedWriter out) throws IOException;
+	public void endNodes(final Writer out) throws IOException;
 
 	//////////////////////////////////////////////////////////////////////
 	// <links ... > ... </links>
 	//////////////////////////////////////////////////////////////////////
 
-	public void startLinks(final Network network, final BufferedWriter out) throws IOException;
+	public void startLinks(final Network network, final Writer out) throws IOException;
 
-	public void endLinks(final BufferedWriter out) throws IOException;
+	public void endLinks(final Writer out) throws IOException;
 
 	//////////////////////////////////////////////////////////////////////
 	// <node ... > ... </node>
 	//////////////////////////////////////////////////////////////////////
 
-	public void startNode(final Node node, final BufferedWriter out) throws IOException;
+	public void startNode(final Node node, final Writer out) throws IOException;
 
-	public void endNode(final BufferedWriter out) throws IOException;
+	public void endNode(final Writer out) throws IOException;
 
 	//////////////////////////////////////////////////////////////////////
 	// <link ... > ... </link>
 	//////////////////////////////////////////////////////////////////////
 
-	public void startLink(final Link link, final BufferedWriter out) throws IOException;
+	public void startLink(final Link link, final Writer out) throws IOException;
 
-	public void endLink(final BufferedWriter out) throws IOException;
+	public void endLink(final Writer out) throws IOException;
 	
-	public void writeSeparator(final BufferedWriter out) throws IOException;
+	public void writeSeparator(final Writer out) throws IOException;
 }

--- a/matsim/src/main/java/org/matsim/core/network/io/NetworkWriterHandlerImplV1.java
+++ b/matsim/src/main/java/org/matsim/core/network/io/NetworkWriterHandlerImplV1.java
@@ -29,7 +29,7 @@ import org.matsim.core.utils.geometry.CoordinateTransformation;
 import org.matsim.core.utils.geometry.transformations.IdentityTransformation;
 import org.matsim.core.utils.misc.Time;
 
-import java.io.BufferedWriter;
+import java.io.Writer;
 import java.io.IOException;
 import java.util.Set;
 
@@ -57,7 +57,7 @@ import static org.matsim.core.utils.io.XmlUtils.encodeAttributeValue;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startNetwork(final Network network, final BufferedWriter out) throws IOException {
+	public void startNetwork(final Network network, final Writer out) throws IOException {
 		out.write("<network");
 		if ((network.getName() != null)) {
 			out.write(" name=\"" + encodeAttributeValue(network.getName()) + "\"");
@@ -66,7 +66,7 @@ import static org.matsim.core.utils.io.XmlUtils.encodeAttributeValue;
 	}
 
 	@Override
-	public void endNetwork(final BufferedWriter out) throws IOException {
+	public void endNetwork(final Writer out) throws IOException {
 		out.write("</network>\n");
 	}
 
@@ -75,12 +75,12 @@ import static org.matsim.core.utils.io.XmlUtils.encodeAttributeValue;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startNodes(final Network network, final BufferedWriter out) throws IOException {
+	public void startNodes(final Network network, final Writer out) throws IOException {
 		out.write("\t<nodes>\n");
 	}
 
 	@Override
-	public void endNodes(final BufferedWriter out) throws IOException {
+	public void endNodes(final Writer out) throws IOException {
 		out.write("\t</nodes>\n\n");
 	}
 
@@ -89,7 +89,7 @@ import static org.matsim.core.utils.io.XmlUtils.encodeAttributeValue;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startLinks(final Network network, final BufferedWriter out) throws IOException {
+	public void startLinks(final Network network, final Writer out) throws IOException {
 		out.write("\t<links");
 		if (network.getCapacityPeriod() != Integer.MIN_VALUE) {
 			out.write(" capperiod=\"" + Time.writeTime(network.getCapacityPeriod()) + "\"");
@@ -102,7 +102,7 @@ import static org.matsim.core.utils.io.XmlUtils.encodeAttributeValue;
 	}
 
 	@Override
-	public void endLinks(final BufferedWriter out) throws IOException {
+	public void endLinks(final Writer out) throws IOException {
 		out.write("\t</links>\n\n");
 	}
 
@@ -111,7 +111,7 @@ import static org.matsim.core.utils.io.XmlUtils.encodeAttributeValue;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startNode(final Node node, final BufferedWriter out) throws IOException {
+	public void startNode(final Node node, final Writer out) throws IOException {
 		out.write("\t\t<node");
 		out.write(" id=\"" + encodeAttributeValue(node.getId().toString()) + "\"");
 		final Coord coord = transformation.transform( node.getCoord() );
@@ -128,7 +128,7 @@ import static org.matsim.core.utils.io.XmlUtils.encodeAttributeValue;
 	}
 
 	@Override
-	public void endNode(final BufferedWriter out) throws IOException {
+	public void endNode(final Writer out) throws IOException {
 	}
 
 	//////////////////////////////////////////////////////////////////////
@@ -139,7 +139,7 @@ import static org.matsim.core.utils.io.XmlUtils.encodeAttributeValue;
 	private String lastModes = null;
 
 	@Override
-	public void startLink(final Link link, final BufferedWriter out) throws IOException {
+	public void startLink(final Link link, final Writer out) throws IOException {
 		out.write("\t\t<link");
 		out.write(" id=\"" + encodeAttributeValue(link.getId().toString()) + "\"");
 		out.write(" from=\"" + encodeAttributeValue(link.getFromNode().getId().toString()) + "\"");
@@ -179,7 +179,7 @@ import static org.matsim.core.utils.io.XmlUtils.encodeAttributeValue;
 	}
 
 	@Override
-	public void endLink(final BufferedWriter out) throws IOException {
+	public void endLink(final Writer out) throws IOException {
 	}
 
 	//////////////////////////////////////////////////////////////////////
@@ -187,7 +187,7 @@ import static org.matsim.core.utils.io.XmlUtils.encodeAttributeValue;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void writeSeparator(final BufferedWriter out) throws IOException {
+	public void writeSeparator(final Writer out) throws IOException {
 		out.write("<!-- =================================================" +
 				"===================== -->\n\n");
 	}

--- a/matsim/src/main/java/org/matsim/core/network/io/NetworkWriterHandlerImplV2.java
+++ b/matsim/src/main/java/org/matsim/core/network/io/NetworkWriterHandlerImplV2.java
@@ -30,7 +30,7 @@ import org.matsim.core.utils.misc.Time;
 import org.matsim.utils.objectattributes.AttributeConverter;
 import org.matsim.utils.objectattributes.attributable.AttributesXmlWriterDelegate;
 
-import java.io.BufferedWriter;
+import java.io.Writer;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
@@ -60,7 +60,7 @@ import static org.matsim.core.utils.io.XmlUtils.encodeAttributeValue;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startNetwork(final Network network, final BufferedWriter out) throws IOException {
+	public void startNetwork(final Network network, final Writer out) throws IOException {
 		out.write("<network");
 		if (network.getName() != null) {
 			out.write(" name=\"" + encodeAttributeValue(network.getName()) + "\"");
@@ -71,7 +71,7 @@ import static org.matsim.core.utils.io.XmlUtils.encodeAttributeValue;
 	}
 
 	@Override
-	public void endNetwork(final BufferedWriter out) throws IOException {
+	public void endNetwork(final Writer out) throws IOException {
 		out.write("</network>\n");
 	}
 
@@ -80,12 +80,12 @@ import static org.matsim.core.utils.io.XmlUtils.encodeAttributeValue;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startNodes(final Network network, final BufferedWriter out) throws IOException {
+	public void startNodes(final Network network, final Writer out) throws IOException {
 		out.write("\t<nodes>\n");
 	}
 
 	@Override
-	public void endNodes(final BufferedWriter out) throws IOException {
+	public void endNodes(final Writer out) throws IOException {
 		out.write("\t</nodes>\n\n");
 	}
 
@@ -94,7 +94,7 @@ import static org.matsim.core.utils.io.XmlUtils.encodeAttributeValue;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startLinks(final Network network, final BufferedWriter out) throws IOException {
+	public void startLinks(final Network network, final Writer out) throws IOException {
 		out.write("\t<links");
 		if (network.getCapacityPeriod() != Integer.MIN_VALUE) {
 			out.write(" capperiod=\"" + Time.writeTime(network.getCapacityPeriod()) + "\"");
@@ -107,7 +107,7 @@ import static org.matsim.core.utils.io.XmlUtils.encodeAttributeValue;
 	}
 
 	@Override
-	public void endLinks(final BufferedWriter out) throws IOException {
+	public void endLinks(final Writer out) throws IOException {
 		out.write("\t</links>\n\n");
 	}
 
@@ -116,7 +116,7 @@ import static org.matsim.core.utils.io.XmlUtils.encodeAttributeValue;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startNode(final Node node, final BufferedWriter out) throws IOException {
+	public void startNode(final Node node, final Writer out) throws IOException {
 		out.write("\t\t<node");
 		out.write(" id=\"" + encodeAttributeValue(node.getId().toString()) + "\"");
 		final Coord coord = transformation.transform( node.getCoord() );
@@ -135,7 +135,7 @@ import static org.matsim.core.utils.io.XmlUtils.encodeAttributeValue;
 	}
 
 	@Override
-	public void endNode(final BufferedWriter out) throws IOException {
+	public void endNode(final Writer out) throws IOException {
 		out.write("\t\t</node>\n");
 	}
 
@@ -147,7 +147,7 @@ import static org.matsim.core.utils.io.XmlUtils.encodeAttributeValue;
 	private String lastModes = null;
 
 	@Override
-	public void startLink(final Link link, final BufferedWriter out) throws IOException {
+	public void startLink(final Link link, final Writer out) throws IOException {
 		out.write("\t\t<link");
 		out.write(" id=\"" + encodeAttributeValue(link.getId().toString()) + "\"");
 		out.write(" from=\"" + encodeAttributeValue(link.getFromNode().getId().toString()) + "\"");
@@ -192,7 +192,7 @@ import static org.matsim.core.utils.io.XmlUtils.encodeAttributeValue;
 	}
 
 	@Override
-	public void endLink(final BufferedWriter out) throws IOException {
+	public void endLink(final Writer out) throws IOException {
 		out.write("\t\t</link>\n");
 	}
 
@@ -201,7 +201,7 @@ import static org.matsim.core.utils.io.XmlUtils.encodeAttributeValue;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void writeSeparator(final BufferedWriter out) throws IOException {
+	public void writeSeparator(final Writer out) throws IOException {
 		out.write("<!-- =================================================" +
 				"===================== -->\n\n");
 	}

--- a/matsim/src/main/java/org/matsim/core/population/io/AbstractPopulationWriterHandler.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/AbstractPopulationWriterHandler.java
@@ -28,7 +28,7 @@ import org.matsim.api.core.v01.population.Plan;
 import org.matsim.api.core.v01.population.Route;
 import org.matsim.core.population.PersonUtils;
 
-import java.io.BufferedWriter;
+import java.io.Writer;
 import java.io.IOException;
 
 /**
@@ -42,7 +42,7 @@ abstract class AbstractPopulationWriterHandler implements PopulationWriterHandle
 	private final static Logger log = LogManager.getLogger(AbstractPopulationWriterHandler.class);
 	
 	@Override
-	public final void writePerson(final Person person, final BufferedWriter writer) throws IOException {
+	public final void writePerson(final Person person, final Writer writer) throws IOException {
 		this.startPerson(person, writer);
 		// travelcards
 		if (PersonUtils.getTravelcards(person) != null) {
@@ -79,28 +79,28 @@ abstract class AbstractPopulationWriterHandler implements PopulationWriterHandle
 		this.writeSeparator(writer);
 	}
 
-	public abstract void startPerson(final Person person, final BufferedWriter out) throws IOException;
+	public abstract void startPerson(final Person person, final Writer out) throws IOException;
 
-	public abstract void endPerson(final BufferedWriter out) throws IOException;
+	public abstract void endPerson(final Writer out) throws IOException;
 
-	public abstract void startTravelCard(final String travelcard, final BufferedWriter out) throws IOException;
+	public abstract void startTravelCard(final String travelcard, final Writer out) throws IOException;
 
-	public abstract void endTravelCard(final BufferedWriter out) throws IOException;
+	public abstract void endTravelCard(final Writer out) throws IOException;
 
-	public abstract void startPlan(final Plan plan, final BufferedWriter out) throws IOException;
+	public abstract void startPlan(final Plan plan, final Writer out) throws IOException;
 
-	public abstract void endPlan(final BufferedWriter out) throws IOException;
+	public abstract void endPlan(final Writer out) throws IOException;
 
-	public abstract void startAct(final Activity act, final BufferedWriter out) throws IOException;
+	public abstract void startAct(final Activity act, final Writer out) throws IOException;
 
-	public abstract void endAct(final BufferedWriter out) throws IOException;
+	public abstract void endAct(final Writer out) throws IOException;
 
-	public abstract void startLeg(final Leg leg, final BufferedWriter out) throws IOException;
+	public abstract void startLeg(final Leg leg, final Writer out) throws IOException;
 
-	public abstract void endLeg(final BufferedWriter out) throws IOException;
+	public abstract void endLeg(final Writer out) throws IOException;
 
-	public abstract void startRoute(final Route route, final BufferedWriter out) throws IOException;
+	public abstract void startRoute(final Route route, final Writer out) throws IOException;
 
-	public abstract void endRoute(final BufferedWriter out) throws IOException;
+	public abstract void endRoute(final Writer out) throws IOException;
 
 }

--- a/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationWriterHandlerV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/ParallelPopulationWriterHandlerV6.java
@@ -38,7 +38,7 @@ import org.matsim.utils.objectattributes.attributable.AttributesUtils;
 import org.matsim.utils.objectattributes.attributable.AttributesXmlWriterDelegate;
 import org.matsim.vehicles.Vehicle;
 
-import java.io.BufferedWriter;
+import java.io.Writer;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.HashMap;
@@ -104,7 +104,7 @@ public class ParallelPopulationWriterHandlerV6 implements PopulationWriterHandle
 		}
 	}
 
-	private void tryInitWriterThread(BufferedWriter out) {
+	private void tryInitWriterThread(Writer out) {
 		if (this.writeThread == null) {
 			this.writer = new ParallelPopulationWriterV6(this.outputQueue, out);
 			writeThread = new Thread(this.writer);
@@ -160,13 +160,13 @@ public class ParallelPopulationWriterHandlerV6 implements PopulationWriterHandle
 	}
 
 	@Override
-	public void writeHeaderAndStartElement(BufferedWriter out) throws IOException {
+	public void writeHeaderAndStartElement(Writer out) throws IOException {
 		out.write("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n");
 		out.write("<!DOCTYPE population SYSTEM \"" + MatsimXmlWriter.DEFAULT_DTD_LOCATION + "population_v6.dtd\">\n\n");
 	}
 
 	@Override
-	public void startPlans(final Population plans, final BufferedWriter out) throws IOException {
+	public void startPlans(final Population plans, final Writer out) throws IOException {
 		out.write("<population");
 		if (plans.getName() != null) {
 			out.write(" desc=\"" + encodeAttributeValue(plans.getName()) + "\"");
@@ -181,7 +181,7 @@ public class ParallelPopulationWriterHandlerV6 implements PopulationWriterHandle
 	}
 
 	@Override
-	public void writePerson(Person person, BufferedWriter out) throws IOException {
+	public void writePerson(Person person, Writer out) throws IOException {
 		try {
 			CompletableFuture<String> f = new CompletableFuture<>();
 			this.inputQueue.put(new PersonData(person, f));
@@ -192,13 +192,13 @@ public class ParallelPopulationWriterHandlerV6 implements PopulationWriterHandle
 	}
 
 	@Override
-	public void endPlans(final BufferedWriter out) throws IOException {
+	public void endPlans(final Writer out) throws IOException {
 		joinThreads();
 		out.write("</population>\n");
 	}
 
 	@Override
-	public void writeSeparator(BufferedWriter out) throws IOException {
+	public void writeSeparator(Writer out) throws IOException {
 		out.append("<!-- ====================================================================== -->\n\n");
 	}
 
@@ -216,10 +216,10 @@ public class ParallelPopulationWriterHandlerV6 implements PopulationWriterHandle
 	public static class ParallelPopulationWriterV6 implements Runnable {
 		private final Counter counter = new Counter("[" + this.getClass().getSimpleName() + "] dumped person # ");
 		private final BlockingQueue<CompletableFuture<String>> outputQueue;
-		private final BufferedWriter out;
+		private final Writer out;
 
 
-		ParallelPopulationWriterV6(BlockingQueue<CompletableFuture<String>> outputQueue, BufferedWriter out) {
+		ParallelPopulationWriterV6(BlockingQueue<CompletableFuture<String>> outputQueue, Writer out) {
 			this.outputQueue = outputQueue;
 			this.out = out;
 		}

--- a/matsim/src/main/java/org/matsim/core/population/io/PopulationWriterHandler.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/PopulationWriterHandler.java
@@ -20,7 +20,7 @@
 
 package org.matsim.core.population.io;
 
-import java.io.BufferedWriter;
+import java.io.Writer;
 import java.io.IOException;
 import java.util.Map;
 
@@ -34,15 +34,15 @@ import org.matsim.utils.objectattributes.AttributeConverter;
  */
 public interface PopulationWriterHandler {
 
-	void writeHeaderAndStartElement(BufferedWriter out) throws IOException;
+	void writeHeaderAndStartElement(Writer out) throws IOException;
 
-	void startPlans(final Population plans, final BufferedWriter out) throws IOException;
+	void startPlans(final Population plans, final Writer out) throws IOException;
 
-	void writePerson(final Person person, final BufferedWriter out) throws IOException;
+	void writePerson(final Person person, final Writer out) throws IOException;
 
-	void endPlans(final BufferedWriter out) throws IOException;
+	void endPlans(final Writer out) throws IOException;
 
-	void writeSeparator(final BufferedWriter out) throws IOException;
+	void writeSeparator(final Writer out) throws IOException;
 
 	default void putAttributeConverters(Map<Class<?>, AttributeConverter<?>> converters) {
 		if (!converters.isEmpty()) {

--- a/matsim/src/main/java/org/matsim/core/population/io/PopulationWriterHandlerImplV0.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/PopulationWriterHandlerImplV0.java
@@ -20,7 +20,7 @@
 
 package org.matsim.core.population.io;
 
-import java.io.BufferedWriter;
+import java.io.Writer;
 import java.io.IOException;
 
 import org.matsim.api.core.v01.Coord;
@@ -58,7 +58,7 @@ import org.matsim.core.utils.misc.Time;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void writeHeaderAndStartElement(BufferedWriter out) throws IOException {
+	public void writeHeaderAndStartElement(Writer out) throws IOException {
 		out.write("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n");
 		out.write("<!DOCTYPE plans SYSTEM \"" + MatsimXmlWriter.DEFAULT_DTD_LOCATION + "plans_v0.dtd\">\n\n");
 	}
@@ -68,12 +68,12 @@ import org.matsim.core.utils.misc.Time;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startPlans(final Population plans, final BufferedWriter out) throws IOException {
+	public void startPlans(final Population plans, final Writer out) throws IOException {
 		out.write("<plans>\n\n");
 	}
 
 	@Override
-	public void endPlans(final BufferedWriter out) throws IOException {
+	public void endPlans(final Writer out) throws IOException {
 		out.write("</plans>\n");
 		out.flush();
 	}
@@ -83,14 +83,14 @@ import org.matsim.core.utils.misc.Time;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startPerson(final Person person, final BufferedWriter out) throws IOException {
+	public void startPerson(final Person person, final Writer out) throws IOException {
 		out.write("\t<person");
 		out.write(" id=\"" + person.getId() + "\"");
 		out.write(">\n");
 	}
 
 	@Override
-	public void endPerson(final BufferedWriter out) throws IOException {
+	public void endPerson(final Writer out) throws IOException {
 		out.write("\t</person>\n\n");
 	}
 
@@ -99,11 +99,11 @@ import org.matsim.core.utils.misc.Time;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startTravelCard(final String travelcard, final BufferedWriter out) throws IOException {
+	public void startTravelCard(final String travelcard, final Writer out) throws IOException {
 	}
 
 	@Override
-	public void endTravelCard(final BufferedWriter out) throws IOException {
+	public void endTravelCard(final Writer out) throws IOException {
 	}
 
 	//////////////////////////////////////////////////////////////////////
@@ -111,7 +111,7 @@ import org.matsim.core.utils.misc.Time;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startPlan(final Plan plan, final BufferedWriter out) throws IOException {
+	public void startPlan(final Plan plan, final Writer out) throws IOException {
 		out.write("\t\t<plan");
 		if (plan.getScore() != null)
 			out.write(" score=\"" + plan.getScore().toString() + "\"");
@@ -123,7 +123,7 @@ import org.matsim.core.utils.misc.Time;
 	}
 
 	@Override
-	public void endPlan(final BufferedWriter out) throws IOException {
+	public void endPlan(final Writer out) throws IOException {
 		out.write("\t\t</plan>\n\n");
 	}
 
@@ -132,7 +132,7 @@ import org.matsim.core.utils.misc.Time;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startAct(final Activity act, final BufferedWriter out) throws IOException {
+	public void startAct(final Activity act, final Writer out) throws IOException {
 		out.write("\t\t\t<act");
 		out.write(" type=\"" + act.getType() + "\"");
 		if (act.getCoord() != null) {
@@ -152,7 +152,7 @@ import org.matsim.core.utils.misc.Time;
 	}
 
 	@Override
-	public void endAct(final BufferedWriter out) throws IOException {
+	public void endAct(final Writer out) throws IOException {
 	}
 
 	//////////////////////////////////////////////////////////////////////
@@ -160,7 +160,7 @@ import org.matsim.core.utils.misc.Time;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startLeg(final Leg leg, final BufferedWriter out) throws IOException {
+	public void startLeg(final Leg leg, final Writer out) throws IOException {
 		out.write("\t\t\t<leg");
 		out.write(" mode=\"" + leg.getMode() + "\"");
 		if (leg.getDepartureTime().seconds() != Integer.MIN_VALUE)
@@ -177,7 +177,7 @@ import org.matsim.core.utils.misc.Time;
 	}
 
 	@Override
-	public void endLeg(final BufferedWriter out) throws IOException {
+	public void endLeg(final Writer out) throws IOException {
 		out.write("\t\t\t</leg>\n");
 	}
 
@@ -186,7 +186,7 @@ import org.matsim.core.utils.misc.Time;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startRoute(final Route route, final BufferedWriter out) throws IOException {
+	public void startRoute(final Route route, final Writer out) throws IOException {
 		out.write("\t\t\t\t<route>");
 
 		if (route instanceof NetworkRoute) {
@@ -199,7 +199,7 @@ import org.matsim.core.utils.misc.Time;
 	}
 
 	@Override
-	public void endRoute(final BufferedWriter out) throws IOException {
+	public void endRoute(final Writer out) throws IOException {
 		out.write("</route>\n");
 	}
 
@@ -208,7 +208,7 @@ import org.matsim.core.utils.misc.Time;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void writeSeparator(final BufferedWriter out) throws IOException {
+	public void writeSeparator(final Writer out) throws IOException {
 		out.write("<!-- =================================================" +
 							"===================== -->\n\n");
 	}

--- a/matsim/src/main/java/org/matsim/core/population/io/PopulationWriterHandlerImplV4.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/PopulationWriterHandlerImplV4.java
@@ -22,7 +22,7 @@ package org.matsim.core.population.io;
 
 import static org.matsim.core.utils.io.XmlUtils.encodeAttributeValue;
 
-import java.io.BufferedWriter;
+import java.io.Writer;
 import java.io.IOException;
 
 import org.matsim.api.core.v01.Coord;
@@ -61,7 +61,7 @@ import org.matsim.core.utils.misc.Time;
 	}
 
 	@Override
-	public void writeHeaderAndStartElement(final BufferedWriter out) throws IOException {
+	public void writeHeaderAndStartElement(final Writer out) throws IOException {
 		out.write("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n");
 		out.write("<!DOCTYPE plans SYSTEM \"" + MatsimXmlWriter.DEFAULT_DTD_LOCATION + "plans_v4.dtd\">\n\n");
 	}
@@ -71,7 +71,7 @@ import org.matsim.core.utils.misc.Time;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startPlans(final Population plans, final BufferedWriter out) throws IOException {
+	public void startPlans(final Population plans, final Writer out) throws IOException {
 		out.write("<plans");
 		if (plans.getName() != null) {
 			out.write(" name=\"" + encodeAttributeValue(plans.getName()) + "\"");
@@ -80,7 +80,7 @@ import org.matsim.core.utils.misc.Time;
 	}
 
 	@Override
-	public void endPlans(final BufferedWriter out) throws IOException {
+	public void endPlans(final Writer out) throws IOException {
 		out.write("</plans>\n");
 		out.flush();
 	}
@@ -90,7 +90,7 @@ import org.matsim.core.utils.misc.Time;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startPerson(final Person person, final BufferedWriter out) throws IOException {
+	public void startPerson(final Person person, final Writer out) throws IOException {
 		out.write("\t<person id=\"");
 		out.write(encodeAttributeValue(person.getId().toString()));
 		out.write("\"");
@@ -123,7 +123,7 @@ import org.matsim.core.utils.misc.Time;
 	}
 
 	@Override
-	public void endPerson(final BufferedWriter out) throws IOException {
+	public void endPerson(final Writer out) throws IOException {
 		out.write("\t</person>\n\n");
 	}
 
@@ -132,14 +132,14 @@ import org.matsim.core.utils.misc.Time;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startTravelCard(final String travelcard, final BufferedWriter out) throws IOException {
+	public void startTravelCard(final String travelcard, final Writer out) throws IOException {
 		out.write("\t\t<travelcard type=\"");
 		out.write(travelcard);
 		out.write("\" />\n\n");
 	}
 
 	@Override
-	public void endTravelCard(final BufferedWriter out) throws IOException {
+	public void endTravelCard(final Writer out) throws IOException {
 	}
 
 	//////////////////////////////////////////////////////////////////////
@@ -147,7 +147,7 @@ import org.matsim.core.utils.misc.Time;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startPlan(final Plan plan, final BufferedWriter out) throws IOException {
+	public void startPlan(final Plan plan, final Writer out) throws IOException {
 		out.write("\t\t<plan");
 		if (plan.getScore() != null) {
 			out.write(" score=\"");
@@ -167,7 +167,7 @@ import org.matsim.core.utils.misc.Time;
 	}
 
 	@Override
-	public void endPlan(final BufferedWriter out) throws IOException {
+	public void endPlan(final Writer out) throws IOException {
 		out.write("\t\t</plan>\n\n");
 	}
 
@@ -176,7 +176,7 @@ import org.matsim.core.utils.misc.Time;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startAct(final Activity act, final BufferedWriter out) throws IOException {
+	public void startAct(final Activity act, final Writer out) throws IOException {
 		out.write("\t\t\t<act type=\"");
 		out.write(encodeAttributeValue(act.getType()));
 		out.write("\"");
@@ -217,7 +217,7 @@ import org.matsim.core.utils.misc.Time;
 	}
 
 	@Override
-	public void endAct(final BufferedWriter out) throws IOException {
+	public void endAct(final Writer out) throws IOException {
 	}
 
 	//////////////////////////////////////////////////////////////////////
@@ -225,7 +225,7 @@ import org.matsim.core.utils.misc.Time;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startLeg(final Leg leg, final BufferedWriter out) throws IOException {
+	public void startLeg(final Leg leg, final Writer out) throws IOException {
 		out.write("\t\t\t<leg mode=\"");
 		out.write(leg.getMode());
 		out.write("\"");
@@ -252,7 +252,7 @@ import org.matsim.core.utils.misc.Time;
 	}
 
 	@Override
-	public void endLeg(final BufferedWriter out) throws IOException {
+	public void endLeg(final Writer out) throws IOException {
 		out.write("\t\t\t</leg>\n");
 	}
 
@@ -261,7 +261,7 @@ import org.matsim.core.utils.misc.Time;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startRoute(final Route route, final BufferedWriter out) throws IOException {
+	public void startRoute(final Route route, final Writer out) throws IOException {
 		out.write("\t\t\t\t<route");
 		if (!Double.isNaN(route.getDistance())) {
 			out.write(" dist=\"");
@@ -293,7 +293,7 @@ import org.matsim.core.utils.misc.Time;
 	}
 
 	@Override
-	public void endRoute(final BufferedWriter out) throws IOException {
+	public void endRoute(final Writer out) throws IOException {
 		out.write("\t\t\t\t</route>\n");
 	}
 
@@ -302,7 +302,7 @@ import org.matsim.core.utils.misc.Time;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void writeSeparator(final BufferedWriter out) throws IOException {
+	public void writeSeparator(final Writer out) throws IOException {
 		out.write("<!-- ====================================================================== -->\n\n");
 	}
 

--- a/matsim/src/main/java/org/matsim/core/population/io/PopulationWriterHandlerImplV5.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/PopulationWriterHandlerImplV5.java
@@ -22,7 +22,7 @@ package org.matsim.core.population.io;
 
 import static org.matsim.core.utils.io.XmlUtils.encodeAttributeValue;
 
-import java.io.BufferedWriter;
+import java.io.Writer;
 import java.io.IOException;
 
 import org.apache.logging.log4j.LogManager;
@@ -58,13 +58,13 @@ import org.matsim.core.utils.misc.Time;
 	}
 
 	@Override
-	public void writeHeaderAndStartElement(final BufferedWriter out) throws IOException {
+	public void writeHeaderAndStartElement(final Writer out) throws IOException {
 		out.write("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n");
 		out.write("<!DOCTYPE population SYSTEM \"" + MatsimXmlWriter.DEFAULT_DTD_LOCATION + "population_v5.dtd\">\n\n");
 	}
 
 	@Override
-	public void startPlans(final Population plans, final BufferedWriter out) throws IOException {
+	public void startPlans(final Population plans, final Writer out) throws IOException {
 		out.write("<population");
 		if (plans.getName() != null) {
 			out.write(" desc=\"" + encodeAttributeValue(plans.getName()) + "\"");
@@ -73,7 +73,7 @@ import org.matsim.core.utils.misc.Time;
 	}
 
 	@Override
-	public void writePerson(final Person person, final BufferedWriter out) throws IOException {
+	public void writePerson(final Person person, final Writer out) throws IOException {
 		PopulationWriterHandlerImplV5.startPerson(person, out);
 		for (Plan plan : person.getPlans()) {
 			PopulationWriterHandlerImplV5.startPlan(plan, out);
@@ -102,12 +102,12 @@ import org.matsim.core.utils.misc.Time;
 	}
 
 	@Override
-	public void endPlans(final BufferedWriter out) throws IOException {
+	public void endPlans(final Writer out) throws IOException {
 		out.write("</population>\n");
 		out.flush();
 	}
 
-	private static void startPerson(final Person person, final BufferedWriter out) throws IOException {
+	private static void startPerson(final Person person, final Writer out) throws IOException {
 		out.write("\t<person id=\"");
 		out.write(encodeAttributeValue(person.getId().toString()));
 		out.write("\"");
@@ -139,11 +139,11 @@ import org.matsim.core.utils.misc.Time;
 		out.write(">\n");
 	}
 
-	private static void endPerson(final BufferedWriter out) throws IOException {
+	private static void endPerson(final Writer out) throws IOException {
 		out.write("\t</person>\n\n");
 	}
 
-	private static void startPlan(final Plan plan, final BufferedWriter out) throws IOException {
+	private static void startPlan(final Plan plan, final Writer out) throws IOException {
 		out.write("\t\t<plan");
 		if (plan.getScore() != null) {
 			out.write(" score=\"");
@@ -162,11 +162,11 @@ import org.matsim.core.utils.misc.Time;
 		out.write(">\n");
 	}
 
-	private static void endPlan(final BufferedWriter out) throws IOException {
+	private static void endPlan(final Writer out) throws IOException {
 		out.write("\t\t</plan>\n\n");
 	}
 
-	private void writeAct(final Activity act, final BufferedWriter out) throws IOException {
+	private void writeAct(final Activity act, final Writer out) throws IOException {
 		out.write("\t\t\t<act type=\"");
 		out.write(encodeAttributeValue(act.getType()));
 		out.write("\"");
@@ -206,7 +206,7 @@ import org.matsim.core.utils.misc.Time;
 		out.write(" />\n");
 	}
 
-	private static void startLeg(final Leg leg, final BufferedWriter out) throws IOException {
+	private static void startLeg(final Leg leg, final Writer out) throws IOException {
 		out.write("\t\t\t<leg mode=\"");
 		out.write(encodeAttributeValue(leg.getMode()));
 		out.write("\"");
@@ -233,11 +233,11 @@ import org.matsim.core.utils.misc.Time;
 		out.write(">\n");
 	}
 
-	private static void endLeg(final BufferedWriter out) throws IOException {
+	private static void endLeg(final Writer out) throws IOException {
 		out.write("\t\t\t</leg>\n");
 	}
 
-	private static void startRoute(final Route route, final BufferedWriter out) throws IOException {
+	private static void startRoute(final Route route, final Writer out) throws IOException {
 		out.write("\t\t\t\t<route ");
 		out.write("type=\"");
 		out.write(encodeAttributeValue(route.getRouteType()));
@@ -269,12 +269,12 @@ import org.matsim.core.utils.misc.Time;
 		}
 	}
 
-	private static void endRoute(final BufferedWriter out) throws IOException {
+	private static void endRoute(final Writer out) throws IOException {
 		out.write("</route>\n");
 	}
 
 	@Override
-	public void writeSeparator(final BufferedWriter out) throws IOException {
+	public void writeSeparator(final Writer out) throws IOException {
 		out.write("<!-- ====================================================================== -->\n\n");
 	}
 

--- a/matsim/src/main/java/org/matsim/core/population/io/PopulationWriterHandlerImplV6.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/PopulationWriterHandlerImplV6.java
@@ -23,7 +23,7 @@ package org.matsim.core.population.io;
 import static org.matsim.core.utils.io.XmlUtils.encodeAttributeValue;
 import static org.matsim.core.utils.io.XmlUtils.encodeContent;
 
-import java.io.BufferedWriter;
+import java.io.Writer;
 import java.io.IOException;
 import java.util.Map;
 
@@ -74,13 +74,13 @@ import org.matsim.vehicles.Vehicle;
 	}
 
 	@Override
-	public void writeHeaderAndStartElement(final BufferedWriter out) throws IOException {
+	public void writeHeaderAndStartElement(final Writer out) throws IOException {
 		out.write("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n");
 		out.write("<!DOCTYPE population SYSTEM \"" + MatsimXmlWriter.DEFAULT_DTD_LOCATION + "population_v6.dtd\">\n\n");
 	}
 
 	@Override
-	public void startPlans(final Population plans, final BufferedWriter out) throws IOException {
+	public void startPlans(final Population plans, final Writer out) throws IOException {
 		out.write("<population");
 		if (plans.getName() != null) {
 			out.write(" desc=\"" + encodeAttributeValue(plans.getName()) + "\"");
@@ -93,7 +93,7 @@ import org.matsim.vehicles.Vehicle;
 	}
 
 	@Override
-	public void writePerson(final Person person, final BufferedWriter out) throws IOException {
+	public void writePerson(final Person person, final Writer out) throws IOException {
 		this.startPerson(person, out);
 		for (Plan plan : person.getPlans()) {
 			startPlan(plan, out);
@@ -122,12 +122,12 @@ import org.matsim.vehicles.Vehicle;
 	}
 
 	@Override
-	public void endPlans(final BufferedWriter out) throws IOException {
+	public void endPlans(final Writer out) throws IOException {
 		out.write("</population>\n");
 		out.flush();
 	}
 
-	private void startPerson(final Person person, final BufferedWriter out) throws IOException {
+	private void startPerson(final Person person, final Writer out) throws IOException {
 		out.write("\t<person id=\"");
 		out.write(encodeAttributeValue(person.getId().toString()));
 		out.write("\"");
@@ -135,11 +135,11 @@ import org.matsim.vehicles.Vehicle;
 		this.attributesWriter.writeAttributes( "\t\t" , out , person.getAttributes() );
 	}
 
-	private static void endPerson(final BufferedWriter out) throws IOException {
+	private static void endPerson(final Writer out) throws IOException {
 		out.write("\t</person>\n\n");
 	}
 
-	private void startPlan(final Plan plan, final BufferedWriter out) throws IOException {
+	private void startPlan(final Plan plan, final Writer out) throws IOException {
 		out.write("\t\t<plan");
 		if (plan.getScore() != null) {
 			out.write(" score=\"");
@@ -161,11 +161,11 @@ import org.matsim.vehicles.Vehicle;
 
 	}
 
-	private static void endPlan(final BufferedWriter out) throws IOException {
+	private static void endPlan(final Writer out) throws IOException {
 		out.write("\t\t</plan>\n\n");
 	}
 
-	private void writeAct(final Activity act, final BufferedWriter out) throws IOException {
+	private void writeAct(final Activity act, final Writer out) throws IOException {
 		out.write("\t\t\t<activity type=\"");
 		out.write(encodeAttributeValue(act.getType()));
 		out.write("\"");
@@ -215,7 +215,7 @@ import org.matsim.vehicles.Vehicle;
 		out.write("\t\t\t</activity>\n");
 	}
 
-	private void startLeg(final Leg leg, final BufferedWriter out) throws IOException {
+	private void startLeg(final Leg leg, final Writer out) throws IOException {
 		out.write("\t\t\t<leg mode=\"");
 		out.write(encodeAttributeValue(leg.getMode()));
 		out.write("\"");
@@ -249,11 +249,11 @@ import org.matsim.vehicles.Vehicle;
 		} else this.attributesWriter.writeAttributes( "\t\t\t\t" , out , leg.getAttributes() );
 	}
 
-	private static void endLeg(final BufferedWriter out) throws IOException {
+	private static void endLeg(final Writer out) throws IOException {
 		out.write("\t\t\t</leg>\n");
 	}
 
-	private static void startRoute(final Route route, final BufferedWriter out) throws IOException {
+	private static void startRoute(final Route route, final Writer out) throws IOException {
 		out.write("\t\t\t\t<route ");
 		out.write("type=\"");
 		out.write(encodeAttributeValue(route.getRouteType()));
@@ -287,12 +287,12 @@ import org.matsim.vehicles.Vehicle;
 		}
 	}
 
-	private static void endRoute(final BufferedWriter out) throws IOException {
+	private static void endRoute(final Writer out) throws IOException {
 		out.write("</route>\n");
 	}
 
 	@Override
-	public void writeSeparator(final BufferedWriter out) throws IOException {
+	public void writeSeparator(final Writer out) throws IOException {
 		out.write("<!-- ====================================================================== -->\n\n");
 	}
 

--- a/matsim/src/main/java/org/matsim/core/population/io/StreamingPopulationWriter.java
+++ b/matsim/src/main/java/org/matsim/core/population/io/StreamingPopulationWriter.java
@@ -36,7 +36,7 @@ import org.matsim.utils.objectattributes.AttributeConverter;
 import org.matsim.utils.objectattributes.attributable.Attributes;
 import org.matsim.utils.objectattributes.attributable.AttributesImpl;
 
-import java.io.BufferedWriter;
+import java.io.Writer;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.HashMap;
@@ -52,7 +52,7 @@ public final class StreamingPopulationWriter implements PersonAlgorithm {
 	private final Map<Class<?>, AttributeConverter<?>> attributeConverters = new HashMap<>();
 
 	private static class DummyMatsimWriter extends AbstractMatsimWriter {
-		BufferedWriter getWriter() {
+		Writer getWriter() {
 			return writer;
 		}
 		void openHere(String filename ) {

--- a/matsim/src/main/java/org/matsim/core/utils/io/AbstractMatsimWriter.java
+++ b/matsim/src/main/java/org/matsim/core/utils/io/AbstractMatsimWriter.java
@@ -70,11 +70,9 @@ public abstract class AbstractMatsimWriter {
 	 */
 	protected final void openFile(final String filename) throws UncheckedIOException {
 		assertNotAlreadyOpen();
-		if (this.useCompression == null) {
-			this.writer = new FastBufferedWriter(IOUtils.getBufferedWriter(filename));
-		} else {
-			this.writer = new FastBufferedWriter(IOUtils.getBufferedWriter(filename + ".gz"));
-		}
+		final String target = (this.useCompression == null) ? filename : filename + ".gz";
+		final OutputStream outputStream = IOUtils.getOutputStream(IOUtils.getFileUrl(target), false);
+		this.writer = new FastBufferedWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8));
 	}
 
 	/**

--- a/matsim/src/main/java/org/matsim/core/utils/io/AbstractMatsimWriter.java
+++ b/matsim/src/main/java/org/matsim/core/utils/io/AbstractMatsimWriter.java
@@ -71,9 +71,9 @@ public abstract class AbstractMatsimWriter {
 	protected final void openFile(final String filename) throws UncheckedIOException {
 		assertNotAlreadyOpen();
 		if (this.useCompression == null) {
-			this.writer = IOUtils.getBufferedWriter(filename);
+			this.writer = new FastBufferedWriter(IOUtils.getBufferedWriter(filename));
 		} else {
-			this.writer = IOUtils.getBufferedWriter(filename + ".gz");
+			this.writer = new FastBufferedWriter(IOUtils.getBufferedWriter(filename + ".gz"));
 		}
 	}
 
@@ -85,9 +85,9 @@ public abstract class AbstractMatsimWriter {
 		assertNotAlreadyOpen();
 		try {
 			if (this.useCompression == null || this.useCompression) {
-				this.writer = new BufferedWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8));
+				this.writer = new FastBufferedWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8));
 			} else {
-				this.writer = new BufferedWriter(new OutputStreamWriter(new GZIPOutputStream(outputStream), StandardCharsets.UTF_8));
+				this.writer = new FastBufferedWriter(new OutputStreamWriter(new GZIPOutputStream(outputStream), StandardCharsets.UTF_8));
 			}
 		} catch (IOException e) {
 			throw new UncheckedIOException(e);

--- a/matsim/src/main/java/org/matsim/core/utils/io/AbstractMatsimWriter.java
+++ b/matsim/src/main/java/org/matsim/core/utils/io/AbstractMatsimWriter.java
@@ -20,11 +20,11 @@
 
 package org.matsim.core.utils.io;
 
-import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.UncheckedIOException;
+import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPOutputStream;
 
@@ -41,7 +41,7 @@ public abstract class AbstractMatsimWriter {
 	protected static final String NL = "\n";
 
 	/** The writer output can be written to. */
-	protected BufferedWriter writer = null;
+	protected Writer writer = null;
 
 	/** Whether or not the output is gzip-compressed. If <code>null</code>, the
 	 * usage of compression is decided by the filename (whether it ends with .gz

--- a/matsim/src/main/java/org/matsim/core/utils/io/FastBufferedWriter.java
+++ b/matsim/src/main/java/org/matsim/core/utils/io/FastBufferedWriter.java
@@ -20,7 +20,6 @@
 
 package org.matsim.core.utils.io;
 
-import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.Writer;
 
@@ -31,15 +30,13 @@ import java.io.Writer;
  * monitor, which dominates the serialization cost for large scenarios (populations, households, ...). This class makes
  * each small write a plain unsynchronized array copy and only touches the underlying writer once per full buffer.
  *
- * <p>The produced bytes are identical to those of {@link java.io.BufferedWriter}. It extends {@link BufferedWriter}
- * only so it can be used wherever a {@code BufferedWriter} is expected; the inherited buffer is left unused (size 1)
- * because every write path is overridden to go through this class' own buffer.</p>
- *
- * <p>Not thread-safe. MATSim file writing is single-threaded, so this is fine.</p>
+ * <p>The produced bytes are identical to those of {@link java.io.BufferedWriter}. Unlike {@code BufferedWriter} it is
+ * not synchronized, so it must only be used by a single thread &ndash; which is always the case for MATSim file
+ * writing.</p>
  *
  * @author Hannes Rewald
  */
-final class FastBufferedWriter extends BufferedWriter {
+final class FastBufferedWriter extends Writer {
 
 	private static final int DEFAULT_BUFFER_SIZE = 1 << 16; // 64k chars
 
@@ -52,8 +49,6 @@ final class FastBufferedWriter extends BufferedWriter {
 	}
 
 	FastBufferedWriter(final Writer out, final int bufferSize) {
-		// The BufferedWriter buffer (size 1) is never used; all writes are routed through our own buffer below.
-		super(out, 1);
 		this.out = out;
 		this.buffer = new char[bufferSize];
 	}
@@ -99,11 +94,6 @@ final class FastBufferedWriter extends BufferedWriter {
 		}
 		s.getChars(off, off + len, this.buffer, this.count);
 		this.count += len;
-	}
-
-	@Override
-	public void newLine() throws IOException {
-		write(System.lineSeparator());
 	}
 
 	@Override

--- a/matsim/src/main/java/org/matsim/core/utils/io/FastBufferedWriter.java
+++ b/matsim/src/main/java/org/matsim/core/utils/io/FastBufferedWriter.java
@@ -1,0 +1,141 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * FastBufferedWriter.java
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2026 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.core.utils.io;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * A drop-in replacement for {@link java.io.BufferedWriter} intended for single-threaded use. It removes the per-call
+ * synchronization of {@link java.io.BufferedWriter} and uses a large character buffer. MATSim's XML writers emit a
+ * large file as a great many tiny {@code write(...)} calls; with the JDK writer each of those takes an uncontended
+ * monitor, which dominates the serialization cost for large scenarios (populations, households, ...). This class makes
+ * each small write a plain unsynchronized array copy and only touches the underlying writer once per full buffer.
+ *
+ * <p>The produced bytes are identical to those of {@link java.io.BufferedWriter}. It extends {@link BufferedWriter}
+ * only so it can be used wherever a {@code BufferedWriter} is expected; the inherited buffer is left unused (size 1)
+ * because every write path is overridden to go through this class' own buffer.</p>
+ *
+ * <p>Not thread-safe. MATSim file writing is single-threaded, so this is fine.</p>
+ *
+ * @author Hannes Rewald
+ */
+final class FastBufferedWriter extends BufferedWriter {
+
+	private static final int DEFAULT_BUFFER_SIZE = 1 << 16; // 64k chars
+
+	private final Writer out;
+	private final char[] buffer;
+	private int count;
+
+	FastBufferedWriter(final Writer out) {
+		this(out, DEFAULT_BUFFER_SIZE);
+	}
+
+	FastBufferedWriter(final Writer out, final int bufferSize) {
+		// The BufferedWriter buffer (size 1) is never used; all writes are routed through our own buffer below.
+		super(out, 1);
+		this.out = out;
+		this.buffer = new char[bufferSize];
+	}
+
+	private void drainBuffer() throws IOException {
+		if (this.count > 0) {
+			this.out.write(this.buffer, 0, this.count);
+			this.count = 0;
+		}
+	}
+
+	@Override
+	public void write(final int c) throws IOException {
+		if (this.count >= this.buffer.length) {
+			drainBuffer();
+		}
+		this.buffer[this.count++] = (char) c;
+	}
+
+	@Override
+	public void write(final char[] cbuf, final int off, final int len) throws IOException {
+		if (len >= this.buffer.length) {
+			drainBuffer();
+			this.out.write(cbuf, off, len);
+			return;
+		}
+		if (this.count + len > this.buffer.length) {
+			drainBuffer();
+		}
+		System.arraycopy(cbuf, off, this.buffer, this.count, len);
+		this.count += len;
+	}
+
+	@Override
+	public void write(final String s, final int off, final int len) throws IOException {
+		if (len >= this.buffer.length) {
+			drainBuffer();
+			this.out.write(s, off, len);
+			return;
+		}
+		if (this.count + len > this.buffer.length) {
+			drainBuffer();
+		}
+		s.getChars(off, off + len, this.buffer, this.count);
+		this.count += len;
+	}
+
+	@Override
+	public void newLine() throws IOException {
+		write(System.lineSeparator());
+	}
+
+	@Override
+	public Writer append(final CharSequence csq) throws IOException {
+		write(String.valueOf(csq));
+		return this;
+	}
+
+	@Override
+	public Writer append(final CharSequence csq, final int start, final int end) throws IOException {
+		write((csq == null ? "null" : csq).subSequence(start, end).toString());
+		return this;
+	}
+
+	@Override
+	public Writer append(final char c) throws IOException {
+		write(c);
+		return this;
+	}
+
+	@Override
+	public void flush() throws IOException {
+		drainBuffer();
+		this.out.flush();
+	}
+
+	@Override
+	public void close() throws IOException {
+		try {
+			drainBuffer();
+		} finally {
+			this.out.close();
+		}
+	}
+}

--- a/matsim/src/main/java/org/matsim/counts/CountsWriterHandler.java
+++ b/matsim/src/main/java/org/matsim/counts/CountsWriterHandler.java
@@ -19,25 +19,25 @@
  * *********************************************************************** */
 
 package org.matsim.counts;
-import java.io.BufferedWriter;
+import java.io.Writer;
 import java.io.IOException;
 
 interface CountsWriterHandler {
 	//////////////////////////////////////////////////////////////////////
 	// <counts ... > ... </counts>
 	//////////////////////////////////////////////////////////////////////
-	public void startCounts(final Counts counts, final BufferedWriter out) throws IOException;
-	public void endCounts(final BufferedWriter out) throws IOException;
+	public void startCounts(final Counts counts, final Writer out) throws IOException;
+	public void endCounts(final Writer out) throws IOException;
 	//////////////////////////////////////////////////////////////////////
 	// <count ... > ... </count>
 	//////////////////////////////////////////////////////////////////////
-	public void startCount(final Count count, final BufferedWriter out) throws IOException;
-	public void endCount(final BufferedWriter out) throws IOException;
+	public void startCount(final Count count, final Writer out) throws IOException;
+	public void endCount(final Writer out) throws IOException;
 	//////////////////////////////////////////////////////////////////////
 	// <volume ... />
 	//////////////////////////////////////////////////////////////////////
-	public void startVolume(final Volume volume, final BufferedWriter out) throws IOException;
-	public void endVolume(final BufferedWriter out) throws IOException;
+	public void startVolume(final Volume volume, final Writer out) throws IOException;
+	public void endVolume(final Writer out) throws IOException;
 	
-	public void writeSeparator(final BufferedWriter out) throws IOException;
+	public void writeSeparator(final Writer out) throws IOException;
 }

--- a/matsim/src/main/java/org/matsim/counts/CountsWriterHandlerImplV1.java
+++ b/matsim/src/main/java/org/matsim/counts/CountsWriterHandlerImplV1.java
@@ -22,7 +22,7 @@ package org.matsim.counts;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.core.utils.geometry.CoordinateTransformation;
 
-import java.io.BufferedWriter;
+import java.io.Writer;
 import java.io.IOException;
 /*package*/ class CountsWriterHandlerImplV1 implements CountsWriterHandler {
 	private final CoordinateTransformation coordinateTransformation;
@@ -32,7 +32,7 @@ import java.io.IOException;
 	}
 
 	@Override
-	public void startCounts(final Counts counts, final BufferedWriter out) throws IOException {
+	public void startCounts(final Counts counts, final Writer out) throws IOException {
 		out.write("<counts ");
 		out.write("xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n");
 		out.write("xsi:noNamespaceSchemaLocation=\"http://matsim.org/files/dtd/counts_v1.xsd\"\n");
@@ -50,12 +50,12 @@ import java.io.IOException;
 	}
 
 	@Override
-	public void endCounts(final BufferedWriter out) throws IOException {
+	public void endCounts(final Writer out) throws IOException {
 		out.write("</counts>\n");
 	}
 
 	@Override
-	public void startCount(final Count count, final BufferedWriter out) throws IOException {
+	public void startCount(final Count count, final Writer out) throws IOException {
 		out.write("\t<count");
 		out.write(" loc_id=\"" + count.getId() + "\"");
 		out.write(" cs_id=\"" + count.getCsLabel() + "\"");
@@ -68,12 +68,12 @@ import java.io.IOException;
 	}
 
 	@Override
-	public void endCount(final BufferedWriter out) throws IOException {
+	public void endCount(final Writer out) throws IOException {
 		out.write("\t</count>\n\n");
 	}
 
 	@Override
-	public void startVolume(final Volume volume, final BufferedWriter out) throws IOException {
+	public void startVolume(final Volume volume, final Writer out) throws IOException {
 		out.write("\t\t<volume");
 		out.write(" h=\"" + volume.getHourOfDayStartingWithOne() + "\"");
 		out.write(" val=\"" + volume.getValue() + "\"");
@@ -81,11 +81,11 @@ import java.io.IOException;
 	}
 
 	@Override
-	public void endVolume(final BufferedWriter out) throws IOException {
+	public void endVolume(final Writer out) throws IOException {
 	}
 
 	@Override
-	public void writeSeparator(final BufferedWriter out) throws IOException {
+	public void writeSeparator(final Writer out) throws IOException {
 		out.write("<!-- ====================================================================== -->\n\n");
 	}
 }

--- a/matsim/src/main/java/org/matsim/facilities/FacilitiesWriterV1.java
+++ b/matsim/src/main/java/org/matsim/facilities/FacilitiesWriterV1.java
@@ -28,7 +28,7 @@ import org.matsim.core.utils.misc.Time;
 import org.matsim.utils.objectattributes.AttributeConverter;
 import org.matsim.utils.objectattributes.attributable.AttributesXmlWriterDelegate;
 
-import java.io.BufferedWriter;
+import java.io.Writer;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
@@ -118,7 +118,7 @@ class FacilitiesWriterV1 extends MatsimXmlWriter implements MatsimWriter {
     // <facilities ... > ... </facilities>
     //////////////////////////////////////////////////////////////////////
 
-    private void startFacilities(final ActivityFacilities facilities, final BufferedWriter out) {
+    private void startFacilities(final ActivityFacilities facilities, final Writer out) {
         List<Tuple<String, String>> attributes = new ArrayList<>();
         if (facilities.getName() != null) {
             attributes.add(new Tuple<>("name", facilities.getName()));
@@ -182,7 +182,7 @@ class FacilitiesWriterV1 extends MatsimXmlWriter implements MatsimWriter {
     // <capacity ... />
     //////////////////////////////////////////////////////////////////////
 
-    private void writeCapacity(final ActivityOptionImpl activity, final BufferedWriter out) throws IOException {
+    private void writeCapacity(final ActivityOptionImpl activity, final Writer out) throws IOException {
         if (activity.getCapacity() != Integer.MAX_VALUE) {
             out.write("\t\t\t<capacity");
             out.write(" value=\"" + activity.getCapacity() + "\"");
@@ -194,7 +194,7 @@ class FacilitiesWriterV1 extends MatsimXmlWriter implements MatsimWriter {
     // <opentime ... />
     //////////////////////////////////////////////////////////////////////
 
-    private void writeOpentime(final OpeningTime opentime, final BufferedWriter out) throws IOException {
+    private void writeOpentime(final OpeningTime opentime, final Writer out) throws IOException {
         out.write("\t\t\t<opentime");
         out.write(" day=\"wkday\"");
         out.write(" start_time=\"" + Time.writeTime(opentime.getStartTime()) + "\"");

--- a/matsim/src/main/java/org/matsim/facilities/FacilitiesWriterV2.java
+++ b/matsim/src/main/java/org/matsim/facilities/FacilitiesWriterV2.java
@@ -28,7 +28,7 @@ import org.matsim.core.utils.misc.Time;
 import org.matsim.utils.objectattributes.AttributeConverter;
 import org.matsim.utils.objectattributes.attributable.AttributesXmlWriterDelegate;
 
-import java.io.BufferedWriter;
+import java.io.Writer;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
@@ -118,7 +118,7 @@ class FacilitiesWriterV2 extends MatsimXmlWriter implements MatsimWriter {
     // <facilities ... > ... </facilities>
     //////////////////////////////////////////////////////////////////////
 
-    private void startFacilities(final ActivityFacilities facilities, final BufferedWriter out) {
+    private void startFacilities(final ActivityFacilities facilities, final Writer out) {
         List<Tuple<String, String>> attributes = new ArrayList<>();
         if (facilities.getName() != null) {
             attributes.add(new Tuple<>("name", facilities.getName()));
@@ -185,7 +185,7 @@ class FacilitiesWriterV2 extends MatsimXmlWriter implements MatsimWriter {
     // <capacity ... />
     //////////////////////////////////////////////////////////////////////
 
-    private void writeCapacity(final ActivityOptionImpl activity, final BufferedWriter out) throws IOException {
+    private void writeCapacity(final ActivityOptionImpl activity, final Writer out) throws IOException {
         if (activity.getCapacity() != Integer.MAX_VALUE) {
             out.write("\t\t\t<capacity");
             out.write(" value=\"" + activity.getCapacity() + "\"");
@@ -197,7 +197,7 @@ class FacilitiesWriterV2 extends MatsimXmlWriter implements MatsimWriter {
     // <opentime ... />
     //////////////////////////////////////////////////////////////////////
 
-    private void writeOpentime(final OpeningTime opentime, final BufferedWriter out) throws IOException {
+    private void writeOpentime(final OpeningTime opentime, final Writer out) throws IOException {
         out.write("\t\t\t<opentime");
         out.write(" day=\"wkday\"");
         out.write(" start_time=\"" + Time.writeTime(opentime.getStartTime()) + "\"");

--- a/matsim/src/main/java/org/matsim/matrices/MatricesWriterHandler.java
+++ b/matsim/src/main/java/org/matsim/matrices/MatricesWriterHandler.java
@@ -20,7 +20,7 @@
 
 package org.matsim.matrices;
 
-import java.io.BufferedWriter;
+import java.io.Writer;
 import java.io.IOException;
 
 interface MatricesWriterHandler {
@@ -29,25 +29,25 @@ interface MatricesWriterHandler {
 	// <matrices ... > ... </matrices>
 	//////////////////////////////////////////////////////////////////////
 
-	public void startMatrices(final Matrices matrices, final BufferedWriter out) throws IOException;
+	public void startMatrices(final Matrices matrices, final Writer out) throws IOException;
 
-	public void endMatrices(final BufferedWriter out) throws IOException;
+	public void endMatrices(final Writer out) throws IOException;
 
 	//////////////////////////////////////////////////////////////////////
 	// <matrix ... > ... </matrix>
 	//////////////////////////////////////////////////////////////////////
 
-	public void startMatrix(final Matrix matrix, final BufferedWriter out) throws IOException;
+	public void startMatrix(final Matrix matrix, final Writer out) throws IOException;
 
-	public void endMatrix(final BufferedWriter out) throws IOException;
+	public void endMatrix(final Writer out) throws IOException;
 
 	//////////////////////////////////////////////////////////////////////
 	// <entry ... />
 	//////////////////////////////////////////////////////////////////////
 
-	public void startEntry(final Entry entry, final BufferedWriter out) throws IOException;
+	public void startEntry(final Entry entry, final Writer out) throws IOException;
 
-	public void endEntry(final BufferedWriter out) throws IOException;
+	public void endEntry(final Writer out) throws IOException;
 	
-	public void writeSeparator(final BufferedWriter out) throws IOException;
+	public void writeSeparator(final Writer out) throws IOException;
 }

--- a/matsim/src/main/java/org/matsim/matrices/MatricesWriterHandlerImplV1.java
+++ b/matsim/src/main/java/org/matsim/matrices/MatricesWriterHandlerImplV1.java
@@ -20,7 +20,7 @@
 
 package org.matsim.matrices;
 
-import java.io.BufferedWriter;
+import java.io.Writer;
 import java.io.IOException;
 
 /*package*/ class MatricesWriterHandlerImplV1 implements MatricesWriterHandler {
@@ -40,7 +40,7 @@ import java.io.IOException;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startMatrices(final Matrices matrices, final BufferedWriter out) throws IOException {
+	public void startMatrices(final Matrices matrices, final Writer out) throws IOException {
 		out.write("<matrices");
 		if (matrices.getName() != null) {
 			out.write(" name=\"" + matrices.getName() + "\"");
@@ -49,7 +49,7 @@ import java.io.IOException;
 	}
 
 	@Override
-	public void endMatrices(final BufferedWriter out) throws IOException {
+	public void endMatrices(final Writer out) throws IOException {
 		out.write("</matrices>\n");
 	}
 
@@ -58,7 +58,7 @@ import java.io.IOException;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startMatrix(final Matrix matrix, final BufferedWriter out) throws IOException {
+	public void startMatrix(final Matrix matrix, final Writer out) throws IOException {
 		out.write("\t<matrix");
 		out.write(" id=\"" + matrix.getId() + "\"");
 
@@ -69,7 +69,7 @@ import java.io.IOException;
 	}
 
 	@Override
-	public void endMatrix(final BufferedWriter out) throws IOException {
+	public void endMatrix(final Writer out) throws IOException {
 		out.write("\t</matrix>\n\n");
 	}
 
@@ -78,7 +78,7 @@ import java.io.IOException;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void startEntry(final Entry entry, final BufferedWriter out) throws IOException {
+	public void startEntry(final Entry entry, final Writer out) throws IOException {
 		out.write("\t\t<entry");
 		out.write(" from_id=\"" + entry.getFromLocation() + "\"");
 		out.write(" to_id=\"" + entry.getToLocation() + "\"");
@@ -87,7 +87,7 @@ import java.io.IOException;
 	}
 
 	@Override
-	public void endEntry(final BufferedWriter out) throws IOException {
+	public void endEntry(final Writer out) throws IOException {
 	}
 
 	//////////////////////////////////////////////////////////////////////
@@ -95,7 +95,7 @@ import java.io.IOException;
 	//////////////////////////////////////////////////////////////////////
 
 	@Override
-	public void writeSeparator(final BufferedWriter out) throws IOException {
+	public void writeSeparator(final Writer out) throws IOException {
 		out.write("<!-- =================================================" +
 							"===================== -->\n\n");
 	}

--- a/matsim/src/main/java/org/matsim/utils/objectattributes/attributable/AttributesXmlWriterDelegate.java
+++ b/matsim/src/main/java/org/matsim/utils/objectattributes/attributable/AttributesXmlWriterDelegate.java
@@ -25,7 +25,7 @@ import org.matsim.core.utils.io.XmlUtils;
 import org.matsim.utils.objectattributes.AttributeConverter;
 import org.matsim.utils.objectattributes.ObjectAttributesConverter;
 
-import java.io.BufferedWriter;
+import java.io.Writer;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Map;
@@ -36,7 +36,7 @@ import java.util.Map;
 public class AttributesXmlWriterDelegate {
 	private final ObjectAttributesConverter converter = new ObjectAttributesConverter();
 
-	public final void writeAttributes(final String indentation, final BufferedWriter writer, final Attributes attributes) {
+	public final void writeAttributes(final String indentation, final Writer writer, final Attributes attributes) {
 		writeAttributes(indentation, writer, attributes, true);
 	}
 
@@ -44,7 +44,7 @@ public class AttributesXmlWriterDelegate {
 		writeAttributes(indentation, writer, attributes, true);
 	}
 
-	public final void writeAttributes(final String indentation, final BufferedWriter writer, final Attributes attributes, boolean emptyLineAfter) {
+	public final void writeAttributes(final String indentation, final Writer writer, final Attributes attributes, boolean emptyLineAfter) {
 		if (attributes.size() == 0) {
 			return;
 		}

--- a/matsim/src/main/java/org/matsim/vehicles/VehicleWriterV2.java
+++ b/matsim/src/main/java/org/matsim/vehicles/VehicleWriterV2.java
@@ -92,7 +92,7 @@ final class VehicleWriterV2 extends MatsimXmlWriter {
 				this.writeStartTag(VehicleSchemaV2Names.VEHICLE, atts, true);
 			} else {
 				this.writeStartTag(VehicleSchemaV2Names.VEHICLE, atts, false);
-				this.writer.newLine();
+				this.writer.write(NL);
 				attributesWriter.writeAttributes("\t\t", this.writer, v.getAttributes(), false);
 				this.writeEndTag(VehicleSchemaV2Names.VEHICLE);
 			}

--- a/matsim/src/test/java/org/matsim/core/utils/io/FastBufferedWriterBenchmark.java
+++ b/matsim/src/test/java/org/matsim/core/utils/io/FastBufferedWriterBenchmark.java
@@ -1,0 +1,129 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * FastBufferedWriterBenchmark.java
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2026 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.core.utils.io;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A dependency-free A/B microbenchmark comparing {@link FastBufferedWriter} against {@link java.io.BufferedWriter} on a
+ * workload that mirrors how MATSim's XML writers serialize a scenario: a great many tiny {@code write(String)} calls,
+ * draining into a real character-encoding {@link OutputStreamWriter}. The downstream stream discards its bytes so that
+ * only the writer/encoding cost (not disk or compression) is measured.
+ *
+ * <p>This is not a unit test and is skipped by default. Run it explicitly with:</p>
+ * <pre>
+ * mvn -o -pl matsim test -Dtest=FastBufferedWriterBenchmark \
+ *     -Dsurefire.failIfNoSpecifiedTests=false -Dmatsim.benchmark=true
+ * </pre>
+ *
+ * @author Hannes Rewald
+ */
+class FastBufferedWriterBenchmark {
+
+	/** Number of "elements" written; each element issues {@link #WRITES_PER_ELEMENT} tiny writes. */
+	private static final int ELEMENTS = 2_000_000;
+
+	/** Tiny writes per element, mimicking how a person/household is emitted as dozens of small fragments. */
+	private static final int WRITES_PER_ELEMENT = 25;
+
+	private static final int WARMUP_ROUNDS = 3;
+	private static final int MEASURED_ROUNDS = 5;
+
+	/** Representative small XML fragments, like attribute names/values and tags emitted per element. */
+	private static final String[] FRAGMENTS = {
+			"\t\t<person id=\"", "12345678", "\" sex=\"m\" age=\"", "42", "\">",
+			"\n\t\t\t<attributes>", "\n\t\t\t\t<attribute name=\"", "homeX", "\" class=\"java.lang.Double\">",
+			"678910.123", "</attribute>", "\n\t\t\t</attributes>", "\n\t\t\t<plan selected=\"yes\">",
+			"\n\t\t\t\t<activity type=\"", "home", "\" x=\"", "678910.1", "\" y=\"", "245678.9",
+			"\" end_time=\"", "08:00:00", "\" />", "\n\t\t\t</plan>", "\n\t\t</person>", "\n"
+	};
+
+	@Test
+	void benchmarkTinyWrites() throws IOException {
+		Assumptions.assumeTrue(Boolean.getBoolean("matsim.benchmark"),
+				"microbenchmark - run with -Dmatsim.benchmark=true to enable");
+
+		System.out.println();
+		System.out.println("FastBufferedWriter A/B benchmark");
+		System.out.printf("  workload: %,d elements x %d tiny write(String) calls = %,d writes per round%n",
+				ELEMENTS, WRITES_PER_ELEMENT, (long) ELEMENTS * WRITES_PER_ELEMENT);
+		System.out.printf("  warmup rounds: %d, measured rounds: %d%n", WARMUP_ROUNDS, MEASURED_ROUNDS);
+		System.out.println();
+
+		// BEFORE: the JDK's synchronized BufferedWriter (8 KB default buffer).
+		final Function<Writer, Writer> baseline = out -> new java.io.BufferedWriter(out, 8192);
+		// AFTER: the unsynchronized FastBufferedWriter (64 KB buffer).
+		final Function<Writer, Writer> candidate = out -> new FastBufferedWriter(out);
+
+		final double baselineMs = measure("java.io.BufferedWriter (before)", baseline);
+		final double candidateMs = measure("FastBufferedWriter      (after)", candidate);
+
+		System.out.println();
+		System.out.printf("  before: %8.1f ms/round (median)%n", baselineMs);
+		System.out.printf("  after:  %8.1f ms/round (median)%n", candidateMs);
+		System.out.printf("  speedup: %.2fx  (%.1f%% less time)%n",
+				baselineMs / candidateMs, 100.0 * (baselineMs - candidateMs) / baselineMs);
+		System.out.println();
+	}
+
+	private static double measure(final String label, final Function<Writer, Writer> wrapperFactory) throws IOException {
+		final double[] timings = new double[MEASURED_ROUNDS];
+
+		for (int round = 0; round < WARMUP_ROUNDS + MEASURED_ROUNDS; round++) {
+			final long start = System.nanoTime();
+			runWorkload(wrapperFactory);
+			final long elapsedNs = System.nanoTime() - start;
+
+			if (round >= WARMUP_ROUNDS) {
+				timings[round - WARMUP_ROUNDS] = elapsedNs / 1_000_000.0;
+			}
+		}
+
+		Arrays.sort(timings);
+		final double median = timings[timings.length / 2];
+		System.out.printf("  %-34s median %8.1f ms  (rounds %s ms)%n", label, median, Arrays.toString(timings));
+		return median;
+	}
+
+	private static void runWorkload(final Function<Writer, Writer> wrapperFactory) throws IOException {
+		// A real encoding writer onto a discarding stream: same StreamEncoder path as production, no disk/compression.
+		final Writer encoding = new OutputStreamWriter(OutputStream.nullOutputStream(), StandardCharsets.UTF_8);
+		final Writer writer = wrapperFactory.apply(encoding);
+		try {
+			for (int element = 0; element < ELEMENTS; element++) {
+				for (int w = 0; w < WRITES_PER_ELEMENT; w++) {
+					writer.write(FRAGMENTS[w]);
+				}
+			}
+		} finally {
+			writer.close();
+		}
+	}
+}

--- a/matsim/src/test/java/org/matsim/core/utils/io/FastBufferedWriterTest.java
+++ b/matsim/src/test/java/org/matsim/core/utils/io/FastBufferedWriterTest.java
@@ -65,7 +65,7 @@ class FastBufferedWriterTest {
 
 	@FunctionalInterface
 	private interface WriterScript {
-		void run(java.io.BufferedWriter writer) throws IOException;
+		void run(Writer writer) throws IOException;
 	}
 
 	@Test
@@ -127,18 +127,6 @@ class FastBufferedWriterTest {
 				w.append((CharSequence) null);        // must yield "null"
 				w.append((CharSequence) null, 1, 3);  // must yield "ul"
 				w.append(new StringBuilder("from-builder"));
-			});
-		}
-	}
-
-	@Test
-	void newLineMatchesPlatform() throws IOException {
-		for (int bufferSize : new int[] { 1, 2, 16 }) {
-			assertEquivalent(bufferSize, w -> {
-				w.write("line1");
-				w.newLine();
-				w.write("line2");
-				w.newLine();
 			});
 		}
 	}

--- a/matsim/src/test/java/org/matsim/core/utils/io/FastBufferedWriterTest.java
+++ b/matsim/src/test/java/org/matsim/core/utils/io/FastBufferedWriterTest.java
@@ -1,0 +1,386 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ * FastBufferedWriterTest.java
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2026 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.core.utils.io;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link FastBufferedWriter}. The central property under test is that {@code FastBufferedWriter} produces
+ * byte-for-byte the same output as {@link java.io.BufferedWriter} for every write path and at every buffer boundary,
+ * while batching the data into far fewer calls to the underlying writer.
+ *
+ * @author Hannes Rewald
+ */
+class FastBufferedWriterTest {
+
+	// ---------------------------------------------------------------------------------------------------------------
+	// Equivalence with java.io.BufferedWriter
+	// ---------------------------------------------------------------------------------------------------------------
+
+	/** Applies the same operations to a FastBufferedWriter and a reference java.io.BufferedWriter and compares. */
+	private static void assertEquivalent(final int bufferSize, final WriterScript script) throws IOException {
+		final StringWriter fastTarget = new StringWriter();
+		final StringWriter refTarget = new StringWriter();
+
+		final FastBufferedWriter fast = new FastBufferedWriter(fastTarget, bufferSize);
+		final java.io.BufferedWriter ref = new java.io.BufferedWriter(refTarget);
+
+		script.run(fast);
+		script.run(ref);
+
+		fast.flush();
+		ref.flush();
+
+		assertEquals(refTarget.toString(), fastTarget.toString(),
+				"FastBufferedWriter output must equal java.io.BufferedWriter output (bufferSize=" + bufferSize + ")");
+	}
+
+	@FunctionalInterface
+	private interface WriterScript {
+		void run(java.io.BufferedWriter writer) throws IOException;
+	}
+
+	@Test
+	void writeSingleChars() throws IOException {
+		for (int bufferSize : new int[] { 1, 2, 3, 8, 64 }) {
+			assertEquivalent(bufferSize, w -> {
+				for (int i = 0; i < 200; i++) {
+					w.write('a' + (i % 26));
+				}
+			});
+		}
+	}
+
+	@Test
+	void writeFullStrings() throws IOException {
+		for (int bufferSize : new int[] { 1, 4, 16, 64 }) {
+			assertEquivalent(bufferSize, w -> {
+				w.write("");
+				w.write("a");
+				w.write("hello world");
+				w.write("a string that is clearly longer than the small buffers under test");
+			});
+		}
+	}
+
+	@Test
+	void writeStringRegion() throws IOException {
+		final String source = "0123456789abcdefghijklmnopqrstuvwxyz";
+		for (int bufferSize : new int[] { 1, 3, 7, 16, 64 }) {
+			assertEquivalent(bufferSize, w -> {
+				w.write(source, 0, 0);   // empty region
+				w.write(source, 0, 5);
+				w.write(source, 10, 20); // region longer than small buffers
+				w.write(source, source.length() - 1, 1);
+			});
+		}
+	}
+
+	@Test
+	void writeCharArrayRegion() throws IOException {
+		final char[] source = "0123456789abcdefghijklmnopqrstuvwxyz".toCharArray();
+		for (int bufferSize : new int[] { 1, 3, 7, 16, 64 }) {
+			assertEquivalent(bufferSize, w -> {
+				w.write(source, 0, 0);   // empty region
+				w.write(source, 0, 5);
+				w.write(source, 10, 20); // region longer than small buffers
+				w.write(source);         // whole array
+			});
+		}
+	}
+
+	@Test
+	void appendVariants() throws IOException {
+		for (int bufferSize : new int[] { 1, 4, 16, 64 }) {
+			assertEquivalent(bufferSize, w -> {
+				w.append('x');
+				w.append("charsequence");
+				w.append("subsequence-source", 3, 11);
+				w.append((CharSequence) null);        // must yield "null"
+				w.append((CharSequence) null, 1, 3);  // must yield "ul"
+				w.append(new StringBuilder("from-builder"));
+			});
+		}
+	}
+
+	@Test
+	void newLineMatchesPlatform() throws IOException {
+		for (int bufferSize : new int[] { 1, 2, 16 }) {
+			assertEquivalent(bufferSize, w -> {
+				w.write("line1");
+				w.newLine();
+				w.write("line2");
+				w.newLine();
+			});
+		}
+	}
+
+	// ---------------------------------------------------------------------------------------------------------------
+	// Buffer-boundary behaviour
+	// ---------------------------------------------------------------------------------------------------------------
+
+	@Test
+	void exactlyFillsBufferThenWritesMore() throws IOException {
+		final int bufferSize = 8;
+		assertEquivalent(bufferSize, w -> {
+			w.write("01234567"); // exactly fills the buffer
+			w.write('8');          // forces a drain, then stores one char
+			w.write("9abcdef0");   // exactly fills again
+			w.write("X");          // drain + store
+		});
+	}
+
+	@Test
+	void writeLargerThanBufferBypassesBuffer() throws IOException {
+		final int bufferSize = 4;
+		assertEquivalent(bufferSize, w -> {
+			w.write("ab");                 // partially fill
+			w.write("LONG-PAYLOAD-LARGER"); // longer than buffer -> must drain "ab" first, then write payload directly
+			w.write("cd");
+		});
+	}
+
+	@Test
+	void charArrayLargerThanBufferAfterPartialFill() throws IOException {
+		final int bufferSize = 4;
+		final char[] big = "LONG-PAYLOAD-LARGER".toCharArray();
+		assertEquivalent(bufferSize, w -> {
+			w.write("ab");
+			w.write(big, 0, big.length);
+			w.write("cd");
+		});
+	}
+
+	// ---------------------------------------------------------------------------------------------------------------
+	// Randomized differential stress test
+	// ---------------------------------------------------------------------------------------------------------------
+
+	@Test
+	void randomizedDifferentialAgainstBufferedWriter() throws IOException {
+		final String alphabet = "abcdefghijklmnopqrstuvwxyz0123456789 \t<>/\"=\n\u00e4\u00f6\u00fc\u20ac";
+		for (int bufferSize : new int[] { 1, 2, 3, 5, 8, 13, 64, 1 << 16 }) {
+			final long seed = 0xC0FFEE * (long) bufferSize + 17;
+			assertEquivalent(bufferSize, w -> {
+				final Random random = new Random(seed);
+				for (int i = 0; i < 5000; i++) {
+					final int choice = random.nextInt(6);
+					switch (choice) {
+						case 0:
+							w.write(alphabet.charAt(random.nextInt(alphabet.length())));
+							break;
+						case 1:
+							w.write(randomString(random, alphabet, random.nextInt(40)));
+							break;
+						case 2: {
+							final String s = randomString(random, alphabet, 1 + random.nextInt(40));
+							final int off = random.nextInt(s.length());
+							final int len = random.nextInt(s.length() - off);
+							w.write(s, off, len);
+							break;
+						}
+						case 3: {
+							final char[] c = randomString(random, alphabet, random.nextInt(40)).toCharArray();
+							w.write(c);
+							break;
+						}
+						case 4:
+							w.append(randomString(random, alphabet, random.nextInt(40)));
+							break;
+						default:
+							w.append(alphabet.charAt(random.nextInt(alphabet.length())));
+							break;
+					}
+				}
+			});
+		}
+	}
+
+	private static String randomString(final Random random, final String alphabet, final int length) {
+		final StringBuilder builder = new StringBuilder(length);
+		for (int i = 0; i < length; i++) {
+			builder.append(alphabet.charAt(random.nextInt(alphabet.length())));
+		}
+		return builder.toString();
+	}
+
+	// ---------------------------------------------------------------------------------------------------------------
+	// Batching, flush and close behaviour
+	// ---------------------------------------------------------------------------------------------------------------
+
+	@Test
+	void batchesManySmallWritesIntoFewUnderlyingWrites() throws IOException {
+		final CountingWriter underlying = new CountingWriter();
+		final FastBufferedWriter writer = new FastBufferedWriter(underlying, 1024);
+
+		for (int i = 0; i < 10000; i++) {
+			writer.write("x"); // 10000 tiny writes, total 10000 chars
+		}
+		writer.flush();
+
+		// 10000 chars through a 1024-char buffer: about 10 drains plus the flush, never one-per-write.
+		assertTrue(underlying.writeCalls <= 12,
+				"expected the buffer to coalesce small writes, but underlying received " + underlying.writeCalls + " writes");
+		assertEquals(10000, underlying.charsWritten);
+	}
+
+	@Test
+	void nothingReachesUnderlyingBeforeBufferFillsOrFlush() throws IOException {
+		final CountingWriter underlying = new CountingWriter();
+		final FastBufferedWriter writer = new FastBufferedWriter(underlying, 64);
+
+		writer.write("small");
+		assertEquals(0, underlying.charsWritten, "data must stay buffered until the buffer fills or flush is called");
+
+		writer.flush();
+		assertEquals(5, underlying.charsWritten);
+	}
+
+	@Test
+	void flushDrainsBufferAndFlushesUnderlying() throws IOException {
+		final CountingWriter underlying = new CountingWriter();
+		final FastBufferedWriter writer = new FastBufferedWriter(underlying, 64);
+
+		writer.write("payload");
+		writer.flush();
+
+		assertEquals("payload", underlying.builder.toString());
+		assertTrue(underlying.flushed, "flush() must propagate to the underlying writer");
+	}
+
+	@Test
+	void closeDrainsBufferAndClosesUnderlying() throws IOException {
+		final CountingWriter underlying = new CountingWriter();
+		final FastBufferedWriter writer = new FastBufferedWriter(underlying, 64);
+
+		writer.write("to-be-flushed-on-close");
+		writer.close();
+
+		assertEquals("to-be-flushed-on-close", underlying.builder.toString(),
+				"close() must drain remaining buffered data");
+		assertTrue(underlying.closed, "close() must propagate to the underlying writer");
+	}
+
+	@Test
+	void closeStillClosesUnderlyingWhenDrainFails() {
+		final ThrowOnWriteWriter underlying = new ThrowOnWriteWriter();
+		final FastBufferedWriter writer = new FastBufferedWriter(underlying, 64);
+
+		try {
+			writer.write("data that will fail to drain");
+			writer.close();
+		} catch (IOException expected) {
+			// the drain inside close() is expected to throw
+		}
+		assertTrue(underlying.closed, "underlying writer must be closed even if draining fails");
+	}
+
+	@Test
+	void appendReturnsSelfForChaining() throws IOException {
+		final FastBufferedWriter writer = new FastBufferedWriter(new StringWriter(), 64);
+		assertSame(writer, writer.append('a'));
+		assertSame(writer, writer.append("b"));
+		assertSame(writer, writer.append("cd", 0, 1));
+		writer.close();
+	}
+
+	@Test
+	void emptyOutputProducesEmptyFile() throws IOException {
+		final CountingWriter underlying = new CountingWriter();
+		final FastBufferedWriter writer = new FastBufferedWriter(underlying, 64);
+		writer.flush();
+		writer.close();
+		assertEquals("", underlying.builder.toString());
+		assertEquals(0, underlying.charsWritten);
+		assertFalse(underlying.writeCalls > 0, "no characters were written, so the underlying writer must not be written to");
+	}
+
+	// ---------------------------------------------------------------------------------------------------------------
+	// Test doubles
+	// ---------------------------------------------------------------------------------------------------------------
+
+	/** A Writer that records what it receives, so batching, flush and close propagation can be asserted. */
+	private static final class CountingWriter extends Writer {
+		private final StringBuilder builder = new StringBuilder();
+		private int writeCalls;
+		private int charsWritten;
+		private boolean flushed;
+		private boolean closed;
+
+		@Override
+		public void write(final char[] cbuf, final int off, final int len) {
+			this.writeCalls++;
+			this.charsWritten += len;
+			this.builder.append(cbuf, off, len);
+		}
+
+		@Override
+		public void write(final String str, final int off, final int len) {
+			this.writeCalls++;
+			this.charsWritten += len;
+			this.builder.append(str, off, off + len);
+		}
+
+		@Override
+		public void flush() {
+			this.flushed = true;
+		}
+
+		@Override
+		public void close() {
+			this.closed = true;
+		}
+	}
+
+	/** A Writer whose writes always fail, used to verify close() still closes the underlying writer. */
+	private static final class ThrowOnWriteWriter extends Writer {
+		private boolean closed;
+
+		@Override
+		public void write(final char[] cbuf, final int off, final int len) throws IOException {
+			throw new IOException("write failure for test");
+		}
+
+		@Override
+		public void write(final String str, final int off, final int len) throws IOException {
+			throw new IOException("write failure for test");
+		}
+
+		@Override
+		public void flush() throws IOException {
+			throw new IOException("flush failure for test");
+		}
+
+		@Override
+		public void close() {
+			this.closed = true;
+		}
+	}
+}


### PR DESCRIPTION
Replaces the JDK's synchronized `BufferedWriter` in MATSim's writers with an unsynchronized buffered writer, making scenario serialization ~3× faster with byte-identical output.

### Problem

JFR profiling showed ~72% of self-time during scenario serialization is spent in `java.io.BufferedWriter.write`'s per-call synchronization, because the XML writers emit each element as dozens of tiny `write(...)` calls. This single-threaded synchronization cost dominates writing for large scenarios (persons, households, vehicles, network, facilities).

### Solution

Add `FastBufferedWriter`, an unsynchronized drop-in `BufferedWriter` with a 64 KB buffer, and wire it into `AbstractMatsimWriter` so all writers benefit transparently. A property-gated A/B microbenchmark (enable with `-Dmatsim.benchmark=true`) confirms **3.13× faster writing (68% less time)**, and a 17-case differential test verifies byte-identical output against `java.io.BufferedWriter`.

The relevant change in `AbstractMatsimWriter` is here:
https://github.com/matsim-org/matsim-libs/pull/5017/changes#diff-fcfc872dfbfdd6424d93f45ac798a618bd905158aa344b1a71729025852cdc5dR71-R93