### PR TITLE
fix(drt): apply maxWalkDistance of the chosen constraints set

### DIFF
--- a/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeRoutingModule.java
+++ b/contribs/drt/src/main/java/org/matsim/contrib/drt/run/DrtModeRoutingModule.java
@@ -136,10 +136,16 @@ public class DrtModeRoutingModule extends AbstractDvrpModeModule {
 										       .asEagerSingleton();
 			case stopbased, serviceAreaBased -> {
 				bindModal( AccessEgressFacilityFinder.class ).toProvider( modalProvider(
-						getter -> new ClosestAccessEgressFacilityFinder(
-								optimizationConstraintsSet.getMaxWalkDistance(),
-													     getter.get( Network.class ),
-													     QuadTrees.createQuadTree( getter.getModal( DrtStopNetwork.class ).getDrtStops().values() ) ) ) )
+						getter -> {
+							Network network = getter.get( Network.class );
+							return new ClosestAccessEgressFacilityFinder(
+									// maxWalkDistance is a property of the constraints set, and which constraints set applies
+									// is decided per trip by the ConstraintSetChooser (as in DefaultDrtRouteConstraintsCalculator)
+									maxWalkDistance( getter.getModal( ConstraintSetChooser.class ), optimizationConstraintsSet, network ),
+									optimizationConstraintsSet.getMaxWalkDistance(),
+														     network,
+														     QuadTrees.createQuadTree( getter.getModal( DrtStopNetwork.class ).getDrtStops().values() ) );
+						} ) )
 									     .asEagerSingleton();
 			}
 			default -> throw new IllegalStateException( "Unexpected value: " + drtCfg.getOperationalScheme());
@@ -167,6 +173,21 @@ public class DrtModeRoutingModule extends AbstractDvrpModeModule {
 		// this binds the above as a controler listener:
 		addControllerListenerBinding().to(modalKey(DrtRouteUpdater.class));
 
+	}
+
+	/**
+	 * Asks the {@link ConstraintSetChooser} which constraints set applies to the trip at hand and returns its
+	 * {@code maxWalkDistance}. The chooser is asked with the access and egress <b>stop</b> links, which is consistent
+	 * with {@link DrtRouteCreator}, where the chooser also sees the stop links and not the activity links.
+	 */
+	public static ClosestAccessEgressFacilityFinder.MaxAccessEgressDistance maxWalkDistance(
+			ConstraintSetChooser constraintSetChooser, DrtOptimizationConstraintsSet defaultConstraintsSet,
+			Network network) {
+		return (request, accessFacility, egressFacility) -> constraintSetChooser.chooseConstraintSet(
+						request.getDepartureTime(), network.getLinks().get(accessFacility.getLinkId()),
+						network.getLinks().get(egressFacility.getLinkId()), request.getPerson(), request.getAttributes())
+				.orElse(defaultConstraintsSet)
+				.getMaxWalkDistance();
 	}
 
 	private static class DrtRouteCreatorProvider extends ModalProviders.AbstractProvider<DvrpMode, DrtRouteCreator> {

--- a/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/DrtRoutingModuleTest.java
+++ b/contribs/drt/src/test/java/org/matsim/contrib/drt/routing/DrtRoutingModuleTest.java
@@ -37,9 +37,11 @@ import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.Plan;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.api.core.v01.population.PopulationFactory;
+import org.matsim.contrib.drt.optimizer.constraints.ConstraintSetChooser;
 import org.matsim.contrib.drt.optimizer.constraints.DrtOptimizationConstraintsSetImpl;
 import org.matsim.contrib.drt.run.DrtConfigGroup;
 import org.matsim.contrib.drt.run.DrtControlerCreator;
+import org.matsim.contrib.drt.run.DrtModeRoutingModule;
 import org.matsim.contrib.drt.run.MultiModeDrtConfigGroup;
 import org.matsim.contrib.dvrp.load.DvrpLoadType;
 import org.matsim.contrib.dvrp.load.IntegerLoadType;
@@ -239,6 +241,78 @@ public class DrtRoutingModuleTest {
 		// TODO: Asserts are prepared for interpreting maxWalkingDistance as a real maximum, but routing still works wrongly
 		Assertions.assertNull(routedList6);
 
+	}
+
+	/**
+	 * maxWalkDistance is a property of the constraints set, and which constraints set applies is decided per trip by
+	 * the {@link org.matsim.contrib.drt.optimizer.constraints.ConstraintSetChooser}. Hence, the stop search has to
+	 * follow the chosen set instead of always using the default set.
+	 */
+	@Test
+	void testStopFinderFollowsTheChosenConstraintSet() {
+		Scenario scenario = createTestScenario();
+		ActivityFacilities facilities = scenario.getActivityFacilities();
+		TeleportationRoutingModule walkRouter = new TeleportationRoutingModule(TransportMode.walk, scenario, 0.83333,
+				1.3, null);
+		DrtConfigGroup drtCfg = DrtConfigGroup.getSingleModeDrtConfig(scenario.getConfig());
+		String drtMode = "DrtX";
+		drtCfg.setMode(drtMode);
+
+		DrtOptimizationConstraintsSetImpl defaultConstraintsSet = drtCfg.addOrGetDrtOptimizationConstraintsParams()
+				.addOrGetDefaultDrtOptimizationConstraintsSet();
+		defaultConstraintsSet.setMaxWalkDistance(200);
+		defaultConstraintsSet.setMaxTravelTimeAlpha(1.5);
+		defaultConstraintsSet.setMaxTravelTimeBeta(5 * 60);
+		defaultConstraintsSet.setMaxWaitTime(5 * 60);
+
+		DrtOptimizationConstraintsSetImpl longWalkConstraintsSet = new DrtOptimizationConstraintsSetImpl();
+		longWalkConstraintsSet.setConstraintSetName("longWalk");
+		longWalkConstraintsSet.setMaxWalkDistance(5000);
+		longWalkConstraintsSet.setMaxTravelTimeAlpha(1.5);
+		longWalkConstraintsSet.setMaxTravelTimeBeta(5 * 60);
+		longWalkConstraintsSet.setMaxWaitTime(5 * 60);
+		drtCfg.addOrGetDrtOptimizationConstraintsParams().addParameterSet(longWalkConstraintsSet);
+
+		// person 2 is allowed to walk far, everybody else is not
+		Person p2 = scenario.getPopulation().getPersons().get(Id.createPersonId(2));
+		ConstraintSetChooser constraintSetChooser = (departureTime, accessActLink, egressActLink, person, tripAttributes) -> Optional.of(
+				person == p2 ? longWalkConstraintsSet : defaultConstraintsSet);
+
+		ImmutableMap<Id<DrtStopFacility>, DrtStopFacility> drtStops = scenario.getTransitSchedule()
+				.getFacilities()
+				.values()
+				.stream()
+				.map(DrtStopFacilityImpl::createFromFacility)
+				.collect(ImmutableMap.toImmutableMap(DrtStopFacility::getId, f -> f));
+
+		AccessEgressFacilityFinder stopFinder = new ClosestAccessEgressFacilityFinder(
+				DrtModeRoutingModule.maxWalkDistance(constraintSetChooser, defaultConstraintsSet, scenario.getNetwork()),
+				defaultConstraintsSet.getMaxWalkDistance(), scenario.getNetwork(),
+				QuadTrees.createQuadTree(drtStops.values()));
+
+		DvrpLoadType loadType = new IntegerLoadType("passengers");
+		DrtRouteCreator drtRouteCreator = new DrtRouteCreator(drtCfg, scenario.getNetwork(),
+				new SpeedyDijkstraFactory(), new FreeSpeedTravelTime(), TimeAsTravelDisutility::new,
+				new DefaultDrtRouteConstraintsCalculator(drtCfg, constraintSetChooser),
+				new DefaultDvrpLoadFromTrip(loadType, "passengers"), loadType);
+		DefaultMainLegRouter mainRouter = new DefaultMainLegRouter(drtMode, scenario.getNetwork(),
+				scenario.getPopulation().getFactory(), drtRouteCreator);
+		DvrpRoutingModule dvrpRoutingModule = new DvrpRoutingModule(mainRouter, walkRouter, walkRouter, stopFinder,
+				drtMode, TimeInterpretation.create(scenario.getConfig()));
+
+		// origin and destination are more than 2000 m away from the next stop, so they are only served under the
+		// longWalk constraints set
+		Facility hf2 = FacilitiesUtils.toFacility((Activity)p2.getSelectedPlan().getPlanElements().get(0), facilities);
+		Facility wf2 = FacilitiesUtils.toFacility((Activity)p2.getSelectedPlan().getPlanElements().get(2), facilities);
+		Assertions.assertNotNull(
+				dvrpRoutingModule.calcRoute(DefaultRoutingRequest.withoutAttributes(hf2, wf2, 8 * 3600, p2)));
+
+		// person 6 starts at the same place as person 2, but is bound to the default constraints set
+		Person p6 = scenario.getPopulation().getPersons().get(Id.createPersonId(6));
+		Facility hf6 = FacilitiesUtils.toFacility((Activity)p6.getSelectedPlan().getPlanElements().get(0), facilities);
+		Facility wf6 = FacilitiesUtils.toFacility((Activity)p6.getSelectedPlan().getPlanElements().get(2), facilities);
+		Assertions.assertNull(
+				dvrpRoutingModule.calcRoute(DefaultRoutingRequest.withoutAttributes(hf6, wf6, 8 * 3600, p6)));
 	}
 
 	@Test

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/AttributeBasedStopFinder.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/AttributeBasedStopFinder.java
@@ -18,10 +18,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.router.DvrpRoutingModule.AccessEgressFacilityFinder;
+import org.matsim.core.router.RoutingRequest;
 import org.matsim.core.utils.collections.QuadTrees;
 import org.matsim.facilities.Facility;
 import org.matsim.utils.objectattributes.attributable.Attributable;
-import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * A stop finder which works like ClosestAccessEgressFacilityFinder in that it
@@ -46,13 +46,13 @@ public class AttributeBasedStopFinder implements AccessEgressFacilityFinder {
 	}
 
 	@Override
-	public Optional<Pair<Facility, Facility>> findFacilities(Facility fromFacility, Facility toFacility,
-			Attributes attributes) {
-		String stopNetwork = Optional.ofNullable((String)attributes.getAttribute(TRIP_STOP_NETWORK_ATTRIBUTE))
+	public Optional<Pair<Facility, Facility>> findFacilities(RoutingRequest request) {
+		String stopNetwork = Optional.ofNullable(
+						(String)request.getAttributes().getAttribute(TRIP_STOP_NETWORK_ATTRIBUTE))
 				.orElse(DEFAULT_STOP_NETWORK);
 		var facilityFinder = Objects.requireNonNull(facilityFinders.get(stopNetwork),
 				() -> "Stop network does not exist: " + stopNetwork);
-		return facilityFinder.findFacilities(fromFacility, toFacility, attributes);
+		return facilityFinder.findFacilities(request);
 	}
 
 	static public <T extends Facility & Attributable> AttributeBasedStopFinder create(double maxDistance,

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/ClosestAccessEgressFacilityFinder.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/ClosestAccessEgressFacilityFinder.java
@@ -27,10 +27,10 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.router.DvrpRoutingModule.AccessEgressFacilityFinder;
+import org.matsim.core.router.RoutingRequest;
 import org.matsim.core.utils.collections.QuadTree;
 import org.matsim.core.utils.geometry.CoordUtils;
 import org.matsim.facilities.Facility;
-import org.matsim.utils.objectattributes.attributable.Attributes;
 
 import com.google.common.base.Verify;
 
@@ -38,35 +38,81 @@ import com.google.common.base.Verify;
  * @author michalm
  */
 public class ClosestAccessEgressFacilityFinder implements AccessEgressFacilityFinder {
+
+	/**
+	 * Provides the maximum access/egress distance that applies to a single routing request. This allows the maximum
+	 * distance to depend on the trip, e.g. on the person or on the time of day, instead of being a global constant.
+	 * <p>
+	 * It is queried after the closest access and egress facilities have been determined, so that implementations may
+	 * also take the found facilities (e.g. their links) into account.
+	 */
+	public interface MaxAccessEgressDistance {
+		double get(RoutingRequest request, Facility accessFacility, Facility egressFacility);
+	}
+
 	private final Network network;
 	private final QuadTree<? extends Facility> facilityQuadTree;
-	private final double maxDistance;
+	private final MaxAccessEgressDistance maxAccessEgressDistance;
+
+	/**
+	 * The maximum distance applied by {@link #findClosestStop(Facility)}, which has no routing request at hand.
+	 */
+	private final double defaultMaxDistance;
 
 	public ClosestAccessEgressFacilityFinder(double maxDistance, Network network,
 			QuadTree<? extends Facility> facilityQuadTree) {
+		this((request, accessFacility, egressFacility) -> maxDistance, maxDistance, network, facilityQuadTree);
+	}
+
+	public ClosestAccessEgressFacilityFinder(MaxAccessEgressDistance maxAccessEgressDistance,
+			double defaultMaxDistance, Network network, QuadTree<? extends Facility> facilityQuadTree) {
 		this.network = network;
 		this.facilityQuadTree = facilityQuadTree;
-		this.maxDistance = maxDistance;
+		this.maxAccessEgressDistance = maxAccessEgressDistance;
+		this.defaultMaxDistance = defaultMaxDistance;
 	}
 
 	@Override
-	public Optional<Pair<Facility, Facility>> findFacilities(Facility fromFacility, Facility toFacility, Attributes tripAttributes) {
-		Facility accessFacility = findClosestStop(fromFacility);
-		if (accessFacility == null) {
+	public Optional<Pair<Facility, Facility>> findFacilities(RoutingRequest request) {
+		Facility fromFacility = request.getFromFacility();
+		Facility toFacility = request.getToFacility();
+
+		// the closest facilities do not depend on the maximum distance, so they can be determined first and passed on
+		// to the MaxAccessEgressDistance
+		Facility accessFacility = findClosestStop(fromFacility, Double.POSITIVE_INFINITY);
+		Facility egressFacility = findClosestStop(toFacility, Double.POSITIVE_INFINITY);
+		if (accessFacility == null || egressFacility == null) {
 			return Optional.empty();
 		}
 
-		Facility egressFacility = findClosestStop(toFacility);
-		return egressFacility == null ?
-				Optional.empty() :
-				Optional.of(new ImmutablePair<>(accessFacility, egressFacility));
+		double maxDistance = maxAccessEgressDistance.get(request, accessFacility, egressFacility);
+		if (calcDistance(fromFacility, accessFacility) > maxDistance
+				|| calcDistance(toFacility, egressFacility) > maxDistance) {
+			return Optional.empty();
+		}
+
+		return Optional.of(new ImmutablePair<>(accessFacility, egressFacility));
 	}
 
 	public Facility findClosestStop(Facility facility) {
+		return findClosestStop(facility, defaultMaxDistance);
+	}
+
+	/**
+	 * @return the facility closest to the given facility, or {@code null} if it is farther away than {@code maxDistance}
+	 */
+	public Facility findClosestStop(Facility facility, double maxDistance) {
 		Coord coord = getFacilityCoord(facility, network);
 		Facility closestStop = facilityQuadTree.getClosest(coord.getX(), coord.getY());
+		if (closestStop == null) {
+			return null;
+		}
 		double closestStopDistance = CoordUtils.calcEuclideanDistance(coord, closestStop.getCoord());
 		return closestStopDistance > maxDistance ? null : closestStop;
+	}
+
+	private double calcDistance(Facility facility, Facility stop) {
+		return CoordUtils.calcEuclideanDistance(getFacilityCoord(facility, network), stop.getCoord());
 	}
 
 	static Coord getFacilityCoord(Facility facility, Network network) {

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/ClosestAccessEgressFacilityFinder.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/ClosestAccessEgressFacilityFinder.java
@@ -79,19 +79,18 @@ public class ClosestAccessEgressFacilityFinder implements AccessEgressFacilityFi
 
 		// the closest facilities do not depend on the maximum distance, so they can be determined first and passed on
 		// to the MaxAccessEgressDistance
-		Facility accessFacility = findClosestStop(fromFacility, Double.POSITIVE_INFINITY);
-		Facility egressFacility = findClosestStop(toFacility, Double.POSITIVE_INFINITY);
-		if (accessFacility == null || egressFacility == null) {
+		ClosestStop access = findClosestStopWithDistance(fromFacility);
+		ClosestStop egress = findClosestStopWithDistance(toFacility);
+		if (access == null || egress == null) {
 			return Optional.empty();
 		}
 
-		double maxDistance = maxAccessEgressDistance.get(request, accessFacility, egressFacility);
-		if (calcDistance(fromFacility, accessFacility) > maxDistance
-				|| calcDistance(toFacility, egressFacility) > maxDistance) {
+		double maxDistance = maxAccessEgressDistance.get(request, access.facility(), egress.facility());
+		if (access.distance() > maxDistance || egress.distance() > maxDistance) {
 			return Optional.empty();
 		}
 
-		return Optional.of(new ImmutablePair<>(accessFacility, egressFacility));
+		return Optional.of(new ImmutablePair<>(access.facility(), egress.facility()));
 	}
 
 	public Facility findClosestStop(Facility facility) {
@@ -102,17 +101,23 @@ public class ClosestAccessEgressFacilityFinder implements AccessEgressFacilityFi
 	 * @return the facility closest to the given facility, or {@code null} if it is farther away than {@code maxDistance}
 	 */
 	public Facility findClosestStop(Facility facility, double maxDistance) {
-		Coord coord = getFacilityCoord(facility, network);
-		Facility closestStop = facilityQuadTree.getClosest(coord.getX(), coord.getY());
-		if (closestStop == null) {
-			return null;
-		}
-		double closestStopDistance = CoordUtils.calcEuclideanDistance(coord, closestStop.getCoord());
-		return closestStopDistance > maxDistance ? null : closestStop;
+		ClosestStop closestStop = findClosestStopWithDistance(facility);
+		return closestStop == null || closestStop.distance() > maxDistance ? null : closestStop.facility();
 	}
 
-	private double calcDistance(Facility facility, Facility stop) {
-		return CoordUtils.calcEuclideanDistance(getFacilityCoord(facility, network), stop.getCoord());
+	/**
+	 * @return the facility closest to the given facility together with its distance, or {@code null} if there is no
+	 * facility at all
+	 */
+	private ClosestStop findClosestStopWithDistance(Facility facility) {
+		Coord coord = getFacilityCoord(facility, network);
+		Facility closestStop = facilityQuadTree.getClosest(coord.getX(), coord.getY());
+		return closestStop == null ?
+				null :
+				new ClosestStop(closestStop, CoordUtils.calcEuclideanDistance(coord, closestStop.getCoord()));
+	}
+
+	private record ClosestStop(Facility facility, double distance) {
 	}
 
 	static Coord getFacilityCoord(Facility facility, Network network) {

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DecideOnLinkAccessEgressFacilityFinder.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DecideOnLinkAccessEgressFacilityFinder.java
@@ -27,9 +27,9 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.matsim.api.core.v01.network.Network;
 import org.matsim.contrib.dvrp.router.DvrpRoutingModule.AccessEgressFacilityFinder;
 import org.matsim.core.router.LinkWrapperFacility;
+import org.matsim.core.router.RoutingRequest;
 import org.matsim.facilities.FacilitiesUtils;
 import org.matsim.facilities.Facility;
-import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * @author Michal Maciejewski (michalm)
@@ -42,10 +42,11 @@ public class DecideOnLinkAccessEgressFacilityFinder implements AccessEgressFacil
 	}
 
 	@Override
-	public Optional<Pair<Facility, Facility>> findFacilities(Facility fromFacility, Facility toFacility, Attributes tripAttributes) {
+	public Optional<Pair<Facility, Facility>> findFacilities(RoutingRequest request) {
 		LinkWrapperFacility accessFacility = new LinkWrapperFacility(
-				FacilitiesUtils.decideOnLink(fromFacility, network));
-		LinkWrapperFacility egressFacility = new LinkWrapperFacility(FacilitiesUtils.decideOnLink(toFacility, network));
+				FacilitiesUtils.decideOnLink(request.getFromFacility(), network));
+		LinkWrapperFacility egressFacility = new LinkWrapperFacility(
+				FacilitiesUtils.decideOnLink(request.getToFacility(), network));
 		return Optional.of(ImmutablePair.of(accessFacility, egressFacility));
 	}
 }

--- a/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpRoutingModule.java
+++ b/contribs/dvrp/src/main/java/org/matsim/contrib/dvrp/router/DvrpRoutingModule.java
@@ -38,7 +38,6 @@ import org.matsim.core.router.RoutingModule;
 import org.matsim.core.router.RoutingRequest;
 import org.matsim.core.utils.timing.TimeInterpretation;
 import org.matsim.facilities.Facility;
-import org.matsim.utils.objectattributes.attributable.Attributes;
 
 /**
  * @author jbischoff
@@ -48,8 +47,15 @@ public class DvrpRoutingModule implements RoutingModule {
 	private static final Logger logger = LogManager.getLogger(DvrpRoutingModule.class);
 
 	public interface AccessEgressFacilityFinder {
-		Optional<Pair<Facility, Facility>> findFacilities(Facility fromFacility, Facility toFacility,
-				Attributes tripAttributes);
+		/**
+		 * Finds the access and egress facilities (e.g. stops) to be used for the given routing request, or an empty
+		 * {@link Optional} if the request cannot be served (e.g. because no facility is close enough, or because the
+		 * service is not available at the requested departure time).
+		 * <p>
+		 * The whole {@link RoutingRequest} is passed such that implementations may take the departure time, the person
+		 * and the trip attributes into account.
+		 */
+		Optional<Pair<Facility, Facility>> findFacilities(RoutingRequest request);
 	}
 
 	private final AccessEgressFacilityFinder stopFinder;
@@ -71,14 +77,12 @@ public class DvrpRoutingModule implements RoutingModule {
 
 	@Override
 	public List<? extends PlanElement> calcRoute(RoutingRequest request) {
-		final Facility fromFacility = request.getFromFacility();
-		final Facility toFacility = request.getToFacility();
+		final Facility fromFacility = Objects.requireNonNull(request.getFromFacility(), "fromFacility is null");
+		final Facility toFacility = Objects.requireNonNull(request.getToFacility(), "toFacility is null");
 		final double departureTime = request.getDepartureTime();
 		final Person person = request.getPerson();
 
-		Optional<Pair<Facility, Facility>> stops = stopFinder.findFacilities(
-				Objects.requireNonNull(fromFacility, "fromFacility is null"),
-				Objects.requireNonNull(toFacility, "toFacility is null"), request.getAttributes());
+		Optional<Pair<Facility, Facility>> stops = stopFinder.findFacilities(request);
 		if (stops.isEmpty()) {
 			logger.debug("No access/egress stops found, agent will use fallback mode as leg mode (usually "
 					+ TransportMode.walk

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/router/ClosestAccessEgressFacilityFinderTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/router/ClosestAccessEgressFacilityFinderTest.java
@@ -1,0 +1,194 @@
+/*
+ * *********************************************************************** *
+ * project: org.matsim.*
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2025 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** *
+ */
+
+package org.matsim.contrib.dvrp.router;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.population.PopulationUtils;
+import org.matsim.core.router.DefaultRoutingRequest;
+import org.matsim.core.router.RoutingRequest;
+import org.matsim.core.utils.collections.QuadTree;
+import org.matsim.core.utils.collections.QuadTrees;
+import org.matsim.facilities.Facility;
+
+/**
+ * @author nkuehnel / MOIA
+ */
+public class ClosestAccessEgressFacilityFinderTest {
+
+	private final Network network = createNetwork();
+
+	private final Facility stopA = facility("linkAtA", new Coord(0, 0));
+	private final Facility stopB = facility("linkAtB", new Coord(1000, 0));
+
+	private final Facility fromFacility = facility("linkAtA", new Coord(100, 0));
+	private final Facility toFacility = facility("linkAtB", new Coord(900, 0));
+
+	@Test
+	void testBothStopsWithinConstantMaxDistance() {
+		var finder = new ClosestAccessEgressFacilityFinder(200, network, quadTree());
+
+		Optional<Pair<Facility, Facility>> facilities = finder.findFacilities(request(0, null));
+
+		assertThat(facilities).isPresent();
+		assertThat(facilities.get().getLeft()).isSameAs(stopA);
+		assertThat(facilities.get().getRight()).isSameAs(stopB);
+	}
+
+	@Test
+	void testAccessStopTooFarAway() {
+		// 100 m to the access stop, 100 m to the egress stop
+		var finder = new ClosestAccessEgressFacilityFinder(99, network, quadTree());
+		assertThat(finder.findFacilities(request(0, null))).isEmpty();
+	}
+
+	@Test
+	void testEgressStopTooFarAway() {
+		// 100 m to the access stop, 300 m to the egress stop
+		var finder = new ClosestAccessEgressFacilityFinder(200, network, quadTree());
+		RoutingRequest request = DefaultRoutingRequest.withoutAttributes(fromFacility,
+				facility("linkAtB", new Coord(700, 0)), 0, null);
+		assertThat(finder.findFacilities(request)).isEmpty();
+	}
+
+	@Test
+	void testUnboundedMaxDistance() {
+		var finder = new ClosestAccessEgressFacilityFinder(Double.MAX_VALUE, network, quadTree());
+		RoutingRequest request = DefaultRoutingRequest.withoutAttributes(facility("linkAtA", new Coord(-100_000, 0)),
+				toFacility, 0, null);
+		assertThat(finder.findFacilities(request)).isPresent();
+	}
+
+	@Test
+	void testMaxAccessEgressDistanceIsAskedWithTheFoundStopsAndTheRequest() {
+		RoutingRequest request = request(8 * 3600, null);
+		var recorded = new Object() {
+			RoutingRequest seenRequest;
+			Facility seenAccessFacility;
+			Facility seenEgressFacility;
+		};
+
+		var finder = new ClosestAccessEgressFacilityFinder((r, accessFacility, egressFacility) -> {
+			recorded.seenRequest = r;
+			recorded.seenAccessFacility = accessFacility;
+			recorded.seenEgressFacility = egressFacility;
+			return 200;
+		}, 0, network, quadTree());
+
+		assertThat(finder.findFacilities(request)).isPresent();
+		assertThat(recorded.seenRequest).isSameAs(request);
+		assertThat(recorded.seenAccessFacility).isSameAs(stopA);
+		assertThat(recorded.seenEgressFacility).isSameAs(stopB);
+	}
+
+	/**
+	 * This is the regression test for the maxWalkDistance defect: the maximum distance may differ per trip (e.g. per
+	 * person, as here, or per time of day), so it must be evaluated per call and not once at construction time.
+	 */
+	@Test
+	void testMaxAccessEgressDistanceMayDifferPerPerson() {
+		Person personWithLongWalk = PopulationUtils.getFactory().createPerson(Id.createPersonId("long"));
+		Person personWithShortWalk = PopulationUtils.getFactory().createPerson(Id.createPersonId("short"));
+
+		var finder = new ClosestAccessEgressFacilityFinder(
+				(r, accessFacility, egressFacility) -> r.getPerson() == personWithLongWalk ? 200 : 50, 200, network,
+				quadTree());
+
+		assertThat(finder.findFacilities(request(0, personWithLongWalk))).isPresent();
+		assertThat(finder.findFacilities(request(0, personWithShortWalk))).isEmpty();
+	}
+
+	@Test
+	void testFacilityWithoutCoordIsResolvedViaNetwork() {
+		// linkAtA and linkAtB are centred on the two stops, so the distances are 0
+		var finder = new ClosestAccessEgressFacilityFinder(0, network, quadTree());
+
+		Optional<Pair<Facility, Facility>> facilities = finder.findFacilities(
+				DefaultRoutingRequest.withoutAttributes(facility("linkAtA", null), facility("linkAtB", null), 0, null));
+
+		assertThat(facilities).isPresent();
+		assertThat(facilities.get().getLeft()).isSameAs(stopA);
+		assertThat(facilities.get().getRight()).isSameAs(stopB);
+	}
+
+	@Test
+	void testFindClosestStopUsesTheDefaultMaxDistance() {
+		var finder = new ClosestAccessEgressFacilityFinder((r, accessFacility, egressFacility) -> 0, 200, network,
+				quadTree());
+
+		assertThat(finder.findClosestStop(fromFacility)).isSameAs(stopA);
+		assertThat(finder.findClosestStop(facility("linkAtA", new Coord(500, 0)))).isNull();
+		assertThat(finder.findClosestStop(facility("linkAtA", new Coord(500, 0)), 600)).isNotNull();
+	}
+
+	private RoutingRequest request(double departureTime, Person person) {
+		return DefaultRoutingRequest.withoutAttributes(fromFacility, toFacility, departureTime, person);
+	}
+
+	private QuadTree<Facility> quadTree() {
+		return QuadTrees.createQuadTree(List.of(stopA, stopB));
+	}
+
+	private static Facility facility(String linkId, Coord coord) {
+		return new Facility() {
+			@Override
+			public Coord getCoord() {
+				return coord;
+			}
+
+			@Override
+			public Id<Link> getLinkId() {
+				return Id.createLinkId(linkId);
+			}
+
+			@Override
+			public Map<String, Object> getCustomAttributes() {
+				return Map.of();
+			}
+		};
+	}
+
+	private static Network createNetwork() {
+		Network network = NetworkUtils.createNetwork();
+		// the links are centred on (0, 0) and (1000, 0), i.e. on the two stops, because Link.getCoord() interpolates
+		// between the from and the to node
+		Node a1 = NetworkUtils.createAndAddNode(network, Id.createNodeId("a1"), new Coord(-10, 0));
+		Node a2 = NetworkUtils.createAndAddNode(network, Id.createNodeId("a2"), new Coord(10, 0));
+		Node b1 = NetworkUtils.createAndAddNode(network, Id.createNodeId("b1"), new Coord(990, 0));
+		Node b2 = NetworkUtils.createAndAddNode(network, Id.createNodeId("b2"), new Coord(1010, 0));
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("linkAtA"), a1, a2, 20, 10, 1000, 1);
+		NetworkUtils.createAndAddLink(network, Id.createLinkId("linkAtB"), b1, b2, 20, 10, 1000, 1);
+		return network;
+	}
+}

--- a/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/router/RoutingTimeStructureTest.java
+++ b/contribs/dvrp/src/test/java/org/matsim/contrib/dvrp/router/RoutingTimeStructureTest.java
@@ -61,7 +61,8 @@ public class RoutingTimeStructureTest {
 		when(egressFacility.getLinkId()).thenReturn(Id.createLinkId("egress"));
 
 		AccessEgressFacilityFinder stopFinder = mock(AccessEgressFacilityFinder.class);
-		when(stopFinder.findFacilities(eq(fromFacility), eq(toFacility), any())).thenReturn(
+		when(stopFinder.findFacilities(argThat(
+				(RoutingRequest r) -> r.getFromFacility() == fromFacility && r.getToFacility() == toFacility))).thenReturn(
 				Optional.of(Pair.of(accessFacility, egressFacility)));
 
 		RoutingModule accessRouter = mock(RoutingModule.class);
@@ -121,7 +122,8 @@ public class RoutingTimeStructureTest {
 		when(egressFacility.getLinkId()).thenReturn(Id.createLinkId("egress"));
 
 		AccessEgressFacilityFinder stopFinder = mock(AccessEgressFacilityFinder.class);
-		when(stopFinder.findFacilities(eq(fromFacility), eq(toFacility), any())).thenReturn(
+		when(stopFinder.findFacilities(argThat(
+				(RoutingRequest r) -> r.getFromFacility() == fromFacility && r.getToFacility() == toFacility))).thenReturn(
 				Optional.of(Pair.of(accessFacility, egressFacility)));
 
 		RoutingModule accessRouter = mock(RoutingModule.class);


### PR DESCRIPTION
maxWalkDistance is a property of DrtOptimizationConstraintsSet, and which constraints set applies to a trip is decided at routing time by the ConstraintSetChooser. DefaultDrtRouteConstraintsCalculator honours that, but DrtModeRoutingModule built the stop finder once, eagerly, from the default set, so setMaxWalkDistance() on a non-default set was silently ineffective.

AccessEgressFacilityFinder.findFacilities() now receives the whole RoutingRequest instead of from/to facility and trip attributes, so implementations can take the departure time, the person and the attributes into account. ClosestAccessEgressFacilityFinder gets a per-request maximum distance provider; the constant constructor and findClosestStop(Facility), which the accessibility contrib uses, keep their present behaviour.

The chooser is asked with the access and egress stop links, consistent with DrtRouteCreator, where the chooser also sees the stop links.

