### PR TITLE
perf(network): speed up `MultimodalNetworkCleaner` on large networks

### DIFF
--- a/matsim/src/main/java/org/matsim/core/network/algorithms/MultimodalNetworkCleaner.java
+++ b/matsim/src/main/java/org/matsim/core/network/algorithms/MultimodalNetworkCleaner.java
@@ -107,16 +107,29 @@ public final class MultimodalNetworkCleaner {
 		// search the biggest cluster of nodes in the network
 		log.info("  checking " + this.network.getNodes().size() + " nodes and " +
 				this.network.getLinks().size() + " links for dead-ends...");
+
+		// Pre-compute the set of link IDs whose allowedModes intersect combinedModes. This way the
+		// BFS hot loop in findCluster only has to do a single HashSet#contains lookup per edge visit
+		// instead of allocating a fresh HashSet/HashMap iterator inside intersectingSets each time.
+		// (For large networks this set-intersection check dominated the runtime; see profile.)
+		final Set<Id<Link>> modeLinkIds = new HashSet<>();
+		for (Link link : this.network.getLinks().values()) {
+			if (intersectingSets(combinedModes, link.getAllowedModes())) {
+				modeLinkIds.add(link.getId());
+			}
+		}
+
 		boolean stillSearching = true;
 		Iterator<? extends Link> iter = this.network.getLinks().values().iterator();
 		while (iter.hasNext() && stillSearching) {
 			Link startLink = iter.next();
-			if ((!visitedLinks.containsKey(startLink.getId())) && (intersectingSets(combinedModes, startLink.getAllowedModes()))) {
-				Map<Id<Link>, Link> cluster = this.findCluster(startLink, combinedModes);
+			if ((!visitedLinks.containsKey(startLink.getId())) && modeLinkIds.contains(startLink.getId())) {
+				Map<Id<Link>, Link> cluster = this.findCluster(startLink, modeLinkIds);
 				visitedLinks.putAll(cluster);
 				if (cluster.size() > biggestCluster.size()) {
 					biggestCluster = cluster;
-					if (biggestCluster.size() >= (this.network.getLinks().size() - visitedLinks.size())) {
+					// upper bound: only mode-matching, not-yet-visited links can ever join a cluster
+					if (biggestCluster.size() >= (modeLinkIds.size() - visitedLinks.size())) {
 						// stop searching here, because we cannot find a bigger cluster in the lasting nodes
 						stillSearching = false;
 					}
@@ -159,10 +172,12 @@ public final class MultimodalNetworkCleaner {
 	 * and from where it is also possible to return again to <code>startLink</code>.
 	 *
 	 * @param startLink the link to start building the cluster
-	 * @param modes the set of modes that are allowed to
+	 * @param modeLinkIds the set of link IDs whose allowed modes intersect the modes being cleaned
+	 *        (pre-computed by {@link #run(Set, Set)} so the BFS does not have to repeat the
+	 *        set-intersection check per edge visit)
 	 * @return cluster of links <pre>startLink</pre> is part of
 	 */
-	private Map<Id<Link>, Link> findCluster(final Link startLink, final Set<String> modes) {
+	private Map<Id<Link>, Link> findCluster(final Link startLink, final Set<Id<Link>> modeLinkIds) {
 
 		final Map<Id<Link>, DoubleFlagRole> linkRoles = new HashMap<>(this.network.getLinks().size());
 
@@ -179,7 +194,7 @@ public final class MultimodalNetworkCleaner {
 			int idx = pendingForward.size() - 1;
 			Node currNode = pendingForward.remove(idx); // get the last element to prevent object shifting in the array
 			for (Link link : currNode.getOutLinks().values()) {
-				if (intersectingSets(modes, link.getAllowedModes())) {
+				if (modeLinkIds.contains(link.getId())) {
 					DoubleFlagRole r = getDoubleFlag(link, linkRoles);
 					if (!r.forwardFlag) {
 						r.forwardFlag = true;
@@ -194,7 +209,7 @@ public final class MultimodalNetworkCleaner {
 			int idx = pendingBackward.size()-1;
 			Node currNode = pendingBackward.remove(idx); // get the last element to prevent object shifting in the array
 			for (Link link : currNode.getInLinks().values()) {
-				if (intersectingSets(modes, link.getAllowedModes())) {
+				if (modeLinkIds.contains(link.getId())) {
 					DoubleFlagRole r = getDoubleFlag(link, linkRoles);
 					if (!r.backwardFlag) {
 						r.backwardFlag = true;

--- a/matsim/src/main/java/org/matsim/core/network/algorithms/MultimodalNetworkCleaner.java
+++ b/matsim/src/main/java/org/matsim/core/network/algorithms/MultimodalNetworkCleaner.java
@@ -21,7 +21,6 @@ package org.matsim.core.network.algorithms;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -179,7 +178,13 @@ public final class MultimodalNetworkCleaner {
 	 */
 	private Map<Id<Link>, Link> findCluster(final Link startLink, final Set<Id<Link>> modeLinkIds) {
 
-		final Map<Id<Link>, DoubleFlagRole> linkRoles = new HashMap<>(this.network.getLinks().size());
+		// Per-link forward/backward reachability flags, indexed by Id#index() instead of a
+		// HashMap<Id<Link>, ...>. This turns the per-edge-visit lookup in the BFS below into a plain array access
+		// (the HashMap get/put previously dominated the runtime on large networks) and avoids allocating a role
+		// object per visited link.
+		final int linkIdCount = Id.getNumberOfIds(Link.class);
+		final boolean[] forwardFlags = new boolean[linkIdCount];
+		final boolean[] backwardFlags = new boolean[linkIdCount];
 
 		ArrayList<Node> pendingForward = new ArrayList<>();
 		ArrayList<Node> pendingBackward = new ArrayList<>();
@@ -195,9 +200,9 @@ public final class MultimodalNetworkCleaner {
 			Node currNode = pendingForward.remove(idx); // get the last element to prevent object shifting in the array
 			for (Link link : currNode.getOutLinks().values()) {
 				if (modeLinkIds.contains(link.getId())) {
-					DoubleFlagRole r = getDoubleFlag(link, linkRoles);
-					if (!r.forwardFlag) {
-						r.forwardFlag = true;
+					int linkIndex = link.getId().index();
+					if (!forwardFlags[linkIndex]) {
+						forwardFlags[linkIndex] = true;
 						pendingForward.add(link.getToNode());
 					}
 				}
@@ -210,11 +215,11 @@ public final class MultimodalNetworkCleaner {
 			Node currNode = pendingBackward.remove(idx); // get the last element to prevent object shifting in the array
 			for (Link link : currNode.getInLinks().values()) {
 				if (modeLinkIds.contains(link.getId())) {
-					DoubleFlagRole r = getDoubleFlag(link, linkRoles);
-					if (!r.backwardFlag) {
-						r.backwardFlag = true;
+					int linkIndex = link.getId().index();
+					if (!backwardFlags[linkIndex]) {
+						backwardFlags[linkIndex] = true;
 						pendingBackward.add(link.getFromNode());
-						if (r.forwardFlag) {
+						if (forwardFlags[linkIndex]) {
 							// the node can be reached forward and backward, add it to the cluster
 							clusterLinks.put(link.getId(), link);
 						}
@@ -259,20 +264,6 @@ public final class MultimodalNetworkCleaner {
 			}
 		}
 		return false;
-	}
-
-	private static DoubleFlagRole getDoubleFlag(final Link l, final Map<Id<Link>, DoubleFlagRole> linkRoles) {
-		DoubleFlagRole r = linkRoles.get(l.getId());
-		if (null == r) {
-			r = new DoubleFlagRole();
-			linkRoles.put(l.getId(), r);
-		}
-		return r;
-	}
-
-	static class DoubleFlagRole {
-		boolean forwardFlag = false;
-		boolean backwardFlag = false;
 	}
 
 }

--- a/matsim/src/main/java/org/matsim/core/network/algorithms/MultimodalNetworkCleaner.java
+++ b/matsim/src/main/java/org/matsim/core/network/algorithms/MultimodalNetworkCleaner.java
@@ -107,14 +107,16 @@ public final class MultimodalNetworkCleaner {
 		log.info("  checking " + this.network.getNodes().size() + " nodes and " +
 				this.network.getLinks().size() + " links for dead-ends...");
 
-		// Pre-compute the set of link IDs whose allowedModes intersect combinedModes. This way the
-		// BFS hot loop in findCluster only has to do a single HashSet#contains lookup per edge visit
-		// instead of allocating a fresh HashSet/HashMap iterator inside intersectingSets each time.
-		// (For large networks this set-intersection check dominated the runtime; see profile.)
-		final Set<Id<Link>> modeLinkIds = new HashSet<>();
+		// Pre-compute which links have an allowed mode intersecting combinedModes, stored in a boolean[] keyed by
+		// Id#index(). This way the BFS hot loop in findCluster only does a plain array read per edge visit instead of
+		// a HashSet#contains (which in turn replaced an even more expensive per-edge set-intersection).
+		// (For large networks this check dominated the runtime; see profile.)
+		final boolean[] isModeLink = new boolean[Id.getNumberOfIds(Link.class)];
+		int modeLinkCount = 0;
 		for (Link link : this.network.getLinks().values()) {
 			if (intersectingSets(combinedModes, link.getAllowedModes())) {
-				modeLinkIds.add(link.getId());
+				isModeLink[link.getId().index()] = true;
+				modeLinkCount++;
 			}
 		}
 
@@ -122,13 +124,13 @@ public final class MultimodalNetworkCleaner {
 		Iterator<? extends Link> iter = this.network.getLinks().values().iterator();
 		while (iter.hasNext() && stillSearching) {
 			Link startLink = iter.next();
-			if ((!visitedLinks.containsKey(startLink.getId())) && modeLinkIds.contains(startLink.getId())) {
-				Map<Id<Link>, Link> cluster = this.findCluster(startLink, modeLinkIds);
+			if ((!visitedLinks.containsKey(startLink.getId())) && isModeLink[startLink.getId().index()]) {
+				Map<Id<Link>, Link> cluster = this.findCluster(startLink, isModeLink);
 				visitedLinks.putAll(cluster);
 				if (cluster.size() > biggestCluster.size()) {
 					biggestCluster = cluster;
 					// upper bound: only mode-matching, not-yet-visited links can ever join a cluster
-					if (biggestCluster.size() >= (modeLinkIds.size() - visitedLinks.size())) {
+					if (biggestCluster.size() >= (modeLinkCount - visitedLinks.size())) {
 						// stop searching here, because we cannot find a bigger cluster in the lasting nodes
 						stillSearching = false;
 					}
@@ -171,12 +173,12 @@ public final class MultimodalNetworkCleaner {
 	 * and from where it is also possible to return again to <code>startLink</code>.
 	 *
 	 * @param startLink the link to start building the cluster
-	 * @param modeLinkIds the set of link IDs whose allowed modes intersect the modes being cleaned
-	 *        (pre-computed by {@link #run(Set, Set)} so the BFS does not have to repeat the
+	 * @param isModeLink flags, indexed by {@link Id#index()}, marking links whose allowed modes intersect the modes
+	 *        being cleaned (pre-computed by {@link #run(Set, Set)} so the BFS does not have to repeat the
 	 *        set-intersection check per edge visit)
 	 * @return cluster of links <pre>startLink</pre> is part of
 	 */
-	private Map<Id<Link>, Link> findCluster(final Link startLink, final Set<Id<Link>> modeLinkIds) {
+	private Map<Id<Link>, Link> findCluster(final Link startLink, final boolean[] isModeLink) {
 
 		// Per-link forward/backward reachability flags, indexed by Id#index() instead of a
 		// HashMap<Id<Link>, ...>. This turns the per-edge-visit lookup in the BFS below into a plain array access
@@ -199,12 +201,10 @@ public final class MultimodalNetworkCleaner {
 			int idx = pendingForward.size() - 1;
 			Node currNode = pendingForward.remove(idx); // get the last element to prevent object shifting in the array
 			for (Link link : currNode.getOutLinks().values()) {
-				if (modeLinkIds.contains(link.getId())) {
-					int linkIndex = link.getId().index();
-					if (!forwardFlags[linkIndex]) {
-						forwardFlags[linkIndex] = true;
-						pendingForward.add(link.getToNode());
-					}
+				int linkIndex = link.getId().index();
+				if (isModeLink[linkIndex] && !forwardFlags[linkIndex]) {
+					forwardFlags[linkIndex] = true;
+					pendingForward.add(link.getToNode());
 				}
 			}
 		}
@@ -214,15 +214,13 @@ public final class MultimodalNetworkCleaner {
 			int idx = pendingBackward.size()-1;
 			Node currNode = pendingBackward.remove(idx); // get the last element to prevent object shifting in the array
 			for (Link link : currNode.getInLinks().values()) {
-				if (modeLinkIds.contains(link.getId())) {
-					int linkIndex = link.getId().index();
-					if (!backwardFlags[linkIndex]) {
-						backwardFlags[linkIndex] = true;
-						pendingBackward.add(link.getFromNode());
-						if (forwardFlags[linkIndex]) {
-							// the node can be reached forward and backward, add it to the cluster
-							clusterLinks.put(link.getId(), link);
-						}
+				int linkIndex = link.getId().index();
+				if (isModeLink[linkIndex] && !backwardFlags[linkIndex]) {
+					backwardFlags[linkIndex] = true;
+					pendingBackward.add(link.getFromNode());
+					if (forwardFlags[linkIndex]) {
+						// the node can be reached forward and backward, add it to the cluster
+						clusterLinks.put(link.getId(), link);
 					}
 				}
 			}


### PR DESCRIPTION
While cleaning a large multimodal network with `MultimodalNetworkCleaner` it showed two CPU hot spots.

**1. Precompute the mode-matching links**

The cluster search visited every out-/in-link and, for each visit, recomputed whether the link's allowed modes intersect the modes being cleaned (`intersectingSets(modes, link.getAllowedModes())`). That set-intersection ran once per edge visit, repeatedly for the same links.

Now the set of link IDs whose allowed modes intersect the cleaning modes is computed **once** up front, and the BFS just does a single `HashSet.contains(linkId)` per edge visit. The early-stop upper bound is also tightened to only mode-matching links (`modeLinkIds.size()` instead of the full link count), so the outer search can terminate sooner.

**2. Replace the per-edge HashMap with link-index arrays**

`findCluster` tracked forward/backward reachability in a `HashMap<Id<Link>, DoubleFlagRole>`, allocated fresh at full network size on every call, with a `get`/`put` (and a role-object allocation) on every edge visit. Those map lookups were the remaining hot spot after fix #1.

Since MATSim `Id`s expose a dense `index()` (already used this way in e.g. `SubsequentLinksAnalyzer`), the map is replaced with two `boolean[]` sized to `Id.getNumberOfIds(Link.class)` and indexed by `link.getId().index()`. Per-edge work drops from a hash lookup + possible object allocation to a plain array read/write, and no `DoubleFlagRole` objects are allocated.

**3. Replace the mode-matching set with a link-index boolean[]**

After fixes 1 and 2, the only hash lookup left in the `findCluster` inner loop was `modeLinkIds.contains(link.getId())` - and profiling a 12.9M-link network showed that `HashSet.contains` (i.e. `HashMap.getNode`) still dominated the cleaning stage. Since the mode-matching links are already precomputed once up front, this stores them in a `boolean[]` keyed by `Id#index()` (mirroring the forward/backward flag arrays) instead of a `HashSet<Id<Link>>`, with an int count kept for the early-stop bound. The per-edge mode check becomes a single array read, so the BFS inner loop is now completely free of hash lookups and per-visit allocation. 

