### PR TITLE
fix(vsp): resolve analysis input files regardless of compression (gz/lz4/zst)

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/analysis/population/ExperiencedPlansWriter.java
+++ b/contribs/application/src/main/java/org/matsim/application/analysis/population/ExperiencedPlansWriter.java
@@ -66,16 +66,17 @@ public class ExperiencedPlansWriter implements MATSimAppCommand {
 		runId = config.controller().getRunId();
 		String runPrefix = Objects.nonNull(runId) ? runId + "." : "";
 
-		Path eventsPath = path.resolve(runPrefix + "output_" + Controler.DefaultFiles.events.getFilename() + ".gz");
+		// glob the input reads with a trailing "*" (instead of a hardcoded ".gz") so any compression (gz/lz4/zst) or none is matched; default output is now zst:
+		Path eventsPath = ApplicationUtils.globFile( path, runPrefix + "*output_" + Controler.DefaultFiles.events.getFilename() + "*" );
 		Path experiencedPlansPath = eventsPath.getParent().resolve(runPrefix + "output_" + Controler.DefaultFiles.experiencedPlans.getFilename() + ".gz");
 
 		Scenario scenario = new ScenarioUtils.ScenarioBuilder(config)
-			.setNetwork(NetworkUtils.readNetwork(path.resolve(runPrefix + "output_" + Controler.DefaultFiles.network.getFilename() + ".gz").toString()))
-			.setPopulation(PopulationUtils.readPopulation(path.resolve(runPrefix + "output_" + Controler.DefaultFiles.population.getFilename() + ".gz").toString()))
+			.setNetwork(NetworkUtils.readNetwork(ApplicationUtils.globFile( path, runPrefix + "*output_" + Controler.DefaultFiles.network.getFilename() + "*" ).toString()))
+			.setPopulation(PopulationUtils.readPopulation(ApplicationUtils.globFile( path, runPrefix + "*output_" + Controler.DefaultFiles.population.getFilename() + "*" ).toString()))
 			.build();
 
 		if ( config.transit().isUseTransit() ){
-			new TransitScheduleReader( scenario ).readFile( path.resolve( runPrefix + "output_" + Controler.DefaultFiles.transitSchedule.getFilename() + ".gz" ).toString() );
+			new TransitScheduleReader( scenario ).readFile( ApplicationUtils.globFile( path, runPrefix + "*output_" + Controler.DefaultFiles.transitSchedule.getFilename() + "*" ).toString() );
 		}
 
 		config.counts().setInputFile( null );

--- a/contribs/vsp/src/main/java/org/matsim/application/analysis/population/AddPersonAttribsToExperiencedPlans.java
+++ b/contribs/vsp/src/main/java/org/matsim/application/analysis/population/AddPersonAttribsToExperiencedPlans.java
@@ -13,7 +13,6 @@ import picocli.CommandLine;
 
 import java.nio.file.Path;
 import java.util.Map;
-import java.util.Objects;
 
 import static org.matsim.application.ApplicationUtils.globFile;
 
@@ -41,14 +40,14 @@ public class AddPersonAttribsToExperiencedPlans implements MATSimAppCommand {
 	public Integer call() throws Exception {
 
 //		Path outputPopPath = path.resolve( runPrefix + "output_" + Controler.DefaultFiles.population.getFilename() + ".gz");
-		Path outputPopPath = globFile( path, "*output_" + Controler.DefaultFiles.population.getFilename() + ".gz" );
+		Path outputPopPath = globFile( path, "*output_" + Controler.DefaultFiles.population.getFilename() + "*" );
+		// (trailing "*" instead of ".gz" so any compression (gz/lz4/zst) or none is matched; default output is now zst)
 
-		// extracting the runPrefix from the outputPopPath:
-		String tmp = outputPopPath.toString().replace( ".output_" + Controler.DefaultFiles.population.getFilename() + ".gz", "" );
-		String runPrefix = Objects.nonNull(tmp ) ? tmp + "." : "";
+		// extract the runId prefix (everything up to and including "output_"'s leading part) from the matched file name:
+		String popFileName = outputPopPath.getFileName().toString();
+		String runPrefix = popFileName.substring( 0, popFileName.indexOf( "output_" ) );  // "" if no runId, else "<runId>."
 
-		Path expPlansPath =  path.resolve( runPrefix + "output_" + Controler.DefaultFiles.experiencedPlans.getFilename() + ".gz");
-//		Path expPlansPath = globFile( path, Controler.DefaultFiles.experiencedPlans.getFilename() + ".gz");
+		Path expPlansPath = globFile( path, "*output_" + Controler.DefaultFiles.experiencedPlans.getFilename() + "*" );
 
 		Path postprocExpPlansPath = path.resolve( runPrefix + "postproc_" + Controler.DefaultFiles.experiencedPlans.getFilename() + ".gz");
 

--- a/contribs/vsp/src/main/java/org/matsim/application/analysis/population/AddVttsEtcToActivities.java
+++ b/contribs/vsp/src/main/java/org/matsim/application/analysis/population/AddVttsEtcToActivities.java
@@ -33,7 +33,6 @@ import tech.tablesaw.plotly.components.Figure;
 import tech.tablesaw.plotly.components.Layout;
 import tech.tablesaw.plotly.traces.HistogramTrace;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.NumberFormat;
 import java.util.List;
@@ -42,6 +41,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static java.lang.Math.exp;
+import static org.matsim.application.ApplicationUtils.globFile;
 import static tech.tablesaw.aggregate.AggregateFunctions.*;
 
 @CommandLine.Command(name = "run-vtts-analysis", description = "")
@@ -72,17 +72,11 @@ public class AddVttsEtcToActivities implements MATSimAppCommand {
 		String runPrefix = Objects.nonNull(runId ) ? runId + "." : "";
 		Path configPath = path.resolve(runPrefix + "output_" + Controler.DefaultFiles.config.getFilename() );
 
-		Path eventsPath = path.resolve(runPrefix + "output_" + Controler.DefaultFiles.events.getFilename() + ".gz");
+		Path eventsPath = globFile( path, runPrefix + "*output_" + Controler.DefaultFiles.events.getFilename() + "*" );
+		// (trailing "*" instead of a hardcoded ".gz"/".zst" so any compression (gz/lz4/zst) or none is matched)
 //		if ( prefix!=null ){
 //			eventsPath = ApplicationUtils.globFile( path, "*" + prefix + "output_events_filtered.xml.gz" );
 //		}
-
-		Path populationFilename = path.resolve( runPrefix + "postproc_" + Controler.DefaultFiles.experiencedPlans.getFilename() + ".gz" );
-		if ( !Files.exists( populationFilename ) ){
-			populationFilename = path.resolve( runPrefix + "output_" + Controler.DefaultFiles.experiencedPlans.getFilename() + ".gz" );
-		}
-
-		// ---
 
 		Config config = ConfigUtils.loadConfig(configPath.toString());
 		config.eventsManager().setNumberOfThreads(numberOfThreads);
@@ -104,9 +98,17 @@ public class AddVttsEtcToActivities implements MATSimAppCommand {
 
 		// ---
 
+		// prefer the postproc_ experienced plans, fall back to output_; match any (or no) compression suffix:
+		Path populationFilename;
+		try {
+			populationFilename = globFile( path, runPrefix + "*postproc_" + Controler.DefaultFiles.experiencedPlans.getFilename() + "*" );
+		} catch ( IllegalStateException e ) {
+			populationFilename = globFile( path, runPrefix + "*output_" + Controler.DefaultFiles.experiencedPlans.getFilename() + "*" );
+		}
+
 		Scenario scenario = new ScenarioUtils.ScenarioBuilder(config)
 //								.setNetwork(NetworkUtils.readNetwork(path.resolve(runPrefix + "output_" + Controler.DefaultFiles.network.getFilename() + ".gz").toString()))
-								.setPopulation(PopulationUtils.readPopulation( populationFilename.toString() ) )
+								.setPopulation(PopulationUtils.readPopulation( populationFilename.toString() ))
 								.build();
 
 //		new TransitScheduleReader(scenario).readFile(path.resolve(runPrefix + "output_" + Controler.DefaultFiles.transitSchedule.getFilename() + ".gz").toString());

--- a/contribs/vsp/src/main/java/org/matsim/application/analysis/population/AgentWiseComparisonKN.java
+++ b/contribs/vsp/src/main/java/org/matsim/application/analysis/population/AgentWiseComparisonKN.java
@@ -164,7 +164,8 @@ public class AgentWiseComparisonKN implements MATSimAppCommand{
 		new AgentWiseComparisonKN().execute( args );
 	}
 	private static void generateFilteredEventsFile( String baseDir ){
-		String inFileName = globFile( Path.of( baseDir ),  "*output_" + DefaultFiles.events.getFilename() + ".gz" ).toString();
+		String inFileName = globFile( Path.of( baseDir ),  "*output_" + DefaultFiles.events.getFilename() + "*" ).toString();
+		// (trailing "*" instead of ".gz" so that any compression (gz/lz4/zst) or no compression is matched; kn's default output is now zst)
 		String outFileName = baseDir + "/" + onlyMoneyAndStuck+"output_events_filtered.xml.gz";
 		// (yy Das lässt die runId weg.)
 
@@ -205,10 +206,10 @@ public class AgentWiseComparisonKN implements MATSimAppCommand{
 		List<String> eventsFilePatterns = new ArrayList<>();
 		if( !prefixList.isEmpty() ){
 			for( String prefix : prefixList ){
-				eventsFilePatterns.add( "*" + prefix + "output_events_filtered.xml.gz" );
+				eventsFilePatterns.add( "*" + prefix + "output_events_filtered.xml*" );
 			}
 		} else{
-			eventsFilePatterns.add( "*output_events.xml.gz" );
+			eventsFilePatterns.add( "*output_events.xml*" );
 		}
 
 		// ############################

--- a/contribs/vsp/src/main/java/org/matsim/application/analysis/population/AgentWiseComparisonKNUtils.java
+++ b/contribs/vsp/src/main/java/org/matsim/application/analysis/population/AgentWiseComparisonKNUtils.java
@@ -643,15 +643,15 @@ class AgentWiseComparisonKNUtils{
 
 		String basePopulationFilename;
 		try {
-			basePopulationFilename = globFile( path, "*reduced_plans.xml" ).toString();
+			basePopulationFilename = globFile( path, "*reduced_plans.xml*" ).toString();
 		} catch ( IllegalStateException e0 ) {
 			try {
-				basePopulationFilename = globFile( path, "*vtts_experienced_plans.xml.gz" ).toString();
+				basePopulationFilename = globFile( path, "*vtts_experienced_plans.xml*" ).toString();
 			} catch ( IllegalStateException ee ){
 				try{
-					basePopulationFilename = globFile( path, "*postproc_experienced_plans.xml.gz" ).toString();
+					basePopulationFilename = globFile( path, "*postproc_experienced_plans.xml*" ).toString();
 				} catch( IllegalStateException e2 ){
-					basePopulationFilename = globFile( path, "*experienced_plans.xml.gz" ).toString();
+					basePopulationFilename = globFile( path, "*experienced_plans.xml*" ).toString();
 				}
 			}
 		}


### PR DESCRIPTION
The default output compression changed to `zst`, which broke analysis snippets that hardcoded `.gz` (or, after a local edit, `.zst`) when resolving **input** files. Since `IOUtils` already picks the decompressor from the actual file extension, the only breakage is filename construction.

## Change
Input-file **reads** now glob with a trailing `*` instead of a literal compression suffix, so any compression (gz/lz4/zst) — or none — is matched:

```java
globFile(path, "*output_" + DefaultFiles.events.getFilename() + "*")
```

### contribs/vsp
- **AddVttsEtcToActivities**: glob the events and experienced-plans reads; restore the `postproc_`-preferred / `output_`-fallback lookup; drop now-unused `Files` import.
- **AddPersonAttribsToExperiencedPlans**: glob the population and experienced-plans reads; derive the runId prefix from the matched filename instead of string-stripping a hardcoded `.gz` suffix; drop now-unused `Objects` import.
- **AgentWiseComparisonKN (+Utils)**: glob the events and base-population reads.

### contribs/application
- **ExperiencedPlansWriter**: glob the events, network, population and transitSchedule reads (the config read already used `globFile`).

## Not changed
- Writes still emit `.gz`; every downstream reader now matches regardless of suffix. (Switching writes over to `config.controller().getCompressionType().fileEnding` — the idiom already used in `AgentWiseComparisonKNUtils.prepareConfig` — could be a follow-up.)
- The rest of `contribs/application` was already robust: standard analysis commands resolve inputs via `ApplicationUtils.matchInput(...)`, which is compression-agnostic.

Both `contribs/vsp` and `contribs/application` compile cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)