### PR TITLE
fix(core): Fix String-casting of a long value.

### DIFF
--- a/matsim/src/main/java/org/matsim/core/network/NetworkUtils.java
+++ b/matsim/src/main/java/org/matsim/core/network/NetworkUtils.java
@@ -674,7 +674,8 @@ public final class NetworkUtils {
 //		} else {
 //			throw new RuntimeException( "getType not possible for this implementation of interface Link" ) ;
 //		}
-		return (String) link.getAttributes().getAttribute(TYPE);
+		Object type = link.getAttributes().getAttribute(TYPE);
+		return type == null ? null : type.toString();
 	}
 
 	/**
@@ -722,7 +723,7 @@ public final class NetworkUtils {
 //		} else {
 //			throw new RuntimeException("wrong implementation of Link interface do getOrigId" ) ;
 //		}
-		String o = (String) link.getAttributes().getAttribute(ORIGID);
+		Object o = link.getAttributes().getAttribute(ORIGID);
 		return o == null ? null : o.toString();
 	}
 
@@ -742,7 +743,6 @@ public final class NetworkUtils {
 	 */
 	public static Integer getPartition(Attributable obj) {
 		return (Integer) obj.getAttributes().getAttribute(NetworkPartitioning.ATTRIBUTE);
-
 	}
 
 	public static Link createLink(Id<Link> id, Node from, Node to, Network network, double length, double freespeed,

--- a/matsim/src/test/java/org/matsim/core/network/NetworkUtilsTest.java
+++ b/matsim/src/test/java/org/matsim/core/network/NetworkUtilsTest.java
@@ -18,8 +18,6 @@
  * *********************************************************************** */
 package org.matsim.core.network;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -40,15 +38,17 @@ import org.matsim.testcases.MatsimTestUtils;
 import java.util.List;
 import java.util.TreeMap;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 /**
  * @author nagel
  *
  */
 public class NetworkUtilsTest {
-	private static final Logger log = LogManager.getLogger( NetworkUtilsTest.class ) ;
+	private static final Logger log = LogManager.getLogger(NetworkUtilsTest.class);
 
 	@RegisterExtension
-	private MatsimTestUtils utils = new MatsimTestUtils() ;
+	private MatsimTestUtils utils = new MatsimTestUtils();
 
 	/**
 	 * Test method for {@link org.matsim.core.network.NetworkUtils#isMultimodal(org.matsim.api.core.v01.network.Network)}.
@@ -57,13 +57,13 @@ public class NetworkUtilsTest {
 	final void testIsMultimodal() {
 
 		Config config = utils.createConfigWithInputResourcePathAsContext();
-		config.network().setInputFile("network.xml" );
+		config.network().setInputFile("network.xml");
 
-		Scenario scenario = ScenarioUtils.loadScenario(config) ;
+		Scenario scenario = ScenarioUtils.loadScenario(config);
 
-		Network network = scenario.getNetwork() ;
+		Network network = scenario.getNetwork();
 
-		Assertions.assertTrue( NetworkUtils.isMultimodal( network ) );
+		Assertions.assertTrue(NetworkUtils.isMultimodal(network));
 
 	}
 
@@ -74,140 +74,140 @@ public class NetworkUtilsTest {
 		final Network network = ScenarioUtils.createScenario(ConfigUtils.createConfig()).getNetwork();
 		// (we need the network to properly connect the links)
 
-		NetworkFactory nf = network.getFactory() ;
+		NetworkFactory nf = network.getFactory();
 
 		// a number of potentially outgoing links:
 
-		Node nd0 = nf.createNode(Id.createNodeId("0"), new Coord(0.,0.) ) ;
-		Node ndN = nf.createNode(Id.createNodeId("N"), new Coord(0.,100.) ) ;
-		Node ndNE = nf.createNode(Id.createNodeId("NE"), new Coord(100.,100.) ) ;
-		Node ndE = nf.createNode(Id.createNodeId("E"), new Coord(100.,0.) ) ;
-		Node ndSE = nf.createNode(Id.createNodeId("SE"), new Coord(100.,-100.) ) ;
-		Node ndS = nf.createNode(Id.createNodeId("S"), new Coord(0.,-100.) ) ;
-		Node ndSW = nf.createNode(Id.createNodeId("SW"), new Coord(-100.,-100.) ) ;
-		Node ndW = nf.createNode(Id.createNodeId("W"), new Coord(-100.,0.) ) ;
-		Node ndNW = nf.createNode(Id.createNodeId("NW"), new Coord(-100.,+100.) ) ;
+		Node nd0 = nf.createNode(Id.createNodeId("0"), new Coord(0., 0.));
+		Node ndN = nf.createNode(Id.createNodeId("N"), new Coord(0., 100.));
+		Node ndNE = nf.createNode(Id.createNodeId("NE"), new Coord(100., 100.));
+		Node ndE = nf.createNode(Id.createNodeId("E"), new Coord(100., 0.));
+		Node ndSE = nf.createNode(Id.createNodeId("SE"), new Coord(100., -100.));
+		Node ndS = nf.createNode(Id.createNodeId("S"), new Coord(0., -100.));
+		Node ndSW = nf.createNode(Id.createNodeId("SW"), new Coord(-100., -100.));
+		Node ndW = nf.createNode(Id.createNodeId("W"), new Coord(-100., 0.));
+		Node ndNW = nf.createNode(Id.createNodeId("NW"), new Coord(-100., +100.));
 
-		network.addNode( nd0 );
-		network.addNode( ndN );
-		network.addNode( ndNE );
-		network.addNode( ndE );
-		network.addNode( ndSE );
-		network.addNode( ndS );
-		network.addNode( ndSW );
-		network.addNode( ndW );
-		network.addNode( ndNW );
+		network.addNode(nd0);
+		network.addNode(ndN);
+		network.addNode(ndNE);
+		network.addNode(ndE);
+		network.addNode(ndSE);
+		network.addNode(ndS);
+		network.addNode(ndSW);
+		network.addNode(ndW);
+		network.addNode(ndNW);
 
-		Link liN = nf.createLink( Id.createLinkId("N"), nd0, ndN ) ;
-		Link liNE = nf.createLink( Id.createLinkId("NE"), nd0, ndNE ) ;
-		Link liE = nf.createLink( Id.createLinkId("E"), nd0, ndE ) ;
-		Link liSE = nf.createLink( Id.createLinkId("SE"), nd0, ndSE ) ;
-		Link liS = nf.createLink( Id.createLinkId("S"), nd0, ndS ) ;
-		Link liSW = nf.createLink( Id.createLinkId("SW"), nd0, ndSW ) ;
-		Link liW = nf.createLink( Id.createLinkId("W"), nd0, ndW ) ;
-		Link liNW = nf.createLink( Id.createLinkId("NW"), nd0, ndNW ) ;
+		Link liN = nf.createLink(Id.createLinkId("N"), nd0, ndN);
+		Link liNE = nf.createLink(Id.createLinkId("NE"), nd0, ndNE);
+		Link liE = nf.createLink(Id.createLinkId("E"), nd0, ndE);
+		Link liSE = nf.createLink(Id.createLinkId("SE"), nd0, ndSE);
+		Link liS = nf.createLink(Id.createLinkId("S"), nd0, ndS);
+		Link liSW = nf.createLink(Id.createLinkId("SW"), nd0, ndSW);
+		Link liW = nf.createLink(Id.createLinkId("W"), nd0, ndW);
+		Link liNW = nf.createLink(Id.createLinkId("NW"), nd0, ndNW);
 
-		network.addLink( liN );
-		network.addLink( liNE );
-		network.addLink( liE );
-		network.addLink( liSE );
-		network.addLink( liS );
-		network.addLink( liSW );
-		network.addLink( liW );
-		network.addLink( liNW );
+		network.addLink(liN);
+		network.addLink(liNE);
+		network.addLink(liE);
+		network.addLink(liSE);
+		network.addLink(liS);
+		network.addLink(liSW);
+		network.addLink(liW);
+		network.addLink(liNW);
 
 		log.info("===");
 		// a link coming north to south:
 		{
-			Link inLink = nf.createLink( Id.createLinkId("fromNorth"), ndN, nd0 ) ;
-			TreeMap<Double, Link> result = NetworkUtils.getOutLinksSortedClockwiseByAngle(inLink) ;
-			for ( Link outLink : result.values() ) {
-				log.info( outLink );
+			Link inLink = nf.createLink(Id.createLinkId("fromNorth"), ndN, nd0);
+			TreeMap<Double, Link> result = NetworkUtils.getOutLinksSortedClockwiseByAngle(inLink);
+			for (Link outLink : result.values()) {
+				log.info(outLink);
 			}
 
-			Link[] actuals = result.values().toArray( new Link[result.size()] ) ;
-			Link[] expecteds = {liNE,liE,liSE,liS,liSW,liW,liNW} ;
+			Link[] actuals = result.values().toArray(new Link[result.size()]);
+			Link[] expecteds = {liNE, liE, liSE, liS, liSW, liW, liNW};
 			Assertions.assertArrayEquals(expecteds, actuals);
 
 		}
 		log.info("===");
 		// a link coming south to north:
 		{
-			Link inLink = nf.createLink( Id.createLinkId("fromSouth"), ndS, nd0 ) ;
-			TreeMap<Double, Link> result = NetworkUtils.getOutLinksSortedClockwiseByAngle(inLink) ;
-			for ( Link outLink : result.values() ) {
-				log.info( outLink );
+			Link inLink = nf.createLink(Id.createLinkId("fromSouth"), ndS, nd0);
+			TreeMap<Double, Link> result = NetworkUtils.getOutLinksSortedClockwiseByAngle(inLink);
+			for (Link outLink : result.values()) {
+				log.info(outLink);
 			}
-			Link[] actuals = result.values().toArray( new Link[result.size()] ) ;
-			Link[] expecteds = {liSW,liW,liNW,liN,liNE,liE,liSE} ;
+			Link[] actuals = result.values().toArray(new Link[result.size()]);
+			Link[] expecteds = {liSW, liW, liNW, liN, liNE, liE, liSE};
 			Assertions.assertArrayEquals(expecteds, actuals);
 		}
 		log.info("===");
 	}
 
 	@Test
-	void testfindNearestPointOnLink(){
+	void testfindNearestPointOnLink() {
 		Network network = NetworkUtils.createNetwork();
-        Coord n1 = new Coord(1, 1);
-		Coord n2 = new Coord(100,100);
-		Coord plainX = new Coord(1,100);
-		Coord plainY = new Coord(100,1);
-		Node node1 = NetworkUtils.createNode(Id.createNodeId(1),n1);
-		Node node2 = NetworkUtils.createNode(Id.createNodeId(2),n2);
-		Node plainXNode = NetworkUtils.createNode(Id.createNodeId(3),plainX);
-		Node plainYNode = NetworkUtils.createNode(Id.createNodeId(4),plainY);
+		Coord n1 = new Coord(1, 1);
+		Coord n2 = new Coord(100, 100);
+		Coord plainX = new Coord(1, 100);
+		Coord plainY = new Coord(100, 1);
+		Node node1 = NetworkUtils.createNode(Id.createNodeId(1), n1);
+		Node node2 = NetworkUtils.createNode(Id.createNodeId(2), n2);
+		Node plainXNode = NetworkUtils.createNode(Id.createNodeId(3), plainX);
+		Node plainYNode = NetworkUtils.createNode(Id.createNodeId(4), plainY);
 
-		Link link = NetworkUtils.createLink(Id.createLinkId("1-2"),node1,node2,network,150,1,20,1);
-		Link plainXLink = NetworkUtils.createLink(Id.createLinkId("plainX"),node1,plainXNode,network,150,1,20,1);
-		Link plainYLink = NetworkUtils.createLink(Id.createLinkId("plainY"),node1,plainYNode,network,150,1,20,1);
-		Link loop = NetworkUtils.createLink(Id.createLinkId("1-1"),node1,node1,network,150,1,20,1);
+		Link link = NetworkUtils.createLink(Id.createLinkId("1-2"), node1, node2, network, 150, 1, 20, 1);
+		Link plainXLink = NetworkUtils.createLink(Id.createLinkId("plainX"), node1, plainXNode, network, 150, 1, 20, 1);
+		Link plainYLink = NetworkUtils.createLink(Id.createLinkId("plainY"), node1, plainYNode, network, 150, 1, 20, 1);
+		Link loop = NetworkUtils.createLink(Id.createLinkId("1-1"), node1, node1, network, 150, 1, 20, 1);
 
 		//fromNode
-		Coord tp1 = new Coord(1,1);
-		assertEquals(n1,NetworkUtils.findNearestPointOnLink(tp1,link));
+		Coord tp1 = new Coord(1, 1);
+		assertEquals(n1, NetworkUtils.findNearestPointOnLink(tp1, link));
 
 		//toNode
-		Coord tp2 = new Coord(100,100);
-		assertEquals(n2,NetworkUtils.findNearestPointOnLink(tp2,link));
+		Coord tp2 = new Coord(100, 100);
+		assertEquals(n2, NetworkUtils.findNearestPointOnLink(tp2, link));
 
 		//on the link
-		Coord tp3 = new Coord(50,50);
-		assertEquals(tp3,NetworkUtils.findNearestPointOnLink(tp3,link));
+		Coord tp3 = new Coord(50, 50);
+		assertEquals(tp3, NetworkUtils.findNearestPointOnLink(tp3, link));
 
 		//along the link vector, but before link
-		Coord tp4 = new Coord(-50,-50);
-		assertEquals(n1,NetworkUtils.findNearestPointOnLink(tp4,link));
+		Coord tp4 = new Coord(-50, -50);
+		assertEquals(n1, NetworkUtils.findNearestPointOnLink(tp4, link));
 
 		//along the link vector, but after link ends
-		Coord tp5 = new Coord(150,150);
-		assertEquals(n2,NetworkUtils.findNearestPointOnLink(tp5,link));
+		Coord tp5 = new Coord(150, 150);
+		assertEquals(n2, NetworkUtils.findNearestPointOnLink(tp5, link));
 
 		//off the link, but before link start
-		Coord tp6 = new Coord(1,0);
-		assertEquals(new Coord(1,1),NetworkUtils.findNearestPointOnLink(tp6,link));
+		Coord tp6 = new Coord(1, 0);
+		assertEquals(new Coord(1, 1), NetworkUtils.findNearestPointOnLink(tp6, link));
 
 		//off the link, parallel to it
-		Coord tp7 = new Coord(2,1);
-		assertEquals(new Coord(1.5,1.5),NetworkUtils.findNearestPointOnLink(tp7,link));
+		Coord tp7 = new Coord(2, 1);
+		assertEquals(new Coord(1.5, 1.5), NetworkUtils.findNearestPointOnLink(tp7, link));
 
 		//off the link, parallel to it
-		Coord tp8 = new Coord(30,45);
-		assertEquals(new Coord(37.5,37.5),NetworkUtils.findNearestPointOnLink(tp8,link));
+		Coord tp8 = new Coord(30, 45);
+		assertEquals(new Coord(37.5, 37.5), NetworkUtils.findNearestPointOnLink(tp8, link));
 
 		//loop link
-		assertEquals(n1,NetworkUtils.findNearestPointOnLink(tp8,loop));
+		assertEquals(n1, NetworkUtils.findNearestPointOnLink(tp8, loop));
 
 		//link is plain in x & y
-		assertEquals(new Coord(1,45),NetworkUtils.findNearestPointOnLink(tp8,plainXLink));
-		assertEquals(new Coord(30,1),NetworkUtils.findNearestPointOnLink(tp8,plainYLink));
+		assertEquals(new Coord(1, 45), NetworkUtils.findNearestPointOnLink(tp8, plainXLink));
+		assertEquals(new Coord(30, 1), NetworkUtils.findNearestPointOnLink(tp8, plainYLink));
 
 	}
 
 	@Test
 	void getOriginalGeometry() {
 
-        var network = NetworkUtils.createNetwork();
-        var fromNode = NetworkUtils.createAndAddNode(network, Id.createNodeId("from"), new Coord(0, 0));
+		var network = NetworkUtils.createNetwork();
+		var fromNode = NetworkUtils.createAndAddNode(network, Id.createNodeId("from"), new Coord(0, 0));
 		var toNode = NetworkUtils.createAndAddNode(network, Id.createNodeId("to"), new Coord(100, 100));
 		var link = network.getFactory().createLink(Id.createLinkId("link"), fromNode, toNode);
 		network.addLink(link);
@@ -237,8 +237,8 @@ public class NetworkUtilsTest {
 	@Test
 	void getOriginalGeometry_noGeometryStored() {
 
-        var network = NetworkUtils.createNetwork();
-        var fromNode = NetworkUtils.createAndAddNode(network, Id.createNodeId("from"), new Coord(0, 0));
+		var network = NetworkUtils.createNetwork();
+		var fromNode = NetworkUtils.createAndAddNode(network, Id.createNodeId("from"), new Coord(0, 0));
 		var toNode = NetworkUtils.createAndAddNode(network, Id.createNodeId("to"), new Coord(100, 100));
 		var link = network.getFactory().createLink(Id.createLinkId("link"), fromNode, toNode);
 		network.addLink(link);
@@ -264,9 +264,8 @@ public class NetworkUtilsTest {
 	 */
 	@Test
 	void getOriginalGeometry_emptyGeometryStored() {
-
-        var network = NetworkUtils.createNetwork();
-        var fromNode = NetworkUtils.createAndAddNode(network, Id.createNodeId("from"), new Coord(0, 0));
+		var network = NetworkUtils.createNetwork();
+		var fromNode = NetworkUtils.createAndAddNode(network, Id.createNodeId("from"), new Coord(0, 0));
 		var toNode = NetworkUtils.createAndAddNode(network, Id.createNodeId("to"), new Coord(100, 100));
 		var link = network.getFactory().createLink(Id.createLinkId("link"), fromNode, toNode);
 		link.getAttributes().putAttribute(NetworkUtils.ORIG_GEOM, "");
@@ -286,6 +285,23 @@ public class NetworkUtilsTest {
 			assertEquals(expectedNode.getCoord(), actualNode.getCoord());
 		}
 
+	}
+
+	/**
+	 * Created this test when getting a ClasCastException from the attribute types.
+	 */
+	@Test
+	void getOrigId() {
+		var network = NetworkUtils.createNetwork();
+		var fromNode = NetworkUtils.createAndAddNode(network, Id.createNodeId("from"), new Coord(0, 0));
+		var toNode = NetworkUtils.createAndAddNode(network, Id.createNodeId("to"), new Coord(100, 100));
+		var link = network.getFactory().createLink(Id.createLinkId("link"), fromNode, toNode);
+
+		assertNull(NetworkUtils.getOrigId(link));
+		long origId = 123456L;
+		link.getAttributes().putAttribute(NetworkUtils.ORIGID, origId);
+		assertNotNull(NetworkUtils.getOrigId(link));
+		assertEquals(String.valueOf(origId), NetworkUtils.getOrigId(link));
 	}
 }
 


### PR DESCRIPTION
See issue #5106 where the `NetworkUtils` assumes the original Id is a `String` but it often is not. And a `long` being cast to a `String` results in a `ClassCastException`.