### PR TITLE
fix(Traffic Analysis): update avg_speed calculation from km/h to m/s for clarity

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/analysis/traffic/TrafficAnalysis.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/traffic/TrafficAnalysis.java
@@ -257,8 +257,8 @@ public class TrafficAnalysis implements MATSimAppCommand {
 
 				row.setDouble("excess_travel_time_index", calc.getLinkExcessTravelTimeIndex(link, startTime, endTime));
 
-				// as km/h
-				row.setDouble("avg_speed", calc.getAvgSpeed(link, startTime, endTime) * 3.6);
+				// Beforehand, the avg_speed was in km/h. That was very confusing. I (paul) set to m/s. paul, jul '26.
+				row.setDouble("avg_speed", calc.getAvgSpeed(link, startTime, endTime));
 
 				double capacity = link.getCapacity() * sample.getSample();
 				row.setDouble("road_capacity_utilization", vol[h] / capacity);


### PR DESCRIPTION
beforehand, the avg_speed in the simwrapper dashboards was km/h, whereas everything else was m/s. That was very confusing, especially because it wasn't even consistent in that figure: 
<img width="2798" height="936" alt="image" src="https://github.com/user-attachments/assets/03791380-56d4-4758-8918-48c161ef4766" />

@rakow any reason why you decided to use km/h for the avg_speed?