### PR TITLE
fix(pseudosimulation): count SpotBugs findings, not lines that contain one

### DIFF
--- a/contribs/pseudosimulation/scripts/quality-metrics.sh
+++ b/contribs/pseudosimulation/scripts/quality-metrics.sh
@@ -64,12 +64,14 @@ read_attribute_total() {
 	printf '%d\n' "$total"
 }
 
+# Counts occurrences, not matching lines. SpotBugs writes the whole BugCollection
+# on a single line, so `grep -c` would report 1 for any non-zero number of findings.
 count_pattern() {
 	local pattern=$1
 	local file=$2
 	local count
-	count=$(grep -c -- "$pattern" "$file" || true)
-	printf '%d\n' "$count"
+	count=$(grep -o -- "$pattern" "$file" | wc -l)
+	printf '%d\n' "$((count))"
 }
 
 baseline_value() {


### PR DESCRIPTION
`count_pattern` in `contribs/pseudosimulation/scripts/quality-metrics.sh` uses `grep -c`, which counts matching *lines* rather than matches. SpotBugs writes its entire `<BugCollection>` element on a single line, so `spotbugs_findings` reads `1` for any non-zero number of findings, and `0` only when there are none.

This is masked in this module today because its baseline is `spotbugs_findings=0`: the first finding reads 1, exceeds 0, and is still flagged. It bites in two ways regardless.

The metric cannot report magnitude: a jump from one finding to fifty shows as `+1`.

More seriously, `--ratchet` writes current values, so ratcheting a tree that has any findings records `spotbugs_findings=1` whatever the real count is. From that point the metric is inert. Every later measurement also reads 1, which is never greater than 1, so the gate reports PASS no matter what happens to the count. Anyone adopting this harness on a module that starts with existing findings, which is the interesting case for a ratchet, gets a gate that silently never fires on this metric.

### Reproduction

Against this script unmodified, with a fixture shaped like real SpotBugs output (all `BugInstance` elements on one line), 4 findings against a baseline of 4:

```
spotbugs_findings                             1            4        -3  PASS
```

Raising the fixture to 9 findings against the same baseline of 4:

```
spotbugs_findings                             1            4        -3  PASS
gate exit: 0
```

A 4 to 9 regression passes. With this change, the same fixture:

```
spotbugs_findings                             9            4        +5  REGRESSION
gate exit: 1
```

### Impact on this module

None. `contribs/pseudosimulation/target/spotbugsXml.xml` is 76KB on a single line with 0 findings, and the old and new expressions both read 0, so `quality/metrics-baseline.properties` needs no change and the gate behaves identically here.

Checkstyle was never affected: it writes one `<error>` element per line, so counting lines and counting occurrences agree. The shared helper was the defect, and both call sites are now correct.

### Verification

Shell-only change, no Java touched. Verified by running the script directly against fixtures for three cases: a regression above baseline (now fails, previously passed), a count exactly at baseline (passes), and zero findings (reads 0, matching current behaviour here). Also checked against this module's real SpotBugs report.

Found while porting this harness to another MATSim project that starts with 6 SpotBugs findings, where the gate passed a deliberate 6 to 7 regression. Credit to @MartinPeris for the harness (#5122); this is a one-line correction to it.