### PR TITLE
fix(dsim): Avoid undefined state of shared files for SharedMemoryCommunicator

### DIFF
--- a/contribs/distributed-simulation/src/main/java/org/matsim/core/communication/SharedMemoryCommunicator.java
+++ b/contribs/distributed-simulation/src/main/java/org/matsim/core/communication/SharedMemoryCommunicator.java
@@ -15,6 +15,7 @@ import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 
 /**
@@ -47,11 +48,12 @@ public class SharedMemoryCommunicator implements Communicator {
 
 		try {
 			Files.createDirectories(tmpDir);
+			Files.deleteIfExists(tmpDir.resolve("q-" + rank + ".init"));
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
 
-		this.subscription = new IPC(qFilePath, size, true);
+		this.subscription = new IPC(qFilePath, true);
 		this.others = new IPC[size];
 	}
 
@@ -77,7 +79,7 @@ public class SharedMemoryCommunicator implements Communicator {
 				while (!Files.exists(name))
 					idle.idle();
 
-				others[i] = new IPC(name, size, false);
+				others[i] = new IPC(name, false);
 			}
 		}
 	}
@@ -178,33 +180,39 @@ public class SharedMemoryCommunicator implements Communicator {
 			return 1L << (64 - Long.numberOfLeadingZeros(value - 1));
 		}
 
-		public IPC(Path path, long total, boolean clear) {
+		public IPC(Path path, boolean owner) {
 
 			this.path = path;
+
+			String bufferSizeEnv = System.getenv("MSG_BUFFER_SIZE");
+			long capacity = bufferSizeEnv != null
+				? nextPowerOfTwo(Long.parseLong(bufferSizeEnv))
+				: 1L << 30; // 1 GB
+			while (capacity + RingBufferDescriptor.TRAILER_LENGTH > Integer.MAX_VALUE)
+				capacity >>= 1;
+			long size = capacity + RingBufferDescriptor.TRAILER_LENGTH;
+
+			// Owner: write to a temp path and rename atomically after zeroing, so connect()
+			// in other processes only sees the file once it is fully initialized.
+			Path openPath = owner ? path.resolveSibling(path.getFileName() + ".init") : path;
 			try {
-				channel = FileChannel.open(path, StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
+				channel = owner
+					? FileChannel.open(openPath, StandardOpenOption.CREATE_NEW, StandardOpenOption.READ, StandardOpenOption.WRITE)
+					: FileChannel.open(path, StandardOpenOption.READ, StandardOpenOption.WRITE);
 			} catch (IOException e) {
 				throw new RuntimeException(e);
 			}
 
-			String bufferSize = System.getenv("MSG_BUFFER_SIZE");
-			int s = bufferSize != null ? Integer.parseInt(bufferSize) : 32 * 1024 * 1024;
-			long n = nextPowerOfTwo(total * s + RingBufferDescriptor.TRAILER_LENGTH);
-			long size = n * s + RingBufferDescriptor.TRAILER_LENGTH;
-			while (size > Integer.MAX_VALUE) {
-				n = n >> 1;
-				size = n * s + RingBufferDescriptor.TRAILER_LENGTH;
-			}
-
-			// Create a memory-mapped file
 			MappedByteBuffer buffer = mapBuffer(size);
-
-			// Zero the buffer before using it
-			if (clear) {
-				while (buffer.hasRemaining()) {
+			if (owner) {
+				while (buffer.hasRemaining())
 					buffer.put((byte) 0);
-				}
 				buffer.clear();
+				try {
+					Files.move(openPath, path, StandardCopyOption.ATOMIC_MOVE);
+				} catch (IOException e) {
+					throw new RuntimeException(e);
+				}
 			}
 
 			UnsafeBuffer ub = new UnsafeBuffer(buffer);

--- a/contribs/distributed-simulation/src/main/java/org/matsim/core/communication/SharedMemoryCommunicator.java
+++ b/contribs/distributed-simulation/src/main/java/org/matsim/core/communication/SharedMemoryCommunicator.java
@@ -1,6 +1,5 @@
 package org.matsim.core.communication;
 
-import io.aeron.CommonContext;
 import org.agrona.concurrent.IdleStrategy;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.agrona.concurrent.YieldingIdleStrategy;
@@ -16,6 +15,7 @@ import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 
 /**
  * Communicates using shared memory.
@@ -26,39 +26,46 @@ public class SharedMemoryCommunicator implements Communicator {
 
 	private final int rank;
 	private final int size;
+	private final Path tmpDir;
 
 	private final IdleStrategy idle = new YieldingIdleStrategy();
 
 	private final IPC subscription;
 	private final IPC[] others;
 
-	public SharedMemoryCommunicator(int rank, int size) {
+	public SharedMemoryCommunicator(int rank, int size, Path tmpDir) {
 		this.rank = rank;
 		this.size = size;
+		this.tmpDir = tmpDir;
 
-		File name = getName(rank);
-		log.info("Serving on {}", name);
+		var qFilePath = getQFilePath(rank);
+		if (Files.exists(qFilePath)) {
+			throw new RuntimeException("Shared memory file already exists: " + qFilePath + ". This indicates that a previous run was not properly" +
+				" finished. Clean up the directory before starting a simulation to ensure proper message exchange!");
+		}
+		log.info("Serving on {}", qFilePath);
 
 		try {
-			Files.createDirectories(Path.of(CommonContext.getAeronDirectoryName()));
+			Files.createDirectories(tmpDir);
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
 
-		this.subscription = new IPC(name, size, true);
+		this.subscription = new IPC(qFilePath, size, true);
 		this.others = new IPC[size];
 	}
 
 	static void main() {
-		try (SharedMemoryCommunicator comm = new SharedMemoryCommunicator(0, 1)) {
+		var globalTmpDir = System.getProperty("java.io.tmpdir");
+		try (SharedMemoryCommunicator comm = new SharedMemoryCommunicator(0, 1, Path.of(globalTmpDir, "dsim-shared-mem-comm"))) {
 			comm.connect();
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}
 	}
 
-	private File getName(int rank) {
-		return new File(CommonContext.getAeronDirectoryName() + "/q-" + rank);
+	private Path getQFilePath(int rank) {
+		return tmpDir.resolve("q-" + rank);
 	}
 
 	public void connect() {
@@ -66,8 +73,8 @@ public class SharedMemoryCommunicator implements Communicator {
 		for (int i = 0; i < size; i++) {
 			if (i != rank) {
 
-				File name = getName(i);
-				while (!name.exists())
+				var name = getQFilePath(i);
+				while (!Files.exists(name))
 					idle.idle();
 
 				others[i] = new IPC(name, size, false);
@@ -136,7 +143,7 @@ public class SharedMemoryCommunicator implements Communicator {
 	@Override
 	public void recv(MessageReceiver expectsNext, MessageConsumer handleReceive) {
 		while (expectsNext.expectsMoreMessages()) {
-			int read = subscription.rb.read((msgTypeId, buffer, index, length) -> {
+			int read = subscription.rb.read((_, buffer, index, length) -> {
 				ByteBuffer bb = buffer.byteBuffer();
 				if (bb == null)
 					bb = ByteBuffer.wrap(buffer.byteArray(), index, length);
@@ -148,7 +155,7 @@ public class SharedMemoryCommunicator implements Communicator {
 				} catch (IOException e) {
 					throw new UncheckedIOException(e);
 				}
-			});
+			}, 1);
 
 			if (read == 0) {
 				idle.idle();
@@ -161,27 +168,24 @@ public class SharedMemoryCommunicator implements Communicator {
 	private static final class IPC {
 
 		final ManyToOneRingBuffer rb;
-		private final File path;
-		private final RandomAccessFile file;
 		private final FileChannel channel;
-		private final MappedByteBuffer buffer;
-		private final UnsafeBuffer ub;
+		private final Path path;
 
 		/**
-		 * Compute next power of two for the given value.
-		 *
-		 * @param value
-		 * @return
+		 * Compute the next power of two for the given value.
 		 */
 		private long nextPowerOfTwo(long value) {
 			return 1L << (64 - Long.numberOfLeadingZeros(value - 1));
 		}
 
-		public IPC(File path, long total, boolean clear) {
+		public IPC(Path path, long total, boolean clear) {
 
 			this.path = path;
-			file = getRandomAccessFile(path);
-			channel = file.getChannel();
+			try {
+				channel = FileChannel.open(path, StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
 
 			String bufferSize = System.getenv("MSG_BUFFER_SIZE");
 			int s = bufferSize != null ? Integer.parseInt(bufferSize) : 32 * 1024 * 1024;
@@ -193,7 +197,7 @@ public class SharedMemoryCommunicator implements Communicator {
 			}
 
 			// Create a memory-mapped file
-			buffer = mapBuffer(size);
+			MappedByteBuffer buffer = mapBuffer(size);
 
 			// Zero the buffer before using it
 			if (clear) {
@@ -203,7 +207,7 @@ public class SharedMemoryCommunicator implements Communicator {
 				buffer.clear();
 			}
 
-			ub = new UnsafeBuffer(buffer);
+			UnsafeBuffer ub = new UnsafeBuffer(buffer);
 			rb = new ManyToOneRingBuffer(ub);
 		}
 
@@ -215,19 +219,10 @@ public class SharedMemoryCommunicator implements Communicator {
 			}
 		}
 
-		private RandomAccessFile getRandomAccessFile(File path) {
-			try {
-				return new RandomAccessFile(path, "rw");
-			} catch (FileNotFoundException e) {
-				throw new RuntimeException(e);
-			}
-		}
-
 		public void close(boolean delete) {
 
 			try {
 				channel.close();
-				file.close();
 			} catch (IOException e) {
 				throw new RuntimeException(e);
 			}
@@ -237,8 +232,9 @@ public class SharedMemoryCommunicator implements Communicator {
 		}
 
 		private void delete() {
-			boolean deleted = path.delete();
-			if (!deleted) {
+			try {
+				Files.delete(path);
+			} catch (IOException e) {
 				log.warn("Could not delete file {}", path);
 			}
 		}

--- a/contribs/distributed-simulation/src/main/java/org/matsim/dsim/RunDistributedSim.java
+++ b/contribs/distributed-simulation/src/main/java/org/matsim/dsim/RunDistributedSim.java
@@ -25,31 +25,31 @@ import java.util.concurrent.Callable;
 	description = "Run a distributed simulation")
 public class RunDistributedSim implements Callable<Integer> {
 
-	@CommandLine.Option(names = {"-r", "--rank"}, description = "Rank of this node", defaultValue = "0")
+	@CommandLine.Option(names = { "-r", "--rank" }, description = "Rank of this node", defaultValue = "0")
 	private int rank;
 
-	@CommandLine.Option(names = {"-t", "--total"}, description = "Total number of nodes", defaultValue = "1")
+	@CommandLine.Option(names = { "-t", "--total" }, description = "Total number of nodes", defaultValue = "1")
 	private int total;
 
-	@CommandLine.Option(names = {"--threads"}, description = "Number of threads on a node", defaultValue = "4")
+	@CommandLine.Option(names = { "--threads" }, description = "Number of threads on a node", defaultValue = "4")
 	private int threads;
 
-	@CommandLine.Option(names = {"--write-events"}, description = "Write events to the output directory", defaultValue = "false")
+	@CommandLine.Option(names = { "--write-events" }, description = "Write events to the output directory", defaultValue = "false")
 	private boolean writeEvents;
 
-	@CommandLine.Option(names = {"--nodes"}, description = "List of all nodes", defaultValue = "")
+	@CommandLine.Option(names = { "--nodes" }, description = "List of all nodes", defaultValue = "")
 	private String nodes;
 
-	@CommandLine.Option(names = {"--address"}, description = "Address of this node", defaultValue = "")
+	@CommandLine.Option(names = { "--address" }, description = "Address of this node", defaultValue = "")
 	private String address;
 
-	@CommandLine.Option(names = {"-c", "--communicator"}, description = "Type of communicator", defaultValue = "LOCAL")
+	@CommandLine.Option(names = { "-c", "--communicator" }, description = "Type of communicator", defaultValue = "LOCAL")
 	private Type communicator;
 
-	@CommandLine.Option(names = {"-s", "--scenario"}, description = "Scenario to run (from matsim-examples)", defaultValue = "kelheim")
+	@CommandLine.Option(names = { "-s", "--scenario" }, description = "Scenario to run (from matsim-examples)", defaultValue = "kelheim")
 	private String scenario;
 
-	@CommandLine.Option(names = {"-o", "--output"}, description = "Overwrite output path in the config")
+	@CommandLine.Option(names = { "-o", "--output" }, description = "Overwrite output path in the config")
 	private String output;
 
 	public static void main(String[] args) {
@@ -76,7 +76,7 @@ public class RunDistributedSim implements Callable<Integer> {
 			case AERON -> new AeronCommunicator(rank, total, false, address);
 			case AERON_IPC -> new AeronCommunicator(rank, total, true, address);
 			case HAZELCAST -> new HazelcastCommunicator(rank, total, Communicator.parseNodeList(address, nodes));
-			case SHM -> new SharedMemoryCommunicator(rank, total);
+			case SHM -> new SharedMemoryCommunicator(rank, total, Path.of(System.getProperty("java.io.tmpdir"), "dsim-shared-mem-comm"));
 			case LOCAL -> new NullCommunicator();
 		};
 

--- a/contribs/distributed-simulation/src/main/java/org/matsim/dsim/RunMessagingBenchmark.java
+++ b/contribs/distributed-simulation/src/main/java/org/matsim/dsim/RunMessagingBenchmark.java
@@ -12,55 +12,56 @@ import picocli.CommandLine;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.nio.ByteBuffer;
+import java.nio.file.Path;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 @CommandLine.Command(name = "distributed-benchmark", mixinStandardHelpOptions = true,
-        description = "Benchmark for distributed message passing")
+	description = "Benchmark for distributed message passing")
 public class RunMessagingBenchmark implements Callable<Integer> {
 
-    private static final Logger log = LogManager.getLogger(RunMessagingBenchmark.class);
+	private static final Logger log = LogManager.getLogger(RunMessagingBenchmark.class);
 
-    @CommandLine.Option(names = {"-r", "--rank"}, description = "Rank of this process", required = true)
-    private int rank;
+	@CommandLine.Option(names = { "-r", "--rank" }, description = "Rank of this process", required = true)
+	private int rank;
 
-    @CommandLine.Option(names = {"-t", "--total"}, description = "Total number of processes", required = true)
-    private int total;
+	@CommandLine.Option(names = { "-t", "--total" }, description = "Total number of processes", required = true)
+	private int total;
 
-    @CommandLine.Option(names = {"-n", "--number"}, description = "Number of thousand messages to send", defaultValue = "100")
-    private int n;
+	@CommandLine.Option(names = { "-n", "--number" }, description = "Number of thousand messages to send", defaultValue = "100")
+	private int n;
 
-    @CommandLine.Option(names = {"-c", "--communicator"}, description = "Type of communicator", defaultValue = "SHM")
-    private RunDistributedSim.Type communicator;
+	@CommandLine.Option(names = { "-c", "--communicator" }, description = "Type of communicator", defaultValue = "SHM")
+	private RunDistributedSim.Type communicator;
 
-    @CommandLine.Option(names = {"--nodes"}, description = "List of all nodes", defaultValue = "")
-    private String nodes;
+	@CommandLine.Option(names = { "--nodes" }, description = "List of all nodes", defaultValue = "")
+	private String nodes;
 
-    @CommandLine.Option(names = {"--address"}, description = "Address of this node", defaultValue = "")
-    private String address;
+	@CommandLine.Option(names = { "--address" }, description = "Address of this node", defaultValue = "")
+	private String address;
 
-    @CommandLine.Option(names = {"-s", "--size"}, description = "Size of the messages in bytes", defaultValue = "16")
-    private long size;
+	@CommandLine.Option(names = { "-s", "--size" }, description = "Size of the messages in bytes", defaultValue = "16")
+	private long size;
 
-    public static void main(String[] args) {
-        new CommandLine(new RunMessagingBenchmark()).execute(args);
-    }
+	public static void main(String[] args) {
+		new CommandLine(new RunMessagingBenchmark()).execute(args);
+	}
 
-    @Override
-    public Integer call() throws Exception {
+	@Override
+	public Integer call() throws Exception {
 
 		log.info("Communicator: {}", communicator);
-        log.info("Starting distributed benchmark as rank {} of {} and {}k messages ({} bytes)", rank, total, n, size);
+		log.info("Starting distributed benchmark as rank {} of {} and {}k messages ({} bytes)", rank, total, n, size);
 
 		Communicator comm = total == 1 ? new NullCommunicator() : switch (communicator) {
 			case AERON -> new AeronCommunicator(rank, total, false, address);
 			case AERON_IPC -> new AeronCommunicator(rank, total, true, address);
 			case HAZELCAST -> new HazelcastCommunicator(rank, total, Communicator.parseNodeList(address, nodes));
-			case SHM -> new SharedMemoryCommunicator(rank, total);
+			case SHM -> new SharedMemoryCommunicator(rank, total, Path.of(System.getProperty("java.io.tmpdir"), "dsim-shared-mem-comm"));
 			case LOCAL -> throw new IllegalArgumentException("Local communicator is not supported");
 		};
 
-        Histogram histogram = new Histogram(TimeUnit.SECONDS.toNanos(10), 3);
+		Histogram histogram = new Histogram(TimeUnit.SECONDS.toNanos(10), 3);
 
 		if (size < Integer.BYTES) {
 			throw new IllegalArgumentException("Size must be at least 4 bytes");
@@ -75,17 +76,17 @@ public class RunMessagingBenchmark implements Callable<Integer> {
 			bb.putInt(i);
 		}
 
-        int N = n * 1000;
+		int N = n * 1000;
 
-        comm.connect();
+		comm.connect();
 
-        log.info("Connected");
+		log.info("Connected");
 
 		// Timestamps received from other nodes
 		IntList backlog = new IntArrayList();
 
-        for (int k = 0; k < N; k++) {
-            long start = System.nanoTime();
+		for (int k = 0; k < N; k++) {
+			long start = System.nanoTime();
 
 			// Received messages
 			IntList received = new IntArrayList(backlog);
@@ -97,13 +98,13 @@ public class RunMessagingBenchmark implements Callable<Integer> {
 
 			comm.send(Communicator.BROADCAST_TO_ALL, data, 0, size);
 
-//			System.out.println("Sent: " + k);
+			//			System.out.println("Sent: " + k);
 
 			int finalK = k;
 			comm.recv(() -> received.size() < total - 1, (buf) -> {
 				int seq = buf.getInt(); // seq
 
-//				System.out.println("Received: " + seq + " at " + finalK);
+				//				System.out.println("Received: " + seq + " at " + finalK);
 
 				if (seq == finalK) {
 					received.add(seq);
@@ -111,26 +112,26 @@ public class RunMessagingBenchmark implements Callable<Integer> {
 					backlog.add(seq);
 			});
 
-            if (received.size() > total - 1) {
-                System.out.println("At k=" + k);
-                System.out.println(received);
-                throw new IllegalStateException("Received more messages than expected");
-            }
+			if (received.size() > total - 1) {
+				System.out.println("At k=" + k);
+				System.out.println(received);
+				throw new IllegalStateException("Received more messages than expected");
+			}
 
-            // First messages are warmup
-            if (k > 10000)
-                histogram.recordValue(System.nanoTime() - start);
+			// First messages are warmup
+			if (k > 10000)
+				histogram.recordValue(System.nanoTime() - start);
 
-            if (k % 10000 == 0)
-                log.info("Rank {} of {} has sent {}k messages", rank, total, k / 1_000);
+			if (k % 10000 == 0)
+				log.info("Rank {} of {} has sent {}k messages", rank, total, k / 1_000);
 
-        }
+		}
 
-        if (rank == 0)
-            histogram.outputPercentileDistribution(System.out, 1000.0);
+		if (rank == 0)
+			histogram.outputPercentileDistribution(System.out, 1000.0);
 
-        comm.close();
+		comm.close();
 
-        return 0;
-    }
+		return 0;
+	}
 }

--- a/contribs/distributed-simulation/src/test/java/org/matsim/dsim/SharedMemoryCommunicatorTest.java
+++ b/contribs/distributed-simulation/src/test/java/org/matsim/dsim/SharedMemoryCommunicatorTest.java
@@ -1,0 +1,100 @@
+package org.matsim.dsim;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.matsim.core.communication.SharedMemoryCommunicator;
+import org.matsim.testcases.MatsimTestUtils;
+
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SharedMemoryCommunicatorTest {
+
+	@RegisterExtension
+	MatsimTestUtils utils = new MatsimTestUtils();
+
+	@Test
+	void createsAndDeletesSharedMemoryFile() throws Exception {
+		Path tmpFolder = Path.of(utils.getOutputDirectory());
+
+		try (var _ = new SharedMemoryCommunicator(0, 1, tmpFolder)) {
+			assertThat(tmpFolder.resolve("q-0")).exists();
+		}
+
+		assertThat(tmpFolder.resolve("q-0")).doesNotExist();
+	}
+
+	@Test
+	void throwsWhenFileAlreadyExists() throws IOException {
+		Path tmpFolder = Path.of(utils.getOutputDirectory());
+		Files.createDirectories(tmpFolder);
+		Files.createFile(tmpFolder.resolve("q-0"));
+
+		assertThatThrownBy(() -> {
+			try (var _ = new SharedMemoryCommunicator(0, 1, tmpFolder)) {
+				// nothing.
+			}
+		})
+			.isInstanceOf(RuntimeException.class)
+			.hasMessageContaining("already exists");
+	}
+
+	@Test
+	void communicatesBetweenTwoRanks() throws Exception {
+		Path tmpFolder = Path.of(utils.getOutputDirectory());
+
+		byte[] payload0 = "hello from rank 0".getBytes(StandardCharsets.UTF_8);
+		byte[] payload1 = "hello from rank 1".getBytes(StandardCharsets.UTF_8);
+
+		var received0 = new AtomicReference<byte[]>();
+		var received1 = new AtomicReference<byte[]>();
+
+		try (var comm0 = new SharedMemoryCommunicator(0, 2, tmpFolder);
+			 var comm1 = new SharedMemoryCommunicator(1, 2, tmpFolder);
+			 var exec = Executors.newVirtualThreadPerTaskExecutor()) {
+
+			var f0 = exec.submit(() -> {
+				comm0.connect();
+				try (Arena arena = Arena.ofConfined()) {
+					MemorySegment seg = arena.allocate(payload0.length);
+					seg.asByteBuffer().put(payload0);
+					comm0.send(1, seg, 0, payload0.length);
+				}
+				comm0.recv(() -> received0.get() == null, buf -> {
+					byte[] bytes = new byte[buf.remaining()];
+					buf.get(bytes);
+					received0.set(bytes);
+				});
+			});
+
+			var f1 = exec.submit(() -> {
+				comm1.connect();
+				try (Arena arena = Arena.ofConfined()) {
+					MemorySegment seg = arena.allocate(payload1.length);
+					seg.asByteBuffer().put(payload1);
+					comm1.send(0, seg, 0, payload1.length);
+				}
+				comm1.recv(() -> received1.get() == null, buf -> {
+					byte[] bytes = new byte[buf.remaining()];
+					buf.get(bytes);
+					received1.set(bytes);
+				});
+			});
+
+			f0.get();
+			f1.get();
+		}
+
+		assertThat(received0.get()).isEqualTo(payload1);
+		assertThat(received1.get()).isEqualTo(payload0);
+	}
+}

--- a/contribs/distributed-simulation/src/test/java/org/matsim/dsim/SharedMemoryCommunicatorTest.java
+++ b/contribs/distributed-simulation/src/test/java/org/matsim/dsim/SharedMemoryCommunicatorTest.java
@@ -11,6 +11,9 @@ import java.lang.foreign.MemorySegment;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -40,6 +43,7 @@ class SharedMemoryCommunicatorTest {
 		Files.createFile(tmpFolder.resolve("q-0"));
 
 		assertThatThrownBy(() -> {
+			//noinspection EmptyTryBlock
 			try (var _ = new SharedMemoryCommunicator(0, 1, tmpFolder)) {
 				// nothing.
 			}
@@ -59,8 +63,8 @@ class SharedMemoryCommunicatorTest {
 		var received1 = new AtomicReference<byte[]>();
 
 		try (var comm0 = new SharedMemoryCommunicator(0, 2, tmpFolder);
-			 var comm1 = new SharedMemoryCommunicator(1, 2, tmpFolder);
-			 var exec = Executors.newVirtualThreadPerTaskExecutor()) {
+			var comm1 = new SharedMemoryCommunicator(1, 2, tmpFolder);
+			var exec = Executors.newVirtualThreadPerTaskExecutor()) {
 
 			var f0 = exec.submit(() -> {
 				comm0.connect();
@@ -96,5 +100,117 @@ class SharedMemoryCommunicatorTest {
 
 		assertThat(received0.get()).isEqualTo(payload1);
 		assertThat(received1.get()).isEqualTo(payload0);
+	}
+
+	@Test
+	void preservesMessageOrderWhenSentBeforeReading() throws Exception {
+		Path tmpFolder = Path.of(utils.getOutputDirectory());
+
+		byte[] msg1 = "message 1".getBytes(StandardCharsets.UTF_8);
+		byte[] msg2 = "message 2".getBytes(StandardCharsets.UTF_8);
+
+		var sendsDone = new CountDownLatch(1);
+		var received = new ArrayList<String>();
+
+		try (var comm0 = new SharedMemoryCommunicator(0, 2, tmpFolder);
+			var comm1 = new SharedMemoryCommunicator(1, 2, tmpFolder);
+			var exec = Executors.newVirtualThreadPerTaskExecutor()) {
+
+			var f0 = exec.submit(() -> {
+				comm0.connect();
+				try (Arena arena = Arena.ofConfined()) {
+					MemorySegment seg = arena.allocate(msg1.length);
+					seg.asByteBuffer().put(msg1);
+					comm0.send(1, seg, 0, msg1.length);
+				}
+				try (Arena arena = Arena.ofConfined()) {
+					MemorySegment seg = arena.allocate(msg2.length);
+					seg.asByteBuffer().put(msg2);
+					comm0.send(1, seg, 0, msg2.length);
+				}
+				sendsDone.countDown();
+			});
+
+			var f1 = exec.submit(() -> {
+				comm1.connect();
+				try {
+					sendsDone.await();
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new RuntimeException(e);
+				}
+				comm1.recv(() -> received.size() < 2, buf -> {
+					byte[] bytes = new byte[buf.remaining()];
+					buf.get(bytes);
+					received.add(new String(bytes, StandardCharsets.UTF_8));
+				});
+			});
+
+			f0.get();
+			f1.get();
+		}
+
+		assertThat(received).containsExactly("message 1", "message 2");
+	}
+
+	@Test
+	void noCorruptionWhenConstructedConcurrently() throws Exception {
+		Path tmpFolder = Path.of(utils.getOutputDirectory());
+		Files.createDirectories(tmpFolder);
+
+		var barrier = new CyclicBarrier(2);
+		var comm0Ref = new AtomicReference<SharedMemoryCommunicator>();
+		var comm1Ref = new AtomicReference<SharedMemoryCommunicator>();
+
+		try (var exec = Executors.newVirtualThreadPerTaskExecutor()) {
+			var f0 = exec.submit(() -> {
+				try {
+					barrier.await();
+				} catch (Exception e) {
+					throw new RuntimeException(e);
+				}
+				comm0Ref.set(new SharedMemoryCommunicator(0, 2, tmpFolder));
+			});
+			var f1 = exec.submit(() -> {
+				try {
+					barrier.await();
+				} catch (Exception e) {
+					throw new RuntimeException(e);
+				}
+				comm1Ref.set(new SharedMemoryCommunicator(1, 2, tmpFolder));
+			});
+			f0.get();
+			f1.get();
+		}
+
+		byte[] payload = "hello".getBytes(StandardCharsets.UTF_8);
+		var received = new AtomicReference<byte[]>();
+
+		try (var comm0 = comm0Ref.get();
+			var comm1 = comm1Ref.get();
+			var exec = Executors.newVirtualThreadPerTaskExecutor()) {
+
+			var f0 = exec.submit(() -> {
+				comm0.connect();
+				try (Arena arena = Arena.ofConfined()) {
+					MemorySegment seg = arena.allocate(payload.length);
+					seg.asByteBuffer().put(payload);
+					comm0.send(1, seg, 0, payload.length);
+				}
+			});
+			var f1 = exec.submit(() -> {
+				comm1.connect();
+				comm1.recv(() -> received.get() == null, buf -> {
+					byte[] bytes = new byte[buf.remaining()];
+					buf.get(bytes);
+					received.set(bytes);
+				});
+			});
+
+			f0.get();
+			f1.get();
+		}
+
+		assertThat(received.get()).isEqualTo(payload);
 	}
 }


### PR DESCRIPTION
The `SharedMemoryCommunicator` takes a path to where shared files are written to. 

Additionally, communicators crash on initialization if the shared memory file they should create already exists. This prevents communicators to re-use left over files from previous runs with undefined content in them. 

Also, each process creates a temporary file on initialization and initializes it. After initialization the file is renamed to the actual file name. This way other parties only discover the file once it is ready to be written to, avoiding undefined state during the first message exhchange. 