### PR TITLE
fix(sbb-extensions): pt skim normalization and documentation

### DIFF
--- a/contribs/sbb-extensions/README.md
+++ b/contribs/sbb-extensions/README.md
@@ -404,7 +404,7 @@ This repository contains code to calculate a variety of skim matrices based on M
   - travel time, routed on network (loaded or unloaded)
   - travel distances, routed on network (loaded or unloaded)
 - for public transport:
-  - travel time (from departure at first stop to arrival at last stop of a trip)
+  - travel time (from origin to destination, including access and egress time)
   - access time (from origin to first stop)
   - egress time (from last stop to destination)
   - number of transfers required
@@ -414,6 +414,8 @@ This repository contains code to calculate a variety of skim matrices based on M
   - percentage of the travel time spent in rail-based transportation within a public transport trip 
 - general:
   - bee-line distances between zones
+
+For public transport skims, travel time, access time, egress time, distance, transfer count, transfer wait time, and train-share values describe a typical trip within the selected departure-time window.
 
 ### Usage
 

--- a/contribs/sbb-extensions/README.md
+++ b/contribs/sbb-extensions/README.md
@@ -404,7 +404,7 @@ This repository contains code to calculate a variety of skim matrices based on M
   - travel time, routed on network (loaded or unloaded)
   - travel distances, routed on network (loaded or unloaded)
 - for public transport:
-  - travel time (from origin to destination, including access and egress time)
+  - travel time (from origin to destination, including access, egress, in-vehicle time and transfer time)
   - access time (from origin to first stop)
   - egress time (from last stop to destination)
   - number of transfers required
@@ -415,7 +415,7 @@ This repository contains code to calculate a variety of skim matrices based on M
 - general:
   - bee-line distances between zones
 
-For public transport skims, travel time, access time, egress time, distance, transfer count, transfer wait time, and train-share values describe a typical trip within the selected departure-time window.
+For public transport skims, `pt_travel_times.csv.gz` describes a typical origin-to-destination trip within the selected departure-time window. Initial waiting/adaption time is reported separately in `pt_adaptiontimes.csv.gz`.
 
 ### Usage
 

--- a/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/analysis/skims/PTSkimMatrices.java
+++ b/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/analysis/skims/PTSkimMatrices.java
@@ -44,8 +44,8 @@ import java.util.stream.Collectors;
 /**
  * Calculates zone-to-zone matrices containing a number of performance indicators related to public transport.
  * <p>
- * Amongst the performance indicators are: - travel time (measured from the first departure to the last arrival, without access/egress time) - travel distance (measured from first departure to last
- * arrival, without access/egress time) - access time - egress time - perceived frequency - share of travel time within trains - share of travel distance within trains
+ * Amongst the performance indicators are: - travel time (including access/egress time) - travel distance (measured from first departure to last arrival, without access/egress time) - access time -
+ * egress time - perceived frequency - share of travel time within trains - share of travel distance within trains
  * <p>
  * The main idea to calculate the frequencies follows the rooftop-algorithm from Niek Guis (ca. 2015).
  * <p>

--- a/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/analysis/skims/RooftopUtils.java
+++ b/contribs/sbb-extensions/src/main/java/ch/sbb/matsim/analysis/skims/RooftopUtils.java
@@ -87,6 +87,7 @@ public class RooftopUtils {
 
     public static double calcAverageAdaptionTime(List<ODConnection> connections, double minDepartureTime, double maxDepartureTime) {
         ODConnection prevConnection = null;
+        double duration = maxDepartureTime - minDepartureTime;
         double sum = 0;
         for (ODConnection connection : connections) {
             if (prevConnection != null) {
@@ -138,10 +139,10 @@ public class RooftopUtils {
             double depTime = prevConnection.departureTime - prevConnection.accessTime;
             if (depTime < minDepartureTime) {
                 double delta = minDepartureTime - depTime;
-                sum = (3600 + delta) * (3600 + delta) / 2 - (delta * delta / 2);
+                sum = (duration + delta) * (duration + delta) / 2 - (delta * delta / 2);
             } else if (depTime > maxDepartureTime) {
                 double delta = depTime - maxDepartureTime;
-                sum = (3600 + delta) * (3600 + delta) / 2 - (delta * delta / 2);
+                sum = (duration + delta) * (duration + delta) / 2 - (delta * delta / 2);
             } else {
                 sum += (maxDepartureTime - depTime) * (maxDepartureTime - depTime) / 2;
             }
@@ -152,7 +153,7 @@ public class RooftopUtils {
                 sum += (maxDepartureTime - depTime) * (maxDepartureTime - depTime) / 2;
             }
         }
-        return sum / (maxDepartureTime - minDepartureTime);
+        return sum / duration;
     }
 
     /**
@@ -160,6 +161,7 @@ public class RooftopUtils {
      */
     public static Map<ODConnection, Double> calcConnectionShares(List<ODConnection> connections, double minDepartureTime, double maxDepartureTime) {
         Map<ODConnection, Double> shares = new HashMap<>();
+        double duration = maxDepartureTime - minDepartureTime;
 
         ODConnection prevConnection = null;
         for (ODConnection connection : connections) {
@@ -184,8 +186,8 @@ public class RooftopUtils {
                     double deltaTravelTime = travelTime2 - travelTime1;
                     double zenith = ((depTime1 + deltaTravelTime) + depTime2) / 2;
 
-                    double share1 = (zenith - depTime1) / 3600;
-                    double share2 = (depTime2 - zenith) / 3600;
+                    double share1 = (zenith - depTime1) / duration;
+                    double share2 = (depTime2 - zenith) / duration;
 
                     if (share1 < 0) {
                         // this can happen if zenith if before minDepTime
@@ -209,7 +211,7 @@ public class RooftopUtils {
                 double depTime = connection.departureTime - connection.accessTime;
                 if (depTime >= minDepartureTime && depTime < maxDepartureTime) {
                     // calculate the first triangle
-                    double share = (depTime - minDepartureTime) / 3600;
+                    double share = (depTime - minDepartureTime) / duration;
                     shares.compute(connection, (c, oldVal) -> (oldVal == null ? share : (oldVal + share)));
                 }
             }
@@ -221,7 +223,7 @@ public class RooftopUtils {
             double depTime = prevConnection.departureTime - prevConnection.accessTime;
             if (depTime < maxDepartureTime) {
                 // there is no departure after maxDepartureTime, so we're still missing the final part
-                double share = (maxDepartureTime - depTime) / 3600;
+                double share = (maxDepartureTime - depTime) / duration;
                 shares.compute(prevConnection, (c, oldVal) -> (oldVal == null ? share : (oldVal + share)));
             }
         }

--- a/contribs/sbb-extensions/src/test/java/ch/sbb/matsim/analysis/skims/RooftopUtilsTest.java
+++ b/contribs/sbb-extensions/src/test/java/ch/sbb/matsim/analysis/skims/RooftopUtilsTest.java
@@ -227,6 +227,20 @@ public class RooftopUtilsTest {
     }
 
 	@Test
+	void testCalcAverageAdaptionTime_singleDepartureEarlyTwoHourWindow() {
+        List<ODConnection> connections = new ArrayList<>();
+
+        // Departure time is 06:15, access time is 5min, so the effective departure time is 06:10.
+        connections.add(new ODConnection(Time.parseTime("06:15:00"), 16080, 300, 125, 5, null));
+
+        double adaptionTime = RooftopUtils.calcAverageAdaptionTime(connections, Time.parseTime("07:00:00"), Time.parseTime("09:00:00"));
+
+        // Over the two-hour window, adaption time grows from 50min at 07:00 to 170min at 09:00.
+        // Average adaption time is therefore (50min + 170min) / 2 = 110min = 6600s.
+        Assertions.assertEquals(6600.0, adaptionTime, 1e-7);
+    }
+
+	@Test
 	void testCalcConnectionShares() {
         List<ODConnection> connections = new ArrayList<>();
 
@@ -282,6 +296,26 @@ public class RooftopUtilsTest {
         Assertions.assertEquals(8.0 / 60.0, shares.get(c3), 1e-7);
         Assertions.assertEquals(20.0 / 60.0, shares.get(c7), 1e-7);
         Assertions.assertEquals(2.0 / 60.0, shares.get(c5), 1e-7);
+    }
+
+	@Test
+	void testCalcConnectionShares_twoHourWindow() {
+        List<ODConnection> connections = new ArrayList<>();
+
+        // 15-min headway over a two-hour skim window.
+        for (String departureTime : List.of("07:50:00", "08:05:00", "08:20:00", "08:35:00", "08:50:00", "09:05:00", "09:20:00", "09:35:00", "09:50:00", "10:05:00")) {
+            connections.add(new ODConnection(Time.parseTime(departureTime), 600, 60, 150, 0, null));
+        }
+
+        Map<ODConnection, Double> shares = RooftopUtils.calcConnectionShares(connections, Time.parseTime("08:00:00"), Time.parseTime("10:00:00"));
+
+        // Shares are fractions of the selected skim window. They must sum to 1.0 even if the window is longer than one hour.
+        Assertions.assertEquals(10, shares.size());
+        Assertions.assertEquals(1.0, sum(shares), 1e-7);
+
+        // A regular middle connection covers 15min of the 120min window, so its share is 15/120.
+        // With the old hard-coded 3600s denominator, this would incorrectly have been 15/60.
+        Assertions.assertEquals(15.0 / 120.0, shares.get(connections.get(2)), 1e-7);
     }
 
 	@Test
@@ -429,5 +463,13 @@ public class RooftopUtilsTest {
 
         Map<ODConnection, Double> shares = RooftopUtils.calcConnectionShares(connections, Time.parseTime("07:00:00"), Time.parseTime("08:00:00"));
         Assertions.assertEquals(1.0, shares.get(c0), 1e-7);
+    }
+
+    private static double sum(Map<ODConnection, Double> shares) {
+        double sum = 0;
+        for (double share : shares.values()) {
+            sum += share;
+        }
+        return sum;
     }
 }


### PR DESCRIPTION
## Summary

Normalizes SBB PT skim connection shares by the selected departure-time window instead of assuming a one-hour window. 

Relevant issues: #2115, #3150

This fixes cases where PT skim values such as travel time, access time, and egress time scaled roughly with the number of hours in the requested skim period.

  ## Details

`RooftopUtils.calcConnectionShares(...)` previously divided connection coverage by `3600`. That worked for one-hour windows, but produced shares summing to about `2.0` for two-hour windows and `3.0` for three-hour windows.

Those shares are used as weights when calculating PT skim values. When they summed to about `2.0` for a two-hour window, values such as `pt_travel_times.csv.gz`, `pt_access_times.csv.gz`, and `pt_egress_times.csv.gz` could be about twice as large as expected.
  
The fix uses the actual skim window duration:
  ```java
  maxDepartureTime - minDepartureTime
```

The PR also updates SBB skim documentation/Javadoc to clarify that pt_travel_times.csv.gz currently represents origin-to-destination PT travel time, including access, egress, in-vehicle time, and transfer time. Initial waiting/adaption time is reported separately in pt_adaptiontimes.csv.gz.

cc: @panostsolerid who explained the issue to me