### PR TITLE
refactor(scoring): Clarify scoring parameter access for subpopulations

### DIFF
--- a/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/AccessibilityUtils.java
+++ b/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/AccessibilityUtils.java
@@ -77,7 +77,7 @@ public class AccessibilityUtils {
 			double distance_m = NetworkUtils.getEuclideanDistance(opportunity.getCoord(), nearestNode.getCoord());
 
 			// in MATSim this is [utils/h]: cnScoringGroup.getTravelingWalk_utils_hr() - cnScoringGroup.getPerforming_utils_hr()
-			double walkBetaTT_utils_h = config.scoring().getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling()
+			double walkBetaTT_utils_h = config.scoring().getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling()
 					- config.scoring().getPerforming_utils_hr(); // default values: -12 = (-6.) - (6.)
 			double VjkWalkTravelTime = walkBetaTT_utils_h * (distance_m / walkSpeed_m_h);
 
@@ -146,9 +146,9 @@ public class AccessibilityUtils {
 	public static double getModeSpecificConstantForAccessibilities(String mode, ScoringConfigGroup scoringConfigGroup) {
 		double modeSpecificConstant;
 		if (mode.equals(Modes4Accessibility.freespeed.name())) {
-			modeSpecificConstant = scoringConfigGroup.getModes().get(TransportMode.car).getConstant();
+			modeSpecificConstant = scoringConfigGroup.getDefaultModeParams().get(TransportMode.car).getConstant();
 		} else {
-			modeSpecificConstant = scoringConfigGroup.getModes().get(mode).getConstant();
+			modeSpecificConstant = scoringConfigGroup.getDefaultModeParams().get(mode).getConstant();
 		}
 		return modeSpecificConstant;
 	}

--- a/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/ConstantSpeedAccessibilityExpContributionCalculator.java
+++ b/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/ConstantSpeedAccessibilityExpContributionCalculator.java
@@ -95,8 +95,8 @@ final class ConstantSpeedAccessibilityExpContributionCalculator implements Acces
 		betaModeTD = modeParams.getMarginalUtilityOfDistance();
 		constMode = modeParams.getConstant();
 
-		betaWalkTT = scoringConfigGroup.getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling() - scoringConfigGroup.getPerforming_utils_hr();
-		betaWalkTD = scoringConfigGroup.getModes().get(TransportMode.walk).getMarginalUtilityOfDistance();
+		betaWalkTT = scoringConfigGroup.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() - scoringConfigGroup.getPerforming_utils_hr();
+		betaWalkTD = scoringConfigGroup.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfDistance();
 		this.walkSpeed_m_h = config.routing().getTeleportedModeSpeeds().get(TransportMode.walk) * 3600;
 	}
 

--- a/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/EstimatedDrtAccessibilityContributionCalculator.java
+++ b/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/EstimatedDrtAccessibilityContributionCalculator.java
@@ -87,12 +87,12 @@ final class EstimatedDrtAccessibilityContributionCalculator implements Accessibi
 		}
 
 		// drt params
-		this.betaDrtTT_h = scoringConfigGroup.getModes().get(TransportMode.drt).getMarginalUtilityOfTraveling() - scoringConfigGroup.getPerforming_utils_hr();
-		this.betaDrtDist_m = scoringConfigGroup.getModes().get(TransportMode.drt).getMarginalUtilityOfDistance();
+		this.betaDrtTT_h = scoringConfigGroup.getDefaultModeParams().get(TransportMode.drt).getMarginalUtilityOfTraveling() - scoringConfigGroup.getPerforming_utils_hr();
+		this.betaDrtDist_m = scoringConfigGroup.getDefaultModeParams().get(TransportMode.drt).getMarginalUtilityOfDistance();
 
 		// walk params
-		this.betaWalkTT_h = scoringConfigGroup.getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling() - scoringConfigGroup.getPerforming_utils_hr();
-		this.betaWalkDist_m = scoringConfigGroup.getModes().get(TransportMode.walk).getMarginalUtilityOfDistance();
+		this.betaWalkTT_h = scoringConfigGroup.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() - scoringConfigGroup.getPerforming_utils_hr();
+		this.betaWalkDist_m = scoringConfigGroup.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfDistance();
 
 	}
 

--- a/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/NetworkModeAccessibilityExpContributionCalculator.java
+++ b/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/NetworkModeAccessibilityExpContributionCalculator.java
@@ -78,7 +78,7 @@ final class NetworkModeAccessibilityExpContributionCalculator implements Accessi
 		//FastMultiNodeDijkstraFactory fastMultiNodeDijkstraFactory = new FastMultiNodeDijkstraFactory(true);
 		//this.multiNodePathCalculator = (MultiNodePathCalculator) fastMultiNodeDijkstraFactory.createPathCalculator(network, travelDisutility, travelTime);
 
-		betaWalkTT = scoringConfigGroup.getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling() - scoringConfigGroup.getPerforming_utils_hr();
+		betaWalkTT = scoringConfigGroup.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() - scoringConfigGroup.getPerforming_utils_hr();
 
 		this.walkSpeed_m_s = scenario.getConfig().routing().getTeleportedModeSpeeds().get(TransportMode.walk);
 	}

--- a/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/SwissRailRaptorAccessibilityContributionCalculator.java
+++ b/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/SwissRailRaptorAccessibilityContributionCalculator.java
@@ -79,8 +79,8 @@ class SwissRailRaptorAccessibilityContributionCalculator implements Accessibilit
 		this.scenario = scenario;
 		this.tripRouter = tripRouter;
 
-		this.betaWalkTT_h = scoringConfigGroup.getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling() - scoringConfigGroup.getPerforming_utils_hr();
-		this.betaWalkDist_m = scoringConfigGroup.getModes().get(TransportMode.walk).getMarginalUtilityOfDistance();
+		this.betaWalkTT_h = scoringConfigGroup.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() - scoringConfigGroup.getPerforming_utils_hr();
+		this.betaWalkDist_m = scoringConfigGroup.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfDistance();
 	}
 
 

--- a/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/TeleportedModeContributionCalculator.java
+++ b/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/TeleportedModeContributionCalculator.java
@@ -38,9 +38,9 @@ public class TeleportedModeContributionCalculator implements AccessibilityContri
 		this.mode = mode;
 		this.scoringConfigGroup = scoringConfigGroup;
 
-		this.betaTT_h = scoringConfigGroup.getModes().get(mode).getMarginalUtilityOfTraveling() - scoringConfigGroup.getPerforming_utils_hr();
-		this.betaDist_m = scoringConfigGroup.getModes().get(mode).getMarginalUtilityOfDistance();
-		this.asc = scoringConfigGroup.getModes().get(mode).getConstant();
+		this.betaTT_h = scoringConfigGroup.getDefaultModeParams().get(mode).getMarginalUtilityOfTraveling() - scoringConfigGroup.getPerforming_utils_hr();
+		this.betaDist_m = scoringConfigGroup.getDefaultModeParams().get(mode).getMarginalUtilityOfDistance();
+		this.asc = scoringConfigGroup.getDefaultModeParams().get(mode).getConstant();
 
 	}
 

--- a/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/TravelTimeBasedTravelDisutility.java
+++ b/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/TravelTimeBasedTravelDisutility.java
@@ -46,7 +46,7 @@ class TravelTimeBasedTravelDisutility implements TravelDisutility{
 		/* Usually, the travel-utility should be negative (it's a disutility)
 		 * but the cost should be positive. Thus negate the utility.
 		 */
-		this.marginalCostOfTime = (-cnScoringGroup.getModes().get(TransportMode.car).getMarginalUtilityOfTraveling() / 3600.0) + (cnScoringGroup.getPerforming_utils_hr() / 3600.0);
+		this.marginalCostOfTime = (-cnScoringGroup.getDefaultModeParams().get(TransportMode.car).getMarginalUtilityOfTraveling() / 3600.0) + (cnScoringGroup.getPerforming_utils_hr() / 3600.0);
 	}
 
 	@Override

--- a/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/TripRouterAccessibilityContributionCalculator.java
+++ b/contribs/accessibility/src/main/java/org/matsim/contrib/accessibility/TripRouterAccessibilityContributionCalculator.java
@@ -88,7 +88,7 @@ class TripRouterAccessibilityContributionCalculator implements AccessibilityCont
 		this.networkConfigGroup = scenario.getConfig().network();
 		this.scenario = scenario;
 
-		betaWalkTT = scoringConfigGroup.getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling() - scoringConfigGroup.getPerforming_utils_hr();
+		betaWalkTT = scoringConfigGroup.getModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() - scoringConfigGroup.getPerforming_utils_hr();
 
 		this.walkSpeed_m_s = scenario.getConfig().routing().getTeleportedModeSpeeds().get(TransportMode.walk);
 
@@ -152,12 +152,12 @@ class TripRouterAccessibilityContributionCalculator implements AccessibilityCont
 
 				// Note: The following computation where the end link length is added is only correct once the end link is removed from the route
 				// in the NetworkRoutingModule (route.setDistance(RouteUtils.calcDistance(route, 1.0, 0.0, this.network));)
-				if (this.scoringConfigGroup.getModes().get(leg.getMode()).getMarginalUtilityOfDistance() != 0.) {
+				if (this.scoringConfigGroup.getDefaultModeParams().get(leg.getMode()).getMarginalUtilityOfDistance() != 0.) {
 					LOG.warn("A computation including a marginal utility of distance will only be correct if the route time/distance" +
 							"inconsistency in the NetworkRoutingModule is solved.");
 				}
-				utility += (leg.getRoute().getDistance() + endLinkLength) * this.scoringConfigGroup.getModes().get(leg.getMode()).getMarginalUtilityOfDistance();
-				utility += (leg.getRoute().getTravelTime().seconds() + estimatedEndLinkTT) * this.scoringConfigGroup.getModes().get(leg.getMode()).getMarginalUtilityOfTraveling() / 3600.;
+				utility += (leg.getRoute().getDistance() + endLinkLength) * this.scoringConfigGroup.getDefaultModeParams().get(leg.getMode()).getMarginalUtilityOfDistance();
+				utility += (leg.getRoute().getTravelTime().seconds() + estimatedEndLinkTT) * this.scoringConfigGroup.getDefaultModeParams().get(leg.getMode()).getMarginalUtilityOfTraveling() / 3600.;
 				utility += -(leg.getRoute().getTravelTime().seconds() + estimatedEndLinkTT) * this.scoringConfigGroup.getPerforming_utils_hr() / 3600.;
 			}
 

--- a/contribs/accessibility/src/test/java/org/matsim/contrib/accessibility/run/EstimatedDrtAccessibilityTest.java
+++ b/contribs/accessibility/src/test/java/org/matsim/contrib/accessibility/run/EstimatedDrtAccessibilityTest.java
@@ -245,7 +245,7 @@ public class EstimatedDrtAccessibilityTest {
 
 		Config config = createTestConfig(network);
 
-		config.scoring().getModes().get(TransportMode.drt).setMarginalUtilityOfDistance(-0.001);
+		config.scoring().getDefaultModeParams().get(TransportMode.drt).setMarginalUtilityOfDistance(-0.001);
 
 
 		// Create  Scenario
@@ -312,7 +312,7 @@ public class EstimatedDrtAccessibilityTest {
 
 		Config config = createTestConfig(network);
 
-		config.scoring().getModes().get(TransportMode.drt).setConstant(10);
+		config.scoring().getDefaultModeParams().get(TransportMode.drt).setConstant(10);
 
 
 		// Create  Scenario

--- a/contribs/accessibility/src/test/java/org/matsim/contrib/accessibility/run/TinyAccessibilityTest.java
+++ b/contribs/accessibility/src/test/java/org/matsim/contrib/accessibility/run/TinyAccessibilityTest.java
@@ -228,7 +228,7 @@ public class TinyAccessibilityTest {
 		final Config config = createTestConfig();
 
 
-		config.scoring().getModes().get(TransportMode.walk).setConstant(-10);
+		config.scoring().getDefaultModeParams().get(TransportMode.walk).setConstant(-10);
 		double min = 0.; // Values for bounding box usually come from a config file
 		double max = 200.;
 

--- a/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/BicycleTravelDisutility.java
+++ b/contribs/bicycle/src/main/java/org/matsim/contrib/bicycle/BicycleTravelDisutility.java
@@ -68,9 +68,9 @@ class BicycleTravelDisutility implements TravelDisutility {
 
 	BicycleTravelDisutility(BicycleConfigGroup bicycleConfigGroup, ScoringConfigGroup cnScoringGroup,
 													RoutingConfigGroup routingConfigGroup, TravelTime timeCalculator, double normalization, BicycleParams bicycleParams) {
-		final ScoringConfigGroup.ModeParams bicycleModeParams = cnScoringGroup.getModes().get(bicycleConfigGroup.getBicycleMode());
+		final ScoringConfigGroup.ModeParams bicycleModeParams = cnScoringGroup.getDefaultModeParams().get(bicycleConfigGroup.getBicycleMode());
 		if (bicycleModeParams == null) {
-			throw new NullPointerException("Mode " + bicycleConfigGroup.getBicycleMode() + " is not part of the valid mode parameters " + cnScoringGroup.getModes().keySet());
+			throw new NullPointerException("Mode " + bicycleConfigGroup.getBicycleMode() + " is not part of the valid mode parameters " + cnScoringGroup.getDefaultModeParams().keySet());
 		}
 
 		this.bicycleParams = bicycleParams;

--- a/contribs/common/src/test/java/org/matsim/integration/always/BetaTravelTest66IT.java
+++ b/contribs/common/src/test/java/org/matsim/integration/always/BetaTravelTest66IT.java
@@ -322,7 +322,7 @@ public class BetaTravelTest66IT {
 		@Override
 		public void notifyStartup(final StartupEvent event) {
             // do some test to ensure the scenario is correct
-			double beta_travel = event.getServices().getConfig().scoring().getModes().get(TransportMode.car).getMarginalUtilityOfTraveling();
+			double beta_travel = event.getServices().getConfig().scoring().getDefaultModeParams().get(TransportMode.car).getMarginalUtilityOfTraveling();
             if ((beta_travel != -6.0) && (beta_travel != -66.0)) {
                 throw new IllegalArgumentException("Unexpected value for beta_travel. Expected -6.0 or -66.0, actual value is " + beta_travel);
             }
@@ -365,7 +365,7 @@ public class BetaTravelTest66IT {
 				event.getServices().getEvents().removeHandler(this.ttAnalyzer);
 			}
 			if (iteration == 100) {
-				double beta_travel = event.getServices().getConfig().scoring().getModes().get(TransportMode.car).getMarginalUtilityOfTraveling();
+				double beta_travel = event.getServices().getConfig().scoring().getDefaultModeParams().get(TransportMode.car).getMarginalUtilityOfTraveling();
 				/* ***************************************************************
 				 * AUTOMATIC VERIFICATION OF THE TESTS:
 				 *

--- a/contribs/common/src/test/java/org/matsim/integration/always/BetaTravelTest6IT.java
+++ b/contribs/common/src/test/java/org/matsim/integration/always/BetaTravelTest6IT.java
@@ -320,7 +320,7 @@ public class BetaTravelTest6IT {
 		@Override
 		public void notifyStartup(final StartupEvent event) {
             // do some test to ensure the scenario is correct
-			double beta_travel = event.getServices().getConfig().scoring().getModes().get(TransportMode.car).getMarginalUtilityOfTraveling();
+			double beta_travel = event.getServices().getConfig().scoring().getDefaultModeParams().get(TransportMode.car).getMarginalUtilityOfTraveling();
             if ((beta_travel != -6.0) && (beta_travel != -66.0)) {
                 throw new IllegalArgumentException("Unexpected value for beta_travel. Expected -6.0 or -66.0, actual value is " + beta_travel);
             }
@@ -363,7 +363,7 @@ public class BetaTravelTest6IT {
 				event.getServices().getEvents().removeHandler(this.ttAnalyzer);
 			}
 			if (iteration == 100) {
-				double beta_travel = event.getServices().getConfig().scoring().getModes().get(TransportMode.car).getMarginalUtilityOfTraveling();
+				double beta_travel = event.getServices().getConfig().scoring().getDefaultModeParams().get(TransportMode.car).getMarginalUtilityOfTraveling();
 				/* ***************************************************************
 				 * AUTOMATIC VERIFICATION OF THE TESTS:
 				 *

--- a/contribs/decongestion/src/main/java/org/matsim/contrib/decongestion/tollSetting/DecongestionTollingP_MCP.java
+++ b/contribs/decongestion/src/main/java/org/matsim/contrib/decongestion/tollSetting/DecongestionTollingP_MCP.java
@@ -56,7 +56,7 @@ public class DecongestionTollingP_MCP implements DecongestionTollSetting, LinkLe
 	public void updateTolls() {
 
 		final double vtts = ( this.congestionInfo.getScenario().getConfig().scoring().getPerforming_utils_hr()
-				- this.congestionInfo.getScenario().getConfig().scoring().getModes().get(TransportMode.car).getMarginalUtilityOfTraveling() )
+				- this.congestionInfo.getScenario().getConfig().scoring().getDefaultModeParams().get(TransportMode.car).getMarginalUtilityOfTraveling() )
 				/ this.congestionInfo.getScenario().getConfig().scoring().getMarginalUtilityOfMoney();
 
 

--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigs.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtConfigs.java
@@ -51,7 +51,7 @@ public class DrtConfigs {
 		ScoringConfigGroup.ActivityParams params = new ScoringConfigGroup.ActivityParams(stageActivityType);
 		params.setTypicalDuration(1);
 		params.setScoringThisActivityAtAll(false);
-		planCalcScoreCfg.getScoringParametersPerSubpopulation().values().forEach(k -> k.addActivityParams(params));
+		planCalcScoreCfg.getAllScoringParameterSetsPerSubpopulation().values().forEach(k -> k.addActivityParams(params));
 		if (planCalcScoreCfg.getScoringParameters(null) != null)
 			planCalcScoreCfg.addActivityParams(params);
 		LOGGER.info("drt interaction scoring parameters not set. Adding default values (activity will not be scored).");

--- a/contribs/hybridsim/src/main/java/org/matsim/contrib/hybridsim/run/RunExample.java
+++ b/contribs/hybridsim/src/main/java/org/matsim/contrib/hybridsim/run/RunExample.java
@@ -349,8 +349,8 @@ public class RunExample {
 		c.scoring().addActivityParams(pre);
 		c.scoring().addActivityParams(post);
 
-		c.scoring().setLateArrival_utils_hr(0.);
-		c.scoring().setPerforming_utils_hr(0.);
+		c.scoring().setDefaultLateArrival_utils_hr(0.);
+		c.scoring().setDefaultPerforming_utils_hr(0.);
 	}
 
 	private static void createPopulation(Scenario sc) {

--- a/contribs/locationchoice/src/main/java/org/matsim/contrib/locationchoice/frozenepsilons/BestReplyLocationChoicePlanAlgorithm.java
+++ b/contribs/locationchoice/src/main/java/org/matsim/contrib/locationchoice/frozenepsilons/BestReplyLocationChoicePlanAlgorithm.java
@@ -227,7 +227,7 @@ final class BestReplyLocationChoicePlanAlgorithm implements PlanAlgorithm {
 		 * here one could do a much more sophisticated calculation including time use and travel speed estimations (from previous iteration)
 		 */
 		double travelSpeedCrowFly = this.dccg.getTravelSpeed_car();
-		double betaTime = this.scenario.getConfig().scoring().getModes().get(TransportMode.car ).getMarginalUtilityOfTraveling();
+		double betaTime = this.scenario.getConfig().scoring().getDefaultModeParams().get(TransportMode.car ).getMarginalUtilityOfTraveling();
 //		if ( Boolean.getBoolean(this.scenario.getConfig().vspExperimental().getValue(VspExperimentalConfigKey.isUsingOpportunityCostOfTimeForLocationChoice)) ) {
 		if ( this.scenario.getConfig().vspExperimental().isUsingOpportunityCostOfTimeForLocationChoice() ) {
 			betaTime -= this.scenario.getConfig().scoring().getPerforming_utils_hr() ;

--- a/contribs/matrixbasedptrouter/src/main/java/org/matsim/contrib/matrixbasedptrouter/PtMatrix.java
+++ b/contribs/matrixbasedptrouter/src/main/java/org/matsim/contrib/matrixbasedptrouter/PtMatrix.java
@@ -294,11 +294,11 @@ public final class PtMatrix {
 	}
 
 	public LeastCostPathCalculator asPathCalculator(ScoringConfigGroup scoringConfigGroup) {
-		final double betaWalkTT	= scoringConfigGroup.getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling() - scoringConfigGroup.getPerforming_utils_hr();
-		final double betaWalkTD	= scoringConfigGroup.getModes().get(TransportMode.walk).getMarginalUtilityOfDistance();
-		final double betaPtTT = scoringConfigGroup.getModes().get(TransportMode.pt).getMarginalUtilityOfTraveling() - scoringConfigGroup.getPerforming_utils_hr();
-		final double betaPtTD = scoringConfigGroup.getMarginalUtilityOfMoney() * scoringConfigGroup.getModes().get(TransportMode.pt).getMonetaryDistanceRate();
-		final double constPt = scoringConfigGroup.getModes().get(TransportMode.pt).getConstant();
+		final double betaWalkTT	= scoringConfigGroup.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() - scoringConfigGroup.getPerforming_utils_hr();
+		final double betaWalkTD	= scoringConfigGroup.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfDistance();
+		final double betaPtTT = scoringConfigGroup.getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling() - scoringConfigGroup.getPerforming_utils_hr();
+		final double betaPtTD = scoringConfigGroup.getMarginalUtilityOfMoney() * scoringConfigGroup.getDefaultModeParams().get(TransportMode.pt).getMonetaryDistanceRate();
+		final double constPt = scoringConfigGroup.getDefaultModeParams().get(TransportMode.pt).getConstant();
 
 		return new LeastCostPathCalculator() {
 			@Override

--- a/contribs/vsp/src/main/java/org/matsim/application/analysis/population/AgentWiseComparisonKN.java
+++ b/contribs/vsp/src/main/java/org/matsim/application/analysis/population/AgentWiseComparisonKN.java
@@ -362,7 +362,7 @@ public class AgentWiseComparisonKN implements MATSimAppCommand{
 				boolean haveAddedFirstPtAscOfTrip = false;
 				for( Leg leg : trip.getLegsOnly() ){
 					final ScoringParameterSet subpopScoringParams = config.scoring().getScoringParameters( PopulationUtils.getSubpopulation( person ) );
-					final ModeParams modeParams = subpopScoringParams.getModes().get( leg.getMode() );
+					final ModeParams modeParams = subpopScoringParams.getModeParams().get( leg.getMode() );
 
 					// ttime:
 					sumTtimes += leg.getTravelTime().seconds();

--- a/contribs/vsp/src/main/java/org/matsim/application/analysis/population/AgentWiseComparisonKNDeprecated.java
+++ b/contribs/vsp/src/main/java/org/matsim/application/analysis/population/AgentWiseComparisonKNDeprecated.java
@@ -98,7 +98,7 @@ class AgentWiseComparisonKNDeprecated extends AgentWiseComparisonKN{
 				boolean haveAddedFirstPtAscOfTrip = false;
 				for( Leg leg : trip.getLegsOnly() ){
 					final ScoringConfigGroup.ScoringParameterSet subpopScoringParams = config.scoring().getScoringParameters( PopulationUtils.getSubpopulation( person ) );
-					final ScoringConfigGroup.ModeParams modeParams = subpopScoringParams.getModes().get( leg.getMode() );
+					final ScoringConfigGroup.ModeParams modeParams = subpopScoringParams.getModeParams().get( leg.getMode() );
 
 					// ttime:
 					tripTtime += leg.getTravelTime().seconds();

--- a/contribs/vsp/src/main/java/org/matsim/application/analysis/population/AgentWiseComparisonKNExample.java
+++ b/contribs/vsp/src/main/java/org/matsim/application/analysis/population/AgentWiseComparisonKNExample.java
@@ -170,7 +170,7 @@ class AgentWiseComparisonKNExample{
 		config.scoring().addActivityParams( new ActivityParams( "home_12" ).setTypicalDuration( 12. * 3600 ) );
 		config.scoring().addActivityParams( new ActivityParams( "work_12" ).setTypicalDuration( 12. * 3600 ) );
 
-		for( ModeParams modeParams : config.scoring().getModes().values() ){
+		for( ModeParams modeParams : config.scoring().getDefaultModeParams().values() ){
 			modeParams.setMarginalUtilityOfTraveling( 0. );
 		}
 	}

--- a/contribs/vsp/src/main/java/org/matsim/application/analysis/population/AgentWiseComparisonKNUtils.java
+++ b/contribs/vsp/src/main/java/org/matsim/application/analysis/population/AgentWiseComparisonKNUtils.java
@@ -419,7 +419,7 @@ class AgentWiseComparisonKNUtils{
 	static void writeAscTable( Config config ){
 		Table summaryTable = Table.create( DoubleColumn.create( "ASC" ), StringColumn.create( "mode" ));
 
-		for( ScoringConfigGroup.ModeParams modeParams : config.scoring().getModes().values() ){
+		for( ScoringConfigGroup.ModeParams modeParams : config.scoring().getDefaultModeParams().values() ){
 			summaryTable.doubleColumn( "ASC" ).append( modeParams.getConstant() );
 			summaryTable.stringColumn( "mode" ).append( modeParams.getMode() ) ;
 		}

--- a/contribs/vsp/src/main/java/org/matsim/application/analysis/population/VTTSHandler.java
+++ b/contribs/vsp/src/main/java/org/matsim/application/analysis/population/VTTSHandler.java
@@ -147,7 +147,7 @@ public final class VTTSHandler implements ActivityStartEventHandler, ActivityEnd
 		this.currentIteration = Integer.MIN_VALUE;
 		this.defaultVTTS_moneyPerHour =
 				(this.scenario.getConfig().scoring().getPerforming_utils_hr()
-						 + this.scenario.getConfig().scoring().getModes().get( TransportMode.car ).getMarginalUtilityOfTraveling() * (-1.0)
+						 + this.scenario.getConfig().scoring().getModeParams().get( TransportMode.car ).getMarginalUtilityOfTraveling() * (-1.0)
 				) / this.scenario.getConfig().scoring().getMarginalUtilityOfMoney();
 	}
 
@@ -421,8 +421,8 @@ public final class VTTSHandler implements ActivityStartEventHandler, ActivityEnd
 		// (Could be done similarly to the activity delay disutility. As long as it is computed linearly, the following should be okay.)
 		String mode = simData.trips.getLast().mode;
 		double directMarginalUtilityOfTraveling = 0.;
-		if( scoringConfigGroup.getModes().get( mode ) != null ){
-			directMarginalUtilityOfTraveling = scoringConfigGroup.getModes().get( mode ).getMarginalUtilityOfTraveling();
+		if( scoringConfigGroup.getDefaultModeParams().get( mode ) != null ){
+			directMarginalUtilityOfTraveling = scoringConfigGroup.getDefaultModeParams().get( mode ).getMarginalUtilityOfTraveling();
 		} else{
 			log.warn( "Could not identify the marginal utility of traveling for mode={}. Setting this value to zero. (Probably using subpopulations...)", mode );
 		}

--- a/contribs/vsp/src/main/java/org/matsim/contrib/vsp/pt/fare/PtFareModule.java
+++ b/contribs/vsp/src/main/java/org/matsim/contrib/vsp/pt/fare/PtFareModule.java
@@ -15,8 +15,8 @@ public class PtFareModule extends AbstractModule {
 
 	@Override
 	public void install() {
-		getConfig().scoring().getModes().get(TransportMode.pt).setDailyMonetaryConstant(0);
-		getConfig().scoring().getModes().get(TransportMode.pt).setMarginalUtilityOfDistance(0);
+		getConfig().scoring().getDefaultModeParams().get(TransportMode.pt).setDailyMonetaryConstant(0);
+		getConfig().scoring().getDefaultModeParams().get(TransportMode.pt).setMarginalUtilityOfDistance(0);
 		Multibinder<PtFareCalculator> ptFareCalculator = Multibinder.newSetBinder(binder(), PtFareCalculator.class);
 
 		PtFareConfigGroup ptFareConfigGroup = ConfigUtils.addOrGetModule(this.getConfig(), PtFareConfigGroup.class);

--- a/contribs/vsp/src/main/java/org/matsim/core/scoring/functions/PersonScoringParametersFromPersonAttributes.java
+++ b/contribs/vsp/src/main/java/org/matsim/core/scoring/functions/PersonScoringParametersFromPersonAttributes.java
@@ -160,7 +160,7 @@ public class PersonScoringParametersFromPersonAttributes implements ScoringParam
             Map<String, String> personalScoringModeConstants = PersonUtils.getModeConstants(person);
             if (personalScoringModeConstants != null) {
                 for (Map.Entry<String, String> entry: personalScoringModeConstants.entrySet()) {
-					ScoringConfigGroup.ModeParams subpopulationModeParams = subpopulationScoringParams.getModes().get(entry.getKey());
+					ScoringConfigGroup.ModeParams subpopulationModeParams = subpopulationScoringParams.getModeParams().get(entry.getKey());
 					ModeUtilityParameters.Builder modeUtilityParamsBuilder = new ModeUtilityParameters.Builder();
                     try {
                         modeUtilityParamsBuilder.setConstant(Double.parseDouble(entry.getValue()) +

--- a/contribs/vsp/src/main/java/org/matsim/core/scoring/functions/VehicleTypeBasedScoringUtils.java
+++ b/contribs/vsp/src/main/java/org/matsim/core/scoring/functions/VehicleTypeBasedScoringUtils.java
@@ -12,7 +12,7 @@ final class VehicleTypeBasedScoringUtils {
 	static ScoringConfigGroup.ModeParams getOrCreateModeParams(ScoringConfigGroup.ScoringParameterSet scoringParameterSet, VehicleType vehicleType) {
 		synchronized (scoringParameterSet) {
 			String mode = vehicleType.getId().toString();
-			ScoringConfigGroup.ModeParams modeParams = scoringParameterSet.getModes().get(mode);
+			ScoringConfigGroup.ModeParams modeParams = scoringParameterSet.getModeParams().get(mode);
 			if (modeParams != null) {
 				return modeParams;
 			}

--- a/contribs/vsp/src/main/java/playground/vsp/congestion/analysis/CongestionAnalysisEventHandler.java
+++ b/contribs/vsp/src/main/java/playground/vsp/congestion/analysis/CongestionAnalysisEventHandler.java
@@ -95,7 +95,7 @@ public class CongestionAnalysisEventHandler implements PersonMoneyEventHandler, 
 		if (useMoneyEvents) {
 			log.warn("Money events may be thrown later than the congestion events... May result in a wrong interpretation of the results. Better use directly the congestion events for analysis.");
 		}
-		this.vtts_car = (this.scenario.getConfig().scoring().getModes().get(TransportMode.car).getMarginalUtilityOfTraveling() - this.scenario.getConfig().scoring().getPerforming_utils_hr()) / this.scenario.getConfig().scoring().getMarginalUtilityOfMoney();
+		this.vtts_car = (this.scenario.getConfig().scoring().getDefaultModeParams().get(TransportMode.car).getMarginalUtilityOfTraveling() - this.scenario.getConfig().scoring().getPerforming_utils_hr()) / this.scenario.getConfig().scoring().getMarginalUtilityOfMoney();
 		log.info("Anlayzing the congestion events during the simulation. Assuming the following VTTS (equal for all agents): " + vtts_car);
 	}
 

--- a/contribs/vsp/src/main/java/playground/vsp/congestion/handlers/AdvancedMarginalCongestionPricingHandler.java
+++ b/contribs/vsp/src/main/java/playground/vsp/congestion/handlers/AdvancedMarginalCongestionPricingHandler.java
@@ -246,7 +246,7 @@ public class AdvancedMarginalCongestionPricingHandler implements CongestionEvent
 			}
 
 			// Calculate the agent's trip delay disutility (could be done similar to the activity delay disutility).
-			double tripDelayDisutility = (totalDelayThisPerson / 3600.) * this.scenario.getConfig().scoring().getModes().get(TransportMode.car).getMarginalUtilityOfTraveling() * (-1);
+			double tripDelayDisutility = (totalDelayThisPerson / 3600.) * this.scenario.getConfig().scoring().getDefaultModeParams().get(TransportMode.car).getMarginalUtilityOfTraveling() * (-1);
 
 			// Translate the disutility into monetary units.
 			double totalDelayCost = (activityDelayDisutility + tripDelayDisutility) / this.scenario.getConfig().scoring().getMarginalUtilityOfMoney();

--- a/contribs/vsp/src/main/java/playground/vsp/congestion/handlers/MarginalCongestionPricingHandler.java
+++ b/contribs/vsp/src/main/java/playground/vsp/congestion/handlers/MarginalCongestionPricingHandler.java
@@ -59,7 +59,7 @@ public class MarginalCongestionPricingHandler implements CongestionEventHandler 
 	public MarginalCongestionPricingHandler(EventsManager eventsManager, Scenario scenario, double factor) {
 		this.events = eventsManager;
 		this.scenario = scenario;
-		this.vtts_car = (this.scenario.getConfig().scoring().getModes().get(TransportMode.car).getMarginalUtilityOfTraveling() - this.scenario.getConfig().scoring().getPerforming_utils_hr()) / this.scenario.getConfig().scoring().getMarginalUtilityOfMoney();
+		this.vtts_car = (this.scenario.getConfig().scoring().getDefaultModeParams().get(TransportMode.car).getMarginalUtilityOfTraveling() - this.scenario.getConfig().scoring().getPerforming_utils_hr()) / this.scenario.getConfig().scoring().getMarginalUtilityOfMoney();
 		this.factor = factor;
 
 		log.info("Using the toll factor " + factor);

--- a/contribs/vsp/src/main/java/playground/vsp/congestion/handlers/TollHandler.java
+++ b/contribs/vsp/src/main/java/playground/vsp/congestion/handlers/TollHandler.java
@@ -68,7 +68,7 @@ public class TollHandler implements CongestionEventHandler, LinkEnterEventHandle
 	private double congestionTollFactor;
 
 	public TollHandler(Scenario scenario, double congestionTollFactor) {
-		this.vtts_car = (scenario.getConfig().scoring().getModes().get(TransportMode.car).getMarginalUtilityOfTraveling() - scenario.getConfig().scoring().getPerforming_utils_hr()) / scenario.getConfig().scoring().getMarginalUtilityOfMoney();
+		this.vtts_car = (scenario.getConfig().scoring().getDefaultModeParams().get(TransportMode.car).getMarginalUtilityOfTraveling() - scenario.getConfig().scoring().getPerforming_utils_hr()) / scenario.getConfig().scoring().getMarginalUtilityOfMoney();
 		this.congestionTollFactor = congestionTollFactor;
 		log.info("VTTS_car: " + vtts_car);
 		log.info("Congestion toll factor: " + congestionTollFactor);

--- a/contribs/vsp/src/main/java/playground/vsp/congestion/routing/TollTravelDisutilityCalculator.java
+++ b/contribs/vsp/src/main/java/playground/vsp/congestion/routing/TollTravelDisutilityCalculator.java
@@ -59,9 +59,9 @@ public class TollTravelDisutilityCalculator implements TravelDisutility{
 	public TollTravelDisutilityCalculator(TravelTime timeCalculator, ScoringConfigGroup cnScoringGroup, TollHandler tollHandler) {
 		this.timeCalculator = timeCalculator;
 		this.marginalUtlOfMoney = cnScoringGroup.getMarginalUtilityOfMoney();
-		this.distanceCostRateCar = cnScoringGroup.getModes().get(TransportMode.car).getMonetaryDistanceRate();
-		// ignores cnScoringGroup.getModes().get(TransportMode.car).getMarginalUtilityOfDistance();
-		this.marginalUtlOfTravelTime = (-cnScoringGroup.getModes().get(TransportMode.car).getMarginalUtilityOfTraveling() / 3600.0) + (cnScoringGroup.getPerforming_utils_hr() / 3600.0);
+		this.distanceCostRateCar = cnScoringGroup.getDefaultModeParams().get(TransportMode.car).getMonetaryDistanceRate();
+		// ignores cnScoringGroup.getModeParams().get(TransportMode.car).getMarginalUtilityOfDistance();
+		this.marginalUtlOfTravelTime = (-cnScoringGroup.getDefaultModeParams().get(TransportMode.car).getMarginalUtilityOfTraveling() / 3600.0) + (cnScoringGroup.getPerforming_utils_hr() / 3600.0);
 		this.tollHandler = tollHandler;
 
 		log.info("The 'blend factor' which is used for the calculation of the expected tolls in the next iteration is set to " + this.blendFactor);

--- a/contribs/vsp/src/test/java/org/matsim/contrib/vsp/pt/fare/PtTripFareEstimatorTest.java
+++ b/contribs/vsp/src/test/java/org/matsim/contrib/vsp/pt/fare/PtTripFareEstimatorTest.java
@@ -55,7 +55,6 @@ public class PtTripFareEstimatorTest {
 
 		Config config = TestScenario.loadConfig(utils);
 
-		Map<String, ScoringConfigGroup.ModeParams> modes = config.scoring().getScoringParameters("person").getModes();
 		group = ConfigUtils.addOrGetModule(config, InformedModeChoiceConfigGroup.class);
 
 		PtFareConfigGroup fare = ConfigUtils.addOrGetModule(config, PtFareConfigGroup.class);

--- a/contribs/vsp/src/test/java/org/matsim/core/scoring/functions/PersonScoringParametersFromPersonAttributesIT.java
+++ b/contribs/vsp/src/test/java/org/matsim/core/scoring/functions/PersonScoringParametersFromPersonAttributesIT.java
@@ -52,7 +52,7 @@ public class PersonScoringParametersFromPersonAttributesIT {
         config.controller().setOutputDirectory(testUtils.getOutputDirectory());
         config.controller().setLastIteration(0);
         config.scoring().setPerforming_utils_hr(0.0d);
-        config.scoring().getModes().get(TransportMode.car).setMarginalUtilityOfTraveling(0.0d);
+        config.scoring().getDefaultModeParams().get(TransportMode.car).setMarginalUtilityOfTraveling(0.0d);
         config.plans().setInputFile("plans2.xml");
 		//This is needed because the plans don't contain access/egress legs. The test would otherwise fail. paul, jul'26
 		config.routing().setAccessEgressConsistencyCheck(RoutingConfigGroup.AccessEgressConsistencyCheck.disable);

--- a/contribs/vsp/src/test/java/org/matsim/core/scoring/functions/VehicleTypeBasedLegScoringTest.java
+++ b/contribs/vsp/src/test/java/org/matsim/core/scoring/functions/VehicleTypeBasedLegScoringTest.java
@@ -126,10 +126,10 @@ class VehicleTypeBasedLegScoringTest {
 		);
 		freightScoring.handleTrip(TripStructureUtils.getTrips2(List.of(createLeg(TransportMode.car, 20, 30, freightTruckId))).getFirst());
 
-		assertVehicleTypeParams(privateScoringParameterSet.getModes().get("privateTruck"));
-		assertNull(privateScoringParameterSet.getModes().get("freightTruck"));
-		assertVehicleTypeParams(freightScoringParameterSet.getModes().get("freightTruck"));
-		assertNull(freightScoringParameterSet.getModes().get("privateTruck"));
+		assertVehicleTypeParams(privateScoringParameterSet.getModeParams().get("privateTruck"));
+		assertNull(privateScoringParameterSet.getModeParams().get("freightTruck"));
+		assertVehicleTypeParams(freightScoringParameterSet.getModeParams().get("freightTruck"));
+		assertNull(freightScoringParameterSet.getModeParams().get("privateTruck"));
 
 		var outFile = utils.getOutputDirectory() + "/vehicle-type-based-scoring-config.xml";
 		new ConfigWriter(config).write(outFile);
@@ -139,10 +139,10 @@ class VehicleTypeBasedLegScoringTest {
 
 		var readPrivateParams = readConfig.scoring().getScoringParameters("private");
 		var readFreightParams = readConfig.scoring().getScoringParameters("freight");
-		assertVehicleTypeParams(readPrivateParams.getModes().get("privateTruck"));
-		assertNull(readPrivateParams.getModes().get("freightTruck"));
-		assertVehicleTypeParams(readFreightParams.getModes().get("freightTruck"));
-		assertNull(readFreightParams.getModes().get("privateTruck"));
+		assertVehicleTypeParams(readPrivateParams.getModeParams().get("privateTruck"));
+		assertNull(readPrivateParams.getModeParams().get("freightTruck"));
+		assertVehicleTypeParams(readFreightParams.getModeParams().get("freightTruck"));
+		assertNull(readFreightParams.getModeParams().get("privateTruck"));
 	}
 
 	@Test
@@ -167,7 +167,7 @@ class VehicleTypeBasedLegScoringTest {
 		var scoring = new VehicleTypeBasedLegScoring(vehicles, params, scoringParameterSet, Set.of());
 		scoring.handleTrip(TripStructureUtils.getTrips2(List.of(createLeg(TransportMode.car, 20, 30, truckId))).getFirst());
 
-		var truckParams = scoringConfig.getScoringParameters(null).getModes().get("truck");
+		var truckParams = scoringConfig.getScoringParameters(null).getModeParams().get("truck");
 		assertNotNull(truckParams);
 		assertEquals(-99.0, truckParams.getConstant(), MatsimTestUtils.EPSILON);
 		assertEquals(-88.0, truckParams.getMarginalUtilityOfTraveling(), MatsimTestUtils.EPSILON);

--- a/contribs/vsp/src/test/java/org/matsim/integration/drtAndPt/PtAlongALine2Test.java
+++ b/contribs/vsp/src/test/java/org/matsim/integration/drtAndPt/PtAlongALine2Test.java
@@ -195,7 +195,7 @@ public class PtAlongALine2Test {
 
 		// === SCORING: ===
 
-		double margUtlTravPt = config.scoring().getModes().get(TransportMode.pt).getMarginalUtilityOfTraveling();
+		double margUtlTravPt = config.scoring().getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling();
 		if (drtMode != DrtMode.none) {
 			// (scoring parameters for drt modes)
 			config.scoring()
@@ -654,8 +654,7 @@ public class PtAlongALine2Test {
 
 		// === SCORING: ===
 		{
-			double margUtlTravPt = config.scoring()
-					.getModes()
+			double margUtlTravPt = config.scoring().getDefaultModeParams()
 					.get(TransportMode.pt)
 					.getMarginalUtilityOfTraveling();
 			config.scoring()

--- a/contribs/vsp/src/test/java/playground/vsp/congestion/AdvancedMarginalCongestionPricingIT.java
+++ b/contribs/vsp/src/test/java/playground/vsp/congestion/AdvancedMarginalCongestionPricingIT.java
@@ -307,7 +307,7 @@ public class AdvancedMarginalCongestionPricingIT {
 		Assertions.assertEquals(2.0, delay, MatsimTestUtils.EPSILON, "Wrong delay.");
 
 		double amountFromEvent = moneyEvents.get(0).getAmount();
-		double tripDelayDisutility = delay / 3600. * controler.getConfig().scoring().getModes().get(TransportMode.car).getMarginalUtilityOfTraveling() * (-1);
+		double tripDelayDisutility = delay / 3600. * controler.getConfig().scoring().getDefaultModeParams().get(TransportMode.car).getMarginalUtilityOfTraveling() * (-1);
 		// with delay --> 70.570685898554200
 		// without delay --> 70.573360291244900
 		double activityDelayDisutility = 70.573360291244900 - 70.570685898554200;
@@ -387,7 +387,7 @@ public class AdvancedMarginalCongestionPricingIT {
 		Assertions.assertEquals(2.0, delay, MatsimTestUtils.EPSILON, "Wrong delay.");
 
 		double amountFromEvent = moneyEvents.get(0).getAmount();
-		double tripDelayDisutility = delay / 3600. * controler.getConfig().scoring().getModes().get(TransportMode.car).getMarginalUtilityOfTraveling() * (-1);
+		double tripDelayDisutility = delay / 3600. * controler.getConfig().scoring().getDefaultModeParams().get(TransportMode.car).getMarginalUtilityOfTraveling() * (-1);
 
 		// home duration morning: 28800.
 		// home duration evening with delay: (24 * 3600.) - 57705.

--- a/contribs/vsp/src/test/java/playground/vsp/congestion/AdvancedMarginalCongestionPricingIT.java
+++ b/contribs/vsp/src/test/java/playground/vsp/congestion/AdvancedMarginalCongestionPricingIT.java
@@ -84,10 +84,10 @@ public class AdvancedMarginalCongestionPricingIT {
 		activityParams.setClosingTime(18 * 3600.);
 
 		plansCalcScoreConfigGroup.addActivityParams(activityParams);
-		plansCalcScoreConfigGroup.setEarlyDeparture_utils_hr(0.);
-		plansCalcScoreConfigGroup.setLateArrival_utils_hr(0.);
-		plansCalcScoreConfigGroup.setMarginalUtlOfWaiting_utils_hr(0.);
-		plansCalcScoreConfigGroup.setPerforming_utils_hr(6.);
+		plansCalcScoreConfigGroup.setDefaultEarlyDeparture_utils_hr(0.);
+		plansCalcScoreConfigGroup.setDefaultLateArrival_utils_hr(0.);
+		plansCalcScoreConfigGroup.setDefaultMarginalUtlOfWaiting_utils_hr(0.);
+		plansCalcScoreConfigGroup.setDefaultPerforming_utils_hr(6.);
 
 		ScenarioConfigGroup scenarioConfig = new ScenarioConfigGroup();
 
@@ -142,19 +142,19 @@ public class AdvancedMarginalCongestionPricingIT {
 	@Test
 	final void test0b(){
 
-		ScoringConfigGroup plansCalcScoreConfigGroup = new ScoringConfigGroup();
+		ScoringConfigGroup scoringConfigGroup = new ScoringConfigGroup();
 		ActivityParams activityParams = new ActivityParams("overnightActivity");
 		activityParams.setTypicalDuration(12 * 3600.);
 
-		plansCalcScoreConfigGroup.addActivityParams(activityParams);
-		plansCalcScoreConfigGroup.setEarlyDeparture_utils_hr(0.);
-		plansCalcScoreConfigGroup.setLateArrival_utils_hr(0.);
-		plansCalcScoreConfigGroup.setMarginalUtlOfWaiting_utils_hr(0.);
-		plansCalcScoreConfigGroup.setPerforming_utils_hr(6.);
+		scoringConfigGroup.addActivityParams(activityParams);
+		scoringConfigGroup.setDefaultEarlyDeparture_utils_hr(0.);
+		scoringConfigGroup.setDefaultLateArrival_utils_hr(0.);
+		scoringConfigGroup.setDefaultMarginalUtlOfWaiting_utils_hr(0.);
+		scoringConfigGroup.setDefaultPerforming_utils_hr(6.);
 
 		ScenarioConfigGroup scenarioConfig = new ScenarioConfigGroup();
 
-		ScoringParameters params = new ScoringParameters.Builder(plansCalcScoreConfigGroup, plansCalcScoreConfigGroup.getScoringParameters(null), scenarioConfig).build();
+		ScoringParameters params = new ScoringParameters.Builder(scoringConfigGroup, scoringConfigGroup.getScoringParameters(null), scenarioConfig).build();
 
 		MarginalSumScoringFunction marginaSumScoringFunction = new MarginalSumScoringFunction(params);
 
@@ -201,10 +201,10 @@ public class AdvancedMarginalCongestionPricingIT {
 		plansCalcScoreConfigGroup.addActivityParams(activityParams1);
 		plansCalcScoreConfigGroup.addActivityParams(activityParams2);
 
-		plansCalcScoreConfigGroup.setEarlyDeparture_utils_hr(0.);
-		plansCalcScoreConfigGroup.setLateArrival_utils_hr(0.);
-		plansCalcScoreConfigGroup.setMarginalUtlOfWaiting_utils_hr(0.);
-		plansCalcScoreConfigGroup.setPerforming_utils_hr(6.);
+		plansCalcScoreConfigGroup.setDefaultEarlyDeparture_utils_hr(0.);
+		plansCalcScoreConfigGroup.setDefaultLateArrival_utils_hr(0.);
+		plansCalcScoreConfigGroup.setDefaultMarginalUtlOfWaiting_utils_hr(0.);
+		plansCalcScoreConfigGroup.setDefaultPerforming_utils_hr(6.);
 
 		ScenarioConfigGroup scenarioConfig = new ScenarioConfigGroup();
 		ScoringParameters params = new ScoringParameters.Builder(plansCalcScoreConfigGroup, plansCalcScoreConfigGroup.getScoringParameters(null), scenarioConfig).build();
@@ -311,7 +311,7 @@ public class AdvancedMarginalCongestionPricingIT {
 		// with delay --> 70.570685898554200
 		// without delay --> 70.573360291244900
 		double activityDelayDisutility = 70.573360291244900 - 70.570685898554200;
-		double amount = (-1) * (activityDelayDisutility + tripDelayDisutility) / controler.getConfig().scoring().getMarginalUtilityOfMoney();
+		double amount = (-1) * (activityDelayDisutility + tripDelayDisutility) / controler.getConfig().scoring().getDefaultMarginalUtilityOfMoney();
 		Assertions.assertEquals(amount, amountFromEvent, MatsimTestUtils.EPSILON, "Wrong amount.");
 	 }
 
@@ -397,7 +397,7 @@ public class AdvancedMarginalCongestionPricingIT {
 		// without delay --> 80.584243964094500
 
 		double activityDelayDisutility = 80.584243964094500 - 80.581739442040600;
-		double amount = (-1) * (activityDelayDisutility + tripDelayDisutility) / controler.getConfig().scoring().getMarginalUtilityOfMoney();
+		double amount = (-1) * (activityDelayDisutility + tripDelayDisutility) / controler.getConfig().scoring().getDefaultMarginalUtilityOfMoney();
 		Assertions.assertEquals(amount, amountFromEvent, MatsimTestUtils.EPSILON, "Wrong amount.");
 	 }
 

--- a/contribs/vsp/src/test/java/playground/vsp/pt/ptdisturbances/EditTripsTest.java
+++ b/contribs/vsp/src/test/java/playground/vsp/pt/ptdisturbances/EditTripsTest.java
@@ -309,8 +309,8 @@ public class EditTripsTest {
 		String outputDirectory = utils.getOutputDirectory();
 		config.controller()
 			.setOutputDirectory(outputDirectory);
-		config.scoring().getModes().get(TransportMode.walk).setMarginalUtilityOfTraveling(
-			config.scoring().getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling() - 3);
+		config.scoring().getDefaultModeParams().get(TransportMode.walk).setMarginalUtilityOfTraveling(
+			config.scoring().getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() - 3);
 		Scenario scenario = ScenarioUtils.loadScenario(config);
 		scenario.getPopulation().getPersons().clear();
 		double activityEndTime = 7. * 3600 + 22. * 60;

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/IndividualRaptorParametersForPerson.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/IndividualRaptorParametersForPerson.java
@@ -62,7 +62,7 @@ public class IndividualRaptorParametersForPerson implements RaptorParametersForP
 
 		ScoringConfigGroup pcsConfig = config.scoring();
 
-		for (Map.Entry<String, ScoringConfigGroup.ModeParams> e : pcsConfig.getModes().entrySet()) {
+		for (Map.Entry<String, ScoringConfigGroup.ModeParams> e : pcsConfig.getDefaultModeParams().entrySet()) {
 			String mode = e.getKey();
 			ModeUtilityParameters modeParams = scoringParameters.modeParams.get(mode);
 

--- a/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/RaptorUtils.java
+++ b/matsim/src/main/java/ch/sbb/matsim/routing/pt/raptor/RaptorUtils.java
@@ -116,7 +116,7 @@ public final class RaptorUtils {
 
         ScoringConfigGroup pcsConfig = config.scoring();
         double marginalUtilityPerforming = pcsConfig.getPerforming_utils_hr() / 3600.0;
-        for (Map.Entry<String, ScoringConfigGroup.ModeParams> e : pcsConfig.getModes().entrySet()) {
+        for (Map.Entry<String, ScoringConfigGroup.ModeParams> e : pcsConfig.getDefaultModeParams().entrySet()) {
             String mode = e.getKey();
             ScoringConfigGroup.ModeParams modeParams = e.getValue();
             double marginalUtility_utl_s = modeParams.getMarginalUtilityOfTraveling()/3600.0 - marginalUtilityPerforming;

--- a/matsim/src/main/java/org/matsim/core/config/consistency/ConfigConsistencyCheckerImpl.java
+++ b/matsim/src/main/java/org/matsim/core/config/consistency/ConfigConsistencyCheckerImpl.java
@@ -68,22 +68,22 @@ public final class ConfigConsistencyCheckerImpl implements ConfigConsistencyChec
 	}
 
 	/*package because of test */ static void checkPlanCalcScore(final Config c) {
-		ModeParams ptModeParams = c.scoring().getModes().get(TransportMode.pt);
+		ModeParams ptModeParams = c.scoring().getDefaultModeParams().get(TransportMode.pt);
 		if (ptModeParams!=null && ptModeParams.getMarginalUtilityOfTraveling() > 0) {
 			log.warn(ScoringConfigGroup.GROUP_NAME + ".travelingPt is > 0. This values specifies a utility. " +
 					"Typically, this should be a disutility, i.e. have a negative value.");
 		}
-		ModeParams carModeParams = c.scoring().getModes().get(TransportMode.car);
+		ModeParams carModeParams = c.scoring().getDefaultModeParams().get(TransportMode.car);
 		if (carModeParams!=null && carModeParams.getMarginalUtilityOfTraveling() > 0) {
 			log.warn(ScoringConfigGroup.GROUP_NAME + ".traveling is > 0. This values specifies a utility. " +
 			"Typically, this should be a disutility, i.e. have a negative value.");
 		}
-		ModeParams bikeModeParams = c.scoring().getModes().get(TransportMode.bike);
+		ModeParams bikeModeParams = c.scoring().getDefaultModeParams().get(TransportMode.bike);
 		if (bikeModeParams!=null && bikeModeParams.getMarginalUtilityOfTraveling() > 0) {
 			log.warn(ScoringConfigGroup.GROUP_NAME + ".travelingBike is > 0. This values specifies a utility. " +
 			"Typically, this should be a disutility, i.e. have a negative value.");
 		}
-		ModeParams walkModeParams = c.scoring().getModes().get(TransportMode.walk);
+		ModeParams walkModeParams = c.scoring().getDefaultModeParams().get(TransportMode.walk);
 		if (walkModeParams!=null && walkModeParams.getMarginalUtilityOfTraveling() > 0) {
 			log.warn(ScoringConfigGroup.GROUP_NAME + ".travelingWalk is > 0. This values specifies a utility. " +
 			"Typically, this should be a disutility, i.e. have a negative value.");

--- a/matsim/src/main/java/org/matsim/core/config/consistency/VspConfigConsistencyCheckerImpl.java
+++ b/matsim/src/main/java/org/matsim/core/config/consistency/VspConfigConsistencyCheckerImpl.java
@@ -416,7 +416,7 @@ public final class VspConfigConsistencyCheckerImpl implements ConfigConsistencyC
 					throw new RuntimeException("unexpected setting; aborting ... ");
 			}
 		}
-		for (ModeParams params : config.scoring().getModes().values()) {
+		for (ModeParams params : config.scoring().getDefaultModeParams().values()) {
 			if (params.getMonetaryDistanceRate() > 0.) {
 				problem = true;
 				System.out.flush();
@@ -428,10 +428,10 @@ public final class VspConfigConsistencyCheckerImpl implements ConfigConsistencyC
 			}
 		}
 
-		if (config.scoring().getModes().get( car ) != null && config.scoring().getModes().get( car ).getMonetaryDistanceRate() > 0) {
+		if (config.scoring().getDefaultModeParams().get( car ) != null && config.scoring().getDefaultModeParams().get( car ).getMonetaryDistanceRate() > 0) {
 			problem = true;
 		}
-		final ModeParams modeParamsPt = config.scoring().getModes().get( pt );
+		final ModeParams modeParamsPt = config.scoring().getDefaultModeParams().get( pt );
 		if (modeParamsPt != null && modeParamsPt.getMonetaryDistanceRate() > 0) {
 			problem = true;
 			System.out.flush();

--- a/matsim/src/main/java/org/matsim/core/config/consistency/VspConfigConsistencyCheckerImpl.java
+++ b/matsim/src/main/java/org/matsim/core/config/consistency/VspConfigConsistencyCheckerImpl.java
@@ -463,8 +463,8 @@ public final class VspConfigConsistencyCheckerImpl implements ConfigConsistencyC
 		}
 
 		// added may'23
-		for( ScoringConfigGroup.ScoringParameterSet scoringParams : config.scoring().getScoringParametersPerSubpopulation().values() ){
-			for( ModeParams params : scoringParams.getModes().values() ){
+		for( ScoringConfigGroup.ScoringParameterSet scoringParams : config.scoring().getAllScoringParameterSetsPerSubpopulation().values() ){
+			for( ModeParams params : scoringParams.getModeParams().values() ){
 				switch( config.vspExperimental().getCheckingOfMarginalUtilityOfTravellng() ){
 					case allZeroExceptBikeAndRide -> {
 

--- a/matsim/src/main/java/org/matsim/core/config/consistency/VspConfigConsistencyCheckerImpl.java
+++ b/matsim/src/main/java/org/matsim/core/config/consistency/VspConfigConsistencyCheckerImpl.java
@@ -454,7 +454,7 @@ public final class VspConfigConsistencyCheckerImpl implements ConfigConsistencyC
 		}
 
 		// added apr'21:
-		for (Map.Entry<String, ScoringConfigGroup.ScoringParameterSet> entry : config.scoring().getScoringParametersPerSubpopulation().entrySet()) {
+		for (Map.Entry<String, ScoringConfigGroup.ScoringParameterSet> entry : config.scoring().getAllScoringParameterSetsPerSubpopulation().entrySet()) {
 			for (ActivityParams activityParam : entry.getValue().getActivityParams()) {
 				if (activityParam.getMinimalDuration().isDefined()) {
 					log.log(lvl, "Vsp default is to not define minimal duration.  Activity type=" + activityParam.getActivityType() + "; subpopulation=" + entry.getKey());

--- a/matsim/src/main/java/org/matsim/core/config/consistency/VspConfigConsistencyCheckerImpl.java
+++ b/matsim/src/main/java/org/matsim/core/config/consistency/VspConfigConsistencyCheckerImpl.java
@@ -393,14 +393,14 @@ public final class VspConfigConsistencyCheckerImpl implements ConfigConsistencyC
 		}
 
 		// added aug'13:
-		if (config.scoring().getMarginalUtlOfWaiting_utils_hr() != 0.) {
+		if (config.scoring().getDefaultMarginalUtlOfWaiting_utils_hr() != 0.) {
 			problem = true;
 			System.out.flush();
 			log.log(lvl, "found marginal utility of waiting != 0.  vsp default is setting this to 0. ");
 		}
 
 		// added apr'15:
-		for (ActivityParams params : config.scoring().getActivityParams()) {
+		for (ActivityParams params : config.scoring().getDefaultActivityParams()) {
 			if (PtConstants.TRANSIT_ACTIVITY_TYPE.equals(params.getActivityType())) {
 				// they have typicalDurationScoreComputation==relative, but are not scored anyways. benjamin/kai, nov'15
 				continue;
@@ -437,7 +437,7 @@ public final class VspConfigConsistencyCheckerImpl implements ConfigConsistencyC
 			System.out.flush();
 			log.error("found monetary distance rate pt > 0.  You probably want a value < 0 here.");
 		}
-		if (config.scoring().getMarginalUtilityOfMoney() < 0.) {
+		if (config.scoring().getDefaultMarginalUtilityOfMoney() < 0.) {
 			problem = true;
 			System.out.flush();
 			log.error("found marginal utility of money < 0.  You almost certainly want a value > 0 here. ");

--- a/matsim/src/main/java/org/matsim/core/config/groups/ScoringConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/ScoringConfigGroup.java
@@ -438,7 +438,7 @@ public final class ScoringConfigGroup extends ConfigGroup {
 			return getScoringParameters(null).getActivityParamsPerType().keySet();
 		else {
 			Set<String> activities = new HashSet<>();
-			getScoringParametersPerSubpopulation().values().forEach(item -> activities.addAll(item.getActivityParamsPerType().keySet()));
+			getAllScoringParameterSetsPerSubpopulation().values().forEach(item -> activities.addAll(item.getActivityParamsPerType().keySet()));
 			return activities;
 		}
 	}
@@ -507,8 +507,10 @@ public final class ScoringConfigGroup extends ConfigGroup {
 			throw new RuntimeException("Default subpopulation is not defined");
 	}
 
-
-	public Map<String, ScoringParameterSet> getScoringParametersPerSubpopulation() {
+	/**
+	 * Returns all scoring parameter sets indexed by their subpopulation key, including default entries.
+	 */
+	public Map<String, ScoringParameterSet> getAllScoringParameterSetsPerSubpopulation() {
 		@SuppressWarnings("unchecked") final Collection<ScoringParameterSet> parameters = (Collection<ScoringParameterSet>) getParameterSets(
 			ScoringParameterSet.SET_TYPE);
 		final Map<String, ScoringParameterSet> map = new LinkedHashMap<>();
@@ -521,6 +523,29 @@ public final class ScoringConfigGroup extends ConfigGroup {
 		}
 
 		return map;
+	}
+
+	/**
+	 * Returns only explicitly configured non-default scoring parameter sets indexed by their subpopulation key.
+	 */
+	public Map<String, ScoringParameterSet> getExplicitScoringParameterSetsPerSubpopulation() {
+		final Map<String, ScoringParameterSet> map = new LinkedHashMap<>();
+
+		for (Map.Entry<String, ScoringParameterSet> entry : getAllScoringParameterSetsPerSubpopulation().entrySet()) {
+			if (entry.getKey() != null && !DEFAULT_SUBPOPULATION.equals(entry.getKey())) {
+				map.put(entry.getKey(), entry.getValue());
+			}
+		}
+		return map;
+	}
+
+	/**
+	 * @deprecated Use {@link #getAllScoringParameterSetsPerSubpopulation()} when default parameter sets should be included,
+	 * or {@link #getExplicitScoringParameterSetsPerSubpopulation()} when only real subpopulation parameter sets should be returned.
+	 */
+	@Deprecated(since = "2026-06")
+	public Map<String, ScoringParameterSet> getScoringParametersPerSubpopulation() {
+		return getAllScoringParameterSetsPerSubpopulation();
 	}
 
 	/* direct access */
@@ -617,8 +642,12 @@ public final class ScoringConfigGroup extends ConfigGroup {
 		else return getScoringParameters(DEFAULT_SUBPOPULATION) != null;
 	}
 
+	/**
+	 * Returns the explicitly configured scoring parameter set for the given subpopulation,
+	 * creating one if necessary.
+	 */
 	public ScoringParameterSet getOrCreateScoringParameters(String subpopulation) {
-		ScoringParameterSet params = getScoringParametersPerSubpopulation().get(subpopulation);
+		ScoringParameterSet params = getAllScoringParameterSetsPerSubpopulation().get(subpopulation);
 
 		if (params == null) {
 			params = new ScoringParameterSet(subpopulation);
@@ -707,8 +736,8 @@ public final class ScoringConfigGroup extends ConfigGroup {
 			throw new RuntimeException(msg);
 		}
 
-		if (getScoringParametersPerSubpopulation().size() > 1) {
-			if (!getScoringParametersPerSubpopulation().containsKey(ScoringConfigGroup.DEFAULT_SUBPOPULATION)) {
+		if (getAllScoringParameterSetsPerSubpopulation().size() > 1) {
+			if (!getAllScoringParameterSetsPerSubpopulation().containsKey(ScoringConfigGroup.DEFAULT_SUBPOPULATION)) {
 				throw new RuntimeException("Using several subpopulations in " + ScoringConfigGroup.GROUP_NAME + " requires defining a \"" + ScoringConfigGroup.DEFAULT_SUBPOPULATION + " \" subpopulation."
 					+ " Otherwise, crashes can be expected.");
 			}
@@ -724,7 +753,7 @@ public final class ScoringConfigGroup extends ConfigGroup {
 		// adding the interaction activities that result from access/egress routing. this is strictly speaking not a consistency
 		// check, but I don't know a better place where to add this. kai, jan'18
 
-		for (ScoringParameterSet scoringParameterSet : this.getScoringParametersPerSubpopulation().values()) {
+		for (ScoringParameterSet scoringParameterSet : this.getAllScoringParameterSetsPerSubpopulation().values()) {
 
 			for (String mode : config.routing().getNetworkModes()) {
 				createAndAddInteractionActivity(scoringParameterSet, mode);

--- a/matsim/src/main/java/org/matsim/core/config/groups/ScoringConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/ScoringConfigGroup.java
@@ -505,7 +505,7 @@ public final class ScoringConfigGroup extends ConfigGroup {
 		if (scoringParameterSet != null)
 			return scoringParameterSet.getModeParams();
 		else
-			throw new RuntimeException("Default subpopulation is not defined");
+			throw new RuntimeException("Mode parameters for subpopulation " + subpopulation + " are not defined");
 	}
 
 	/**

--- a/matsim/src/main/java/org/matsim/core/config/groups/ScoringConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/ScoringConfigGroup.java
@@ -657,6 +657,65 @@ public final class ScoringConfigGroup extends ConfigGroup {
 		return params;
 	}
 
+	/**
+	 * Sets the scoring parameters of an existing subpopulation as the default subpopulation.
+	 *
+	 * @param subpopulation the subpopulation whose scoring parameters should be used as default
+	 * @return the scoring parameters registered for {@link #DEFAULT_SUBPOPULATION}
+	 * @throws RuntimeException if no scoring parameters exist for the given subpopulation
+	 * @throws RuntimeException if scoring parameters for {@link #DEFAULT_SUBPOPULATION} already exist
+	 */
+	public ScoringParameterSet setScoringParametersAsDefaultSubpopulation(String subpopulation) {
+		final ScoringParameterSet params = getAllScoringParameterSetsPerSubpopulation().get(subpopulation);
+		if (params == null) {
+			throw new RuntimeException("ScoringParams for subpopulation " + subpopulation + " are not defined");
+		}
+		return setScoringParametersAsDefaultSubpopulation(params);
+	}
+
+	/**
+	 * Sets the given scoring parameters as the default subpopulation.
+	 *
+	 * @param params the scoring parameters to use as default
+	 * @return the scoring parameters registered for {@link #DEFAULT_SUBPOPULATION}
+	 * @throws RuntimeException if scoring parameters for {@link #DEFAULT_SUBPOPULATION} already exist and {@code params} is not that default set
+	 */
+	public ScoringParameterSet setScoringParametersAsDefaultSubpopulation(ScoringParameterSet params) {
+		testForLocked();
+		if (DEFAULT_SUBPOPULATION.equals(params.getSubpopulation())) {
+			return params;
+		}
+		if (getAllScoringParameterSetsPerSubpopulation().containsKey(DEFAULT_SUBPOPULATION)) {
+			throw new RuntimeException("ScoringParams for default subpopulation are already defined");
+		}
+
+		final ScoringParameterSet defaultParams = copyScoringParameterSet(params, DEFAULT_SUBPOPULATION);
+		addScoringParameterSet(defaultParams);
+		return defaultParams;
+	}
+
+	private static ScoringParameterSet copyScoringParameterSet(ScoringParameterSet source, String subpopulation) {
+		final ScoringParameterSet copy = new ScoringParameterSet(subpopulation);
+
+		copy.lateArrival = source.lateArrival;
+		copy.earlyDeparture = source.earlyDeparture;
+		copy.performing = source.performing;
+		copy.waiting = source.waiting;
+		copy.marginalUtilityOfMoney = source.marginalUtilityOfMoney;
+		copy.utilityOfLineSwitch = source.utilityOfLineSwitch;
+		copy.waitingPt = source.waitingPt;
+
+		for (Collection<? extends ConfigGroup> sourceSets : source.getParameterSets().values()) {
+			for (ConfigGroup sourceSet : sourceSets) {
+				final ConfigGroup copySet = copy.createParameterSet(sourceSet.getName());
+				ConfigUtils.copyFromTo(sourceSet, copySet);
+				copy.addParameterSet(copySet);
+			}
+		}
+
+		return copy;
+	}
+
 	@Override
 	public void addParameterSet(final ConfigGroup set) {
 		switch (set.getName()) {

--- a/matsim/src/main/java/org/matsim/core/config/groups/ScoringConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/ScoringConfigGroup.java
@@ -27,6 +27,7 @@ import org.matsim.api.core.v01.TransportMode;
 import org.matsim.core.api.internal.MatsimParameters;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigGroup;
+import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.config.ReflectiveConfigGroup;
 import org.matsim.core.gbl.Gbl;
 import org.matsim.core.utils.misc.OptionalTime;

--- a/matsim/src/main/java/org/matsim/core/config/groups/ScoringConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/ScoringConfigGroup.java
@@ -198,7 +198,7 @@ public final class ScoringConfigGroup extends ConfigGroup {
 			throw new RuntimeException("Please use monetaryDistanceRate (without `cost').  Even better, use config v2, "
 				+ "mode-parameters (see output of any recent run), and mode-specific monetary " + "distance rate.");
 		} else if (WAITING_PT.equals(key)) {
-			setMarginalUtlOfWaitingPt_utils_hr(Double.parseDouble(value));
+			setDefaultMarginalUtlOfWaitingPt_utils_hr(Double.parseDouble(value));
 		}
 
 		// backward compatibility: underscored
@@ -458,14 +458,25 @@ public final class ScoringConfigGroup extends ConfigGroup {
 		}
 
 	}
-	@Deprecated // should move everywhere to subpopulation-based params. This is minimally necessary to correctly differentiate between private and commercial traffic. kai, feb'26
+	/**
+	 * Returns all activity parameter sets of the default scoring parameters.
+	 */
+	public Collection<ActivityParams> getDefaultActivityParams() {
+		return getDefaultScoringParameterSet().getActivityParams();
+	}
+
+	/**
+	 * @deprecated Use {@link #getDefaultActivityParams()} for default scoring parameters.
+	 */
+	@Deprecated(since = "2026-02")
 	public Collection<ActivityParams> getActivityParams() {
-		if (getScoringParameters(null) != null)
-			return getScoringParameters(null).getActivityParams();
-		else if (getScoringParameters(DEFAULT_SUBPOPULATION) != null)
-			return getScoringParameters(DEFAULT_SUBPOPULATION).getActivityParams();
-		else
-			throw new RuntimeException("Default subpopulation is not defined");
+		return getDefaultActivityParams();
+	}
+	/**
+	 * Returns all mode parameters of the default/root scoring parameters.
+	 */
+	public Map<String, ModeParams> getDefaultModeParams() {
+		return getDefaultScoringParameterSet().getModeParams();
 	}
 
 	/**
@@ -514,38 +525,96 @@ public final class ScoringConfigGroup extends ConfigGroup {
 
 	/* direct access */
 
-	@Deprecated // should move everywhere to subpopulation-based params. This is minimally necessary to correctly differentiate between private and commercial traffic. kai, feb'26
+	/**
+	 * Returns the PT waiting utility of the default/root scoring parameters.
+	 */
+	public double getDefaultMarginalUtlOfWaitingPt_utils_hr() {
+		return getDefaultScoringParameterSet().getMarginalUtlOfWaitingPt_utils_hr();
+	}
+
+	/**
+	 * @deprecated Use {@link #getDefaultMarginalUtlOfWaitingPt_utils_hr()} for default scoring parameters.
+	 */
+	@Deprecated(since = "2026-02")
 	public double getMarginalUtlOfWaitingPt_utils_hr() {
-		if (getScoringParameters(null) != null)
-			return getScoringParameters(null).getMarginalUtlOfWaitingPt_utils_hr();
-		else if (getScoringParameters(DEFAULT_SUBPOPULATION) != null)
-			return getScoringParameters(DEFAULT_SUBPOPULATION).getMarginalUtlOfWaitingPt_utils_hr();
-		else
-			throw new RuntimeException("Default subpopulation is not defined");
-
+		return getDefaultMarginalUtlOfWaitingPt_utils_hr();
 	}
 
-	@Deprecated // should move everywhere to subpopulation-based params. This is minimally necessary to correctly differentiate between private and commercial traffic. kai, feb'26
+	/**
+	 * Returns the activity parameters explicitly configured for the given subpopulation key.
+	 * In contrast to {@link #getScoringParameters(String)}, this method does not apply any fallback.
+	 */
+	public Collection<ActivityParams> getActivityParamsForSubpopulation(String subpopulation) {
+		final ScoringParameterSet scoringParameterSet = getExplicitScoringParameterSetsPerSubpopulation().get(subpopulation);
+		if (scoringParameterSet != null)
+			return scoringParameterSet.getActivityParams();
+		else
+			throw new RuntimeException("Activity parameters for subpopulation " + subpopulation + " are not defined");
+	}
+
+	/**
+	 * Sets the PT waiting utility on the default scoring parameters.
+	 */
+	public void setDefaultMarginalUtlOfWaitingPt_utils_hr(double val) {
+		getDefaultScoringParameterSet().setMarginalUtlOfWaitingPt_utils_hr(val);
+	}
+
+	/**
+	 * @deprecated Use {@link #setDefaultMarginalUtlOfWaitingPt_utils_hr(double)} for default scoring parameters.
+	 */
+	@Deprecated(since = "2026-02")
 	public void setMarginalUtlOfWaitingPt_utils_hr(double val) {
-		getScoringParameters(null).setMarginalUtlOfWaitingPt_utils_hr(val);
+		setDefaultMarginalUtlOfWaitingPt_utils_hr(val);
 	}
 
-	@Deprecated // should move everywhere to subpopulation-based params. This is minimally necessary to correctly differentiate between private and commercial traffic. kai, feb'26
+
+	/**
+	 * Returns the activity parameters for one activity type from the default scoring parameters.
+	 * This is the type-specific accessor and differs from {@link #getDefaultActivityParams()}, which returns
+	 * the full collection of configured activity parameter sets.
+	 */
+	public ActivityParams getDefaultActivityParams(final String actType) {
+		return getDefaultScoringParameterSet().getActivityParams(actType);
+	}
+
+	/**
+	 * @deprecated Use {@link #getDefaultActivityParams(String)} for default scoring parameters.
+	 */
+	@Deprecated(since = "2026-02")
 	public ActivityParams getActivityParams(final String actType) {
-		if (getScoringParameters(null) != null)
-			return getScoringParameters(null).getActivityParams(actType);
-		else if (getScoringParameters(DEFAULT_SUBPOPULATION) != null)
-			return getScoringParameters(DEFAULT_SUBPOPULATION).getActivityParams(actType);
-		else
-			throw new RuntimeException("Default subpopulation is not defined");
-
+		return getDefaultActivityParams(actType);
 	}
 
+	/**
+	 * Returns the activity parameters for one activity type for the explicitly configured
+	 * scoring parameter set of the given subpopulation key.
+	 */
+	public ActivityParams getActivityParamsForSubpopulation(final String actType, String subpopulation) {
+		final ScoringParameterSet scoringParameterSet = getExplicitScoringParameterSetsPerSubpopulation().get(subpopulation);
+		if (scoringParameterSet != null)
+			return scoringParameterSet.getActivityParams(actType);
+		else
+			throw new RuntimeException("Activity parameters for subpopulation " + subpopulation + " are not defined");
+	}
+
+	/**
+	 * Looks up the scoring parameter set for the given subpopulation and falls back to the
+	 * default entry identified by {@code null}. This method is intentionally not using
+	 * {@link #DEFAULT_SUBPOPULATION} as an additional implicit fallback because config
+	 * management code relies on stable "exact-or-root" semantics.
+	 */
 	public ScoringParameterSet getScoringParameters(String subpopulation) {
-		final ScoringParameterSet params = getScoringParametersPerSubpopulation().get(subpopulation);
-		// If no config parameters defined for a specific subpopulation,
-		// use the ones of the "default" subpopulation
-		return params != null ? params : getScoringParametersPerSubpopulation().get(null);
+		final ScoringParameterSet params = getAllScoringParameterSetsPerSubpopulation().get(subpopulation);
+		return params != null ? params : getAllScoringParameterSetsPerSubpopulation().get(null);
+	}
+
+	/**
+	 * @return {@code true} if there is a default scoring parameter set (i.e. with key {@code null} or {@link #DEFAULT_SUBPOPULATION}), {@code false} otherwise.
+	 */
+	public boolean hasDefaultScoringParameters() {
+		if (getScoringParameters(null) != null)
+			return true;
+		else return getScoringParameters(DEFAULT_SUBPOPULATION) != null;
 	}
 
 	public ScoringParameterSet getOrCreateScoringParameters(String subpopulation) {
@@ -669,15 +738,25 @@ public final class ScoringConfigGroup extends ConfigGroup {
 			}
 		}
 //		}
-
-		for (ActivityParams params : this.getActivityParams()) {
-			if (params.isScoringThisActivityAtAll() && params.getTypicalDuration().isUndefined()) {
-				throw new RuntimeException("In activity type=" + params.getActivityType()
-					+ ", the typical duration is undefined.  This will lead to errors that are difficult to debug, "
-					+ "so rather aborting here.");
+		if (hasDefaultScoringParameters()) {
+			for (ActivityParams params : getDefaultActivityParams()) {
+				if (params.isScoringThisActivityAtAll() && params.getTypicalDuration().isUndefined()) {
+					throw new RuntimeException("In activity type=" + params.getActivityType()
+						+ ", the typical duration is undefined.  This will lead to errors that are difficult to debug, "
+						+ "so rather aborting here.");
+				}
 			}
 		}
-
+		this.getAllScoringParameterSetsPerSubpopulation().values()
+			.forEach(scoringParameterSet -> {
+				for (ActivityParams params : scoringParameterSet.getActivityParams()) {
+					if (params.isScoringThisActivityAtAll() && params.getTypicalDuration().isUndefined()) {
+						throw new RuntimeException("In activity type=" + params.getActivityType()
+							+ ", the typical duration is undefined.  This will lead to errors that are difficult to debug, "
+							+ "so rather aborting here.");
+					}
+				}
+			});
 	}
 
 	private static void createAndAddInteractionActivity(ScoringParameterSet scoringParameterSet, String mode) {
@@ -729,84 +808,162 @@ public final class ScoringConfigGroup extends ConfigGroup {
 		delegate.setPathSizeLogitBeta(beta);
 	}
 
-	@Deprecated // should move everywhere to subpopulation-based params. This is minimally necessary to correctly differentiate between private and commercial traffic. kai, feb'26
+	/**
+	 * Returns the late arrival utility of the default/root scoring parameters.
+	 */
+	public double getDefaultLateArrival_utils_hr() {
+		return getDefaultScoringParameterSet().getLateArrival_utils_hr();
+	}
+
+	/**
+	 * @deprecated Use {@link #getDefaultLateArrival_utils_hr()} for default scoring parameters or
+	 * {@link ScoringParameterSet#getLateArrival_utils_hr()} on an explicit subpopulation scoring parameter set.
+	 */
+	@Deprecated(since = "2026-02")
 	public double getLateArrival_utils_hr() {
-		if (getScoringParameters(null) != null)
-			return getScoringParameters(null).getLateArrival_utils_hr();
-		else if (getScoringParameters(DEFAULT_SUBPOPULATION) != null)
-			return getScoringParameters(DEFAULT_SUBPOPULATION).getLateArrival_utils_hr();
-		else
-			throw new RuntimeException("Default subpopulation is not defined");
+		return getDefaultLateArrival_utils_hr();
 	}
 
+	public void setDefaultLateArrival_utils_hr(double lateArrival) {
+		getDefaultScoringParameterSet().setLateArrival_utils_hr(lateArrival);
+	}
+
+	/**
+	 * @deprecated Use {@link #setDefaultLateArrival_utils_hr(double)} for default scoring parameters or
+	 * {@link ScoringParameterSet#setLateArrival_utils_hr(double)} on an explicit subpopulation scoring parameter set.
+	 */
+	@Deprecated(since = "2026-06")
 	public void setLateArrival_utils_hr(double lateArrival) {
-		getScoringParameters(null).setLateArrival_utils_hr(lateArrival);
+		setDefaultLateArrival_utils_hr(lateArrival);
 	}
 
-	@Deprecated // should move everywhere to subpopulation-based params. This is minimally necessary to correctly differentiate between private and commercial traffic. kai, feb'26
+	/**
+	 * Returns the early departure utility of the default/root scoring parameters.
+	 */
+	public double getDefaultEarlyDeparture_utils_hr() {
+		return getDefaultScoringParameterSet().getEarlyDeparture_utils_hr();
+	}
+
+	/**
+	 * @deprecated Use {@link #getDefaultEarlyDeparture_utils_hr()} for default scoring parameters or
+	 * {@link ScoringParameterSet#getEarlyDeparture_utils_hr()} on an explicit subpopulation scoring parameter set.
+	 */
+	@Deprecated(since = "2026-02")
 	public double getEarlyDeparture_utils_hr() {
-		if (getScoringParameters(null) != null)
-			return getScoringParameters(null).getEarlyDeparture_utils_hr();
-		else if (getScoringParameters(DEFAULT_SUBPOPULATION) != null)
-			return getScoringParameters(DEFAULT_SUBPOPULATION).getEarlyDeparture_utils_hr();
-		else
-			throw new RuntimeException("Default subpopulation is not defined");
-
+		return getDefaultEarlyDeparture_utils_hr();
 	}
 
+	public void setDefaultEarlyDeparture_utils_hr(double earlyDeparture) {
+		getDefaultScoringParameterSet().setEarlyDeparture_utils_hr(earlyDeparture);
+	}
+
+	/**
+	 * @deprecated Use {@link #setDefaultEarlyDeparture_utils_hr(double)} for default scoring parameters or
+	 * {@link ScoringParameterSet#setEarlyDeparture_utils_hr(double)} on an explicit subpopulation scoring parameter set.
+	 */
+	@Deprecated(since = "2026-06")
 	public void setEarlyDeparture_utils_hr(double earlyDeparture) {
-		getScoringParameters(null).setEarlyDeparture_utils_hr(earlyDeparture);
+		setDefaultEarlyDeparture_utils_hr(earlyDeparture);
 	}
 
-	@Deprecated // should move everywhere to subpopulation-based params. This is minimally necessary to correctly differentiate between private and commercial traffic. kai, feb'26
+	/**
+	 * Returns the performing utility of the default/root scoring parameters.
+	 */
+	public double getDefaultPerforming_utils_hr() {
+		return getDefaultScoringParameterSet().getPerforming_utils_hr();
+	}
+
+	/**
+	 * @deprecated Use {@link #getDefaultPerforming_utils_hr()} for default scoring parameters or
+	 * {@link ScoringParameterSet#getPerforming_utils_hr()} on an explicit subpopulation scoring parameter set.
+	 */
+	@Deprecated(since = "2026-02")
 	public double getPerforming_utils_hr() {
-		if (getScoringParameters(null) != null)
-			return getScoringParameters(null).getPerforming_utils_hr();
-		else if (getScoringParameters(DEFAULT_SUBPOPULATION) != null)
-			return getScoringParameters(DEFAULT_SUBPOPULATION).getPerforming_utils_hr();
-		else
-			throw new RuntimeException("Default subpopulation is not defined");
-
+		return getDefaultPerforming_utils_hr();
 	}
 
+	public void setDefaultPerforming_utils_hr(double performing) {
+		getDefaultScoringParameterSet().setPerforming_utils_hr(performing);
+	}
+
+	/**
+	 * @deprecated Use {@link #setDefaultPerforming_utils_hr(double)} for default scoring parameters or
+	 * {@link ScoringParameterSet#setPerforming_utils_hr(double)} on an explicit subpopulation scoring parameter set.
+	 */
+	@Deprecated(since = "2026-06")
 	public void setPerforming_utils_hr(double performing) {
-		getScoringParameters(null).setPerforming_utils_hr(performing);
+		setDefaultPerforming_utils_hr(performing);
 	}
 
-	@Deprecated // should move everywhere to subpopulation-based params. This is minimally necessary to correctly differentiate between private and commercial traffic. kai, feb'26
+	/**
+	 * @deprecated Use {@link #getDefaultMarginalUtilityOfMoney()} for default scoring parameters or
+	 * {@link #getMarginalUtilityOfMoney(String)} for explicit subpopulation scoring parameters.
+	 */
+	@Deprecated(since = "2026-02")
 	public double getMarginalUtilityOfMoney() {
-		if (getScoringParameters(null) != null)
-			return getScoringParameters(null).getMarginalUtilityOfMoney();
-		else if (getScoringParameters(DEFAULT_SUBPOPULATION) != null)
-			return getScoringParameters(DEFAULT_SUBPOPULATION).getMarginalUtilityOfMoney();
-		else
-			throw new RuntimeException("Default subpopulation is not defined");
-
+		return getDefaultMarginalUtilityOfMoney();
 	}
 
+	public double getDefaultMarginalUtilityOfMoney() {
+		return getDefaultScoringParameterSet().getMarginalUtilityOfMoney();
+	}
+
+	public double getMarginalUtilityOfMoney(String subpopulation) {
+		final ScoringParameterSet scoringParameterSet = getExplicitScoringParameterSetsPerSubpopulation().get(subpopulation);
+		if (scoringParameterSet != null)
+			return scoringParameterSet.getMarginalUtilityOfMoney();
+		else
+			throw new RuntimeException("MarginalUtilityOfMoney for subpopulation " + subpopulation + " is not defined or the scoringParams for subpopulation is not defined");
+	}
+
+	public void setDefaultMarginalUtilityOfMoney(double marginalUtilityOfMoney) {
+		getDefaultScoringParameterSet().setMarginalUtilityOfMoney(marginalUtilityOfMoney);
+	}
+
+	/**
+	 * @deprecated Use {@link #setDefaultMarginalUtilityOfMoney(double)} for default scoring parameters.
+	 */
+	@Deprecated(since = "2026-06")
 	public void setMarginalUtilityOfMoney(double marginalUtilityOfMoney) {
-		getScoringParameters(null).setMarginalUtilityOfMoney(marginalUtilityOfMoney);
+		setDefaultMarginalUtilityOfMoney(marginalUtilityOfMoney);
 	}
 
-	@Deprecated // should move everywhere to subpopulation-based params. This is minimally necessary to correctly differentiate between private and commercial traffic. kai, feb'26
+	/**
+	 * Returns the line switch utility of the default/root scoring parameters.
+	 */
+	public double getDefaultUtilityOfLineSwitch() {
+		return getDefaultScoringParameterSet().getUtilityOfLineSwitch();
+	}
+
+	/**
+	 * @deprecated Use {@link #getDefaultUtilityOfLineSwitch()} for default scoring parameters or
+	 * {@link ScoringParameterSet#getUtilityOfLineSwitch()} on an explicit subpopulation scoring parameter set.
+	 */
+	@Deprecated(since = "2026-02")
 	public double getUtilityOfLineSwitch() {
-		if (getScoringParameters(null) != null)
-			return getScoringParameters(null).getUtilityOfLineSwitch();
-		else if (getScoringParameters(DEFAULT_SUBPOPULATION) != null)
-			return getScoringParameters(DEFAULT_SUBPOPULATION).getUtilityOfLineSwitch();
-		else
-			throw new RuntimeException("Default subpopulation is not defined");
-
+		return getDefaultUtilityOfLineSwitch();
 	}
 
+	public void setDefaultUtilityOfLineSwitch(double utilityOfLineSwitch) {
+		getDefaultScoringParameterSet().setUtilityOfLineSwitch(utilityOfLineSwitch);
+	}
+
+	/**
+	 * @deprecated Use {@link #setDefaultUtilityOfLineSwitch(double)} for default scoring parameters or
+	 * {@link ScoringParameterSet#setUtilityOfLineSwitch(double)} on an explicit subpopulation scoring parameter set.
+	 */
+	@Deprecated(since = "2026-06")
 	public void setUtilityOfLineSwitch(double utilityOfLineSwitch) {
-		getScoringParameters(null).setUtilityOfLineSwitch(utilityOfLineSwitch);
+		setDefaultUtilityOfLineSwitch(utilityOfLineSwitch);
 	}
 
 	public boolean isUsingOldScoringBelowZeroUtilityDuration() {
 		return delegate.isUsingOldScoringBelowZeroUtilityDuration();
 	}
 
+	/**
+	 * @deprecated This switch exists only for backwards compatibility with old below-zero utility duration behavior.
+	 */
 	@Deprecated
 	public void setUsingOldScoringBelowZeroUtilityDuration(boolean usingOldScoringBelowZeroUtilityDuration) {
 		delegate.setUsingOldScoringBelowZeroUtilityDuration(usingOldScoringBelowZeroUtilityDuration);
@@ -820,19 +977,46 @@ public final class ScoringConfigGroup extends ConfigGroup {
 		delegate.setWriteExperiencedPlans(writeExperiencedPlans);
 	}
 
-	@Deprecated // should move everywhere to subpopulation-based params. This is minimally necessary to correctly differentiate between private and commercial traffic. kai, feb'26
+	/**
+	 * @deprecated Use {@link #getDefaultMarginalUtlOfWaiting_utils_hr()} for default scoring parameters or
+	 * {@link #getMarginalUtlOfWaiting_utils_hr(String)} for explicit subpopulation scoring parameters.
+	 */
+	@Deprecated(since = "2026-02")
 	public double getMarginalUtlOfWaiting_utils_hr() {
-		if (getScoringParameters(null) != null)
-			return getScoringParameters(null).getMarginalUtlOfWaiting_utils_hr();
-		else if (getScoringParameters(DEFAULT_SUBPOPULATION) != null)
-			return getScoringParameters(DEFAULT_SUBPOPULATION).getMarginalUtlOfWaiting_utils_hr();
-		else
-			throw new RuntimeException("Default subpopulation is not defined");
-
+		return getDefaultMarginalUtlOfWaiting_utils_hr();
 	}
 
+	public double getDefaultMarginalUtlOfWaiting_utils_hr() {
+		return getDefaultScoringParameterSet().getMarginalUtlOfWaiting_utils_hr();
+	}
+
+	public double getMarginalUtlOfWaiting_utils_hr(String subpopulation) {
+		final ScoringParameterSet scoringParameterSet = getExplicitScoringParameterSetsPerSubpopulation().get(subpopulation);
+		if (scoringParameterSet != null)
+			return scoringParameterSet.getMarginalUtlOfWaiting_utils_hr();
+		else
+			throw new RuntimeException("MarginalUtlOfWaiting_utils_hr for subpopulation " + subpopulation + " is not defined");
+	}
+
+	public void setDefaultMarginalUtlOfWaiting_utils_hr(double waiting) {
+		getDefaultScoringParameterSet().setMarginalUtlOfWaiting_utils_hr(waiting);
+	}
+
+	/**
+	 * @deprecated Use {@link #setDefaultMarginalUtlOfWaiting_utils_hr(double)} for default scoring parameters.
+	 */
+	@Deprecated(since = "2026-06")
 	public void setMarginalUtlOfWaiting_utils_hr(double waiting) {
-		getScoringParameters(null).setMarginalUtlOfWaiting_utils_hr(waiting);
+		setDefaultMarginalUtlOfWaiting_utils_hr(waiting);
+	}
+
+	private ScoringParameterSet getDefaultScoringParameterSet() {
+		if (getScoringParameters(null) != null)
+			return getScoringParameters(null);
+		else if (getScoringParameters(DEFAULT_SUBPOPULATION) != null)
+			return getScoringParameters(DEFAULT_SUBPOPULATION);
+		else
+			throw new RuntimeException("Default subpopulation is not defined");
 	}
 
 	public void setFractionOfIterationsToStartScoreMSA(Double val) {

--- a/matsim/src/main/java/org/matsim/core/config/groups/ScoringConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/ScoringConfigGroup.java
@@ -752,8 +752,24 @@ public final class ScoringConfigGroup extends ConfigGroup {
 		getScoringParameters(null).addModeParams(params);
 	}
 
+	public void addModeParamsForSubpopulation(final ModeParams params, String subpopulation) {
+		final ScoringParameterSet scoringParameterSet = getExplicitScoringParameterSetsPerSubpopulation().get(subpopulation);
+		if (scoringParameterSet == null) {
+			throw new RuntimeException("ScoringParams for subpopulation " + subpopulation + " are not defined");
+		}
+		scoringParameterSet.addModeParams(params);
+	}
+
 	public void addActivityParams(final ActivityParams params) {
 		getScoringParameters(null).addActivityParams(params);
+	}
+
+	public void addActivityParamsForSubpopulation(final ActivityParams params, String subpopulation) {
+		final ScoringParameterSet scoringParameterSet = getExplicitScoringParameterSetsPerSubpopulation().get(subpopulation);
+		if (scoringParameterSet == null) {
+			throw new RuntimeException("ScoringParams for subpopulation " + subpopulation + " are not defined");
+		}
+		scoringParameterSet.addActivityParams(params);
 	}
 
 	public enum TypicalDurationScoreComputation {

--- a/matsim/src/main/java/org/matsim/core/config/groups/ScoringConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/ScoringConfigGroup.java
@@ -287,65 +287,65 @@ public final class ScoringConfigGroup extends ConfigGroup {
 		else if ("traveling".equals(key)) {
 			log.warn(key + msg);
 			usesDeprecatedSyntax = true;
-			this.getModes().get(TransportMode.car).setMarginalUtilityOfTraveling(Double.parseDouble(value));
+			this.getModeParams().get(TransportMode.car).setMarginalUtilityOfTraveling(Double.parseDouble(value));
 		} else if ("travelingPt".equals(key)) {
 			log.warn(key + msg);
 			usesDeprecatedSyntax = true;
-			this.getModes().get(TransportMode.pt).setMarginalUtilityOfTraveling(Double.parseDouble(value));
+			this.getModeParams().get(TransportMode.pt).setMarginalUtilityOfTraveling(Double.parseDouble(value));
 		} else if ("travelingWalk".equals(key)) {
 			log.warn(key + msg);
 			usesDeprecatedSyntax = true;
-			this.getModes().get(TransportMode.walk).setMarginalUtilityOfTraveling(Double.parseDouble(value));
+			this.getModeParams().get(TransportMode.walk).setMarginalUtilityOfTraveling(Double.parseDouble(value));
 		} else if ("travelingOther".equals(key)) {
 			log.warn(key + msg);
 			usesDeprecatedSyntax = true;
-			this.getModes().get(TransportMode.other).setMarginalUtilityOfTraveling(Double.parseDouble(value));
+			this.getModeParams().get(TransportMode.other).setMarginalUtilityOfTraveling(Double.parseDouble(value));
 		} else if ("travelingBike".equals(key)) {
 			log.warn(key + msg);
 			usesDeprecatedSyntax = true;
-			this.getModes().get(TransportMode.bike).setMarginalUtilityOfTraveling(Double.parseDouble(value));
+			this.getModeParams().get(TransportMode.bike).setMarginalUtilityOfTraveling(Double.parseDouble(value));
 		}
 
 		// backward compatibility: "typed" util of distance
 		else if ("marginalUtlOfDistanceCar".equals(key)) {
 			log.warn(key + msg);
 			usesDeprecatedSyntax = true;
-			this.getModes().get(TransportMode.car).setMarginalUtilityOfDistance(Double.parseDouble(value));
+			this.getModeParams().get(TransportMode.car).setMarginalUtilityOfDistance(Double.parseDouble(value));
 		} else if ("marginalUtlOfDistancePt".equals(key)) {
 			log.warn(key + msg);
 			usesDeprecatedSyntax = true;
-			this.getModes().get(TransportMode.pt).setMarginalUtilityOfDistance(Double.parseDouble(value));
+			this.getModeParams().get(TransportMode.pt).setMarginalUtilityOfDistance(Double.parseDouble(value));
 		} else if ("marginalUtlOfDistanceWalk".equals(key)) {
 			log.warn(key + msg);
 			usesDeprecatedSyntax = true;
-			this.getModes().get(TransportMode.walk).setMarginalUtilityOfDistance(Double.parseDouble(value));
+			this.getModeParams().get(TransportMode.walk).setMarginalUtilityOfDistance(Double.parseDouble(value));
 		} else if ("marginalUtlOfDistanceOther".equals(key)) {
 			log.warn(key + msg);
 			usesDeprecatedSyntax = true;
-			this.getModes().get(TransportMode.other).setMarginalUtilityOfDistance(Double.parseDouble(value));
+			this.getModeParams().get(TransportMode.other).setMarginalUtilityOfDistance(Double.parseDouble(value));
 		}
 
 		// backward compatibility: "typed" constants
 		else if ("constantCar".equals(key)) {
 			log.warn(key + msg);
 			usesDeprecatedSyntax = true;
-			getModes().get(TransportMode.car).setConstant(Double.parseDouble(value));
+			getModeParams().get(TransportMode.car).setConstant(Double.parseDouble(value));
 		} else if ("constantWalk".equals(key)) {
 			log.warn(key + msg);
 			usesDeprecatedSyntax = true;
-			getModes().get(TransportMode.walk).setConstant(Double.parseDouble(value));
+			getModeParams().get(TransportMode.walk).setConstant(Double.parseDouble(value));
 		} else if ("constantOther".equals(key)) {
 			log.warn(key + msg);
 			usesDeprecatedSyntax = true;
-			getModes().get(TransportMode.other).setConstant(Double.parseDouble(value));
+			getModeParams().get(TransportMode.other).setConstant(Double.parseDouble(value));
 		} else if ("constantPt".equals(key)) {
 			log.warn(key + msg);
 			usesDeprecatedSyntax = true;
-			getModes().get(TransportMode.pt).setConstant(Double.parseDouble(value));
+			getModeParams().get(TransportMode.pt).setConstant(Double.parseDouble(value));
 		} else if ("constantBike".equals(key)) {
 			log.warn(key + msg);
 			usesDeprecatedSyntax = true;
-			getModes().get(TransportMode.bike).setConstant(Double.parseDouble(value));
+			getModeParams().get(TransportMode.bike).setConstant(Double.parseDouble(value));
 		}
 
 		// old-fashioned scoring parameters: default subpopulation
@@ -449,11 +449,11 @@ public final class ScoringConfigGroup extends ConfigGroup {
 	 */
 	public Collection<String> getAllModes() {
 		if (getScoringParameters(null) != null) {
-			return getScoringParameters(null).getModes().keySet();
+			return getScoringParameters(null).getModeParams().keySet();
 
 		} else {
 			Set<String> modes = new HashSet<>();
-			getScoringParametersPerSubpopulation().values().forEach(item -> modes.addAll(item.getModes().keySet()));
+			getAllScoringParameterSetsPerSubpopulation().values().forEach(item -> modes.addAll(item.getModeParams().keySet()));
 			return modes;
 		}
 
@@ -468,12 +468,22 @@ public final class ScoringConfigGroup extends ConfigGroup {
 			throw new RuntimeException("Default subpopulation is not defined");
 	}
 
-	@Deprecated // should move everywhere to subpopulation-based params. This is minimally necessary to correctly differentiate between private and commercial traffic. kai, feb'26
+	/**
+	 * @deprecated Use {@link #getDefaultModeParams()} for default scoring parameters.
+	 */
+	@Deprecated(since = "2026-02")
+	public Map<String, ModeParams> getModeParams() {
+		return getDefaultModeParams();
+	}
+
+	/**
+	 * @deprecated Use {@link #getDefaultModeParams()} for default scoring parameters.
+	 */
+	@Deprecated(since = "2026-02")
 	public Map<String, ModeParams> getModes() {
-		if (getScoringParameters(null) != null)
-			return getScoringParameters(null).getModes();
-		else if (getScoringParameters(DEFAULT_SUBPOPULATION) != null)
-			return getScoringParameters(DEFAULT_SUBPOPULATION).getModes();
+		return getModeParams();
+	}
+
 		else
 			throw new RuntimeException("Default subpopulation is not defined");
 	}
@@ -646,7 +656,7 @@ public final class ScoringConfigGroup extends ConfigGroup {
 			// There is, however, a test that checks if all network modes from planCalcRoute have
 			// interaction activities.  So we rather satisfy it than changing the test.  kai, jan'21
 
-			for (String mode : scoringParameterSet.getModes().keySet()) {
+			for (String mode : scoringParameterSet.getModeParams().keySet()) {
 				createAndAddInteractionActivity(scoringParameterSet, mode);
 			}
 		}
@@ -1406,10 +1416,10 @@ public final class ScoringConfigGroup extends ConfigGroup {
 		@StringGetter(WAITING_PT)
 		public double getMarginalUtlOfWaitingPt_utils_hr() {
 			if( waitingPt != null ) return waitingPt;
-			final ModeParams modeParams = this.getModes().get( TransportMode.pt );
+			final ModeParams modeParams = this.getModeParams().get( TransportMode.pt );
 
 			if ( modeParams==null ) {
-				log.fatal( "this.getModes().get( TransportMode.pt ) returns null; cannot continue; possibly some confusion with setting mode params for subpopulations. subpop={}", this.getSubpopulation() ) ;
+				log.fatal( "this.getModeParams().get( TransportMode.pt ) returns null; cannot continue; possibly some confusion with setting mode params for subpopulations. subpop={}", this.getSubpopulation() ) ;
 				throw new RuntimeException("see log statement" );
 			}
 
@@ -1449,7 +1459,7 @@ public final class ScoringConfigGroup extends ConfigGroup {
 						throw new RuntimeException("wrong class for " + module);
 					}
 					final String m = ((ModeParams) module).getMode();
-					if (getModes().get(m) != null) {
+					if (getModeParams().get(m) != null) {
 						throw new IllegalStateException("already a parameter set for mode " + m);
 					}
 					break;
@@ -1507,7 +1517,7 @@ public final class ScoringConfigGroup extends ConfigGroup {
 			return params;
 		}
 
-		public Map<String, ModeParams> getModes() {
+		public Map<String, ModeParams> getModeParams() {
 			@SuppressWarnings("unchecked") final Collection<ModeParams> modes = (Collection<ModeParams>) getParameterSets(ModeParams.SET_TYPE);
 			final Map<String, ModeParams> map = new LinkedHashMap<>();
 
@@ -1524,8 +1534,16 @@ public final class ScoringConfigGroup extends ConfigGroup {
 			}
 		}
 
+		/**
+		 * @deprecated Use {@link #getModeParams()}.
+		 */
+		@Deprecated(since = "2026-02")
+		public Map<String, ModeParams> getModes() {
+			return getModeParams();
+		}
+
 		public ModeParams getOrCreateModeParams(String modeName) {
-			ModeParams modeParams = getModes().get(modeName);
+			ModeParams modeParams = getModeParams().get(modeName);
 			if (modeParams == null) {
 				modeParams = new ModeParams(modeName);
 				addParameterSet(modeParams);
@@ -1534,7 +1552,7 @@ public final class ScoringConfigGroup extends ConfigGroup {
 		}
 
 		public void addModeParams(final ModeParams params) {
-			final ModeParams previous = this.getModes().get(params.getMode());
+			final ModeParams previous = this.getModeParams().get(params.getMode());
 
 			if (previous != null) {
 				final boolean removed = removeParameterSet(previous);

--- a/matsim/src/main/java/org/matsim/core/config/groups/ScoringConfigGroup.java
+++ b/matsim/src/main/java/org/matsim/core/config/groups/ScoringConfigGroup.java
@@ -90,7 +90,7 @@ public final class ScoringConfigGroup extends ConfigGroup {
 	public ScoringConfigGroup() {
 		super(GROUP_NAME);
 
-		this.addScoringParameters(new ScoringParameterSet());
+		this.addScoringParameterSet(new ScoringParameterSet());
 
 		// what follows now has weird consequences:
 		// * the material is added to the ScoringParameterSet of the default subpopulation
@@ -484,6 +484,14 @@ public final class ScoringConfigGroup extends ConfigGroup {
 		return getModeParams();
 	}
 
+	/**
+	 * Returns the mode parameters explicitly configured for the given subpopulation key.
+	 * In contrast to {@link #getScoringParameters(String)}, this method does not apply any fallback.
+	 */
+	public Map<String, ModeParams> getModeParamsForSubpopulation(String subpopulation) {
+		final ScoringParameterSet scoringParameterSet = getExplicitScoringParameterSetsPerSubpopulation().get(subpopulation);
+		if (scoringParameterSet != null)
+			return scoringParameterSet.getModeParams();
 		else
 			throw new RuntimeException("Default subpopulation is not defined");
 	}
@@ -545,7 +553,7 @@ public final class ScoringConfigGroup extends ConfigGroup {
 
 		if (params == null) {
 			params = new ScoringParameterSet(subpopulation);
-			this.addScoringParameters(params);
+			this.addScoringParameterSet(params);
 		}
 
 		return params;
@@ -561,14 +569,14 @@ public final class ScoringConfigGroup extends ConfigGroup {
 				addModeParams((ModeParams) set);
 				break;
 			case ScoringParameterSet.SET_TYPE:
-				addScoringParameters((ScoringParameterSet) set);
+				addScoringParameterSet((ScoringParameterSet) set);
 				break;
 			default:
 				throw new IllegalArgumentException(set.getName());
 		}
 	}
 
-	private void addScoringParameters(final ScoringParameterSet params) {
+	private void addScoringParameterSet(final ScoringParameterSet params) {
 		final ScoringParameterSet previous = this.getScoringParameters(params.getSubpopulation());
 
 		if (previous != null) {

--- a/matsim/src/main/java/org/matsim/core/router/costcalculators/FreespeedTravelTimeAndDisutility.java
+++ b/matsim/src/main/java/org/matsim/core/router/costcalculators/FreespeedTravelTimeAndDisutility.java
@@ -81,9 +81,9 @@ public class FreespeedTravelTimeAndDisutility implements TravelDisutility, Trave
 	}
 
 	public FreespeedTravelTimeAndDisutility(ScoringConfigGroup cnScoringGroup){
-		this(cnScoringGroup.getModes().get(TransportMode.car).getMarginalUtilityOfTraveling() / 3600.0, cnScoringGroup.getPerforming_utils_hr() / 3600.0,
+		this(cnScoringGroup.getDefaultModeParams().get(TransportMode.car).getMarginalUtilityOfTraveling() / 3600.0, cnScoringGroup.getPerforming_utils_hr() / 3600.0,
 //				cnScoringGroup.getMarginalUtlOfDistanceCar());
-				cnScoringGroup.getModes().get(TransportMode.car).getMonetaryDistanceRate() *cnScoringGroup.getMarginalUtilityOfMoney());
+				cnScoringGroup.getDefaultModeParams().get(TransportMode.car).getMonetaryDistanceRate() *cnScoringGroup.getMarginalUtilityOfMoney());
 	}
 
 	@Override

--- a/matsim/src/main/java/org/matsim/core/router/costcalculators/RandomizingTimeDistanceTravelDisutilityFactory.java
+++ b/matsim/src/main/java/org/matsim/core/router/costcalculators/RandomizingTimeDistanceTravelDisutilityFactory.java
@@ -67,7 +67,7 @@ public class RandomizingTimeDistanceTravelDisutilityFactory implements TravelDis
 		// ).getMarginalUtilityOfMoney(); That line, or some variant of it, would need to be in the TravelDisutility directly. And I am quite unsure what is the status of
 		// the "default" subpopulation anyways ... I seem to recall that Thibaut wanted to get rid of that.  The following method at least outputs
 		// a warning.  However, we know by now that few people think about such warnings. kai, mar'20
-		final ScoringConfigGroup.ModeParams params = cnScoringGroup.getModes().get( mode ) ;
+		final ScoringConfigGroup.ModeParams params = cnScoringGroup.getDefaultModeParams().get( mode ) ;
 		if ( params == null ) {
 			throw new IllegalStateException("No scoring parameters are defined for mode '" + mode
 				+ "'. Please add a modeParams parameter set for mode '" + mode + "' to the scoring configuration.");

--- a/matsim/src/main/java/org/matsim/core/router/costcalculators/RandomizingTimeDistanceTravelDisutilityFactory.java
+++ b/matsim/src/main/java/org/matsim/core/router/costcalculators/RandomizingTimeDistanceTravelDisutilityFactory.java
@@ -104,7 +104,7 @@ public class RandomizingTimeDistanceTravelDisutilityFactory implements TravelDis
 			}
 
 			final Set<String> monoSubpopKeyset = Collections.singleton( null );
-			if ( !cnScoringGroup.getScoringParametersPerSubpopulation().keySet().equals( monoSubpopKeyset ) ) {
+			if ( !cnScoringGroup.getAllScoringParameterSetsPerSubpopulation().keySet().equals( monoSubpopKeyset ) ) {
 				log.warn( "Scoring parameters are defined for different subpopulations." +
 						" The routing disutility will only consider the ones of the default subpopulation.");
 				log.warn( "This warning can safely be ignored if disutility of traveling only depends on travel time.");

--- a/matsim/src/main/java/org/matsim/core/scenario/checkers/VspScenarioCheckerImpl.java
+++ b/matsim/src/main/java/org/matsim/core/scenario/checkers/VspScenarioCheckerImpl.java
@@ -113,7 +113,7 @@ public final class VspScenarioCheckerImpl implements ScenarioChecker {
 
 		// check if there are corresponding scoring params for all subpopulations.
 		for (String subpopulation : subpopulations) {
-			if (!scenario.getConfig().scoring().getScoringParametersPerSubpopulation().containsKey(subpopulation)) {
+			if (!scenario.getConfig().scoring().getAllScoringParameterSetsPerSubpopulation().containsKey(subpopulation)) {
 				log.log(lvl,
 					"Found subpopulation '{}' but no corresponding scoring parameters. Please add scoring parameters for this subpopulation.",
 					subpopulation);

--- a/matsim/src/main/java/org/matsim/core/scoring/functions/CharyparNagelScoringFunctionModule.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/functions/CharyparNagelScoringFunctionModule.java
@@ -41,7 +41,7 @@ public class CharyparNagelScoringFunctionModule extends AbstractModule {
     public void install() {
         bind(ScoringFunctionFactory.class).to(CharyparNagelScoringFunctionFactory.class);
 
-		Map<String, ScoringConfigGroup.ScoringParameterSet> scoringParameter = getConfig().scoring().getScoringParametersPerSubpopulation();
+		Map<String, ScoringConfigGroup.ScoringParameterSet> scoringParameter = getConfig().scoring().getAllScoringParameterSetsPerSubpopulation();
 
 		boolean tasteVariations = scoringParameter.values().stream().anyMatch(s -> s.getTasteVariationsParams() != null);
 

--- a/matsim/src/main/java/org/matsim/core/scoring/functions/IndividualPersonScoringOutputWriter.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/functions/IndividualPersonScoringOutputWriter.java
@@ -51,7 +51,7 @@ public class IndividualPersonScoringOutputWriter implements IterationEndsListene
 		Set<String> modes = new LinkedHashSet<>();
 		Set<ModeUtilityParameters.Type> paramsTypes = new LinkedHashSet<>();
 
-		for (Map.Entry<String, ScoringConfigGroup.ScoringParameterSet> e : config.getScoringParametersPerSubpopulation().entrySet()) {
+		for (Map.Entry<String, ScoringConfigGroup.ScoringParameterSet> e : config.getAllScoringParameterSetsPerSubpopulation().entrySet()) {
 
 			TasteVariationsConfigParameterSet tasteVariationsParams = e.getValue().getTasteVariationsParams();
 			if (tasteVariationsParams != null) {

--- a/matsim/src/main/java/org/matsim/core/scoring/functions/IndividualPersonScoringOutputWriter.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/functions/IndividualPersonScoringOutputWriter.java
@@ -58,7 +58,7 @@ public class IndividualPersonScoringOutputWriter implements IterationEndsListene
 				subpopulations.add(e.getKey());
 				excludeSubpopulations.addAll(tasteVariationsParams.getExcludeSubpopulations());
 				paramsTypes.addAll(tasteVariationsParams.getVariationsOf());
-				modes.addAll(e.getValue().getModes().keySet());
+				modes.addAll(e.getValue().getModeParams().keySet());
 			}
 		}
 

--- a/matsim/src/main/java/org/matsim/core/scoring/functions/ScoringParameters.java
+++ b/matsim/src/main/java/org/matsim/core/scoring/functions/ScoringParameters.java
@@ -148,7 +148,7 @@ public class ScoringParameters implements MatsimParameters {
 			}
 
 			modeParams = new TreeMap<>() ;
-			Map<String, ScoringConfigGroup.ModeParams> modes = scoringParameterSet.getModes();
+			Map<String, ScoringConfigGroup.ModeParams> modes = scoringParameterSet.getModeParams();
 			double worstMarginalUtilityOfTraveling_s = 0.0;
 			for (Map.Entry<String, ScoringConfigGroup.ModeParams> mode : modes.entrySet()) {
 				String modeName = mode.getKey();
@@ -199,7 +199,7 @@ public class ScoringParameters implements MatsimParameters {
 			utilParams = activityParams;
 
 			modeParams = new TreeMap<>() ;
-			Map<String, ScoringConfigGroup.ModeParams> modes = scoringParameterSet.getModes();
+			Map<String, ScoringConfigGroup.ModeParams> modes = scoringParameterSet.getModeParams();
 			double worstMarginalUtilityOfTraveling_s = 0.0;
 			for (Map.Entry<String, ScoringConfigGroup.ModeParams> mode : modes.entrySet()) {
 				String modeName = mode.getKey();

--- a/matsim/src/main/java/org/matsim/pt/router/TransitRouterConfig.java
+++ b/matsim/src/main/java/org/matsim/pt/router/TransitRouterConfig.java
@@ -114,7 +114,7 @@ public class TransitRouterConfig implements MatsimParameters {
 	{
 		pcsConfig.setLocked(); routingConfig.setLocked() ; trConfig.setLocked() ; vspConfig.setLocked() ;
 
-		if (pcsConfig.getScoringParametersPerSubpopulation().size()>1){
+		if (pcsConfig.getAllScoringParameterSetsPerSubpopulation().size()>1){
 			subPopulationWarning.warn("More than one subpopulation is used in plansCalcScore. "
 				+ "This is not currently implemented in the TransitRouter (but should work for scoring),"
 				+ " so the values for the \"default\" subpopulation will be used. (jb, Feb 2018)");

--- a/matsim/src/main/java/org/matsim/pt/router/TransitRouterConfig.java
+++ b/matsim/src/main/java/org/matsim/pt/router/TransitRouterConfig.java
@@ -141,18 +141,18 @@ public class TransitRouterConfig implements MatsimParameters {
 		// yyyyyy the two above need to be moved away from walk since otherwise one is not able to move walk routing to network routing!!!!!! Now trying access_walk ...  kai,
 		// apr'19
 
-		this.marginalUtilityOfTravelTimeWalk_utl_s = pcsConfig.getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling() /3600.0 - pcsConfig.getPerforming_utils_hr()/3600. ;
+		this.marginalUtilityOfTravelTimeWalk_utl_s = pcsConfig.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() /3600.0 - pcsConfig.getPerforming_utils_hr()/3600. ;
 
 		this.marginalUtilityOfTravelDistanceWalk_utl_m = pcsConfig.getMarginalUtilityOfMoney() *
-				pcsConfig.getModes().get(TransportMode.walk).getMonetaryDistanceRate() +
-				pcsConfig.getModes().get(TransportMode.walk).getMarginalUtilityOfDistance();
+				pcsConfig.getDefaultModeParams().get(TransportMode.walk).getMonetaryDistanceRate() +
+				pcsConfig.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfDistance();
 
 		// pt:
-		this.marginalUtilityOfTravelTimeTransit_utl_s = pcsConfig.getModes().get(TransportMode.pt).getMarginalUtilityOfTraveling() /3600.0 - pcsConfig.getPerforming_utils_hr()/3600. ;
+		this.marginalUtilityOfTravelTimeTransit_utl_s = pcsConfig.getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling() /3600.0 - pcsConfig.getPerforming_utils_hr()/3600. ;
 
 		this.marginalUtilityOfTravelDistanceTransit_utl_m = pcsConfig.getMarginalUtilityOfMoney() *
-				pcsConfig.getModes().get(TransportMode.pt).getMonetaryDistanceRate() +
-				pcsConfig.getModes().get(TransportMode.pt).getMarginalUtilityOfDistance();
+				pcsConfig.getDefaultModeParams().get(TransportMode.pt).getMonetaryDistanceRate() +
+				pcsConfig.getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfDistance();
 
 		this.marginalUtilityOfWaitingPt_utl_s = pcsConfig.getMarginalUtlOfWaitingPt_utils_hr() / 3600.0 - pcsConfig.getPerforming_utils_hr()/3600. ;
 

--- a/matsim/src/main/java/org/matsim/pt/router/TransitRouterConfig.java
+++ b/matsim/src/main/java/org/matsim/pt/router/TransitRouterConfig.java
@@ -141,22 +141,22 @@ public class TransitRouterConfig implements MatsimParameters {
 		// yyyyyy the two above need to be moved away from walk since otherwise one is not able to move walk routing to network routing!!!!!! Now trying access_walk ...  kai,
 		// apr'19
 
-		this.marginalUtilityOfTravelTimeWalk_utl_s = pcsConfig.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() /3600.0 - pcsConfig.getPerforming_utils_hr()/3600. ;
+		this.marginalUtilityOfTravelTimeWalk_utl_s = pcsConfig.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() /3600.0 - pcsConfig.getDefaultPerforming_utils_hr()/3600. ;
 
-		this.marginalUtilityOfTravelDistanceWalk_utl_m = pcsConfig.getMarginalUtilityOfMoney() *
+		this.marginalUtilityOfTravelDistanceWalk_utl_m = pcsConfig.getDefaultMarginalUtilityOfMoney() *
 				pcsConfig.getDefaultModeParams().get(TransportMode.walk).getMonetaryDistanceRate() +
 				pcsConfig.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfDistance();
 
 		// pt:
-		this.marginalUtilityOfTravelTimeTransit_utl_s = pcsConfig.getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling() /3600.0 - pcsConfig.getPerforming_utils_hr()/3600. ;
+		this.marginalUtilityOfTravelTimeTransit_utl_s = pcsConfig.getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling() /3600.0 - pcsConfig.getDefaultPerforming_utils_hr()/3600. ;
 
-		this.marginalUtilityOfTravelDistanceTransit_utl_m = pcsConfig.getMarginalUtilityOfMoney() *
+		this.marginalUtilityOfTravelDistanceTransit_utl_m = pcsConfig.getDefaultMarginalUtilityOfMoney() *
 				pcsConfig.getDefaultModeParams().get(TransportMode.pt).getMonetaryDistanceRate() +
 				pcsConfig.getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfDistance();
 
-		this.marginalUtilityOfWaitingPt_utl_s = pcsConfig.getMarginalUtlOfWaitingPt_utils_hr() / 3600.0 - pcsConfig.getPerforming_utils_hr()/3600. ;
+		this.marginalUtilityOfWaitingPt_utl_s = pcsConfig.getDefaultMarginalUtlOfWaitingPt_utils_hr() / 3600.0 - pcsConfig.getDefaultPerforming_utils_hr()/3600. ;
 
-		this.utilityOfLineSwitch_utl = pcsConfig.getUtilityOfLineSwitch();
+		this.utilityOfLineSwitch_utl = pcsConfig.getDefaultUtilityOfLineSwitch();
 
 		// router:
 		this.setSearchRadius(trConfig.getSearchRadius());

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorIntermodalTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorIntermodalTest.java
@@ -498,7 +498,7 @@ public class SwissRailRaptorIntermodalTest {
 
         // we need to set special values for walk and bike as the defaults are the same for walk, bike and waiting
         // which would result in all options having the same cost in the end.
-        f.config.scoring().getModes().get(TransportMode.bike).setMarginalUtilityOfTraveling(-8);
+        f.config.scoring().getDefaultModeParams().get(TransportMode.bike).setMarginalUtilityOfTraveling(-8);
 
         ScoringConfigGroup.ModeParams walk = new ScoringConfigGroup.ModeParams(TransportMode.walk);
         walk.setMarginalUtilityOfTraveling(-7);
@@ -593,7 +593,7 @@ public class SwissRailRaptorIntermodalTest {
 
         // we need to set special values for walk and bike as the defaults are the same for walk, bike and waiting
         // which would result in all options having the same cost in the end.
-        f.config.scoring().getModes().get(TransportMode.bike).setMarginalUtilityOfTraveling(-8);
+        f.config.scoring().getDefaultModeParams().get(TransportMode.bike).setMarginalUtilityOfTraveling(-8);
 
         ScoringConfigGroup.ModeParams walk = new ScoringConfigGroup.ModeParams(TransportMode.walk);
         walk.setMarginalUtilityOfTraveling(-7);
@@ -1484,7 +1484,7 @@ public class SwissRailRaptorIntermodalTest {
 
             // we need to set special values for walk and bike as the defaults are the same for walk, bike and waiting
             // which would result in all options having the same cost in the end.
-            this.config.scoring().getModes().get(TransportMode.bike).setMarginalUtilityOfTraveling(-8);
+            this.config.scoring().getDefaultModeParams().get(TransportMode.bike).setMarginalUtilityOfTraveling(-8);
 
             this.config.transitRouter().setMaxBeelineWalkConnectionDistance(150);
 

--- a/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorTest.java
+++ b/matsim/src/test/java/ch/sbb/matsim/routing/pt/raptor/SwissRailRaptorTest.java
@@ -370,7 +370,7 @@ public class SwissRailRaptorTest {
 		//changing from train to ship is so expensive that direct walk is cheaper
 		assertNull(legs);
 	}
-	
+
 	@Test
 	void testLineChangeWithDifferentTravelTimeUtils() {
         Fixture f = new Fixture();
@@ -380,22 +380,22 @@ public class SwissRailRaptorTest {
 		swissRailRaptorConfigGroup.setTransferWalkMargin(0);
 		RaptorParameters raptorParams = RaptorUtils.createParameters(f.config);
         SwissRailRaptorData data = SwissRailRaptorData.create(f.schedule, null, RaptorUtils.createStaticConfig(f.config), f.network, null);
-        TransitRouter router = new SwissRailRaptor.Builder(data, f.config).with(new RaptorParametersForPerson() {	
+        TransitRouter router = new SwissRailRaptor.Builder(data, f.config).with(new RaptorParametersForPerson() {
 			@Override
 			public RaptorParameters getRaptorParameters(Person person) {
 				return raptorParams;
 			}
 		}).build();
-        
+
         // from C to G (see Fixture), competing between red line (express) and blue line (regular)
 		Coord fromCoord = new Coord(12000, 5000);
 		Coord toCoord = new Coord(28000, 5000);
-		
+
 		// default case
 		List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(fromCoord), new FakeFacility(toCoord), 6.0*3600 - 60.0, null));
 		assertEquals(3, legs.size());
 		assertEquals("red", ((TransitPassengerRoute) ((Leg) legs.get(1)).getRoute()).getLineId().toString());
-		
+
 		// routing by transport mode, same costs, choose red (train) again
 		raptorParams.setUseTransportModeUtilities(true);
 		raptorParams.setMarginalUtilityOfTravelTime_utl_s("train", -1e-3);
@@ -466,7 +466,7 @@ public class SwissRailRaptorTest {
          */
         Fixture f = new Fixture();
         f.init();
-        f.config.scoring().setUtilityOfLineSwitch(0);
+        f.config.scoring().setDefaultUtilityOfLineSwitch(0);
         RaptorParameters raptorParams = RaptorUtils.createParameters(f.config);
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
         List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(new Coord(11900, 5100)), new FakeFacility(new Coord(24100, 4950)), 6.0*3600 - 5.0*60, null));
@@ -481,7 +481,7 @@ public class SwissRailRaptorTest {
 
         Config config = ConfigUtils.createConfig();
         double transferUtility = 300.0 * raptorParams.getMarginalUtilityOfTravelTime_utl_s(TransportMode.pt); // corresponds to 5 minutes transit travel time
-        config.scoring().setUtilityOfLineSwitch(transferUtility);
+        config.scoring().setDefaultUtilityOfLineSwitch(transferUtility);
         raptorParams = RaptorUtils.createParameters(config);
         Assertions.assertEquals(-transferUtility, raptorParams.getTransferPenaltyFixCostPerTransfer(), 0.0);
         router = createTransitRouter(f.schedule, config, f.network);
@@ -505,7 +505,7 @@ public class SwissRailRaptorTest {
          */
         Fixture f = new Fixture();
         f.init();
-        f.config.scoring().setUtilityOfLineSwitch(0);
+        f.config.scoring().setDefaultUtilityOfLineSwitch(0);
         f.config.transitRouter().setAdditionalTransferTime(0);
         TransitRouter router = createTransitRouter(f.schedule, f.config, f.network);
         List<? extends PlanElement> legs = router.calcRoute(DefaultRoutingRequest.withoutAttributes(new FakeFacility(new Coord(11900, 5100)), new FakeFacility(new Coord(24100, 4950)), 6.0*3600 - 5.0*60, null));
@@ -972,7 +972,7 @@ public class SwissRailRaptorTest {
         walkParameters.setTeleportedModeSpeed(beelineDistanceFactor); // set it such that the beelineWalkSpeed is exactly 1
         config.routing().addParameterSet(walkParameters);
 
-        config.scoring().setUtilityOfLineSwitch(-transferFixedCost);
+        config.scoring().setDefaultUtilityOfLineSwitch(-transferFixedCost);
         srrConfig.setTransferPenaltyBaseCost(transferFixedCost);
         srrConfig.setTransferPenaltyCostPerTravelTimeHour(transferRelativeCostFactor);
 

--- a/matsim/src/test/java/org/matsim/application/ConfigYamlUpdateTest.java
+++ b/matsim/src/test/java/org/matsim/application/ConfigYamlUpdateTest.java
@@ -40,13 +40,13 @@ public class ConfigYamlUpdateTest {
 
 		ScoringConfigGroup scoring = ConfigUtils.addOrGetModule(config, ScoringConfigGroup.class);
 
-		assertThat(scoring.getModes())
+		assertThat(scoring.getDefaultModeParams())
 			.hasSize(7);
 
 		assertThat(scoring.getPerforming_utils_hr())
 			.isEqualTo(6.88);
 
-		ScoringConfigGroup.ModeParams car = scoring.getModes().get(TransportMode.car);
+		ScoringConfigGroup.ModeParams car = scoring.getDefaultModeParams().get(TransportMode.car);
 
 		assertThat(car.getConstant()).isEqualTo(-0.62);
 		assertThat(car.getMarginalUtilityOfTraveling()).isEqualTo(0);

--- a/matsim/src/test/java/org/matsim/core/config/ConfigReaderMatsimV2Test.java
+++ b/matsim/src/test/java/org/matsim/core/config/ConfigReaderMatsimV2Test.java
@@ -289,7 +289,7 @@ public class ConfigReaderMatsimV2Test {
 		r2.getConfigAliases().addAlias("theMode", "mode", "scoring", "scoringParameters", "modeParams");
 		r2.readStream(bais);
 
-		Assertions.assertEquals(-5.6, config.scoring().getModes().get("car").getMarginalUtilityOfTraveling(), 1e-7);
-		Assertions.assertEquals(-8.7, config.scoring().getModes().get("unicycle").getMarginalUtilityOfTraveling(), 1e-7);
+		Assertions.assertEquals(-5.6, config.scoring().getDefaultModeParams().get("car").getMarginalUtilityOfTraveling(), 1e-7);
+		Assertions.assertEquals(-8.7, config.scoring().getDefaultModeParams().get("unicycle").getMarginalUtilityOfTraveling(), 1e-7);
 	}
 }

--- a/matsim/src/test/java/org/matsim/core/config/consistency/ConfigConsistencyCheckerImplTest.java
+++ b/matsim/src/test/java/org/matsim/core/config/consistency/ConfigConsistencyCheckerImplTest.java
@@ -94,7 +94,7 @@ public class ConfigConsistencyCheckerImplTest {
 		Config config = new Config();
 		config.addCoreModules();
 
-		config.scoring().getModes().get(TransportMode.bike).setMarginalUtilityOfTraveling(3.0);
+		config.scoring().getDefaultModeParams().get(TransportMode.bike).setMarginalUtilityOfTraveling(3.0);
 
 		LogCounter logger = new LogCounter(Level.WARN);
 		try {
@@ -112,7 +112,7 @@ public class ConfigConsistencyCheckerImplTest {
 		Config config = new Config();
 		config.addCoreModules();
 
-		config.scoring().getModes().get(TransportMode.walk).setMarginalUtilityOfTraveling(3.0);
+		config.scoring().getDefaultModeParams().get(TransportMode.walk).setMarginalUtilityOfTraveling(3.0);
 
 		LogCounter logger = new LogCounter(Level.WARN);
 		try {

--- a/matsim/src/test/java/org/matsim/core/config/consistency/ConfigConsistencyCheckerImplTest.java
+++ b/matsim/src/test/java/org/matsim/core/config/consistency/ConfigConsistencyCheckerImplTest.java
@@ -58,7 +58,7 @@ public class ConfigConsistencyCheckerImplTest {
 		Config config = new Config();
 		config.addCoreModules();
 
-		config.scoring().getModes().get(TransportMode.car).setMarginalUtilityOfTraveling(3.0);
+		config.scoring().getDefaultModeParams().get(TransportMode.car).setMarginalUtilityOfTraveling(3.0);
 
 		LogCounter logger = new LogCounter(Level.WARN);
 		try {
@@ -76,7 +76,7 @@ public class ConfigConsistencyCheckerImplTest {
 		Config config = new Config();
 		config.addCoreModules();
 
-		config.scoring().getModes().get(TransportMode.pt).setMarginalUtilityOfTraveling(3.0);
+		config.scoring().getDefaultModeParams().get(TransportMode.pt).setMarginalUtilityOfTraveling(3.0);
 
 		LogCounter logger = new LogCounter(Level.WARN);
 		try {

--- a/matsim/src/test/java/org/matsim/core/config/groups/ScoringConfigGroupTest.java
+++ b/matsim/src/test/java/org/matsim/core/config/groups/ScoringConfigGroupTest.java
@@ -53,12 +53,12 @@ import org.matsim.testcases.MatsimTestUtils;
 
 		if ( ! fullyHierarchical ){
 			// mode params are there for default modes:
-			Assertions.assertNotNull( scoringConfig.getModeParams().get( TransportMode.car ) );
-			Assertions.assertNotNull( scoringConfig.getModeParams().get( TransportMode.walk ) );
-			Assertions.assertNotNull( scoringConfig.getModeParams().get( TransportMode.bike ) );
-			Assertions.assertNotNull( scoringConfig.getModeParams().get( TransportMode.ride ) );
-			Assertions.assertNotNull( scoringConfig.getModeParams().get( TransportMode.pt ) );
-			Assertions.assertNotNull( scoringConfig.getModeParams().get( TransportMode.other ) );
+			Assertions.assertNotNull( scoringConfig.getDefaultModeParams().get( TransportMode.car ) );
+			Assertions.assertNotNull( scoringConfig.getDefaultModeParams().get( TransportMode.walk ) );
+			Assertions.assertNotNull( scoringConfig.getDefaultModeParams().get( TransportMode.bike ) );
+			Assertions.assertNotNull( scoringConfig.getDefaultModeParams().get( TransportMode.ride ) );
+			Assertions.assertNotNull( scoringConfig.getDefaultModeParams().get( TransportMode.pt ) );
+			Assertions.assertNotNull( scoringConfig.getDefaultModeParams().get( TransportMode.other ) );
 
 			// default stage/interaction params are there for pt and drt (as a service):
 			Assertions.assertNotNull( scoringConfig.getActivityParams( createStageActivityType( TransportMode.pt ) ) );
@@ -84,7 +84,7 @@ import org.matsim.testcases.MatsimTestUtils;
 		ScoringConfigGroup scoringConfig = config.scoring() ;
 		testResultsBeforeCheckConsistency( config, true ) ;
 		log.warn( "" );
-		for( ModeParams modeParams : scoringConfig.getModeParams().values() ){
+		for( ModeParams modeParams : scoringConfig.getDefaultModeParams().values() ){
 			log.warn(  modeParams );
 		}
 		log.warn( "" );
@@ -97,7 +97,7 @@ import org.matsim.testcases.MatsimTestUtils;
 		scoringConfig.checkConsistency( config );
 		testResultsAfterCheckConsistency( config );
 		log.warn( "" );
-		for( ModeParams modeParams : scoringConfig.getModeParams().values() ){
+		for( ModeParams modeParams : scoringConfig.getDefaultModeParams().values() ){
 			log.warn(  modeParams );
 		}
 		log.warn( "" );
@@ -113,7 +113,7 @@ import org.matsim.testcases.MatsimTestUtils;
 		ScoringConfigGroup scoringConfig = config.scoring() ;
 		testResultsBeforeCheckConsistency( config, false ) ;
 		log.warn( "" );
-		for( ModeParams modeParams : scoringConfig.getModeParams().values() ){
+		for( ModeParams modeParams : scoringConfig.getDefaultModeParams().values() ){
 			log.warn(  modeParams );
 		}
 		log.warn( "" );
@@ -126,7 +126,7 @@ import org.matsim.testcases.MatsimTestUtils;
 		scoringConfig.checkConsistency( config );
 		testResultsAfterCheckConsistency( config );
 		log.warn( "" );
-		for( ModeParams modeParams : scoringConfig.getModeParams().values() ){
+		for( ModeParams modeParams : scoringConfig.getDefaultModeParams().values() ){
 			log.warn(  modeParams );
 		}
 		log.warn( "" );
@@ -184,28 +184,28 @@ import org.matsim.testcases.MatsimTestUtils;
 				1e-7,
 				"wrong brainExpBeta "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModeParams().get(TransportMode.bike).getConstant(),
-				inputConfigGroup.getModeParams().get(TransportMode.bike).getConstant(),
+				initialGroup.getDefaultModeParams().get(TransportMode.bike).getConstant(),
+				inputConfigGroup.getDefaultModeParams().get(TransportMode.bike).getConstant(),
 				1e-7,
 				"wrong constantBike "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModeParams().get(TransportMode.car).getConstant(),
-				inputConfigGroup.getModeParams().get(TransportMode.car).getConstant(),
+				initialGroup.getDefaultModeParams().get(TransportMode.car).getConstant(),
+				inputConfigGroup.getDefaultModeParams().get(TransportMode.car).getConstant(),
 				1e-7,
 				"wrong constantCar "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModeParams().get(TransportMode.other).getConstant(),
-				inputConfigGroup.getModeParams().get(TransportMode.other).getConstant(),
+				initialGroup.getDefaultModeParams().get(TransportMode.other).getConstant(),
+				inputConfigGroup.getDefaultModeParams().get(TransportMode.other).getConstant(),
 				1e-7,
 				"wrong constantOther "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModeParams().get(TransportMode.pt).getConstant(),
-				inputConfigGroup.getModeParams().get(TransportMode.pt).getConstant(),
+				initialGroup.getDefaultModeParams().get(TransportMode.pt).getConstant(),
+				inputConfigGroup.getDefaultModeParams().get(TransportMode.pt).getConstant(),
 				1e-7,
 				"wrong constantPt "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModeParams().get(TransportMode.walk).getConstant(),
-				inputConfigGroup.getModeParams().get(TransportMode.walk).getConstant(),
+				initialGroup.getDefaultModeParams().get(TransportMode.walk).getConstant(),
+				inputConfigGroup.getDefaultModeParams().get(TransportMode.walk).getConstant(),
 				1e-7,
 				"wrong constantWalk "+msg);
 		Assertions.assertEquals(
@@ -229,13 +229,13 @@ import org.matsim.testcases.MatsimTestUtils;
 				1e-7,
 				"wrong marginalUtilityOfMoney "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModeParams().get(TransportMode.other).getMarginalUtilityOfDistance(),
-				inputConfigGroup.getModeParams().get(TransportMode.other).getMarginalUtilityOfDistance(),
+				initialGroup.getDefaultModeParams().get(TransportMode.other).getMarginalUtilityOfDistance(),
+				inputConfigGroup.getDefaultModeParams().get(TransportMode.other).getMarginalUtilityOfDistance(),
 				1e-7,
 				"wrong marginalUtlOfDistanceOther "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModeParams().get(TransportMode.walk).getMarginalUtilityOfDistance(),
-				inputConfigGroup.getModeParams().get(TransportMode.walk).getMarginalUtilityOfDistance(),
+				initialGroup.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfDistance(),
+				inputConfigGroup.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfDistance(),
 				1e-7,
 				"wrong marginalUtlOfDistanceWalk "+msg);
 		Assertions.assertEquals(
@@ -249,13 +249,13 @@ import org.matsim.testcases.MatsimTestUtils;
 				1e-7,
 				"wrong marginalUtlOfWaitingPt_utils_hr "+msg );
 		Assertions.assertEquals(
-				initialGroup.getModeParams().get(TransportMode.car).getMonetaryDistanceRate(),
-				inputConfigGroup.getModeParams().get(TransportMode.car).getMonetaryDistanceRate(),
+				initialGroup.getDefaultModeParams().get(TransportMode.car).getMonetaryDistanceRate(),
+				inputConfigGroup.getDefaultModeParams().get(TransportMode.car).getMonetaryDistanceRate(),
 				1e-7,
 				"wrong monetaryDistanceCostRateCar "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModeParams().get(TransportMode.pt).getMonetaryDistanceRate(),
-				inputConfigGroup.getModeParams().get(TransportMode.pt).getMonetaryDistanceRate(),
+				initialGroup.getDefaultModeParams().get(TransportMode.pt).getMonetaryDistanceRate(),
+				inputConfigGroup.getDefaultModeParams().get(TransportMode.pt).getMonetaryDistanceRate(),
 				1e-7,
 				"wrong monetaryDistanceCostRatePt "+msg);
 		Assertions.assertEquals(
@@ -269,28 +269,28 @@ import org.matsim.testcases.MatsimTestUtils;
 				1e-7,
 				"wrong performing_utils_hr "+msg );
 		Assertions.assertEquals(
-				initialGroup.getModeParams().get(TransportMode.car).getMarginalUtilityOfTraveling(),
-				inputConfigGroup.getModeParams().get(TransportMode.car).getMarginalUtilityOfTraveling(),
+				initialGroup.getDefaultModeParams().get(TransportMode.car).getMarginalUtilityOfTraveling(),
+				inputConfigGroup.getDefaultModeParams().get(TransportMode.car).getMarginalUtilityOfTraveling(),
 				1e-7,
 				"wrong traveling_utils_hr "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModeParams().get(TransportMode.bike).getMarginalUtilityOfTraveling(),
-				inputConfigGroup.getModeParams().get(TransportMode.bike).getMarginalUtilityOfTraveling(),
+				initialGroup.getDefaultModeParams().get(TransportMode.bike).getMarginalUtilityOfTraveling(),
+				inputConfigGroup.getDefaultModeParams().get(TransportMode.bike).getMarginalUtilityOfTraveling(),
 				1e-7,
 				"wrong travelingBike_utils_hr "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModeParams().get(TransportMode.other).getMarginalUtilityOfTraveling(),
-				inputConfigGroup.getModeParams().get(TransportMode.other).getMarginalUtilityOfTraveling(),
+				initialGroup.getDefaultModeParams().get(TransportMode.other).getMarginalUtilityOfTraveling(),
+				inputConfigGroup.getDefaultModeParams().get(TransportMode.other).getMarginalUtilityOfTraveling(),
 				1e-7,
 				"wrong travelingOther_utils_hr "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling(),
-				inputConfigGroup.getModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling(),
+				initialGroup.getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling(),
+				inputConfigGroup.getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling(),
 				1e-7,
 				"wrong travelingPt_utils_hr "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling(),
-				inputConfigGroup.getModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling(),
+				initialGroup.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling(),
+				inputConfigGroup.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling(),
 				1e-7,
 				"wrong travelingWalk_utils_hr "+msg);
 		Assertions.assertEquals(
@@ -338,9 +338,9 @@ import org.matsim.testcases.MatsimTestUtils;
 					"wrong typicalDuration "+msg);
 		}
 
-		for ( ModeParams initialSettings : initialGroup.getModeParams().values() ) {
+		for ( ModeParams initialSettings : initialGroup.getDefaultModeParams().values() ) {
 			final String mode = initialSettings.getMode();
-			final ModeParams inputSettings = inputConfigGroup.getModeParams().get( mode );
+			final ModeParams inputSettings = inputConfigGroup.getDefaultModeParams().get( mode );
 			Assertions.assertEquals(
 					initialSettings.getConstant(),
 					inputSettings.getConstant(),
@@ -392,7 +392,7 @@ import org.matsim.testcases.MatsimTestUtils;
 			settings.getTypicalDuration().ifDefined(t -> module.addParam("activityTypicalDuration_" + suffix, "" + t));
 		}
 
-		for ( ModeParams settings : initialGroup.getModeParams().values() ) {
+		for ( ModeParams settings : initialGroup.getDefaultModeParams().values() ) {
 			final String mode = settings.getMode();
 			module.addParam( "constant_"+mode , ""+settings.getConstant() );
 			module.addParam( "marginalUtlOfDistance_"+mode , ""+settings.getMarginalUtilityOfDistance() );
@@ -412,29 +412,29 @@ import org.matsim.testcases.MatsimTestUtils;
 		final ScoringConfigGroup group = new ScoringConfigGroup();
 
 		group.setBrainExpBeta( 124);
-		group.setLateArrival_utils_hr( 345 );
-		group.setEarlyDeparture_utils_hr( 5 );
-		group.getModeParams().get(TransportMode.bike).setConstant((double) 98);
-		group.getModeParams().get(TransportMode.car).setConstant((double) 345);
-		group.getModeParams().get(TransportMode.other).setConstant((double) 345);
-		group.getModeParams().get(TransportMode.pt).setConstant((double) 983);
-		group.getModeParams().get(TransportMode.walk).setConstant((double) 89);
+		group.setDefaultLateArrival_utils_hr( 345 );
+		group.setDefaultEarlyDeparture_utils_hr( 5 );
+		group.getDefaultModeParams().get(TransportMode.bike).setConstant((double) 98);
+		group.getDefaultModeParams().get(TransportMode.car).setConstant((double) 345);
+		group.getDefaultModeParams().get(TransportMode.other).setConstant((double) 345);
+		group.getDefaultModeParams().get(TransportMode.pt).setConstant((double) 983);
+		group.getDefaultModeParams().get(TransportMode.walk).setConstant((double) 89);
 		group.setLearningRate( 98 );
-		group.setMarginalUtilityOfMoney( 9 );
-		group.setMarginalUtlOfWaiting_utils_hr( 65798 );
-		group.setMarginalUtlOfWaitingPt_utils_hr( 9867 );
-		group.getModeParams().get(TransportMode.other).setMarginalUtilityOfDistance((double) 23);
-		group.getModeParams().get(TransportMode.walk).setMarginalUtilityOfDistance((double) 8675);
-		group.getModeParams().get(TransportMode.car).setMonetaryDistanceRate((double) 240358);
-		group.getModeParams().get(TransportMode.pt).setMonetaryDistanceRate((double) 9835);
+		group.setDefaultMarginalUtilityOfMoney( 9 );
+		group.setDefaultMarginalUtlOfWaiting_utils_hr( 65798 );
+		group.setDefaultMarginalUtlOfWaitingPt_utils_hr( 9867 );
+		group.getDefaultModeParams().get(TransportMode.other).setMarginalUtilityOfDistance((double) 23);
+		group.getDefaultModeParams().get(TransportMode.walk).setMarginalUtilityOfDistance((double) 8675);
+		group.getDefaultModeParams().get(TransportMode.car).setMonetaryDistanceRate((double) 240358);
+		group.getDefaultModeParams().get(TransportMode.pt).setMonetaryDistanceRate((double) 9835);
 		group.setPathSizeLogitBeta( 8 );
-		group.setPerforming_utils_hr( 678 );
-		group.setUtilityOfLineSwitch( 396 );
-		group.getModeParams().get(TransportMode.car).setMarginalUtilityOfTraveling((double) 246);
-		group.getModeParams().get(TransportMode.bike).setMarginalUtilityOfTraveling((double) 968);
-		group.getModeParams().get(TransportMode.other).setMarginalUtilityOfTraveling((double) 206);
-		group.getModeParams().get(TransportMode.pt).setMarginalUtilityOfTraveling((double) 957);
-		group.getModeParams().get(TransportMode.walk).setMarginalUtilityOfTraveling((double) 983455);
+		group.setDefaultPerforming_utils_hr( 678 );
+		group.setDefaultUtilityOfLineSwitch( 396 );
+		group.getDefaultModeParams().get(TransportMode.car).setMarginalUtilityOfTraveling((double) 246);
+		group.getDefaultModeParams().get(TransportMode.bike).setMarginalUtilityOfTraveling((double) 968);
+		group.getDefaultModeParams().get(TransportMode.other).setMarginalUtilityOfTraveling((double) 206);
+		group.getDefaultModeParams().get(TransportMode.pt).setMarginalUtilityOfTraveling((double) 957);
+		group.getDefaultModeParams().get(TransportMode.walk).setMarginalUtilityOfTraveling((double) 983455);
 
 		final Random random = new Random( 925 );
 		for ( int i=0; i < 10; i++ ) {
@@ -461,8 +461,6 @@ import org.matsim.testcases.MatsimTestUtils;
 
 			group.addParameterSet( settings );
 		}
-
-
 		return group;
 	}
 }

--- a/matsim/src/test/java/org/matsim/core/config/groups/ScoringConfigGroupTest.java
+++ b/matsim/src/test/java/org/matsim/core/config/groups/ScoringConfigGroupTest.java
@@ -148,6 +148,157 @@ import org.matsim.testcases.MatsimTestUtils;
 		Assertions.assertEquals(ap, c.getDefaultActivityParams("type1"));
         Assertions.assertEquals(originalSize + 1, c.getDefaultActivityParams().size());
 	}
+
+	@Test
+	void testExplicitSubpopulationGettersDoNotFallback() {
+		// Explicit subpopulation accessors should only return parameters defined for exactly that subpopulation.
+		ScoringConfigGroup scoringConfigGroup = new ScoringConfigGroup();
+
+		ScoringConfigGroup.ScoringParameterSet freightParams = scoringConfigGroup.getOrCreateScoringParameters("freight");
+		ModeParams truckModeParams = new ModeParams("truck");
+		ActivityParams freightActivityParams = new ActivityParams("freightInteraction");
+		freightActivityParams.setTypicalDuration(600.);
+		freightParams.addModeParams(truckModeParams);
+		freightParams.addActivityParams(freightActivityParams);
+
+		Assertions.assertThrows(RuntimeException.class,
+			() -> scoringConfigGroup.getModeParamsForSubpopulation("missing"));
+		Assertions.assertThrows(RuntimeException.class,
+			() -> scoringConfigGroup.getActivityParamsForSubpopulation("missing"));
+		Assertions.assertThrows(RuntimeException.class,
+			() -> scoringConfigGroup.getActivityParamsForSubpopulation("freightInteraction", "missing"));
+		Assertions.assertThrows(RuntimeException.class,
+			() -> scoringConfigGroup.getMarginalUtilityOfMoney("missing"));
+		Assertions.assertThrows(RuntimeException.class,
+			() -> scoringConfigGroup.getMarginalUtlOfWaiting_utils_hr("missing"));
+
+		Assertions.assertSame(truckModeParams,
+			scoringConfigGroup.getModeParamsForSubpopulation("freight").get("truck"));
+		Assertions.assertSame(freightActivityParams,
+			scoringConfigGroup.getActivityParamsForSubpopulation("freightInteraction", "freight"));
+		Assertions.assertEquals(freightParams.getMarginalUtilityOfMoney(),
+			scoringConfigGroup.getMarginalUtilityOfMoney("freight"), 1e-7);
+		Assertions.assertEquals(freightParams.getMarginalUtlOfWaiting_utils_hr(),
+			scoringConfigGroup.getMarginalUtlOfWaiting_utils_hr("freight"), 1e-7);
+		Assertions.assertTrue(scoringConfigGroup.getAllScoringParameterSetsPerSubpopulation().containsKey("freight"));
+		Assertions.assertTrue(scoringConfigGroup.getExplicitScoringParameterSetsPerSubpopulation().containsKey("freight"));
+		Assertions.assertFalse(scoringConfigGroup.getExplicitScoringParameterSetsPerSubpopulation().containsKey(null));
+	}
+
+	@Test
+	void testAddParamsForSubpopulationRequiresExplicitSubpopulation() {
+		// Adding mode and activity parameters for a subpopulation should require that the subpopulation already exists.
+		ScoringConfigGroup scoringConfigGroup = new ScoringConfigGroup();
+
+		scoringConfigGroup.getOrCreateScoringParameters("freight");
+
+		ModeParams truckModeParams = new ModeParams("truck");
+		ActivityParams freightActivityParams = new ActivityParams("freightInteraction");
+		freightActivityParams.setTypicalDuration(600.);
+
+		scoringConfigGroup.addModeParamsForSubpopulation(truckModeParams, "freight");
+		scoringConfigGroup.addActivityParamsForSubpopulation(freightActivityParams, "freight");
+
+		Assertions.assertSame(truckModeParams,
+			scoringConfigGroup.getModeParamsForSubpopulation("freight").get("truck"));
+		Assertions.assertSame(freightActivityParams,
+			scoringConfigGroup.getActivityParamsForSubpopulation("freightInteraction", "freight"));
+
+		Assertions.assertThrows(RuntimeException.class,
+			() -> scoringConfigGroup.addModeParamsForSubpopulation(new ModeParams("van"), "missing"));
+		Assertions.assertThrows(RuntimeException.class,
+			() -> scoringConfigGroup.addActivityParamsForSubpopulation(new ActivityParams("missingInteraction"), "missing"));
+	}
+
+	@Test
+	void testSetScoringParametersAsDefaultSubpopulationUsesExistingParameters() {
+		// Setting an existing subpopulation as default should create an independent default parameter set.
+		ScoringConfigGroup scoringConfigGroup = new ScoringConfigGroup();
+
+		ScoringConfigGroup.ScoringParameterSet freightParams = scoringConfigGroup.getOrCreateScoringParameters("freight");
+		ModeParams truckModeParams = new ModeParams("truck");
+		truckModeParams.setConstant(23.);
+		ActivityParams freightActivityParams = new ActivityParams("freightInteraction");
+		freightActivityParams.setTypicalDuration(600.);
+		freightParams.addModeParams(truckModeParams);
+		freightParams.addActivityParams(freightActivityParams);
+		freightParams.setMarginalUtilityOfMoney(4.);
+
+		ScoringConfigGroup.ScoringParameterSet defaultParams =
+			scoringConfigGroup.setScoringParametersAsDefaultSubpopulation("freight");
+
+		Assertions.assertNotSame(freightParams, defaultParams);
+		Assertions.assertSame(defaultParams,
+			scoringConfigGroup.getAllScoringParameterSetsPerSubpopulation().get(ScoringConfigGroup.DEFAULT_SUBPOPULATION));
+		Assertions.assertSame(freightParams,
+			scoringConfigGroup.getAllScoringParameterSetsPerSubpopulation().get("freight"));
+		Assertions.assertFalse(scoringConfigGroup.getExplicitScoringParameterSetsPerSubpopulation().containsKey(ScoringConfigGroup.DEFAULT_SUBPOPULATION));
+		Assertions.assertEquals(4., scoringConfigGroup.getDefaultMarginalUtilityOfMoney(), 1e-7);
+		Assertions.assertEquals(23.,
+			scoringConfigGroup.getModeParams().get("truck").getConstant(), 1e-7);
+		Assertions.assertEquals(freightActivityParams.getTypicalDuration(),
+			scoringConfigGroup.getActivityParams("freightInteraction").getTypicalDuration());
+		Assertions.assertThrows(RuntimeException.class,
+			() -> scoringConfigGroup.getModeParamsForSubpopulation(ScoringConfigGroup.DEFAULT_SUBPOPULATION));
+		Assertions.assertThrows(RuntimeException.class,
+			() -> scoringConfigGroup.getActivityParamsForSubpopulation(ScoringConfigGroup.DEFAULT_SUBPOPULATION));
+		Assertions.assertThrows(RuntimeException.class,
+			() -> scoringConfigGroup.getActivityParamsForSubpopulation("freightInteraction", ScoringConfigGroup.DEFAULT_SUBPOPULATION));
+		Assertions.assertThrows(RuntimeException.class,
+			() -> scoringConfigGroup.getMarginalUtilityOfMoney(ScoringConfigGroup.DEFAULT_SUBPOPULATION));
+		Assertions.assertThrows(RuntimeException.class,
+			() -> scoringConfigGroup.getMarginalUtlOfWaiting_utils_hr(ScoringConfigGroup.DEFAULT_SUBPOPULATION));
+
+		scoringConfigGroup.setDefaultMarginalUtilityOfMoney(5.);
+		scoringConfigGroup.setDefaultMarginalUtlOfWaiting_utils_hr(-2.);
+		scoringConfigGroup.setDefaultMarginalUtlOfWaitingPt_utils_hr(-3.);
+		scoringConfigGroup.setDefaultLateArrival_utils_hr(-4.);
+		scoringConfigGroup.setDefaultEarlyDeparture_utils_hr(-5.);
+		scoringConfigGroup.setDefaultPerforming_utils_hr(6.);
+		scoringConfigGroup.setDefaultUtilityOfLineSwitch(-7.);
+
+		Assertions.assertEquals(5., scoringConfigGroup.getDefaultMarginalUtilityOfMoney(), 1e-7);
+		Assertions.assertEquals(4., scoringConfigGroup.getMarginalUtilityOfMoney("freight"), 1e-7);
+		Assertions.assertEquals(-2., scoringConfigGroup.getDefaultMarginalUtlOfWaiting_utils_hr(), 1e-7);
+		Assertions.assertEquals(0., scoringConfigGroup.getMarginalUtlOfWaiting_utils_hr("freight"), 1e-7);
+		Assertions.assertEquals(-3., scoringConfigGroup.getDefaultMarginalUtlOfWaitingPt_utils_hr(), 1e-7);
+		Assertions.assertEquals(-4., scoringConfigGroup.getDefaultLateArrival_utils_hr(), 1e-7);
+		Assertions.assertEquals(-18., freightParams.getLateArrival_utils_hr(), 1e-7);
+		Assertions.assertEquals(-5., scoringConfigGroup.getDefaultEarlyDeparture_utils_hr(), 1e-7);
+		Assertions.assertEquals(-0., freightParams.getEarlyDeparture_utils_hr(), 1e-7);
+		Assertions.assertEquals(6., scoringConfigGroup.getDefaultPerforming_utils_hr(), 1e-7);
+		Assertions.assertEquals(6., freightParams.getPerforming_utils_hr(), 1e-7);
+		Assertions.assertEquals(-7., scoringConfigGroup.getDefaultUtilityOfLineSwitch(), 1e-7);
+		Assertions.assertEquals(-1., freightParams.getUtilityOfLineSwitch(), 1e-7);
+
+		truckModeParams.setConstant(42.);
+
+		Assertions.assertEquals(23.,
+			scoringConfigGroup.getModeParams().get("truck").getConstant(), 1e-7);
+		Assertions.assertEquals(42.,
+			scoringConfigGroup.getModeParamsForSubpopulation("freight").get("truck").getConstant(), 1e-7);
+	}
+
+	@Test
+	void testSetScoringParametersAsDefaultSubpopulationRequiresExistingSubpopulation() {
+		// Missing subpopulations should fail instead of creating an empty default by accident.
+		ScoringConfigGroup scoringConfigGroup = new ScoringConfigGroup();
+
+		Assertions.assertThrows(RuntimeException.class,
+			() -> scoringConfigGroup.setScoringParametersAsDefaultSubpopulation("missing"));
+	}
+
+	@Test
+	void testSetScoringParametersAsDefaultSubpopulationFailsIfDefaultAlreadyExists() {
+		// An already explicit default should not be overwritten by another subpopulation.
+		ScoringConfigGroup scoringConfigGroup = new ScoringConfigGroup();
+
+		scoringConfigGroup.getOrCreateScoringParameters("freight");
+		scoringConfigGroup.setScoringParametersAsDefaultSubpopulation("freight");
+		scoringConfigGroup.getOrCreateScoringParameters("person");
+
+		Assertions.assertThrows(RuntimeException.class,
+			() -> scoringConfigGroup.setScoringParametersAsDefaultSubpopulation("person"));
 	}
 
 	 @Test

--- a/matsim/src/test/java/org/matsim/core/config/groups/ScoringConfigGroupTest.java
+++ b/matsim/src/test/java/org/matsim/core/config/groups/ScoringConfigGroupTest.java
@@ -53,12 +53,12 @@ import org.matsim.testcases.MatsimTestUtils;
 
 		if ( ! fullyHierarchical ){
 			// mode params are there for default modes:
-			Assertions.assertNotNull( scoringConfig.getModes().get( TransportMode.car ) );
-			Assertions.assertNotNull( scoringConfig.getModes().get( TransportMode.walk ) );
-			Assertions.assertNotNull( scoringConfig.getModes().get( TransportMode.bike ) );
-			Assertions.assertNotNull( scoringConfig.getModes().get( TransportMode.ride ) );
-			Assertions.assertNotNull( scoringConfig.getModes().get( TransportMode.pt ) );
-			Assertions.assertNotNull( scoringConfig.getModes().get( TransportMode.other ) );
+			Assertions.assertNotNull( scoringConfig.getModeParams().get( TransportMode.car ) );
+			Assertions.assertNotNull( scoringConfig.getModeParams().get( TransportMode.walk ) );
+			Assertions.assertNotNull( scoringConfig.getModeParams().get( TransportMode.bike ) );
+			Assertions.assertNotNull( scoringConfig.getModeParams().get( TransportMode.ride ) );
+			Assertions.assertNotNull( scoringConfig.getModeParams().get( TransportMode.pt ) );
+			Assertions.assertNotNull( scoringConfig.getModeParams().get( TransportMode.other ) );
 
 			// default stage/interaction params are there for pt and drt (as a service):
 			Assertions.assertNotNull( scoringConfig.getActivityParams( createStageActivityType( TransportMode.pt ) ) );
@@ -84,7 +84,7 @@ import org.matsim.testcases.MatsimTestUtils;
 		ScoringConfigGroup scoringConfig = config.scoring() ;
 		testResultsBeforeCheckConsistency( config, true ) ;
 		log.warn( "" );
-		for( ModeParams modeParams : scoringConfig.getModes().values() ){
+		for( ModeParams modeParams : scoringConfig.getModeParams().values() ){
 			log.warn(  modeParams );
 		}
 		log.warn( "" );
@@ -97,7 +97,7 @@ import org.matsim.testcases.MatsimTestUtils;
 		scoringConfig.checkConsistency( config );
 		testResultsAfterCheckConsistency( config );
 		log.warn( "" );
-		for( ModeParams modeParams : scoringConfig.getModes().values() ){
+		for( ModeParams modeParams : scoringConfig.getModeParams().values() ){
 			log.warn(  modeParams );
 		}
 		log.warn( "" );
@@ -113,7 +113,7 @@ import org.matsim.testcases.MatsimTestUtils;
 		ScoringConfigGroup scoringConfig = config.scoring() ;
 		testResultsBeforeCheckConsistency( config, false ) ;
 		log.warn( "" );
-		for( ModeParams modeParams : scoringConfig.getModes().values() ){
+		for( ModeParams modeParams : scoringConfig.getModeParams().values() ){
 			log.warn(  modeParams );
 		}
 		log.warn( "" );
@@ -126,7 +126,7 @@ import org.matsim.testcases.MatsimTestUtils;
 		scoringConfig.checkConsistency( config );
 		testResultsAfterCheckConsistency( config );
 		log.warn( "" );
-		for( ModeParams modeParams : scoringConfig.getModes().values() ){
+		for( ModeParams modeParams : scoringConfig.getModeParams().values() ){
 			log.warn(  modeParams );
 		}
 		log.warn( "" );
@@ -184,28 +184,28 @@ import org.matsim.testcases.MatsimTestUtils;
 				1e-7,
 				"wrong brainExpBeta "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModes().get(TransportMode.bike).getConstant(),
-				inputConfigGroup.getModes().get(TransportMode.bike).getConstant(),
+				initialGroup.getModeParams().get(TransportMode.bike).getConstant(),
+				inputConfigGroup.getModeParams().get(TransportMode.bike).getConstant(),
 				1e-7,
 				"wrong constantBike "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModes().get(TransportMode.car).getConstant(),
-				inputConfigGroup.getModes().get(TransportMode.car).getConstant(),
+				initialGroup.getModeParams().get(TransportMode.car).getConstant(),
+				inputConfigGroup.getModeParams().get(TransportMode.car).getConstant(),
 				1e-7,
 				"wrong constantCar "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModes().get(TransportMode.other).getConstant(),
-				inputConfigGroup.getModes().get(TransportMode.other).getConstant(),
+				initialGroup.getModeParams().get(TransportMode.other).getConstant(),
+				inputConfigGroup.getModeParams().get(TransportMode.other).getConstant(),
 				1e-7,
 				"wrong constantOther "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModes().get(TransportMode.pt).getConstant(),
-				inputConfigGroup.getModes().get(TransportMode.pt).getConstant(),
+				initialGroup.getModeParams().get(TransportMode.pt).getConstant(),
+				inputConfigGroup.getModeParams().get(TransportMode.pt).getConstant(),
 				1e-7,
 				"wrong constantPt "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModes().get(TransportMode.walk).getConstant(),
-				inputConfigGroup.getModes().get(TransportMode.walk).getConstant(),
+				initialGroup.getModeParams().get(TransportMode.walk).getConstant(),
+				inputConfigGroup.getModeParams().get(TransportMode.walk).getConstant(),
 				1e-7,
 				"wrong constantWalk "+msg);
 		Assertions.assertEquals(
@@ -229,13 +229,13 @@ import org.matsim.testcases.MatsimTestUtils;
 				1e-7,
 				"wrong marginalUtilityOfMoney "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModes().get(TransportMode.other).getMarginalUtilityOfDistance(),
-				inputConfigGroup.getModes().get(TransportMode.other).getMarginalUtilityOfDistance(),
+				initialGroup.getModeParams().get(TransportMode.other).getMarginalUtilityOfDistance(),
+				inputConfigGroup.getModeParams().get(TransportMode.other).getMarginalUtilityOfDistance(),
 				1e-7,
 				"wrong marginalUtlOfDistanceOther "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModes().get(TransportMode.walk).getMarginalUtilityOfDistance(),
-				inputConfigGroup.getModes().get(TransportMode.walk).getMarginalUtilityOfDistance(),
+				initialGroup.getModeParams().get(TransportMode.walk).getMarginalUtilityOfDistance(),
+				inputConfigGroup.getModeParams().get(TransportMode.walk).getMarginalUtilityOfDistance(),
 				1e-7,
 				"wrong marginalUtlOfDistanceWalk "+msg);
 		Assertions.assertEquals(
@@ -249,13 +249,13 @@ import org.matsim.testcases.MatsimTestUtils;
 				1e-7,
 				"wrong marginalUtlOfWaitingPt_utils_hr "+msg );
 		Assertions.assertEquals(
-				initialGroup.getModes().get(TransportMode.car).getMonetaryDistanceRate(),
-				inputConfigGroup.getModes().get(TransportMode.car).getMonetaryDistanceRate(),
+				initialGroup.getModeParams().get(TransportMode.car).getMonetaryDistanceRate(),
+				inputConfigGroup.getModeParams().get(TransportMode.car).getMonetaryDistanceRate(),
 				1e-7,
 				"wrong monetaryDistanceCostRateCar "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModes().get(TransportMode.pt).getMonetaryDistanceRate(),
-				inputConfigGroup.getModes().get(TransportMode.pt).getMonetaryDistanceRate(),
+				initialGroup.getModeParams().get(TransportMode.pt).getMonetaryDistanceRate(),
+				inputConfigGroup.getModeParams().get(TransportMode.pt).getMonetaryDistanceRate(),
 				1e-7,
 				"wrong monetaryDistanceCostRatePt "+msg);
 		Assertions.assertEquals(
@@ -269,28 +269,28 @@ import org.matsim.testcases.MatsimTestUtils;
 				1e-7,
 				"wrong performing_utils_hr "+msg );
 		Assertions.assertEquals(
-				initialGroup.getModes().get(TransportMode.car).getMarginalUtilityOfTraveling(),
-				inputConfigGroup.getModes().get(TransportMode.car).getMarginalUtilityOfTraveling(),
+				initialGroup.getModeParams().get(TransportMode.car).getMarginalUtilityOfTraveling(),
+				inputConfigGroup.getModeParams().get(TransportMode.car).getMarginalUtilityOfTraveling(),
 				1e-7,
 				"wrong traveling_utils_hr "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModes().get(TransportMode.bike).getMarginalUtilityOfTraveling(),
-				inputConfigGroup.getModes().get(TransportMode.bike).getMarginalUtilityOfTraveling(),
+				initialGroup.getModeParams().get(TransportMode.bike).getMarginalUtilityOfTraveling(),
+				inputConfigGroup.getModeParams().get(TransportMode.bike).getMarginalUtilityOfTraveling(),
 				1e-7,
 				"wrong travelingBike_utils_hr "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModes().get(TransportMode.other).getMarginalUtilityOfTraveling(),
-				inputConfigGroup.getModes().get(TransportMode.other).getMarginalUtilityOfTraveling(),
+				initialGroup.getModeParams().get(TransportMode.other).getMarginalUtilityOfTraveling(),
+				inputConfigGroup.getModeParams().get(TransportMode.other).getMarginalUtilityOfTraveling(),
 				1e-7,
 				"wrong travelingOther_utils_hr "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModes().get(TransportMode.pt).getMarginalUtilityOfTraveling(),
-				inputConfigGroup.getModes().get(TransportMode.pt).getMarginalUtilityOfTraveling(),
+				initialGroup.getModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling(),
+				inputConfigGroup.getModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling(),
 				1e-7,
 				"wrong travelingPt_utils_hr "+msg);
 		Assertions.assertEquals(
-				initialGroup.getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling(),
-				inputConfigGroup.getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling(),
+				initialGroup.getModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling(),
+				inputConfigGroup.getModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling(),
 				1e-7,
 				"wrong travelingWalk_utils_hr "+msg);
 		Assertions.assertEquals(
@@ -338,9 +338,9 @@ import org.matsim.testcases.MatsimTestUtils;
 					"wrong typicalDuration "+msg);
 		}
 
-		for ( ModeParams initialSettings : initialGroup.getModes().values() ) {
+		for ( ModeParams initialSettings : initialGroup.getModeParams().values() ) {
 			final String mode = initialSettings.getMode();
-			final ModeParams inputSettings = inputConfigGroup.getModes().get( mode );
+			final ModeParams inputSettings = inputConfigGroup.getModeParams().get( mode );
 			Assertions.assertEquals(
 					initialSettings.getConstant(),
 					inputSettings.getConstant(),
@@ -392,7 +392,7 @@ import org.matsim.testcases.MatsimTestUtils;
 			settings.getTypicalDuration().ifDefined(t -> module.addParam("activityTypicalDuration_" + suffix, "" + t));
 		}
 
-		for ( ModeParams settings : initialGroup.getModes().values() ) {
+		for ( ModeParams settings : initialGroup.getModeParams().values() ) {
 			final String mode = settings.getMode();
 			module.addParam( "constant_"+mode , ""+settings.getConstant() );
 			module.addParam( "marginalUtlOfDistance_"+mode , ""+settings.getMarginalUtilityOfDistance() );
@@ -412,29 +412,29 @@ import org.matsim.testcases.MatsimTestUtils;
 		final ScoringConfigGroup group = new ScoringConfigGroup();
 
 		group.setBrainExpBeta( 124);
-		group.getModes().get(TransportMode.bike).setConstant((double) 98);
-		group.getModes().get(TransportMode.car).setConstant((double) 345);
-		group.getModes().get(TransportMode.other).setConstant((double) 345);
-		group.getModes().get(TransportMode.pt).setConstant((double) 983);
-		group.getModes().get(TransportMode.walk).setConstant((double) 89);
 		group.setLateArrival_utils_hr( 345 );
 		group.setEarlyDeparture_utils_hr( 5 );
+		group.getModeParams().get(TransportMode.bike).setConstant((double) 98);
+		group.getModeParams().get(TransportMode.car).setConstant((double) 345);
+		group.getModeParams().get(TransportMode.other).setConstant((double) 345);
+		group.getModeParams().get(TransportMode.pt).setConstant((double) 983);
+		group.getModeParams().get(TransportMode.walk).setConstant((double) 89);
 		group.setLearningRate( 98 );
 		group.setMarginalUtilityOfMoney( 9 );
-		group.getModes().get(TransportMode.other).setMarginalUtilityOfDistance((double) 23);
-		group.getModes().get(TransportMode.walk).setMarginalUtilityOfDistance((double) 8675);
 		group.setMarginalUtlOfWaiting_utils_hr( 65798 );
 		group.setMarginalUtlOfWaitingPt_utils_hr( 9867 );
-		group.getModes().get(TransportMode.car).setMonetaryDistanceRate((double) 240358);
-		group.getModes().get(TransportMode.pt).setMonetaryDistanceRate((double) 9835);
+		group.getModeParams().get(TransportMode.other).setMarginalUtilityOfDistance((double) 23);
+		group.getModeParams().get(TransportMode.walk).setMarginalUtilityOfDistance((double) 8675);
+		group.getModeParams().get(TransportMode.car).setMonetaryDistanceRate((double) 240358);
+		group.getModeParams().get(TransportMode.pt).setMonetaryDistanceRate((double) 9835);
 		group.setPathSizeLogitBeta( 8 );
 		group.setPerforming_utils_hr( 678 );
-		group.getModes().get(TransportMode.car).setMarginalUtilityOfTraveling((double) 246);
-		group.getModes().get(TransportMode.bike).setMarginalUtilityOfTraveling((double) 968);
-		group.getModes().get(TransportMode.other).setMarginalUtilityOfTraveling((double) 206);
-		group.getModes().get(TransportMode.pt).setMarginalUtilityOfTraveling((double) 957);
-		group.getModes().get(TransportMode.walk).setMarginalUtilityOfTraveling((double) 983455);
 		group.setUtilityOfLineSwitch( 396 );
+		group.getModeParams().get(TransportMode.car).setMarginalUtilityOfTraveling((double) 246);
+		group.getModeParams().get(TransportMode.bike).setMarginalUtilityOfTraveling((double) 968);
+		group.getModeParams().get(TransportMode.other).setMarginalUtilityOfTraveling((double) 206);
+		group.getModeParams().get(TransportMode.pt).setMarginalUtilityOfTraveling((double) 957);
+		group.getModeParams().get(TransportMode.walk).setMarginalUtilityOfTraveling((double) 983455);
 
 		final Random random = new Random( 925 );
 		for ( int i=0; i < 10; i++ ) {

--- a/matsim/src/test/java/org/matsim/core/config/groups/ScoringConfigGroupTest.java
+++ b/matsim/src/test/java/org/matsim/core/config/groups/ScoringConfigGroupTest.java
@@ -532,7 +532,7 @@ import org.matsim.testcases.MatsimTestUtils;
 			final String suffix = r.nextBoolean() ? ""+ca++ : settings.getActivityType();
 
 			if ( !suffix.equals( settings.getActivityType() ) ) {
-				module.addParam( "activityType_"+suffix , ""+settings.getActivityType() );
+				module.addParam( "activityType_"+suffix , settings.getActivityType());
 			}
 
 			settings.getClosingTime().ifDefined(t -> module.addParam("activityClosingTime_" + suffix, "" + t));

--- a/matsim/src/test/java/org/matsim/core/config/groups/ScoringConfigGroupTest.java
+++ b/matsim/src/test/java/org/matsim/core/config/groups/ScoringConfigGroupTest.java
@@ -61,8 +61,8 @@ import org.matsim.testcases.MatsimTestUtils;
 			Assertions.assertNotNull( scoringConfig.getDefaultModeParams().get( TransportMode.other ) );
 
 			// default stage/interaction params are there for pt and drt (as a service):
-			Assertions.assertNotNull( scoringConfig.getActivityParams( createStageActivityType( TransportMode.pt ) ) );
-			Assertions.assertNotNull( scoringConfig.getActivityParams( createStageActivityType( TransportMode.drt ) ) );
+			Assertions.assertNotNull(scoringConfig.getDefaultActivityParams(createStageActivityType(TransportMode.pt)));
+			Assertions.assertNotNull( scoringConfig.getDefaultActivityParams( createStageActivityType( TransportMode.drt ) ) );
 		}
 		// default stage/interaction params for modes routed on the network are not yet there:
 //		for( String networkMode : config.plansCalcRoute().getNetworkModes() ){
@@ -74,7 +74,7 @@ import org.matsim.testcases.MatsimTestUtils;
 
 		// default stage/interaction params for modes routed on the network are now there:
 		for( String networkMode : config.routing().getNetworkModes() ){
-			Assertions.assertNotNull( scoringConfig.getActivityParams( createStageActivityType( networkMode ) ) );
+			Assertions.assertNotNull( scoringConfig.getDefaultActivityParams( createStageActivityType( networkMode ) ) );
 		}
 	}
 
@@ -88,7 +88,7 @@ import org.matsim.testcases.MatsimTestUtils;
 			log.warn(  modeParams );
 		}
 		log.warn( "" );
-		for( ActivityParams activityParams : scoringConfig.getActivityParams() ){
+		for( ActivityParams activityParams : scoringConfig.getDefaultActivityParams() ){
 			log.warn(  activityParams );
 		}
 		log.warn( "" );
@@ -101,7 +101,7 @@ import org.matsim.testcases.MatsimTestUtils;
 			log.warn(  modeParams );
 		}
 		log.warn( "" );
-		for( ActivityParams activityParams : scoringConfig.getActivityParams() ){
+		for( ActivityParams activityParams : scoringConfig.getDefaultActivityParams() ){
 			log.warn(  activityParams );
 		}
 		log.warn( "" );
@@ -117,7 +117,7 @@ import org.matsim.testcases.MatsimTestUtils;
 			log.warn(  modeParams );
 		}
 		log.warn( "" );
-		for( ActivityParams activityParams : scoringConfig.getActivityParams() ){
+		for( ActivityParams activityParams : scoringConfig.getDefaultActivityParams() ){
 			log.warn(  activityParams );
 		}
 		log.warn( "" );
@@ -130,7 +130,7 @@ import org.matsim.testcases.MatsimTestUtils;
 			log.warn(  modeParams );
 		}
 		log.warn( "" );
-		for( ActivityParams activityParams : scoringConfig.getActivityParams() ){
+		for( ActivityParams activityParams : scoringConfig.getDefaultActivityParams() ){
 			log.warn(  activityParams );
 		}
 		log.warn( "" );
@@ -139,14 +139,15 @@ import org.matsim.testcases.MatsimTestUtils;
 	 @Test
 	 void testAddActivityParams() {
 		ScoringConfigGroup c = new ScoringConfigGroup();
-        int originalSize = c.getActivityParams().size();
-		Assertions.assertNull(c.getActivityParams("type1"));
-        Assertions.assertEquals(originalSize, c.getActivityParams().size());
+        int originalSize = c.getDefaultActivityParams().size();
+		Assertions.assertNull(c.getDefaultActivityParams("type1"));
+        Assertions.assertEquals(originalSize, c.getDefaultActivityParams().size());
 
 		ActivityParams ap = new ActivityParams("type1");
 		c.addActivityParams(ap);
-		Assertions.assertEquals(ap, c.getActivityParams("type1"));
-        Assertions.assertEquals(originalSize + 1, c.getActivityParams().size());
+		Assertions.assertEquals(ap, c.getDefaultActivityParams("type1"));
+        Assertions.assertEquals(originalSize + 1, c.getDefaultActivityParams().size());
+	}
 	}
 
 	 @Test
@@ -209,13 +210,13 @@ import org.matsim.testcases.MatsimTestUtils;
 				1e-7,
 				"wrong constantWalk "+msg);
 		Assertions.assertEquals(
-				initialGroup.getLateArrival_utils_hr(),
-				inputConfigGroup.getLateArrival_utils_hr(),
+				initialGroup.getDefaultLateArrival_utils_hr(),
+				inputConfigGroup.getDefaultLateArrival_utils_hr(),
 				1e-7,
 				"wrong lateArrival_utils_hr "+msg );
 		Assertions.assertEquals(
-				initialGroup.getEarlyDeparture_utils_hr(),
-				inputConfigGroup.getEarlyDeparture_utils_hr(),
+				initialGroup.getDefaultEarlyDeparture_utils_hr(),
+				inputConfigGroup.getDefaultEarlyDeparture_utils_hr(),
 				1e-7,
 				"wrong earlyDeparture_utils_hr "+msg );
 		Assertions.assertEquals(
@@ -224,8 +225,8 @@ import org.matsim.testcases.MatsimTestUtils;
 				1e-7,
 				"wrong learningRate "+msg );
 		Assertions.assertEquals(
-				initialGroup.getMarginalUtilityOfMoney(),
-				inputConfigGroup.getMarginalUtilityOfMoney() ,
+				initialGroup.getDefaultMarginalUtilityOfMoney(),
+				inputConfigGroup.getDefaultMarginalUtilityOfMoney() ,
 				1e-7,
 				"wrong marginalUtilityOfMoney "+msg);
 		Assertions.assertEquals(
@@ -239,13 +240,13 @@ import org.matsim.testcases.MatsimTestUtils;
 				1e-7,
 				"wrong marginalUtlOfDistanceWalk "+msg);
 		Assertions.assertEquals(
-				initialGroup.getMarginalUtlOfWaiting_utils_hr(),
-				inputConfigGroup.getMarginalUtlOfWaiting_utils_hr(),
+				initialGroup.getDefaultMarginalUtlOfWaiting_utils_hr(),
+				inputConfigGroup.getDefaultMarginalUtlOfWaiting_utils_hr(),
 				1e-7,
 				"wrong marginalUtlOfWaiting_utils_hr "+msg );
 		Assertions.assertEquals(
-				initialGroup.getMarginalUtlOfWaitingPt_utils_hr(),
-				inputConfigGroup.getMarginalUtlOfWaitingPt_utils_hr(),
+				initialGroup.getDefaultMarginalUtlOfWaitingPt_utils_hr(),
+				inputConfigGroup.getDefaultMarginalUtlOfWaitingPt_utils_hr(),
 				1e-7,
 				"wrong marginalUtlOfWaitingPt_utils_hr "+msg );
 		Assertions.assertEquals(
@@ -264,8 +265,8 @@ import org.matsim.testcases.MatsimTestUtils;
 				1e-7,
 				"wrong pathSizeLogitBeta "+msg );
 		Assertions.assertEquals(
-				initialGroup.getPerforming_utils_hr(),
-				inputConfigGroup.getPerforming_utils_hr(),
+				initialGroup.getDefaultPerforming_utils_hr(),
+				inputConfigGroup.getDefaultPerforming_utils_hr(),
 				1e-7,
 				"wrong performing_utils_hr "+msg );
 		Assertions.assertEquals(
@@ -294,14 +295,14 @@ import org.matsim.testcases.MatsimTestUtils;
 				1e-7,
 				"wrong travelingWalk_utils_hr "+msg);
 		Assertions.assertEquals(
-				initialGroup.getUtilityOfLineSwitch(),
-				inputConfigGroup.getUtilityOfLineSwitch(),
+				initialGroup.getDefaultUtilityOfLineSwitch(),
+				inputConfigGroup.getDefaultUtilityOfLineSwitch(),
 				1e-7,
 				"wrong utilityOfLineSwitch "+msg );
 
-		for ( ActivityParams initialSettings : initialGroup.getActivityParams() ) {
+		for ( ActivityParams initialSettings : initialGroup.getDefaultActivityParams() ) {
 			final ActivityParams inputSettings =
-				inputConfigGroup.getActivityParams(
+				inputConfigGroup.getDefaultActivityParams(
 						initialSettings.getActivityType() );
 			Assertions.assertEquals(
 					initialSettings.getActivityType(),
@@ -376,7 +377,7 @@ import org.matsim.testcases.MatsimTestUtils;
 
 		final Random r = new Random( 456 );
 		int ca = 0;
-		for ( ActivityParams settings : initialGroup.getActivityParams() ) {
+		for ( ActivityParams settings : initialGroup.getDefaultActivityParams()) {
 			final String suffix = r.nextBoolean() ? ""+ca++ : settings.getActivityType();
 
 			if ( !suffix.equals( settings.getActivityType() ) ) {

--- a/matsim/src/test/java/org/matsim/core/router/NetworkRoutingModuleTest.java
+++ b/matsim/src/test/java/org/matsim/core/router/NetworkRoutingModuleTest.java
@@ -118,7 +118,7 @@ public class NetworkRoutingModuleTest {
 
 		{
 			double monetaryDistanceRateCar = -1.;
-			f.s.getConfig().scoring().getModes().get(TransportMode.car).setMonetaryDistanceRate(monetaryDistanceRateCar);
+			f.s.getConfig().scoring().getDefaultModeParams().get(TransportMode.car).setMonetaryDistanceRate(monetaryDistanceRateCar);
 
                         TravelDisutility costObject = new RandomizingTimeDistanceTravelDisutilityFactory( TransportMode.car,
                                         f.s.getConfig() ).createTravelDisutility(timeObject );

--- a/matsim/src/test/java/org/matsim/core/scoring/functions/CharyparNagelActivityScoringTypicalDurationTest.java
+++ b/matsim/src/test/java/org/matsim/core/scoring/functions/CharyparNagelActivityScoringTypicalDurationTest.java
@@ -25,9 +25,9 @@ public class CharyparNagelActivityScoringTypicalDurationTest {
 	private static Config config() {
 		Config config = ConfigUtils.createConfig();
 		ScoringConfigGroup scoring = config.scoring();
-		scoring.setPerforming_utils_hr(6.);
-		scoring.setLateArrival_utils_hr(-18.);
-		scoring.setEarlyDeparture_utils_hr(-6.);
+		scoring.setDefaultPerforming_utils_hr(6.);
+		scoring.setDefaultLateArrival_utils_hr(-18.);
+		scoring.setDefaultEarlyDeparture_utils_hr(-6.);
 		for (String type : new String[]{"home", "work", "home_evening"}) {
 			scoring.addActivityParams(new ScoringConfigGroup.ActivityParams(type).setTypicalDuration(2. * 3600.));
 		}
@@ -133,15 +133,15 @@ public class CharyparNagelActivityScoringTypicalDurationTest {
 		for (ScoringConfigGroup.TypicalDurationScoreComputation computation : ScoringConfigGroup.TypicalDurationScoreComputation.values()) {
 			// A: work typical 2h in the config, but 8h as activity attribute (home/home_evening attribute-less in this plan)
 			Config configA = config();
-			configA.scoring().getActivityParams("work").setTypicalDurationScoreComputation(computation);
+			configA.scoring().getDefaultActivityParams("work").setTypicalDurationScoreComputation(computation);
 			Plan planA = planWithWorkTypical(28800.);
 			((Activity) planA.getPlanElements().get(0)).getAttributes().removeAttribute(ActivityAttributeTypicalDurationCalculator.TYPICAL_DURATION_ATTRIBUTE);
 			double withAttribute = score(attributeScoring(configA, person(planA)), 30600., 59400.);
 
 			// B: work typical 8h in the config, stock scoring on the bare activities
 			Config configB = config();
-			configB.scoring().getActivityParams("work").setTypicalDurationScoreComputation(computation);
-			configB.scoring().getActivityParams("work").setTypicalDuration(28800.);
+			configB.scoring().getDefaultActivityParams("work").setTypicalDurationScoreComputation(computation);
+			configB.scoring().getDefaultActivityParams("work").setTypicalDuration(28800.);
 			double fromConfig = score(new CharyparNagelActivityScoring(params(configB)), 30600., 59400.);
 
 			assertEquals(fromConfig, withAttribute, 1e-9, "computation mode " + computation);

--- a/matsim/src/test/java/org/matsim/core/scoring/functions/CharyparNagelLegScoringTest.java
+++ b/matsim/src/test/java/org/matsim/core/scoring/functions/CharyparNagelLegScoringTest.java
@@ -114,7 +114,7 @@ public class CharyparNagelLegScoringTest {
 			})
 			.sum();
 		// we know that the second pt trip has a line switch this is rather difficult to figure out otherwise
-		var expectedLineSwitch = scoringParams.getUtilityOfLineSwitch();
+		var expectedLineSwitch = scoringParams.getDefaultUtilityOfLineSwitch();
 		// we know that we have one daily constant in this scenario
 		var dailyScore = calcDailyConstant(scoringParams, transitMode);
 		var expectedScore = dailyScore + expectedConstantPerTrip + expectedLegScore + expectedLineSwitch;
@@ -136,7 +136,7 @@ public class CharyparNagelLegScoringTest {
 		// distance: distance * marginalUtilityOfDistance
 		var utilDist = travelDist * modeParams.getMarginalUtilityOfDistance();
 		// distance costs: distance * monetaryDistanceCosts * marginalUtilityOfMoney
-		var utilDistCosts = travelDist * modeParams.getMonetaryDistanceRate() * scoringParams.getMarginalUtilityOfMoney();
+		var utilDistCosts = travelDist * modeParams.getMonetaryDistanceRate() * scoringParams.getDefaultMarginalUtilityOfMoney();
 
 		return utilTravelTime + utilDist + utilDistCosts;
 	}
@@ -144,7 +144,7 @@ public class CharyparNagelLegScoringTest {
 	private static double calcWaitScore(ScoringConfigGroup scoringParams, Leg leg) {
 		if (leg.getRoute() instanceof TransitPassengerRoute tpr) {
 			var waitTime = tpr.getBoardingTime().seconds() - leg.getDepartureTime().seconds();
-			var waitUtil = scoringParams.getMarginalUtlOfWaitingPt_utils_hr() / 3600 - scoringParams.getOrCreateModeParams(leg.getMode()).getMarginalUtilityOfTraveling() / 3600;
+			var waitUtil = scoringParams.getDefaultMarginalUtlOfWaitingPt_utils_hr() / 3600 - scoringParams.getOrCreateModeParams(leg.getMode()).getMarginalUtilityOfTraveling() / 3600;
 			return waitTime * waitUtil;
 		} else {
 			return 0.;
@@ -153,7 +153,7 @@ public class CharyparNagelLegScoringTest {
 
 	private static double calcDailyConstant(ScoringConfigGroup scoringParams, String mode) {
 		var modeParams = scoringParams.getOrCreateModeParams(mode);
-		return modeParams.getDailyUtilityConstant() + scoringParams.getMarginalUtilityOfMoney() * modeParams.getDailyMonetaryConstant();
+		return modeParams.getDailyUtilityConstant() + scoringParams.getDefaultMarginalUtilityOfMoney() * modeParams.getDailyMonetaryConstant();
 	}
 
 	private static double calcTripConstant(ScoringConfigGroup scoringParams, String mode) {
@@ -185,12 +185,12 @@ public class CharyparNagelLegScoringTest {
 
 	private static ScoringConfigGroup createScoringParams(String mode) {
 		var config = new ScoringConfigGroup();
-		config.setMarginalUtlOfWaitingPt_utils_hr(-3);
-		config.setMarginalUtilityOfMoney(5);
-		config.setEarlyDeparture_utils_hr(-7);
-		config.setLateArrival_utils_hr(-11);
-		config.setPerforming_utils_hr(13);
-		config.setUtilityOfLineSwitch(-17);
+		config.setDefaultMarginalUtlOfWaitingPt_utils_hr(-3);
+		config.setDefaultMarginalUtilityOfMoney(5);
+		config.setDefaultEarlyDeparture_utils_hr(-7);
+		config.setDefaultLateArrival_utils_hr(-11);
+		config.setDefaultPerforming_utils_hr(13);
+		config.setDefaultUtilityOfLineSwitch(-17);
 
 		config.getOrCreateModeParams(mode)
 			.setConstant(-19)

--- a/matsim/src/test/java/org/matsim/core/scoring/functions/CharyparNagelScoringFunctionTest.java
+++ b/matsim/src/test/java/org/matsim/core/scoring/functions/CharyparNagelScoringFunctionTest.java
@@ -185,10 +185,10 @@ public class CharyparNagelScoringFunctionTest {
 	void testTravelingAndConstantCar() {
 		Fixture f = new Fixture();
 		final double traveling = -6.0;
-		f.config.scoring().getModes().get(TransportMode.car).setMarginalUtilityOfTraveling(traveling);
+		f.config.scoring().getDefaultModeParams().get(TransportMode.car).setMarginalUtilityOfTraveling(traveling);
 		assertEquals(-3.0, calcScore(f), EPSILON);
 		double constantCar = -6.0;
-		f.config.scoring().getModes().get(TransportMode.car).setConstant(constantCar);
+		f.config.scoring().getDefaultModeParams().get(TransportMode.car).setConstant(constantCar);
 		assertEquals(-9.0, calcScore(f), EPSILON);
 	}
 
@@ -196,10 +196,10 @@ public class CharyparNagelScoringFunctionTest {
 	void testTravelingPtAndConstantPt() {
 		Fixture f = new Fixture();
 		final double travelingPt = -9.0;
-		f.config.scoring().getModes().get(TransportMode.pt).setMarginalUtilityOfTraveling(travelingPt);
+		f.config.scoring().getDefaultModeParams().get(TransportMode.pt).setMarginalUtilityOfTraveling(travelingPt);
 		assertEquals(-2.25, calcScore(f), EPSILON);
 		double constantPt = -3.0;
-		f.config.scoring().getModes().get(TransportMode.pt).setConstant(constantPt);
+		f.config.scoring().getDefaultModeParams().get(TransportMode.pt).setConstant(constantPt);
 		assertEquals(-5.25, calcScore(f), EPSILON);
 	}
 
@@ -207,10 +207,10 @@ public class CharyparNagelScoringFunctionTest {
 	void testTravelingWalkAndConstantWalk() {
 		Fixture f = new Fixture();
 		final double travelingWalk = -18.0;
-		f.config.scoring().getModes().get(TransportMode.walk).setMarginalUtilityOfTraveling(travelingWalk);
+		f.config.scoring().getDefaultModeParams().get(TransportMode.walk).setMarginalUtilityOfTraveling(travelingWalk);
 		assertEquals(-9.0, calcScore(f), EPSILON);
 		double constantWalk = -1.0;
-		f.config.scoring().getModes().get(TransportMode.walk).setConstant(constantWalk);
+		f.config.scoring().getDefaultModeParams().get(TransportMode.walk).setConstant(constantWalk);
 		assertEquals(-10.0, calcScore(f), EPSILON);
 	}
 
@@ -218,10 +218,10 @@ public class CharyparNagelScoringFunctionTest {
 	void testTravelingBikeAndConstantBike() {
 		Fixture f = new Fixture();
 		final double travelingBike = -6.0;
-		f.config.scoring().getModes().get(TransportMode.bike).setMarginalUtilityOfTraveling(travelingBike);
+		f.config.scoring().getDefaultModeParams().get(TransportMode.bike).setMarginalUtilityOfTraveling(travelingBike);
 		assertEquals(-1.5, calcScore(f), EPSILON);
 		double constantBike = -2.0;
-		f.config.scoring().getModes().get(TransportMode.bike).setConstant(constantBike);
+		f.config.scoring().getDefaultModeParams().get(TransportMode.bike).setConstant(constantBike);
 		assertEquals(-3.5, calcScore(f), EPSILON);
 	}
 
@@ -434,7 +434,7 @@ public class CharyparNagelScoringFunctionTest {
 		// test 1 where late arrival has the biggest impact
 		f.config.scoring().setLateArrival_utils_hr(-18.0);
 		final double traveling1 = -6.0;
-		f.config.scoring().getModes().get(TransportMode.car).setMarginalUtilityOfTraveling(traveling1);
+		f.config.scoring().getDefaultModeParams().get(TransportMode.car).setMarginalUtilityOfTraveling(traveling1);
 
 		ScoringFunction testee = getScoringFunctionInstance(f, f.person);
 		var trip = TripStructureUtils.getTrips(f.plan.getPlanElements().subList(0, 4)).getFirst();
@@ -455,7 +455,7 @@ public class CharyparNagelScoringFunctionTest {
 		// test 2 where traveling has the biggest impact
 		f.config.scoring().setLateArrival_utils_hr(-3.0);
 		final double traveling = -6.0;
-		f.config.scoring().getModes().get(TransportMode.car).setMarginalUtilityOfTraveling(traveling);
+		f.config.scoring().getDefaultModeParams().get(TransportMode.car).setMarginalUtilityOfTraveling(traveling);
 
 		testee = getScoringFunctionInstance(f, f.person);
 		testee.handleActivity((Activity) f.plan.getPlanElements().get(0));
@@ -478,13 +478,13 @@ public class CharyparNagelScoringFunctionTest {
 		f.config.scoring().setMarginalUtilityOfMoney(1.0);
 		//		this.config.charyparNagelScoring().setMarginalUtlOfDistanceCar(-0.00001);
 		double monetaryDistanceRateCar1 = -0.00001;
-		f.config.scoring().getModes().get(TransportMode.car).setMonetaryDistanceRate(monetaryDistanceRateCar1);
+		f.config.scoring().getDefaultModeParams().get(TransportMode.car).setMonetaryDistanceRate(monetaryDistanceRateCar1);
 
 		assertEquals(-0.25, calcScore(f), EPSILON);
 
 		// test 2 where MonetaryDistanceCostRate is fixed to -1.0
 		double monetaryDistanceRateCar = -1.0;
-		f.config.scoring().getModes().get(TransportMode.car).setMonetaryDistanceRate(monetaryDistanceRateCar);
+		f.config.scoring().getDefaultModeParams().get(TransportMode.car).setMonetaryDistanceRate(monetaryDistanceRateCar);
 		f.config.scoring().setMarginalUtilityOfMoney(0.5);
 
 		assertEquals(-12500.0, calcScore(f), EPSILON);
@@ -497,13 +497,13 @@ public class CharyparNagelScoringFunctionTest {
 		f.config.scoring().setMarginalUtilityOfMoney(1.0);
 		//		this.config.charyparNagelScoring().setMarginalUtlOfDistancePt(-0.00001);
 		double monetaryDistanceRatePt1 = -0.00001;
-		f.config.scoring().getModes().get(TransportMode.pt).setMonetaryDistanceRate(monetaryDistanceRatePt1);
+		f.config.scoring().getDefaultModeParams().get(TransportMode.pt).setMonetaryDistanceRate(monetaryDistanceRatePt1);
 
 		assertEquals(-0.20, calcScore(f), EPSILON);
 
 		// test 2 where MonetaryDistanceCostRate is fixed to -1.0
 		double monetaryDistanceRatePt = -1.0;
-		f.config.scoring().getModes().get(TransportMode.pt).setMonetaryDistanceRate(monetaryDistanceRatePt);
+		f.config.scoring().getDefaultModeParams().get(TransportMode.pt).setMonetaryDistanceRate(monetaryDistanceRatePt);
 		f.config.scoring().setMarginalUtilityOfMoney(0.5);
 
 		assertEquals(-10000.0, calcScore(f), EPSILON);
@@ -725,23 +725,23 @@ public class CharyparNagelScoringFunctionTest {
 			ScoringConfigGroup scoring = this.config.scoring();
 			scoring.setBrainExpBeta(2.0);
 
-			scoring.getModes().get(TransportMode.car).setConstant(0.0);
-			scoring.getModes().get(TransportMode.pt).setConstant(0.0);
-			scoring.getModes().get(TransportMode.walk).setConstant(0.0);
-			scoring.getModes().get(TransportMode.bike).setConstant(0.0);
+			scoring.getDefaultModeParams().get(TransportMode.car).setConstant(0.0);
+			scoring.getDefaultModeParams().get(TransportMode.pt).setConstant(0.0);
+			scoring.getDefaultModeParams().get(TransportMode.walk).setConstant(0.0);
+			scoring.getDefaultModeParams().get(TransportMode.bike).setConstant(0.0);
 
 			scoring.setEarlyDeparture_utils_hr(0.0);
 			scoring.setLateArrival_utils_hr(0.0);
 			scoring.setMarginalUtlOfWaiting_utils_hr(0.0);
 			scoring.setPerforming_utils_hr(0.0);
-			scoring.getModes().get(TransportMode.car).setMarginalUtilityOfTraveling(0.0);
-			scoring.getModes().get(TransportMode.pt).setMarginalUtilityOfTraveling(0.0);
-			scoring.getModes().get(TransportMode.walk).setMarginalUtilityOfTraveling(0.0);
-			scoring.getModes().get(TransportMode.bike).setMarginalUtilityOfTraveling(0.0);
+			scoring.getDefaultModeParams().get(TransportMode.car).setMarginalUtilityOfTraveling(0.0);
+			scoring.getDefaultModeParams().get(TransportMode.pt).setMarginalUtilityOfTraveling(0.0);
+			scoring.getDefaultModeParams().get(TransportMode.walk).setMarginalUtilityOfTraveling(0.0);
+			scoring.getDefaultModeParams().get(TransportMode.bike).setMarginalUtilityOfTraveling(0.0);
 
 			scoring.setMarginalUtilityOfMoney(1.);
-			scoring.getModes().get(TransportMode.car).setMonetaryDistanceRate(0.0);
-			scoring.getModes().get(TransportMode.pt).setMonetaryDistanceRate(0.0);
+			scoring.getDefaultModeParams().get(TransportMode.car).setMonetaryDistanceRate(0.0);
+			scoring.getDefaultModeParams().get(TransportMode.pt).setMonetaryDistanceRate(0.0);
 
 
 			// setup activity types h and w for scoring

--- a/matsim/src/test/java/org/matsim/core/scoring/functions/CharyparNagelScoringFunctionTest.java
+++ b/matsim/src/test/java/org/matsim/core/scoring/functions/CharyparNagelScoringFunctionTest.java
@@ -237,10 +237,10 @@ public class CharyparNagelScoringFunctionTest {
 		double zeroUtilDurW = getZeroUtilDuration_hrs(3.0, 1.0, typicalDurationComputation);
 		double zeroUtilDurH = getZeroUtilDuration_hrs(15.0, 1.0, typicalDurationComputation);
 
-		f.config.scoring().setPerforming_utils_hr(perf);
+		f.config.scoring().setDefaultPerforming_utils_hr(perf);
 
 		if (typicalDurationComputation.equals(TypicalDurationScoreComputation.uniform)) {
-			for (ActivityParams p : f.config.scoring().getActivityParams()) {
+			for (ActivityParams p : f.config.scoring().getDefaultActivityParams()) {
 				p.setTypicalDurationScoreComputation(TypicalDurationScoreComputation.uniform);
 			}
 		}
@@ -265,10 +265,10 @@ public class CharyparNagelScoringFunctionTest {
 	void testOpeningTime() {
 		Fixture f = new Fixture();
 		double perf = +6.0;
-		f.config.scoring().setPerforming_utils_hr(perf);
+		f.config.scoring().setDefaultPerforming_utils_hr(perf);
 		double initialScore = calcScore(f);
 
-		ActivityParams wParams = f.config.scoring().getActivityParams("w");
+		ActivityParams wParams = f.config.scoring().getDefaultActivityParams("w");
 		wParams.setOpeningTime(8 * 3600.0); // now the agent arrives 30min early to the FIRST work activity and has to wait
 		double score = calcScore(f);
 
@@ -283,10 +283,10 @@ public class CharyparNagelScoringFunctionTest {
 	void testClosingTime() {
 		Fixture f = new Fixture();
 		double perf = +6.0;
-		f.config.scoring().setPerforming_utils_hr(perf);
+		f.config.scoring().setDefaultPerforming_utils_hr(perf);
 		double initialScore = calcScore(f);
 
-		ActivityParams wParams = f.config.scoring().getActivityParams("w");
+		ActivityParams wParams = f.config.scoring().getDefaultActivityParams("w");
 		wParams.setClosingTime(15 * 3600.0); // now the agent stays 1h too long at the LAST work activity
 		double score = calcScore(f);
 
@@ -302,10 +302,10 @@ public class CharyparNagelScoringFunctionTest {
 	void testOpeningClosingTime(TypicalDurationScoreComputation typicalDurationComputation) {
 		Fixture f = new Fixture();
 		double perf_hrs = +6.0;
-		f.config.scoring().setPerforming_utils_hr(perf_hrs);
+		f.config.scoring().setDefaultPerforming_utils_hr(perf_hrs);
 
 		if (typicalDurationComputation.equals(TypicalDurationScoreComputation.uniform)) {
-			for (ActivityParams p : f.config.scoring().getActivityParams()) {
+			for (ActivityParams p : f.config.scoring().getDefaultActivityParams()) {
 				p.setTypicalDurationScoreComputation(TypicalDurationScoreComputation.uniform);
 			}
 		}
@@ -314,7 +314,7 @@ public class CharyparNagelScoringFunctionTest {
 
 		// test1: agents has to wait before and after
 
-		ActivityParams wParams = f.config.scoring().getActivityParams("w");
+		ActivityParams wParams = f.config.scoring().getDefaultActivityParams("w");
 		wParams.setOpeningTime(8 * 3600.0); // the agent arrives 30min early
 		wParams.setClosingTime(15 * 3600.0); // the agent stays 1h too long
 		double score = calcScore(f);
@@ -366,9 +366,9 @@ public class CharyparNagelScoringFunctionTest {
 	void testWaitingTime() {
 		Fixture f = new Fixture();
 		double waiting = -10.0;
-		f.config.scoring().setMarginalUtlOfWaiting_utils_hr(waiting);
+		f.config.scoring().setDefaultMarginalUtlOfWaiting_utils_hr(waiting);
 
-		ActivityParams wParams = f.config.scoring().getActivityParams("w");
+		ActivityParams wParams = f.config.scoring().getDefaultActivityParams("w");
 		wParams.setOpeningTime(8 * 3600.0); // the agent arrives 30min early
 		wParams.setClosingTime(15 * 3600.0); // the agent stays 1h too long
 
@@ -383,9 +383,9 @@ public class CharyparNagelScoringFunctionTest {
 	void testEarlyDeparture() {
 		Fixture f = new Fixture();
 		double disutility = -10.0;
-		f.config.scoring().setEarlyDeparture_utils_hr(disutility);
+		f.config.scoring().setDefaultEarlyDeparture_utils_hr(disutility);
 
-		ActivityParams wParams = f.config.scoring().getActivityParams("w");
+		ActivityParams wParams = f.config.scoring().getDefaultActivityParams("w");
 		wParams.setEarliestEndTime(10.75 * 3600.0); // require the agent to work until 16:45
 
 		// the agent left 45mins too early
@@ -399,9 +399,9 @@ public class CharyparNagelScoringFunctionTest {
 	void testMinimumDuration() {
 		Fixture f = new Fixture();
 		double disutility = -10.0;
-		f.config.scoring().setEarlyDeparture_utils_hr(disutility);
+		f.config.scoring().setDefaultEarlyDeparture_utils_hr(disutility);
 
-		ActivityParams wParams = f.config.scoring().getActivityParams("w");
+		ActivityParams wParams = f.config.scoring().getDefaultActivityParams("w");
 		wParams.setMinimalDuration(3 * 3600.0); // require the agent to be 3 hours at every working activity
 
 		// the agent overall works 1.25h too short
@@ -415,9 +415,9 @@ public class CharyparNagelScoringFunctionTest {
 	void testLateArrival() {
 		Fixture f = new Fixture();
 		double disutility = -10.0;
-		f.config.scoring().setLateArrival_utils_hr(disutility);
+		f.config.scoring().setDefaultLateArrival_utils_hr(disutility);
 
-		ActivityParams wParams = f.config.scoring().getActivityParams("w");
+		ActivityParams wParams = f.config.scoring().getDefaultActivityParams("w");
 		wParams.setLatestStartTime(13 * 3600.0); // agent should start working latest at 13 o'clock
 
 		// the agent arrived 30mins late
@@ -432,7 +432,7 @@ public class CharyparNagelScoringFunctionTest {
 	void testStuckPenalty() {
 		Fixture f = new Fixture();
 		// test 1 where late arrival has the biggest impact
-		f.config.scoring().setLateArrival_utils_hr(-18.0);
+		f.config.scoring().setDefaultLateArrival_utils_hr(-18.0);
 		final double traveling1 = -6.0;
 		f.config.scoring().getDefaultModeParams().get(TransportMode.car).setMarginalUtilityOfTraveling(traveling1);
 
@@ -453,7 +453,7 @@ public class CharyparNagelScoringFunctionTest {
 		assertEquals(24 * -18.0 - 6.0 * 0.50, testee.getScore(), EPSILON); // stuck penalty + 30min traveling
 
 		// test 2 where traveling has the biggest impact
-		f.config.scoring().setLateArrival_utils_hr(-3.0);
+		f.config.scoring().setDefaultLateArrival_utils_hr(-3.0);
 		final double traveling = -6.0;
 		f.config.scoring().getDefaultModeParams().get(TransportMode.car).setMarginalUtilityOfTraveling(traveling);
 
@@ -475,7 +475,7 @@ public class CharyparNagelScoringFunctionTest {
 	void testDistanceCostScoringCar() {
 		Fixture f = new Fixture();
 		// test 1 where marginalUtitityOfMoney is fixed to 1.0
-		f.config.scoring().setMarginalUtilityOfMoney(1.0);
+		f.config.scoring().setDefaultMarginalUtilityOfMoney(1.0);
 		//		this.config.charyparNagelScoring().setMarginalUtlOfDistanceCar(-0.00001);
 		double monetaryDistanceRateCar1 = -0.00001;
 		f.config.scoring().getDefaultModeParams().get(TransportMode.car).setMonetaryDistanceRate(monetaryDistanceRateCar1);
@@ -485,7 +485,7 @@ public class CharyparNagelScoringFunctionTest {
 		// test 2 where MonetaryDistanceCostRate is fixed to -1.0
 		double monetaryDistanceRateCar = -1.0;
 		f.config.scoring().getDefaultModeParams().get(TransportMode.car).setMonetaryDistanceRate(monetaryDistanceRateCar);
-		f.config.scoring().setMarginalUtilityOfMoney(0.5);
+		f.config.scoring().setDefaultMarginalUtilityOfMoney(0.5);
 
 		assertEquals(-12500.0, calcScore(f), EPSILON);
 	}
@@ -494,7 +494,7 @@ public class CharyparNagelScoringFunctionTest {
 	void testDistanceCostScoringPt() {
 		Fixture f = new Fixture();
 		// test 1 where marginalUtitityOfMoney is fixed to 1.0
-		f.config.scoring().setMarginalUtilityOfMoney(1.0);
+		f.config.scoring().setDefaultMarginalUtilityOfMoney(1.0);
 		//		this.config.charyparNagelScoring().setMarginalUtlOfDistancePt(-0.00001);
 		double monetaryDistanceRatePt1 = -0.00001;
 		f.config.scoring().getDefaultModeParams().get(TransportMode.pt).setMonetaryDistanceRate(monetaryDistanceRatePt1);
@@ -504,7 +504,7 @@ public class CharyparNagelScoringFunctionTest {
 		// test 2 where MonetaryDistanceCostRate is fixed to -1.0
 		double monetaryDistanceRatePt = -1.0;
 		f.config.scoring().getDefaultModeParams().get(TransportMode.pt).setMonetaryDistanceRate(monetaryDistanceRatePt);
-		f.config.scoring().setMarginalUtilityOfMoney(0.5);
+		f.config.scoring().setDefaultMarginalUtilityOfMoney(0.5);
 
 		assertEquals(-10000.0, calcScore(f), EPSILON);
 	}
@@ -730,16 +730,16 @@ public class CharyparNagelScoringFunctionTest {
 			scoring.getDefaultModeParams().get(TransportMode.walk).setConstant(0.0);
 			scoring.getDefaultModeParams().get(TransportMode.bike).setConstant(0.0);
 
-			scoring.setEarlyDeparture_utils_hr(0.0);
-			scoring.setLateArrival_utils_hr(0.0);
-			scoring.setMarginalUtlOfWaiting_utils_hr(0.0);
-			scoring.setPerforming_utils_hr(0.0);
+			scoring.setDefaultEarlyDeparture_utils_hr(0.0);
+			scoring.setDefaultLateArrival_utils_hr(0.0);
+			scoring.setDefaultMarginalUtlOfWaiting_utils_hr(0.0);
+			scoring.setDefaultPerforming_utils_hr(0.0);
 			scoring.getDefaultModeParams().get(TransportMode.car).setMarginalUtilityOfTraveling(0.0);
 			scoring.getDefaultModeParams().get(TransportMode.pt).setMarginalUtilityOfTraveling(0.0);
 			scoring.getDefaultModeParams().get(TransportMode.walk).setMarginalUtilityOfTraveling(0.0);
 			scoring.getDefaultModeParams().get(TransportMode.bike).setMarginalUtilityOfTraveling(0.0);
 
-			scoring.setMarginalUtilityOfMoney(1.);
+			scoring.setDefaultMarginalUtilityOfMoney(1.);
 			scoring.getDefaultModeParams().get(TransportMode.car).setMonetaryDistanceRate(0.0);
 			scoring.getDefaultModeParams().get(TransportMode.pt).setMonetaryDistanceRate(0.0);
 

--- a/matsim/src/test/java/org/matsim/examples/simple/PtScoringTest.java
+++ b/matsim/src/test/java/org/matsim/examples/simple/PtScoringTest.java
@@ -58,7 +58,7 @@ public class PtScoringTest {
 		ScoringConfigGroup pcs = config.scoring() ;
 
 		if(typicalDurationScoreComputation.equals(TypicalDurationScoreComputation.uniform)){
-			for(ActivityParams params : pcs.getActivityParams()){
+			for(ActivityParams params : pcs.getDefaultActivityParams()){
 				params.setTypicalDurationScoreComputation(typicalDurationScoreComputation);
 			}
 		}
@@ -82,11 +82,11 @@ public class PtScoringTest {
 
 
 
-		double typicalDuration_s = pcs.getActivityParams("home").getTypicalDuration().seconds();
+		double typicalDuration_s = pcs.getDefaultActivityParams("home").getTypicalDuration().seconds();
 		double priority = 1. ;
 
 //		double zeroUtilityDurationHome_s = CharyparNagelScoringUtils.computeZeroUtilityDuration_s(priority, typicalDuration_s);
-		ActivityUtilityParameters.Builder builder = new ActivityUtilityParameters.Builder( pcs.getActivityParams("home") ) ;
+		ActivityUtilityParameters.Builder builder = new ActivityUtilityParameters.Builder( pcs.getDefaultActivityParams("home") ) ;
 		ActivityUtilityParameters params = builder.build() ;
 		double zeroUtilityDurationHome_s = params.getZeroUtilityDuration_h() * 3600. ;
 
@@ -112,7 +112,7 @@ public class PtScoringTest {
 		double ptIA6ActEnd = leaveVeh3 ;
 		double home3Arr = 19866 ;
 
-		double score = pcs.getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (stop1Arr-homeAct1End)/3600. ;
+		double score = pcs.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (stop1Arr-homeAct1End)/3600. ;
 		System.out.println("score after walk: " + score ) ;
 
 		// (pt interaction activity)
@@ -120,24 +120,24 @@ public class PtScoringTest {
 
 		// yyyy wait is not separately scored!!
 		//			score += pcs.getMarginalUtlOfWaitingPt_utils_hr() * timeTransitWait/3600. ;
-		score += pcs.getModes().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (enterVeh-ptIA1ActEnd)/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (enterVeh-ptIA1ActEnd)/3600. ;
 		System.out.println("score after wait: " + score ) ;
 
-		score += pcs.getModes().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (leaveVeh-enterVeh)/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (leaveVeh-enterVeh)/3600. ;
 		System.out.println("score after travel pt: " + score ) ;
 
 		// (pt interaction activity)
 		System.out.println("score after pt interact: " + score ) ;
 
-		score += pcs.getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (home2Arr-ptIA2ActEnd)/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (home2Arr-ptIA2ActEnd)/3600. ;
 		System.out.println("score after walk: " + score ) ;
 
 		final double duration = homeAct2End-home2Arr;
-		double tmpScore = (pcs.getPerforming_utils_hr()/3600.) * typicalDuration_s
+		double tmpScore = (pcs.getDefaultPerforming_utils_hr()/3600.) * typicalDuration_s
 				* Math.log(duration/zeroUtilityDurationHome_s) ;
 		if ( tmpScore < 0 ) {
 			System.out.println("home2score< 0; replacing ... ") ;
-			double slope = (pcs.getPerforming_utils_hr()/3600.) * typicalDuration_s / zeroUtilityDurationHome_s ;
+			double slope = (pcs.getDefaultPerforming_utils_hr()/3600.) * typicalDuration_s / zeroUtilityDurationHome_s ;
 			tmpScore = zeroUtilityDurationHome_s * slope ;
 		}
 		score += tmpScore ;
@@ -145,25 +145,25 @@ public class PtScoringTest {
 
 		// ======
 
-		score += pcs.getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (stop2Arr-homeAct2End)/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (stop2Arr-homeAct2End)/3600. ;
 		System.out.println("score after walk: " + score ) ;
 
 		// (pt interaction activity)
 		System.out.println("score after pt int act: " + score ) ;
 
-		score += pcs.getModes().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (enterVeh2-ptIA3ActEnd)/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (enterVeh2-ptIA3ActEnd)/3600. ;
 		System.out.println("score after wait: " + score ) ;
 
-		score += pcs.getModes().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (leaveVeh2-enterVeh2)/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (leaveVeh2-enterVeh2)/3600. ;
 		System.out.println("score after travel pt: " + score ) ;
 
 		// (pt interaction activity)
 		System.out.println("score after pt int act: " + score ) ;
 
-		score += pcs.getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (stop3Arr-ptIA4ActEnd)/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (stop3Arr-ptIA4ActEnd)/3600. ;
 		System.out.println("score after walk: " + score ) ;
 
-		score += pcs.getUtilityOfLineSwitch() ;
+		score += pcs.getDefaultUtilityOfLineSwitch() ;
 		System.out.println("score after line switch: " + score ) ;
 
 		// ------
@@ -171,19 +171,19 @@ public class PtScoringTest {
 		// (pt interaction activity)
 		System.out.println("score after pt int act: " + score ) ;
 
-		score += pcs.getModes().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (enterVeh3-ptIA5ActEnd)/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (enterVeh3-ptIA5ActEnd)/3600. ;
 		System.out.println("score after wait: " + score ) ;
 
-		score += pcs.getModes().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (leaveVeh3-enterVeh3)/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (leaveVeh3-enterVeh3)/3600. ;
 		System.out.println("score after travel pt: " + score ) ;
 
 		// (pt interaction activity)
 		System.out.println("score after pt int act: " + score ) ;
 
-		score += pcs.getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (home3Arr-ptIA6ActEnd)/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (home3Arr-ptIA6ActEnd)/3600. ;
 		System.out.println("score after walk: " + score ) ;
 
-		score += (pcs.getPerforming_utils_hr()/3600.) * typicalDuration_s
+		score += (pcs.getDefaultPerforming_utils_hr()/3600.) * typicalDuration_s
 				* Math.log((homeAct1End-home3Arr+24.*3600)/zeroUtilityDurationHome_s) ;
 		System.out.println("score after home act: " + score ) ;
 
@@ -212,12 +212,12 @@ public class PtScoringTest {
 		ScoringConfigGroup pcs = config.scoring() ;
 
 		if(typicalDurationScoreComputation.equals(TypicalDurationScoreComputation.uniform))
-			for(ActivityParams params : pcs.getActivityParams()){
+			for(ActivityParams params : pcs.getDefaultActivityParams()){
 				params.setTypicalDurationScoreComputation(typicalDurationScoreComputation);
 		}
 
 		pcs.setWriteExperiencedPlans(true);
-		pcs.getModes().get(TransportMode.pt).setConstant(1.);
+		pcs.getDefaultModeParams().get(TransportMode.pt).setConstant(1.);
 
 		Controler controler = new Controler(config);
 		controler.getConfig().controller().setOverwriteFileSetting(OutputDirectoryHierarchy.OverwriteFileSetting.overwriteExistingFiles);
@@ -234,11 +234,11 @@ public class PtScoringTest {
 			System.out.println(event.toString());
 		}
 
-		double typicalDuration_s = pcs.getActivityParams("home").getTypicalDuration().seconds();
+		double typicalDuration_s = pcs.getDefaultActivityParams("home").getTypicalDuration().seconds();
 		double priority = 1. ;
 
 //		double zeroUtilityDurationHome_s = CharyparNagelScoringUtils.computeZeroUtilityDuration_s(priority, typicalDuration_s);
-		ActivityUtilityParameters.Builder builder = new ActivityUtilityParameters.Builder( pcs.getActivityParams("home") ) ;
+		ActivityUtilityParameters.Builder builder = new ActivityUtilityParameters.Builder( pcs.getDefaultActivityParams("home") ) ;
 		ActivityUtilityParameters params = builder.build() ;
 		double zeroUtilityDurationHome_s = params.getZeroUtilityDuration_h() * 3600. ;
 
@@ -263,34 +263,34 @@ public class PtScoringTest {
 		double ptIA6ActEnd = leaveVeh3 ;
 		double home3Arr = 19866 ;
 
-		double score = pcs.getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (stop1Arr-homeAct1End)/3600. ;
+		double score = pcs.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (stop1Arr-homeAct1End)/3600. ;
 		System.out.println("score after walk: " + score ) ;
 
 		// (pt interaction activity)
 		System.out.println("score after pt interact: " + score ) ;
 
-		score += pcs.getModes().get(TransportMode.pt).getConstant();
+		score += pcs.getDefaultModeParams().get(TransportMode.pt).getConstant();
 		System.out.println("score after addition of pt constant: " + score ) ;
 
 		// yyyy wait is not separately scored!!
 		//			score += pcs.getMarginalUtlOfWaitingPt_utils_hr() * timeTransitWait/3600. ;
-		score += pcs.getModes().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (enterVeh-ptIA1ActEnd)/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (enterVeh-ptIA1ActEnd)/3600. ;
 		System.out.println("score after wait: " + score ) ;
 
-		score += pcs.getModes().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (leaveVeh-enterVeh)/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (leaveVeh-enterVeh)/3600. ;
 		System.out.println("score after travel pt: " + score ) ;
 
 		// (pt interaction activity)
 		System.out.println("score after pt interact: " + score ) ;
 
-		score += pcs.getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (home2Arr-ptIA2ActEnd)/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (home2Arr-ptIA2ActEnd)/3600. ;
 		System.out.println("score after walk: " + score ) ;
 
-		double tmpScore = (pcs.getPerforming_utils_hr()/3600.) * typicalDuration_s
+		double tmpScore = (pcs.getDefaultPerforming_utils_hr()/3600.) * typicalDuration_s
 				* Math.log((homeAct2End-home2Arr)/zeroUtilityDurationHome_s) ;
 		if ( tmpScore < 0 ) {
 			System.out.println("home2score< 0; replacing ... ") ;
-			double slope = (pcs.getPerforming_utils_hr()/3600.) * typicalDuration_s / zeroUtilityDurationHome_s ;
+			double slope = (pcs.getDefaultPerforming_utils_hr()/3600.) * typicalDuration_s / zeroUtilityDurationHome_s ;
 			tmpScore = zeroUtilityDurationHome_s * slope ;
 		}
 		score += tmpScore ;
@@ -298,28 +298,28 @@ public class PtScoringTest {
 
 		// ======
 
-		score += pcs.getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (stop2Arr-homeAct2End)/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (stop2Arr-homeAct2End)/3600. ;
 		System.out.println("score after walk: " + score ) ;
 
 		// (pt interaction activity)
 		System.out.println("score after pt int act: " + score ) ;
 
-		score += pcs.getModes().get(TransportMode.pt).getConstant();
+		score += pcs.getDefaultModeParams().get(TransportMode.pt).getConstant();
 		System.out.println("score after addition of pt constant: " + score ) ;
 
-		score += pcs.getModes().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (enterVeh2-ptIA3ActEnd)/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (enterVeh2-ptIA3ActEnd)/3600. ;
 		System.out.println("score after wait: " + score ) ;
 
-		score += pcs.getModes().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (leaveVeh2-enterVeh2)/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (leaveVeh2-enterVeh2)/3600. ;
 		System.out.println("score after travel pt: " + score ) ;
 
 		// (pt interaction activity)
 		System.out.println("score after pt int act: " + score ) ;
 
-		score += pcs.getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (stop3Arr-ptIA4ActEnd)/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (stop3Arr-ptIA4ActEnd)/3600. ;
 		System.out.println("score after walk: " + score ) ;
 
-		score += pcs.getUtilityOfLineSwitch() ;
+		score += pcs.getDefaultUtilityOfLineSwitch() ;
 		System.out.println("score after line switch: " + score ) ;
 
 		// ------
@@ -327,19 +327,19 @@ public class PtScoringTest {
 		// (pt interaction activity)
 		System.out.println("score after pt int act: " + score ) ;
 
-		score += pcs.getModes().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (enterVeh3-ptIA5ActEnd)/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (enterVeh3-ptIA5ActEnd)/3600. ;
 		System.out.println("score after wait: " + score ) ;
 
-		score += pcs.getModes().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (leaveVeh3-enterVeh3)/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling() * (leaveVeh3-enterVeh3)/3600. ;
 		System.out.println("score after travel pt: " + score ) ;
 
 		// (pt interaction activity)
 		System.out.println("score after pt int act: " + score ) ;
 
-		score += pcs.getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (home3Arr-ptIA6ActEnd)/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (home3Arr-ptIA6ActEnd)/3600. ;
 		System.out.println("score after walk: " + score ) ;
 
-		score += (pcs.getPerforming_utils_hr()/3600.) * typicalDuration_s
+		score += (pcs.getDefaultPerforming_utils_hr()/3600.) * typicalDuration_s
 				* Math.log((homeAct1End-home3Arr+24.*3600)/zeroUtilityDurationHome_s) ;
 		System.out.println("score after home act: " + score ) ;
 
@@ -369,13 +369,13 @@ public class PtScoringTest {
 		ScoringConfigGroup pcs = config.scoring();
 
 		if(typicalDurationScoreComputation.equals(TypicalDurationScoreComputation.uniform)){
-			for(ActivityParams params : pcs.getActivityParams()){
+			for(ActivityParams params : pcs.getDefaultActivityParams()){
 				params.setTypicalDurationScoreComputation(typicalDurationScoreComputation);
 			}
 		}
 
 		pcs.setWriteExperiencedPlans(true);
-		pcs.setMarginalUtlOfWaitingPt_utils_hr(-18.0) ;
+		pcs.setDefaultMarginalUtlOfWaitingPt_utils_hr(-18.0) ;
 
 		Controler controler = new Controler(config);
 		controler.getConfig().controller().setOverwriteFileSetting(OutputDirectoryHierarchy.OverwriteFileSetting.overwriteExistingFiles);
@@ -392,11 +392,11 @@ public class PtScoringTest {
 			System.out.println(event.toString());
 		}
 
-		double typicalDuration_s = pcs.getActivityParams("home").getTypicalDuration().seconds();
+		double typicalDuration_s = pcs.getDefaultActivityParams("home").getTypicalDuration().seconds();
 		double priority = 1. ;
 
 //		double zeroUtilityDurationHome_s = CharyparNagelScoringUtils.computeZeroUtilityDuration_s(priority, typicalDuration_s);
-		ActivityUtilityParameters.Builder builder = new ActivityUtilityParameters.Builder( pcs.getActivityParams("home") ) ;
+		ActivityUtilityParameters.Builder builder = new ActivityUtilityParameters.Builder( pcs.getDefaultActivityParams("home") ) ;
 		ActivityUtilityParameters params = builder.build() ;
 		double zeroUtilityDurationHome_s = params.getZeroUtilityDuration_h() * 3600. ;
 
@@ -407,29 +407,29 @@ public class PtScoringTest {
 		double timeTransitWalk2 = 18446. - 18423. ;
 		double timeHome = 18060. + 24.*3600 - 18446 ;
 
-		double score = pcs.getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (timeTransitWalk/3600.) ;
+		double score = pcs.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (timeTransitWalk/3600.) ;
 		System.out.println("score: " + score ) ;
 
 		// (pt interaction activity)
 		System.out.println("score: " + score ) ;
 
-		System.out.println("marginalUtlOfWaitPt: " + pcs.getMarginalUtlOfWaitingPt_utils_hr() ) ;
+		System.out.println("marginalUtlOfWaitPt: " + pcs.getDefaultMarginalUtlOfWaitingPt_utils_hr() ) ;
 
-		score += pcs.getMarginalUtlOfWaitingPt_utils_hr() * timeTransitWait/3600. ;
+		score += pcs.getDefaultMarginalUtlOfWaitingPt_utils_hr() * timeTransitWait/3600. ;
 		//			score += pcs.getTravelingPt_utils_hr() * timeTransitWait/3600. ;
 		// yyyy wait is not separately scored!!
 		System.out.println("score: " + score ) ;
 
-		score += pcs.getModes().get(TransportMode.pt).getMarginalUtilityOfTraveling() * timeTransitInVeh/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling() * timeTransitInVeh/3600. ;
 		System.out.println("score: " + score ) ;
 
 		// (pt interaction activity)
 		System.out.println("score: " + score ) ;
 
-		score += pcs.getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling() * timeTransitWalk2/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() * timeTransitWalk2/3600. ;
 		System.out.println("score: " + score ) ;
 
-		score += (pcs.getPerforming_utils_hr()/3600.) * typicalDuration_s * Math.log(timeHome/zeroUtilityDurationHome_s) ;
+		score += (pcs.getDefaultPerforming_utils_hr()/3600.) * typicalDuration_s * Math.log(timeHome/zeroUtilityDurationHome_s) ;
 		System.out.println("final score: " + score ) ;
 
 		Scenario sc = controler.getScenario();
@@ -456,7 +456,7 @@ public class PtScoringTest {
 		ScoringConfigGroup pcs = config.scoring() ;
 
 		if(typicalDurationScoreComputation.equals(TypicalDurationScoreComputation.uniform))
-		for(ActivityParams params : pcs.getActivityParams()){
+		for(ActivityParams params : pcs.getDefaultActivityParams()){
 			params.setTypicalDurationScoreComputation(typicalDurationScoreComputation);
 		}
 
@@ -477,11 +477,11 @@ public class PtScoringTest {
 			System.out.println(event.toString());
 		}
 
-		double typicalDuration_s = pcs.getActivityParams("home").getTypicalDuration().seconds();
+		double typicalDuration_s = pcs.getDefaultActivityParams("home").getTypicalDuration().seconds();
 		double priority = 1. ;
 
 //		double zeroUtilityDurationHome_s = CharyparNagelScoringUtils.computeZeroUtilityDuration_s(priority, typicalDuration_s);
-		ActivityUtilityParameters.Builder builder = new ActivityUtilityParameters.Builder( pcs.getActivityParams("home") ) ;
+		ActivityUtilityParameters.Builder builder = new ActivityUtilityParameters.Builder( pcs.getDefaultActivityParams("home") ) ;
 		ActivityUtilityParameters params = builder.build() ;
 		double zeroUtilityDurationHome_s = params.getZeroUtilityDuration_h() * 3600. ;
 
@@ -492,27 +492,27 @@ public class PtScoringTest {
 		double timeTransitWalk2 = 18446. - 18423. ;
 		double timeHome = 18060. + 24.*3600 - 18446 ;
 
-		double score = pcs.getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (timeTransitWalk/3600.) ;
+		double score = pcs.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() * (timeTransitWalk/3600.) ;
 		System.out.println("score: " + score ) ;
 
 		// (pt interaction activity)
 		System.out.println("score: " + score ) ;
 
 		//			score += pcs.getMarginalUtlOfWaitingPt_utils_hr() * timeTransitWait/3600. ;
-		score += pcs.getModes().get(TransportMode.pt).getMarginalUtilityOfTraveling() * timeTransitWait/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling() * timeTransitWait/3600. ;
 		// yyyy wait is not separately scored!!
 		System.out.println("score: " + score ) ;
 
-		score += pcs.getModes().get(TransportMode.pt).getMarginalUtilityOfTraveling() * timeTransitInVeh/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.pt).getMarginalUtilityOfTraveling() * timeTransitInVeh/3600. ;
 		System.out.println("score: " + score ) ;
 
 		// (pt interaction activity)
 		System.out.println("score: " + score ) ;
 
-		score += pcs.getModes().get(TransportMode.walk).getMarginalUtilityOfTraveling() * timeTransitWalk2/3600. ;
+		score += pcs.getDefaultModeParams().get(TransportMode.walk).getMarginalUtilityOfTraveling() * timeTransitWalk2/3600. ;
 		System.out.println("score: " + score ) ;
 
-		score += (pcs.getPerforming_utils_hr()/3600.) * typicalDuration_s * Math.log(timeHome/zeroUtilityDurationHome_s) ;
+		score += (pcs.getDefaultPerforming_utils_hr()/3600.) * typicalDuration_s * Math.log(timeHome/zeroUtilityDurationHome_s) ;
 		System.out.println("score: " + score ) ;
 
 		Scenario sc = controler.getScenario();

--- a/matsim/src/test/java/org/matsim/integration/SimulateAndScoreTest.java
+++ b/matsim/src/test/java/org/matsim/integration/SimulateAndScoreTest.java
@@ -101,11 +101,11 @@ public class SimulateAndScoreTest {
 		transitActivityParams.setTypicalDuration(120.0);
 
 		config.scoring().setPerforming_utils_hr(0);
-		config.scoring().getModes().get(TransportMode.car).setMarginalUtilityOfTraveling((double) 0);
-		config.scoring().getModes().get(TransportMode.pt).setMarginalUtilityOfTraveling((double) 0);
-		config.scoring().getModes().get(TransportMode.walk).setMarginalUtilityOfTraveling((double) 0);
-		config.scoring().getModes().get(TransportMode.car).setMonetaryDistanceRate((double) 10);
-		config.scoring().getModes().get(TransportMode.pt).setMonetaryDistanceRate((double) 0);
+		config.scoring().getDefaultModeParams().get(TransportMode.car).setMarginalUtilityOfTraveling((double) 0);
+		config.scoring().getDefaultModeParams().get(TransportMode.pt).setMarginalUtilityOfTraveling((double) 0);
+		config.scoring().getDefaultModeParams().get(TransportMode.walk).setMarginalUtilityOfTraveling((double) 0);
+		config.scoring().getDefaultModeParams().get(TransportMode.car).setMonetaryDistanceRate((double) 10);
+		config.scoring().getDefaultModeParams().get(TransportMode.pt).setMonetaryDistanceRate((double) 0);
 		config.scoring().addActivityParams(h);
 		config.scoring().addActivityParams(w);
 		config.scoring().addActivityParams(transitActivityParams);
@@ -291,9 +291,9 @@ public class SimulateAndScoreTest {
 		w.setTypicalDuration(8 * 3600);
 		scenario.getConfig().scoring().setPerforming_utils_hr(0);
 		final double travelingPt = -1.00;
-		scenario.getConfig().scoring().getModes().get(TransportMode.pt).setMarginalUtilityOfTraveling(travelingPt);
+		scenario.getConfig().scoring().getDefaultModeParams().get(TransportMode.pt).setMarginalUtilityOfTraveling(travelingPt);
 		double monetaryDistanceRatePt = -0.001;
-		scenario.getConfig().scoring().getModes().get(TransportMode.pt).setMonetaryDistanceRate(monetaryDistanceRatePt);
+		scenario.getConfig().scoring().getDefaultModeParams().get(TransportMode.pt).setMonetaryDistanceRate(monetaryDistanceRatePt);
 		scenario.getConfig().scoring().addActivityParams(h);
 		scenario.getConfig().scoring().addActivityParams(w);
 		EventsToScore scorer = EventsToScore.createWithScoreUpdating(scenario, new CharyparNagelScoringFunctionFactory(scenario), events);

--- a/matsim/src/test/java/org/matsim/integration/invertednetworks/InvertedNetworkRoutingTestFixture.java
+++ b/matsim/src/test/java/org/matsim/integration/invertednetworks/InvertedNetworkRoutingTestFixture.java
@@ -94,7 +94,7 @@ public class InvertedNetworkRoutingTestFixture {
 		stratSets.setWeight(1.0);
 		config.replanning().addStrategySettings(stratSets);
 		final double traveling = -1200.0;
-		config.scoring().getModes().get(TransportMode.car).setMarginalUtilityOfTraveling(traveling);
+		config.scoring().getDefaultModeParams().get(TransportMode.car).setMarginalUtilityOfTraveling(traveling);
 		ActivityParams params = new ActivityParams("home");
 		params.setTypicalDuration(24.0 * 3600.0);
 		config.scoring().addActivityParams(params);

--- a/matsim/src/test/java/org/matsim/pt/router/TransitRouterConfigTest.java
+++ b/matsim/src/test/java/org/matsim/pt/router/TransitRouterConfigTest.java
@@ -40,9 +40,9 @@ public class TransitRouterConfigTest {
 		VspExperimentalConfigGroup vspConfig = new VspExperimentalConfigGroup() ;
 
 		final double travelingPt = -9.0;
-		planScoring.getModes().get(TransportMode.pt).setMarginalUtilityOfTraveling(travelingPt);
+		planScoring.getDefaultModeParams().get(TransportMode.pt).setMarginalUtilityOfTraveling(travelingPt);
 		final double travelingWalk = -11.0;
-		planScoring.getModes().get(TransportMode.walk).setMarginalUtilityOfTraveling(travelingWalk);
+		planScoring.getDefaultModeParams().get(TransportMode.walk).setMarginalUtilityOfTraveling(travelingWalk);
 
 //		planScoring.setMarginalUtlOfWaiting_utils_hr(-13.0);
 		planScoring.setMarginalUtlOfWaitingPt_utils_hr(-13.0);

--- a/matsim/src/test/java/org/matsim/pt/router/TransitRouterConfigTest.java
+++ b/matsim/src/test/java/org/matsim/pt/router/TransitRouterConfigTest.java
@@ -45,12 +45,12 @@ public class TransitRouterConfigTest {
 		planScoring.getDefaultModeParams().get(TransportMode.walk).setMarginalUtilityOfTraveling(travelingWalk);
 
 //		planScoring.setMarginalUtlOfWaiting_utils_hr(-13.0);
-		planScoring.setMarginalUtlOfWaitingPt_utils_hr(-13.0);
+		planScoring.setDefaultMarginalUtlOfWaitingPt_utils_hr(-13.0);
 		// naturally, this failed after the functionality was moved to a separate planCalcScore parameter.  kai, oct'12
 
-		planScoring.setPerforming_utils_hr(+6.0);
+		planScoring.setDefaultPerforming_utils_hr(+6.0);
 
-		planScoring.setUtilityOfLineSwitch(-2.34);
+		planScoring.setDefaultUtilityOfLineSwitch(-2.34);
 
 		planRouting.setTeleportedModeSpeed(TransportMode.walk, 1.37 );
 		// (this will clear all defaults!)


### PR DESCRIPTION
## Summary

Introduce the core subpopulation scoring API and migrate relevant call sites to the clearer scoring accessors.

This separates default/root scoring from explicitly configured subpopulation scoring via `getModeParams()`, `getDefaultModeParams()`, `getAllScoringParameterSetsPerSubpopulation()`, and `getExplicitScoringParameterSetsPerSubpopulation()`.

Existing legacy methods remain available for compatibility, while MATSim and contrib usages of the old scoring access patterns are updated where they directly map to the new API.