### PR TITLE
feat: move consistency check from mobsim start to where it belongs

### DIFF
--- a/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/config/SBBTransitConfigGroup.java
+++ b/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/config/SBBTransitConfigGroup.java
@@ -22,6 +22,10 @@ package ch.sbb.matsim.config;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import org.apache.logging.log4j.LogManager;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.ReflectiveConfigGroup;
 import org.matsim.core.utils.collections.CollectionUtils;
 
@@ -79,4 +83,41 @@ public class SBBTransitConfigGroup extends ReflectiveConfigGroup {
                 "\t\t\t\t\"useful for visualization or analysis purposes. Defaults to 0. `0' disables the creation of events completely.");
         return comments;
     }
+
+	@Override
+	protected void checkConsistency(Config config) {
+		super.checkConsistency(config);
+
+		Set<String> deterministicModes = ConfigUtils.addOrGetModule(config, SBBTransitConfigGroup.class).getDeterministicServiceModes();
+			if (deterministicModes == null || deterministicModes.isEmpty()) {
+				return;
+			}
+			if (!"hermes".equals(config.controller().getMobsim())) {
+				Set<String> passengerModes = config.transit().getTransitModes();
+				Set<String> commonModes = new HashSet<>(deterministicModes);
+				commonModes.retainAll(passengerModes);
+				if (!commonModes.isEmpty()) {
+					throw new RuntimeException(
+						"There are modes configured to be pt passenger modes as well as deterministic service modes. This will not work! common modes = "
+							+ CollectionUtils.setToString(commonModes));
+				}
+				Set<String> mainModes = switch (config.controller().getMobsim()) {
+					case "qsim" -> new HashSet<>(config.qsim().getMainModes());
+					case "dsim" -> new HashSet<>(config.dsim().getNetworkModes());
+					case "hermes" -> new HashSet<>();
+					default -> throw new RuntimeException("Unknown mobsim: " + config.controller().getMobsim());
+				};
+				mainModes.retainAll(deterministicModes);
+				if (!mainModes.isEmpty()) {
+					throw new RuntimeException(
+						"There are modes configured to be deterministic service modes as well as qsim main modes. This will not work! common modes = "
+							+ CollectionUtils.setToString(mainModes));
+				}
+			}
+			else  {
+				LogManager.getLogger(SBBTransitConfigGroup.class).warn("Deterministic PT for Hermes needs to be set in the hermes config group." +
+					" Enabling it via the SBB Transit Config Group does not have an effect.");
+			}
+
+	}
 }

--- a/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitEngine.java
+++ b/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/mobsim/qsim/pt/SBBTransitEngine.java
@@ -88,7 +88,6 @@ public class SBBTransitEngine
 		final boolean writingEventsAtAll = createEventsInterval > 0;
 		final boolean regularWriteEvents = writingEventsAtAll && iteration % createEventsInterval == 0;
 		createLinkEvents = writingEventsAtAll && regularWriteEvents;
-		validateModeConfiguration();
 	}
 
 	@Override
@@ -115,28 +114,9 @@ public class SBBTransitEngine
 		eventQueue.clear();
 	}
 
-	private void validateModeConfiguration() {
-		Set<String> deterministicModes = this.config.getDeterministicServiceModes();
-		Set<String> passengerModes = this.ptConfig.getTransitModes();
-		Set<String> commonModes = new HashSet<>(deterministicModes);
-		commonModes.retainAll(passengerModes);
-		if (!commonModes.isEmpty()) {
-			throw new RuntimeException(
-				"There are modes configured to be pt passenger modes as well as deterministic service modes. This will not work! common modes = "
-					+ CollectionUtils.setToString(commonModes));
-		}
-		Set<String> mainModes = new HashSet<>(scenario.getConfig().qsim().getMainModes());
-		mainModes.retainAll(deterministicModes);
-		if (!mainModes.isEmpty()) {
-			throw new RuntimeException(
-				"There are modes configured to be deterministic service modes as well as qsim main modes. This will not work! common modes = "
-					+ CollectionUtils.setToString(mainModes));
-		}
-	}
 
 	@Override
 	public boolean handleDeparture(double now, MobsimAgent agent, Id<Link> linkId) {
-
 		String mode = agent.getMode();
 		if (this.ptConfig.getTransitModes().contains(mode)) {
 			handlePassengerDeparture(agent, linkId);

--- a/contribs/sbb-extensions/src/test/java/ch/sbb/matsim/config/SBBTransitConfigGroupTest.java
+++ b/contribs/sbb-extensions/src/test/java/ch/sbb/matsim/config/SBBTransitConfigGroupTest.java
@@ -23,6 +23,9 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
 import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.matsim.core.config.Config;
@@ -59,4 +62,35 @@ public class SBBTransitConfigGroupTest {
         Assertions.assertTrue(ptConfig2.getDeterministicServiceModes().contains("schienenfahrzeug"));
         Assertions.assertEquals(4, ptConfig2.getCreateLinkEventsInterval());
     }
+	@Test
+	void testConsistencyChecker(){
+		SBBTransitConfigGroup sbbTransitConfigGroup = new SBBTransitConfigGroup();
+		Config config = ConfigUtils.createConfig(sbbTransitConfigGroup);
+		config.qsim().setMainModes(List.of(("car")));
+		sbbTransitConfigGroup.setDeterministicServiceModes(Set.of("train"));
+		config.controller().setMobsim("qsim");
+		sbbTransitConfigGroup.checkConsistency(config);
+	}
+
+	@Test
+	void testConsistencyCheckerFailsMainMode(){
+		SBBTransitConfigGroup sbbTransitConfigGroup = new SBBTransitConfigGroup();
+		Config config = ConfigUtils.createConfig(sbbTransitConfigGroup);
+		config.qsim().setMainModes(List.of("train"));
+		config.controller().setMobsim("qsim");
+		config.transit().setTransitModes(Set.of("rail"));
+		sbbTransitConfigGroup.setDeterministicServiceModes(Set.of("train"));
+		Assertions.assertThrows(RuntimeException.class, () -> sbbTransitConfigGroup.checkConsistency(config));
+
+	}
+	@Test
+	void testConsistencyCheckerFailsPtMode(){
+		SBBTransitConfigGroup sbbTransitConfigGroup = new SBBTransitConfigGroup();
+		Config config = ConfigUtils.createConfig(sbbTransitConfigGroup);
+		config.controller().setMobsim("qsim");
+		config.transit().setTransitModes(Set.of("train"));
+		sbbTransitConfigGroup.setDeterministicServiceModes(Set.of("train"));
+		Assertions.assertThrows(RuntimeException.class, () -> sbbTransitConfigGroup.checkConsistency(config));
+
+	}
 }


### PR DESCRIPTION
Saves a couple of population loadings that end in exceptions because of a bad config setting  ;)