### PR TITLE
ci: retry transient Maven Central HTTP failures in verify-push

### DIFF
--- a/.github/workflows/verify-push.yaml
+++ b/.github/workflows/verify-push.yaml
@@ -96,11 +96,11 @@ jobs:
 
       - name: Build module (with dependencies)
         if: ${{matrix.module != 'matsim' || steps.detect-changes.outputs.outside-contribs == 'true'}}
-        run: mvn install --batch-mode --also-make --projects ${{matrix.module}} -DskipTests -Dsource.skip
+        run: mvn install --batch-mode ${{env.MAVEN_HTTP_RETRY}} --also-make --projects ${{matrix.module}} -DskipTests -Dsource.skip
 
       - name: Test module
         if: ${{matrix.module != 'matsim' || steps.detect-changes.outputs.outside-contribs == 'true'}}
-        run: mvn verify --batch-mode -Dmaven.test.redirectTestOutputToFile -Dmatsim.preferLocalDtds=true --fail-at-end -Dsource.skip
+        run: mvn verify --batch-mode ${{env.MAVEN_HTTP_RETRY}} -Dmaven.test.redirectTestOutputToFile -Dmatsim.preferLocalDtds=true --fail-at-end -Dsource.skip
         #run: mvn verify --batch-mode -Dmatsim.preferLocalDtds=true --fail-at-end -Dsource.skip
         working-directory: ${{matrix.module}}
 
@@ -121,6 +121,8 @@ jobs:
 
     env:
       MAVEN_OPTS: -Xmx2g
+      # retry transient HTTP failures when fetching from Maven Central (e.g. sporadic 403/timeout on cache miss)
+      MAVEN_HTTP_RETRY: -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
 
   verify-all-jobs-successful:
     # always() - to ensure this job is executed (regardless of the status of the previous job)


### PR DESCRIPTION
## Problem
`verify-push` intermittently fails a whole run when a single matrix job gets a transient error from Maven Central. Example from a recent PR run — the `contribs/application` job died in 30s at the *Build module* step:

```
maven-install-plugin:3.1.4 could not be resolved:
Could not transfer artifact ... from central (repo.maven.apache.org):
status code: 403, reason phrase: Forbidden (403)
```

This is not a dependency problem: `setup-java` already caches `~/.m2`. But on a **cache miss** (GitHub evicts caches after ~7 days idle or when the store exceeds its size cap), all ~50 matrix jobs pull from Central simultaneously and one occasionally gets rate-limited with a 403. There is currently no retry, so a transient hiccup fails the whole build and blocks the merge gate.

## Change
Add maven-wagon HTTP retry to both `mvn` invocations via a shared `MAVEN_HTTP_RETRY` env var:

```
-Dmaven.wagon.http.retryHandler.count=3
-Dmaven.wagon.http.retryHandler.requestSentEnabled=true
```

Transient 403/timeout downloads now retry instead of failing the job. No behavioral change to builds/tests; on the happy path (cache hit) nothing is downloaded and the flags are inert.

## Not included (possible follow-ups)
- Building matsim-core once instead of rebuilding it via `--also-make` in every one of the ~50 matrix jobs.
- Per-module change detection so a diff only builds affected modules (today `paths-filter` only gates the `matsim` job).

Both would cut CI minutes and *reduce* the concurrent-cache-miss bursts that trigger these 403s, but are larger changes and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)