### PR TITLE
feat(core): per-activity typical durations in CharyparNagelActivityScoring

### DIFF
--- a/contribs/vsp/src/main/java/org/matsim/application/analysis/population/MarginalSumScoringFunction.java
+++ b/contribs/vsp/src/main/java/org/matsim/application/analysis/population/MarginalSumScoringFunction.java
@@ -30,6 +30,8 @@ import org.matsim.core.scoring.functions.ActivityUtilityParameters;
 import org.matsim.core.scoring.functions.CharyparNagelActivityScoring;
 import org.matsim.core.scoring.functions.ScoringParameters;
 
+import java.util.function.Supplier;
+
 /**
  * @author ikaddoura
  *
@@ -38,13 +40,23 @@ public final class MarginalSumScoringFunction {
 	private final static Logger log = LogManager.getLogger(MarginalSumScoringFunction.class);
 	private final ScoringParameters params;
 
-	CharyparNagelActivityScoring activityScoringA;
-	CharyparNagelActivityScoring activityScoringB;
+	private final Supplier<SumScoringFunction.ActivityScoring> activityScoringFactory;
 
 	public MarginalSumScoringFunction(ScoringParameters params) {
+		this(params, () -> new CharyparNagelActivityScoring(params));
+	}
+
+	/**
+	 * @param activityScoringFactory creates the activity scoring used for the marginal computations, so that scoring
+	 *   variants other than the stock {@link CharyparNagelActivityScoring} can be used (e.g. one with a
+	 *   {@link org.matsim.core.scoring.functions.TypicalDurationCalculator}).  A fresh instance is obtained for every
+	 *   computation, so stateful implementations are fine.  Implementations must read everything they need off the
+	 *   handed activities themselves; each computation only handles a single activity (or a morning/evening pair),
+	 *   never a person's full daily activity sequence.
+	 */
+	public MarginalSumScoringFunction(ScoringParameters params, Supplier<SumScoringFunction.ActivityScoring> activityScoringFactory) {
 		this.params = params;
-		activityScoringA = new CharyparNagelActivityScoring(params);
-		activityScoringB = new CharyparNagelActivityScoring(params);
+		this.activityScoringFactory = activityScoringFactory;
 	}
 
 	private static int deltaScoreZeroWrnCnt = 0;
@@ -61,11 +73,10 @@ public final class MarginalSumScoringFunction {
 	public final Scores getNormalActivityDelayDisutility( Id<Person> personId, Activity activity, double earlier ) {
 
 		SumScoringFunction sumScoringNormal = new SumScoringFunction() ;
-		sumScoringNormal.addScoringFunction(activityScoringA);
-		// yyyyyy it is not clear to me why this does not add the same scoring fct contribution multiple times.  kai, dec'25
+		sumScoringNormal.addScoringFunction(activityScoringFactory.get());
 
 		SumScoringFunction sumScoringEarly = new SumScoringFunction() ;
-		sumScoringEarly.addScoringFunction(activityScoringB);
+		sumScoringEarly.addScoringFunction(activityScoringFactory.get());
 
 		if (activity.getStartTime().seconds() != Double.NEGATIVE_INFINITY && activity.getEndTime().seconds() != Double.NEGATIVE_INFINITY) {
         	// activity is not the first and not the last activity
@@ -113,10 +124,10 @@ public final class MarginalSumScoringFunction {
 	public final Scores getOvernightActivityDelayDisutility(Activity activityMorning, Activity activityEveningNormal, double earlier) {
 
 		SumScoringFunction normalScoring = new SumScoringFunction() ;
-		normalScoring.addScoringFunction(activityScoringA);
+		normalScoring.addScoringFunction(activityScoringFactory.get());
 
 		SumScoringFunction earlyScoring = new SumScoringFunction() ;
-		earlyScoring.addScoringFunction(activityScoringB);
+		earlyScoring.addScoringFunction(activityScoringFactory.get());
 
 	//	log.info("activityMorning: " + activityMorning.toString());
 	//	log.info("activityEveningNormal: " + activityEveningNormal.toString());

--- a/contribs/vsp/src/main/java/org/matsim/application/analysis/population/VTTSHandler.java
+++ b/contribs/vsp/src/main/java/org/matsim/application/analysis/population/VTTSHandler.java
@@ -40,15 +40,19 @@ import org.matsim.core.config.groups.ScoringConfigGroup;
 import org.matsim.core.gbl.Gbl;
 import org.matsim.core.population.PopulationUtils;
 import org.matsim.core.router.StageActivityTypeIdentifier;
+import org.matsim.core.router.TripStructureUtils;
+import org.matsim.core.scoring.SumScoringFunction;
 import org.matsim.core.scoring.functions.ScoringParameters;
 import org.matsim.core.scoring.functions.ScoringParametersForPerson;
 import org.matsim.core.utils.misc.OptionalTime;
+import org.matsim.utils.objectattributes.attributable.AttributesUtils;
 import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.IntColumn;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
 
 import java.util.*;
+import java.util.function.Function;
 
 
 /**
@@ -82,6 +86,15 @@ public final class VTTSHandler implements ActivityStartEventHandler, ActivityEnd
 		List<TripData> trips = new ArrayList<>();
 		double firstActivityEndTime = Double.NaN;
 		String firstActivityType ;
+
+		// The activities handed to the scoring below are reconstructed from the events and carry no attributes.  So we
+		// align them with the main (non-stage) activities of the person's selected plan and copy the plan activities'
+		// attributes over, so that scoring variants which read per-activity parameters off the activity (e.g. a
+		// per-activity typical duration) see the same values as in the simulated run.
+		List<Activity> planActivities;
+		int nextPlanActivityIndex = 1;
+		Activity firstPlanActivity;
+		Activity currentPlanActivity;
 	}
 	private final Map<Id<Person>,SimData> simDataMap = new HashMap<>();
 
@@ -102,12 +115,28 @@ public final class VTTSHandler implements ActivityStartEventHandler, ActivityEnd
 
 	private final ScoringParametersForPerson scoringParametersForPerson;
 
+	/** Creates the activity scoring the marginal computations use; null means the stock Charypar-Nagel activity scoring. */
+	private final Function<ScoringParameters, SumScoringFunction.ActivityScoring> activityScoringFactory;
+
 
 	@Inject VTTSHandler( Scenario scenario, ScoringParametersForPerson scoringParametersForPerson ) {
+		this( scenario, scoringParametersForPerson, null );
+	}
+
+	/**
+	 * @param activityScoringFactory creates the activity scoring used for the marginal computations, so that scoring
+	 *   variants other than the stock Charypar-Nagel activity scoring can be used (e.g. one with a
+	 *   {@link org.matsim.core.scoring.functions.TypicalDurationCalculator}); null means the stock scoring.  The
+	 *   activities handed to it carry the attributes of the corresponding selected-plan activities, so implementations
+	 *   must read per-activity parameters off the handed activities themselves (do not pass a person).
+	 */
+	public VTTSHandler( Scenario scenario, ScoringParametersForPerson scoringParametersForPerson,
+			Function<ScoringParameters, SumScoringFunction.ActivityScoring> activityScoringFactory ) {
 		// yyyy it would (presumably) be much better to pull the scoring function from injection.  Rather than self-constructing the
 		// scoring function here, where we need to rely on having the same ("default") scoring function in the model implementation.
 		// Which we almost surely do not have (e.g. bicycle scoring addition, bus penalty addition, ...).  Also see a similar comment further
 		// down, where the local scoring fct is constructed.  kai, gr, jul'25
+		this.activityScoringFactory = activityScoringFactory;
 
 		if (scenario.getConfig().scoring().getMarginalUtilityOfMoney() == 0.) {
 			log.warn("The marginal utility of money must not be 0.0. The VTTS is computed in Money per Time.");
@@ -140,6 +169,7 @@ public final class VTTSHandler implements ActivityStartEventHandler, ActivityEnd
 
 		incompletedPlanWarning = 0;
 		noCarVTTSWarning = 0;
+		planAlignmentWarnCnt = 0;
 
 		this.personIdsToBeIgnored.clear();
 		this.departedPersonIds.clear();
@@ -198,6 +228,42 @@ public final class VTTSHandler implements ActivityStartEventHandler, ActivityEnd
 		SimData simData = simDataMap.get( personId );
 		simData.currentActivityStartTime = event.getTime();
 		simData.currentActivityType = event.getActType();
+		simData.currentPlanActivity = planActivity( personId, simData, simData.nextPlanActivityIndex++, event.getActType() );
+	}
+
+	private static int planAlignmentWarnCnt = 0;
+
+	/**
+	 * The main activity of the person's selected plan at the given index, as the source of per-activity scoring
+	 * parameters (attributes) for the activity observed in the events; null (i.e. no attributes, scoring falls back
+	 * to the activity type's config parameters) if the observed activity cannot be aligned with the plan.
+	 */
+	private Activity planActivity( Id<Person> personId, SimData simData, int index, String actType ) {
+		if ( simData.planActivities == null ) {
+			Person person = this.scenario.getPopulation().getPersons().get( personId );
+			if ( person == null || person.getSelectedPlan() == null ) {
+				return null;
+			}
+			simData.planActivities = TripStructureUtils.getActivities( person.getSelectedPlan(), TripStructureUtils.StageActivityHandling.ExcludeStageActivities );
+		}
+		if ( index < simData.planActivities.size() && simData.planActivities.get( index ).getType().equals( actType ) ) {
+			return simData.planActivities.get( index );
+		}
+		if ( planAlignmentWarnCnt < 10 ) {
+			planAlignmentWarnCnt++;
+			log.warn( "Cannot align activity (type={}) of person {} with main activity # {} of the selected plan; "
+					+ "scoring this activity without the plan activity's attributes.", actType, personId, index );
+			if ( planAlignmentWarnCnt == 10 ) {
+				log.warn( Gbl.FUTURE_SUPPRESSED );
+			}
+		}
+		return null;
+	}
+
+	private static void copyPlanAttributes( Activity planActivity, Activity to ) {
+		if ( planActivity != null ) {
+			AttributesUtils.copyAttributesFromTo( planActivity, to );
+		}
 	}
 
 	@Override
@@ -218,6 +284,7 @@ public final class VTTSHandler implements ActivityStartEventHandler, ActivityEnd
 			simData = new SimData();
 			simData.firstActivityEndTime = event.getTime();
 			simData.firstActivityType = event.getActType();
+			simData.firstPlanActivity = planActivity( personId, simData, 0, event.getActType() );
 			simDataMap.put( personId, simData );
 		} else {
 			// this is NOT the first activity ...
@@ -227,6 +294,7 @@ public final class VTTSHandler implements ActivityStartEventHandler, ActivityEnd
 
 			simData.currentActivityType = null;
 			simData.currentActivityStartTime = Double.NaN;
+			simData.currentPlanActivity = null;
 
 			this.departedPersonIds.remove( personId );
 		}
@@ -306,8 +374,11 @@ public final class VTTSHandler implements ActivityStartEventHandler, ActivityEnd
 			Person person = this.scenario.getPopulation().getPersons().get( personId );
 			String subpop = PopulationUtils.getSubpopulation( person );
 
-			final MarginalSumScoringFunction marginalSumScoringFunction = new MarginalSumScoringFunction(
-							new ScoringParameters.Builder( scoringConfigGroup, scoringConfigGroup.getScoringParameters( subpop ), scenario.getConfig().scenario() ).build() );
+			final ScoringParameters scoringParameters =
+							new ScoringParameters.Builder( scoringConfigGroup, scoringConfigGroup.getScoringParameters( subpop ), scenario.getConfig().scenario() ).build();
+			final MarginalSumScoringFunction marginalSumScoringFunction = this.activityScoringFactory == null ?
+							new MarginalSumScoringFunction( scoringParameters ) :
+							new MarginalSumScoringFunction( scoringParameters, () -> this.activityScoringFactory.apply( scoringParameters ) );
 			// yyyy it would (presumably) be much better to pull the scoring function from injection.  Rather than self-constructing the
 			// scoring function here, where we need to rely on having the same ("default") scoring function in the model implementation.
 			// Which we almost surely do not have (e.g. bicycle scoring addition, bus penalty addition, ...).  kai, gr, jul'25
@@ -319,9 +390,11 @@ public final class VTTSHandler implements ActivityStartEventHandler, ActivityEnd
 				// ... now handle the first and last OR overnight activity. This is figured out by the scoring function itself (depending on the activity types).
 
 				Activity activityMorning = PopulationUtils.createActivityFromLinkId( simData.firstActivityType, null );
+				copyPlanAttributes( simData.firstPlanActivity, activityMorning );
 				activityMorning.setEndTime( simData.firstActivityEndTime );
 
 				Activity activityEvening = PopulationUtils.createActivityFromLinkId( simData.currentActivityType, null );
+				copyPlanAttributes( simData.currentPlanActivity, activityEvening );
 				activityEvening.setStartTime( simData.currentActivityStartTime );
 
 				scores = marginalSumScoringFunction.getOvernightActivityDelayDisutility( activityMorning, activityEvening, 1.0 );
@@ -333,6 +406,7 @@ public final class VTTSHandler implements ActivityStartEventHandler, ActivityEnd
 				// The activity has an end time indicating a 'normal' activity.
 
 				Activity activity = PopulationUtils.createActivityFromLinkId( simData.currentActivityType, null );
+				copyPlanAttributes( simData.currentPlanActivity, activity );
 				activity.setStartTime( simData.currentActivityStartTime );
 				activity.setEndTime( activityEndTime.seconds() );
 				scores = marginalSumScoringFunction.getNormalActivityDelayDisutility( personId, activity, 1.0 );

--- a/contribs/vsp/src/test/java/org/matsim/application/analysis/population/VTTSHandlerPerActivityTypicalDurationTest.java
+++ b/contribs/vsp/src/test/java/org/matsim/application/analysis/population/VTTSHandlerPerActivityTypicalDurationTest.java
@@ -1,0 +1,106 @@
+package org.matsim.application.analysis.population;
+
+import org.junit.jupiter.api.Test;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.api.core.v01.events.ActivityEndEvent;
+import org.matsim.api.core.v01.events.ActivityStartEvent;
+import org.matsim.api.core.v01.events.PersonDepartureEvent;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.population.Activity;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Plan;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.config.groups.ScoringConfigGroup;
+import org.matsim.core.population.PopulationUtils;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.core.scoring.functions.ActivityAttributeTypicalDurationCalculator;
+import org.matsim.core.scoring.functions.CharyparNagelActivityScoring;
+import org.matsim.core.scoring.functions.SubpopulationScoringParameters;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Verifies that {@link VTTSHandler} can be instantiated with a per-activity-parameterized activity scoring: the
+ * activities it reconstructs from the events are aligned with the selected plan and carry the plan activities'
+ * attributes, so an {@link ActivityAttributeTypicalDurationCalculator}-based scoring sees the per-activity typical
+ * durations.  The equivalence tested here is the defining property: an activity carrying typical duration T must
+ * yield exactly the marginals of a run whose config gives its activity type typical duration T.
+ */
+public class VTTSHandlerPerActivityTypicalDurationTest {
+
+	private static final Id<Person> PID = Id.createPersonId("p");
+	private static final Id<Link> LINK = Id.createLinkId("l");
+
+	private static Config config(double workTypicalDuration) {
+		Config config = ConfigUtils.createConfig();
+		ScoringConfigGroup scoring = config.scoring();
+		scoring.setPerforming_utils_hr(6.);
+		scoring.addActivityParams(new ScoringConfigGroup.ActivityParams("home").setTypicalDuration(8. * 3600.));
+		scoring.addActivityParams(new ScoringConfigGroup.ActivityParams("work").setTypicalDuration(workTypicalDuration));
+		scoring.addActivityParams(new ScoringConfigGroup.ActivityParams("home_evening").setTypicalDuration(8. * 3600.));
+		return config;
+	}
+
+	private static Scenario scenario(Config config, Double workTypicalDurationAttribute) {
+		Scenario scenario = ScenarioUtils.createScenario(config);
+		Person person = scenario.getPopulation().getFactory().createPerson(PID);
+		Plan plan = PopulationUtils.createPlan();
+		Activity home = PopulationUtils.createAndAddActivityFromLinkId(plan, "home", LINK);
+		home.setEndTime(28800.);
+		PopulationUtils.createAndAddLeg(plan, "car");
+		Activity work = PopulationUtils.createAndAddActivityFromLinkId(plan, "work", LINK);
+		work.setEndTime(59400.);
+		if (workTypicalDurationAttribute != null) {
+			work.getAttributes().putAttribute(ActivityAttributeTypicalDurationCalculator.TYPICAL_DURATION_ATTRIBUTE, workTypicalDurationAttribute);
+		}
+		PopulationUtils.createAndAddLeg(plan, "car");
+		PopulationUtils.createAndAddActivityFromLinkId(plan, "home_evening", LINK);
+		person.addPlan(plan);
+		person.setSelectedPlan(plan);
+		scenario.getPopulation().addPerson(person);
+		return scenario;
+	}
+
+	/** The events of the day home - car - work - car - home_evening; the handler reconstructs bare activities from them. */
+	private static double workTripMarginalUtilityOfActivityTime(VTTSHandler handler) {
+		handler.reset(0);
+		handler.handleEvent(new ActivityEndEvent(28800., PID, LINK, null, "home"));
+		handler.handleEvent(new PersonDepartureEvent(28800., PID, LINK, "car", "car"));
+		handler.handleEvent(new ActivityStartEvent(30600., PID, LINK, null, "work"));
+		handler.handleEvent(new ActivityEndEvent(59400., PID, LINK, null, "work"));
+		handler.handleEvent(new PersonDepartureEvent(59400., PID, LINK, "car", "car"));
+		handler.handleEvent(new ActivityStartEvent(61200., PID, LINK, null, "home_evening"));
+		handler.computeFinalVTTS();
+		List<VTTSHandler.TripData> trips = handler.getTripDataMap().get(PID);
+		// trip 0 is the trip to work; its marginal utility of schedule delay refers to the work activity
+		return trips.get(0).musl_h;
+	}
+
+	@Test
+	void attributeReproducesConfigTypicalDuration() {
+		// A: work typical 2h in the config, but 8h as attribute of the plan's work activity, scored per activity
+		Scenario scenarioA = scenario(config(2. * 3600.), 8. * 3600.);
+		VTTSHandler withAttribute = new VTTSHandler(scenarioA, new SubpopulationScoringParameters(scenarioA),
+				params -> new CharyparNagelActivityScoring(params, new ActivityAttributeTypicalDurationCalculator(), null));
+
+		// B: work typical 8h in the config, stock scoring
+		Scenario scenarioB = scenario(config(8. * 3600.), null);
+		VTTSHandler fromConfig = new VTTSHandler(scenarioB, new SubpopulationScoringParameters(scenarioB), null);
+
+		// C: same as A but with stock scoring, which ignores the attribute
+		Scenario scenarioC = scenario(config(2. * 3600.), 8. * 3600.);
+		VTTSHandler stock = new VTTSHandler(scenarioC, new SubpopulationScoringParameters(scenarioC), null);
+
+		double marginalWithAttribute = workTripMarginalUtilityOfActivityTime(withAttribute);
+		double marginalFromConfig = workTripMarginalUtilityOfActivityTime(fromConfig);
+		double marginalStock = workTripMarginalUtilityOfActivityTime(stock);
+
+		assertEquals(marginalFromConfig, marginalWithAttribute, 1e-9);
+		assertNotEquals(marginalStock, marginalWithAttribute, 1e-3);
+	}
+}

--- a/matsim/src/main/java/org/matsim/core/scoring/functions/ActivityAttributeTypicalDurationCalculator.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/functions/ActivityAttributeTypicalDurationCalculator.java
@@ -1,0 +1,35 @@
+package org.matsim.core.scoring.functions;
+
+import org.matsim.api.core.v01.population.Activity;
+import org.matsim.core.config.groups.ScoringConfigGroup;
+import org.matsim.core.utils.misc.OptionalTime;
+
+/**
+ * Takes the typical duration from the {@value #TYPICAL_DURATION_ATTRIBUTE} attribute (in seconds) of the activity
+ * itself, so that every activity can carry its own typical duration instead of encoding it in the activity type
+ * (e.g. one config activity type per duration bin, {@code home_30}, {@code home_60}, ...).  Activities without the
+ * attribute (or with a non-positive value) fall back to the typical duration of their activity type from the
+ * scoring config.
+ * <p>
+ * Note that the activities handed to the scoring during a simulation are reconstructed from events and carry no
+ * attributes; pass the {@link org.matsim.api.core.v01.population.Person} to
+ * {@link CharyparNagelActivityScoring} so that the attributes are read from the selected plan.
+ */
+public final class ActivityAttributeTypicalDurationCalculator implements TypicalDurationCalculator {
+
+	/**
+	 * Attribute key under which an activity carries its typical duration (in seconds); deliberately the same string
+	 * as the config parameter {@link ScoringConfigGroup.ActivityParams#TYPICAL_DURATION}.
+	 */
+	public static final String TYPICAL_DURATION_ATTRIBUTE = ScoringConfigGroup.ActivityParams.TYPICAL_DURATION;
+
+	@Override
+	public OptionalTime getTypicalDuration(Activity act) {
+		Object value = act.getAttributes().getAttribute(TYPICAL_DURATION_ATTRIBUTE);
+		if (value instanceof Number number && number.doubleValue() > 0) {
+			return OptionalTime.defined(number.doubleValue());
+		}
+		return OptionalTime.undefined();
+	}
+
+}

--- a/matsim/src/main/java/org/matsim/core/scoring/functions/ActivityUtilityParameters.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/functions/ActivityUtilityParameters.java
@@ -166,6 +166,8 @@ public final class ActivityUtilityParameters implements MatsimParameters {
 		public ActivityUtilityParameters build() {
 			ActivityUtilityParameters params = new ActivityUtilityParameters(this.type) ;
 			params.scoreAtAll = this.scoreAtAll;
+			params.priority = this.priority;
+			params.zeroUtilityComputation = this.zeroUtilityComputation;
 			this.typicalDuration_s.ifDefined( duration -> params.typicalDuration_s = duration ) ;
 			this.typicalDuration_s.ifDefined( duration -> params.zeroUtilityDuration_h = this.zeroUtilityComputation.computeZeroUtilityDuration_s(priority, duration ) / 3600. );
 			// (I think that the only way in which the typical duration can be undefined is if the activity is not scored at all.  Maybe change the condition. kai, may'22)
@@ -186,6 +188,8 @@ public final class ActivityUtilityParameters implements MatsimParameters {
 
 	private final String type;
 	private double typicalDuration_s = 0;
+	private double priority = 1.;
+	private ZeroUtilityComputation zeroUtilityComputation = new SameRelativeScore();
 
 	/**
 	 * 	"duration at which the [performance] utility starts to be positive"
@@ -222,6 +226,16 @@ public final class ActivityUtilityParameters implements MatsimParameters {
 
 	public final double getZeroUtilityDuration_h() {
 		return this.zeroUtilityDuration_h;
+	}
+
+	/**
+	 * The zero-utility duration (in hours) that belongs to the given typical duration, using the same
+	 * {@link ZeroUtilityComputation} and priority that produced {@link #getZeroUtilityDuration_h()} from
+	 * {@link #getTypicalDuration()}.  Use this when the typical duration of an individual activity deviates from the
+	 * typical duration of its activity type, so that the scoring curve stays self-consistent.
+	 */
+	public final double computeZeroUtilityDuration_h(double typicalDuration_s) {
+		return this.zeroUtilityComputation.computeZeroUtilityDuration_s(this.priority, typicalDuration_s) / 3600.;
 	}
 
 	public final OptionalTime getMinimalDuration() {

--- a/matsim/src/main/java/org/matsim/core/scoring/functions/CharyparNagelActivityScoring.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/functions/CharyparNagelActivityScoring.java
@@ -23,12 +23,30 @@ package org.matsim.core.scoring.functions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.population.Activity;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.core.router.StageActivityTypeIdentifier;
+import org.matsim.core.router.TripStructureUtils;
 import org.matsim.core.scoring.ScoringFunction;
 import org.matsim.core.utils.misc.OptionalTime;
+
+import java.util.List;
 
 /**
  * This is a re-implementation of the original CharyparNagel function, based on a
  * modular approach.
+ * <p>
+ * Optionally, the typical duration can be resolved per individual activity (instead of per activity type) via a
+ * {@link TypicalDurationCalculator}, e.g. from an activity attribute
+ * ({@link ActivityAttributeTypicalDurationCalculator}).  Note that during a simulation the activities handed to
+ * this class are reconstructed from events ({@link org.matsim.core.scoring.EventsToActivities}) and carry no
+ * attributes.  When constructed with the {@link Person}, this class therefore aligns the handed activities with
+ * the main (non-stage) activities of the person's selected plan and resolves per-activity typical durations from
+ * the plan activities, while all times still come from the handed ones.  The plan is resolved lazily at the first
+ * scoring callback, i.e. after replanning; scoring functions may be created before replanning (see
+ * {@code ControllerConfigGroup#getEventTypeToCreateScoringFunctions()}), when the selected plan is not yet the
+ * plan that will be executed.  If the handed activity sequence diverges from the plan (e.g. with within-day
+ * replanning), the alignment is abandoned with a warning and the affected activities are scored against their
+ * type's config parameters, as without the calculator.
  * @see <a href="http://www.matsim.org/node/263">http://www.matsim.org/node/263</a>
  * @author rashid_waraich
  */
@@ -39,11 +57,21 @@ public final class CharyparNagelActivityScoring implements org.matsim.core.scori
 
 	private static int firstLastActWarning = 0;
 	private static short firstLastActOpeningTimesWarning = 0;
+	private static int planAlignmentWarning = 0;
 
 	private final ScoringParameters params;
 	private final OpeningIntervalCalculator openingIntervalCalculator;
+	private final TypicalDurationCalculator typicalDurationCalculator;
+
+	/** Owner of the plan whose main activities per-activity parameters are resolved from; null means the handed activities are used directly. */
+	private final Person person;
+	private List<Activity> planActivities;
+	private int planActivityIndex = 0;
+	private boolean planAlignmentBroken = false;
 
 	private Activity firstActivity;
+	/** Source for per-activity parameters aligned with {@link #firstActivity}; the first activity is only scored at {@link #finish()}. */
+	private Activity firstActivitySource;
 
 	private static final Logger log = LogManager.getLogger(CharyparNagelActivityScoring.class);
 
@@ -52,11 +80,63 @@ public final class CharyparNagelActivityScoring implements org.matsim.core.scori
 	}
 
 	public CharyparNagelActivityScoring(final ScoringParameters params, final OpeningIntervalCalculator openingIntervalCalculator) {
+		this(params, openingIntervalCalculator, act -> OptionalTime.undefined(), null);
+	}
+
+	public CharyparNagelActivityScoring(final ScoringParameters params, final TypicalDurationCalculator typicalDurationCalculator, final Person person) {
+		this(params, new ActivityTypeOpeningIntervalCalculator(params), typicalDurationCalculator, person);
+	}
+
+	public CharyparNagelActivityScoring(final ScoringParameters params, final OpeningIntervalCalculator openingIntervalCalculator,
+			final TypicalDurationCalculator typicalDurationCalculator, final Person person) {
 		this.params = params;
 
 //		firstLastActWarning = 0 ;
 //		firstLastActOpeningTimesWarning = 0 ;
 		this.openingIntervalCalculator = openingIntervalCalculator;
+		this.typicalDurationCalculator = typicalDurationCalculator;
+		this.person = person;
+	}
+
+	/**
+	 * The activity from which per-activity parameters are resolved for a handed activity: the aligned main activity
+	 * of the selected plan when a person was given, otherwise the handed activity itself.  Stage activities bypass
+	 * the alignment on both sides: their count varies with routing, and they are not really scored.  On a type
+	 * mismatch (or more handed main activities than the plan contains) the alignment is abandoned with a warning and
+	 * scoring falls back to the handed activities.
+	 */
+	private Activity resolveActivitySource(Activity handed) {
+		if (this.person == null || this.planAlignmentBroken || StageActivityTypeIdentifier.isStageActivity(handed.getType())) {
+			return handed;
+		}
+		if (this.planActivities == null) {
+			// lazily: at the first callback we are past replanning, so this is the executed plan
+			this.planActivities = TripStructureUtils.getActivities(this.person.getSelectedPlan(), TripStructureUtils.StageActivityHandling.ExcludeStageActivities);
+		}
+		if (this.planActivityIndex >= this.planActivities.size()) {
+			warnPlanAlignmentBroken(handed, "more main activities than the selected plan contains");
+			return handed;
+		}
+		Activity planned = this.planActivities.get(this.planActivityIndex);
+		if (!planned.getType().equals(handed.getType())) {
+			warnPlanAlignmentBroken(handed, "activity type " + handed.getType() + " does not match plan activity type " + planned.getType() + " at main-activity index " + this.planActivityIndex);
+			return handed;
+		}
+		this.planActivityIndex++;
+		return planned;
+	}
+
+	private void warnPlanAlignmentBroken(Activity handed, String reason) {
+		this.planAlignmentBroken = true;
+		if (planAlignmentWarning <= 10) {
+			log.warn("Cannot align the activities of person {} with the main activities of the selected plan: {}. "
+					+ "Falling back to per-activity-type scoring parameters for this person's remaining activities (activity: {}).",
+					this.person.getId(), reason, handed);
+			if (planAlignmentWarning == 10) {
+				log.warn("Additional warnings of this type are suppressed.");
+			}
+			planAlignmentWarning++;
+		}
 	}
 
 	@Override
@@ -86,7 +166,7 @@ public final class CharyparNagelActivityScoring implements org.matsim.core.scori
 		out.append("actEarlyDeparture_s=").append(this.score.actEarlyDeparture_s);
 	}
 
-	private Score calcActScore(final double arrivalTime, final double departureTime, final Activity act) {
+	private Score calcActScore(final double arrivalTime, final double departureTime, final Activity act, final Activity activitySource) {
 
 		ActivityUtilityParameters actParams = this.params.actParams.get(act.getType() );
 		if (actParams == null) {
@@ -165,14 +245,29 @@ public final class CharyparNagelActivityScoring implements org.matsim.core.scori
 
 			// utility of performing an action, duration is >= 1, thus log is no problem
 			// (why is duration >=1?  Also, the computations below would allow for duration <= 0.  kai, nov'25)
-			double typicalDuration = actParams.getTypicalDuration();
+			double typicalDuration;
+			double zeroUtilityDuration_h;
+			OptionalTime typicalDurationOverride = this.typicalDurationCalculator.getTypicalDuration(activitySource);
+			if (typicalDurationOverride.isDefined()) {
+				typicalDuration = typicalDurationOverride.seconds();
+				zeroUtilityDuration_h = actParams.computeZeroUtilityDuration_h(typicalDuration);
+				if (zeroUtilityDuration_h <= 0.0) {
+					// same condition as ActivityUtilityParameters.checkConsistency: with a typical duration of <=48s (at
+					// priority 1) the zero-utility duration underflows to 0.0 and the computations below break down.
+					throw new RuntimeException("zeroUtilityDuration of activity " + activitySource + " must be greater than 0.0. "
+							+ "The per-activity typical duration " + typicalDuration + "s is too small.");
+				}
+			} else {
+				typicalDuration = actParams.getTypicalDuration();
+				zeroUtilityDuration_h = actParams.getZeroUtilityDuration_h();
+			}
 
 			tmpScore.actPerforming_s += duration;
 
 			if ( this.params.usingOldScoringBelowZeroUtilityDuration ) {
 				if (duration > 0) {
 					double utilPerf = this.params.marginalUtilityOfPerforming_s * typicalDuration
-							* Math.log((duration / 3600.0) / actParams.getZeroUtilityDuration_h());
+							* Math.log((duration / 3600.0) / zeroUtilityDuration_h);
 					double utilWait = this.params.marginalUtilityOfWaiting_s * duration;
 
 					tmpScore.actPerforming_util += Math.max(0, Math.max(utilPerf, utilWait));
@@ -180,9 +275,9 @@ public final class CharyparNagelActivityScoring implements org.matsim.core.scori
 					tmpScore.actLateArrival_util += 2*this.params.marginalUtilityOfLateArrival_s*Math.abs(duration);
 				}
 			} else {
-				if ( duration >= 3600.*actParams.getZeroUtilityDuration_h() ) {
+				if ( duration >= 3600.*zeroUtilityDuration_h ) {
 					double utilPerf = this.params.marginalUtilityOfPerforming_s * typicalDuration
-							* Math.log((duration / 3600.0) / actParams.getZeroUtilityDuration_h());
+							* Math.log((duration / 3600.0) / zeroUtilityDuration_h);
 					// also removing the "wait" alternative scoring.
 					tmpScore.actPerforming_util += utilPerf ;
 				} else {
@@ -195,17 +290,17 @@ public final class CharyparNagelActivityScoring implements org.matsim.core.scori
 //					}
 
 					// below zeroUtilityDuration, we linearly extend the slope ...:
-					double slopeAtZeroUtility = this.params.marginalUtilityOfPerforming_s * typicalDuration / ( 3600.*actParams.getZeroUtilityDuration_h() ) ;
+					double slopeAtZeroUtility = this.params.marginalUtilityOfPerforming_s * typicalDuration / ( 3600.*zeroUtilityDuration_h ) ;
 					// (this slope is actually always beta_perf * e !!)
 
 					if ( slopeAtZeroUtility < 0. ) {
 						// (beta_perf might be = 0)
 						System.err.println("beta_perf: " + this.params.marginalUtilityOfPerforming_s);
 						System.err.println("typicalDuration: " + typicalDuration );
-						System.err.println( "zero utl duration: " + actParams.getZeroUtilityDuration_h() );
+						System.err.println( "zero utl duration: " + zeroUtilityDuration_h );
 						throw new RuntimeException( "slope at zero utility < 0.; this should not happen ...");
 					}
-					double durationUnderrun = actParams.getZeroUtilityDuration_h()*3600. - duration ;
+					double durationUnderrun = zeroUtilityDuration_h*3600. - duration ;
 					if ( durationUnderrun < 0. ) {
 						throw new RuntimeException( "durationUnderrun < 0; this should not happen ...") ;
 					}
@@ -240,7 +335,7 @@ public final class CharyparNagelActivityScoring implements org.matsim.core.scori
 		return tmpScore;
 	}
 
-	private void handleOvernightActivity(Activity lastActivity) {
+	private void handleOvernightActivity(Activity lastActivity, Activity lastActivitySource) {
 		assert firstActivity != null;
 		assert lastActivity != null;
 
@@ -265,7 +360,7 @@ public final class CharyparNagelActivityScoring implements org.matsim.core.scori
 			}
 
 			Score calcActScore = calcActScore(lastActivity.getStartTime().seconds(),
-					this.firstActivity.getEndTime().seconds() + 24 * 3600, lastActivity);
+					this.firstActivity.getEndTime().seconds() + 24 * 3600, lastActivity, lastActivitySource);
 			this.score.add(calcActScore); // SCENARIO_DURATION
 		} else {
 			// the first Act and the last Act have NOT the same type:
@@ -285,10 +380,10 @@ public final class CharyparNagelActivityScoring implements org.matsim.core.scori
 				}
 
 				// score first activity
-				this.score.add(calcActScore(0.0, this.firstActivity.getEndTime().seconds(), firstActivity));
+				this.score.add(calcActScore(0.0, this.firstActivity.getEndTime().seconds(), firstActivity, firstActivitySource));
 				// score last activity
 				this.score.add(calcActScore(lastActivity.getStartTime().seconds(),
-						this.params.simulationPeriodInDays * 24 * 3600, lastActivity));
+						this.params.simulationPeriodInDays * 24 * 3600, lastActivity, lastActivitySource));
 			}
 		}
 	}
@@ -296,23 +391,24 @@ public final class CharyparNagelActivityScoring implements org.matsim.core.scori
 	private void handleMorningActivity() {
 		assert firstActivity != null;
 		// score first activity
-		this.score.add(calcActScore(0.0, this.firstActivity.getEndTime().seconds(), firstActivity));
+		this.score.add(calcActScore(0.0, this.firstActivity.getEndTime().seconds(), firstActivity, firstActivitySource));
 	}
 
 	@Override
 	public void handleFirstActivity(Activity act) {
 		assert act != null;
 		this.firstActivity = act;
+		this.firstActivitySource = resolveActivitySource(act);
 	}
 
 	@Override
 	public void handleActivity(Activity act) {
-		this.score.add(calcActScore(act.getStartTime().seconds(), act.getEndTime().seconds(), act));
+		this.score.add(calcActScore(act.getStartTime().seconds(), act.getEndTime().seconds(), act, resolveActivitySource(act)));
 	}
 
 	@Override
 	public void handleLastActivity(Activity act) {
-		this.handleOvernightActivity(act);
+		this.handleOvernightActivity(act, resolveActivitySource(act));
 		this.firstActivity = null;
 	}
 

--- a/matsim/src/main/java/org/matsim/core/scoring/functions/TypicalDurationCalculator.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/functions/TypicalDurationCalculator.java
@@ -1,0 +1,20 @@
+package org.matsim.core.scoring.functions;
+
+import org.matsim.api.core.v01.population.Activity;
+import org.matsim.core.utils.misc.OptionalTime;
+
+/**
+ * Resolves the Charypar-Nagel typical duration for an individual activity, analogous to
+ * {@link OpeningIntervalCalculator} for opening times.  A defined result overrides the typical duration of the
+ * activity's type from the scoring config, and the zero-utility duration is recomputed from it via
+ * {@link ActivityUtilityParameters#computeZeroUtilityDuration_h(double)} so that the scoring curve stays
+ * self-consistent.  An undefined result means the activity is scored against its type's config parameters, exactly
+ * as without this hook.
+ *
+ * @see ActivityAttributeTypicalDurationCalculator
+ */
+public interface TypicalDurationCalculator {
+
+	OptionalTime getTypicalDuration(final Activity act);
+
+}

--- a/matsim/src/test/java/org/matsim/core/scoring/functions/CharyparNagelActivityScoringTypicalDurationTest.java
+++ b/matsim/src/test/java/org/matsim/core/scoring/functions/CharyparNagelActivityScoringTypicalDurationTest.java
@@ -1,0 +1,219 @@
+package org.matsim.core.scoring.functions;
+
+import org.junit.jupiter.api.Test;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.population.Activity;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.Plan;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.config.groups.ScoringConfigGroup;
+import org.matsim.core.population.PopulationUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Tests for the per-activity typical duration ({@link TypicalDurationCalculator}) in
+ * {@link CharyparNagelActivityScoring}.  During a simulation, the scoring is handed attribute-less activity
+ * reconstructions (see {@link org.matsim.core.scoring.EventsToActivities}); these tests feed exactly such bare
+ * activities and verify that the alignment with the selected plan supplies the attributes.
+ */
+public class CharyparNagelActivityScoringTypicalDurationTest {
+
+	private static Config config() {
+		Config config = ConfigUtils.createConfig();
+		ScoringConfigGroup scoring = config.scoring();
+		scoring.setPerforming_utils_hr(6.);
+		scoring.setLateArrival_utils_hr(-18.);
+		scoring.setEarlyDeparture_utils_hr(-6.);
+		for (String type : new String[]{"home", "work", "home_evening"}) {
+			scoring.addActivityParams(new ScoringConfigGroup.ActivityParams(type).setTypicalDuration(2. * 3600.));
+		}
+		ScoringConfigGroup.ActivityParams interaction = new ScoringConfigGroup.ActivityParams("pt interaction");
+		interaction.setScoringThisActivityAtAll(false);
+		scoring.addActivityParams(interaction);
+		return config;
+	}
+
+	private static Person person(Plan plan) {
+		Person person = PopulationUtils.getFactory().createPerson(Id.createPersonId("p"));
+		person.addPlan(plan);
+		person.setSelectedPlan(plan);
+		return person;
+	}
+
+	private static ScoringParameters params(Config config) {
+		return new ScoringParameters.Builder(config.scoring(), config.scoring().getScoringParameters(null), config.scenario()).build();
+	}
+
+	private static CharyparNagelActivityScoring attributeScoring(Config config, Person person) {
+		return new CharyparNagelActivityScoring(params(config), new ActivityAttributeTypicalDurationCalculator(), person);
+	}
+
+	/** The plan with attributes: home(t*=8h) - work(t*=8h) - home_evening (no attribute). */
+	private static Plan plan() {
+		return planWithWorkTypical(28800.);
+	}
+
+	private static Plan planWithWorkTypical(double workTypicalDuration) {
+		Plan plan = PopulationUtils.createPlan();
+		Activity home = PopulationUtils.createAndAddActivityFromCoord(plan, "home", new Coord(0., 0.));
+		home.setEndTime(28800.);
+		home.getAttributes().putAttribute(ActivityAttributeTypicalDurationCalculator.TYPICAL_DURATION_ATTRIBUTE, 28800.);
+		PopulationUtils.createAndAddLeg(plan, "car");
+		Activity work = PopulationUtils.createAndAddActivityFromCoord(plan, "work", new Coord(1., 0.));
+		work.setEndTime(59400.);
+		work.getAttributes().putAttribute(ActivityAttributeTypicalDurationCalculator.TYPICAL_DURATION_ATTRIBUTE, workTypicalDuration);
+		PopulationUtils.createAndAddLeg(plan, "car");
+		PopulationUtils.createAndAddActivityFromCoord(plan, "home_evening", new Coord(0., 0.));
+		return plan;
+	}
+
+	/** Bare activity as EventsToActivities produces it: type and times only, no attributes. */
+	private static Activity bare(String type, Double start, Double end) {
+		Activity act = PopulationUtils.createActivityFromCoord(type, new Coord(0., 0.));
+		if (start != null) act.setStartTime(start);
+		if (end != null) act.setEndTime(end);
+		return act;
+	}
+
+	private static double score(CharyparNagelActivityScoring scoring, double workStart, double workEnd) {
+		scoring.handleFirstActivity(bare("home", null, 28800.));
+		scoring.handleActivity(bare("work", workStart, workEnd));
+		scoring.handleLastActivity(bare("home_evening", workEnd + 1800., null));
+		scoring.finish();
+		return scoring.getScore();
+	}
+
+	@Test
+	void planAlignmentSuppliesTheAttributes() {
+		Config config = config();
+		// with the plan alignment, home and work are scored against their 8h attribute typical; without a person, the
+		// bare activities fall back to the 2h config typical -- the scores must differ.
+		double scoreWithPlan = score(attributeScoring(config, person(plan())), 30600., 59400.);
+		double scoreWithoutPlan = score(attributeScoring(config, null), 30600., 59400.);
+		assertNotEquals(scoreWithPlan, scoreWithoutPlan, 1.);
+
+		// gold standard: handing in the attribute-carrying plan activities directly must give exactly the same result
+		// as the alignment.
+		CharyparNagelActivityScoring direct = attributeScoring(config, null);
+		Plan p = plan();
+		direct.handleFirstActivity((Activity) p.getPlanElements().get(0));
+		Activity work = (Activity) p.getPlanElements().get(2);
+		work.setStartTime(30600.);
+		direct.handleActivity(work);
+		Activity last = (Activity) p.getPlanElements().get(4);
+		last.setStartTime(61200.);
+		direct.handleLastActivity(last);
+		direct.finish();
+		assertEquals(direct.getScore(), scoreWithPlan, 1e-9);
+	}
+
+	/** Without attributes, the calculator variant must reproduce the stock scoring exactly. */
+	@Test
+	void withoutAttributesEqualsStockScoring() {
+		Config config = config();
+		Plan barePlan = plan();
+		barePlan.getPlanElements().forEach(pe -> {
+			if (pe instanceof Activity act) act.getAttributes().removeAttribute(ActivityAttributeTypicalDurationCalculator.TYPICAL_DURATION_ATTRIBUTE);
+		});
+		double calculatorVariant = score(attributeScoring(config, person(barePlan)), 30600., 59400.);
+		double stock = score(new CharyparNagelActivityScoring(params(config)), 30600., 59400.);
+		assertEquals(stock, calculatorVariant, 1e-9);
+	}
+
+	/**
+	 * The essential consistency property: an activity carrying typical duration T must be scored exactly as if its
+	 * activity type had typical duration T in the config, for both zero-utility-duration computation modes.
+	 */
+	@Test
+	void attributeReproducesConfigTypicalDuration() {
+		for (ScoringConfigGroup.TypicalDurationScoreComputation computation : ScoringConfigGroup.TypicalDurationScoreComputation.values()) {
+			// A: work typical 2h in the config, but 8h as activity attribute (home/home_evening attribute-less in this plan)
+			Config configA = config();
+			configA.scoring().getActivityParams("work").setTypicalDurationScoreComputation(computation);
+			Plan planA = planWithWorkTypical(28800.);
+			((Activity) planA.getPlanElements().get(0)).getAttributes().removeAttribute(ActivityAttributeTypicalDurationCalculator.TYPICAL_DURATION_ATTRIBUTE);
+			double withAttribute = score(attributeScoring(configA, person(planA)), 30600., 59400.);
+
+			// B: work typical 8h in the config, stock scoring on the bare activities
+			Config configB = config();
+			configB.scoring().getActivityParams("work").setTypicalDurationScoreComputation(computation);
+			configB.scoring().getActivityParams("work").setTypicalDuration(28800.);
+			double fromConfig = score(new CharyparNagelActivityScoring(params(configB)), 30600., 59400.);
+
+			assertEquals(fromConfig, withAttribute, 1e-9, "computation mode " + computation);
+		}
+	}
+
+	/**
+	 * Stage activities must not consume the plan alignment: the realized stream contains "pt interaction" activities
+	 * whose count varies with routing, while the alignment covers main activities only.  Scores must equal the
+	 * interaction-free day exactly (interactions have scoringThisActivityAtAll=false).
+	 */
+	@Test
+	void stageActivitiesBypassThePlanAlignment() {
+		Config config = config();
+		CharyparNagelActivityScoring withStages = attributeScoring(config, person(plan()));
+		withStages.handleFirstActivity(bare("home", null, 28800.));
+		withStages.handleActivity(bare("pt interaction", 29000., 29000.));
+		withStages.handleActivity(bare("pt interaction", 29800., 29800.));
+		withStages.handleActivity(bare("work", 30600., 59400.));
+		withStages.handleActivity(bare("pt interaction", 60000., 60000.));
+		withStages.handleLastActivity(bare("home_evening", 61200., null));
+		withStages.finish();
+
+		double plain = score(attributeScoring(config, person(plan())), 30600., 59400.);
+		assertEquals(plain, withStages.getScore(), 1e-9);
+	}
+
+	/**
+	 * Scoring functions may be created at iteration start, BEFORE replanning: the plan selected at construction time
+	 * is not necessarily the executed one.  The alignment must resolve the plan lazily -- here the person's selected
+	 * plan is replaced after construction (with a different work typical duration standing in for a structurally
+	 * different plan), and the scoring must use the replacement.
+	 */
+	@Test
+	void planIsResolvedAtFirstCallbackNotAtConstruction() {
+		Config config = config();
+		Person person = person(plan());
+		CharyparNagelActivityScoring scoring = attributeScoring(config, person);
+
+		// "replanning": a new selected plan with a different work typical duration (4h instead of 8h)
+		person.addPlan(planWithWorkTypical(14400.));
+		person.setSelectedPlan(person.getPlans().get(1));
+
+		double lazily = score(scoring, 30600., 59400.);
+		double onReplanned = score(attributeScoring(config, person(planWithWorkTypical(14400.))), 30600., 59400.);
+		double onStale = score(attributeScoring(config, person(plan())), 30600., 59400.);
+		assertEquals(onReplanned, lazily, 1e-9);
+		assertNotEquals(onStale, lazily, 1.);
+	}
+
+	/**
+	 * When the handed activity sequence diverges from the selected plan (e.g. with within-day replanning), the
+	 * alignment is abandoned with a warning and scoring falls back to the activity types' config parameters, i.e.
+	 * behaves like the stock scoring.
+	 */
+	@Test
+	void alignmentMismatchFallsBackToConfigParameters() {
+		Config config = config();
+		config.scoring().addActivityParams(new ScoringConfigGroup.ActivityParams("unexpected").setTypicalDuration(2. * 3600.));
+
+		CharyparNagelActivityScoring diverged = attributeScoring(config, person(plan()));
+		diverged.handleFirstActivity(bare("unexpected", null, 28800.));
+		diverged.handleActivity(bare("work", 30600., 59400.));
+		diverged.handleLastActivity(bare("home_evening", 61200., null));
+		diverged.finish();
+
+		CharyparNagelActivityScoring stock = new CharyparNagelActivityScoring(params(config));
+		stock.handleFirstActivity(bare("unexpected", null, 28800.));
+		stock.handleActivity(bare("work", 30600., 59400.));
+		stock.handleLastActivity(bare("home_evening", 61200., null));
+		stock.finish();
+
+		assertEquals(stock.getScore(), diverged.getScore(), 1e-9);
+	}
+}


### PR DESCRIPTION
Allows scoring each activity against its own typical duration instead of its activity type's, replacing the duration-binned-activity-types workaround (`home_30`, `home_60`, ...).

- New `TypicalDurationCalculator` strategy interface, analogous to `OpeningIntervalCalculator`; `ActivityAttributeTypicalDurationCalculator` reads the `typicalDuration` activity attribute (config fallback when absent).
- The zero-utility duration is recomputed consistently with the type's configured computation mode and priority, via the new `ActivityUtilityParameters.computeZeroUtilityDuration_h`.
- Activities handed to the scoring at runtime are reconstructed from events and carry no attributes, so `CharyparNagelActivityScoring` can optionally be given the `Person` and then aligns them with the selected plan's main activities (resolved lazily after replanning; warns and falls back to config parameters on divergence).
- No config switch: enabled by constructing/binding the scoring accordingly. Default constructors are behaviorally unchanged.
- vsp VTTS analysis: `MarginalSumScoringFunction` and `VTTSHandler` accept an activity-scoring factory, create fresh scoring instances per marginal computation, and give their event-reconstructed activities the attributes of the corresponding selected-plan activities.

[![AI detection: 100% generated](https://img.shields.io/badge/AI_detection-100%25_generated-success?logo=claude&logoColor=white)](https://claude.com/claude-code)