### PR TITLE
feat(common): bring your own random in WeightedRandomSelection

### DIFF
--- a/contribs/common/src/main/java/org/matsim/contrib/common/util/WeightedRandomSelection.java
+++ b/contribs/common/src/main/java/org/matsim/contrib/common/util/WeightedRandomSelection.java
@@ -50,6 +50,10 @@ public class WeightedRandomSelection<T> {
 	}
 
 	public T select() {
+		return this.select(random);
+	}
+
+	public T select(RandomGenerator random) {
 		Preconditions.checkState(!entryList.isEmpty(), "No entries in the list to select from");
 		Preconditions.checkState(totalWeight > 0, "Total weight is not positive");
 


### PR DESCRIPTION
This change adds a `select(RandomGenerator)` method, that uses a supplied random for selecting from the WRS. The helps determinism when a WRS is used in multiple threads.

The alternative would be, to create multiple copies of the WRS for each thread, however, only managing thread-local `RandomGenerator`s  instead of (potentially) a lot of WRS makes implementations cleaner.