### PR TITLE
fix(application): write counts-from-bast hours 0 based

### DIFF
--- a/contribs/application/src/main/java/org/matsim/application/prepare/counts/CreateCountsFromBAStData.java
+++ b/contribs/application/src/main/java/org/matsim/application/prepare/counts/CreateCountsFromBAStData.java
@@ -133,7 +133,8 @@ public class CreateCountsFromBAStData implements MATSimAppCommand {
 		var freightTrafficVolumes = station.getFreightTrafficVolume();
 
 		for (String hour : mivTrafficVolumes.keySet()) {
-			int h = Integer.parseInt(hour);
+			//BASt counts the hours 01 to 24, where 01 is the hour from 00:00 to 01:00, while a Measurable starts at 0
+			int h = Integer.parseInt(hour) - 1;
 			Double mivAtHour = mivTrafficVolumes.get(hour);
 			Double freightAtHour = freightTrafficVolumes.get(hour);
 

--- a/contribs/application/src/test/java/org/matsim/application/prepare/counts/CreateCountsFromBAStDataTest.java
+++ b/contribs/application/src/test/java/org/matsim/application/prepare/counts/CreateCountsFromBAStDataTest.java
@@ -66,6 +66,12 @@ public class CreateCountsFromBAStDataTest {
 
 			assertThat(e.getValue().hasMeasurableForMode(Measurable.VOLUMES, TransportMode.truck))
 				.isTrue();
+
+			// BASt hour 01 covers 00:00 to 01:00, so a profile runs from hour 0 to hour 23
+			Measurable volumes = e.getValue().getVolumesForMode(TransportMode.car);
+			assertThat(volumes.getAtHour(0)).isPresent();
+			assertThat(volumes.getAtHour(23)).isPresent();
+			assertThat(volumes.getAtHour(24)).isEmpty();
 		}
 	}
 


### PR DESCRIPTION
BASt counts the hours 01 to 24, where 01 is the hour from 00:00 to 01:00, but the hour was passed to setAtHour unchanged. The profiles therefore ran t=3600 to t=86400, with no value at t=0 and one value past midnight.

A Measurable stores its values on a second axis, and aggregateAtHour reads the half open bin [h*3600, (h+1)*3600), so hour 0 is the hour from 00:00 to 01:00. It is the old Count API that counts from 1 to 24, which is why it rejects the hour 0 and converts with setAtHour(h - 1) before handing the value on. This command writes to a Measurable directly and did not convert.

The effect was not cosmetic. CountComparisonAnalysis aggregates the observed values over the hours 0 to 23, so every hour was compared against the simulated volume of the hour before it. The value at t=86400 fell outside that range and was dropped, and the absent value at t=0 was read from an Int2DoubleOpenHashMap as its default 0, so the first hour of the day was compared against an observed zero.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>