### PR TITLE
fix(ParkingProxy): Skip parking search penalty when no capacity is available

### DIFF
--- a/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/parking/BellochePenaltyFunction.java
+++ b/matsim/src/main/java/org/matsim/core/mobsim/qsim/qnetsimengine/parking/BellochePenaltyFunction.java
@@ -28,8 +28,11 @@ public class BellochePenaltyFunction implements ParkingSearchTimeFunction {
 		Tuple<Double, Double> weightedOccK = getWeightedOccK(parkingCount);
 
 		if (weightedOccK.getSecond() == 0) {
-			// The total capacity of parking spots is 0. As fallback, we assume that the occupancy rate is 1, so each link is full.
-			return alpha * Math.exp(-beta);
+			// No parking capacity exists in the considered area. This may occur when the
+			// destination link does not support parking, for example on a motorway.
+			// In that case, parking search is considered not applicable and no penalty is applied.
+			// To model parking scarcity, provide an explicit positive parking capacity.
+			return 0.0;
 		}
 
 		return alpha * Math.exp(-beta * (weightedOccK.getFirst() / weightedOccK.getSecond()));


### PR DESCRIPTION
## Summary
Return zero parking-search time when the weighted parking capacity in the considered area is zero.
## Motivation
Previously, `BellochePenaltyFunction` treated zero parking capacity as full occupancy-
