### PR TITLE
fix(network): keep every change event when several share a start time

### DIFF
--- a/matsim/src/main/java/org/matsim/core/network/FixedIntervalTimeVariantAttribute.java
+++ b/matsim/src/main/java/org/matsim/core/network/FixedIntervalTimeVariantAttribute.java
@@ -20,7 +20,9 @@
 package org.matsim.core.network;
 
 import java.util.Arrays;
-import java.util.TreeMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
 
 import org.matsim.core.network.NetworkChangeEvent.ChangeValue;
 import org.matsim.core.trafficmonitoring.TimeBinUtils;
@@ -54,7 +56,7 @@ final class FixedIntervalTimeVariantAttribute implements TimeVariantAttribute {
 
 	//TODO before calling this method we could convert changeEvents into a sequence of non-null changeValues
 	@Override
-	public void recalc(TreeMap<Double, NetworkChangeEvent> changeEvents, ChangeValueGetter valueGetter,
+	public void recalc(NavigableMap<Double, List<NetworkChangeEvent>> changeEvents, ChangeValueGetter valueGetter,
 			double baseValue1) {
 		this.baseValue = baseValue1;
 
@@ -65,44 +67,39 @@ final class FixedIntervalTimeVariantAttribute implements TimeVariantAttribute {
 		//To save memory, the array is constructed only if there is at least one ChangeEvent.
 		//This saves a lot of memory in cases when only one attribute is time variant, while
 		//the remaining two are invariant.
-		if (values == null) {
-			values = new double[numSlots];
-		}
+		double[] newValues = values == null ? new double[numSlots] : values;
 
 		int numEvent = 0;
 		int fromBin = 0;//inclusive
 		double currentValue = baseValue1;
 		if (changeEvents != null) {
-			for (NetworkChangeEvent event : changeEvents.values()) {
-				ChangeValue value = valueGetter.getChangeValue(event);
-				if (value != null) {
-					numEvent++;
-
-					Preconditions.checkArgument(event.getStartTime() >= 0,
-							"The current implementation supports only non-negative change event times");
-					int toBin = (int)(event.getStartTime() / timeSlice);//exclusive
-					Arrays.fill(values, fromBin, toBin, currentValue);
-
-					switch (value.getType()) {
-						case ABSOLUTE_IN_SI_UNITS:
-							currentValue = value.getValue();
-							break;
-						case FACTOR:
-							currentValue *= value.getValue();
-							break;
-						case OFFSET_IN_SI_UNITS:
-							currentValue += value.getValue();
-							break;
-						default:
-							throw new RuntimeException("unknown ChangeType");
+			for (Map.Entry<Double, List<NetworkChangeEvent>> entry : changeEvents.entrySet()) {
+				// Several events may share a start time. They all apply, in registration order, but they fill the
+				// bins once, so the attribute takes a single value from that time onwards.
+				double valueHere = currentValue;
+				boolean changedHere = false;
+				for (NetworkChangeEvent event : entry.getValue()) {
+					ChangeValue value = valueGetter.getChangeValue(event);
+					if (value != null) {
+						Preconditions.checkArgument(event.getStartTime() >= 0,
+								"The current implementation supports only non-negative change event times");
+						valueHere = apply(valueHere, value);
+						changedHere = true;
 					}
+				}
+
+				if (changedHere) {
+					numEvent++;
+					int toBin = (int)(entry.getKey() / timeSlice);//exclusive
+					Arrays.fill(newValues, fromBin, toBin, currentValue);
+					currentValue = valueHere;
 					fromBin = toBin;
 				}
 			}
 		}
-		Arrays.fill(values, fromBin, values.length, currentValue);
-		eventsCountWhenLastRecalc = eventsCount;
 
+		// Validate before publishing: leaving eventsCountWhenLastRecalc updated after a failure would make
+		// isRecalcRequired() report false and the half-filled array would then be read as if it were complete.
 		if (numEvent != this.eventsCount) {
 			throw new RuntimeException("Expected number of change events ("
 					+ (this.eventsCount)
@@ -110,6 +107,18 @@ final class FixedIntervalTimeVariantAttribute implements TimeVariantAttribute {
 					+ numEvent
 					+ ")!");
 		}
+
+		Arrays.fill(newValues, fromBin, newValues.length, currentValue);
+		this.values = newValues;
+		eventsCountWhenLastRecalc = eventsCount;
+	}
+
+	private static double apply(final double currentValue, final ChangeValue value) {
+		return switch (value.getType()) {
+			case ABSOLUTE_IN_SI_UNITS -> value.getValue();
+			case FACTOR -> currentValue * value.getValue();
+			case OFFSET_IN_SI_UNITS -> currentValue + value.getValue();
+		};
 	}
 
 	@Override

--- a/matsim/src/main/java/org/matsim/core/network/TimeVariantAttribute.java
+++ b/matsim/src/main/java/org/matsim/core/network/TimeVariantAttribute.java
@@ -19,7 +19,8 @@
 
 package org.matsim.core.network;
 
-import java.util.TreeMap;
+import java.util.List;
+import java.util.NavigableMap;
 
 import org.matsim.core.network.NetworkChangeEvent.ChangeValue;
 
@@ -58,7 +59,13 @@ public interface TimeVariantAttribute
 
 	boolean isRecalcRequired();
 
-	void recalc(TreeMap<Double, NetworkChangeEvent> changeEvents, ChangeValueGetter valueGetter, double baseValue);
+	/**
+	 * @param changeEvents all change events registered on the link, grouped by start time. Several events may share a
+	 *                     start time; every event at a given time is applied, in registration order, and together they
+	 *                     yield a single value for that time.
+	 */
+	void recalc(NavigableMap<Double, List<NetworkChangeEvent>> changeEvents, ChangeValueGetter valueGetter,
+			double baseValue);
 
 	void incChangeEvents();
 

--- a/matsim/src/main/java/org/matsim/core/network/TimeVariantLinkImpl.java
+++ b/matsim/src/main/java/org/matsim/core/network/TimeVariantLinkImpl.java
@@ -20,6 +20,8 @@
 
 package org.matsim.core.network;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.TreeMap;
 
 import org.matsim.api.core.v01.Id;
@@ -36,7 +38,12 @@ import org.matsim.api.core.v01.network.*;
 	// member variables
 	//////////////////////////////////////////////////////////////////////
 
-	private TreeMap<Double,NetworkChangeEvent> changeEvents;
+	/**
+	 * Change events by start time. Several events may be registered for the same start time, so each time maps to a
+	 * list rather than to a single event. Keying by time alone would let a later event silently evict an earlier one
+	 * while the attributes' event counters still expected both.
+	 */
+	private TreeMap<Double,List<NetworkChangeEvent>> changeEvents;
 
 	private final TimeVariantAttribute variableFreespeed;
 	private final TimeVariantAttribute variableFlowCapacity;
@@ -87,17 +94,36 @@ import org.matsim.api.core.v01.network.*;
 		if(this.changeEvents == null)
 			this.changeEvents = new TreeMap<>();
 
-		this.changeEvents.put(event.getStartTime(), event);
+		List<NetworkChangeEvent> atSameTime = this.changeEvents.computeIfAbsent(event.getStartTime(),
+				k -> new ArrayList<>(1));
 
-		if (event.getFreespeedChange() != null) {
+		// An attribute yields one value per distinct start time, however many events at that time change it. So an
+		// attribute's counter is only incremented when this event is the first at this time to change it.
+		boolean freespeedAlreadyChangedHere = hasChange(atSameTime, TimeVariantAttribute.FREESPEED_GETTER);
+		boolean flowCapacityAlreadyChangedHere = hasChange(atSameTime, TimeVariantAttribute.FLOW_CAPACITY_GETTER);
+		boolean lanesAlreadyChangedHere = hasChange(atSameTime, TimeVariantAttribute.LANES_GETTER);
+
+		atSameTime.add(event);
+
+		if (event.getFreespeedChange() != null && !freespeedAlreadyChangedHere) {
 			this.variableFreespeed.incChangeEvents();
 		}
-		if (event.getFlowCapacityChange() != null) {
+		if (event.getFlowCapacityChange() != null && !flowCapacityAlreadyChangedHere) {
 			this.variableFlowCapacity.incChangeEvents();
 		}
-		if (event.getLanesChange() != null) {
+		if (event.getLanesChange() != null && !lanesAlreadyChangedHere) {
 			this.variableLanes.incChangeEvents();
 		}
+	}
+
+	private static boolean hasChange(final List<NetworkChangeEvent> events,
+			final TimeVariantAttribute.ChangeValueGetter valueGetter) {
+		for (NetworkChangeEvent event : events) {
+			if (valueGetter.getChangeValue(event) != null) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 

--- a/matsim/src/main/java/org/matsim/core/network/VariableIntervalTimeVariantAttribute.java
+++ b/matsim/src/main/java/org/matsim/core/network/VariableIntervalTimeVariantAttribute.java
@@ -20,7 +20,9 @@
 package org.matsim.core.network;
 
 import java.util.Arrays;
-import java.util.TreeMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
 
 import org.matsim.core.network.NetworkChangeEvent.ChangeValue;
 
@@ -51,40 +53,35 @@ implements TimeVariantAttribute
 
 
 	@Override
-	public void recalc(TreeMap<Double, NetworkChangeEvent> changeEvents,
+	public void recalc(NavigableMap<Double, List<NetworkChangeEvent>> changeEvents,
 			ChangeValueGetter valueGetter, double baseValue)
 	{
-		this.aTimes = new double[this.aEvents];
-		this.aValues = new double[this.aEvents];
-		this.aTimes[0] = Double.NEGATIVE_INFINITY;
-		this.aValues[0] = baseValue;
+		// Built locally and only published once validated. getValue() binary-searches aTimes and indexes aValues with
+		// the result, so a partially filled pair of arrays would be read as if it were complete.
+		double[] times = new double[this.aEvents];
+		double[] values = new double[this.aEvents];
+		times[0] = Double.NEGATIVE_INFINITY;
+		values[0] = baseValue;
 
 		int numEvent = 0;
 		if (changeEvents != null) {
 			// go through all change events in chronological sequence:
-			for (NetworkChangeEvent event : changeEvents.values()) {
-				ChangeValue value = valueGetter.getChangeValue(event);
-				if (value != null) {
-					switch( value.getType() ) {
-					case ABSOLUTE_IN_SI_UNITS:
-						// here, we just need to replace the value:
-						this.aValues[++numEvent] = value.getValue();
-						this.aTimes[numEvent] = event.getStartTime();
-						break;
-					case FACTOR: {
-						// there, the change event multiplies what we have so far:
-						double currentValue = this.aValues[numEvent];
-						this.aValues[++numEvent] = currentValue * value.getValue();
-						this.aTimes[numEvent] = event.getStartTime();
-						break; }
-					case OFFSET_IN_SI_UNITS: {
-						double currentValue = this.aValues[numEvent];
-						this.aValues[++numEvent] = currentValue + value.getValue();
-						this.aTimes[numEvent] = event.getStartTime();
-						break; }
-					default:
-						throw new RuntimeException( "unknown ChangeType" ) ;
+			for (Map.Entry<Double, List<NetworkChangeEvent>> entry : changeEvents.entrySet()) {
+				// Several events may share a start time. They all apply, in registration order, but they collapse into
+				// a single (time, value) pair: aTimes must stay strictly increasing for the binary search in getValue.
+				double currentValue = values[numEvent];
+				boolean changedHere = false;
+				for (NetworkChangeEvent event : entry.getValue()) {
+					ChangeValue value = valueGetter.getChangeValue(event);
+					if (value == null) {
+						continue;
 					}
+					currentValue = apply(currentValue, value);
+					changedHere = true;
+				}
+				if (changedHere) {
+					values[++numEvent] = currentValue;
+					times[numEvent] = entry.getKey();
 				}
 			}
 		}
@@ -93,6 +90,20 @@ implements TimeVariantAttribute
 			throw new RuntimeException("Expected number of change events (" + (this.aEvents - 1)
 					+ ") differs from the number of events found (" + numEvent + ")!");
 		}
+
+		this.aTimes = times;
+		this.aValues = values;
+	}
+
+	private static double apply(final double currentValue, final ChangeValue value)
+	{
+		return switch (value.getType()) {
+			// here, we just need to replace the value:
+			case ABSOLUTE_IN_SI_UNITS -> value.getValue();
+			// there, the change event multiplies what we have so far:
+			case FACTOR -> currentValue * value.getValue();
+			case OFFSET_IN_SI_UNITS -> currentValue + value.getValue();
+		};
 	}
 
 

--- a/matsim/src/test/java/org/matsim/core/mobsim/qsim/qnetsimengine/NetworkChangeEventLanesTest.java
+++ b/matsim/src/test/java/org/matsim/core/mobsim/qsim/qnetsimengine/NetworkChangeEventLanesTest.java
@@ -1,0 +1,244 @@
+/* *********************************************************************** *
+ * project: org.matsim.*
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ * copyright       : (C) 2026 by the members listed in the COPYING,        *
+ *                   LICENSE and WARRANTY file.                            *
+ * email           : info at matsim dot org                                *
+ *                                                                         *
+ * *********************************************************************** *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *   See also COPYING, LICENSE and WARRANTY file                           *
+ *                                                                         *
+ * *********************************************************************** */
+
+package org.matsim.core.mobsim.qsim.qnetsimengine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.matsim.api.core.v01.Coord;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.network.Link;
+import org.matsim.api.core.v01.network.Network;
+import org.matsim.api.core.v01.network.Node;
+import org.matsim.core.api.experimental.events.EventsManager;
+import org.matsim.core.config.Config;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.events.EventsUtils;
+import org.matsim.core.mobsim.qsim.QSim;
+import org.matsim.core.mobsim.qsim.QSimBuilder;
+import org.matsim.core.network.NetworkChangeEvent;
+import org.matsim.core.network.NetworkChangeEvent.ChangeType;
+import org.matsim.core.network.NetworkChangeEvent.ChangeValue;
+import org.matsim.core.network.NetworkUtils;
+import org.matsim.core.scenario.MutableScenario;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.testcases.MatsimTestUtils;
+
+/**
+ * Characterises what a {@link NetworkChangeEvent} carrying a lanes change actually does to the QSim.
+ * <p>
+ * The existing coverage in {@code org.matsim.integration.timevariantnetworks.QSimIntegrationTest} exercises
+ * freespeed and flow capacity but never lanes, so the behaviour asserted here was previously untested.
+ * <p>
+ * The mechanism is not obvious from reading {@link QueueWithBuffer#calculateStorageCapacity()} alone, because that
+ * method reads a cached {@code effectiveNumberOfLanesUsedInQsim} field and the time-dependent lookup next to it is
+ * commented out. The cache is refreshed by {@link QLinkImpl#recalcTimeVariantAttributes()}, which pushes
+ * {@code getNumberOfLanes(now)} into the lane before recalculating -- "flowCap &amp; nLanes are 'push', freeSpeed is
+ * 'pull'", as the source comment there puts it.
+ *
+ * @author pieterfourie
+ */
+class NetworkChangeEventLanesTest {
+
+	private static final double LENGTH = 1000.0;
+	private static final double FREESPEED = 10.0;
+	private static final double CAPACITY = 1800.0;
+	private static final double INITIAL_LANES = 2.0;
+	private static final double REDUCED_LANES = 1.0;
+
+	/** {@code NetworkImpl.DEFAULT_EFFECTIVE_CELL_SIZE}, the length in metres that one queued vehicle occupies. */
+	private static final double EFFECTIVE_CELL_SIZE = 7.5;
+
+	private static final double CHANGE_TIME = 3600.0;
+	private static final Id<Link> LINK_ID = Id.create("1", Link.class);
+
+	/**
+	 * The gate: a lanes change must reach the QSim's storage capacity, otherwise nothing can be built on top of it.
+	 * <p>
+	 * Storage capacity is {@code length * lanes / effectiveCellSize * storageCapFactor}. The link is deliberately long
+	 * and fast enough that neither the buffer floor nor the slow-link floor in
+	 * {@link QueueWithBuffer#calculateStorageCapacity()} clamps the result: the slow-link floor here is
+	 * {@code (1000/10) * 0.5 = 50} vehicles, well below both expected values.
+	 */
+	@Test
+	void lanesChangeAltersQsimStorageCapacity() {
+		Fixture f = new Fixture();
+
+		assertEquals(LENGTH * INITIAL_LANES / EFFECTIVE_CELL_SIZE, f.qlink.getSpaceCap(), MatsimTestUtils.EPSILON,
+			"before the change event is due, storage capacity should reflect the link's two lanes");
+
+		f.qsim.getSimTimer().setTime(CHANGE_TIME);
+		f.qlink.recalcTimeVariantAttributes();
+
+		assertEquals(LENGTH * REDUCED_LANES / EFFECTIVE_CELL_SIZE, f.qlink.getSpaceCap(), MatsimTestUtils.EPSILON,
+			"after the lanes change is due, storage capacity should have halved");
+	}
+
+	/**
+	 * The lanes change must not disturb flow capacity. Storage and flow are independent in the network file, and a
+	 * kerb-parking model that reduces lanes needs to know it is not silently throttling throughput as well.
+	 */
+	@Test
+	void lanesChangeLeavesFlowCapacityAlone() {
+		Fixture f = new Fixture();
+		double flowCapBefore = f.qlink.getSimulatedFlowCapacityPerTimeStep();
+
+		f.qsim.getSimTimer().setTime(CHANGE_TIME);
+		f.qlink.recalcTimeVariantAttributes();
+
+		assertEquals(flowCapBefore, f.qlink.getSimulatedFlowCapacityPerTimeStep(), MatsimTestUtils.EPSILON,
+			"a lanes-only change event must not alter flow capacity");
+	}
+
+	/**
+	 * The time-variant link itself must report the changed value; this is the "pull" half of the mechanism, and it
+	 * failing would point at the network layer rather than at the QSim.
+	 */
+	@Test
+	void timeVariantLinkReportsTheChangedLaneCount() {
+		Fixture f = new Fixture();
+
+		assertEquals(INITIAL_LANES, f.link.getNumberOfLanes(CHANGE_TIME - 1), MatsimTestUtils.EPSILON,
+			"before the change event is due the link should still report two lanes");
+		assertEquals(REDUCED_LANES, f.link.getNumberOfLanes(CHANGE_TIME), MatsimTestUtils.EPSILON,
+			"from the change event onwards the link should report one lane");
+	}
+
+	/**
+	 * The within-day path that a kerb-parking model would use: the change event does not exist when the mobsim starts,
+	 * and is injected once a vehicle parks. {@code NetworkChangeEventsEngine#addNetworkChangeEvent} registers the event
+	 * on the network and, when its start time has already passed, applies it straight away; this reproduces that pair
+	 * of steps without needing to stub {@code InternalInterface}.
+	 */
+	@Test
+	void eventInjectedDuringTheSimTakesEffectImmediately() {
+		Fixture f = new Fixture(false);
+
+		f.qsim.getSimTimer().setTime(7200.0);
+		assertEquals(LENGTH * INITIAL_LANES / EFFECTIVE_CELL_SIZE, f.qlink.getSpaceCap(), MatsimTestUtils.EPSILON,
+			"with no change event registered, storage capacity should still reflect two lanes");
+
+		NetworkChangeEvent injected = new NetworkChangeEvent(7200.0);
+		injected.addLink(f.link);
+		injected.setLanesChange(new ChangeValue(ChangeType.ABSOLUTE_IN_SI_UNITS, REDUCED_LANES));
+		NetworkUtils.addNetworkChangeEvent(f.network, injected);
+		f.qlink.recalcTimeVariantAttributes();
+
+		assertEquals(LENGTH * REDUCED_LANES / EFFECTIVE_CELL_SIZE, f.qlink.getSpaceCap(), MatsimTestUtils.EPSILON,
+			"an event injected mid-simulation for the current time should apply at once");
+	}
+
+	/**
+	 * Several change events on one link at one second all apply, and each attribute keeps its own value.
+	 * <p>
+	 * Change events are grouped by start time, so an event no longer evicts an earlier one at the same second. The
+	 * events at a given time are applied in registration order and collapse into a single value per attribute, which
+	 * keeps the times strictly increasing for the binary search in {@code getValue}.
+	 */
+	@Test
+	void twoEventsAtTheSameSecondOnOneLinkBothApply() {
+		Fixture f = new Fixture(false);
+
+		NetworkChangeEvent lanes = new NetworkChangeEvent(1800.0);
+		lanes.addLink(f.link);
+		lanes.setLanesChange(new ChangeValue(ChangeType.ABSOLUTE_IN_SI_UNITS, REDUCED_LANES));
+		NetworkUtils.addNetworkChangeEvent(f.network, lanes);
+
+		NetworkChangeEvent freespeed = new NetworkChangeEvent(1800.0);
+		freespeed.addLink(f.link);
+		freespeed.setFreespeedChange(new ChangeValue(ChangeType.ABSOLUTE_IN_SI_UNITS, FREESPEED / 2.0));
+		NetworkUtils.addNetworkChangeEvent(f.network, freespeed);
+
+		assertEquals(REDUCED_LANES, f.link.getNumberOfLanes(1800.0), MatsimTestUtils.EPSILON,
+			"the lanes event must survive a same-second event on another attribute");
+		assertEquals(FREESPEED / 2.0, f.link.getFreespeed(1800.0), MatsimTestUtils.EPSILON,
+			"the freespeed event must apply too");
+
+		assertEquals(INITIAL_LANES, f.link.getNumberOfLanes(0.0), MatsimTestUtils.EPSILON,
+			"before the change time the link keeps its base lane count");
+		assertEquals(FREESPEED, f.link.getFreespeed(0.0), MatsimTestUtils.EPSILON,
+			"before the change time the link keeps its base freespeed");
+	}
+
+	/**
+	 * Two events at one second changing the <em>same</em> attribute are applied in registration order, so the later
+	 * one wins for an absolute change. They still collapse into a single value for that time.
+	 */
+	@Test
+	void twoEventsAtTheSameSecondOnOneAttributeApplyInOrder() {
+		Fixture f = new Fixture(false);
+
+		NetworkChangeEvent first = new NetworkChangeEvent(1800.0);
+		first.addLink(f.link);
+		first.setLanesChange(new ChangeValue(ChangeType.ABSOLUTE_IN_SI_UNITS, INITIAL_LANES));
+		NetworkUtils.addNetworkChangeEvent(f.network, first);
+
+		NetworkChangeEvent second = new NetworkChangeEvent(1800.0);
+		second.addLink(f.link);
+		second.setLanesChange(new ChangeValue(ChangeType.OFFSET_IN_SI_UNITS, -1.0));
+		NetworkUtils.addNetworkChangeEvent(f.network, second);
+
+		assertEquals(INITIAL_LANES - 1.0, f.link.getNumberOfLanes(1800.0), MatsimTestUtils.EPSILON,
+			"the offset must be applied on top of the absolute change registered before it");
+		assertEquals(INITIAL_LANES, f.link.getNumberOfLanes(0.0), MatsimTestUtils.EPSILON,
+			"before the change time the link keeps its base lane count");
+	}
+
+	private static final class Fixture {
+		private final Link link;
+		private final Network network;
+		private final QSim qsim;
+		private final QLinkImpl qlink;
+
+		/**
+		 * @param withPreloadedLaneReduction register a lanes change at {@link #CHANGE_TIME} before the mobsim is built
+		 */
+		private Fixture(boolean withPreloadedLaneReduction) {
+			Config config = ConfigUtils.createConfig();
+			config.network().setTimeVariantNetwork(true);
+
+			MutableScenario scenario = (MutableScenario) ScenarioUtils.createScenario(config);
+			this.network = scenario.getNetwork();
+			this.network.setCapacityPeriod(3600.0);
+
+			Node node1 = NetworkUtils.createAndAddNode(this.network, Id.create("1", Node.class), new Coord(0, 0));
+			Node node2 = NetworkUtils.createAndAddNode(this.network, Id.create("2", Node.class), new Coord(LENGTH, 0));
+			this.link = NetworkUtils.createAndAddLink(this.network, LINK_ID, node1, node2, LENGTH, FREESPEED, CAPACITY,
+				INITIAL_LANES);
+
+			if (withPreloadedLaneReduction) {
+				NetworkChangeEvent laneReduction = new NetworkChangeEvent(CHANGE_TIME);
+				laneReduction.addLink(this.link);
+				laneReduction.setLanesChange(new ChangeValue(ChangeType.ABSOLUTE_IN_SI_UNITS, REDUCED_LANES));
+				NetworkUtils.addNetworkChangeEvent(this.network, laneReduction);
+			}
+
+			EventsManager eventsManager = EventsUtils.createEventsManager();
+			this.qsim = new QSimBuilder(config).useDefaults().build(scenario, eventsManager);
+			this.qlink = (QLinkImpl) this.qsim.getNetsimNetwork().getNetsimLink(LINK_ID);
+		}
+
+		private Fixture() {
+			this(true);
+		}
+	}
+}


### PR DESCRIPTION
## Defect

`TimeVariantLinkImpl` stores change events in a `TreeMap` keyed by start time, so a second event on the same link at the same second **evicts** the first. The evicted event's attribute counter has already been incremented by `incChangeEvents()`, so `recalc()` then finds fewer events than it expects and throws:

```
Expected number of change events (2) differs from the number of events found (1)!
```

Worse than the throw: both `VariableIntervalTimeVariantAttribute` and `FixedIntervalTimeVariantAttribute` publish their arrays **before** validating. Once published, `isRecalcRequired()` compares equal, no further recalc is attempted, and the half-filled arrays are read as if valid. The unwritten slot returns **0.0** — so a link reads zero lanes at every time, including times before the change, permanently. A zero-lane link is a network cut.

This is reachable from within the mobsim via `NetworkChangeEventsEngineI.addNetworkChangeEvent`, not only from a change-events file. The two colliding events do not need to change the same attribute: a lanes change and a freespeed change at the same second collide, because the map is keyed by time alone.

## Fix

- Change events are grouped by start time (`TreeMap<Double, List<NetworkChangeEvent>>`). All events at a time are applied in registration order and collapse into a single value per attribute, keeping `aTimes` strictly increasing for the binary search in `getValue()`.
- An attribute's counter is incremented only when an event is the first at that time to change that attribute.
- Both implementations now validate before publishing, so a future mismatch fails loudly instead of leaving a corrupt link.

Behaviour for events at distinct times is unchanged. Existing `TimeVariantLinkImplTest`, `QSimIntegrationTest` (timevariantnetworks) and `NetworkChangeEventsEngineTest` pass unmodified.

## Tests

Adds `NetworkChangeEventLanesTest`, 6 tests:

- a lanes change event alters QSim storage capacity (previously the only untested change type — freespeed and flow capacity were covered, lanes was not)
- a lanes change leaves flow capacity alone
- the time-variant link reports the changed lane count
- an event injected during the sim takes effect immediately
- two events at the same second on one link both apply
- two events at the same second on one attribute apply in registration order

Regression: `org.matsim.core.network.**`, `org.matsim.core.mobsim.qsim.**`, `org.matsim.integration.timevariantnetworks.**` — 546 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
